### PR TITLE
fix(mcp-runtime): don't mark healthy MCP pods failed on K8s API throttling

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -7288,3 +7288,192 @@ describe("K8sDeployment selector self-heal (multitenant drift)", () => {
     });
   });
 });
+
+describe("K8sDeployment transient API-server errors (429/5xx)", () => {
+  function createDeployment(
+    mockK8sApi: Partial<k8s.CoreV1Api>,
+    mockK8sAppsApi: Partial<k8s.AppsV1Api>,
+  ): K8sDeployment {
+    const mockMcpServer = {
+      id: "test-server-id",
+      name: "test-server",
+      // No catalogId: startOrCreateDeployment must not depend on a catalog
+      // row existing for these state-machine tests.
+      catalogId: null,
+      secretId: null,
+      ownerId: null,
+      reinstallRequired: false,
+      localInstallationStatus: "idle",
+      localInstallationError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as unknown as McpServer;
+
+    return new K8sDeployment({
+      mcpServer: mockMcpServer,
+      k8sApi: mockK8sApi as k8s.CoreV1Api,
+      k8sAppsApi: mockK8sAppsApi as k8s.AppsV1Api,
+      k8sNetworkingApi: {} as k8s.NetworkingV1Api,
+      k8sAttach: {} as Attach,
+      k8sLog: {} as Log,
+      k8sExec: {} as Exec,
+      namespace: "default",
+      catalogItem: null,
+    });
+  }
+
+  // Shaped like the client's ApiException: an Error carrying `code` and the
+  // API server's Priority & Fairness response headers.
+  const throttledError = Object.assign(
+    new Error(
+      'HTTP-Code: 429 Message: Unknown API Status Code! Body: "Too many requests, please try again later.\\n"',
+    ),
+    { code: 429, headers: { "retry-after": "0.001" } },
+  );
+
+  test("a throttled reconcile leaves state pending (retryable), not failed", async () => {
+    const readDeployment = vi.fn().mockRejectedValue(throttledError);
+    const deployment = createDeployment(
+      { readNamespacedPod: vi.fn().mockRejectedValue({ statusCode: 404 }) },
+      { readNamespacedDeployment: readDeployment },
+    );
+
+    await expect(deployment.startOrCreateDeployment()).rejects.toEqual(
+      throttledError,
+    );
+
+    // The initial read is retried before giving up...
+    expect(readDeployment).toHaveBeenCalledTimes(3);
+    // ...and a still-throttled reconcile must not latch a terminal "failed":
+    // the pod may be perfectly healthy — status polling re-reads the truth.
+    expect(deployment.statusSummary.state).toBe("pending");
+    expect(deployment.statusSummary.error).toContain("Too many requests");
+  });
+
+  test("a non-transient reconcile error still fails the deployment", async () => {
+    const forbidden = { code: 403, message: "forbidden" };
+    const deployment = createDeployment(
+      { readNamespacedPod: vi.fn().mockRejectedValue({ statusCode: 404 }) },
+      { readNamespacedDeployment: vi.fn().mockRejectedValue(forbidden) },
+    );
+
+    await expect(deployment.startOrCreateDeployment()).rejects.toEqual(
+      forbidden,
+    );
+    expect(deployment.statusSummary.state).toBe("failed");
+  });
+});
+
+describe("K8sDeployment.refreshState failed-state recovery", () => {
+  const crashLoopPod: k8s.V1Pod = {
+    metadata: {
+      name: "mcp-test-server-abc12",
+      creationTimestamp: new Date(),
+    },
+    status: {
+      phase: "Running",
+      containerStatuses: [
+        {
+          name: "mcp-server",
+          restartCount: 3,
+          state: {
+            waiting: {
+              reason: "CrashLoopBackOff",
+              message: "back-off 5m0s restarting failed container",
+            },
+          },
+        } as k8s.V1ContainerStatus,
+      ],
+    },
+  };
+
+  const healthyPod: k8s.V1Pod = {
+    metadata: {
+      name: "mcp-test-server-abc12",
+      creationTimestamp: new Date(),
+    },
+    status: {
+      phase: "Running",
+      containerStatuses: [
+        {
+          name: "mcp-server",
+          restartCount: 3,
+          state: { running: { startedAt: new Date() } },
+        } as k8s.V1ContainerStatus,
+      ],
+    },
+  };
+
+  function createDeployment(scenario: { healthy: boolean }): K8sDeployment {
+    const mockMcpServer = {
+      id: "test-server-id",
+      name: "test-server",
+      catalogId: null,
+      secretId: null,
+      ownerId: null,
+      reinstallRequired: false,
+      localInstallationStatus: "idle",
+      localInstallationError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as unknown as McpServer;
+
+    const mockK8sApi = {
+      listNamespacedPod: vi.fn().mockImplementation(async () => ({
+        items: [scenario.healthy ? healthyPod : crashLoopPod],
+      })),
+    } as unknown as k8s.CoreV1Api;
+
+    const mockK8sAppsApi = {
+      readNamespacedDeployment: vi.fn().mockImplementation(async () => ({
+        status: { availableReplicas: scenario.healthy ? 1 : 0 },
+      })),
+    } as unknown as k8s.AppsV1Api;
+
+    return new K8sDeployment({
+      mcpServer: mockMcpServer,
+      k8sApi: mockK8sApi,
+      k8sAppsApi: mockK8sAppsApi,
+      k8sNetworkingApi: {} as k8s.NetworkingV1Api,
+      k8sAttach: {} as Attach,
+      k8sLog: {} as Log,
+      k8sExec: {} as Exec,
+      namespace: "default",
+      catalogItem: null,
+    });
+  }
+
+  test("a failed deployment that is verifiably available again flips back to running", async () => {
+    const scenario = { healthy: false };
+    const deployment = createDeployment(scenario);
+
+    // Drive the deployment into "failed" through the public refresh path:
+    // a crashlooping pod with no available replicas.
+    // @ts-expect-error - seeding an active state so refreshState evaluates it
+    deployment.state = "running";
+    await deployment.refreshState();
+    expect(deployment.statusSummary.state).toBe("failed");
+    expect(deployment.statusSummary.error).toContain("back-off");
+
+    // The pod recovers (e.g. the failure was transient); the next poll must
+    // self-heal instead of leaving the server red until a manual restart.
+    scenario.healthy = true;
+    await deployment.refreshState();
+    expect(deployment.statusSummary.state).toBe("running");
+    expect(deployment.statusSummary.error).toBeNull();
+  });
+
+  test("a genuinely broken deployment stays failed across refreshes", async () => {
+    const scenario = { healthy: false };
+    const deployment = createDeployment(scenario);
+
+    // @ts-expect-error - seeding an active state so refreshState evaluates it
+    deployment.state = "running";
+    await deployment.refreshState();
+    expect(deployment.statusSummary.state).toBe("failed");
+
+    await deployment.refreshState();
+    expect(deployment.statusSummary.state).toBe("failed");
+    expect(deployment.statusSummary.error).toContain("back-off");
+  });
+});

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -18,8 +18,10 @@ import {
   ensureStringIsRfc1123Compliant,
   isK8sConflictError,
   isK8sNotFoundError,
+  isTransientK8sApiError,
   sanitizeLabelValue,
   sanitizeMetadataLabels,
+  withK8sApiRetry,
 } from "@/k8s/shared";
 import logger from "@/logging";
 import { InternalMcpCatalogModel } from "@/models";
@@ -2492,13 +2494,19 @@ export default class K8sDeployment {
         }
       }
 
-      // Check if deployment already exists
+      // Check if deployment already exists. Retried on 429/5xx: at startup
+      // every install reconciles at once, and an API server throttling that
+      // burst (API Priority & Fairness) must not make an existing healthy
+      // deployment look broken.
       try {
-        const existingDeployment =
-          await this.k8sAppsApi.readNamespacedDeployment({
-            name: this.deploymentName,
-            namespace: this.namespace,
-          });
+        const existingDeployment = await withK8sApiRetry(
+          () =>
+            this.k8sAppsApi.readNamespacedDeployment({
+              name: this.deploymentName,
+              namespace: this.namespace,
+            }),
+          { label: `readNamespacedDeployment ${this.deploymentName}` },
+        );
 
         // SELF-HEAL: a Deployment created before the catalog-stable selector fix
         // (#6340) still labels its pods with the per-install `mcpServer.id`, while
@@ -2676,7 +2684,12 @@ export default class K8sDeployment {
       this.state = "pending";
       logger.info(`Deployment ${this.deploymentName} initiated`);
     } catch (error: unknown) {
-      this.state = "failed";
+      // A throttled/unavailable API server (429/5xx) says nothing about the
+      // workload — an already-running pod is most likely still healthy. Stay
+      // "pending" so the periodic status refresh re-reads the real state,
+      // instead of latching a terminal "failed" that sticks until a manual
+      // restart.
+      this.state = isTransientK8sApiError(error) ? "pending" : "failed";
       this.errorMessage =
         error instanceof Error ? error.message : "Unknown error";
       logger.error(
@@ -3823,9 +3836,16 @@ export default class K8sDeployment {
         this.cachedPodName = anyPod.metadata?.name ?? null;
       }
 
-      // Don't re-evaluate state for terminal failed (user must reinstall)
-      // but DO keep refreshing pod metadata above
-      if (this.state !== "pending" && this.state !== "running") {
+      // "failed" is re-evaluated too: it can be a false positive — e.g. a
+      // transient API-server error (429/5xx) latched during a reconcile while
+      // the pod kept running fine, or a crashloop that has since recovered.
+      // A deployment that is verifiably available flips (back) to "running";
+      // one that is genuinely broken re-derives the same failed state below.
+      if (
+        this.state !== "pending" &&
+        this.state !== "running" &&
+        this.state !== "failed"
+      ) {
         return;
       }
 

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -5,6 +5,7 @@ import {
   checkNamespaceDeployAccess,
   createK8sClients,
   loadKubeConfig,
+  mapWithConcurrency,
   namespaceAccessMessage,
   sanitizeLabelValue,
 } from "@/k8s/shared";
@@ -228,15 +229,19 @@ export class McpServerRuntimeManager {
       const networkPolicyResolutionCache =
         await this.buildNetworkPolicyResolutionCache(localCatalogItems);
 
-      // Start all local servers in parallel
-      const startPromises = localServers.map(async (mcpServer) => {
-        await this.startServer(mcpServer, undefined, undefined, {
-          networkPolicyCapabilities,
-          networkPolicyResolutionCache,
-        });
-      });
-
-      const results = await Promise.allSettled(startPromises);
+      // Start all local servers with bounded parallelism: each startServer
+      // fires a burst of K8s API calls, and reconciling every install at
+      // once can trip the API server's Priority & Fairness throttling
+      // (429 "Too many requests"), making healthy deployments look broken.
+      const results = await mapWithConcurrency(
+        localServers,
+        K8S_API_FANOUT_CONCURRENCY,
+        (mcpServer) =>
+          this.startServer(mcpServer, undefined, undefined, {
+            networkPolicyCapabilities,
+            networkPolicyResolutionCache,
+          }),
+      );
 
       // Count successes and failures
       const failures = results.filter((result) => result.status === "rejected");
@@ -1317,10 +1322,14 @@ export class McpServerRuntimeManager {
    * Detects state changes like a running pod entering CrashLoopBackOff.
    */
   async refreshAllStates(): Promise<void> {
-    const refreshPromises = Array.from(
-      this.mcpServerIdToDeploymentMap.values(),
-    ).map((deployment) => deployment.refreshState().catch(() => {}));
-    await Promise.all(refreshPromises);
+    // Bounded: each refresh makes several K8s API calls, and this runs every
+    // status-poll tick — unbounded parallelism across a large install base
+    // is a steady source of API Priority & Fairness throttling (429s).
+    await mapWithConcurrency(
+      Array.from(this.mcpServerIdToDeploymentMap.values()),
+      K8S_API_FANOUT_CONCURRENCY,
+      (deployment) => deployment.refreshState(),
+    );
   }
 
   /**
@@ -1971,5 +1980,13 @@ function getDockerConfigRegistryServers(secret: k8s.V1Secret): string[] {
     return [];
   }
 }
+
+/**
+ * Max concurrent per-server operations when fanning out over the whole
+ * install base (startup reconcile, periodic state refresh). Each operation
+ * makes several K8s API calls; unbounded fan-out trips the API server's
+ * Priority & Fairness throttling (429s) on large installs.
+ */
+const K8S_API_FANOUT_CONCURRENCY = 5;
 
 export default new McpServerRuntimeManager();

--- a/platform/backend/src/k8s/shared.test.ts
+++ b/platform/backend/src/k8s/shared.test.ts
@@ -451,3 +451,109 @@ describe("shared K8s utilities", () => {
     });
   });
 });
+
+describe("isTransientK8sApiError", () => {
+  test("throttling and API-server unavailability are transient", async () => {
+    const { isTransientK8sApiError } = await import("./shared");
+    expect(isTransientK8sApiError({ code: 429 })).toBe(true);
+    expect(isTransientK8sApiError({ statusCode: 429 })).toBe(true);
+    expect(isTransientK8sApiError({ response: { statusCode: 503 } })).toBe(
+      true,
+    );
+    expect(isTransientK8sApiError({ code: 500 })).toBe(true);
+    expect(isTransientK8sApiError({ code: 502 })).toBe(true);
+    expect(isTransientK8sApiError({ code: 504 })).toBe(true);
+  });
+
+  test("caller errors and unknown shapes are not transient", async () => {
+    const { isTransientK8sApiError } = await import("./shared");
+    expect(isTransientK8sApiError({ code: 404 })).toBe(false);
+    expect(isTransientK8sApiError({ code: 403 })).toBe(false);
+    expect(isTransientK8sApiError({ code: 409 })).toBe(false);
+    expect(isTransientK8sApiError(new Error("boom"))).toBe(false);
+    expect(isTransientK8sApiError(undefined)).toBe(false);
+    expect(isTransientK8sApiError("429")).toBe(false);
+  });
+});
+
+describe("withK8sApiRetry", () => {
+  test("retries a 429 honoring retry-after and returns the eventual result", async () => {
+    const { withK8sApiRetry } = await import("./shared");
+    const throttled = {
+      code: 429,
+      message: "Too many requests, please try again later.",
+      headers: { "retry-after": "0.001" },
+    };
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(throttled)
+      .mockRejectedValueOnce(throttled)
+      .mockResolvedValue("ok");
+
+    await expect(withK8sApiRetry(fn)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test("throws the last error once attempts are exhausted", async () => {
+    const { withK8sApiRetry } = await import("./shared");
+    const throttled = {
+      code: 429,
+      message: "Too many requests, please try again later.",
+      headers: { "retry-after": "0.001" },
+    };
+    const fn = vi.fn().mockRejectedValue(throttled);
+
+    await expect(withK8sApiRetry(fn, { attempts: 2 })).rejects.toEqual(
+      throttled,
+    );
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry non-transient errors", async () => {
+    const { withK8sApiRetry } = await import("./shared");
+    const notFound = { code: 404, message: "not found" };
+    const fn = vi.fn().mockRejectedValue(notFound);
+
+    await expect(withK8sApiRetry(fn)).rejects.toEqual(notFound);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("mapWithConcurrency", () => {
+  test("preserves item order and captures per-item rejections", async () => {
+    const { mapWithConcurrency } = await import("./shared");
+    const results = await mapWithConcurrency([1, 2, 3], 2, async (n) => {
+      if (n === 2) throw new Error("nope");
+      return n * 10;
+    });
+
+    expect(results).toEqual([
+      { status: "fulfilled", value: 10 },
+      { status: "rejected", reason: new Error("nope") },
+      { status: "fulfilled", value: 30 },
+    ]);
+  });
+
+  test("never runs more than `limit` items at once", async () => {
+    const { mapWithConcurrency } = await import("./shared");
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    await mapWithConcurrency(
+      Array.from({ length: 10 }, (_, i) => i),
+      3,
+      () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        return new Promise<void>((resolve) =>
+          setTimeout(() => {
+            inFlight--;
+            resolve();
+          }, 5),
+        );
+      },
+    );
+
+    expect(maxInFlight).toBe(3);
+  });
+});

--- a/platform/backend/src/k8s/shared.ts
+++ b/platform/backend/src/k8s/shared.ts
@@ -151,24 +151,7 @@ export function getK8sNamespace(): string {
  * K8s client errors can have `statusCode`, `code`, or `response.statusCode` set.
  */
 export function isK8sConflictError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
-
-  if ("statusCode" in error && error.statusCode === 409) {
-    return true;
-  }
-
-  if ("code" in error && error.code === 409) {
-    return true;
-  }
-
-  if (
-    "response" in error &&
-    (error as { response: { statusCode: number } }).response?.statusCode === 409
-  ) {
-    return true;
-  }
-
-  return false;
+  return getK8sErrorStatusCode(error) === 409;
 }
 
 /**
@@ -176,26 +159,94 @@ export function isK8sConflictError(error: unknown): boolean {
  * K8s client errors can have `statusCode`, `code`, or `response.statusCode` set to 404.
  */
 export function isK8sNotFoundError(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
+  return getK8sErrorStatusCode(error) === 404;
+}
 
-  if ("statusCode" in error && error.statusCode === 404) {
-    return true;
-  }
+/**
+ * Whether a Kubernetes API call failed for a reason that says nothing about
+ * the workload itself: the API server throttled the request (429, API
+ * Priority & Fairness) or was itself unavailable/overloaded (5xx). Such
+ * failures must never be treated as a deployment failure — the pod may be
+ * perfectly healthy — only as "we couldn't ask right now".
+ */
+export function isTransientK8sApiError(error: unknown): boolean {
+  const status = getK8sErrorStatusCode(error);
+  return (
+    status === 429 ||
+    status === 500 ||
+    status === 502 ||
+    status === 503 ||
+    status === 504
+  );
+}
 
-  if ("code" in error && error.code === 404) {
-    return true;
-  }
+/**
+ * Run `fn` over `items` with at most `limit` in flight at once. Used to bound
+ * fan-outs that hit the Kubernetes API for every MCP server — full
+ * parallelism across a large install base trips the API server's Priority &
+ * Fairness throttling (429 "Too many requests"). Per-item failures are
+ * captured, not thrown, mirroring `Promise.allSettled`.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results = new Array<PromiseSettledResult<R>>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex++;
+        try {
+          results[index] = {
+            status: "fulfilled",
+            value: await fn(items[index] as T),
+          };
+        } catch (reason) {
+          results[index] = { status: "rejected", reason };
+        }
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
 
-  if (
-    "response" in error &&
-    (error as { response: { statusCode: number } }).response?.statusCode === 404
-  ) {
-    return true;
+/**
+ * Retry a Kubernetes API call on transient API-server errors (429/5xx),
+ * honoring the server's `retry-after` header when present (API Priority &
+ * Fairness sends one with every 429). Non-transient errors (404, 403, 409,
+ * validation failures, …) are rethrown immediately.
+ */
+export async function withK8sApiRetry<T>(
+  fn: () => Promise<T>,
+  options?: { attempts?: number; label?: string },
+): Promise<T> {
+  const attempts = options?.attempts ?? K8S_RETRY_DEFAULT_ATTEMPTS;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (!isTransientK8sApiError(error) || attempt >= attempts) {
+        throw error;
+      }
+      const retryAfterSeconds = getK8sRetryAfterSeconds(error);
+      const baseDelayMs =
+        retryAfterSeconds !== undefined
+          ? retryAfterSeconds * 1000
+          : K8S_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+      const delayMs =
+        Math.min(baseDelayMs, K8S_RETRY_MAX_DELAY_MS) +
+        Math.floor(Math.random() * K8S_RETRY_JITTER_MS);
+      logger.warn(
+        { err: error, attempt, attempts, delayMs, label: options?.label },
+        "Transient Kubernetes API error; retrying",
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
   }
-
-  return false;
 }
 
 /**
@@ -345,3 +396,57 @@ export function sanitizeMetadataLabels(
   }
   return sanitized;
 }
+
+// === Internal helpers ===
+
+/**
+ * Extract the HTTP status code from a Kubernetes client error, if any.
+ * Depending on the client codepath the code lands on `statusCode`, `code`
+ * (the generated ApiException), or `response.statusCode`.
+ */
+function getK8sErrorStatusCode(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  if ("statusCode" in error && typeof error.statusCode === "number") {
+    return error.statusCode;
+  }
+
+  if ("code" in error && typeof error.code === "number") {
+    return error.code;
+  }
+
+  if ("response" in error) {
+    const statusCode = (error as { response?: { statusCode?: unknown } })
+      .response?.statusCode;
+    if (typeof statusCode === "number") {
+      return statusCode;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse the `retry-after` header (delay-seconds form) from a Kubernetes
+ * ApiException, if present.
+ */
+function getK8sRetryAfterSeconds(error: unknown): number | undefined {
+  if (!error || typeof error !== "object" || !("headers" in error)) {
+    return undefined;
+  }
+  const headers = (error as { headers?: unknown }).headers;
+  if (!headers || typeof headers !== "object") {
+    return undefined;
+  }
+  const raw = (headers as Record<string, unknown>)["retry-after"];
+  const seconds =
+    typeof raw === "string" || typeof raw === "number" ? Number(raw) : NaN;
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : undefined;
+}
+
+const K8S_RETRY_DEFAULT_ATTEMPTS = 3;
+const K8S_RETRY_BASE_DELAY_MS = 1_000;
+const K8S_RETRY_MAX_DELAY_MS = 15_000;
+const K8S_RETRY_JITTER_MS = 250;


### PR DESCRIPTION
## Problem

When the Kubernetes API server throttles the platform's requests (HTTP 429 "Too many requests" from API Priority & Fairness) or is briefly unavailable (5xx), the MCP server runtime treated that like a deployment failure:

1. `startOrCreateDeployment`'s catch-all latched `state = "failed"` with the raw `ApiException` text for **any** error — including a transient 429 on the initial "does the deployment exist?" read.
2. `refreshState()` deliberately never re-evaluated `failed` deployments, so the state stuck until a manual restart/reinstall.

Net effect: a perfectly healthy, long-running MCP pod (0 restarts, clean logs) shows a red **Deployment failed** badge with a raw 429 error, and never recovers on its own. The platform also makes it easy to *trigger* the throttling: startup reconciles every installed local server in unbounded parallel (each firing a burst of K8s API calls), and the status poll refreshes every server at full parallelism every 10s.

## Fix

- **Classify 429/5xx as transient** (`isTransientK8sApiError` in `k8s/shared.ts`): an API server that throttled or dropped our call says nothing about the workload, so a reconcile hitting one leaves the deployment `pending` (error still surfaced) instead of latching terminal `failed`.
- **Retry the initial deployment read** with `retry-after`-aware backoff (`withK8sApiRetry`), so a throttled startup reconcile still finds the running deployment and short-circuits to `running`.
- **Let `refreshState` self-heal `failed` states**: a deployment that is verifiably available again (available replicas + running pod) flips back to `running`; a genuinely broken one re-derives the same failed state. This also un-bricks servers already latched into the bogus state after upgrading — no reinstall needed.
- **Bound the fan-outs** (`mapWithConcurrency`, limit 5) for the startup reconcile and the periodic status refresh, shrinking the API-call bursts that trip API Priority & Fairness in the first place.

## Testing

- New behavior tests: throttled reconcile → `pending` + retried read; non-transient error → still `failed`; failed deployment that recovers → self-heals to `running`; genuinely crashlooping deployment → stays `failed`.
- Unit tests for `isTransientK8sApiError`, `withK8sApiRetry` (retry-after honoring, attempt exhaustion, no retry on non-transient), and `mapWithConcurrency` (order, per-item rejection capture, concurrency cap).
- Full `backend/src/k8s` suite passes (485 tests), `tsc --noEmit` clean, knip clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>