### PR TITLE
test: pin calendar-month cleanup test to the database month boundary

### DIFF
--- a/platform/backend/src/models/limit.test.ts
+++ b/platform/backend/src/models/limit.test.ts
@@ -2295,13 +2295,21 @@ describe("cleanupLimitsIfNeeded", () => {
       500,
     );
 
-    const previousMonth = new Date();
-    previousMonth.setMonth(previousMonth.getMonth() - 1, 15);
-    const currentMonth = new Date();
-    currentMonth.setDate(1);
-    currentMonth.setHours(12, 0, 0, 0);
-    await LimitModel.patch(dueLimit.id, { lastCleanup: previousMonth });
-    await LimitModel.patch(currentMonthLimit.id, { lastCleanup: currentMonth });
+    // Straddle the month boundary the cleanup query itself computes. That
+    // boundary is `date_trunc('month', now())` evaluated in the database's
+    // timezone, so timestamps derived from the JS local calendar disagree with
+    // it whenever the runner's timezone and the database's sit on opposite
+    // sides of a month boundary — the two are hours apart around midnight on
+    // the 1st, which used to flip both assertions.
+    const monthStart = sql`date_trunc('month', now())`;
+    await db
+      .update(schema.limitsTable)
+      .set({ lastCleanup: sql`${monthStart} - interval '1 second'` })
+      .where(eq(schema.limitsTable.id, dueLimit.id));
+    await db
+      .update(schema.limitsTable)
+      .set({ lastCleanup: monthStart })
+      .where(eq(schema.limitsTable.id, currentMonthLimit.id));
 
     await LimitModel.cleanupLimitsIfNeeded({
       allForOrganizationId: org.id,


### PR DESCRIPTION
## Problem

`models/limit.test.ts > resets calendar monthly limits only after the month boundary` fails on the 1st of the month depending on the runner's timezone.

The test built its `last_cleanup` timestamps from the **JS local calendar**:

```ts
const currentMonth = new Date();
currentMonth.setDate(1);
currentMonth.setHours(12, 0, 0, 0);
```

but the code under test compares `last_cleanup` against a boundary computed **in the database**:

```ts
lt(schema.limitsTable.lastCleanup, sql`date_trunc('month', now())`)
```

PGlite's session `TimeZone` is `GMT` regardless of the runner's `TZ` (verified: `show timezone` → `GMT`), and Drizzle writes `timestamp without time zone` columns as `value.toISOString()` — i.e. the UTC wall clock. So around midnight on the 1st, JS and the database disagree about which month it is, and "the 1st of the current month at noon, local" lands in the *previous* month as far as the query is concerned. The limit that was supposed to be left alone gets reset:

```
AssertionError: expected +0 to be 500
  2315|     expect(currentMonthUsage[0].currentUsageTokensIn).toBe(500);
```

Reproduced deterministically at `2026-08-01T06:41Z` with `TZ=America/Los_Angeles` (local `Jul 31 23:41`, database already in August).

## Fix

Derive both timestamps from the same `date_trunc('month', now())` expression the cleanup query uses, one second either side of it. Both values are computed and stored entirely inside the database, so no JS-vs-database timezone skew can flip the result.

This also tightens the test. Pinning `currentMonthLimit` *exactly* to the boundary means the test now pins the strictness of the comparison too — mutating `lt` to `lte` in `buildCleanupDueCondition` makes it fail, which the old "1st at noon" value did not catch.

## Verification

- Full `limit.test.ts` (104 tests) passes under `UTC`, `America/Los_Angeles` (−07:00), `Asia/Kolkata` (+05:30), `Pacific/Auckland` (+12:00), `Pacific/Kiritimati` (+14:00) and the host's +04:00 — on the failing date.
- Confirmed still failing pre-fix under `TZ=America/Los_Angeles`, passing post-fix.
- Mutation check: `lt` → `lte` in `buildCleanupDueCondition` fails the test.
- `pnpm lint` and `pnpm type-check` clean.

Test-only change; no production code touched.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>