### PR TITLE
feat: import MCP server configurations from JSON

### DIFF
--- a/docs/pages/platform-private-registry.md
+++ b/docs/pages/platform-private-registry.md
@@ -3,7 +3,7 @@ title: Private MCP Registry
 category: MCP
 order: 2
 description: Managing your organization's MCP servers in a private registry
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-01
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -35,6 +35,8 @@ Registry entries can describe either a remote server or a self-hosted server.
 **Remote servers** run outside Archestra and are reached over HTTP. Use this for provider-hosted MCP servers or internal services already operated by another team. The registry entry stores the server URL, optional docs URL, authentication configuration, and any install-time fields users must provide.
 
 **Self-hosted servers** run in Kubernetes through the [MCP Orchestrator](/docs/platform-orchestrator). Use this when Archestra should own the runtime. The registry entry can define the command, arguments, Docker image, transport type, environment variables, image pull secrets, and optional deployment YAML overrides.
+
+When you add an entry, you can paste an MCP configuration instead of filling each field. The importer supports common client configs, official MCP Registry `server.json`, and Archestra catalog manifests. It fills the server type, connection details, arguments, environment variables, and headers. Review the result before saving.
 
 Self-hosted servers support two transports:
 

--- a/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useCreateMcpServerInstallationRequest } from "@/lib/mcp/mcp-server-installation-request.query";
+import { parseMcpArguments } from "./mcp-config-import";
 
 const customServerRequestSchema = z
   .object({
@@ -119,10 +120,7 @@ export function CustomServerRequestDialog({
             serverType: "local" as const,
             localConfig: {
               command: values.command,
-              arguments: values.arguments
-                .split("\n")
-                .map((arg) => arg.trim())
-                .filter((arg) => arg.length > 0),
+              arguments: parseMcpArguments(values.arguments),
               environment:
                 values.environment.length > 0 ? values.environment : undefined,
             },
@@ -276,7 +274,9 @@ export function CustomServerRequestDialog({
                     name="arguments"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Arguments (one per line)</FormLabel>
+                        <FormLabel>
+                          Arguments (one per line or JSON array)
+                        </FormLabel>
                         <FormControl>
                           <Textarea
                             placeholder={`/path/to/server.js\n--verbose`}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -107,6 +107,7 @@ import {
   transformCatalogItemToFormValues,
   transformFormToApiData,
 } from "./mcp-catalog-form.utils";
+import { parseMcpConfigJson } from "./mcp-config-import";
 
 const ExternalSecretSelector = lazy(
   () =>
@@ -310,6 +311,11 @@ export function McpCatalogForm({
           environmentId: null,
         }),
   });
+
+  const [configImportJson, setConfigImportJson] = useState("");
+  const [configImportStatus, setConfigImportStatus] = useState<
+    { kind: "success" | "error"; message: string } | undefined
+  >();
 
   // Expose imperative submit to parent
   useEffect(() => {
@@ -750,7 +756,12 @@ export function McpCatalogForm({
   const showByosOption = useFeature("byosEnabled");
 
   // Use field array for environment variables
-  const { fields, append, remove } = useFieldArray({
+  const {
+    fields,
+    append,
+    remove,
+    replace: replaceEnvironment,
+  } = useFieldArray({
     control: form.control,
     name: "localConfig.environment",
   });
@@ -780,10 +791,69 @@ export function McpCatalogForm({
     fields: additionalHeaderFields,
     append: appendAdditionalHeader,
     remove: removeAdditionalHeader,
+    replace: replaceAdditionalHeaders,
   } = useFieldArray({
     control: form.control,
     name: "additionalHeaders",
   });
+
+  const applyImportedConfig = () => {
+    try {
+      const imported = parseMcpConfigJson(configImportJson);
+      if (imported.serverType === "local" && !isLocalMcpEnabled) {
+        throw new Error(
+          "Self-hosted MCP servers are unavailable in this deployment.",
+        );
+      }
+
+      form.setValue("serverType", imported.serverType, { shouldDirty: true });
+      if (imported.name) {
+        form.setValue("name", imported.name, { shouldDirty: true });
+      }
+      if (imported.description) {
+        form.setValue("description", imported.description, {
+          shouldDirty: true,
+        });
+      }
+
+      form.setValue("authMethod", imported.authMethod, { shouldDirty: true });
+      form.setValue("includeBearerPrefix", imported.includeBearerPrefix, {
+        shouldDirty: true,
+      });
+      replaceAdditionalHeaders(imported.additionalHeaders);
+
+      if (imported.serverType === "remote") {
+        form.setValue("serverUrl", imported.serverUrl ?? "", {
+          shouldDirty: true,
+        });
+      } else {
+        form.setValue("serverUrl", "", { shouldDirty: true });
+        form.setValue("localConfig.command", imported.command ?? "", {
+          shouldDirty: true,
+        });
+        form.setValue("localConfig.arguments", imported.arguments, {
+          shouldDirty: true,
+        });
+        form.setValue("localConfig.dockerImage", imported.dockerImage ?? "", {
+          shouldDirty: true,
+        });
+        replaceEnvironment(imported.environment);
+      }
+
+      setConfigImportStatus({
+        kind: "success",
+        message: `Imported ${imported.serverType} MCP server configuration.`,
+      });
+    } catch (error) {
+      setConfigImportStatus({
+        kind: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Unable to import this MCP configuration.",
+      });
+    }
+  };
 
   const [headerDialog, setHeaderDialog] = useState<
     { mode: "add" } | { mode: "edit"; index: number } | null
@@ -1224,6 +1294,60 @@ export function McpCatalogForm({
                 </div>
               )}
               {mode === "create" && (
+                <div className="space-y-2 rounded-lg border border-border p-4">
+                  <div className="space-y-1">
+                    <Label htmlFor="mcp-config-import">
+                      Paste MCP server configuration
+                    </Label>
+                    <p className="text-sm text-muted-foreground">
+                      Supports common client configs, the official MCP Registry
+                      server.json format, and {appName} catalog manifests.
+                    </p>
+                  </div>
+                  <Textarea
+                    id="mcp-config-import"
+                    value={configImportJson}
+                    onChange={(event) => {
+                      setConfigImportJson(event.target.value);
+                      setConfigImportStatus(undefined);
+                    }}
+                    placeholder={`{
+  "mcpServers": {
+    "example": { "command": "npx", "args": ["-y", "@example/mcp"] }
+  }
+}`}
+                    className="min-h-28 font-mono text-xs"
+                    spellCheck={false}
+                  />
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={applyImportedConfig}
+                      disabled={!configImportJson.trim()}
+                    >
+                      Apply configuration
+                    </Button>
+                    {configImportStatus && (
+                      <p
+                        role={
+                          configImportStatus.kind === "error"
+                            ? "alert"
+                            : "status"
+                        }
+                        className={
+                          configImportStatus.kind === "error"
+                            ? "text-sm text-destructive"
+                            : "text-sm text-muted-foreground"
+                        }
+                      >
+                        {configImportStatus.message}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+              {mode === "create" && (
                 <div className="space-y-2">
                   <Label>Server Type</Label>
                   <div className="flex rounded-lg border border-border overflow-hidden">
@@ -1427,7 +1551,7 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
+                          Arguments (one per line or JSON array)
                           <ReinstallHint show={isArgumentsDirty} />
                         </FormLabel>
                         <FormControl>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -8,6 +8,7 @@ import {
 } from "@archestra/shared";
 import { parseDockerArgsToLocalConfig } from "./docker-args-parser";
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
+import { parseMcpArguments } from "./mcp-config-import";
 
 type McpCatalogApiData =
   archestraApiTypes.CreateInternalMcpCatalogItemData["body"];
@@ -34,13 +35,8 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
-    const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
-      : [];
+    // Accept both one argument per line and copy-pasted JSON arrays.
+    const argumentsArray = parseMcpArguments(values.localConfig.arguments);
 
     data.localConfig = {
       command: values.localConfig.command || undefined,

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-config-import.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-config-import.test.ts
@@ -16,6 +16,26 @@ describe("parseMcpArguments", () => {
 });
 
 describe("parseMcpConfigJson", () => {
+  it("imports the Context7 config from its setup instructions", () => {
+    const result = parseMcpConfigJson(
+      JSON.stringify({
+        mcpServers: {
+          context7: {
+            command: "npx",
+            args: ["-y", "@upstash/context7-mcp"],
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      name: "context7",
+      serverType: "local",
+      command: "npx",
+      arguments: "-y\n@upstash/context7-mcp",
+    });
+  });
+
   it("imports Claude-style local configs", () => {
     const result = parseMcpConfigJson(
       JSON.stringify({

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-config-import.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-config-import.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import { parseMcpArguments, parseMcpConfigJson } from "./mcp-config-import";
+
+describe("parseMcpArguments", () => {
+  it("keeps newline-delimited arguments", () => {
+    expect(parseMcpArguments("run\n--verbose\n")).toEqual(["run", "--verbose"]);
+  });
+
+  it("accepts a JSON array", () => {
+    expect(parseMcpArguments('["run", "--verbose", 3]')).toEqual([
+      "run",
+      "--verbose",
+      "3",
+    ]);
+  });
+});
+
+describe("parseMcpConfigJson", () => {
+  it("imports Claude-style local configs", () => {
+    const result = parseMcpConfigJson(
+      JSON.stringify({
+        mcpServers: {
+          github: {
+            command: "docker",
+            args: ["run", "--rm", "mcp/github"],
+            env: { GITHUB_TOKEN: "<token>", LOG_LEVEL: "debug" },
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      name: "github",
+      serverType: "local",
+      command: "docker",
+      arguments: "run\n--rm\nmcp/github",
+    });
+    expect(result.environment).toEqual([
+      expect.objectContaining({
+        key: "GITHUB_TOKEN",
+        type: "secret",
+        promptOnInstallation: true,
+      }),
+      expect.objectContaining({
+        key: "LOG_LEVEL",
+        value: "debug",
+        promptOnInstallation: false,
+      }),
+    ]);
+  });
+
+  it("imports VS Code servers with declared inputs", () => {
+    const result = parseMcpConfigJson(
+      JSON.stringify({
+        servers: {
+          github: {
+            type: "http",
+            url: "https://api.githubcopilot.com/mcp/",
+            headers: {
+              Authorization: `Bearer \${input:github_mcp_pat}`,
+            },
+          },
+        },
+        inputs: [
+          {
+            type: "promptString",
+            id: "github_mcp_pat",
+            description: "GitHub token",
+            password: true,
+          },
+        ],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      name: "github",
+      serverType: "remote",
+      serverUrl: "https://api.githubcopilot.com/mcp/",
+      authMethod: "bearer",
+      includeBearerPrefix: true,
+    });
+  });
+
+  it("imports official Registry remote manifests", () => {
+    const result = parseMcpConfigJson(
+      JSON.stringify({
+        name: "com.example/acme-analytics",
+        title: "ACME Analytics",
+        description: "Business intelligence",
+        version: "2.0.0",
+        remotes: [
+          {
+            type: "streamable-http",
+            url: "https://analytics.example.com/mcp",
+            headers: [
+              {
+                name: "X-API-Key",
+                description: "API key",
+                isRequired: true,
+                isSecret: true,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      name: "ACME Analytics",
+      description: "Business intelligence",
+      serverType: "remote",
+      serverUrl: "https://analytics.example.com/mcp",
+    });
+    expect(result.additionalHeaders).toEqual([
+      expect.objectContaining({
+        headerName: "X-API-Key",
+        promptOnInstallation: true,
+        sensitive: true,
+      }),
+    ]);
+  });
+
+  it("imports wrapped official Registry API responses", () => {
+    const result = parseMcpConfigJson(
+      JSON.stringify({
+        server: {
+          name: "com.example/docs",
+          title: "Docs",
+          remotes: [
+            {
+              type: "streamable-http",
+              url: "https://docs.example.com/mcp",
+            },
+          ],
+        },
+        _meta: { "io.modelcontextprotocol.registry/official": true },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      name: "Docs",
+      serverType: "remote",
+      serverUrl: "https://docs.example.com/mcp",
+    });
+  });
+
+  it("imports official Registry npm packages", () => {
+    const result = parseMcpConfigJson(
+      JSON.stringify({
+        name: "io.github.example/server",
+        version: "1.2.3",
+        packages: [
+          {
+            registryType: "npm",
+            identifier: "@example/mcp-server",
+            version: "1.2.3",
+            transport: { type: "stdio" },
+            environmentVariables: [
+              {
+                name: "API_KEY",
+                description: "Service API key",
+                isRequired: true,
+                isSecret: true,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      serverType: "local",
+      command: "npx",
+      arguments: "-y\n@example/mcp-server@1.2.3",
+    });
+    expect(result.environment[0]).toMatchObject({
+      key: "API_KEY",
+      type: "secret",
+      required: true,
+    });
+  });
+
+  it("imports Archestra manifests", () => {
+    const result = parseMcpConfigJson(
+      JSON.stringify({
+        name: "sonarqube",
+        description: "SonarQube MCP",
+        user_config: {
+          token: {
+            sensitive: true,
+            required: true,
+            description: "SonarQube token",
+          },
+        },
+        server: {
+          type: "local",
+          command: "docker",
+          args: ["run", "mcp/sonarqube"],
+          env: { SONARQUBE_TOKEN: `\${user_config.token}` },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      name: "sonarqube",
+      serverType: "local",
+      command: "docker",
+      arguments: "run\nmcp/sonarqube",
+    });
+    expect(result.environment[0]).toMatchObject({
+      key: "SONARQUBE_TOKEN",
+      type: "secret",
+      promptOnInstallation: true,
+      required: true,
+      description: "SonarQube token",
+    });
+  });
+
+  it("rejects unrelated JSON", () => {
+    expect(() => parseMcpConfigJson('{"hello":"world"}')).toThrow(
+      "No MCP server configuration",
+    );
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-config-import.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-config-import.ts
@@ -1,0 +1,432 @@
+type JsonObject = Record<string, unknown>;
+
+interface ImportedEnvironmentVariable {
+  key: string;
+  type: "plain_text" | "secret";
+  value?: string;
+  promptOnInstallation: boolean;
+  required: boolean;
+  description: string;
+}
+
+interface ImportedHeader {
+  fieldName?: string;
+  headerName: string;
+  promptOnInstallation: boolean;
+  required: boolean;
+  value?: string;
+  description: string;
+  includeBearerPrefix: boolean;
+  sensitive: boolean;
+}
+
+interface ImportedMcpConfig {
+  name?: string;
+  description?: string;
+  serverType: "local" | "remote";
+  serverUrl?: string;
+  command?: string;
+  arguments: string;
+  dockerImage?: string;
+  environment: ImportedEnvironmentVariable[];
+  additionalHeaders: ImportedHeader[];
+  authMethod: "none" | "bearer";
+  includeBearerPrefix: boolean;
+}
+
+/** Accept both the historical one-argument-per-line form and JSON arrays. */
+export function parseMcpArguments(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map(stringifyScalar)
+        .filter((argument): argument is string => argument !== undefined);
+    }
+  } catch {
+    // A normal newline-delimited value is not JSON and remains supported.
+  }
+
+  return value
+    .split("\n")
+    .map((argument) => argument.trim())
+    .filter(Boolean);
+}
+
+export function parseMcpConfigJson(value: string): ImportedMcpConfig {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("The pasted configuration is not valid JSON.");
+  }
+  if (!isObject(parsed)) {
+    throw new Error("The MCP configuration must be a JSON object.");
+  }
+
+  const { config, inferredName } = selectServerConfig(parsed);
+  const inputs = getInputDefinitions(parsed.inputs);
+  const manifest =
+    isObject(parsed.server) &&
+    ("packages" in parsed.server || "remotes" in parsed.server)
+      ? parsed.server
+      : parsed;
+  const name =
+    inferredName ??
+    optionalString(parsed.title) ??
+    optionalString(config.title) ??
+    optionalString(parsed.name) ??
+    optionalString(config.name);
+  const description =
+    optionalString(parsed.description) ?? optionalString(config.description);
+
+  const remote = Array.isArray(manifest.remotes)
+    ? manifest.remotes.find(isObject)
+    : undefined;
+  const remoteUrl =
+    optionalString(remote?.url) ??
+    optionalString(config.url) ??
+    optionalString(config.serverUrl);
+  const headers = parseHeaders(remote?.headers ?? config.headers, inputs);
+
+  if (remoteUrl) {
+    return {
+      name,
+      description,
+      serverType: "remote",
+      serverUrl: remoteUrl,
+      arguments: "",
+      environment: [],
+      ...headers,
+    };
+  }
+
+  const packageConfig = packageToLocalConfig(manifest.packages);
+  const command = optionalString(config.command) ?? packageConfig?.command;
+  const dockerImage =
+    optionalString(config.docker_image) ??
+    optionalString(config.dockerImage) ??
+    packageConfig?.dockerImage;
+
+  if (!command && !dockerImage && config.type !== "local") {
+    throw new Error(
+      "The JSON does not contain a remote URL, local command, or supported package.",
+    );
+  }
+
+  const environment = environmentFromObject({
+    env: config.env,
+    inputDefinitions: inputs,
+    userConfig: parsed.user_config,
+  });
+  const firstPackage = Array.isArray(manifest.packages)
+    ? manifest.packages.find(isObject)
+    : undefined;
+  const declared = declaredEnvironmentVariables([manifest, firstPackage]);
+  const environmentByKey = new Map(
+    [...environment, ...declared].map((entry) => [entry.key, entry]),
+  );
+
+  return {
+    name,
+    description,
+    serverType: "local",
+    command,
+    arguments:
+      normalizeArguments(config.args ?? config.arguments) ||
+      packageConfig?.arguments ||
+      "",
+    dockerImage,
+    environment: [...environmentByKey.values()],
+    additionalHeaders: [],
+    authMethod: "none",
+    includeBearerPrefix: true,
+  };
+}
+
+interface InputDefinition {
+  id: string;
+  description: string;
+  password: boolean;
+}
+
+const INPUT_PLACEHOLDER = /^\$\{input:([^}]+)\}$/;
+const USER_CONFIG_PLACEHOLDER = /^\$\{user_config\.([^}]+)\}$/;
+const GENERIC_PLACEHOLDER =
+  /^(?:<[^>]+>|YOUR_[A-Z0-9_]+(?:_HERE)?|REPLACE_ME)$/i;
+const SENSITIVE_NAME = /(?:authorization|api[_-]?key|password|secret|token)/i;
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function stringifyScalar(value: unknown): string | undefined {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function getInputDefinitions(value: unknown): Map<string, InputDefinition> {
+  const definitions = new Map<string, InputDefinition>();
+  if (!Array.isArray(value)) return definitions;
+
+  for (const input of value) {
+    if (!isObject(input) || typeof input.id !== "string") continue;
+    definitions.set(input.id, {
+      id: input.id,
+      description: optionalString(input.description) ?? "",
+      password: input.password === true,
+    });
+  }
+  return definitions;
+}
+
+function getPlaceholder(value: string): string | undefined {
+  return value.match(INPUT_PLACEHOLDER)?.[1];
+}
+
+function isPlaceholder(value: string): boolean {
+  return (
+    INPUT_PLACEHOLDER.test(value) ||
+    USER_CONFIG_PLACEHOLDER.test(value) ||
+    GENERIC_PLACEHOLDER.test(value)
+  );
+}
+
+function normalizeArguments(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value
+      .map(stringifyScalar)
+      .filter((argument): argument is string => argument !== undefined)
+      .join("\n");
+  }
+  return typeof value === "string" ? value : "";
+}
+
+function selectServerConfig(root: JsonObject): {
+  config: JsonObject;
+  inferredName?: string;
+} {
+  for (const containerKey of ["mcpServers", "servers"]) {
+    const container = root[containerKey];
+    if (!isObject(container)) continue;
+    const entry = Object.entries(container).find(([, value]) =>
+      isObject(value),
+    );
+    if (entry && isObject(entry[1])) {
+      return { config: entry[1], inferredName: entry[0] };
+    }
+  }
+
+  if (isObject(root.server)) {
+    return {
+      config: root.server,
+      inferredName: optionalString(root.title) ?? optionalString(root.name),
+    };
+  }
+
+  if (
+    "command" in root ||
+    "url" in root ||
+    "serverUrl" in root ||
+    "remotes" in root ||
+    "packages" in root
+  ) {
+    return { config: root };
+  }
+
+  const entry = Object.entries(root).find(([, value]) => {
+    if (!isObject(value)) return false;
+    return (
+      "command" in value ||
+      "url" in value ||
+      "serverUrl" in value ||
+      "type" in value
+    );
+  });
+  if (entry && isObject(entry[1])) {
+    return { config: entry[1], inferredName: entry[0] };
+  }
+
+  throw new Error("No MCP server configuration was found in this JSON.");
+}
+
+function environmentFromObject(params: {
+  env: unknown;
+  inputDefinitions: Map<string, InputDefinition>;
+  userConfig: unknown;
+}): ImportedEnvironmentVariable[] {
+  const { env, inputDefinitions, userConfig } = params;
+  if (!isObject(env)) return [];
+  const userConfigObject = isObject(userConfig) ? userConfig : {};
+
+  return Object.entries(env).map(([key, rawValue]) => {
+    const value = stringifyScalar(rawValue) ?? "";
+    const inputId = getPlaceholder(value);
+    const userConfigId = value.match(USER_CONFIG_PLACEHOLDER)?.[1];
+    const input = inputId ? inputDefinitions.get(inputId) : undefined;
+    const config =
+      userConfigId && isObject(userConfigObject[userConfigId])
+        ? userConfigObject[userConfigId]
+        : undefined;
+    const placeholder = isPlaceholder(value);
+    const sensitive =
+      input?.password === true ||
+      config?.sensitive === true ||
+      SENSITIVE_NAME.test(key);
+
+    return {
+      key,
+      type: sensitive ? "secret" : "plain_text",
+      value: placeholder ? "" : value,
+      promptOnInstallation: placeholder,
+      required: placeholder ? config?.required !== false : false,
+      description:
+        input?.description ?? optionalString(config?.description) ?? "",
+    };
+  });
+}
+
+function declaredEnvironmentVariables(
+  sources: unknown[],
+): ImportedEnvironmentVariable[] {
+  const raw = sources.flatMap((source) => {
+    if (!isObject(source)) return [];
+    const declarations =
+      source.environmentVariables ?? source.environment_variables;
+    return Array.isArray(declarations) ? declarations : [];
+  });
+
+  return raw.flatMap((entry) => {
+    if (!isObject(entry)) return [];
+    const key = optionalString(entry.name);
+    if (!key) return [];
+    return [
+      {
+        key,
+        type:
+          entry.isSecret === true || entry.is_secret === true
+            ? ("secret" as const)
+            : ("plain_text" as const),
+        value: "",
+        promptOnInstallation: true,
+        required: entry.isRequired === true || entry.is_required === true,
+        description: optionalString(entry.description) ?? "",
+      },
+    ];
+  });
+}
+
+function parseHeaders(
+  headers: unknown,
+  inputDefinitions: Map<string, InputDefinition>,
+): {
+  additionalHeaders: ImportedHeader[];
+  authMethod: "none" | "bearer";
+  includeBearerPrefix: boolean;
+} {
+  const normalized: Array<{
+    name: string;
+    value: string;
+    description: string;
+    required: boolean;
+    secret: boolean;
+  }> = [];
+
+  if (isObject(headers)) {
+    for (const [name, rawValue] of Object.entries(headers)) {
+      normalized.push({
+        name,
+        value: stringifyScalar(rawValue) ?? "",
+        description: "",
+        required: true,
+        secret: SENSITIVE_NAME.test(name),
+      });
+    }
+  } else if (Array.isArray(headers)) {
+    for (const header of headers) {
+      if (!isObject(header)) continue;
+      const name = optionalString(header.name);
+      if (!name) continue;
+      normalized.push({
+        name,
+        value: stringifyScalar(header.value) ?? "",
+        description: optionalString(header.description) ?? "",
+        required: header.isRequired !== false,
+        secret: header.isSecret === true || SENSITIVE_NAME.test(name),
+      });
+    }
+  }
+
+  let authMethod: "none" | "bearer" = "none";
+  let includeBearerPrefix = true;
+  const additionalHeaders: ImportedHeader[] = [];
+
+  for (const header of normalized) {
+    if (header.name.toLowerCase() === "authorization") {
+      authMethod = "bearer";
+      includeBearerPrefix = /^bearer\s/i.test(header.value) || !header.value;
+      continue;
+    }
+
+    const inputId = getPlaceholder(header.value);
+    const input = inputId ? inputDefinitions.get(inputId) : undefined;
+    const placeholder = !header.value || isPlaceholder(header.value);
+    additionalHeaders.push({
+      headerName: header.name,
+      promptOnInstallation: placeholder,
+      required: header.required,
+      value: placeholder ? "" : header.value,
+      description: input?.description ?? header.description,
+      includeBearerPrefix: false,
+      sensitive: header.secret || input?.password === true,
+    });
+  }
+
+  return { additionalHeaders, authMethod, includeBearerPrefix };
+}
+
+function packageToLocalConfig(packages: unknown): {
+  command?: string;
+  arguments: string;
+  dockerImage?: string;
+} | null {
+  if (!Array.isArray(packages) || !isObject(packages[0])) return null;
+  const pkg = packages[0];
+  const registryType = optionalString(pkg.registryType)?.toLowerCase();
+  const identifier = optionalString(pkg.identifier);
+  if (!identifier) return null;
+  const version = optionalString(pkg.version);
+  const specifier = version ? `${identifier}@${version}` : identifier;
+
+  if (registryType === "npm") {
+    return { command: "npx", arguments: `-y\n${specifier}` };
+  }
+  if (registryType === "pypi") {
+    return {
+      command: "uvx",
+      arguments: version ? `${identifier}==${version}` : identifier,
+    };
+  }
+  if (registryType === "oci" || registryType === "docker") {
+    return {
+      arguments: "",
+      dockerImage: version ? `${identifier}:${version}` : identifier,
+    };
+  }
+  return { command: identifier, arguments: "" };
+}


### PR DESCRIPTION
/claim #3859

Adds a JSON import panel to the MCP catalog form. It hydrates complete local and remote server configurations from Claude Desktop, Cursor, VS Code, MCP Registry responses, and Archestra manifests. The Context7 setup config from the prior review imports directly. Existing line-per-argument input remains compatible.

Validation:
- 77 focused tests
- frontend type-check
- Biome check for changed files
- Knip