### PR TITLE
ci: reuse already-built images in scanning and staging deploys

### DIFF
--- a/.github/workflows/build-base-mcp-server-docker-image.yml
+++ b/.github/workflows/build-base-mcp-server-docker-image.yml
@@ -16,6 +16,16 @@ on:
         required: false
         type: string
         default: ""
+      enable_tree_reuse:
+        description: >-
+          Skip the multi-arch rebuild when an image for the exact
+          platform/mcp_server_docker_image source tree was already pushed
+          (tree-OID tag lookup + registry retag). Only for internal channels
+          where the version tag is a commit SHA (the staging deploy); release
+          builds keep this off.
+        required: false
+        type: boolean
+        default: false
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER:
         required: false
@@ -77,6 +87,7 @@ jobs:
       auth_provider: gar
       include_latest_tag: true
       checkout_ref: ${{ inputs.checkout_ref }}
+      reuse_tree_path: ${{ inputs.enable_tree_reuse && 'platform/mcp_server_docker_image' || '' }}
     secrets:
       GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.GCP_SERVICE_ACCOUNT_NAME }}
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}

--- a/.github/workflows/build-native-multi-arch-image.yml
+++ b/.github/workflows/build-native-multi-arch-image.yml
@@ -57,6 +57,18 @@ on:
         required: false
         type: boolean
         default: false
+      reuse_tree_path:
+        description: >-
+          Optional repo-relative directory whose git tree OID keys the image
+          contents (e.g. platform/mcp_server_docker_image). When set (and
+          push_image is true), a matching tree-OID tag in the registry is
+          registry-retagged to the version tag instead of rebuilding, and
+          fresh builds additionally push that tree-OID tag for future reuse.
+          Only safe for images that are a pure function of that directory: no
+          VERSION consumed by the Dockerfile, no other build inputs.
+        required: false
+        type: string
+        default: ""
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER:
         required: false
@@ -80,8 +92,102 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Tree-OID image reuse (opt-in via reuse_tree_path): if an image for this
+  # exact source tree was already pushed by a previous run, registry-retag it
+  # to the version tag (a manifest copy — works for multi-arch manifest lists)
+  # and skip BOTH arch build legs and the manifest merge. The tree tag embeds
+  # the arch set (multiarch vs amd64) so a single-arch build can never be
+  # retagged onto a multi-arch destination or vice versa — platform-e2e-tests.yml
+  # pushes amd64-only plain "tree-<oid>" tags into the same repositories, and
+  # those must never satisfy a multi-arch lookup here.
+  resolve-tree-reuse:
+    name: Resolve tree-tag image reuse
+    if: ${{ inputs.push_image && inputs.reuse_tree_path != '' }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    # Advisory only: if this job fails (checkout/auth hiccup), the build legs
+    # below still run and publish normally — a broken resolver must not block
+    # an otherwise healthy build. The resolve step itself never fails on a
+    # cache miss or a lost retag race; it just reports reuse=false.
+    continue-on-error: true
+    timeout-minutes: 10
+    permissions:
+      contents: read # Required to checkout the repository and compute the tree OID.
+      id-token: write # Required for Workload Identity Federation when retagging images.
+    outputs:
+      reuse: ${{ steps.resolve.outputs.reuse }}
+      tree_tag: ${{ steps.resolve.outputs.tree_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.sha }}
+
+      - name: Authenticate to Google Artifact Registry
+        if: ${{ inputs.auth_provider == 'gar' }}
+        uses: ./.github/actions/auth-to-gar
+        with:
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_NAME }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
+
+      - name: Log in to Docker Hub
+        if: ${{ inputs.auth_provider == 'dockerhub' }}
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Resolve tree-tag image reuse
+        id: resolve
+        shell: bash
+        env:
+          IMAGE_REPO: ${{ inputs.image_registry }}/${{ inputs.image_name }}
+          REUSE_TREE_PATH: ${{ inputs.reuse_tree_path }}
+          VERSION: ${{ inputs.version }}
+          INCLUDE_LATEST_TAG: ${{ inputs.include_latest_tag }}
+          ARCH_SET: ${{ inputs.amd64_only && 'amd64' || 'multiarch' }}
+        run: |
+          set -euo pipefail
+          # The image is a deterministic function of this directory's tree (see
+          # the reuse_tree_path input contract), so a matching tree OID
+          # guarantees byte-identical build inputs.
+          TREE_HASH=$(git rev-parse "HEAD:${REUSE_TREE_PATH}")
+          TREE_TAG="${IMAGE_REPO}:tree-${TREE_HASH}-${ARCH_SET}"
+          VERSION_TAG="${IMAGE_REPO}:${VERSION}"
+          echo "tree_tag=${TREE_TAG}" >> "${GITHUB_OUTPUT}"
+          # Default to a build; only skip it if the reused manifest actually
+          # lands on the version tag. A missing/just-pruned tree tag or a
+          # transient registry error falls back to building.
+          REUSE=false
+          if docker buildx imagetools inspect "${TREE_TAG}" >/dev/null 2>&1; then
+            echo "Found cached ${ARCH_SET} image for tree ${TREE_HASH}; copying to ${VERSION_TAG}"
+            EXTRA_TAGS=()
+            if [ "${INCLUDE_LATEST_TAG}" = "true" ]; then
+              # supply-chain-policy: allow-latest internal release channel
+              EXTRA_TAGS+=(--tag "${IMAGE_REPO}:latest")
+            fi
+            # Registry-side manifest copy (no layer pull/push); imagetools
+            # create copies multi-arch manifest lists intact.
+            if docker buildx imagetools create --tag "${VERSION_TAG}" "${EXTRA_TAGS[@]}" "${TREE_TAG}"; then
+              REUSE=true
+            else
+              echo "::warning::tree-tag retag failed (tag may have just been pruned); building instead"
+            fi
+          else
+            echo "No cached ${ARCH_SET} image for tree ${TREE_HASH}; building."
+          fi
+          echo "reuse=${REUSE}" >> "${GITHUB_OUTPUT}"
+
   build-image:
     name: Build ${{ inputs.image_name }} (${{ matrix.os_and_arch }})
+    needs:
+      - resolve-tree-reuse
+    # Runs unless the resolver landed the reused image on the version tag.
+    # `!cancelled()` keeps this job alive when resolve-tree-reuse is skipped
+    # (reuse not enabled — its outputs are then empty) or failed (fallback to
+    # a normal build).
+    if: ${{ !cancelled() && needs.resolve-tree-reuse.outputs.reuse != 'true' }}
     # Pick the runner matching the arch.
     runs-on: ${{ matrix.os_and_arch == 'linux/arm64' && 'blacksmith-16vcpu-ubuntu-2404-arm' || 'blacksmith-16vcpu-ubuntu-2404' }}
     strategy:
@@ -149,9 +255,16 @@ jobs:
 
   merge-manifests:
     name: Create multi-arch manifest
-    if: ${{ inputs.push_image }}
+    # Only after a real build: on a tree-tag reuse hit the build legs are
+    # skipped and the resolver already pushed the version tag, so there is
+    # nothing to stitch. `!cancelled()` is needed because the skipped build
+    # legs would otherwise auto-skip this job before the condition runs; the
+    # explicit `== 'success'` keeps the old fail-fast behavior when a build
+    # leg fails.
+    if: ${{ !cancelled() && inputs.push_image && needs.build-image.result == 'success' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
+      - resolve-tree-reuse
       - build-image
     permissions:
       contents: read # Required to download per-arch digests and publish the merged manifest.
@@ -195,6 +308,12 @@ jobs:
             # supply-chain-policy: allow-latest internal release channel
             EXTRA_TAGS+=(-t "${IMAGE_REGISTRY}/${IMAGE_NAME}:latest")
           fi
+          # Fresh build with tree reuse enabled: also push the tree-OID tag so
+          # the next run of the same source tree retags instead of rebuilding.
+          # Empty when reuse is not enabled (or the resolver job failed).
+          if [ -n "${TREE_TAG}" ]; then
+            EXTRA_TAGS+=(-t "${TREE_TAG}")
+          fi
 
           docker buildx imagetools create \
             -t "${IMAGE_REGISTRY}/${IMAGE_NAME}:${VERSION}" \
@@ -205,6 +324,7 @@ jobs:
           IMAGE_NAME: ${{ inputs.image_name }}
           VERSION: ${{ inputs.version }}
           INCLUDE_LATEST_TAG: ${{ inputs.include_latest_tag }}
+          TREE_TAG: ${{ needs.resolve-tree-reuse.outputs.tree_tag }}
 
       - name: Inspect image
         run: |

--- a/.github/workflows/build-sandbox-base-docker-image.yml
+++ b/.github/workflows/build-sandbox-base-docker-image.yml
@@ -16,6 +16,16 @@ on:
         required: false
         type: string
         default: ""
+      enable_tree_reuse:
+        description: >-
+          Skip the multi-arch rebuild when an image for the exact
+          platform/sandbox_base source tree was already pushed (tree-OID tag
+          lookup + registry retag). Only for internal channels where the
+          version tag is a commit SHA (the staging deploy); release builds
+          keep this off.
+        required: false
+        type: boolean
+        default: false
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER:
         required: false
@@ -77,6 +87,7 @@ jobs:
       auth_provider: gar
       include_latest_tag: true
       checkout_ref: ${{ inputs.checkout_ref }}
+      reuse_tree_path: ${{ inputs.enable_tree_reuse && 'platform/sandbox_base' || '' }}
     secrets:
       GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.GCP_SERVICE_ACCOUNT_NAME }}
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -33,7 +33,9 @@ jobs:
   resolve-previous-platform-image:
     name: Resolve previous platform image
     if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    # A gcloud + kubectl lookup — same workload class as the 2vcpu
+    # deploy-to-staging job in on-commits-to-main.yml.
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read # Required to resolve the currently deployed platform image from staging.
       id-token: write # Required for Workload Identity Federation and GKE credential retrieval.
@@ -117,6 +119,10 @@ jobs:
     with:
       push_to_gcr: true
       version: ${{ inputs.version || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+      # This image rarely changes with the platform: skip the two-arch rebuild
+      # when the platform/mcp_server_docker_image tree is unchanged and retag
+      # the previously pushed multi-arch manifest instead.
+      enable_tree_reuse: true
     secrets:
       GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
@@ -131,6 +137,9 @@ jobs:
     with:
       push_to_gcr: true
       version: ${{ inputs.version || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+      # Same tree-OID reuse as the MCP server base image above, keyed on
+      # platform/sandbox_base.
+      enable_tree_reuse: true
     secrets:
       GCP_SERVICE_ACCOUNT_NAME: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME }}
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER: ${{ secrets.DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}

--- a/.github/workflows/docker-image-scanning.yml
+++ b/.github/workflows/docker-image-scanning.yml
@@ -3,6 +3,14 @@ name: Docker Image Scanning
 # Runs automatically in merge queue and on demand when the "run-docker-scan"
 # label is added to a PR.
 # Remove and re-add the label to re-trigger after new commits.
+#
+# Merge-queue runs do NOT build anything: the Platform E2E Tests workflow in
+# the same merge group already builds and pushes both images to Artifact
+# Registry under the merge-group head SHA (anonymous pulls allowed), so the
+# scan jobs poll for those manifests (the e2e build may still be pushing when
+# this starts), pull, and scan. Label-triggered PR runs keep building locally:
+# the per-SHA registry image only exists if the e2e build also ran for that
+# exact SHA, which the run-docker-scan label alone does not guarantee.
 on:
   pull_request:
     types:
@@ -17,6 +25,12 @@ permissions: {}
 concurrency:
   group: "docker-image-scanning-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}"
   cancel-in-progress: true
+
+env:
+  # Must match platform-e2e-tests.yml's PLATFORM_IMAGE_REGISTRY /
+  # MCP_SERVER_BASE_IMAGE_REGISTRY: merge-queue scans pull the images that
+  # workflow pushes for the same merge-group head SHA.
+  IMAGE_REGISTRY: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public
 
 jobs:
   # Required-check placeholders for ordinary PR updates. The real scans remain
@@ -38,7 +52,13 @@ jobs:
   docker-image-scanning:
     name: Docker Image Scanning (${{ matrix.name }})
     if: ${{ github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.label.name == 'run-docker-scan' && github.event.pull_request.head.repo.fork != true) }}
-    runs-on: ${{ matrix.runner }}
+    # Merge-queue runs only pull + scan — no build — so a small runner is
+    # enough. matrix.runner is sized for the label-triggered PR path, which
+    # still builds the image locally.
+    runs-on: ${{ github.event_name == 'merge_group' && 'blacksmith-4vcpu-ubuntu-2404' || matrix.runner }}
+    # Bounds the merge-queue manifest poll (15 min) plus pull + scan; the PR
+    # build path finishes well inside this too.
+    timeout-minutes: 25
     permissions:
       contents: read # Required to checkout the repository and read Docker build inputs.
     strategy:
@@ -50,6 +70,7 @@ jobs:
             context: ./platform
             dockerfile: ./platform/Dockerfile
             local-tag-prefix: archestra-platform
+            registry-image-name: platform
             use-build-action: true
             scan-exit-code: "true"
           - name: MCP Server Base
@@ -57,6 +78,7 @@ jobs:
             context: ./platform/mcp_server_docker_image
             dockerfile: ./platform/mcp_server_docker_image/Dockerfile
             local-tag-prefix: mcp-server-base
+            registry-image-name: mcp-server-base
             use-build-action: false
             scan-exit-code: "true"
     steps:
@@ -66,14 +88,42 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
+      # Merge queue: the Platform E2E Tests workflow in this same merge group
+      # builds and pushes this exact image (or registry-retags a cached one) to
+      # the anonymous-pull registry under the merge-group head SHA. Poll until
+      # the manifest lands — this workflow starts alongside the e2e build — then
+      # pull it for scanning. No registry auth needed: pulls are anonymous.
+      # 900s matches the e2e jobs' image-pull-timeout-seconds for the same wait.
+      - name: Wait for the already-built image and pull it
+        if: ${{ github.event_name == 'merge_group' }}
+        shell: bash
+        env:
+          IMAGE_REF: ${{ env.IMAGE_REGISTRY }}/${{ matrix.registry-image-name }}:${{ github.sha }}
+          PULL_TIMEOUT_SECONDS: "900"
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + PULL_TIMEOUT_SECONDS ))
+          until docker buildx imagetools inspect "${IMAGE_REF}" >/dev/null 2>&1; do
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+              echo "::error::Timed out waiting for the ${IMAGE_REF} manifest. Did the Platform E2E Tests build job fail or stop pushing per-SHA images?"
+              exit 1
+            fi
+            echo "Manifest for ${IMAGE_REF} not available yet, retrying in 10s..."
+            sleep 10
+          done
+          docker pull "${IMAGE_REF}"
+
+      # Label-triggered PR runs below: build locally, exactly as before. The
+      # e2e workflow only pushes per-SHA images on merge_group / run-e2e, so a
+      # run-docker-scan label on its own has no registry image to pull.
       - name: Setup environment
-        if: ${{ matrix.use-build-action }}
+        if: ${{ github.event_name == 'pull_request' && matrix.use-build-action }}
         uses: ./.github/actions/setup-env
         with:
           working-directory: ./platform
 
       - name: Build Platform image
-        if: ${{ matrix.use-build-action }}
+        if: ${{ github.event_name == 'pull_request' && matrix.use-build-action }}
         uses: ./.github/actions/build-docker-image
         with:
           context: ${{ matrix.context }}
@@ -84,11 +134,11 @@ jobs:
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
 
       - name: Setup Blacksmith Builder
-        if: ${{ !matrix.use-build-action }}
+        if: ${{ github.event_name == 'pull_request' && !matrix.use-build-action }}
         uses: ./.github/actions/setup-blacksmith-builder
 
       - name: Build MCP server base image
-        if: ${{ !matrix.use-build-action }}
+        if: ${{ github.event_name == 'pull_request' && !matrix.use-build-action }}
         uses: ./.github/actions/blacksmith-build-push
         with:
           context: ${{ matrix.context }}
@@ -101,7 +151,7 @@ jobs:
       - name: Scan image for CVEs
         uses: ./.github/actions/scan-docker-image
         with:
-          image: ${{ format('{0}:{1}', matrix.local-tag-prefix, github.sha) }}
+          image: ${{ github.event_name == 'merge_group' && format('{0}/{1}:{2}', env.IMAGE_REGISTRY, matrix.registry-image-name, github.sha) || format('{0}:{1}', matrix.local-tag-prefix, github.sha) }}
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
           exit-code: ${{ matrix.scan-exit-code }}


### PR DESCRIPTION
CI builds images that CI already built. Two measured wastes, one theme: reuse the pushed artifact instead of rebuilding it.

## Waste 1: merge-queue scanning rebuilds the image it scans (~80 vcpu-min/attempt)

The Docker Image Scanning workflow's Platform leg rebuilt the platform image on a 16vcpu runner (~1 min build for ~0.7 min of scanning) on every merge-queue entry, and the MCP Server Base leg rebuilt its image on 4vcpu — while the Platform E2E Tests workflow in the **same merge group** already builds and pushes both images to Artifact Registry under the merge-group head SHA (anonymous pulls allowed).

**Change** (`docker-image-scanning.yml`): on `merge_group`, both scan legs now poll for the per-SHA manifest (`docker buildx imagetools inspect` until it lands, 900s deadline — mirroring the e2e jobs' `image-pull-timeout-seconds`, since scanning starts alongside the e2e build), `docker pull` it anonymously, and scan the pulled ref. Both legs run on 4vcpu (pull + scan is not compute-heavy). Added `timeout-minutes: 25` to bound the poll.

This also makes the scan more honest: on e2e tree-tag reuse hits, the scanned image is now the exact manifest that ships, not a fresh local rebuild of it.

**Fork handling**: unchanged. Fork PRs never reach the real scan job — they always get the placeholder (the existing `if` excludes forks). Label-triggered `run-docker-scan` runs on trusted PRs keep **building locally** exactly as before: the e2e workflow only pushes per-SHA images on `merge_group` / `run-e2e`, so the scan label alone has no registry image to pull. The 16vcpu runner is retained for that path only (`runs-on` picks 4vcpu on `merge_group`, `matrix.runner` otherwise).

## Waste 2: staging deploy rebuilds unchanged base images on both arches (~130 vcpu-min/merge)

Every merge to main rebuilds `mcp-server-base` and `sandbox-base` via `build-native-multi-arch-image.yml`: 16vcpu amd64 + 16vcpu arm64 legs per image plus a 4vcpu manifest stitch — even when `platform/mcp_server_docker_image` / `platform/sandbox_base` didn't change (which is almost every merge). The platform image build already avoids arm64 waste (`amd64_only`) and has its own reuse resolver; the base images had nothing.

**Change**: `build-native-multi-arch-image.yml` gains an opt-in `reuse_tree_path` input, implementing the same tree-OID reuse the e2e workflow uses:

- New `resolve-tree-reuse` job (2vcpu): `git rev-parse HEAD:<tree-path>`, check `docker buildx imagetools inspect` for a `tree-<oid>-multiarch` tag; on hit, `docker buildx imagetools create` registry-retags that manifest **list** to the version tag (+ `:latest` when `include_latest_tag`) — a manifest copy, multi-arch preserved, no layers moved.
- On a miss, the build runs as before and `merge-manifests` additionally pushes the tree-OID tag for the next run.
- The wrappers (`build-base-mcp-server-docker-image.yml`, `build-sandbox-base-docker-image.yml`) expose this as `enable_tree_reuse` (default **false**); only `deploy-dev-platform-images.yml` opts in. Release builds (`release-please.yml`) are untouched and keep building.

**Job-graph correctness on a hit** (traced):

```
resolve-tree-reuse   → success, reuse=true, version tag + :latest already pushed
build-image (amd64)  → skipped:  if !cancelled() && reuse != 'true'  → false
build-image (arm64)  → skipped:  same matrix job
merge-manifests      → skipped:  if !cancelled() && push_image && build-image.result == 'success'
                                 (result is 'skipped', not 'success')
workflow result      → success (skipped jobs don't fail the workflow_call)
deploy-to-staging    → proceeds; the :sha tag exists via the resolver's retag
```

And on a miss / resolver failure:

```
resolve-tree-reuse   → reuse=false (or failed; job is continue-on-error, advisory only)
build-image          → runs: outputs empty ⇒ reuse != 'true', !cancelled() defeats auto-skip
merge-manifests      → runs: build-image.result == 'success'; pushes version [+ latest] [+ tree tag]
```

For all other callers (`reuse_tree_path` unset — dockerhub releases, platform builds): `resolve-tree-reuse` is skipped, `build-image` runs via the same `!cancelled()` guard with empty outputs, `merge-manifests` behaves as today (`TREE_TAG` env is empty).

**Why the arch-set suffix in the tag**: `platform-e2e-tests.yml` already pushes **amd64-only** plain `tree-<oid>` tags for `mcp-server-base` into the same repository. A plain-tag lookup here could retag a single-arch manifest as `:latest` and break arm64 consumers. The deploy's tags are `tree-<oid>-multiarch` (`-amd64` if anyone ever combines reuse with `amd64_only`), so the two schemes cannot cross-contaminate.

**Why tree reuse is sound here**: `build-docker-image` passes `VERSION` as a build arg, but neither Dockerfile declares `ARG VERSION` — both images are pure functions of their build-context directories (base images digest-pinned). Verified by grep; the input contract documents this requirement.

Also: `resolve-previous-platform-image` (a gcloud + kubectl lookup) drops from 16vcpu to 2vcpu — the same workload the 2vcpu `deploy-to-staging` job runs.

## Validation

- `actionlint` clean on all five modified workflows (only pre-existing `runner-label` warnings for Blacksmith's custom labels, which fire on untouched lines too); YAML parses.
- **Scanning**: validated live on this PR via the `run-docker-scan` label (exercises the label path = local build, unchanged behavior) — run linked in comments. The merge-queue pull path gets exercised when this PR enters the queue; its scan legs will show "Wait for the already-built image and pull it" instead of a build step.
- **Staging deploy**: only runs on pushes to main — not triggerable pre-merge. Dry-validated via the job-graph traces above; expressions checked with actionlint. First post-merge run on main validates it live: expect a tree-tag **miss** (no `-multiarch` tags exist yet) with a normal build that pushes the first tree tags, then a **hit** (resolver retag, both arch legs + stitch skipped) on the next merge that doesn't touch the base-image trees.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>