### PR TITLE
ci: run utility jobs on free GitHub-hosted runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,6 +29,8 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule'
+    # Stays on Blacksmith: setup-blacksmith-builder below only works on
+    # Blacksmith runners.
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read # checkout

--- a/.github/workflows/build-base-mcp-server-docker-image.yml
+++ b/.github/workflows/build-base-mcp-server-docker-image.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   python-mcp-lockfile-check:
     name: MCP Python Lockfile Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./platform

--- a/.github/workflows/build-sandbox-base-docker-image.yml
+++ b/.github/workflows/build-sandbox-base-docker-image.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   sandbox-base-lockfile-check:
     name: Sandbox Base Python Lockfile Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./platform

--- a/.github/workflows/claude-coreteam-mentions-shared.yml
+++ b/.github/workflows/claude-coreteam-mentions-shared.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write # Required for Claude to push follow-up commits when explicitly instructed.

--- a/.github/workflows/claude-coreteam-review-shared.yml
+++ b/.github/workflows/claude-coreteam-review-shared.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   pr-review:
     name: PR Review
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository and inspect the PR diff.

--- a/.github/workflows/claude-coreteam-review.yml
+++ b/.github/workflows/claude-coreteam-review.yml
@@ -23,7 +23,7 @@ jobs:
     if: |
       !contains(github.event.pull_request.title, '[WIP]') &&
       !github.event.pull_request.draft
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions: {}
     outputs:
       pr_author: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/clear-github-actions-cache.yml
+++ b/.github/workflows/clear-github-actions-cache.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   clear-cache:
     name: Clear GitHub Actions Cache
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       actions: write # Required to list and delete Actions caches.
       contents: read # Required to checkout the repository for local workflow context.

--- a/.github/workflows/good-first-issue-welcome.yml
+++ b/.github/workflows/good-first-issue-welcome.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   welcome-new-contributor:
     name: Welcome New Contributor
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.label.name == 'good first issue'
     permissions:
       issues: write # Required to post the welcome comment on the labeled issue.

--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -47,7 +47,7 @@ jobs:
 
   deploy-to-staging:
     name: Deploy to staging
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [deploy-dev-platform-images]
     # cancel-in-progress MUST stay false here: cancelling `helm upgrade`
     # mid-flight has previously left the release wedged in pending-upgrade.

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -22,7 +22,7 @@ jobs:
     name: Release Freeze Check
     # Always run so it can be a required status check - passes immediately for
     # non-release-please PRs and merge queue runs.
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read # Required to inspect the repository context for release-please PRs.
       pull-requests: write # Required to request changes on frozen release PRs.
@@ -85,7 +85,7 @@ jobs:
 
   license-compliance-check:
     name: License Compliance Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     defaults:
@@ -126,7 +126,7 @@ jobs:
 
   supply-chain-policy:
     name: Supply Chain Policy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -143,7 +143,7 @@ jobs:
 
   docs-image-policy:
     name: Docs Image Policy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   docs-links:
     name: Docs Link Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -173,7 +173,7 @@ jobs:
 
   migration-kit-checks:
     name: Migration Kit Checks
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -194,7 +194,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read # Required for dependency-review-action to read the PR dependency graph via the API.
       pull-requests: write # Required for dependency-review-action PR comments.
@@ -221,7 +221,7 @@ jobs:
   dependency-review-merge-group:
     name: Dependency Review
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Skip dependency review for merge queue
@@ -591,7 +591,7 @@ jobs:
   # can require a single check ("Backend Unit Tests") regardless of shard count.
   backend-unit-tests-gate:
     name: Backend Unit Tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # always() so the gate still runs (and turns red) when a shard fails,
     # ANDed with the bot-pr-guard (see comment above
     # platform-lint-and-unit-tests): when the shards skip on a bot PR, the
@@ -700,7 +700,7 @@ jobs:
   mac-mini-watchdog:
     name: Mac Mini Watchdog
     if: github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:
       actions: write # Required to cancel this workflow run on failover.
@@ -769,7 +769,7 @@ jobs:
 
   helm-chart-linting-and-tests:
     name: Helm Chart Linting and Tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read # Required to checkout the repository and lint/package the Helm chart.
     defaults:

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -334,7 +334,7 @@ jobs:
     name: Cancel E2E on build failure
     needs: [platform-e2e-build]
     if: ${{ failure() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       actions: write # Required to cancel this workflow run.
@@ -904,7 +904,7 @@ jobs:
     # gate; the event guard keeps it running on merge_group / on-demand runs but
     # reporting skipped (and thus satisfying the ruleset) on ordinary PR pushes.
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     # No permissions needed: this job only inspects `needs.*.result`.
     permissions: {}
@@ -947,7 +947,7 @@ jobs:
         platform-quickstart-e2e-tests,
       ]
     if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read # Required to checkout the repository and merge Playwright reports.

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-pr-title:
     name: PR Title Linter
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read # Required to checkout the repository and read commitlint config.
       pull-requests: read # Required by lint-pr-title to read PR metadata.

--- a/.github/workflows/publish-platform-helm-chart.yml
+++ b/.github/workflows/publish-platform-helm-chart.yml
@@ -33,7 +33,7 @@ jobs:
   # https://medium.com/google-cloud/ci-gitops-with-helm-github-actions-google-artifact-registry-and-config-sync-b48604191fda
   publish-platform-helm-chart:
     name: Publish platform Helm chart
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write # Required to package the chart from the checked-out repository.
       id-token: write # Required for Workload Identity Federation.

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -32,7 +32,7 @@ jobs:
   assign-issue:
     name: Assign Issues
     if: github.event_name == 'issues' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       issues: write # Required to assign issues.
 
@@ -108,7 +108,7 @@ jobs:
   request-recent-pr-reviewers:
     name: Request Recent PR Reviewers
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write # Required to read PR metadata and request reviewers.
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   release-please:
     name: Release Please
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write # Required to update manifests and release metadata in the repository.
       pull-requests: write # Required for release-please PR creation and updates.
@@ -275,7 +275,7 @@ jobs:
     # Un-drafts the GitHub release and triggers the website deploy only after ALL artifacts
     # (MCP server image, sandbox base image, platform Docker image, Helm chart) are published.
     if: ${{ always() && needs.release-please.outputs.platform_should_publish == 'true' && (github.event_name != 'workflow_dispatch' || inputs.finalize_github_release) && (needs.build-and-push-mcp-server-docker-image.result == 'success' || needs.build-and-push-mcp-server-docker-image.result == 'skipped') && (needs.build-and-push-sandbox-base-docker-image.result == 'success' || needs.build-and-push-sandbox-base-docker-image.result == 'skipped') && (needs.build-and-push-platform-docker-image-to-dockerhub.result == 'success' || needs.build-and-push-platform-docker-image-to-dockerhub.result == 'skipped') && (needs.publish-platform-helm-chart.result == 'success' || needs.publish-platform-helm-chart.result == 'skipped') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - release-please
       - build-and-push-mcp-server-docker-image
@@ -342,7 +342,7 @@ jobs:
       - publish-platform-helm-chart
       - publish-github-release
     if: ${{ always() && needs.release-please.outputs.platform_should_publish == 'true' && contains(needs.*.result, 'failure') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Post failure alert to Slack

--- a/.github/workflows/toggle-release-freeze.yml
+++ b/.github/workflows/toggle-release-freeze.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   toggle-release-freeze:
     name: Toggle Release Freeze
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   trigger-website-deploy:
     name: Trigger Website Vercel Deploy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Trigger Vercel Deploy Hook
         env:

--- a/.github/workflows/warm-e2e-image-caches.yml
+++ b/.github/workflows/warm-e2e-image-caches.yml
@@ -39,6 +39,8 @@ jobs:
     name: Warm E2E Image Caches
     # Same arch as the e2e runners (X64) so ${{ runner.arch }} in the keys
     # matches; a small runner suffices — this job only pulls and saves.
+    # Stays on Blacksmith: github-cache is backed by useblacksmith/cache,
+    # which only works on Blacksmith runners.
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## What

Phase 0.5 of CI cost reduction: move small utility jobs from paid `blacksmith-2vcpu-ubuntu-2404` runners to GitHub-hosted `ubuntu-latest`. This repo is public, so GitHub-hosted standard runners are **free and unmetered**. `ubuntu-latest` is also the bigger machine (4 vcpu / 16 GB vs 2 vcpu) on the same ubuntu-24.04 family, so nothing gets slower except occasional queue pickup — acceptable for these jobs.

31 of 33 `blacksmith-2vcpu` occurrences swapped. Every job body was checked for Blacksmith-specific dependencies (useblacksmith cache backend, sticky-disk, blacksmith docker builder) before swapping.

## Moved (31 jobs)

| Workflow | Jobs moved |
|---|---|
| `on-pull-requests.yml` | 11 — release-freeze-check, license-compliance-check, supply-chain-policy, docs-image-policy, docs-links, migration-kit-checks, dependency-review, dependency-review-merge-group, backend-unit-tests-gate, mac-mini-watchdog, helm-chart-linting-and-tests |
| `platform-e2e-tests.yml` | 3 — cancel-on-build-failure, merge-reports gate, publish-report |
| `release-please.yml` | 3 — release-please, publish-github-release, notify-release-failure |
| `random-issue-pr-assignee.yml` | 2 — assign-issue, request-recent-pr-reviewers |
| `build-base-mcp-server-docker-image.yml` | 1 — python lockfile check |
| `build-sandbox-base-docker-image.yml` | 1 — python lockfile check |
| `claude-coreteam-review.yml` | 1 — determine-token |
| `claude-coreteam-review-shared.yml` | 1 — pr-review |
| `claude-coreteam-mentions-shared.yml` | 1 — claude-code |
| `pr-title-linter.yml` | 1 |
| `publish-platform-helm-chart.yml` | 1 |
| `toggle-release-freeze.yml` | 1 |
| `trigger-website-deploy.yml` | 1 |
| `on-commits-to-main.yml` | 1 — deploy-to-staging |
| `clear-github-actions-cache.yml` | 1 |
| `good-first-issue-welcome.yml` | 1 |

## Deliberately stayed on Blacksmith (2 jobs)

- `warm-e2e-image-caches.yml` — uses `./.github/actions/github-cache`, which is backed by `useblacksmith/cache` and only works on Blacksmith runners (comment added in the file)
- `benchmark.yml` — uses `./.github/actions/setup-blacksmith-builder` in the same job (comment added in the file)

Not touched at all: any 4/8/16vcpu runner, the mac-mini routing expression in `frontend-integration-tests` (its `blacksmith-4vcpu` fallback stays), and all build/e2e/scanning jobs.

## Validation

- All 18 touched files parse cleanly (`ruby -ryaml`); actionlint not available locally, but the repo's own supply-chain policy checks run on this PR
- Composite actions used by the moved jobs (`setup-env`, `setup-uv`, `run-claude`, `github-app-token`, `auth-to-gar`, `google-auth`, `github-upload/download-artifact`, `release-freeze-review`) were each checked — none depend on Blacksmith
- Live validation: this PR itself runs several of the moved `pull_request` jobs (PR title linter, policy checks, dependency review, helm lint, gates) on `ubuntu-latest`

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>

## Also evaluated, not moved

- `build-native-multi-arch-image.yml` `merge-manifests` (4vcpu): flagged as a candidate since it is manifest bookkeeping (`docker buildx imagetools create`), but its job body contains a `Setup Blacksmith Builder` step (`./.github/actions/setup-blacksmith-builder`, wrapping `useblacksmith/setup-docker-builder`), which only works on Blacksmith runners — so it stays. If that builder step turns out to be unnecessary for `imagetools create`, moving this job can be a follow-up.

## Live validation results

All checks on this PR passed. Every moved job that executed ran on a GitHub-hosted runner (runner name `GitHub Actions NNN`, label `ubuntu-latest`): PR Title Linter, Release Freeze Check, License Compliance Check, Supply Chain Policy, Docs Image Policy, Docs Link Check, Migration Kit Checks, Dependency Review, Helm Chart Linting and Tests, Backend Unit Tests gate. Guarded moved jobs (Mac Mini Watchdog, dependency-review-merge-group, Claude determine-token, e2e report/gate jobs) correctly reported skipped with `ubuntu-latest` labels. Untouched 4/8/16vcpu jobs all still ran on Blacksmith runners. Zizmor workflow static analysis passed on the changed files.
