### PR TITLE
ci: experiment — backend unit shards on free GitHub-hosted runners

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -525,16 +525,22 @@ jobs:
         run: cargo test --workspace --locked
 
   # Backend unit tests, sharded across parallel runners. Vitest's --shard
-  # slices the file list deterministically (SHA1 of each path), so the four
-  # jobs partition the suite exactly once. Splitting this out of the lint job
-  # takes the suite off the workflow's critical path.
+  # slices the file list deterministically (SHA1 of each path), so the
+  # sixteen jobs partition the suite exactly once. Splitting this out of the
+  # lint job takes the suite off the workflow's critical path.
+  #
+  # EXPERIMENT (measurement PR): 16 shards on free GitHub-hosted ubuntu-latest
+  # (4 vcpu) instead of 4 shards on paid blacksmith-16vcpu. The gate job below
+  # keeps the stable check name either way. Rollback = revert this block to
+  # shard: [1..4] / blacksmith-16vcpu-ubuntu-2404 / --shard=N/4.
   backend-unit-tests:
-    name: Backend Unit Tests (shard ${{ matrix.shard }}/4)
+    name: Backend Unit Tests (shard ${{ matrix.shard }}/16)
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
-    runs-on: blacksmith-16vcpu-ubuntu-2404
-    # A full local suite run is ~4 min on comparable hardware; a shard is a
-    # quarter of that plus setup. 15 minutes means something is hung.
+    runs-on: ubuntu-latest
+    # A full suite run is ~4 min of vitest on 16 fast cores; a 1/16 shard on
+    # 4 slower cores is a few minutes plus setup. 15 minutes means something
+    # is hung.
     timeout-minutes: 15
     permissions:
       contents: read
@@ -549,7 +555,7 @@ jobs:
       # failure picture in one pass.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -581,17 +587,17 @@ jobs:
             pnpm exec turbo build --filter="@backend^..."
           }
 
-      - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
+      - name: Run backend unit tests (shard ${{ matrix.shard }} of 16)
         working-directory: ./platform/backend
         env:
           SHARD: ${{ matrix.shard }}
-        run: pnpm exec vitest run --shard="${SHARD}/4"
+        run: pnpm exec vitest run --shard="${SHARD}/16"
 
   # Stable-named gate over the shard matrix so branch protection / merge queue
   # can require a single check ("Backend Unit Tests") regardless of shard count.
   backend-unit-tests-gate:
     name: Backend Unit Tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # always() so the gate still runs (and turns red) when a shard fails,
     # ANDed with the bot-pr-guard (see comment above
     # platform-lint-and-unit-tests): when the shards skip on a bot PR, the


### PR DESCRIPTION
## Experiment: backend unit shards on free GitHub-hosted runners

**This is a measurement PR, not a merge candidate.** Draft on purpose.

### Hypothesis

The 4× `blacksmith-16vcpu` backend unit shards (the single biggest CI cost line) can run as **16 shards × `ubuntu-latest`** (4 vcpu, free on this public repo) with comparable or better wall-clock. Vitest `--shard` partitions deterministically, so 16 smaller slices on slower cores should trade per-shard compute for parallelism, with per-shard setup overhead as the main risk.

### What changed

- `backend-unit-tests`: matrix `[1..4]` → `[1..16]`, `--shard=N/4` → `--shard=N/16`, `runs-on: blacksmith-16vcpu-ubuntu-2404` → `ubuntu-latest`
- `backend-unit-tests-gate`: `blacksmith-2vcpu` → `ubuntu-latest` (trivial shell step; keeps the pipeline fully free and its queue-wait inside the measurement)
- Gate semantics unchanged: `needs.backend-unit-tests.result` aggregates the whole matrix, so any red shard still fails the stable "Backend Unit Tests" check
- No cache action changes needed: the job's only cache is `actions/setup-node`'s pnpm store cache, which already uses the GitHub cache backend

### Notes / known risks

- **Cache eviction**: everything now leans on GitHub's 10 GB per-repo LRU cache, which CodeQL and other workflows churn (documented in `.github/actions/github-cache`). Cold pnpm-store restores on many shards would show up as setup overhead — that is part of what this measures.
- **Fork caps on 4 vcpu / 16 GB**: `platform/backend/vitest.config.ts` bounds workers by `availableParallelism` and `totalmem/5GB` → ~3 forks per shard. No hardcoded 16-vcpu assumptions.
- **Runner concurrency**: 16 parallel `ubuntu-latest` jobs plus the rest of the workflow may hit the org's hosted-runner concurrency limit; queue-wait is measured explicitly.

### Measurement plan

3–5 runs of the re-sharded suite on this PR (initial push + `gh run rerun`; no `workflow_dispatch` on this workflow). For each run, per shard: queue-wait, setup duration (checkout + setup-env + turbo build deps), vitest duration, total; plus whole-suite wall (first shard start → gate complete) and pnpm cache hit/miss. Baseline: the same metrics from 5 recent main-branch merge-group runs' 4× Blacksmith shards.

**Verdict criteria**: experiment wall ≤ baseline + 1.5 min with cache hits mostly working → recommend adoption. Otherwise document the dominant failure mode (setup overhead vs cache eviction vs slow cores).

Results table will be posted in this PR when runs complete.

### Rollback

Close this PR. No other branches depend on it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>