### PR TITLE
ci: probe — lite e2e on a free GitHub-hosted runner

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -546,7 +546,10 @@ jobs:
     name: Platform E2E Tests (Lite)
     needs: [platform-e2e-build]
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    # PROBE-ONLY: temporarily on the free GitHub-hosted runner (4 vCPU / 16 GB
+    # RAM / ~14 GB usable disk) to measure whether the lite stack fits.
+    # Normally: blacksmith-8vcpu-ubuntu-2404. Revert before merging.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository and read test assets.
@@ -557,6 +560,16 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 1
+
+      # PROBE-ONLY diagnostic: disk/memory headroom before anything is pulled.
+      - name: "[probe] Disk and memory at job start"
+        run: |
+          echo "=== df -h / ==="
+          df -h /
+          echo "=== docker system df -v (top 40 lines) ==="
+          docker system df -v | head -40
+          echo "=== free -h ==="
+          free -h
 
       - name: Setup environment
         uses: ./.github/actions/setup-env
@@ -642,6 +655,17 @@ jobs:
 
           echo "=== Docker Container Status ==="
           docker ps -a
+
+      # PROBE-ONLY diagnostic: disk/memory headroom after the full run.
+      - name: "[probe] Disk and memory at job end"
+        if: ${{ always() }}
+        run: |
+          echo "=== df -h / ==="
+          df -h /
+          echo "=== docker system df -v (top 40 lines) ==="
+          docker system df -v | head -40
+          echo "=== free -h ==="
+          free -h
 
       # No teardown: the runner VM is thrown away after the job anyway.
 


### PR DESCRIPTION
## Probe: can the lite e2e job run on a free GitHub-hosted runner?

**Question.** Does "Platform E2E Tests (Lite)" fit on `ubuntu-latest` (public repo: 4 vCPU / 16 GB RAM / **~14 GB usable SSD**) instead of `blacksmith-8vcpu-ubuntu-2404`?

**Suspected blocker: disk, not CPU.** The lite stack pulls the full platform image (~1 GB compressed, incl. a ~352 MB Dagger engine tar in the non-slim variant), kindest/node (~1 GB), Keycloak, WireMock, the Playwright runner image, plus the embedded Kind cluster's own image copies — plausibly 10-14 GB total. Secondary question: wall-clock regression vs the ~7-8 min Blacksmith baseline.

**What this PR changes (probe-only, not for merging as-is):**
- `runs-on: ubuntu-latest` for the lite job only (K8s and quickstart jobs untouched; build jobs still on Blacksmith)
- `[probe]` diagnostic steps at job start/end: `df -h /`, `docker system df -v`, `free -h`

**Verdict criteria:** green + ≥1.5 GB disk headroom at end + wall ≤ 12 min → viable; otherwise not viable, with the binding constraint named.

**Rollback:** close this PR. Nothing merges.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>