### PR TITLE
ci: move runner-agnostic jobs and backend test shards to GitHub-hosted runners

### DIFF
--- a/.github/workflows/build-base-mcp-server-docker-image.yml
+++ b/.github/workflows/build-base-mcp-server-docker-image.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   python-mcp-lockfile-check:
     name: MCP Python Lockfile Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./platform

--- a/.github/workflows/build-native-multi-arch-image.yml
+++ b/.github/workflows/build-native-multi-arch-image.yml
@@ -150,7 +150,7 @@ jobs:
   merge-manifests:
     name: Create multi-arch manifest
     if: ${{ inputs.push_image }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - build-image
     permissions:
@@ -170,9 +170,8 @@ jobs:
           pattern: ${{ inputs.image_name }}-digests-*
           merge-multiple: true
 
-      - name: Setup Blacksmith Builder
-        uses: ./.github/actions/setup-blacksmith-builder
-
+      # No builder setup needed: `docker buildx imagetools` is a pure registry
+      # manifest operation and runs on the preinstalled buildx CLI.
       - name: Authenticate to Google Artifact Registry
         if: ${{ inputs.auth_provider == 'gar' }}
         uses: ./.github/actions/auth-to-gar

--- a/.github/workflows/build-sandbox-base-docker-image.yml
+++ b/.github/workflows/build-sandbox-base-docker-image.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   sandbox-base-lockfile-check:
     name: Sandbox Base Python Lockfile Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./platform

--- a/.github/workflows/claude-coreteam-mentions-shared.yml
+++ b/.github/workflows/claude-coreteam-mentions-shared.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write # Required for Claude to push follow-up commits when explicitly instructed.

--- a/.github/workflows/claude-coreteam-review-shared.yml
+++ b/.github/workflows/claude-coreteam-review-shared.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   pr-review:
     name: PR Review
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository and inspect the PR diff.

--- a/.github/workflows/claude-coreteam-review.yml
+++ b/.github/workflows/claude-coreteam-review.yml
@@ -23,7 +23,7 @@ jobs:
     if: |
       !contains(github.event.pull_request.title, '[WIP]') &&
       !github.event.pull_request.draft
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions: {}
     outputs:
       pr_author: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/clear-github-actions-cache.yml
+++ b/.github/workflows/clear-github-actions-cache.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   clear-cache:
     name: Clear GitHub Actions Cache
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       actions: write # Required to list and delete Actions caches.
       contents: read # Required to checkout the repository for local workflow context.

--- a/.github/workflows/good-first-issue-welcome.yml
+++ b/.github/workflows/good-first-issue-welcome.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   welcome-new-contributor:
     name: Welcome New Contributor
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.label.name == 'good first issue'
     permissions:
       issues: write # Required to post the welcome comment on the labeled issue.

--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -47,7 +47,7 @@ jobs:
 
   deploy-to-staging:
     name: Deploy to staging
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [deploy-dev-platform-images]
     # cancel-in-progress MUST stay false here: cancelling `helm upgrade`
     # mid-flight has previously left the release wedged in pending-upgrade.

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -431,10 +431,10 @@ jobs:
   # run if the machine stops taking jobs, so a dead mini ejects the PR from
   # the merge queue in minutes instead of blocking it for hours.
   #
-  # The backend unit test shards deliberately stay on Blacksmith: the merge
-  # queue runs several stacked groups concurrently, and 4 shards per group
-  # oversubscribe the machine's 3 runner slots — queued-behind-saturation is
-  # indistinguishable from dead for the jobs involved and adds minutes of
+  # The backend unit test shards deliberately stay off the mac mini: the
+  # merge queue runs several stacked groups concurrently, and 16 shards per
+  # group oversubscribe the machine's 3 runner slots — queued-behind-saturation
+  # is indistinguishable from dead for the jobs involved and adds minutes of
   # merge latency per group.
   #
   # Rust toolchain checks, split out of the lint job so cargo work runs in
@@ -525,16 +525,18 @@ jobs:
         run: cargo test --workspace --locked
 
   # Backend unit tests, sharded across parallel runners. Vitest's --shard
-  # slices the file list deterministically (SHA1 of each path), so the four
-  # jobs partition the suite exactly once. Splitting this out of the lint job
-  # takes the suite off the workflow's critical path.
+  # slices the file list deterministically (SHA1 of each path), so the
+  # sixteen jobs partition the suite exactly once. Splitting this out of the
+  # lint job takes the suite off the workflow's critical path. Standard
+  # GitHub-hosted runners are free on public repos, so the wide shard count
+  # trades (free) per-shard setup for wall-clock.
   backend-unit-tests:
-    name: Backend Unit Tests (shard ${{ matrix.shard }}/4)
+    name: Backend Unit Tests (shard ${{ matrix.shard }}/16)
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # A full local suite run is ~4 min on comparable hardware; a shard is a
-    # quarter of that plus setup. 15 minutes means something is hung.
+    # sixteenth of that plus setup. 15 minutes means something is hung.
     timeout-minutes: 15
     permissions:
       contents: read
@@ -549,7 +551,7 @@ jobs:
       # failure picture in one pass.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -581,11 +583,11 @@ jobs:
             pnpm exec turbo build --filter="@backend^..."
           }
 
-      - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
+      - name: Run backend unit tests (shard ${{ matrix.shard }} of 16)
         working-directory: ./platform/backend
         env:
           SHARD: ${{ matrix.shard }}
-        run: pnpm exec vitest run --shard="${SHARD}/4"
+        run: pnpm exec vitest run --shard="${SHARD}/16"
 
   # Stable-named gate over the shard matrix so branch protection / merge queue
   # can require a single check ("Backend Unit Tests") regardless of shard count.

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -22,7 +22,7 @@ jobs:
     name: Release Freeze Check
     # Always run so it can be a required status check - passes immediately for
     # non-release-please PRs and merge queue runs.
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read # Required to inspect the repository context for release-please PRs.
       pull-requests: write # Required to request changes on frozen release PRs.
@@ -85,7 +85,7 @@ jobs:
 
   license-compliance-check:
     name: License Compliance Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     defaults:
@@ -126,7 +126,7 @@ jobs:
 
   supply-chain-policy:
     name: Supply Chain Policy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -143,7 +143,7 @@ jobs:
 
   docs-image-policy:
     name: Docs Image Policy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   docs-links:
     name: Docs Link Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -173,7 +173,7 @@ jobs:
 
   migration-kit-checks:
     name: Migration Kit Checks
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -194,7 +194,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read # Required for dependency-review-action to read the PR dependency graph via the API.
       pull-requests: write # Required for dependency-review-action PR comments.
@@ -221,7 +221,7 @@ jobs:
   dependency-review-merge-group:
     name: Dependency Review
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Skip dependency review for merge queue
@@ -591,7 +591,7 @@ jobs:
   # can require a single check ("Backend Unit Tests") regardless of shard count.
   backend-unit-tests-gate:
     name: Backend Unit Tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # always() so the gate still runs (and turns red) when a shard fails,
     # ANDed with the bot-pr-guard (see comment above
     # platform-lint-and-unit-tests): when the shards skip on a bot PR, the
@@ -700,7 +700,7 @@ jobs:
   mac-mini-watchdog:
     name: Mac Mini Watchdog
     if: github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:
       actions: write # Required to cancel this workflow run on failover.
@@ -769,7 +769,7 @@ jobs:
 
   helm-chart-linting-and-tests:
     name: Helm Chart Linting and Tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read # Required to checkout the repository and lint/package the Helm chart.
     defaults:

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -334,7 +334,7 @@ jobs:
     name: Cancel E2E on build failure
     needs: [platform-e2e-build]
     if: ${{ failure() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       actions: write # Required to cancel this workflow run.
@@ -904,7 +904,7 @@ jobs:
     # gate; the event guard keeps it running on merge_group / on-demand runs but
     # reporting skipped (and thus satisfying the ruleset) on ordinary PR pushes.
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     # No permissions needed: this job only inspects `needs.*.result`.
     permissions: {}
@@ -947,7 +947,7 @@ jobs:
         platform-quickstart-e2e-tests,
       ]
     if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read # Required to checkout the repository and merge Playwright reports.

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-pr-title:
     name: PR Title Linter
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read # Required to checkout the repository and read commitlint config.
       pull-requests: read # Required by lint-pr-title to read PR metadata.

--- a/.github/workflows/publish-platform-helm-chart.yml
+++ b/.github/workflows/publish-platform-helm-chart.yml
@@ -33,7 +33,7 @@ jobs:
   # https://medium.com/google-cloud/ci-gitops-with-helm-github-actions-google-artifact-registry-and-config-sync-b48604191fda
   publish-platform-helm-chart:
     name: Publish platform Helm chart
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write # Required to package the chart from the checked-out repository.
       id-token: write # Required for Workload Identity Federation.

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -32,7 +32,7 @@ jobs:
   assign-issue:
     name: Assign Issues
     if: github.event_name == 'issues' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       issues: write # Required to assign issues.
 
@@ -108,7 +108,7 @@ jobs:
   request-recent-pr-reviewers:
     name: Request Recent PR Reviewers
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write # Required to read PR metadata and request reviewers.
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   release-please:
     name: Release Please
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write # Required to update manifests and release metadata in the repository.
       pull-requests: write # Required for release-please PR creation and updates.
@@ -275,7 +275,7 @@ jobs:
     # Un-drafts the GitHub release and triggers the website deploy only after ALL artifacts
     # (MCP server image, sandbox base image, platform Docker image, Helm chart) are published.
     if: ${{ always() && needs.release-please.outputs.platform_should_publish == 'true' && (github.event_name != 'workflow_dispatch' || inputs.finalize_github_release) && (needs.build-and-push-mcp-server-docker-image.result == 'success' || needs.build-and-push-mcp-server-docker-image.result == 'skipped') && (needs.build-and-push-sandbox-base-docker-image.result == 'success' || needs.build-and-push-sandbox-base-docker-image.result == 'skipped') && (needs.build-and-push-platform-docker-image-to-dockerhub.result == 'success' || needs.build-and-push-platform-docker-image-to-dockerhub.result == 'skipped') && (needs.publish-platform-helm-chart.result == 'success' || needs.publish-platform-helm-chart.result == 'skipped') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - release-please
       - build-and-push-mcp-server-docker-image
@@ -342,7 +342,7 @@ jobs:
       - publish-platform-helm-chart
       - publish-github-release
     if: ${{ always() && needs.release-please.outputs.platform_should_publish == 'true' && contains(needs.*.result, 'failure') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Post failure alert to Slack

--- a/.github/workflows/toggle-release-freeze.yml
+++ b/.github/workflows/toggle-release-freeze.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   toggle-release-freeze:
     name: Toggle Release Freeze
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   trigger-website-deploy:
     name: Trigger Website Vercel Deploy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Trigger Vercel Deploy Hook
         env:


### PR DESCRIPTION
Two independent commits:

1. **Runner-agnostic jobs → `ubuntu-latest`** — 30 jobs that only need a generic Linux runner (checks, gates, watchdogs, report merging, helm/deploy/trigger jobs), plus `merge-manifests` in the multi-arch build workflow, whose `docker buildx imagetools` work is a pure registry operation and needs no builder setup at all.

2. **Backend unit tests re-shard: 4 → 16 shards on `ubuntu-latest`** — vitest `--shard` partitions deterministically, so shard count is purely a parallelism trade. The `backend-unit-tests-gate` job keeps the stable required-check name, so branch protection is unchanged. Separate commit so it can be reverted alone.

Deliberately untouched for follow-ups: image build jobs and e2e environments (depend on the Blacksmith builder/cache), the benchmark workflow (registry-cache builder), the conditional mac-mini fallbacks (`merge_group` gate and `MAC_MINI_CI` kill switch unchanged), and the cache-warming workflows.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>