### PR TITLE
fix(users): keep SelectValue mounted so the role filter can reopen

### DIFF
--- a/platform/e2e-tests/playwright.config.ts
+++ b/platform/e2e-tests/playwright.config.ts
@@ -57,6 +57,7 @@ const uiTestMatch = [
   "**/quickstart.spec.ts",
   "**/skill-share.spec.ts",
   "**/static-credentials-management.spec.ts",
+  "**/users-role-filter.spec.ts",
 ];
 
 // API specs that run in the lite environment (platform as a plain container

--- a/platform/e2e-tests/tests/users-role-filter.spec.ts
+++ b/platform/e2e-tests/tests/users-role-filter.spec.ts
@@ -1,0 +1,74 @@
+import { E2eTestId } from "@archestra/shared";
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from "../consts";
+import { expect, test } from "../fixtures";
+import { navigateAndVerifyAuth } from "../utils";
+
+/**
+ * The role filter is a Radix Select with a custom trigger label. Radix only
+ * positions an item-aligned dropdown once it can see every part it needs —
+ * including the value node — so a trigger that stops rendering SelectValue
+ * after a selection leaves the list unpositioned off-screen with
+ * `pointer-events: none` still on <body>, which reads to a user as a filter
+ * that opens once and then goes dead.
+ *
+ * These tests drive real clicks, so an off-screen list fails them on
+ * actionability rather than needing a positioning assertion.
+ */
+test.describe("Users settings role filter", () => {
+  test.beforeEach(async ({ page, goToPage }) => {
+    await navigateAndVerifyAuth({
+      page,
+      path: "/settings/users",
+      email: ADMIN_EMAIL,
+      password: ADMIN_PASSWORD,
+      verifyLocator: page.getByTestId(E2eTestId.UsersRoleFilter),
+      goToPage,
+    });
+  });
+
+  test("stays usable across repeated filtering", async ({ page }) => {
+    const filter = page.getByTestId(E2eTestId.UsersRoleFilter);
+
+    // First selection — this much always worked.
+    await filter.click();
+    await page.getByRole("option", { name: "Admin", exact: true }).click();
+    await expect(page).toHaveURL(/role=admin/);
+    await expect(filter).toContainText(/admin/i);
+
+    // Reopening after a selection is the actual regression: the list must be
+    // on-screen and its options clickable, not merely present in the DOM.
+    await filter.click();
+    await page.getByRole("option", { name: "Member", exact: true }).click();
+    await expect(page).toHaveURL(/role=member/);
+    await expect(filter).toContainText(/member/i);
+
+    // And clearing the filter must work from that state too.
+    await filter.click();
+    await page.getByRole("option", { name: "All Roles", exact: true }).click();
+    await expect(page).not.toHaveURL(/role=/);
+
+    // A dropdown that never finished closing strands `pointer-events: none` on
+    // <body>, which disables the whole page rather than just the filter.
+    await expect
+      .poll(() =>
+        page.evaluate(() => document.body.style.pointerEvents || "unset"),
+      )
+      .toBe("unset");
+  });
+
+  test("opens when the page loads already filtered", async ({
+    page,
+    goToPage,
+  }) => {
+    // A direct load of a filtered URL renders the trigger in its selected
+    // state without any navigation, which was broken on the very first open.
+    await goToPage(page, "/settings/users?role=admin&page=1");
+
+    const filter = page.getByTestId(E2eTestId.UsersRoleFilter);
+    await expect(filter).toContainText(/admin/i);
+
+    await filter.click();
+    await page.getByRole("option", { name: "Editor", exact: true }).click();
+    await expect(page).toHaveURL(/role=editor/);
+  });
+});

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -547,17 +547,7 @@ function RoleFilterDropdown() {
   const currentRole = searchParams.get("role") || "all";
   const selectedRole = roles.find((role) => role.role === currentRole);
 
-  // Navigating from inside the Select's own change/close handler destroyed it
-  // mid-close, so Radix never ran the cleanup that removes `pointer-events:
-  // none` and `data-scroll-locked` from <body> — the filter applied once and
-  // then could not be reopened without a reload. (Closing with Escape, which
-  // navigates nothing, always cleaned up correctly.) The choice is held and
-  // applied from an effect instead, which runs after the close has committed
-  // and Radix's teardown has already flushed.
-  const [open, setOpen] = useState(false);
-  const [pendingRole, setPendingRole] = useState<string | null>(null);
-
-  const applyRole = useCallback(
+  const handleChange = useCallback(
     (value: string) => {
       const params = new URLSearchParams(searchParams.toString());
       if (value === "all") {
@@ -571,33 +561,36 @@ function RoleFilterDropdown() {
     [searchParams, router, pathname],
   );
 
-  useEffect(() => {
-    if (open || pendingRole === null) return;
-    const value = pendingRole;
-    setPendingRole(null);
-    applyRole(value);
-  }, [open, pendingRole, applyRole]);
-
   return (
-    <Select
-      open={open}
-      onOpenChange={setOpen}
-      value={pendingRole ?? currentRole}
-      onValueChange={setPendingRole}
-    >
-      <SelectTrigger className="w-[180px]">
-        {selectedRole ? (
-          <RoleOptionLabel
-            predefined={selectedRole.predefined}
-            label={selectedRole.name}
-            className="pr-6"
-          />
-        ) : (
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Shield className="h-4 w-4" />
-            <SelectValue placeholder="Filter by role" />
-          </div>
-        )}
+    <Select value={currentRole} onValueChange={handleChange}>
+      <SelectTrigger
+        className="w-[180px]"
+        data-testid={E2eTestId.UsersRoleFilter}
+      >
+        {/*
+         * SelectValue must stay mounted in every state. Radix positions the
+         * item-aligned dropdown only once it has all of trigger, value node,
+         * content, viewport and selected item; with the value node missing it
+         * silently skips positioning and the list renders unstyled off-screen
+         * while `pointer-events: none` stays on <body> — so the filter looks
+         * dead. Rendering the custom label as SelectValue's children keeps the
+         * node mounted, which is the same shape the other custom-label selects
+         * here use.
+         */}
+        <SelectValue placeholder="Filter by role">
+          {selectedRole ? (
+            <RoleOptionLabel
+              predefined={selectedRole.predefined}
+              label={selectedRole.name}
+              className="pr-6"
+            />
+          ) : (
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <Shield className="h-4 w-4" />
+              Filter by role
+            </span>
+          )}
+        </SelectValue>
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="all">All Roles</SelectItem>

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -547,7 +547,17 @@ function RoleFilterDropdown() {
   const currentRole = searchParams.get("role") || "all";
   const selectedRole = roles.find((role) => role.role === currentRole);
 
-  const handleChange = useCallback(
+  // Navigating from inside the Select's own change/close handler destroyed it
+  // mid-close, so Radix never ran the cleanup that removes `pointer-events:
+  // none` and `data-scroll-locked` from <body> — the filter applied once and
+  // then could not be reopened without a reload. (Closing with Escape, which
+  // navigates nothing, always cleaned up correctly.) The choice is held and
+  // applied from an effect instead, which runs after the close has committed
+  // and Radix's teardown has already flushed.
+  const [open, setOpen] = useState(false);
+  const [pendingRole, setPendingRole] = useState<string | null>(null);
+
+  const applyRole = useCallback(
     (value: string) => {
       const params = new URLSearchParams(searchParams.toString());
       if (value === "all") {
@@ -561,8 +571,20 @@ function RoleFilterDropdown() {
     [searchParams, router, pathname],
   );
 
+  useEffect(() => {
+    if (open || pendingRole === null) return;
+    const value = pendingRole;
+    setPendingRole(null);
+    applyRole(value);
+  }, [open, pendingRole, applyRole]);
+
   return (
-    <Select value={currentRole} onValueChange={handleChange}>
+    <Select
+      open={open}
+      onOpenChange={setOpen}
+      value={pendingRole ?? currentRole}
+      onValueChange={setPendingRole}
+    >
       <SelectTrigger className="w-[180px]">
         {selectedRole ? (
           <RoleOptionLabel

--- a/platform/shared/e2e-test-ids.ts
+++ b/platform/shared/e2e-test-ids.ts
@@ -147,6 +147,8 @@ export const E2eTestId = {
   // Connectivity / offline status bar
   ConnectivityStatusBar: "connectivity-status-bar",
   ConnectivityStatusBarRetry: "connectivity-status-bar-retry",
+  // Users settings
+  UsersRoleFilter: "users-role-filter",
   // Role debugger / impersonation
   ImpersonationBanner: "impersonation-banner",
   ImpersonationStopButton: "impersonation-stop-button",


### PR DESCRIPTION
## The bug

On `/settings/users`, picking a role filters the table. Opening the filter again after that does nothing — it stays dead until the `role` query param is removed and the page reloaded.

## Cause

Not navigation, and not the first selection.

Radix's item-aligned `Select` positions its content only once it can see all of trigger, **value node**, content, viewport, selected item and selected item text. If any one is missing it skips positioning silently — no warning, no error.

This trigger rendered `SelectValue` only in the *unselected* branch:

```tsx
{selectedRole ? (
  <RoleOptionLabel … />              // no SelectValue → value node is null
) : (
  <div>…<SelectValue placeholder="Filter by role" /></div>
)}
```

So the moment a role was selected, the value node unmounted and every later open produced an unpositioned list, while `pointer-events: none` stayed on `<body>`. Measured in the browser:

| | listbox rect | inline styles on the content wrapper |
|---|---|---|
| No role selected (works) | `621,278 173×170` — under the trigger | `position: fixed; min-width: 155px; left: 620px; bottom: 0; height: 912px; margin: 10px 0; min-height: 160px` |
| Role selected (broken) | `0,1200 173×170` — off-screen | `position: fixed; z-index: 50` |

The dropdown *was* opening; it was rendering off the bottom of the viewport. `elementFromPoint` over the trigger returned `<html>`, not the button, because `<body>` was left non-interactive — so the whole page read as dead, not just the filter.

## What the earlier diagnosis got wrong

The first version of this PR blamed `router.push` running inside Radix's close and deferred the navigation to an effect. Measurement disproved it — patched and unpatched builds failed **identically**, so that change was a no-op. It has been dropped.

Three observations rule navigation out:

- The **first** selection was never broken. The **second open** is what fails, which is why a one-cycle manual check passed.
- Loading `/settings/users?role=admin` directly is broken on its very first open, with no navigation anywhere.
- The rows-per-page select on the same page navigates the same way, always keeps `SelectValue` mounted, and always positions correctly.

## Fix

Render the custom label as `SelectValue`'s children so the node stays mounted in both states — the same shape the other custom-label selects in this codebase already use (`messaging-channels/a2a`, `llm/costs`). The inner `<div>` becomes a `<span>`, since it now sits inside one.

I swept all 113 `SelectTrigger` usages: this was the only one that could drop its value node while openable. `RoleSelect` also omits `SelectValue` while roles load, but is `disabled` in exactly that state, so it can't be opened without the value node — left as is.

## Verification

`platform/e2e-tests/tests/users-role-filter.spec.ts` covers two paths: repeated select-and-reopen cycles, and a direct load of an already-filtered URL. Both drive real clicks, so an off-screen list fails on actionability rather than needing a positioning assertion.

Both tests **fail on the previous code and pass on this one** — checked by reverting the trigger and re-running.

Manual check: `/settings/users` → pick a role → the table filters → **click the filter again; it opens** → pick another role → it filters again. Before this change the second open was dead.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
