### PR TITLE
ci: revert backend re-shard to 4 shards on 16vcpu runners

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -431,10 +431,10 @@ jobs:
   # run if the machine stops taking jobs, so a dead mini ejects the PR from
   # the merge queue in minutes instead of blocking it for hours.
   #
-  # The backend unit test shards deliberately stay off the mac mini: the
-  # merge queue runs several stacked groups concurrently, and 16 shards per
-  # group oversubscribe the machine's 3 runner slots — queued-behind-saturation
-  # is indistinguishable from dead for the jobs involved and adds minutes of
+  # The backend unit test shards deliberately stay on Blacksmith: the merge
+  # queue runs several stacked groups concurrently, and 4 shards per group
+  # oversubscribe the machine's 3 runner slots — queued-behind-saturation is
+  # indistinguishable from dead for the jobs involved and adds minutes of
   # merge latency per group.
   #
   # Rust toolchain checks, split out of the lint job so cargo work runs in
@@ -525,18 +525,16 @@ jobs:
         run: cargo test --workspace --locked
 
   # Backend unit tests, sharded across parallel runners. Vitest's --shard
-  # slices the file list deterministically (SHA1 of each path), so the
-  # sixteen jobs partition the suite exactly once. Splitting this out of the
-  # lint job takes the suite off the workflow's critical path. Standard
-  # GitHub-hosted runners are free on public repos, so the wide shard count
-  # trades (free) per-shard setup for wall-clock.
+  # slices the file list deterministically (SHA1 of each path), so the four
+  # jobs partition the suite exactly once. Splitting this out of the lint job
+  # takes the suite off the workflow's critical path.
   backend-unit-tests:
-    name: Backend Unit Tests (shard ${{ matrix.shard }}/16)
+    name: Backend Unit Tests (shard ${{ matrix.shard }}/4)
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     # A full local suite run is ~4 min on comparable hardware; a shard is a
-    # sixteenth of that plus setup. 15 minutes means something is hung.
+    # quarter of that plus setup. 15 minutes means something is hung.
     timeout-minutes: 15
     permissions:
       contents: read
@@ -551,7 +549,7 @@ jobs:
       # failure picture in one pass.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -583,11 +581,11 @@ jobs:
             pnpm exec turbo build --filter="@backend^..."
           }
 
-      - name: Run backend unit tests (shard ${{ matrix.shard }} of 16)
+      - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
         working-directory: ./platform/backend
         env:
           SHARD: ${{ matrix.shard }}
-        run: pnpm exec vitest run --shard="${SHARD}/16"
+        run: pnpm exec vitest run --shard="${SHARD}/4"
 
   # Stable-named gate over the shard matrix so branch protection / merge queue
   # can require a single check ("Backend Unit Tests") regardless of shard count.


### PR DESCRIPTION
Reverts the 16-shard half of #7049 per its measurement gate.

Measured across two runs: 16 shards on `ubuntu-latest` finish in 7–10 min wall-clock vs 3m26s–4m22s for the 4-shard 16vcpu config. Per-shard fixed cost (mainly the turbo remote-cache artifact download for the backend workspace build, 2m30s–3m22s per shard) plus the skewed vitest file split dominate; at ~10 min the shards would also overtake the lite e2e leg (7m) as the merge-queue critical path.

Backend shards return to 4x 16vcpu until the per-shard fixed cost is addressed (build the backend workspace deps once and share dist via artifact, plus a pnpm-store cache). The rest of #7049 (runner-agnostic job moves) stays.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>