### PR TITLE
ci: move rust checks, frontend integration tests, and lint job to GitHub-hosted runners

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -420,13 +420,15 @@ jobs:
           echo "✅ All validation checks passed"
 
   # mac-mini routing: both Rust checks and the frontend integration tests run
-  # on the self-hosted mac-mini-1 runners instead of Blacksmith when BOTH hold:
+  # on the self-hosted mac-mini-1 runners instead of GitHub-hosted when BOTH
+  # hold:
   #   - the event is merge_group (only maintainer-queued code ever reaches the
-  #     self-hosted machine; label-triggered PR runs stay on Blacksmith), and
+  #     self-hosted machine; label-triggered PR runs stay on GitHub-hosted
+  #     runners), and
   #   - the MAC_MINI_CI repository variable is "on" — the kill switch. Flip it
   #     off (gh variable set MAC_MINI_CI --body off) to instantly route
-  #     everything back to Blacksmith with no workflow change; unset/missing
-  #     also means Blacksmith.
+  #     everything back to GitHub-hosted runners with no workflow change;
+  #     unset/missing also means GitHub-hosted.
   # The mac-mini-watchdog job below auto-flips the switch off and cancels the
   # run if the machine stops taking jobs, so a dead mini ejects the PR from
   # the merge queue in minutes instead of blocking it for hours.
@@ -445,7 +447,7 @@ jobs:
     name: Platform Rust Checks
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
-    runs-on: ${{ github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on' && fromJSON('["self-hosted", "mac-mini-1"]') || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ${{ github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on' && fromJSON('["self-hosted", "mac-mini-1"]') || 'ubuntu-latest' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -464,6 +466,14 @@ jobs:
           rustup show
           rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
 
+      # The mac mini keeps its cargo caches on the persistent disk; only the
+      # ephemeral Linux runners need a restored cache.
+      - name: Cache cargo registry and target
+        if: runner.os == 'Linux'
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: platform/archestra-rs
+
       - name: Install Rust musl toolchain dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -480,8 +490,14 @@ jobs:
         run: |
           cargo check --workspace --locked --target x86_64-unknown-linux-musl
 
+      # Prebuilt binary instead of `cargo install` — the source compile was
+      # ~2-4 min of pure waste on ephemeral runners. The action verifies the
+      # download against its pinned manifest and picks the right platform
+      # (Linux runners and the mac mini).
       - name: Install cargo-deny
-        run: cargo install cargo-deny --version 0.20.2 --locked
+        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        with:
+          tool: cargo-deny@0.20.2
 
       - name: Rust dependency policy
         working-directory: ./platform/archestra-rs
@@ -492,7 +508,7 @@ jobs:
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
     # mac-mini routing (see comment above platform-rust-checks)
-    runs-on: ${{ github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on' && fromJSON('["self-hosted", "mac-mini-1"]') || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ${{ github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on' && fromJSON('["self-hosted", "mac-mini-1"]') || 'ubuntu-latest' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -508,6 +524,13 @@ jobs:
 
       - name: Setup Rust
         run: rustup show
+
+      # See the cache note in platform-rust-checks.
+      - name: Cache cargo registry and target
+        if: runner.os == 'Linux'
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: ai-labs
 
       - name: Install uv
         uses: ./.github/actions/setup-uv

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -641,7 +641,7 @@ jobs:
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
     # mac-mini routing (see comment above platform-rust-checks)
-    runs-on: ${{ github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on' && fromJSON('["self-hosted", "mac-mini-1"]') || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ${{ github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on' && fromJSON('["self-hosted", "mac-mini-1"]') || 'ubuntu-latest' }}
     permissions:
       contents: read
     defaults:
@@ -672,11 +672,10 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        # useblacksmith/cache only works on Blacksmith runners; the mac mini
-        # keeps its browser cache on the persistent disk instead.
+        # The mac mini keeps its browser cache on the persistent disk instead.
         if: runner.os == 'Linux'
         id: playwright-cache
-        uses: ./.github/actions/github-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -255,12 +255,14 @@ jobs:
     # bot-pr-guard (see above): contributor bot only — release-please PRs
     # need this job's codegen auto-commit.
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'
-    runs-on: blacksmith-16vcpu-ubuntu-2404
-    # Backstop: every check here finishes in well under 10m, but leaked
-    # test-runner processes (vitest fork workers / esbuild) occasionally orphan
-    # and hold the step's log pipe open, leaving a *finished* job hanging until
-    # GitHub's 6h default. Fail fast instead.
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    # Backstop: on a turbo remote-cache hit every check here finishes well
+    # under 10m, but leaked test-runner processes (vitest fork workers /
+    # esbuild) occasionally orphan and hold the step's log pipe open, leaving
+    # a *finished* job hanging until GitHub's 6h default. Fail fast instead.
+    # 30 (not 20) because fork PRs run without cache secrets and pay a full
+    # cold build on a 4vcpu runner.
+    timeout-minutes: 30
     permissions:
       contents: write # Required to push generated code updates back to release-please PRs.
     defaults:


### PR DESCRIPTION
Three revertable commits, continuing #7049:

1. **Rust checks** — PR-event fallback → `ubuntu-latest`, with `Swatinem/rust-cache` (Linux only; the mac mini has its persistent disk) and cargo-deny as a verified prebuilt binary instead of a 2–4 min source compile. The `merge_group` + `MAC_MINI_CI` routing condition is untouched.
2. **Frontend integration tests** — Playwright browser cache moves from the Blacksmith-only cache wrapper to `actions/cache` (viable now that CodeQL default setup no longer churns the repo's cache budget); fallback → `ubuntu-latest`.
3. **Lint and unit tests** — 16vcpu → `ubuntu-latest`; on turbo remote-cache hits the job is download-bound, so this is measured on this PR. Timeout 20 → 30 for the fork-PR cold-build path. If wall-clock regresses badly, revert just this commit or split by turbo filter.

Still on Blacksmith after this: e2e environments, image builds, scanning (see #7044), benchmark, cache-warming.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>