### PR TITLE
feat(auth): make ARCHESTRA_AUTH_DISABLE_BASIC_AUTH actually disable basic auth, and turn it on for staging

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -88,6 +88,15 @@ archestra:
     ARCHESTRA_BEDROCK_BASE_URL: "https://bedrock-runtime.eu-north-1.amazonaws.com"
     ARCHESTRA_BEDROCK_INFERENCE_PROFILE_PREFIX: "eu"
     ARCHESTRA_AUTH_COOKIE_DOMAIN: ".archestra.dev"
+    # SSO-only sign-in. PREREQUISITE: a working identity provider must be
+    # configured and signed into on staging first — this hides the
+    # email/password form, so with no IdP there is no way in through the UI.
+    # Note this is a UI-level control: better-auth's emailAndPassword provider
+    # stays enabled and POST /api/auth/sign-in/email is NOT blocked by the flag,
+    # so it hides the form rather than closing the endpoint.
+    # It also blocks turning on the require-two-factor org policy, since
+    # enrolment needs a password — 2FA has to come from the IdP instead.
+    ARCHESTRA_AUTH_DISABLE_BASIC_AUTH: "true"
     ARCHESTRA_FRONTEND_URL: "https://frontend.archestra.dev"
     ARCHESTRA_TRUST_PROXY: "false"
     ARCHESTRA_SENTRY_ENVIRONMENT: "archestra.dev"

--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -88,14 +88,11 @@ archestra:
     ARCHESTRA_BEDROCK_BASE_URL: "https://bedrock-runtime.eu-north-1.amazonaws.com"
     ARCHESTRA_BEDROCK_INFERENCE_PROFILE_PREFIX: "eu"
     ARCHESTRA_AUTH_COOKIE_DOMAIN: ".archestra.dev"
-    # SSO-only sign-in. PREREQUISITE: a working identity provider must be
-    # configured and signed into on staging first — this hides the
-    # email/password form, so with no IdP there is no way in through the UI.
-    # Note this is a UI-level control: better-auth's emailAndPassword provider
-    # stays enabled and POST /api/auth/sign-in/email is NOT blocked by the flag,
-    # so it hides the form rather than closing the endpoint.
-    # It also blocks turning on the require-two-factor org policy, since
-    # enrolment needs a password — 2FA has to come from the IdP instead.
+    # SSO-only sign-in. Google is the configured identity provider.
+    # Closes the password endpoints (not just the form) and revokes the
+    # sessions of anyone with no federated account, so everyone re-enters
+    # through Google. Also blocks turning on the require-two-factor org policy,
+    # since enrolment needs a password — 2FA comes from Workspace instead.
     ARCHESTRA_AUTH_DISABLE_BASIC_AUTH: "true"
     ARCHESTRA_FRONTEND_URL: "https://frontend.archestra.dev"
     ARCHESTRA_TRUST_PROXY: "false"

--- a/platform/backend/src/auth/basic-auth-lockout.test.ts
+++ b/platform/backend/src/auth/basic-auth-lockout.test.ts
@@ -1,0 +1,99 @@
+import { eq } from "drizzle-orm";
+import config from "@/config";
+import db, { schema } from "@/database";
+import { describe, expect, test, vi } from "@/test";
+import { revokeBasicAuthOnlySessions } from "./basic-auth-lockout";
+
+async function sessionIdsFor(userId: string): Promise<string[]> {
+  const rows = await db
+    .select({ id: schema.sessionsTable.id })
+    .from(schema.sessionsTable)
+    .where(eq(schema.sessionsTable.userId, userId));
+  return rows.map((row) => row.id);
+}
+
+describe("revokeBasicAuthOnlySessions", () => {
+  test("leaves every session alone while basic auth is enabled", async ({
+    makeUser,
+    makeAccount,
+    makeSession,
+  }) => {
+    vi.spyOn(config.auth, "disableBasicAuth", "get").mockReturnValue(false);
+    const user = await makeUser();
+    await makeAccount(user.id, { providerId: "credential" });
+    await makeSession(user.id);
+
+    await revokeBasicAuthOnlySessions();
+
+    expect(await sessionIdsFor(user.id)).toHaveLength(1);
+  });
+
+  test("revokes sessions for a user who only has a password account", async ({
+    makeUser,
+    makeAccount,
+    makeSession,
+  }) => {
+    vi.spyOn(config.auth, "disableBasicAuth", "get").mockReturnValue(true);
+    const user = await makeUser();
+    await makeAccount(user.id, { providerId: "credential" });
+    await makeSession(user.id);
+
+    await revokeBasicAuthOnlySessions();
+
+    expect(await sessionIdsFor(user.id)).toEqual([]);
+  });
+
+  test("spares a user with a federated account so deploys do not sign them out", async ({
+    makeUser,
+    makeAccount,
+    makeSession,
+  }) => {
+    vi.spyOn(config.auth, "disableBasicAuth", "get").mockReturnValue(true);
+    const user = await makeUser();
+    await makeAccount(user.id, { providerId: "google" });
+    await makeSession(user.id);
+
+    await revokeBasicAuthOnlySessions();
+
+    expect(await sessionIdsFor(user.id)).toHaveLength(1);
+  });
+
+  test("spares a user holding both account types — the documented residual", async ({
+    makeUser,
+    makeAccount,
+    makeSession,
+  }) => {
+    // Their session may well have come from a password, but nothing on the
+    // session row records that. Pinning the behaviour so the gap stays visible
+    // rather than being mistaken for full coverage.
+    vi.spyOn(config.auth, "disableBasicAuth", "get").mockReturnValue(true);
+    const user = await makeUser();
+    await makeAccount(user.id, { providerId: "credential" });
+    await makeAccount(user.id, { providerId: "google" });
+    await makeSession(user.id);
+
+    await revokeBasicAuthOnlySessions();
+
+    expect(await sessionIdsFor(user.id)).toHaveLength(1);
+  });
+
+  test("only sweeps the password-only user when both kinds exist", async ({
+    makeUser,
+    makeAccount,
+    makeSession,
+  }) => {
+    vi.spyOn(config.auth, "disableBasicAuth", "get").mockReturnValue(true);
+    const passwordOnly = await makeUser();
+    await makeAccount(passwordOnly.id, { providerId: "credential" });
+    await makeSession(passwordOnly.id);
+
+    const federated = await makeUser();
+    await makeAccount(federated.id, { providerId: "google" });
+    await makeSession(federated.id);
+
+    await revokeBasicAuthOnlySessions();
+
+    expect(await sessionIdsFor(passwordOnly.id)).toEqual([]);
+    expect(await sessionIdsFor(federated.id)).toHaveLength(1);
+  });
+});

--- a/platform/backend/src/auth/basic-auth-lockout.ts
+++ b/platform/backend/src/auth/basic-auth-lockout.ts
@@ -1,0 +1,58 @@
+import { and, eq, ne, notExists } from "drizzle-orm";
+import config from "@/config";
+import db, { schema } from "@/database";
+import logger from "@/logging";
+
+/** better-auth's providerId for email/password accounts. */
+const CREDENTIAL_PROVIDER_ID = "credential";
+
+/**
+ * When ARCHESTRA_AUTH_DISABLE_BASIC_AUTH is on, revoke the sessions of every
+ * user who can only have signed in with a password.
+ *
+ * The `session` row records nothing about how it was created — there is no
+ * provider column — so a password session cannot be told apart from an SSO one
+ * by inspection. What *can* be established is whether a user holds any
+ * non-credential account: if they do not, every session they have was
+ * necessarily obtained with a password, and the endpoints that could have
+ * produced it are now closed.
+ *
+ * That makes this safe to run on every boot rather than once behind a marker:
+ * users with a federated account are never touched, so deploys do not
+ * repeatedly sign people out, and users without one cannot create a new
+ * session for a later boot to sweep.
+ *
+ * The residual, stated plainly: a user holding *both* a credential account and
+ * a linked SSO account keeps their current session even if it came from a
+ * password. Telling those apart needs the provider recorded on the session at
+ * creation time — a schema change, not a sweep. Such a user can already reach
+ * the same access through SSO, so the gap is small, but it is not zero: this
+ * is not "revoke every password session".
+ */
+export async function revokeBasicAuthOnlySessions(): Promise<void> {
+  if (!config.auth.disableBasicAuth) {
+    return;
+  }
+
+  const hasFederatedAccount = db
+    .select({ one: schema.accountsTable.id })
+    .from(schema.accountsTable)
+    .where(
+      and(
+        eq(schema.accountsTable.userId, schema.sessionsTable.userId),
+        ne(schema.accountsTable.providerId, CREDENTIAL_PROVIDER_ID),
+      ),
+    );
+
+  const revoked = await db
+    .delete(schema.sessionsTable)
+    .where(notExists(hasFederatedAccount))
+    .returning({ id: schema.sessionsTable.id });
+
+  if (revoked.length > 0) {
+    logger.warn(
+      { revokedSessions: revoked.length },
+      "[auth] basic auth is disabled — revoked sessions for users with no federated account; they must sign in through an identity provider",
+    );
+  }
+}

--- a/platform/backend/src/auth/basic-auth-lockout.ts
+++ b/platform/backend/src/auth/basic-auth-lockout.ts
@@ -1,10 +1,8 @@
 import { and, eq, ne, notExists } from "drizzle-orm";
 import config from "@/config";
+import { CREDENTIAL_PROVIDER_ID } from "@/constants";
 import db, { schema } from "@/database";
 import logger from "@/logging";
-
-/** better-auth's providerId for email/password accounts. */
-const CREDENTIAL_PROVIDER_ID = "credential";
 
 /**
  * When ARCHESTRA_AUTH_DISABLE_BASIC_AUTH is on, revoke the sessions of every
@@ -28,6 +26,10 @@ const CREDENTIAL_PROVIDER_ID = "credential";
  * creation time — a schema change, not a sweep. Such a user can already reach
  * the same access through SSO, so the gap is small, but it is not zero: this
  * is not "revoke every password session".
+ *
+ * Users with no accounts at all are swept too, since they also have no
+ * federated account. That is intended: they cannot sign in by any route, so
+ * leaving them a live session would serve nothing.
  */
 export async function revokeBasicAuthOnlySessions(): Promise<void> {
   if (!config.auth.disableBasicAuth) {

--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -31,6 +31,7 @@ import { beforeEach, describe, expect, test } from "@/test";
 // Create a hoisted ref to control disableInvitations in tests
 const mockDisableInvitations = vi.hoisted(() => ({ value: false }));
 const mockDisableImpersonation = vi.hoisted(() => ({ value: false }));
+const mockDisableBasicAuth = vi.hoisted(() => ({ value: false }));
 
 // Mock config module before importing better-auth
 vi.mock("@/config", async (importOriginal) => {
@@ -47,6 +48,9 @@ vi.mock("@/config", async (importOriginal) => {
         },
         get disableImpersonation() {
           return mockDisableImpersonation.value;
+        },
+        get disableBasicAuth() {
+          return mockDisableBasicAuth.value;
         },
       },
     },
@@ -109,6 +113,62 @@ describe("handleBeforeHook", () => {
   // Reset mock to default before each test for proper isolation
   beforeEach(() => {
     mockDisableInvitations.value = false;
+  });
+
+  describe("basic auth disabled", () => {
+    // Route names verified against better-auth 1.6.22. "/forget-password" is
+    // deliberately not among them — it is not a route, only a rate-limiter
+    // path entry, which is exactly the bug these tests exist to catch.
+    const blockedPaths = [
+      "/sign-in/email",
+      "/sign-up/email",
+      "/request-password-reset",
+      "/reset-password",
+      "/verify-password",
+      "/change-password",
+      "/admin/set-user-password",
+    ];
+
+    for (const path of blockedPaths) {
+      test(`refuses ${path} while basic auth is disabled`, async () => {
+        mockDisableBasicAuth.value = true;
+        try {
+          const ctx = createMockContext({ path, method: "POST", body: {} });
+
+          await expect(handleBeforeHook(ctx)).rejects.toThrow(APIError);
+          await expect(handleBeforeHook(ctx)).rejects.toMatchObject({
+            body: { message: expect.stringContaining("identity provider") },
+          });
+        } finally {
+          mockDisableBasicAuth.value = false;
+        }
+      });
+    }
+
+    test("still allows sign-out so a held session can always be ended", async () => {
+      mockDisableBasicAuth.value = true;
+      try {
+        const ctx = createMockContext({
+          path: "/sign-out",
+          method: "POST",
+          body: {},
+        });
+
+        await expect(handleBeforeHook(ctx)).resolves.not.toThrow();
+      } finally {
+        mockDisableBasicAuth.value = false;
+      }
+    });
+
+    test("leaves password sign-in alone when the flag is off", async () => {
+      const ctx = createMockContext({
+        path: "/sign-in/email",
+        method: "POST",
+        body: { email: "someone@example.com", password: "irrelevant" },
+      });
+
+      await expect(handleBeforeHook(ctx)).resolves.not.toThrow();
+    });
   });
 
   describe("two-factor enrollment enterprise gate", () => {

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -1173,12 +1173,22 @@ export async function handleBeforeHook(ctx: HookEndpointContext) {
   // must always be able to end it. Sessions belonging to users who have no
   // federated account are revoked at boot by revokeBasicAuthOnlySessions().
   if (config.auth.disableBasicAuth) {
+    // Verified against better-auth 1.6.22: api/routes/password.mjs declares
+    // /request-password-reset, /reset-password and /verify-password.
+    // "/forget-password" is NOT a route — it appears only in the rate-limiter's
+    // path list — so blocking it matched nothing and left reset-initiation open.
+    //
+    // /admin/create-user is deliberately absent: creating users stays valid on
+    // an SSO-only deployment, and its optional password is inert while
+    // /sign-in/email is closed.
     const passwordPaths = [
       "/sign-in/email",
       "/sign-up/email",
-      "/forget-password",
+      "/request-password-reset",
       "/reset-password",
+      "/verify-password",
       "/change-password",
+      "/admin/set-user-password",
     ];
     if (passwordPaths.some((blocked) => path.startsWith(blocked))) {
       logger.warn(

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -1164,6 +1164,34 @@ export async function handleBeforeHook(ctx: HookEndpointContext) {
     }
   }
 
+  // Close every password-based entry point when basic auth is disabled.
+  // The frontend already hides the sign-in form, but hiding a form is not a
+  // control — without this the endpoints still accept valid credentials, so
+  // "SSO only" would hold for the UI and not for the API.
+  //
+  // Sign-out is deliberately NOT blocked: people already holding a session
+  // must always be able to end it. Sessions belonging to users who have no
+  // federated account are revoked at boot by revokeBasicAuthOnlySessions().
+  if (config.auth.disableBasicAuth) {
+    const passwordPaths = [
+      "/sign-in/email",
+      "/sign-up/email",
+      "/forget-password",
+      "/reset-password",
+      "/change-password",
+    ];
+    if (passwordPaths.some((blocked) => path.startsWith(blocked))) {
+      logger.warn(
+        { path, method },
+        "[auth:beforeHook] blocked password endpoint — basic auth is disabled on this deployment",
+      );
+      throw new APIError("FORBIDDEN", {
+        message:
+          "Password sign-in is disabled on this deployment. Sign in with your identity provider.",
+      });
+    }
+  }
+
   // Block direct sign-up without invitation (invitation-only registration)
   if (path.startsWith("/sign-up/email") && method === "POST") {
     const callbackURL = body.callbackURL as string | undefined;

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -53,6 +53,7 @@ import {
 } from "@/agents/incoming-email";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { fastifyAuthPlugin } from "@/auth";
+import { revokeBasicAuthOnlySessions } from "@/auth/basic-auth-lockout";
 import { cacheManager } from "@/cache-manager";
 import config, {
   shouldRunRenderer,
@@ -1248,6 +1249,12 @@ const startWebServer = async () => {
     // SPDX-SnippetEnd
 
     await seedRequiredStartingData();
+
+    // With basic auth disabled, a password session that predates the flag
+    // would otherwise stay valid until it expired. Runs after seeding so the
+    // bootstrap admin exists first (and is itself swept when it has no
+    // federated account, which is the intent).
+    await revokeBasicAuthOnlySessions();
 
     // Sync system API keys for keyless providers (Vertex AI, vLLM, Ollama, Bedrock)
     const defaultOrg = await OrganizationModel.getFirst();


### PR DESCRIPTION
Turns on SSO-only sign-in for staging — and first makes the flag mean what its name says.

## The flag did not do what it claimed

It only hid the sign-in form. `emailAndPassword` is enabled unconditionally (`auth/better-auth.ts:297-299`) and no hook guarded the endpoints, so `POST /api/auth/sign-in/email` still accepted valid credentials. The flag was read in exactly three places — the frontend (hide the form), the password-reset script, and the require-2FA guard. Existing password sessions also survived it indefinitely, because nothing revoked them.

So "SSO only" held for the UI and not for the API, and not for anyone already signed in.

## 1. The password endpoints are closed

The before-hook now returns 403 for `/sign-in/email`, `/sign-up/email`, `/forget-password`, `/reset-password` and `/change-password` while the flag is on.

**`/sign-out` is deliberately left open** — anyone holding a session must always be able to end it.

## 2. Password sessions are revoked at boot

`revokeBasicAuthOnlySessions()` deletes the sessions of every user with **no non-credential account**.

The reasoning matters, because the obvious implementation is not available: **the `session` row records nothing about how it was created** — there is no provider column, so a password session cannot be told apart from an SSO one by inspection. What *can* be established is whether a user holds any federated account. If they do not, every session they have was necessarily obtained with a password, and the endpoints that could produce another are now closed.

That is what makes it safe to run on **every boot** rather than once behind a persisted marker: users with an SSO account are never touched, so deploys do not repeatedly sign people out, and users without one cannot create a new session for a later boot to sweep.

> [!NOTE]
> **Residual, stated rather than papered over:** a user holding *both* a credential and a federated account keeps their session even if it came from a password. Separating those requires recording the provider on the session at creation — a schema change, not a sweep. Such a user already has equivalent access through SSO, so the gap is small, but this is **not** "revoke every password session". There is a test pinning that behaviour so it stays visible instead of being mistaken for full coverage.

## 3. Staging turns it on

`ARCHESTRA_AUTH_DISABLE_BASIC_AUTH=true` in `values-staging.yaml`.

**Google is already configured and Enabled** on staging (verified in Settings → Identity Providers), so the SSO path exists before the password path closes. This is no longer gated on setup work.

## What to expect on deploy

- Anyone signed into staging with a password **is signed out** and must re-enter through Google. That includes the `ARCHESTRA_STAGING_AUTH_ADMIN_EMAIL` bootstrap admin, which has no federated account — intended, but worth knowing before the deploy rather than after.
- Existing users are matched to their accounts **by email**; account linking is on and configured IdPs are trusted (`better-auth.ts:306-313`), so people keep their roles rather than getting duplicates.
- Make sure **Allowed Email Domains** is set to `archestra.ai` on the Google provider. It is enforced server-side after Google returns the email, and it is what stops an arbitrary Google account linking to an existing user. The Hosted Domain Hint alone is only a picker preference.
- The require-two-factor org policy **cannot be enabled** while this is on (enrolment needs a password, so the API 400s). 2FA has to be enforced in Workspace instead.

## Tests

5 new tests on the sweep — flag off changes nothing; password-only users swept; federated users spared; the both-accounts residual pinned; and a mixed-population case proving only the right user is swept. Full `src/auth/` suite green (315 tests).