### PR TITLE
ci: cache backend workspace build for unit-test shards

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -128,3 +128,63 @@ jobs:
             --values .github/values-staging.yaml \
             --atomic \
             --timeout 15m
+
+  # Keeps the backend-unit-test shards' turbo cache warm for FRESH PR
+  # branches: Actions caches are only shared downward from the default
+  # branch, and the shards themselves never run on main. On an exact key hit
+  # (no backend-dep inputs changed — the overwhelmingly common case) this is
+  # a ~15s lookup; on a miss it rebuilds via the turbo remote cache and
+  # saves once. See the shard job in on-pull-requests.yml for the consumer.
+  warm-backend-build-cache:
+    name: Warm Backend Build Cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: on-commits-to-main-warm-backend-cache
+      cancel-in-progress: true
+    permissions:
+      contents: read # Checkout only; the product is an Actions cache entry.
+    defaults:
+      run:
+        working-directory: ./platform
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      # Key must stay identical to the shard job's restore key.
+      - name: Check for existing cache
+        id: turbo-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: platform/.turbo/cache
+          key: turbo-backend-${{ runner.os }}-${{ hashFiles('platform/pnpm-lock.yaml', 'platform/turbo.json', 'platform/shared/**', 'platform/archestra-rs/**') }}
+          lookup-only: true
+
+      - name: Setup environment
+        if: steps.turbo-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-env
+        with:
+          working-directory: ./platform
+
+      # Retry pattern mirrors the shard job (rustup race on cold cargo builds).
+      - name: Build backend workspace dependencies
+        if: steps.turbo-cache.outputs.cache-hit != 'true'
+        run: |
+          pnpm exec turbo build --filter="@backend^..." || {
+            echo "Build failed — syncing pinned Rust toolchain and retrying once..."
+            rustup show
+            pnpm exec turbo build --filter="@backend^..."
+          }
+
+      - name: Save cache
+        if: steps.turbo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: platform/.turbo/cache
+          key: ${{ steps.turbo-cache.outputs.cache-primary-key }}

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -589,11 +589,29 @@ jobs:
         with:
           working-directory: ./platform
 
+      # Measured on GitHub-hosted runners: without a local turbo cache the
+      # build step below spends 2m30s-3m22s PER SHARD downloading the same
+      # backend workspace artifacts from the turbo remote cache. Restoring
+      # turbo's local cache dir from the Actions cache turns that into a
+      # local replay. The key hashes the inputs of everything
+      # `--filter="@backend^..."` builds (the Rust NAPI crates and shared);
+      # the prefix restore-key falls back to the newest cache so only
+      # changed packages hit the network. Fresh PRs restore the entry saved
+      # by the warm-backend-build-cache job on main pushes.
+      - name: Restore turbo cache for backend workspace deps
+        id: turbo-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: platform/.turbo/cache
+          key: turbo-backend-${{ runner.os }}-${{ hashFiles('platform/pnpm-lock.yaml', 'platform/turbo.json', 'platform/shared/**', 'platform/archestra-rs/**') }}
+          restore-keys: |
+            turbo-backend-${{ runner.os }}-
+
       # Tests load the Rust NAPI bindings (@archestra/app-runtime-rs etc.),
       # which `turbo check:ci` builds implicitly via the task graph. Running
       # vitest directly skips that, so build backend's workspace deps here —
-      # turbo remote caching makes this seconds on a cache hit, and on a hit
-      # no cargo runs, so the pinned Rust toolchain isn't needed at all
+      # the turbo caches make this seconds on a hit, and on a hit no cargo
+      # runs, so the pinned Rust toolchain isn't needed at all
       # (an unconditional `rustup show` cost ~10s per shard). On a miss
       # (fork PRs run without cache secrets, so cargo really builds), turbo's
       # parallel crate builds each trigger a concurrent rustup download of
@@ -607,6 +625,16 @@ jobs:
             rustup show
             pnpm exec turbo build --filter="@backend^..."
           }
+
+      # One shard saves for all sixteen (identical content); the primary key
+      # from the restore step avoids re-hashing after the build wrote
+      # untracked files (cargo target dirs) into the hashed paths.
+      - name: Save turbo cache for backend workspace deps
+        if: matrix.shard == 1 && steps.turbo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: platform/.turbo/cache
+          key: ${{ steps.turbo-cache.outputs.cache-primary-key }}
 
       - name: Run backend unit tests (shard ${{ matrix.shard }} of 16)
         working-directory: ./platform/backend


### PR DESCRIPTION
Follow-up to #7049/#7052. Each backend shard paid 2m30s–3m22s of turbo remote-cache download before vitest ran — `actions/cache` on `platform/.turbo/cache` (keyed on the NAPI crates' + shared's inputs) turns that into a local replay. Shard 1 saves on miss; a small job on main pushes keeps the entry warm for fresh PR branches. Viable since the CodeQL trim freed the repo's 10 GB cache budget.

First run of this PR is the cold path (saves, doesn't restore); the second run measures the real effect. Expected: shard wall-clock ~10 min → ~6-7 min, bounded by the skewed vitest split.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>