### PR TITLE
ci: cache cargo target instead of turbo cache for backend shards

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -129,12 +129,15 @@ jobs:
             --atomic \
             --timeout 15m
 
-  # Keeps the backend-unit-test shards' turbo cache warm for FRESH PR
+  # Keeps the backend-unit-test shards' cargo cache warm for FRESH PR
   # branches: Actions caches are only shared downward from the default
-  # branch, and the shards themselves never run on main. On an exact key hit
-  # (no backend-dep inputs changed — the overwhelmingly common case) this is
-  # a ~15s lookup; on a miss it rebuilds via the turbo remote cache and
-  # saves once. See the shard job in on-pull-requests.yml for the consumer.
+  # branch, and the shards themselves never run on main. The NAPI crate
+  # builds are uncacheable in turbo (cache:false, platform-specific .node
+  # artifacts), so the shards depend on a warm cargo target dir instead —
+  # this job compiles the crates on main and saves the target dir under the
+  # same shared-key the shards restore. With a warm restore the build is an
+  # incremental no-op and the job takes ~1-2 min.
+  # See the shard job in on-pull-requests.yml for the consumer.
   warm-backend-build-cache:
     name: Warm Backend Build Cache
     runs-on: ubuntu-latest
@@ -157,34 +160,23 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      # Key must stay identical to the shard job's restore key.
-      - name: Check for existing cache
-        id: turbo-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # shared-key must stay identical to the shard job's.
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: platform/.turbo/cache
-          key: turbo-backend-${{ runner.os }}-${{ hashFiles('platform/pnpm-lock.yaml', 'platform/turbo.json', 'platform/shared/**', 'platform/archestra-rs/**') }}
-          lookup-only: true
+          workspaces: platform/archestra-rs
+          shared-key: backend-unit-tests
 
       - name: Setup environment
-        if: steps.turbo-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-env
         with:
           working-directory: ./platform
 
       # Retry pattern mirrors the shard job (rustup race on cold cargo builds).
       - name: Build backend workspace dependencies
-        if: steps.turbo-cache.outputs.cache-hit != 'true'
         run: |
           pnpm exec turbo build --filter="@backend^..." || {
             echo "Build failed — syncing pinned Rust toolchain and retrying once..."
             rustup show
             pnpm exec turbo build --filter="@backend^..."
           }
-
-      - name: Save cache
-        if: steps.turbo-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: platform/.turbo/cache
-          key: ${{ steps.turbo-cache.outputs.cache-primary-key }}

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -589,35 +589,29 @@ jobs:
         with:
           working-directory: ./platform
 
-      # Measured on GitHub-hosted runners: without a local turbo cache the
-      # build step below spends 2m30s-3m22s PER SHARD downloading the same
-      # backend workspace artifacts from the turbo remote cache. Restoring
-      # turbo's local cache dir from the Actions cache turns that into a
-      # local replay. The key hashes the inputs of everything
-      # `--filter="@backend^..."` builds (the Rust NAPI crates and shared);
-      # the prefix restore-key falls back to the newest cache so only
-      # changed packages hit the network. Fresh PRs restore the entry saved
-      # by the warm-backend-build-cache job on main pushes.
-      - name: Restore turbo cache for backend workspace deps
-        id: turbo-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # The NAPI package builds are deliberately uncacheable in turbo
+      # (turbo.json sets cache:false on them — the .node artifacts are
+      # platform-specific and the remote cache is shared with dev machines),
+      # so every shard really compiles the three Rust crates: measured at
+      # 2m30s-3m22s per shard on a cold 4vcpu runner. A warm cargo target
+      # dir turns that into an incremental no-op. All sixteen shards restore
+      # the same entry (shared-key); only shard 1 saves. Fresh PR branches
+      # restore the entry maintained by the warm-backend-build-cache job on
+      # main pushes (Actions caches only flow down from the default branch).
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: platform/.turbo/cache
-          key: turbo-backend-${{ runner.os }}-${{ hashFiles('platform/pnpm-lock.yaml', 'platform/turbo.json', 'platform/shared/**', 'platform/archestra-rs/**') }}
-          restore-keys: |
-            turbo-backend-${{ runner.os }}-
+          workspaces: platform/archestra-rs
+          shared-key: backend-unit-tests
+          save-if: ${{ matrix.shard == 1 }}
 
       # Tests load the Rust NAPI bindings (@archestra/app-runtime-rs etc.),
       # which `turbo check:ci` builds implicitly via the task graph. Running
-      # vitest directly skips that, so build backend's workspace deps here —
-      # the turbo caches make this seconds on a hit, and on a hit no cargo
-      # runs, so the pinned Rust toolchain isn't needed at all
-      # (an unconditional `rustup show` cost ~10s per shard). On a miss
-      # (fork PRs run without cache secrets, so cargo really builds), turbo's
-      # parallel crate builds each trigger a concurrent rustup download of
-      # the same toolchain, which races and fails with "could not rename
-      # downloaded file" — so on failure, sync the toolchain serially and
-      # retry once.
+      # vitest directly skips that, so build backend's workspace deps here.
+      # turbo's parallel crate builds each trigger a concurrent rustup
+      # download of the same pinned toolchain on a cold runner, which races
+      # and fails with "could not rename downloaded file" — so on failure,
+      # sync the toolchain serially and retry once.
       - name: Build backend workspace dependencies
         run: |
           pnpm exec turbo build --filter="@backend^..." || {
@@ -625,16 +619,6 @@ jobs:
             rustup show
             pnpm exec turbo build --filter="@backend^..."
           }
-
-      # One shard saves for all sixteen (identical content); the primary key
-      # from the restore step avoids re-hashing after the build wrote
-      # untracked files (cargo target dirs) into the hashed paths.
-      - name: Save turbo cache for backend workspace deps
-        if: matrix.shard == 1 && steps.turbo-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: platform/.turbo/cache
-          key: ${{ steps.turbo-cache.outputs.cache-primary-key }}
 
       - name: Run backend unit tests (shard ${{ matrix.shard }} of 16)
         working-directory: ./platform/backend


### PR DESCRIPTION
Follow-up to #7055 — its measurement showed the turbo-cache approach saves nothing: `turbo.json` deliberately sets `cache: false` on the NAPI crate builds (platform-specific `.node` artifacts, remote cache shared with dev machines), so every shard compiles the three Rust crates for real (`cache bypass, force executing`, 2m30s–3m22s per shard cold).

This swaps the useless turbo-dir cache for `Swatinem/rust-cache` on `platform/archestra-rs` with one shared key: all 16 shards restore it, shard 1 saves, and the main-push warm job maintains the entry for fresh PR branches. Warm target ⇒ the build step becomes an incremental no-op; expected shard wall-clock ~10 min → ~6–7 min (remaining floor is the skewed vitest file split).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>