### PR TITLE
fix: rename the account page to Personal Settings

### DIFF
--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -3,7 +3,7 @@ title: "Authentication"
 category: MCP
 order: 4
 description: "How authentication works for MCP clients and upstream MCP servers"
-lastUpdated: 2026-07-28
+lastUpdated: 2026-08-02
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -104,7 +104,7 @@ To restrict OAuth flows to pre-registered clients only, set `ARCHESTRA_AUTH_DCR_
 
 ### Bearer Token
 
-For direct API integrations, clients can authenticate using a static Bearer token with the header `Authorization: Bearer arch_<token>`. Tokens can be scoped to a specific user, team, or organization. Your personal token is on **Your Account** — click your name in the sidebar. Team tokens are on each team in **Settings > Teams**. The organization token is in **Settings > Organization**.
+For direct API integrations, clients can authenticate using a static Bearer token with the header `Authorization: Bearer arch_<token>`. Tokens can be scoped to a specific user, team, or organization. Your personal token is in **Personal Settings** — click your name in the sidebar. Team tokens are on each team in **Settings > Teams**. The organization token is in **Settings > Organization**.
 
 Bearer tokens authenticate the client to Archestra. They are not enterprise assertions by themselves. If Archestra also needs to exchange the matched user's IdP token and use the result on the downstream MCP request, it must still have a usable IdP token for that user.
 

--- a/docs/pages/platform-agent-triggers-webhook-a2a.md
+++ b/docs/pages/platform-agent-triggers-webhook-a2a.md
@@ -3,7 +3,7 @@ title: Webhook (A2A)
 category: Agents
 order: 9
 description: Invoke agents over HTTP using the A2A protocol
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-02
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -75,7 +75,7 @@ A2A validates the token the same way the [MCP gateway](/docs/mcp-authentication)
 
 | Method | Best for | Acting user | Notes |
 | --- | --- | --- | --- |
-| Bearer token | Direct API integrations and scripts | Personal tokens only | Static platform token from **Your Account** (personal — click your name in the sidebar), **Settings > Teams** (team), or **Settings > Organization** (org). Team and org tokens don't identify a single user. |
+| Bearer token | Direct API integrations and scripts | Personal tokens only | Static platform token from **Personal Settings** (personal — click your name in the sidebar), **Settings > Teams** (team), or **Settings > Organization** (org). Team and org tokens don't identify a single user. |
 | External IdP JWT (JWKS) | Callers signed in through a corporate identity provider | Yes | Bind the agent to an [identity provider](/docs/platform-identity-providers) in its settings; the caller then presents their IdP's JWT directly and Archestra resolves the user — no Archestra token to hand out. |
 | OAuth client credentials | Backend services and machine-to-machine callers | No | Register an [OAuth client](/docs/mcp-authentication) and add the agent to its allowed list. |
 | OAuth authorization code | An app acting for whoever is signed in | Yes | A confidential OAuth client that resolves the individual user. |

--- a/docs/pages/platform-api-reference.md
+++ b/docs/pages/platform-api-reference.md
@@ -3,7 +3,7 @@ title: "API Reference"
 category: Archestra Platform
 description: "Interactive API documentation for Archestra"
 order: 6
-lastUpdated: 2026-07-20
+lastUpdated: 2026-08-02
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -16,7 +16,7 @@ Use a personal API key or service account token in the `Authorization` header.
 
 ### Personal API Keys
 
-Personal API keys are owned by one user. Create them in the API Keys section on **Your Account** — click your name in the sidebar. They use the owner's current role, so permission changes to that user immediately affect the key.
+Personal API keys are owned by one user. Create them in the API Keys section in **Personal Settings** — click your name in the sidebar. They use the owner's current role, so permission changes to that user immediately affect the key.
 
 Use personal keys for local scripts, development tools, and user-owned automation.
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -561,7 +561,7 @@ MCP server pods are protected from SSRF automatically: each pod's egress is conf
 
 ## Infrastructure as Code
 
-Manage Archestra resources from Terraform or Crossplane. Both use the same API key — mint one in the API Keys section on Your Account (click your name in the sidebar) (see [API Reference](/docs/platform-api-reference#authentication)).
+Manage Archestra resources from Terraform or Crossplane. Both use the same API key — mint one in the API Keys section in Personal Settings (click your name in the sidebar) (see [API Reference](/docs/platform-api-reference#authentication)).
 
 ### Terraform
 

--- a/docs/pages/platform-reset-user-password.md
+++ b/docs/pages/platform-reset-user-password.md
@@ -3,7 +3,7 @@ title: "Password Reset"
 category: Administration
 description: "Reset any user's password from the shell when there is no email-based recovery"
 order: 5
-lastUpdated: 2026-07-20
+lastUpdated: 2026-08-02
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -37,7 +37,7 @@ docker exec -it <container> sh -c 'cd /app/backend && \
   node dist/standalone-scripts/reset-user-password.mjs --email user@example.com'
 ```
 
-Omit `--password` and the tool generates a strong random password and prints it once. It is not stored anywhere else, so copy it before closing the shell. The user should sign in and change it on Your Account — click your name in the sidebar.
+Omit `--password` and the tool generates a strong random password and prints it once. It is not stored anywhere else, so copy it before closing the shell. The user should sign in and change it in Personal Settings — click your name in the sidebar.
 
 ## Options
 
@@ -77,6 +77,6 @@ To avoid this, verify at least one SSO provider works before you disable basic a
 
 Acme runs Archestra for its data team.
 
-A member, Jordan, forgets their password. Jordan asks an administrator to reset it. The administrator opens a shell on the backend container and runs the tool with `--email jordan@acme.example`, leaving off `--password`. The tool prints a random password, which the administrator shares with Jordan over a secure channel. Jordan signs in, changes the password on Your Account, and the earlier sign-in attempts are already dead because every session was revoked.
+A member, Jordan, forgets their password. Jordan asks an administrator to reset it. The administrator opens a shell on the backend container and runs the tool with `--email jordan@acme.example`, leaving off `--password`. The tool prints a random password, which the administrator shares with Jordan over a secure channel. Jordan signs in, changes the password in Personal Settings, and the earlier sign-in attempts are already dead because every session was revoked.
 
 Months later Acme enables SSO and sets `ARCHESTRA_AUTH_DISABLE_BASIC_AUTH`. The identity provider's certificate expires over a weekend, and no administrator can sign in. An operator with cluster access runs the tool against their own account, unsets `ARCHESTRA_AUTH_DISABLE_BASIC_AUTH`, signs in with the printed password, and renews the SSO certificate. Once SSO works again, they re-disable basic auth.

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -44,7 +44,7 @@ Load these project skills when the task matches their domain:
 - **Chat**: <http://localhost:3000/chat> (n8n expert chat with MCP tools, conversations in main sidebar)
 - **Tools**: <http://localhost:3000/tools> (Unified tools management with server-side pagination)
 - **Settings**: <http://localhost:3000/settings> (lands on the first permitted tab; tabs: Organization, Service Accounts, Chat, LLM, MCP, Security, Knowledge, Environments, Users, Teams, Roles, GitHub, Identity Providers, Secrets)
-- **Your Account**: <http://localhost:3000/account> (personal profile, API keys, gateway token, sessions; opened by clicking your name in the sidebar)
+- **Personal Settings**: <http://localhost:3000/account> (personal profile, API keys, gateway token, sessions; opened by clicking your name in the sidebar)
 - **MCP Registry**: <http://localhost:3000/mcp/registry> (Install and manage MCP servers)
 - **MCP Installation Requests**: <http://localhost:3000/mcp/registry/installation-requests> (View/manage server installation requests)
 - **LLM Proxy Logs**: <http://localhost:3000/llm/logs> (View LLM proxy request logs)

--- a/platform/frontend/src/app/_parts/sidebar-user-menu.test.tsx
+++ b/platform/frontend/src/app/_parts/sidebar-user-menu.test.tsx
@@ -72,7 +72,7 @@ describe("SidebarUserMenu", () => {
     await user.click(trigger);
 
     expect(
-      await screen.findByRole("menuitem", { name: /Ada Lovelace/ }),
+      await screen.findByRole("menuitem", { name: /personal settings/i }),
     ).toHaveAttribute("href", "/account");
     expect(screen.getByRole("menuitem", { name: /sign out/i })).toHaveAttribute(
       "href",

--- a/platform/frontend/src/app/_parts/sidebar-user-menu.tsx
+++ b/platform/frontend/src/app/_parts/sidebar-user-menu.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ChevronsUpDown, LogOut, Monitor, Moon, Sun } from "lucide-react";
+import {
+  ChevronsUpDown,
+  LogOut,
+  Monitor,
+  Moon,
+  Settings,
+  Sun,
+} from "lucide-react";
 import Link from "next/link";
 import { useTheme } from "next-themes";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -16,9 +23,9 @@ import { useSession } from "@/lib/auth/auth.query";
 import { cn } from "@/lib/utils";
 
 /**
- * Sidebar footer user menu: avatar + name/email trigger. The identity item
- * opens the account page; below it sit the theme switcher and Sign Out.
- * Renders nothing until a session exists.
+ * Sidebar footer user menu: avatar + name/email trigger. The Personal
+ * Settings item opens the account page; below it sit the theme switcher and
+ * Sign Out. Renders nothing until a session exists.
  *
  * The trigger markup (button > div > Avatar + text, chevron as direct svg
  * child) is load-bearing: the collapsed-sidebar styles in sidebar.tsx target
@@ -73,14 +80,8 @@ export function SidebarUserMenu() {
       >
         <DropdownMenuItem asChild>
           <Link href="/account">
-            <div className="min-w-0">
-              <div className="truncate text-sm font-medium">{displayName}</div>
-              {user.name && (
-                <div className="truncate text-xs font-normal text-muted-foreground">
-                  {user.email}
-                </div>
-              )}
-            </div>
+            <Settings className="size-4" />
+            Personal Settings
           </Link>
         </DropdownMenuItem>
         <DropdownMenuSeparator />

--- a/platform/frontend/src/app/account/page.tsx
+++ b/platform/frontend/src/app/account/page.tsx
@@ -35,7 +35,7 @@ function AccountContent() {
 
   return (
     <PageLayout
-      title="Your Account"
+      title="Personal Settings"
       description="Manage your personal profile, API keys, sessions, and sign-in settings."
       actionButton={
         showChangePasswordButton ? (

--- a/platform/frontend/src/app/connection/mcp-client-instructions.tsx
+++ b/platform/frontend/src/app/connection/mcp-client-instructions.tsx
@@ -499,7 +499,7 @@ export function GenericAuthRow({
           href="/account?highlight=personal-token"
           className="underline hover:text-foreground"
         >
-          your account
+          Personal Settings
         </Link>
         .
       </div>


### PR DESCRIPTION
## Summary
- T-947: the sidebar user menu showed your name twice — on the trigger and again as the first dropdown item linking to /account. That item is now a **Personal Settings** link with a settings icon.
- The /account page title changes from "Your Account" to "Personal Settings"; the empty-token hint on the connection page and the docs references (deployment, API reference, MCP authentication, agent triggers, password reset) follow the new name, as does the CLAUDE.md URL list.

## Testing
- `sidebar-user-menu.test.tsx` updated to find the menu item by its new name; frontend vitest run passes.
- Biome check on changed files and frontend `tsc --noEmit` pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>