### PR TITLE
fix: address recurring production error hotspots across the proxy and pre-auth hot paths

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -79573,8 +79573,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -79957,8 +79956,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -122672,8 +122670,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -123056,8 +123053,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -136881,8 +136877,7 @@
                                           },
                                           "required": [
                                             "object",
-                                            "embedding",
-                                            "index"
+                                            "embedding"
                                           ],
                                           "additionalProperties": false
                                         }
@@ -137579,8 +137574,7 @@
                                           },
                                           "required": [
                                             "object",
-                                            "embedding",
-                                            "index"
+                                            "embedding"
                                           ],
                                           "additionalProperties": false
                                         }
@@ -138277,8 +138271,7 @@
                                           },
                                           "required": [
                                             "object",
-                                            "embedding",
-                                            "index"
+                                            "embedding"
                                           ],
                                           "additionalProperties": false
                                         }
@@ -167710,8 +167703,7 @@
                                     },
                                     "required": [
                                       "object",
-                                      "embedding",
-                                      "index"
+                                      "embedding"
                                     ],
                                     "additionalProperties": false
                                   }
@@ -168408,8 +168400,7 @@
                                     },
                                     "required": [
                                       "object",
-                                      "embedding",
-                                      "index"
+                                      "embedding"
                                     ],
                                     "additionalProperties": false
                                   }
@@ -169106,8 +169097,7 @@
                                     },
                                     "required": [
                                       "object",
-                                      "embedding",
-                                      "index"
+                                      "embedding"
                                     ],
                                     "additionalProperties": false
                                   }
@@ -245796,8 +245786,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -246180,8 +246169,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -248892,8 +248880,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -249276,8 +249263,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -251536,8 +251522,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -251920,8 +251905,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -254253,8 +254237,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -254637,8 +254620,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -316803,8 +316785,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -317187,8 +317168,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -318697,8 +318677,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }
@@ -319081,8 +319060,7 @@
                         },
                         "required": [
                           "object",
-                          "embedding",
-                          "index"
+                          "embedding"
                         ],
                         "additionalProperties": false
                       }

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -776,6 +776,28 @@ describe("IdentityProviderModel", () => {
       expect(providerIds).toContain("Google");
       expect(providerIds).toContain("GitHub");
     });
+
+    test("serves the process-local cache until a provider write invalidates it", async ({
+      makeOrganization,
+      makeIdentityProvider,
+    }) => {
+      const org = await makeOrganization();
+      const provider = await makeIdentityProvider(org.id, {
+        providerId: "Okta",
+      });
+
+      // Prime the cache, then insert behind the model's back: the cached
+      // list must be served (that's the point of the cache)...
+      expect(await IdentityProviderModel.findAllPublic()).toHaveLength(1);
+      await makeIdentityProvider(org.id, { providerId: "Google" });
+      expect(await IdentityProviderModel.findAllPublic()).toHaveLength(1);
+
+      // ...while a write through the model must invalidate, so the login
+      // page reflects provider changes immediately on this pod.
+      await IdentityProviderModel.delete(provider.id, org.id);
+      const fresh = await IdentityProviderModel.findAllPublic();
+      expect(fresh.map((p) => p.providerId)).toEqual(["Google"]);
+    });
   });
 
   describe("getTrustedAccountLinkingProviderIds", () => {

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -73,6 +73,21 @@ class IdentityProviderModel {
   );
 
   /**
+   * Process-local cache for {@link findAllPublic}. Backs the unauthenticated
+   * SSO-provider list the login page fetches on every render, so without a
+   * cache each login-page view costs a database query for a list that only
+   * changes when an admin edits identity providers. Same invalidation story
+   * as {@link trustedProviderIdsCache}: writes in this process clear it
+   * immediately; other pods converge within the TTL.
+   */
+  private static readonly publicProvidersCache = registerProcessLocalCache(
+    new LRUCacheManager<PublicIdentityProvider[]>({
+      maxSize: 1,
+      defaultTtl: TimeInMs.Minute,
+    }),
+  );
+
+  /**
    * Evaluates role mapping rules against SSO user data using Handlebars templates.
    *
    * @example
@@ -485,6 +500,13 @@ class IdentityProviderModel {
    * Does NOT expose any sensitive configuration data.
    */
   static async findAllPublic(): Promise<PublicIdentityProvider[]> {
+    const cached = IdentityProviderModel.publicProvidersCache.get(
+      PUBLIC_PROVIDERS_CACHE_KEY,
+    );
+    if (cached) {
+      return cached;
+    }
+
     const idpProviders = await db
       .select({
         id: schema.identityProvidersTable.id,
@@ -493,6 +515,10 @@ class IdentityProviderModel {
       .from(schema.identityProvidersTable)
       .where(eq(schema.identityProvidersTable.ssoLoginEnabled, true));
 
+    IdentityProviderModel.publicProvidersCache.set(
+      PUBLIC_PROVIDERS_CACHE_KEY,
+      idpProviders,
+    );
     return idpProviders;
   }
 
@@ -754,6 +780,7 @@ class IdentityProviderModel {
     }
 
     IdentityProviderModel.trustedProviderIdsCache.clear();
+    IdentityProviderModel.publicProvidersCache.clear();
 
     return {
       ...updatedProvider,
@@ -835,6 +862,7 @@ class IdentityProviderModel {
     if (!updatedProvider) return null;
 
     IdentityProviderModel.trustedProviderIdsCache.clear();
+    IdentityProviderModel.publicProvidersCache.clear();
 
     return {
       ...updatedProvider,
@@ -899,6 +927,7 @@ class IdentityProviderModel {
     });
 
     IdentityProviderModel.trustedProviderIdsCache.clear();
+    IdentityProviderModel.publicProvidersCache.clear();
 
     return true;
   }
@@ -996,6 +1025,7 @@ export default IdentityProviderModel;
 const OIDC_DISCOVERY_TIMEOUT_MS = 10_000;
 const SSO_REGISTRATION_PLACEHOLDER_DOMAIN = "sso-placeholder.example.com";
 const TRUSTED_PROVIDER_IDS_CACHE_KEY = "trusted-provider-ids";
+const PUBLIC_PROVIDERS_CACHE_KEY = "public-providers";
 
 function serializeConfigValue(
   value: string | object | null | undefined,

--- a/platform/backend/src/models/organization.test.ts
+++ b/platform/backend/src/models/organization.test.ts
@@ -60,6 +60,28 @@ describe("OrganizationModel", () => {
       });
     });
 
+    test("serves the process-local cache until patch invalidates it", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+
+      // Prime the cache, then change the row behind the model's back: the
+      // cached value must be served (that's the point of the cache)...
+      const before = await OrganizationModel.getAppearanceSettings();
+      await db
+        .update(schema.organizationsTable)
+        .set({ theme: "twitter" })
+        .where(eq(schema.organizationsTable.id, org.id));
+      const cached = await OrganizationModel.getAppearanceSettings();
+      expect(cached.theme).toBe(before.theme);
+
+      // ...while a write through patch (the appearance update path) must
+      // invalidate, so the next read reflects the new settings immediately.
+      await OrganizationModel.patch(org.id, { theme: "claude" });
+      const fresh = await OrganizationModel.getAppearanceSettings();
+      expect(fresh.theme).toBe("claude");
+    });
+
     test("should return custom theme when set", async ({
       makeOrganization,
     }) => {

--- a/platform/backend/src/models/organization.ts
+++ b/platform/backend/src/models/organization.ts
@@ -4,11 +4,13 @@ import {
   MEMBER_ROLE_NAME,
   type OrganizationCustomFont,
   type SupportedProvider,
+  TimeInMs,
 } from "@archestra/shared";
 import { and, eq, isNull } from "drizzle-orm";
-import { CacheKey, cacheManager } from "@/cache-manager";
+import { CacheKey, cacheManager, LRUCacheManager } from "@/cache-manager";
 import db, { schema } from "@/database";
 import logger from "@/logging";
+import { registerProcessLocalCache } from "@/process-local-cache-registry";
 import type {
   AppearanceSettings,
   NetworkPolicy,
@@ -17,6 +19,22 @@ import type {
 } from "@/types";
 
 class OrganizationModel {
+  /**
+   * Process-local cache for {@link getAppearanceSettings}. The appearance
+   * settings back white-labeling on the unauthenticated login page (and every
+   * subsequent page load), so without a cache each page view costs a database
+   * query for a row that only changes when an admin edits appearance. Being
+   * process-local (not the Postgres-backed cacheManager) it also keeps the
+   * hot path off the database connection pool entirely. Writes in this
+   * process clear it immediately; other pods converge within the TTL.
+   */
+  private static readonly appearanceSettingsCache = registerProcessLocalCache(
+    new LRUCacheManager<AppearanceSettings>({
+      maxSize: 1,
+      defaultTtl: TimeInMs.Minute,
+    }),
+  );
+
   /**
    * Get the first organization in the database (fallback for various operations)
    */
@@ -185,6 +203,7 @@ class OrganizationModel {
     );
     await cacheManager.delete(getOrganizationSettingsCacheKey(id));
     await cacheManager.delete(getOrganizationAuthEnforcementCacheKey(id));
+    OrganizationModel.appearanceSettingsCache.clear();
     return updatedOrganization || null;
   }
 
@@ -430,10 +449,18 @@ class OrganizationModel {
   }
 
   /**
-   * Get appearance settings
+   * Get appearance settings, cached process-locally for the unauthenticated
+   * white-labeling hot path (login page, every page load).
    * Returns default appearance settings if no organization exists.
    */
   static async getAppearanceSettings(): Promise<AppearanceSettings> {
+    const cached = OrganizationModel.appearanceSettingsCache.get(
+      APPEARANCE_SETTINGS_CACHE_KEY,
+    );
+    if (cached) {
+      return cached;
+    }
+
     const [organization] = await db
       .select({
         theme: schema.organizationsTable.theme,
@@ -478,6 +505,10 @@ class OrganizationModel {
       };
     }
 
+    OrganizationModel.appearanceSettingsCache.set(
+      APPEARANCE_SETTINGS_CACHE_KEY,
+      organization,
+    );
     return organization;
   }
 
@@ -577,6 +608,9 @@ class OrganizationModel {
   }
 }
 export default OrganizationModel;
+
+/** Single-org table (`limit 1` read), so one fixed key is enough. */
+const APPEARANCE_SETTINGS_CACHE_KEY = "appearance-settings";
 
 function getOrganizationSettingsCacheKey(organizationId: string) {
   return `${CacheKey.OrganizationSettings}-${organizationId}` as const;

--- a/platform/backend/src/routes/proxy/adapters/cohere.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere.ts
@@ -29,6 +29,7 @@ import {
 } from "@/types";
 import type { ToolCompressionStats as CompressionStats } from "../utils/toon-conversion";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
+import { upstreamHttpError } from "./upstream-http-error";
 
 // =============================================================================
 // TYPE ALIASES
@@ -893,8 +894,9 @@ function createCohereClient(
 
         if (!response.ok) {
           const errorText = await response.text();
-          throw new Error(
+          throw upstreamHttpError(
             `Cohere API error: ${response.status} - ${errorText}`,
+            response.status,
           );
         }
 
@@ -915,8 +917,9 @@ function createCohereClient(
 
         if (!response.ok) {
           const errorText = await response.text();
-          throw new Error(
+          throw upstreamHttpError(
             `Error from Cohere API : ${response.status} - ${errorText}`,
+            response.status,
           );
         }
 

--- a/platform/backend/src/routes/proxy/adapters/minimax.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/minimax.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, vi } from "vitest";
 import { describe, expect, test } from "@/test";
 import type { Minimax } from "@/types/llm-providers";
 import { minimaxAdapterFactory } from "./minimax";
@@ -287,5 +288,37 @@ describe("MinimaxRequestAdapter reasoning_split", () => {
       .toProviderRequest() as Record<string, unknown>;
 
     expect(request.reasoning_split).toBe(false);
+  });
+});
+
+describe("MinimaxClient upstream HTTP errors", () => {
+  // Stubs auto-revert after each test; re-apply per test via beforeEach.
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("rate limited", { status: 429 })),
+    );
+  });
+
+  test("attaches the provider's HTTP status to the thrown error", async () => {
+    const client = minimaxAdapterFactory.createClient(undefined, {
+      source: "api",
+    });
+
+    let thrown: unknown;
+    try {
+      await minimaxAdapterFactory.execute(client, {
+        model: "MiniMax-M2.5",
+        messages: [],
+      } as unknown as Minimax.Types.ChatCompletionsRequest);
+    } catch (error) {
+      thrown = error;
+    }
+
+    // The status must live on the error as a number — the proxy error
+    // boundary relays it to the client; without it a provider 429
+    // surfaced as a 500 and was reported as a crash of ours.
+    expect((thrown as Error & { status?: number }).status).toBe(429);
+    expect((thrown as Error).message).toContain("429");
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/minimax.ts
+++ b/platform/backend/src/routes/proxy/adapters/minimax.ts
@@ -27,6 +27,7 @@ import {
 import type { Minimax } from "@/types/llm-providers";
 import type { ToolCompressionStats } from "../utils/toon-conversion";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
+import { upstreamHttpError } from "./upstream-http-error";
 
 // =============================================================================
 // TYPE ALIASES
@@ -91,7 +92,7 @@ class MinimaxClient {
         errorMessage += ` - ${errorText}`;
       }
 
-      throw new Error(errorMessage);
+      throw upstreamHttpError(errorMessage, response.status);
     }
 
     return response.json() as Promise<MinimaxResponse>;
@@ -115,8 +116,9 @@ class MinimaxClient {
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(
+      throw upstreamHttpError(
         `MiniMax streaming error: ${response.status} - ${errorText}`,
+        response.status,
       );
     }
 

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -1073,7 +1073,10 @@ export class OpenAIStreamAdapter
       };
     }
 
-    const choice = chunk.choices[0];
+    // `choices` can be entirely absent (not just empty) on some
+    // OpenAI-compatible upstreams' usage-only or error-shaped chunks —
+    // reading [0] off it unguarded is a crash.
+    const choice = chunk.choices?.[0];
     if (!choice) {
       // If we have usage, this is the final chunk (OpenAI sends usage in a chunk with empty choices)
       return {

--- a/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
@@ -69,6 +69,26 @@ describe("OpenrouterResponseAdapter", () => {
 
     expect(adapter.getText()).toBe("hello");
   });
+
+  test("surfaces an error-shaped payload without choices as a typed upstream failure, not a TypeError", () => {
+    // OpenRouter can return HTTP 200 with an error body and no `choices`
+    // array at all; reading choices[0] off it unguarded crashed with
+    // "Cannot read properties of undefined (reading '0')".
+    const response = {
+      error: { message: "Provider returned error", code: 502 },
+    } as unknown as Openrouter.Types.ChatCompletionsResponse;
+
+    let thrown: unknown;
+    try {
+      openrouterAdapterFactory.createResponseAdapter(response);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).statusCode).toBe(502);
+    expect((thrown as Error).message).toBe("Provider returned error");
+  });
 });
 
 describe("OpenrouterStreamAdapter", () => {
@@ -91,6 +111,20 @@ describe("OpenrouterStreamAdapter", () => {
     }
 
     expectRetryableEmptyResponseError(thrown);
+  });
+
+  test("tolerates a streamed chunk without a choices array", () => {
+    const adapter = openrouterAdapterFactory.createStreamAdapter();
+
+    const usageOnlyChunk = {
+      id: "chatcmpl-test",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "openrouter/free-model",
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    } as unknown as Openrouter.Types.ChatCompletionChunk;
+
+    expect(() => adapter.processChunk(usageOnlyChunk)).not.toThrow();
   });
 
   test("allows streamed stop responses after text", () => {

--- a/platform/backend/src/routes/proxy/adapters/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.ts
@@ -324,7 +324,9 @@ export const openrouterAdapterFactory: LLMProvider<
 };
 
 function assertOpenrouterResponseHasOutput(response: OpenrouterResponse): void {
-  const choice = response.choices[0];
+  // OpenRouter deviates from the OpenAI schema on some error/edge payloads
+  // and omits `choices` entirely — reading [0] off it unguarded is a crash.
+  const choice = response.choices?.[0];
   if (!choice || choice.finish_reason !== "stop") {
     return;
   }
@@ -346,7 +348,7 @@ function assertOpenrouterStreamChunkHasOutput(
   state: StreamAccumulatorState,
   chunk: OpenrouterStreamChunk,
 ): void {
-  if (chunk.choices[0]?.finish_reason !== "stop") {
+  if (chunk.choices?.[0]?.finish_reason !== "stop") {
     return;
   }
 

--- a/platform/backend/src/routes/proxy/adapters/upstream-http-error.ts
+++ b/platform/backend/src/routes/proxy/adapters/upstream-http-error.ts
@@ -1,0 +1,22 @@
+/**
+ * Build the error thrown for a non-OK HTTP response from an upstream
+ * provider, for the fetch-based adapters that don't go through a provider
+ * SDK (the SDKs attach the HTTP status themselves).
+ *
+ * The status must live on the error as a number, not just in the message
+ * text: the proxy's error boundary (`handleError` in llm-proxy-helpers)
+ * reads `status` to relay the provider's real HTTP code — without it a
+ * provider 429/503 surfaces as a 500 and gets reported to error tracking
+ * as a crash of ours instead of being classified as an expected
+ * client/upstream failure. The `error` payload gives the boundary the
+ * provider-error shape it uses to mark 5xx relays as upstream faults.
+ */
+export function upstreamHttpError(
+  message: string,
+  status: number,
+): Error & { status: number; error: { message: string } } {
+  return Object.assign(new Error(message), {
+    status,
+    error: { message },
+  });
+}

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.ts
@@ -30,6 +30,7 @@ import {
   extractCommonToolCallArguments,
 } from "@/types";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
+import { upstreamHttpError } from "./upstream-http-error";
 
 // =============================================================================
 // TYPE ALIASES
@@ -96,7 +97,7 @@ class ZhipuaiClient {
         errorMessage += ` - ${errorText}`;
       }
 
-      throw new Error(errorMessage);
+      throw upstreamHttpError(errorMessage, response.status);
     }
 
     return response.json() as Promise<ZhipuaiResponse>;
@@ -140,7 +141,7 @@ class ZhipuaiClient {
         errorMessage += ` - ${errorText}`;
       }
 
-      throw new Error(errorMessage);
+      throw upstreamHttpError(errorMessage, response.status);
     }
 
     return this.parseSSEStream(response);

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -78,6 +78,7 @@ vi.mock("@/observability");
 
 // Import after mocks
 import { metrics } from "@/observability";
+import { upstreamHttpError } from "./adapters/upstream-http-error";
 import {
   buildInteractionRecord,
   calculateInteractionCosts,
@@ -730,6 +731,43 @@ describe("handleError", () => {
     expect(throwStatusFor(new TypeError("cannot read x of undefined"))).toBe(
       500,
     );
+  });
+
+  // The fetch-based adapters (Cohere, MiniMax, Zhipu) throw upstreamHttpError
+  // for non-OK responses. The attached status must reach the client (a
+  // provider 429 relays as 429, not 500), and a provider 5xx must be marked
+  // upstream so error tracking drops the relay as expected noise.
+  test("relays a provider 429 thrown as upstreamHttpError with its own status and body", () => {
+    const rateLimited = upstreamHttpError(
+      "Error from Cohere API : 429 - trial key limit",
+      429,
+    );
+
+    const { reply, sent } = makeReply(false);
+    handleError(rateLimited, reply, extractMessage, false, () => undefined);
+
+    expect(sent.statusCode).toBe(429);
+    expect(sent.body).toEqual({
+      error: { message: "Error from Cohere API : 429 - trial key limit" },
+    });
+  });
+
+  test("marks a provider 5xx thrown as upstreamHttpError as an upstream failure", () => {
+    const providerDown = upstreamHttpError(
+      "MiniMax API error: 503 Service Unavailable",
+      503,
+    );
+
+    const { reply } = makeReply(false);
+    let thrown: unknown;
+    try {
+      handleError(providerDown, reply, extractMessage, false, () => undefined);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect((thrown as ApiError).statusCode).toBe(503);
+    expect((thrown as ApiError).upstream).toBe(true);
   });
 
   test("classifies a downstream client abort as a 499", () => {

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -104,7 +104,10 @@ const EmbeddingInteractionResponseSchema =
       z.object({
         object: z.literal("embedding"),
         embedding: z.array(z.number()),
-        index: z.number(),
+        // Optional for the same reason as the canonical embedding schema: a
+        // stored interaction from an OpenAI-compatible upstream that omitted
+        // `index` must not fail the whole interaction list on read-back.
+        index: z.number().optional(),
         truncatedFrom: z.number().optional(),
       }),
     ),

--- a/platform/backend/src/types/llm-providers/openai/api.ts
+++ b/platform/backend/src/types/llm-providers/openai/api.ts
@@ -273,7 +273,11 @@ export const EmbeddingResponseSchema = z.object({
     z.object({
       object: z.literal("embedding"),
       embedding: z.array(z.number()),
-      index: z.number(),
+      // OpenAI itself always sends `index`, but the openai routes also front
+      // arbitrary OpenAI-compatible upstreams via custom base URLs, and a
+      // deviating upstream that omits it would fail response serialization
+      // (500). Tolerated like ChoiceSchema.index above.
+      index: z.number().optional(),
     }),
   ),
   model: z.string(),

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -22841,7 +22841,7 @@ export type AzureEmbeddingsWithDefaultAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -22951,7 +22951,7 @@ export type AzureEmbeddingsWithAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -33889,7 +33889,7 @@ export type GeminiEmbeddingsWithDefaultAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -33999,7 +33999,7 @@ export type GeminiEmbeddingsWithAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -37998,7 +37998,7 @@ export type GetInteractionsResponses = {
                 data: Array<{
                     object: 'embedding';
                     embedding: Array<number>;
-                    index: number;
+                    index?: number;
                     truncatedFrom?: number;
                 }>;
                 model: string;
@@ -38109,7 +38109,7 @@ export type GetInteractionsResponses = {
                 data: Array<{
                     object: 'embedding';
                     embedding: Array<number>;
-                    index: number;
+                    index?: number;
                     truncatedFrom?: number;
                 }>;
                 model: string;
@@ -38220,7 +38220,7 @@ export type GetInteractionsResponses = {
                 data: Array<{
                     object: 'embedding';
                     embedding: Array<number>;
-                    index: number;
+                    index?: number;
                     truncatedFrom?: number;
                 }>;
                 model: string;
@@ -44225,7 +44225,7 @@ export type GetInteractionResponses = {
             data: Array<{
                 object: 'embedding';
                 embedding: Array<number>;
-                index: number;
+                index?: number;
                 truncatedFrom?: number;
             }>;
             model: string;
@@ -44336,7 +44336,7 @@ export type GetInteractionResponses = {
             data: Array<{
                 object: 'embedding';
                 embedding: Array<number>;
-                index: number;
+                index?: number;
                 truncatedFrom?: number;
             }>;
             model: string;
@@ -44447,7 +44447,7 @@ export type GetInteractionResponses = {
             data: Array<{
                 object: 'embedding';
                 embedding: Array<number>;
-                index: number;
+                index?: number;
                 truncatedFrom?: number;
             }>;
             model: string;
@@ -62844,7 +62844,7 @@ export type MistralEmbeddingsWithDefaultAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -62954,7 +62954,7 @@ export type MistralEmbeddingsWithAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -63766,7 +63766,7 @@ export type ModelRouterEmbeddingsWithDefaultAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -63876,7 +63876,7 @@ export type ModelRouterEmbeddingsWithAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -64583,7 +64583,7 @@ export type OllamaEmbeddingsWithDefaultAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -64693,7 +64693,7 @@ export type OllamaEmbeddingsWithAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -65407,7 +65407,7 @@ export type OpenAiEmbeddingsWithDefaultAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -65517,7 +65517,7 @@ export type OpenAiEmbeddingsWithAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -82126,7 +82126,7 @@ export type VllmEmbeddingsWithDefaultAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -82236,7 +82236,7 @@ export type VllmEmbeddingsWithAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -82712,7 +82712,7 @@ export type ZhipuaiEmbeddingsWithDefaultAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {
@@ -82822,7 +82822,7 @@ export type ZhipuaiEmbeddingsWithAgentResponses = {
         data: Array<{
             object: 'embedding';
             embedding: Array<number>;
-            index: number;
+            index?: number;
         }>;
         model: string;
         usage: {


### PR DESCRIPTION
A sweep of the currently-recurring production error hotspots. Four independent slices:

## 1. Fetch-based provider adapters lose the upstream HTTP status (`bc9b172`)

The Cohere, MiniMax, and Zhipu clients threw plain `Error`s with the provider's status embedded only in the message text (`"Error from Cohere API : 429 - …"`). The proxy's error boundary never saw a numeric status, so a provider 429/503 surfaced to callers as a 500 — and got reported as a crash of ours instead of being classified as an expected client/upstream failure. These relays were among the highest-volume recurring errors across customer instances.

`upstreamHttpError` (new, shared by the three adapters) attaches the status as a number plus a provider-error payload, so the boundary relays the provider's real code and marks 5xx relays as upstream faults. Behavior pinned in `llm-proxy-helpers.test.ts` (429 passthrough body + status; 503 marked `upstream`) and `minimax.test.ts` (adapter attaches status end-to-end through a stubbed fetch).

## 2. `choices[0]` TypeError on payloads without a `choices` array (`079dcdb`)

OpenRouter (and other OpenAI-compatible upstreams) can return a 200 with an error-shaped body, or usage-only stream chunks, that omit `choices` entirely. `assertOpenrouterResponseHasOutput` / `assertOpenrouterStreamChunkHasOutput` and the shared OpenAI stream adapter read `choices[0]` unguarded — crashing with `Cannot read properties of undefined (reading '0')` (observed in production on recent releases). Now guarded; the response path falls through to the existing typed `assertResponseHasChoices` 502 carrying the upstream's embedded error message, and the stream path takes the existing no-choice branch.

## 3. Pre-auth hot reads hit the database on every page load (`8aa4940`)

The two most frequent statements in the transient DB-connectivity failure buckets are the appearance-settings select (white-labeling, fetched pre-auth on every page load) and the public SSO-provider list (login page). Neither was cached, so every page view cost pool connections — and under pool pressure these were the first requests to fail.

Both now sit behind a process-local one-minute LRU (deliberately not the Postgres-backed `cacheManager`, which would keep the hot path on the connection pool). Same pattern and invalidation story as the existing `trustedProviderIdsCache`: model writes clear the cache in-process immediately, other pods converge within the TTL. Behavior pinned in both model tests (cache served until a model write invalidates).

This reduces load; it does not claim to fix the underlying pool sizing per deployment. The `get-session` and `/api/apps` slow-query hotspots are separate follow-ups.

## 4. Embeddings `data[].index` required at the proxy boundary (`b611382`)

Validated before changing: OpenAI itself always sends `index` (required in `openai-node`'s `Embedding` type, and both Ollama's and llama.cpp's OpenAI-compat layers always emit it — checked their source). But the openai embeddings routes also front arbitrary OpenAI-compatible upstreams via custom base URLs, and a deviating upstream that omits it fails response serialization with a 500. Every sibling schema (chat `ChoiceSchema.index`, vllm, cerebras, zhipuai, minimax, ollama) already tolerates the omission for exactly this reason — this brings the embeddings schema (and the interaction read-back variant, where one stored nonconforming row would 500 the whole interaction list) in line. Generated client + OpenAPI spec regenerated.