### PR TITLE
fix(bench): run RBAC preflight as benchmark pod

### DIFF
--- a/.github/bench/job.yaml
+++ b/.github/bench/job.yaml
@@ -58,6 +58,7 @@ spec:
         - name: bench
           image: ${BENCH_IMAGE}
           command: ["run-benchmark"]
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: POSTGRES_PASSWORD
               value: "${POSTGRES_PASSWORD}"

--- a/.github/bench/runner-entrypoint.sh
+++ b/.github/bench/runner-entrypoint.sh
@@ -32,6 +32,27 @@ cleanup_dagger() {
 trap cleanup_dagger EXIT
 trap 'exit 143' HUP INT TERM
 
+# Check with the pod's actual identity; the CI deploy identity deliberately cannot impersonate it.
+namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+require_rbac() {
+  description=$1
+  shift
+  if verdict=$(kubectl auth can-i "$@" --namespace "${namespace}" --request-timeout=10s 2>&1) && \
+    [ "${verdict}" = yes ]; then
+    return 0
+  fi
+  if [ "${verdict}" = no ]; then
+    printf 'error: benchmark service account cannot %s in %s\n' "${description}" "${namespace}" >&2
+  else
+    printf 'error: could not check permission to %s: %s\n' "${description}" "${verdict}" >&2
+  fi
+  return 1
+}
+rbac_failures=0
+require_rbac 'exec into pods' create pods --subresource=exec || rbac_failures=$((rbac_failures + 1))
+require_rbac 'delete pods' delete pods || rbac_failures=$((rbac_failures + 1))
+[ "${rbac_failures}" -eq 0 ] || exit 1
+
 # The bench resolves its Postgres from ARCHESTRA_BENCH_DATABASE_URL and creates a fresh per-run
 # database on it; the backend's own ARCHESTRA_DATABASE_URL is then derived from that. `Instance::start`
 # also requires the platform .env file to exist, so writing it here satisfies both. The password must

--- a/.github/bench/runner-entrypoint.sh
+++ b/.github/bench/runner-entrypoint.sh
@@ -10,12 +10,12 @@ umask 077
 : "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (shared with the postgres sidecar)}"
 BENCH_ENVS="${BENCH_ENVS:-basic}"
 BENCH_LANES="${BENCH_LANES:-glm}"
+service_account_dir=/var/run/secrets/kubernetes.io/serviceaccount
 
 cleanup_dagger() {
   status=$?
   trap - EXIT
   if [ -n "${DAGGER_ENGINE_POD:-}" ]; then
-    service_account_dir=/var/run/secrets/kubernetes.io/serviceaccount
     # Never let cleanup decide the exit code: under `set -e` a failed read here would replace the
     # publish status, and that status is the run-health signal CI reads off the pod's terminal phase.
     namespace=$(cat "${service_account_dir}/namespace" 2>/dev/null) || namespace=archestra
@@ -33,7 +33,29 @@ trap cleanup_dagger EXIT
 trap 'exit 143' HUP INT TERM
 
 # Check with the pod's actual identity; the CI deploy identity deliberately cannot impersonate it.
-namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+namespace=$(cat "${service_account_dir}/namespace")
+KUBECONFIG=/tmp/bench-kubeconfig
+export KUBECONFIG
+cat > "${KUBECONFIG}" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: in-cluster
+    cluster:
+      server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS:-443}
+      certificate-authority: ${service_account_dir}/ca.crt
+users:
+  - name: in-cluster
+    user:
+      tokenFile: ${service_account_dir}/token
+contexts:
+  - name: in-cluster
+    context:
+      cluster: in-cluster
+      user: in-cluster
+      namespace: ${namespace}
+current-context: in-cluster
+EOF
 require_rbac() {
   description=$1
   shift

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -211,6 +211,9 @@ jobs:
             case "${PHASE}" in
               Failed)
                 echo "::error::pod ${POD} terminated Failed within the fast-fail window — harness broken"
+                kubectl get pod "${POD}" -n archestra \
+                  -o jsonpath='{.status.containerStatuses[?(@.name=="bench")].state.terminated.message}' || true
+                echo
                 kubectl logs "${POD}" -n archestra -c bench --tail=80 || true
                 exit 1 ;;
               Succeeded)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -103,27 +103,6 @@ jobs:
             exit 1
           fi
 
-      - name: RBAC preflight (platform SA can exec into the Dagger pod)
-        env:
-          PLATFORM_SA: ${{ steps.resolve.outputs.platform_sa }}
-        run: |
-          set -euo pipefail
-          RC=0
-          VERDICT=$(kubectl auth can-i create pods/exec \
-            --as="system:serviceaccount:archestra:${PLATFORM_SA}" -n archestra 2>&1) || RC=$?
-          echo "can-i create pods/exec in archestra: ${VERDICT} (rc=${RC})"
-          DELETE_RC=0
-          DELETE_VERDICT=$(kubectl auth can-i delete pods \
-            --as="system:serviceaccount:archestra:${PLATFORM_SA}" -n archestra 2>&1) || DELETE_RC=$?
-          echo "can-i delete pods in archestra: ${DELETE_VERDICT} (rc=${DELETE_RC})"
-          # Fail closed: only an explicit allow proceeds. An API/impersonation error or a "no - <reason>"
-          # response must not slip through as if permitted.
-          if [ "${RC}" -ne 0 ] || [ "${VERDICT}" != "yes" ] || \
-             [ "${DELETE_RC}" -ne 0 ] || [ "${DELETE_VERDICT}" != "yes" ]; then
-            echo "::error::platform SA ${PLATFORM_SA} needs create pods/exec and delete pods in archestra"
-            exit 1
-          fi
-
       - name: Build and push bench runner image
         id: image
         env:


### PR DESCRIPTION
## Summary

- check Dagger RBAC from the benchmark pod using its actual platform service account
- keep the CI deploy identity least-privileged, without Kubernetes service-account impersonation
- preserve fast-fail logs through the pod termination message when CI cannot read `pods/log`

## Root cause

The preflight asked whether `archestra-platform` could `create pods/exec` and `delete pods` by impersonating it (`--as=system:serviceaccount:archestra:archestra-platform`) from the CI deploy identity. That identity has no `container.clusters.impersonate`, so the check itself errored, and the fail-closed branch aborted the run before the benchmark Job was ever created. Running the check inside the benchmark pod with its own projected token validates the identity that actually needs the permissions and needs no impersonation grant.

Scheduled runs blocked by this: [30731951094](https://github.com/archestra-ai/archestra/actions/runs/30731951094), [30783854218](https://github.com/archestra-ai/archestra/actions/runs/30783854218).

## Validation

- `sh -n .github/bench/runner-entrypoint.sh`
- `shellcheck -e SC2155 .github/bench/runner-entrypoint.sh`
- workflow and rendered Job YAML parsing
- branch benchmark run: https://github.com/archestra-ai/archestra/actions/runs/30819709739

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
