### PR TITLE
fix(frontend): second WCAG AA pass — focus management, keyboard operability, contrast

### DIFF
--- a/platform/frontend/src/app/_parts/app-shell.tsx
+++ b/platform/frontend/src/app/_parts/app-shell.tsx
@@ -178,8 +178,12 @@ export function AppShell({ children }: AppShellProps) {
         <NavigationStatusProvider>
           <SidebarProvider defaultOpen={!shouldCollapse}>
             <SkipToContentLink />
-            <AppSidebar />
+            {/* The toggle is position:fixed, so DOM order only affects focus
+                order: keeping it before the sidebar means expanding it with
+                the keyboard tabs forward into the revealed sidebar content
+                instead of skipping to <main> (WCAG 2.4.3). */}
             <NavAwareSidebarCircleToggle />
+            <AppSidebar />
             <MaintenanceModeOverlay />
             <main
               id={MAIN_CONTENT_ID}

--- a/platform/frontend/src/app/_parts/sidebar-user-menu.tsx
+++ b/platform/frontend/src/app/_parts/sidebar-user-menu.tsx
@@ -73,10 +73,9 @@ export function SidebarUserMenu() {
         // trigger sits in the bottom-left corner.
         collisionPadding={8}
         className="min-w-56"
-        // Closing via an outside click otherwise returns focus to the trigger,
-        // which re-shows its focus ring and reads as a stray border. Keep focus
-        // off the trigger on pointer-driven close (keyboard Tab still rings it).
-        onCloseAutoFocus={(e) => e.preventDefault()}
+        // Let Radix restore focus to the trigger on close (WCAG 2.4.3) — the
+        // trigger's ring is focus-visible-only, so pointer-driven closes don't
+        // show a stray border.
       >
         <DropdownMenuItem asChild>
           <Link href="/account">

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -724,7 +724,11 @@ export function AppSidebar() {
                     together within this region, while the nav above stays
                     pinned. The fade hints there is more content below. */}
               <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 after:pointer-events-none after:absolute after:right-2.5 after:bottom-0 after:left-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-sidebar after:to-transparent">
-                <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto pb-8 [scrollbar-gutter:stable] scrollbar-sidebar">
+                {/* group-data-[collapsible=icon]:overflow-hidden keeps this
+                    scroller out of the tab order while collapsed — Chrome makes
+                    scrollable containers keyboard-focusable, which otherwise
+                    leaves an invisible tab stop on the icon rail (WCAG 2.4.3). */}
+                <SidebarGroupContent className="min-h-0 flex-1 overflow-y-auto group-data-[collapsible=icon]:overflow-hidden pb-8 [scrollbar-gutter:stable] scrollbar-sidebar">
                   <ChatSidebarSection slots={15} flat fadeIn={chatListFadeIn} />
                   <NavSecondary
                     items={[]}

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -113,7 +113,14 @@ function UsersPageContent() {
       loadingFallback={<LoadingSpinner />}
     >
       {activeOrg ? (
-        <div className="space-y-6">
+        <div
+          className="space-y-6"
+          // Single always-mounted panel keeps each tab's aria-controls
+          // pointing at an element that exists (the panel's content swaps).
+          role="tabpanel"
+          id={USERS_TABPANEL_ID}
+          aria-labelledby={`${activeTab}-tab`}
+        >
           {activeTab === "users" ? (
             <MembersTab activeTab={activeTab} onTabChange={setActiveTab} />
           ) : (
@@ -130,6 +137,13 @@ function UsersPageContent() {
   );
 }
 
+const USERS_TABPANEL_ID = "users-tabpanel";
+
+const USER_TABS = [
+  { id: "users", label: "Users" },
+  { id: "invitations", label: "Invitations" },
+] as const;
+
 function TabButtons({
   activeTab,
   onTabChange,
@@ -137,24 +151,47 @@ function TabButtons({
   activeTab: string;
   onTabChange: (tab: string) => void;
 }) {
+  // Switching tabs swaps the whole MembersTab/InvitationsTab subtree —
+  // including this component — so the newly active tab button must be
+  // re-focused after the replacement mounts or keyboard focus drops to <body>.
+  const selectTab = (tabId: string) => {
+    onTabChange(tabId);
+    requestAnimationFrame(() => {
+      document.getElementById(`${tabId}-tab`)?.focus();
+    });
+  };
+
   return (
-    <div className="flex gap-1 rounded-lg bg-muted p-1">
-      <Button
-        variant={activeTab === "users" ? "secondary" : "ghost"}
-        size="sm"
-        onClick={() => onTabChange("users")}
-        className={cn("px-3", activeTab === "users" && "shadow-sm")}
-      >
-        Users
-      </Button>
-      <Button
-        variant={activeTab === "invitations" ? "secondary" : "ghost"}
-        size="sm"
-        onClick={() => onTabChange("invitations")}
-        className={cn("px-3", activeTab === "invitations" && "shadow-sm")}
-      >
-        Invitations
-      </Button>
+    <div
+      role="tablist"
+      aria-label="Users and invitations"
+      className="flex gap-1 rounded-lg bg-muted p-1"
+    >
+      {USER_TABS.map((tab) => {
+        const isActive = activeTab === tab.id;
+        return (
+          <Button
+            key={tab.id}
+            role="tab"
+            id={`${tab.id}-tab`}
+            aria-selected={isActive}
+            aria-controls={USERS_TABPANEL_ID}
+            tabIndex={isActive ? 0 : -1}
+            variant={isActive ? "secondary" : "ghost"}
+            size="sm"
+            onClick={() => selectTab(tab.id)}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+                e.preventDefault();
+                selectTab(tab.id === "users" ? "invitations" : "users");
+              }
+            }}
+            className={cn("px-3", isActive && "shadow-sm")}
+          >
+            {tab.label}
+          </Button>
+        );
+      })}
     </div>
   );
 }

--- a/platform/frontend/src/components/agent-badge.tsx
+++ b/platform/frontend/src/components/agent-badge.tsx
@@ -2,13 +2,17 @@ import type { AgentScope } from "@archestra/shared";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
+// Light-mode text uses the 700/800 palette steps: the 600 steps fall below the
+// 4.5:1 contrast minimum (WCAG 1.4.3) on the tinted /10 fills. Dark mode's 400
+// steps already pass. Keep in sync with scopeStyles in
+// resource-visibility-badge.tsx.
 const styles = {
   personal:
-    "bg-blue-500/10 text-blue-600 border-blue-500/30 dark:text-blue-400 dark:border-blue-400/30",
-  team: "bg-green-500/10 text-green-600 border-green-500/30 dark:text-green-400 dark:border-green-400/30",
-  org: "bg-amber-500/10 text-amber-600 border-amber-500/30 dark:text-amber-400 dark:border-amber-400/30",
+    "bg-blue-500/10 text-blue-700 border-blue-500/30 dark:text-blue-400 dark:border-blue-400/30",
+  team: "bg-green-500/10 text-green-800 border-green-500/30 dark:text-green-400 dark:border-green-400/30",
+  org: "bg-amber-500/10 text-amber-800 border-amber-500/30 dark:text-amber-400 dark:border-amber-400/30",
   builtIn:
-    "bg-purple-500/10 text-purple-600 border-purple-500/30 dark:text-purple-400 dark:border-purple-400/30",
+    "bg-purple-500/10 text-purple-700 border-purple-500/30 dark:text-purple-400 dark:border-purple-400/30",
 } as const;
 const labels = {
   personal: "Personal",

--- a/platform/frontend/src/components/ai-elements/response.tsx
+++ b/platform/frontend/src/components/ai-elements/response.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { type ComponentProps, memo, useMemo } from "react";
-import { defaultRemarkPlugins, Streamdown } from "streamdown";
+import {
+  defaultRehypePlugins,
+  defaultRemarkPlugins,
+  Streamdown,
+} from "streamdown";
 import { cn } from "@/lib/utils";
 
 type ResponseProps = ComponentProps<typeof Streamdown> & {
@@ -47,6 +51,41 @@ const remarkCanonicalizeAppLinks = () => (tree: unknown) =>
 const REMARK_PLUGINS: ResponseProps["remarkPlugins"] = [
   ...Object.values(defaultRemarkPlugins),
   remarkCanonicalizeAppLinks,
+];
+
+// Scrollable code regions must be reachable and scrollable by keyboard
+// (WCAG 2.1.1). Streamdown spreads a fenced block's <pre> properties onto its
+// code-block wrapper div, so tagging the hast node makes the rendered scroll
+// container focusable and named; a bare <pre> receives the attributes directly.
+function tagPreAsFocusableRegion(node: unknown): void {
+  if (node === null || typeof node !== "object") return;
+  const element = node as {
+    type?: unknown;
+    tagName?: unknown;
+    properties?: Record<string, unknown>;
+    children?: unknown;
+  };
+  if (element.type === "element" && element.tagName === "pre") {
+    element.properties = {
+      ...element.properties,
+      tabIndex: 0,
+      role: "region",
+      ariaLabel: "Code block",
+    };
+  }
+  if (Array.isArray(element.children)) {
+    for (const child of element.children) tagPreAsFocusableRegion(child);
+  }
+}
+
+const rehypeFocusablePre = () => (tree: unknown) =>
+  tagPreAsFocusableRegion(tree);
+
+// Appended after the defaults so the sanitizing passes can't strip the
+// attributes we add.
+const REHYPE_PLUGINS: ResponseProps["rehypePlugins"] = [
+  ...Object.values(defaultRehypePlugins),
+  rehypeFocusablePre,
 ];
 
 /**
@@ -104,6 +143,12 @@ export const Response = memo(
           // Only style inline code, not code inside pre elements
           "[&_:not(pre)>code]:bg-muted [&_:not(pre)>code]:text-foreground [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:py-0.5 [&_:not(pre)>code]:rounded",
           "[&_pre]:bg-muted [&_pre]:p-3 [&_pre]:rounded [&_pre]:my-2 [&_pre]:overflow-x-auto",
+          // The focusable element for fenced code is the code-block wrapper
+          // (see rehypeFocusablePre), so it must be the horizontal scroller —
+          // otherwise arrow keys can't scroll the focused region. The inner
+          // <pre> overflows visibly into it instead of clipping.
+          "[&_[data-streamdown='code-block-body']]:overflow-x-auto",
+          "[&_[data-streamdown='code-block-body']_pre]:overflow-x-visible",
           // Fix streamdown code blocks - remove padding from code elements inside them
           "[&_[data-streamdown='code-block']_code]:p-0 [&_[data-streamdown='code-block']_code]:bg-transparent",
           // Streamdown mats tables in an opaque bg-sidebar card (and ignores its
@@ -129,6 +174,7 @@ export const Response = memo(
           className,
         )}
         remarkPlugins={REMARK_PLUGINS}
+        rehypePlugins={REHYPE_PLUGINS}
         linkSafety={mergedLinkSafety}
         {...props}
       />

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -316,9 +316,19 @@ export function InlineChatError({
                     </p>
                   )}
                   {chatError.originalError && (
-                    <pre className="max-h-48 overflow-auto rounded-md bg-muted/50 p-3 text-xs font-mono whitespace-pre-wrap break-words text-foreground">
-                      {formatOriginalError(chatError.originalError)}
-                    </pre>
+                    <>
+                      {/* biome-ignore-start lint/a11y/noNoninteractiveTabindex: scrollable error detail must be keyboard focusable (WCAG 2.1.1) */}
+                      <section
+                        tabIndex={0}
+                        aria-label="Error details"
+                        className="max-h-48 overflow-auto rounded-md bg-muted/50"
+                      >
+                        {/* biome-ignore-end lint/a11y/noNoninteractiveTabindex: scrollable error detail must be keyboard focusable (WCAG 2.1.1) */}
+                        <pre className="p-3 text-xs font-mono whitespace-pre-wrap break-words text-foreground">
+                          {formatOriginalError(chatError.originalError)}
+                        </pre>
+                      </section>
+                    </>
                   )}
                 </CollapsibleContent>
               </Collapsible>

--- a/platform/frontend/src/components/conversation-search-palette.test.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.test.tsx
@@ -291,10 +291,10 @@ describe("ConversationSearchPalette", () => {
     });
 
     // Press 'd' once to enter pending deletion state
-    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
 
     // Press 'd' again to confirm deletion
-    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
 
     // Should have called deleteMutation.mutate with the conversation ID
     expect(mockDeleteMutate).toHaveBeenCalledWith(
@@ -317,10 +317,10 @@ describe("ConversationSearchPalette", () => {
     });
 
     // Press 'd' once to enter pending deletion state
-    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
 
     // Press 'd' again to confirm deletion
-    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
 
     // Should have called deleteMutation.mutate
     expect(mockDeleteMutate).toHaveBeenCalledWith(
@@ -341,8 +341,8 @@ describe("ConversationSearchPalette", () => {
     });
 
     // Press 'd' twice to delete
-    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
-    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
 
     expect(mockDeleteMutate).toHaveBeenCalledWith(
       "conv-1",
@@ -360,17 +360,43 @@ describe("ConversationSearchPalette", () => {
     });
 
     // Press 'd' once → pending state
-    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
     // Press 'd' again → confirms deletion
-    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
 
     expect(mockDeleteMutate).toHaveBeenCalledTimes(1);
 
     // Rapid third 'd' press in the same frame — should be ignored
     // because the ref guard prevents double-deletion before React re-renders
-    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
 
     expect(mockDeleteMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores bare character keys — shortcuts require the Alt modifier", () => {
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    act(() => {
+      capturedOnValueChange?.("conv-conv-1");
+    });
+
+    // Bare "d" (no modifier) must not trigger deletion (WCAG 2.1.4)
+    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+    fireEvent.keyDown(window, { key: "d", code: "KeyD" });
+
+    expect(mockDeleteMutate).not.toHaveBeenCalled();
+  });
+
+  it("announces the delete confirmation prompt via a live region", () => {
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    act(() => {
+      capturedOnValueChange?.("conv-conv-1");
+    });
+
+    fireEvent.keyDown(window, { key: "d", code: "KeyD", altKey: true });
+
+    expect(screen.getByRole("status")).toHaveTextContent("again to confirm");
   });
 
   it("navigates to conversation when selecting it", () => {

--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -237,6 +237,15 @@ export function ConversationSearchPalette({
     setIsPendingDeletion(null);
   }, [selectedValue, searchQuery]);
 
+  // Search replaces the entire item set (nav items ↔ conv-<id> results). With a
+  // controlled value, cmdk only auto-selects the first item when the value is
+  // falsy — a stale selection leaves the fresh list with no selected option, so
+  // ArrowUp and Enter dead-end (WCAG 2.1.1). Clear it whenever the query flips.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reacting to debouncedSearch changes to reset the selection
+  useEffect(() => {
+    setSelectedValue("");
+  }, [debouncedSearch]);
+
   const handleSelectConversation = (conversationId: string) => {
     router.push(`/chat/${conversationId}`);
     onOpenChange(false);
@@ -291,13 +300,16 @@ export function ConversationSearchPalette({
     if (!open) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      // In cmdk, the input always retains focus even during arrow-key navigation.
-      // Only intercept shortcuts when the search input is empty (browse mode).
-      // When the user is typing a search query, let keys pass through normally.
-      if (searchQuery) return;
+      // Alt-qualified shortcuts (WCAG 2.1.4 forbids bare character keys) that
+      // also work while a search query is being typed. Matching on e.code
+      // sidesteps macOS Option dead-key characters, like SHORTCUT_NEW_CHAT.
+      if (!e.altKey || e.metaKey || e.ctrlKey) return;
 
-      // 'd' for delete when conversation is selected
-      if (e.key === SHORTCUT_DELETE.key && selectedValue?.startsWith("conv-")) {
+      // Alt+D deletes the selected conversation (press twice to confirm)
+      if (
+        e.code === SHORTCUT_DELETE.code &&
+        selectedValue?.startsWith("conv-")
+      ) {
         e.preventDefault();
         e.stopPropagation();
         const conversationId = selectedValue.substring(5);
@@ -309,8 +321,8 @@ export function ConversationSearchPalette({
         }
       }
 
-      // 'p' for pin/unpin when conversation is selected
-      if (e.key === SHORTCUT_PIN.key && selectedValue?.startsWith("conv-")) {
+      // Alt+P pins/unpins the selected conversation
+      if (e.code === SHORTCUT_PIN.code && selectedValue?.startsWith("conv-")) {
         e.preventDefault();
         e.stopPropagation();
         const conversationId = selectedValue.substring(5);
@@ -324,7 +336,6 @@ export function ConversationSearchPalette({
   }, [
     open,
     selectedValue,
-    searchQuery,
     isPendingDeletion,
     handleDeleteConversation,
     handlePinConversation,
@@ -450,10 +461,9 @@ export function ConversationSearchPalette({
           {isPending && (
             <Badge
               variant="destructive"
-              role="status"
               className="absolute right-3 top-2.5 text-[10px] shadow-sm animate-in fade-in zoom-in duration-200"
             >
-              Press "{SHORTCUT_DELETE.label}" to confirm
+              Press "{altKey} {SHORTCUT_DELETE.label}" to confirm
             </Badge>
           )}
         </div>
@@ -482,6 +492,17 @@ export function ConversationSearchPalette({
         value={searchQuery}
         onValueChange={setSearchQuery}
       />
+      {/* Persistent live region: mounting the visual confirm badge together
+          with its text is not reliably announced, so the delete-confirmation
+          prompt is mirrored here (WCAG 4.1.3). */}
+      <output aria-live="polite" className="sr-only">
+        {isPendingDeletion && (
+          <span>
+            Press {altKey} {SHORTCUT_DELETE.label} again to confirm deleting the
+            selected conversation.
+          </span>
+        )}
+      </output>
       <CommandList className="max-h-[500px]">
         {isLoading && !isSearching ? (
           <div className="py-6 text-center text-sm text-muted-foreground">
@@ -619,15 +640,25 @@ export function ConversationSearchPalette({
             <span className="text-muted-foreground">New Chat</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <kbd className="inline-flex h-5 min-w-[20px] items-center justify-center rounded bg-muted px-1.5 font-sans text-[10px] font-medium text-muted-foreground border border-border/50">
-              {SHORTCUT_PIN.label}
-            </kbd>
+            <div className="flex items-center gap-1">
+              <kbd className="inline-flex h-5 min-w-[20px] items-center justify-center rounded bg-muted px-1.5 font-sans text-[10px] font-medium text-muted-foreground border border-border/50">
+                {altKey}
+              </kbd>
+              <kbd className="inline-flex h-5 min-w-[20px] items-center justify-center rounded bg-muted px-1.5 font-sans text-[10px] font-medium text-muted-foreground border border-border/50">
+                {SHORTCUT_PIN.label}
+              </kbd>
+            </div>
             <span className="text-muted-foreground">Pin / Unpin Chat</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <kbd className="inline-flex h-5 min-w-[20px] items-center justify-center rounded bg-muted px-1.5 font-sans text-[10px] font-medium text-muted-foreground border border-border/50">
-              {SHORTCUT_DELETE.label}
-            </kbd>
+            <div className="flex items-center gap-1">
+              <kbd className="inline-flex h-5 min-w-[20px] items-center justify-center rounded bg-muted px-1.5 font-sans text-[10px] font-medium text-muted-foreground border border-border/50">
+                {altKey}
+              </kbd>
+              <kbd className="inline-flex h-5 min-w-[20px] items-center justify-center rounded bg-muted px-1.5 font-sans text-[10px] font-medium text-muted-foreground border border-border/50">
+                {SHORTCUT_DELETE.label}
+              </kbd>
+            </div>
             <span className="text-muted-foreground">Delete Chat</span>
           </div>
           <div className="flex items-center gap-1.5">

--- a/platform/frontend/src/components/resource-visibility-badge.tsx
+++ b/platform/frontend/src/components/resource-visibility-badge.tsx
@@ -12,11 +12,14 @@ import {
 import { cn } from "@/lib/utils";
 
 // Scope colors mirror AgentBadge so apps/MCP/proxies/skills share one language.
+// Light-mode text uses the 700/800 palette steps: the 600 steps fall below the
+// 4.5:1 contrast minimum (WCAG 1.4.3) on the tinted /10 fills. Dark mode's 400
+// steps already pass.
 export const scopeStyles = {
   personal:
-    "bg-blue-500/10 text-blue-600 border-blue-500/30 dark:text-blue-400 dark:border-blue-400/30",
-  team: "bg-green-500/10 text-green-600 border-green-500/30 dark:text-green-400 dark:border-green-400/30",
-  org: "bg-amber-500/10 text-amber-600 border-amber-500/30 dark:text-amber-400 dark:border-amber-400/30",
+    "bg-blue-500/10 text-blue-700 border-blue-500/30 dark:text-blue-400 dark:border-blue-400/30",
+  team: "bg-green-500/10 text-green-800 border-green-500/30 dark:text-green-400 dark:border-green-400/30",
+  org: "bg-amber-500/10 text-amber-800 border-amber-500/30 dark:text-amber-400 dark:border-amber-400/30",
 } as const;
 
 export function ResourceVisibilityBadge({

--- a/platform/frontend/src/components/ui/command.tsx
+++ b/platform/frontend/src/components/ui/command.tsx
@@ -49,14 +49,17 @@ function CommandDialog({
 }) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
       <DialogContent
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
+        {/* Must live inside DialogContent: Radix derives the dialog's
+            aria-labelledby/-describedby from the title and description
+            rendered within the portal content. */}
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
         <Command
           shouldFilter={shouldFilter}
           value={value}

--- a/platform/frontend/src/components/ui/dialog.tsx
+++ b/platform/frontend/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -68,17 +68,42 @@ function DialogContent({
   children,
   showCloseButton = true,
   overlayClassName,
+  onOpenAutoFocus,
+  onCloseAutoFocus,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
   /** Override the backdrop, e.g. a heavier dim for immersive surfaces. */
   overlayClassName?: string;
 }) {
+  // Almost every dialog in the app is controlled via `open`/`onOpenChange`
+  // without a `DialogTrigger`, so Radix has no trigger ref to restore focus to
+  // on close (it suppresses its own fallback), and keyboard focus drops to
+  // <body>. Capture the opener ourselves and restore it (WCAG 2.4.3).
+  const returnFocusRef = React.useRef<HTMLElement | null>(null);
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        onOpenAutoFocus={(event) => {
+          // Fires before Radix moves focus into the dialog, so the active
+          // element is still the control that opened it.
+          returnFocusRef.current =
+            document.activeElement instanceof HTMLElement
+              ? document.activeElement
+              : null;
+          onOpenAutoFocus?.(event);
+        }}
+        onCloseAutoFocus={(event) => {
+          onCloseAutoFocus?.(event);
+          if (event.defaultPrevented) return;
+          event.preventDefault();
+          const opener = returnFocusRef.current;
+          if (opener?.isConnected) {
+            opener.focus();
+          }
+        }}
         className={cn(
           // Please keep this class when updating dialog component
           // `overflow-hidden` is load-bearing: it makes DialogContent the

--- a/platform/frontend/src/components/ui/sheet.tsx
+++ b/platform/frontend/src/components/ui/sheet.tsx
@@ -2,7 +2,7 @@
 
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -48,15 +48,37 @@ function SheetContent({
   className,
   children,
   side = "right",
+  onOpenAutoFocus,
+  onCloseAutoFocus,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left";
 }) {
+  // Sheets are controlled without a SheetTrigger, so Radix has no trigger ref
+  // to restore focus to on close. Capture the opener and restore it ourselves
+  // (WCAG 2.4.3) — same rationale as DialogContent in dialog.tsx.
+  const returnFocusRef = React.useRef<HTMLElement | null>(null);
   return (
     <SheetPortal>
       <SheetOverlay />
       <SheetPrimitive.Content
         data-slot="sheet-content"
+        onOpenAutoFocus={(event) => {
+          returnFocusRef.current =
+            document.activeElement instanceof HTMLElement
+              ? document.activeElement
+              : null;
+          onOpenAutoFocus?.(event);
+        }}
+        onCloseAutoFocus={(event) => {
+          onCloseAutoFocus?.(event);
+          if (event.defaultPrevented) return;
+          event.preventDefault();
+          const opener = returnFocusRef.current;
+          if (opener?.isConnected) {
+            opener.focus();
+          }
+        }}
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&

--- a/platform/frontend/src/consts.tsx
+++ b/platform/frontend/src/consts.tsx
@@ -16,13 +16,16 @@ export const SHORTCUT_NEW_CHAT = {
   label: "N",
 } as const;
 
+// Alt-qualified (matching SHORTCUT_NEW_CHAT) so the palette has no bare
+// character-key shortcuts (WCAG 2.1.4) and the keys still work while a search
+// query is being typed. `code` dodges macOS Option dead-key characters.
 export const SHORTCUT_DELETE = {
-  key: "d",
+  code: "KeyD",
   label: "D",
 } as const;
 
 export const SHORTCUT_PIN = {
-  key: "p",
+  code: "KeyP",
   label: "P",
 } as const;
 


### PR DESCRIPTION
## Summary

Follow-up to #6747, addressing the harder accessibility gaps that pass deferred: focus management, keyboard operability of the search palette, scrollable-region focusability, tab semantics, and badge contrast.

### Focus management (WCAG 2.4.3)

- **Every dialog and sheet now returns keyboard focus to its opener on close.** Nearly all our modals are controlled (`open`/`onOpenChange`) with no Radix `Trigger`, a configuration in which Radix suppresses its own focus-restore fallback and focus drops to `<body>` — so the next Tab restarted at the top of the page. `DialogContent`/`SheetContent` capture the opener in `onOpenAutoFocus` (before Radix moves focus) and restore it in `onCloseAutoFocus`. This fixes every consumer at once, including dialogs that are conditionally unmounted on close.
- The sidebar account menu suppressed Radix's focus restore on close (added for a cosmetic focus-ring concern that `focus-visible`-only ring styling already handles); removed.
- The sidebar collapse toggle now precedes the sidebar in DOM order (it's `position: fixed`, so nothing moves visually) — expanding it with the keyboard tabs forward into the revealed content instead of skipping to `<main>`.
- The collapsed sidebar had an invisible tab stop: Chrome makes scrollable containers keyboard-focusable, and the chat-list scroller had no collapsed-state guard. It now matches the `SidebarContent` primitive's `group-data-[collapsible=icon]:overflow-hidden`.

### Conversation search palette (WCAG 2.1.1, 2.1.4, 4.1.3)

- **Arrow keys / Enter no longer dead-end after typing a query.** Search swaps the entire cmdk item set, and the stale controlled selection left the fresh list with no selected option (cmdk only auto-selects when its value is falsy) — ArrowUp and Enter became no-ops. The selection resets when the debounced query changes.
- **Delete/pin shortcuts are Alt-qualified** (`Alt+D` / `Alt+P`): bare character keys violate 2.1.4, swallowed the first typed `d`/`p` in browse mode, and didn't work at all during search. `e.code` matching dodges macOS Option dead-keys, same as the existing `Alt+N`. Footer hints and the confirm badge show the modifier.
- The "press to confirm" deletion prompt is mirrored into a persistent polite live region — mounting the badge together with its text was never announced.
- The palette dialog's sr-only title/description moved inside `DialogContent`, where Radix actually wires `aria-labelledby`/`aria-describedby`; previously the dialog had no accessible name.

### Scrollable code regions in chat (WCAG 2.1.1)

Fenced code blocks in chat messages are horizontally scrollable regions a keyboard user couldn't focus or scroll. A rehype pass tags every `<pre>` as a focusable named region; for fenced blocks the attributes land on the code-block wrapper (streamdown spreads the pre's properties onto it), which now also owns the horizontal scrolling so arrow keys scroll the focused element. The chat error-detail block gets the established focusable-section treatment.

### Tab semantics + contrast (WCAG 4.1.2, 1.4.3)

- The Users/Invitations toggle on `/settings/users` visually acts as tabs but exposed plain buttons. It now exposes `tablist`/`tab` roles, `aria-selected`, roving tabindex, arrow-key switching, and an always-mounted `tabpanel` (so `aria-controls` never points at a missing element). Switching swaps the whole tab subtree, so the newly active tab re-focuses itself after the replacement mounts.
- Scope badges (Personal / Team / Organization / Built-in) move from the 600 to the 700/800 palette steps in light mode: green-600 measured 2.86:1 and amber-600 2.88:1 on their tinted fills, below the 4.5:1 minimum. New ratios are ≈5.9–6.4:1, leaving headroom for custom themes. Dark mode already passed and is unchanged.

## Out of scope

Text reflow at 200% zoom in fixed-layout tables and full 320px-viewport reflow are layout redesigns tracked separately, not point fixes.

## Testing

- Full frontend suite: 370 files / 3462 tests pass.
- New tests: bare character keys are ignored by the palette (modifier required); the delete confirmation is exposed through a live region.
- `pnpm type-check` and lint clean (the two remaining lint findings exist on `main`).