### PR TITLE
fix(llm): Azure AI Foundry direct-path URL handling; optional reranking; native Cohere Rerank support

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -33,10 +33,12 @@ To change the embedding model, click **Drop** to clear the existing index — ev
 
 ![Reranking Configuration card in Settings > Knowledge](/docs/automated_screenshots/platform-knowledge-bases_reranking-configuration.webp)
 
-Pick the LLM that scores and reorders search results by relevance. Reranking is optional — without it, search returns fused results unranked.
+Pick the model that scores and reorders search results by relevance. Reranking is optional — without it, search returns fused results unranked.
 
 - **Key** — any LLM provider key.
-- **Model** — any chat model from that provider. Dedicated rerank-API models (Cohere Rerank, for example) don't work here — reranking uses a chat model with structured output.
+- **Model** — any chat model from that provider. Cohere Rerank models are also supported, on Cohere keys and Azure AI Foundry keys, and are called through their native rerank API.
+
+A chat model also powers query expansion (rephrasings that improve recall). A Cohere Rerank model only scores results, so expansion is skipped with one configured.
 
 ## Creating a Knowledge Base
 

--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -3,7 +3,7 @@ title: Knowledge
 category: Knowledge
 order: 1
 description: Built-in RAG knowledge — Knowledge Bases, connectors, and retrieval architecture
-lastUpdated: 2026-07-28
+lastUpdated: 2026-08-03
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -16,7 +16,7 @@ A Knowledge Base is a set of connectors that index your data for retrieval. Conn
 
 ## Configuration
 
-Open **Settings > Knowledge**. Both an embedding and a reranking model must be set before Knowledge Bases can be used.
+Open **Settings > Knowledge**. An embedding model must be set before Knowledge Bases can be used. A reranking model is optional.
 
 ### Embedding Configuration
 
@@ -33,10 +33,10 @@ To change the embedding model, click **Drop** to clear the existing index — ev
 
 ![Reranking Configuration card in Settings > Knowledge](/docs/automated_screenshots/platform-knowledge-bases_reranking-configuration.webp)
 
-Pick the LLM that scores and reorders search results by relevance.
+Pick the LLM that scores and reorders search results by relevance. Reranking is optional — without it, search returns fused results unranked.
 
 - **Key** — any LLM provider key.
-- **Model** — any chat model from that provider.
+- **Model** — any chat model from that provider. Dedicated rerank-API models (Cohere Rerank, for example) don't work here — reranking uses a chat model with structured output.
 
 ## Creating a Knowledge Base
 
@@ -47,7 +47,7 @@ A Knowledge Base is a set of connectors. Create one from the **Knowledge** page 
 An agent — or an [MCP Gateway](/docs/platform-mcp-gateway) — reaches knowledge through the **Tools & Knowledge Sources** setting in its dialog, which has two modes:
 
 - **Auto** — the agent can search every Knowledge Base and connector the chatting user can access, within the agent's environment. Nothing is assigned; the reachable set follows each user's own visibility.
-- **Custom** — the agent searches only the Knowledge Bases and connectors you assign to it. Pick them under **Knowledge Sources**; the picker stays disabled until an embedding and reranking model are set (see [Configuration](#configuration)).
+- **Custom** — the agent searches only the Knowledge Bases and connectors you assign to it. Pick them under **Knowledge Sources**; the picker stays disabled until an embedding model is set (see [Configuration](#configuration)).
 
 Either mode is still filtered by the chatting user's own visibility, so an agent never surfaces a source the user could not read themselves. Once the agent has at least one reachable source, it gains a `query_knowledge_sources` tool that searches across them and returns the most relevant documents.
 

--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -556,6 +556,82 @@ describe("createDirectLLMModel", () => {
     expect(capturedCreateOpenAICompatibleOptions.includeUsage).toBe(true);
   });
 
+  describe("azure direct base URL handling", () => {
+    // Captures the URL the AI SDK actually requests. The stubbed 500 fails the
+    // call; the URL is captured before that, which is all these tests need.
+    const requestedUrlFor = async (params: {
+      modelName: string;
+      baseUrl: string;
+    }) => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue(new Response("upstream stub", { status: 500 }));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const model = createDirectLLMModel({
+        provider: "azure",
+        apiKey: "test-key",
+        modelName: params.modelName,
+        baseUrl: params.baseUrl,
+      });
+      await generateText({
+        model,
+        prompt: "hi",
+        maxRetries: 0,
+      }).catch(() => {});
+
+      const input = mockFetch.mock.calls[0]?.[0];
+      if (!input) {
+        throw new Error("Expected a request to reach the fetch stub");
+      }
+      return new URL(typeof input === "string" ? input : input.url);
+    };
+
+    it("does not append api-version to Foundry v1 endpoints", async () => {
+      // The v1 endpoint rejects date-based api-version values with
+      // "API version not supported", which broke every direct-path call
+      // (KB reranker verification, title generation) against v1 base URLs.
+      const url = await requestedUrlFor({
+        modelName: "gpt-4.1",
+        baseUrl: "https://my-resource.cognitiveservices.azure.com/openai/v1",
+      });
+      expect(url.pathname).toBe("/openai/v1/chat/completions");
+      expect(url.searchParams.has("api-version")).toBe(false);
+    });
+
+    it("does not append api-version for open-model deployments on v1 endpoints", async () => {
+      // Same guard on the openai-compatible branch.
+      const url = await requestedUrlFor({
+        modelName: "DeepSeek-R1",
+        baseUrl: "https://my-resource.cognitiveservices.azure.com/openai/v1",
+      });
+      expect(url.pathname).toBe("/openai/v1/chat/completions");
+      expect(url.searchParams.has("api-version")).toBe(false);
+    });
+
+    it("routes classic endpoints through the deployment path with api-version", async () => {
+      // Classic resources only serve chat completions under
+      // /openai/deployments/<deployment>; posting to <base>/chat/completions
+      // 404s ("Resource not found").
+      const url = await requestedUrlFor({
+        modelName: "gpt-4.1",
+        baseUrl: "https://my-resource.openai.azure.com/openai",
+      });
+      expect(url.pathname).toBe("/openai/deployments/gpt-4.1/chat/completions");
+      expect(url.searchParams.has("api-version")).toBe(true);
+    });
+
+    it("keeps deployment-scoped base URLs as-is with api-version", async () => {
+      const url = await requestedUrlFor({
+        modelName: "gpt-4o",
+        baseUrl:
+          "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+      });
+      expect(url.pathname).toBe("/openai/deployments/gpt-4o/chat/completions");
+      expect(url.searchParams.has("api-version")).toBe(true);
+    });
+  });
+
   it("throws when azure has no base URL instead of falling back to api.openai.com", () => {
     // Covers the strict-SDK branch too: createOpenAI would otherwise default
     // to api.openai.com and send the Azure api-key there.

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -39,9 +39,11 @@ import { isAnthropicNativeEndpoint } from "@/clients/anthropic-endpoint";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import {
+  buildAzureDeploymentBaseUrl,
   createAzureFetchWithApiVersion,
   isAzureOpenAiFirstPartyModelName,
   normalizeAzureApiKey,
+  shouldUseAzureOpenAiApiVersion,
 } from "@/clients/azure-url";
 import {
   buildBedrockProvider,
@@ -764,13 +766,27 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
       baseURL,
       headers,
       fetch: providedFetch,
+      direct,
     }) => {
-      // The AI SDK client can't set Azure's api-version as a default query param,
-      // so we wrap fetch and inject it on every request.
-      const fetchWithVersion = createAzureFetchWithApiVersion({
-        apiVersion: config.llm.azure.apiVersion,
-        fetch: providedFetch,
-      });
+      // Azure has no usable default endpoint; without this guard createOpenAI
+      // would fall back to api.openai.com and send the Azure api-key there.
+      if (!baseURL) {
+        throw new ApiError(400, "Azure AI Foundry base URL is required.");
+      }
+
+      // The AI SDK client can't set Azure's api-version as a default query
+      // param, so we wrap fetch and inject it on every request — except for
+      // Foundry v1 endpoints (`.../openai/v1`), which reject date-based
+      // api-version values with "API version not supported". On the proxy path
+      // baseURL is the local proxy (never a v1 URL), so injection is unchanged
+      // there and the proxy's azure adapter applies this same guard against
+      // the real target.
+      const fetchWithVersion = shouldUseAzureOpenAiApiVersion(baseURL)
+        ? createAzureFetchWithApiVersion({
+            apiVersion: config.llm.azure.apiVersion,
+            fetch: providedFetch,
+          })
+        : providedFetch;
       const normalizedApiKey = normalizeAzureApiKey(apiKey);
       const sdkApiKey =
         normalizedApiKey ??
@@ -781,11 +797,19 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
         ? { ...headers, "api-key": normalizedApiKey }
         : headers;
 
-      // Azure has no usable default endpoint; without this guard createOpenAI
-      // would fall back to api.openai.com and send the Azure api-key there.
-      if (!baseURL) {
-        throw new ApiError(400, "Azure AI Foundry base URL is required.");
-      }
+      // On the direct path baseURL is the key's own Azure endpoint. Classic
+      // (non-v1) endpoints serve chat completions only under
+      // `/openai/deployments/<deployment>` — posting to `<base>/chat/completions`
+      // 404s — so route through the deployment-scoped URL, the same treatment
+      // the embedding client applies. V1 endpoints pass through unchanged. On
+      // the proxy path baseURL is the local proxy and the adapter builds the
+      // target URL itself.
+      const targetBaseURL = direct
+        ? (buildAzureDeploymentBaseUrl({
+            baseUrl: baseURL,
+            deploymentName: modelName,
+          }) ?? baseURL)
+        : baseURL;
 
       // OpenAI first-party deployments stay on strict @ai-sdk/openai: its name
       // heuristic converts max_tokens → max_completion_tokens for reasoning
@@ -798,7 +822,7 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
       if (isAzureOpenAiFirstPartyModelName(modelName)) {
         return createOpenAI({
           apiKey: sdkApiKey,
-          baseURL,
+          baseURL: targetBaseURL,
           headers: requestHeaders,
           fetch: fetchWithVersion,
         }).chat(modelName);
@@ -807,7 +831,7 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
       return createOpenAICompatible({
         name: "azure",
         apiKey: sdkApiKey,
-        baseURL,
+        baseURL: targetBaseURL,
         headers: requestHeaders,
         fetch: fetchWithVersion,
         // @ai-sdk/openai always sends stream_options.include_usage; the compatible

--- a/platform/backend/src/knowledge-base/kb-llm-client.ts
+++ b/platform/backend/src/knowledge-base/kb-llm-client.ts
@@ -18,6 +18,7 @@ import {
   EmbeddingConfigUnresolvableError,
   RerankerConfigUnresolvableError,
 } from "./errors";
+import { isNativeRerankModel } from "./native-rerank";
 
 export interface EmbeddingConfig {
   /**
@@ -38,11 +39,18 @@ export interface EmbeddingConfig {
   inputModalities: ModelInputModality[] | null;
 }
 
-interface RerankerConfig {
-  llmModel: LLMModel;
+/**
+ * Two reranker shapes: a chat LLM scored via structured output, or a dedicated
+ * rerank-API model (Cohere Rerank, directly or Azure-hosted) called through
+ * the provider's native rerank route.
+ */
+type RerankerConfig = {
   modelName: string;
   provider: SupportedProvider;
-}
+} & (
+  | { kind: "llm"; llmModel: LLMModel }
+  | { kind: "native-rerank"; apiKey: string | null; baseUrl: string | null }
+);
 
 /**
  * Resolve the embedding configuration for an organization.
@@ -112,7 +120,18 @@ export async function resolveRerankerConfig(
 
   const modelName = org.rerankerModel;
 
+  if (isNativeRerankModel({ provider: resolved.provider, model: modelName })) {
+    return {
+      kind: "native-rerank",
+      apiKey: resolved.apiKey,
+      baseUrl: resolved.baseUrl,
+      modelName,
+      provider: resolved.provider,
+    };
+  }
+
   return {
+    kind: "llm",
     llmModel: createDirectLLMModel({
       provider: resolved.provider,
       // createDirectLLMModel expects `string | undefined`; map keyless `null`.

--- a/platform/backend/src/knowledge-base/native-rerank.test.ts
+++ b/platform/backend/src/knowledge-base/native-rerank.test.ts
@@ -1,0 +1,192 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, test } from "@/test";
+import { useMswServer } from "@/test/msw";
+import { callNativeRerank, isNativeRerankModel } from "./native-rerank";
+
+let server: ReturnType<typeof useMswServer>;
+
+describe("isNativeRerankModel", () => {
+  test("matches Cohere rerank models on the cohere provider", () => {
+    expect(
+      isNativeRerankModel({ provider: "cohere", model: "rerank-v3.5" }),
+    ).toBe(true);
+    expect(
+      isNativeRerankModel({ provider: "cohere", model: "rerank-english-v3.0" }),
+    ).toBe(true);
+    expect(
+      isNativeRerankModel({ provider: "cohere", model: "command-r-plus" }),
+    ).toBe(false);
+  });
+
+  test("matches Azure-hosted Cohere rerank deployments", () => {
+    expect(
+      isNativeRerankModel({
+        provider: "azure",
+        model: "Cohere-rerank-v4.0-fast",
+      }),
+    ).toBe(true);
+    expect(isNativeRerankModel({ provider: "azure", model: "gpt-4.1" })).toBe(
+      false,
+    );
+  });
+
+  test("never matches providers without a native rerank surface", () => {
+    // A rerank-named model on e.g. OpenAI has no native route to call; it must
+    // stay on the chat path (and fail verification with the explanatory hint).
+    expect(
+      isNativeRerankModel({ provider: "openai", model: "my-rerank-model" }),
+    ).toBe(false);
+  });
+});
+
+describe("callNativeRerank", () => {
+  server = useMswServer();
+
+  it("calls the Azure rerank route derived from the key's base URL origin", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    let apiKeyHeader: string | null = null;
+    server.use(
+      http.post(
+        "https://my-resource.cognitiveservices.azure.com/providers/cohere/v2/rerank",
+        async ({ request }) => {
+          apiKeyHeader = request.headers.get("api-key");
+          requestBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            id: "rerank-test",
+            results: [
+              { index: 1, relevance_score: 0.9 },
+              { index: 0, relevance_score: 0.2 },
+            ],
+          });
+        },
+      ),
+    );
+
+    const scores = await callNativeRerank({
+      provider: "azure",
+      apiKey: "azure-key",
+      // The stored base URL keeps its inference path; only the origin matters.
+      baseUrl: "https://my-resource.cognitiveservices.azure.com/openai/v1",
+      model: "Cohere-rerank-v4.0-fast",
+      query: "capital of France",
+      documents: ["Berlin doc", "Paris doc"],
+    });
+
+    expect(apiKeyHeader).toBe("azure-key");
+    expect(requestBody).toEqual({
+      model: "Cohere-rerank-v4.0-fast",
+      query: "capital of France",
+      documents: ["Berlin doc", "Paris doc"],
+    });
+    expect(scores).toEqual([
+      { index: 1, score: 0.9 },
+      { index: 0, score: 0.2 },
+    ]);
+  });
+
+  it("strips a Bearer prefix from the Azure api-key", async () => {
+    let apiKeyHeader: string | null = null;
+    server.use(
+      http.post(
+        "https://my-resource.services.ai.azure.com/providers/cohere/v2/rerank",
+        ({ request }) => {
+          apiKeyHeader = request.headers.get("api-key");
+          return HttpResponse.json({ results: [] });
+        },
+      ),
+    );
+
+    await callNativeRerank({
+      provider: "azure",
+      apiKey: "Bearer azure-key",
+      baseUrl: "https://my-resource.services.ai.azure.com/models",
+      model: "Cohere-rerank-v4.0-fast",
+      query: "q",
+      documents: ["d"],
+    });
+
+    expect(apiKeyHeader).toBe("azure-key");
+  });
+
+  it("calls the Cohere v2 rerank route with bearer auth", async () => {
+    let authHeader: string | null = null;
+    server.use(
+      http.post("https://api.cohere.ai/v2/rerank", ({ request }) => {
+        authHeader = request.headers.get("authorization");
+        return HttpResponse.json({
+          results: [{ index: 0, relevance_score: 0.7 }],
+        });
+      }),
+    );
+
+    const scores = await callNativeRerank({
+      provider: "cohere",
+      apiKey: "cohere-key",
+      // The configured default carries a version segment in some setups; the
+      // rerank route lives at /v2/rerank on the API root.
+      baseUrl: "https://api.cohere.ai/v1",
+      model: "rerank-v3.5",
+      query: "q",
+      documents: ["d"],
+    });
+
+    expect(authHeader).toBe("Bearer cohere-key");
+    expect(scores).toEqual([{ index: 0, score: 0.7 }]);
+  });
+
+  it("surfaces the provider's error message on failure", async () => {
+    server.use(
+      http.post(
+        "https://my-resource.cognitiveservices.azure.com/providers/cohere/v2/rerank",
+        () =>
+          HttpResponse.json(
+            { error: { message: "invalid model" } },
+            { status: 400 },
+          ),
+      ),
+    );
+
+    await expect(
+      callNativeRerank({
+        provider: "azure",
+        apiKey: "azure-key",
+        baseUrl: "https://my-resource.cognitiveservices.azure.com/openai/v1",
+        model: "Cohere-rerank-v4.0-fast",
+        query: "q",
+        documents: ["d"],
+      }),
+    ).rejects.toThrow("invalid model");
+  });
+
+  it("rejects a response without a results array", async () => {
+    server.use(
+      http.post("https://api.cohere.ai/v2/rerank", () =>
+        HttpResponse.json({ message: "ok but wrong shape" }),
+      ),
+    );
+
+    await expect(
+      callNativeRerank({
+        provider: "cohere",
+        apiKey: "cohere-key",
+        baseUrl: "https://api.cohere.ai",
+        model: "rerank-v3.5",
+        query: "q",
+        documents: ["d"],
+      }),
+    ).rejects.toThrow("no results array");
+  });
+
+  it("requires an API key for Azure when Entra ID is not enabled", async () => {
+    await expect(
+      callNativeRerank({
+        provider: "azure",
+        apiKey: null,
+        baseUrl: "https://my-resource.cognitiveservices.azure.com/openai/v1",
+        model: "Cohere-rerank-v4.0-fast",
+        query: "q",
+        documents: ["d"],
+      }),
+    ).rejects.toThrow("API key is required");
+  });
+});

--- a/platform/backend/src/knowledge-base/native-rerank.ts
+++ b/platform/backend/src/knowledge-base/native-rerank.ts
@@ -1,0 +1,162 @@
+import type { SupportedProvider } from "@archestra/shared";
+import {
+  getAzureOpenAiBearerTokenProvider,
+  isAzureOpenAiEntraIdEnabled,
+} from "@/clients/azure-openai-credentials";
+import { normalizeAzureApiKey } from "@/clients/azure-url";
+
+interface NativeRerankScore {
+  index: number;
+  /** Cohere relevance score, 0..1. */
+  score: number;
+}
+
+/**
+ * Whether a reranker model should be called through the provider's native
+ * rerank API instead of the chat + structured-output path. Dedicated rerank
+ * models (Cohere Rerank) serve only their own rerank route — the
+ * chat-completions probe 404s — and the native route is what they are for.
+ *
+ * Model/deployment names are free-form, so this is a name heuristic (like the
+ * Azure first-party model detection): Cohere names its rerank models
+ * `rerank-v3.5`, `rerank-english-v3.0`, ...; Azure AI Foundry deployments
+ * default to names like `Cohere-rerank-v4.0-fast`. Only providers with a
+ * known native rerank surface qualify.
+ */
+export function isNativeRerankModel(params: {
+  provider: SupportedProvider;
+  model: string;
+}): boolean {
+  return (
+    NATIVE_RERANK_PROVIDERS.has(params.provider) && /rerank/i.test(params.model)
+  );
+}
+
+/**
+ * Call the provider's native rerank API (Cohere v2 wire format) and return
+ * per-document relevance scores.
+ *
+ * - `cohere` — `<base>/v2/rerank` on the Cohere API with bearer auth.
+ * - `azure` — `<origin>/providers/cohere/v2/rerank`. Azure serves this route
+ *   on every host alias of a Foundry resource (`*.cognitiveservices.azure.com`,
+ *   `*.services.ai.azure.com`, `*.openai.azure.com`), so the origin of the
+ *   key's configured base URL is enough; `model` must be the deployment name.
+ */
+export async function callNativeRerank(params: {
+  provider: SupportedProvider;
+  apiKey: string | null;
+  baseUrl: string | null;
+  model: string;
+  query: string;
+  documents: string[];
+}): Promise<NativeRerankScore[]> {
+  const { url, headers } = await buildRerankRequest(params);
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: params.model,
+      query: params.query,
+      documents: params.documents,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new NativeRerankError(
+      response.status,
+      await describeRerankFailure(response),
+    );
+  }
+
+  const body = (await response.json()) as {
+    results?: { index?: number; relevance_score?: number }[];
+  };
+  if (!Array.isArray(body.results)) {
+    throw new NativeRerankError(
+      502,
+      "The rerank API returned no results array.",
+    );
+  }
+
+  return body.results
+    .filter(
+      (r): r is { index: number; relevance_score: number } =>
+        typeof r.index === "number" && typeof r.relevance_score === "number",
+    )
+    .map((r) => ({ index: r.index, score: r.relevance_score }));
+}
+
+// ===== Internal helpers =====
+
+class NativeRerankError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "NativeRerankError";
+  }
+}
+
+const NATIVE_RERANK_PROVIDERS: ReadonlySet<SupportedProvider> = new Set([
+  "cohere",
+  "azure",
+]);
+
+async function buildRerankRequest(params: {
+  provider: SupportedProvider;
+  apiKey: string | null;
+  baseUrl: string | null;
+}): Promise<{ url: string; headers: Record<string, string> }> {
+  if (params.provider === "azure") {
+    if (!params.baseUrl) {
+      throw new NativeRerankError(
+        400,
+        "Azure AI Foundry base URL is required.",
+      );
+    }
+    const origin = new URL(params.baseUrl).origin;
+    const url = `${origin}/providers/cohere/v2/rerank`;
+    const apiKey = normalizeAzureApiKey(params.apiKey ?? undefined);
+    if (apiKey) {
+      return { url, headers: { "api-key": apiKey } };
+    }
+    if (isAzureOpenAiEntraIdEnabled()) {
+      const token = await getAzureOpenAiBearerTokenProvider(params.baseUrl)();
+      return { url, headers: { Authorization: `Bearer ${token}` } };
+    }
+    throw new NativeRerankError(400, "Azure AI Foundry API key is required.");
+  }
+
+  if (!params.apiKey) {
+    throw new NativeRerankError(400, "Cohere API key is required.");
+  }
+  // The configured Cohere base URL may carry a version segment; the v2 rerank
+  // route lives at /v2/rerank on the API root.
+  const base = (params.baseUrl || COHERE_DEFAULT_BASE_URL)
+    .replace(/\/+$/, "")
+    .replace(/\/v[12]$/, "");
+  return {
+    url: `${base}/v2/rerank`,
+    headers: { Authorization: `Bearer ${params.apiKey}` },
+  };
+}
+
+const COHERE_DEFAULT_BASE_URL = "https://api.cohere.com";
+
+/** Rerank failures are surfaced to the settings UI; keep them short and readable. */
+async function describeRerankFailure(response: Response): Promise<string> {
+  const text = (await response.text().catch(() => "")).slice(0, 500);
+  try {
+    const parsed = JSON.parse(text) as {
+      error?: { message?: string };
+      message?: string;
+    };
+    const message = parsed.error?.message ?? parsed.message;
+    if (message) return message;
+  } catch {
+    // fall through to the raw body
+  }
+  return text || `Rerank request failed with HTTP ${response.status}.`;
+}

--- a/platform/backend/src/knowledge-base/query-expansion.test.ts
+++ b/platform/backend/src/knowledge-base/query-expansion.test.ts
@@ -23,6 +23,7 @@ import { expandQuery } from "./query-expansion";
 let server: ReturnType<typeof useMswServer>;
 
 const MOCK_RERANKER_CONFIG = {
+  kind: "llm" as const,
   llmModel: createOpenAI({
     baseURL: TEST_BASE_URL,
     apiKey: "test-key",
@@ -81,6 +82,27 @@ describe("expandQuery", () => {
 
   it("returns single query when no reranker config", async () => {
     mockResolveRerankerConfig.mockResolvedValue(null);
+
+    const result = await expandQuery({
+      queryText: "test query",
+      organizationId: "org-1",
+    });
+
+    expect(result).toEqual([
+      { queryText: "test query", weight: 1.0, type: "semantic" },
+    ]);
+  });
+
+  it("skips expansion when the reranker is a native rerank model", async () => {
+    // A dedicated rerank-API model can only score documents, not generate
+    // rephrasings — expansion degrades like an unconfigured reranker.
+    mockResolveRerankerConfig.mockResolvedValue({
+      kind: "native-rerank",
+      apiKey: "azure-key",
+      baseUrl: "https://my-resource.cognitiveservices.azure.com/openai/v1",
+      modelName: "Cohere-rerank-v4.0-fast",
+      provider: "azure",
+    });
 
     const result = await expandQuery({
       queryText: "test query",

--- a/platform/backend/src/knowledge-base/query-expansion.ts
+++ b/platform/backend/src/knowledge-base/query-expansion.ts
@@ -46,6 +46,16 @@ async function expandQuery(params: {
     );
     return [{ queryText, weight: 1.0, type: "semantic" }];
   }
+  if (rerankerConfig.kind !== "llm") {
+    // A dedicated rerank-API model (Cohere Rerank) can only score documents —
+    // it cannot generate rephrasings, so expansion degrades like an
+    // unconfigured reranker.
+    logger.debug(
+      { organizationId },
+      "[QueryExpansion] Reranker is a native rerank model, skipping expansion",
+    );
+    return [{ queryText, weight: 1.0, type: "semantic" }];
+  }
 
   const [semanticResult, keywordResult] = await Promise.allSettled([
     semanticRephrase({ queryText, rerankerConfig, connectorId }),

--- a/platform/backend/src/knowledge-base/reranker.test.ts
+++ b/platform/backend/src/knowledge-base/reranker.test.ts
@@ -84,12 +84,26 @@ async function waitForRerankerInteractions() {
 
 function setupRerankerConfig() {
   mockResolveRerankerConfig.mockResolvedValue({
+    kind: "llm",
     llmModel: createOpenAI({
       baseURL: TEST_BASE_URL,
       apiKey: "test-key",
     }).chat("gpt-4o"),
     modelName: "gpt-4o",
     provider: "openai",
+  });
+}
+
+const NATIVE_RERANK_URL =
+  "https://my-resource.cognitiveservices.azure.com/providers/cohere/v2/rerank";
+
+function setupNativeRerankerConfig() {
+  mockResolveRerankerConfig.mockResolvedValue({
+    kind: "native-rerank",
+    apiKey: "azure-key",
+    baseUrl: "https://my-resource.cognitiveservices.azure.com/openai/v1",
+    modelName: "Cohere-rerank-v4.0-fast",
+    provider: "azure",
   });
 }
 
@@ -223,5 +237,67 @@ describe("rerank", () => {
 
     const [row] = await waitForRerankerInteractions();
     expect(row.connectorId).toBeNull();
+  });
+
+  describe("native rerank models", () => {
+    it("reorders and filters chunks by native relevance scores, without any LLM call", async () => {
+      setupNativeRerankerConfig();
+      let sentDocuments: unknown;
+      server.use(
+        http.post(NATIVE_RERANK_URL, async ({ request }) => {
+          const body = (await request.json()) as { documents?: unknown };
+          sentDocuments = body.documents;
+          return HttpResponse.json({
+            results: [
+              { index: 1, relevance_score: 0.9 },
+              { index: 0, relevance_score: 0.4 },
+              // Below RERANKER_NATIVE_MIN_RELEVANCE_SCORE (0.1) — dropped.
+              { index: 2, relevance_score: 0.01 },
+            ],
+          });
+        }),
+      );
+
+      const chunks = [
+        makeChunk("a", "somewhat relevant"),
+        makeChunk("b", "most relevant"),
+        makeChunk("c", "irrelevant"),
+      ];
+      const result = await rerank({
+        queryText: "test query",
+        chunks,
+        organizationId: "test-org-id",
+      });
+
+      expect(sentDocuments).toEqual([
+        "somewhat relevant",
+        "most relevant",
+        "irrelevant",
+      ]);
+      expect(result.map((r) => r.id)).toEqual(["b", "a"]);
+      expect(chatCompletionCalls).toBe(0);
+    });
+
+    it("returns original order when the rerank API fails (graceful degradation)", async () => {
+      setupNativeRerankerConfig();
+      server.use(
+        http.post(NATIVE_RERANK_URL, () =>
+          HttpResponse.json(
+            { error: { message: "throttled" } },
+            { status: 429 },
+          ),
+        ),
+      );
+
+      const chunks = [makeChunk("a", "first"), makeChunk("b", "second")];
+      const result = await rerank({
+        queryText: "test query",
+        chunks,
+        organizationId: "test-org-id",
+      });
+
+      expect(result.map((r) => r.id)).toEqual(["a", "b"]);
+      expect(chatCompletionCalls).toBe(0);
+    });
   });
 });

--- a/platform/backend/src/knowledge-base/reranker.ts
+++ b/platform/backend/src/knowledge-base/reranker.ts
@@ -1,5 +1,8 @@
 import type { SupportedProvider } from "@archestra/shared";
-import { RERANKER_MIN_RELEVANCE_SCORE } from "@archestra/shared";
+import {
+  RERANKER_MIN_RELEVANCE_SCORE,
+  RERANKER_NATIVE_MIN_RELEVANCE_SCORE,
+} from "@archestra/shared";
 import { generateObject } from "ai";
 import { z } from "zod";
 import logger from "@/logging";
@@ -9,6 +12,7 @@ import {
   withKbObservability,
 } from "./kb-interaction";
 import { resolveRerankerConfig } from "./kb-llm-client";
+import { callNativeRerank } from "./native-rerank";
 
 async function rerank(params: {
   queryText: string;
@@ -45,6 +49,10 @@ async function rerank(params: {
       "[Reranker] No reranker API key configured, skipping reranking",
     );
     return chunks;
+  }
+
+  if (rerankerConfig.kind === "native-rerank") {
+    return nativeRerank({ queryText, chunks, config: rerankerConfig });
   }
 
   const numberedList = chunks
@@ -145,6 +153,76 @@ Score each passage from 0 (completely irrelevant) to 10 (perfectly relevant). Re
 export default rerank;
 
 // ===== Internal helpers =====
+
+/**
+ * Rerank through the provider's native rerank API (Cohere Rerank, directly or
+ * Azure-hosted). Same contract as the LLM path: sort by relevance, drop chunks
+ * below the (native-scale) floor, and fall back to the original order on any
+ * failure — reranking stays best-effort.
+ */
+async function nativeRerank(params: {
+  queryText: string;
+  chunks: VectorSearchResult[];
+  config: {
+    provider: SupportedProvider;
+    modelName: string;
+    apiKey: string | null;
+    baseUrl: string | null;
+  };
+}): Promise<VectorSearchResult[]> {
+  const { queryText, chunks, config } = params;
+
+  logger.info(
+    {
+      provider: config.provider,
+      model: config.modelName,
+      chunkCount: chunks.length,
+    },
+    "[Reranker] Calling native rerank API",
+  );
+
+  try {
+    const scores = await callNativeRerank({
+      provider: config.provider,
+      apiKey: config.apiKey,
+      baseUrl: config.baseUrl,
+      model: config.modelName,
+      query: queryText,
+      documents: chunks.map((chunk) => chunk.content),
+    });
+
+    const scoreMap = new Map<number, number>();
+    for (const { index, score } of scores) {
+      scoreMap.set(index, score);
+    }
+
+    const reranked = chunks
+      .map((chunk, idx) => ({ chunk, score: scoreMap.get(idx) ?? 0 }))
+      .sort((a, b) => b.score - a.score);
+
+    const filtered = reranked.filter(
+      (r) => r.score >= RERANKER_NATIVE_MIN_RELEVANCE_SCORE,
+    );
+
+    logger.info(
+      {
+        chunkCount: chunks.length,
+        filteredOut: reranked.length - filtered.length,
+        minRelevanceScore: RERANKER_NATIVE_MIN_RELEVANCE_SCORE,
+        scores: reranked.map(({ score }) => score),
+      },
+      "[Reranker] Native rerank scores received",
+    );
+
+    return filtered.map((r) => r.chunk);
+  } catch (error) {
+    logger.warn(
+      { error },
+      "[Reranker] Native reranking failed, returning original order",
+    );
+    return chunks;
+  }
+}
 
 function buildRerankerInteraction(
   config: { modelName: string; provider: SupportedProvider },

--- a/platform/backend/src/services/knowledge-settings.test.ts
+++ b/platform/backend/src/services/knowledge-settings.test.ts
@@ -108,4 +108,32 @@ describe("knowledgeSettingsService.validateRerankerConfig", () => {
       "Failed to verify reranker model. Raw error: model does not exist",
     );
   });
+
+  test("explains the mismatch when a dedicated rerank-API model fails verification", async ({
+    makeOrganization,
+    makeSecret,
+  }) => {
+    const org = await makeOrganization();
+    const secret = await makeSecret({ secret: { apiKey: "k" } });
+    const key = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      secretId: secret.id,
+      name: "Reranker Key",
+      provider: "azure",
+      scope: "org",
+      userId: null,
+    });
+    // A rerank-API deployment (e.g. Cohere Rerank) has no chat-completions
+    // route, so the provider answers the probe with a bare 404.
+    mockGenerateObject.mockRejectedValue(new Error("Not Found"));
+
+    const result = await knowledgeSettingsService.validateRerankerConfig({
+      keyId: key.id,
+      model: "Cohere-rerank-v4.0-fast",
+      organizationId: org.id,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Raw error: Not Found");
+    expect(result.error).toContain("select a chat model instead");
+  });
 });

--- a/platform/backend/src/services/knowledge-settings.test.ts
+++ b/platform/backend/src/services/knowledge-settings.test.ts
@@ -10,8 +10,10 @@ vi.mock("@/clients/llm-client", () => ({
   createDirectLLMModel: vi.fn().mockReturnValue({ id: "mock-model" }),
 }));
 
+import { HttpResponse, http } from "msw";
 import { LlmProviderApiKeyModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
 import { knowledgeSettingsService } from "./knowledge-settings";
 
 describe("knowledgeSettingsService.validateRerankerConfig", () => {
@@ -109,7 +111,7 @@ describe("knowledgeSettingsService.validateRerankerConfig", () => {
     );
   });
 
-  test("explains the mismatch when a dedicated rerank-API model fails verification", async ({
+  test("explains the mismatch when a rerank-API model is picked on a provider without a native rerank route", async ({
     makeOrganization,
     makeSecret,
   }) => {
@@ -119,21 +121,103 @@ describe("knowledgeSettingsService.validateRerankerConfig", () => {
       organizationId: org.id,
       secretId: secret.id,
       name: "Reranker Key",
-      provider: "azure",
+      provider: "gemini",
       scope: "org",
       userId: null,
     });
-    // A rerank-API deployment (e.g. Cohere Rerank) has no chat-completions
-    // route, so the provider answers the probe with a bare 404.
+    // A rerank-API model has no chat-completions route, so the provider
+    // answers the probe with a bare 404.
     mockGenerateObject.mockRejectedValue(new Error("Not Found"));
 
     const result = await knowledgeSettingsService.validateRerankerConfig({
       keyId: key.id,
-      model: "Cohere-rerank-v4.0-fast",
+      model: "my-rerank-model",
       organizationId: org.id,
     });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("Raw error: Not Found");
     expect(result.error).toContain("select a chat model instead");
+  });
+
+  describe("native rerank models", () => {
+    const server = useMswServer();
+
+    const makeAzureRerankKey = async (fixtures: {
+      makeOrganization: () => Promise<{ id: string }>;
+      makeSecret: (params: {
+        secret: Record<string, string>;
+      }) => Promise<{ id: string }>;
+    }) => {
+      const org = await fixtures.makeOrganization();
+      const secret = await fixtures.makeSecret({ secret: { apiKey: "k" } });
+      const key = await LlmProviderApiKeyModel.create({
+        organizationId: org.id,
+        secretId: secret.id,
+        name: "Azure Foundry Key",
+        provider: "azure",
+        baseUrl: "https://my-resource.cognitiveservices.azure.com/openai/v1",
+        scope: "org",
+        userId: null,
+      });
+      return { org, key };
+    };
+
+    test("verifies through the provider's native rerank route, not chat completions", async ({
+      makeOrganization,
+      makeSecret,
+    }) => {
+      const { org, key } = await makeAzureRerankKey({
+        makeOrganization,
+        makeSecret,
+      });
+      server.use(
+        http.post(
+          "https://my-resource.cognitiveservices.azure.com/providers/cohere/v2/rerank",
+          () =>
+            HttpResponse.json({
+              results: [{ index: 0, relevance_score: 0.9 }],
+            }),
+        ),
+      );
+
+      const result = await knowledgeSettingsService.validateRerankerConfig({
+        keyId: key.id,
+        model: "Cohere-rerank-v4.0-fast",
+        organizationId: org.id,
+      });
+      expect(result).toEqual({ ok: true });
+      expect(mockGenerateObject).not.toHaveBeenCalled();
+    });
+
+    test("surfaces the rerank API's error without the chat-model hint", async ({
+      makeOrganization,
+      makeSecret,
+    }) => {
+      const { org, key } = await makeAzureRerankKey({
+        makeOrganization,
+        makeSecret,
+      });
+      server.use(
+        http.post(
+          "https://my-resource.cognitiveservices.azure.com/providers/cohere/v2/rerank",
+          () =>
+            HttpResponse.json(
+              { error: { message: "unauthorized" } },
+              { status: 401 },
+            ),
+        ),
+      );
+
+      const result = await knowledgeSettingsService.validateRerankerConfig({
+        keyId: key.id,
+        model: "Cohere-rerank-v4.0-fast",
+        organizationId: org.id,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("unauthorized");
+      // The native route IS the right way to call this model; steering the
+      // user to a chat model here would be wrong.
+      expect(result.error).not.toContain("select a chat model");
+    });
   });
 });

--- a/platform/backend/src/services/knowledge-settings.ts
+++ b/platform/backend/src/services/knowledge-settings.ts
@@ -129,9 +129,17 @@ class KnowledgeSettingsService {
         { err: error },
         "[KnowledgeSettings] Reranker validation failed",
       );
+      // A dedicated rerank-API model (e.g. Cohere Rerank) is the natural pick
+      // for this setting, but it only serves its own rerank route — the
+      // provider rejects the chat-completions probe with an unhelpful raw
+      // error (a bare 404), so explain the mismatch when the name gives it
+      // away.
+      const rerankApiHint = /rerank/i.test(model)
+        ? " — this looks like a dedicated rerank-API model, which does not serve chat completions. Reranking uses a chat-capable LLM with structured output; select a chat model instead."
+        : "";
       return {
         ok: false,
-        error: `Failed to verify reranker model. Raw error: ${knowledgeValidationErrorMessage(error)}`,
+        error: `Failed to verify reranker model. Raw error: ${knowledgeValidationErrorMessage(error)}${rerankApiHint}`,
       };
     }
   }

--- a/platform/backend/src/services/knowledge-settings.ts
+++ b/platform/backend/src/services/knowledge-settings.ts
@@ -5,6 +5,10 @@ import { createDirectLLMModel } from "@/clients/llm-client";
 import { callEmbedding } from "@/knowledge-base/embedding-clients";
 import { toKnowledgeBaseUserMessage } from "@/knowledge-base/errors";
 import { resolveApiKeyFromChatApiKey } from "@/knowledge-base/kb-llm-client";
+import {
+  callNativeRerank,
+  isNativeRerankModel,
+} from "@/knowledge-base/native-rerank";
 import logger from "@/logging";
 import { LlmProviderApiKeyModel, ModelModel } from "@/models";
 
@@ -105,13 +109,33 @@ class KnowledgeSettingsService {
     }
 
     try {
+      // Dedicated rerank models are exercised through the provider's native
+      // rerank route; everything else through the chat + structured-output
+      // capability reranking relies on.
+      if (isNativeRerankModel({ provider: resolved.provider, model })) {
+        const scores = await callNativeRerank({
+          provider: resolved.provider,
+          apiKey: resolved.apiKey,
+          baseUrl: resolved.baseUrl,
+          model,
+          query: "hello",
+          documents: ["hello world"],
+        });
+        if (scores.length > 0) {
+          return { ok: true };
+        }
+        return {
+          ok: false,
+          error: "The rerank API returned no relevance scores.",
+        };
+      }
+
       const llmModel = createDirectLLMModel({
         provider: resolved.provider,
         apiKey: resolved.apiKey ?? undefined,
         modelName: model,
         baseUrl: resolved.baseUrl,
       });
-      // Exercise the exact capability reranking relies on: structured output.
       const result = await generateObject({
         model: llmModel,
         schema: RERANKER_VALIDATION_SCHEMA,
@@ -129,14 +153,15 @@ class KnowledgeSettingsService {
         { err: error },
         "[KnowledgeSettings] Reranker validation failed",
       );
-      // A dedicated rerank-API model (e.g. Cohere Rerank) is the natural pick
-      // for this setting, but it only serves its own rerank route — the
-      // provider rejects the chat-completions probe with an unhelpful raw
-      // error (a bare 404), so explain the mismatch when the name gives it
+      // A rerank-named model on a provider with no native rerank surface went
+      // through the chat-completions probe, which such deployments reject with
+      // an unhelpful raw error — explain the mismatch when the name gives it
       // away.
-      const rerankApiHint = /rerank/i.test(model)
-        ? " — this looks like a dedicated rerank-API model, which does not serve chat completions. Reranking uses a chat-capable LLM with structured output; select a chat model instead."
-        : "";
+      const rerankApiHint =
+        /rerank/i.test(model) &&
+        !isNativeRerankModel({ provider: resolved.provider, model })
+          ? " — this looks like a dedicated rerank-API model, which is supported with Cohere and Azure AI Foundry keys. With this provider, select a chat model instead."
+          : "";
       return {
         ok: false,
         error: `Failed to verify reranker model. Raw error: ${knowledgeValidationErrorMessage(error)}${rerankApiHint}`,

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -896,9 +896,9 @@ function KnowledgeSettingsContent() {
           <CardHeader>
             <CardTitle>Reranking Configuration</CardTitle>
             <CardDescription>
-              Configure the LLM used to rerank knowledge base search results for
-              improved relevance. Any LLM provider and model can be used —
-              reranking is optional.
+              Configure the model used to rerank knowledge base search results
+              for improved relevance. Use any chat model, or a Cohere Rerank
+              model (Cohere or Azure AI Foundry keys) — reranking is optional.
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -2135,8 +2135,8 @@ export function AgentDialog({
                                 <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
                               </Button>
                               <p className="text-xs text-muted-foreground">
-                                Configure embedding and reranking to use
-                                knowledge sources.
+                                Configure an embedding model to use knowledge
+                                sources.
                                 {canAccessKnowledgeSettings && (
                                   <>
                                     {" "}

--- a/platform/frontend/src/lib/knowledge/knowledge-base.query.test.tsx
+++ b/platform/frontend/src/lib/knowledge/knowledge-base.query.test.tsx
@@ -57,7 +57,9 @@ describe("useIsKnowledgeBaseConfigured", () => {
     expect(result.current).toBe(false);
   });
 
-  it("returns false when reranker API key is missing", () => {
+  it("returns true without a reranker — reranking is optional", () => {
+    // The backend query path skips reranking when unconfigured, so a missing
+    // reranker must not lock users out of knowledge bases.
     mockOrganization = {
       embeddingChatApiKeyId: "key-1",
       embeddingModel: "text-embedding-3-small",
@@ -67,7 +69,7 @@ describe("useIsKnowledgeBaseConfigured", () => {
     const { result } = renderHook(() => useIsKnowledgeBaseConfigured(), {
       wrapper: createWrapper(),
     });
-    expect(result.current).toBe(false);
+    expect(result.current).toBe(true);
   });
 
   it("returns false when both embedding and reranker are missing", () => {

--- a/platform/frontend/src/lib/knowledge/knowledge-base.query.ts
+++ b/platform/frontend/src/lib/knowledge/knowledge-base.query.ts
@@ -27,11 +27,14 @@ type KnowledgeBasesPaginatedParams = Pick<
 
 /**
  * Check if knowledge base prerequisites are configured.
- * Returns a boolean (all configured) and details about which parts are ready.
+ *
+ * Only embedding is a prerequisite: reranking is optional and best-effort —
+ * the backend query path skips it when unconfigured — so it must not gate
+ * knowledge base creation or agent knowledge-source assignment.
  */
 export function useIsKnowledgeBaseConfigured(): boolean {
   const status = useKnowledgeBaseConfigStatus();
-  return status.embedding && status.reranker;
+  return status.embedding;
 }
 
 export function useKnowledgeBaseConfigStatus() {

--- a/platform/shared/knowledge-base.ts
+++ b/platform/shared/knowledge-base.ts
@@ -146,6 +146,14 @@ export function getConnectorNamePlaceholder(
 export const RERANKER_MIN_RELEVANCE_SCORE = 3;
 
 /**
+ * Minimum relevance score (0..1) for chunks reranked through a native rerank
+ * API (Cohere Rerank). Cohere scores are query-relative with no universal
+ * cutoff, so this is a conservative floor that only drops clearly irrelevant
+ * chunks rather than mirroring the 3/10 LLM threshold.
+ */
+export const RERANKER_NATIVE_MIN_RELEVANCE_SCORE = 0.1;
+
+/**
  * Nomic embedding models require task instruction prefixes in the input text.
  * Documents should use "search_document: " and queries should use "search_query: ".
  * See: https://huggingface.co/nomic-ai/nomic-embed-text-v1.5


### PR DESCRIPTION
## Problem

Configuring a knowledge base reranker with an Azure AI Foundry key fails verification with:

> Failed to verify reranker model. Raw error: API version not supported

while the embedding configuration on the same key works fine. Reproduced locally against a real Foundry resource with a `.../openai/v1` base URL — **any** model fails as reranker there, `gpt-4.1` included.

## Root causes

**1. Direct-path Azure URL handling (`backend/src/clients/llm-client.ts`)**

The azure entry in `providerModelConfigs` built broken request URLs on the direct path (`createDirectLLMModel` — KB reranker verification and query-time reranking, title generation, dual-LLM subagents) for *both* Azure base URL shapes:

- **Foundry v1 endpoints** (`.../openai/v1`): a date-based `api-version` query param was appended unconditionally, and the v1 endpoint rejects it with HTTP 400 `{"error":{"code":"BadRequest","message":"API version not supported"}}` (verified against a live resource; the same request without the param succeeds).
- **Classic endpoints** (`.../openai` or resource root): the `/openai/deployments/<deployment>` segment was never added, so requests went to `<base>/chat/completions` and 404'd with "Resource not found" (also verified live).

The embedding client (`knowledge-base/embedding-clients/azure.ts`) and the proxy adapters already handle both shapes via `buildAzureDeploymentBaseUrl` + `shouldUseAzureOpenAiApiVersion` — which is exactly why embedding worked while reranking failed on the same key. This PR applies the same treatment on the direct path. The proxy path is untouched (its `baseURL` is the local proxy, never a v1 URL, so `shouldUseAzureOpenAiApiVersion` keeps injecting there as before).

Verified live against a real Azure AI Foundry resource after the fix: reranker verification passes for a first-party model (`gpt-4.1`, strict client) and an open model (`grok-4-1-fast-non-reasoning`, openai-compatible client) on a v1 base URL, and for a classic base URL; embedding unchanged.

**2. Reranking was de-facto mandatory despite being optional**

`useIsKnowledgeBaseConfigured()` required *both* embedding and reranker, so the Knowledge pages and the agent-dialog knowledge-sources picker stayed locked until a reranker verified — contradicting the settings card's own "reranking is optional" copy. The backend query path explicitly skips reranking when unconfigured (`knowledge-base/reranker.ts`), and the save route accepts a cleared reranker. The gate now requires embedding only; agent-dialog copy and the Knowledge docs page updated to match.

**3. Unhelpful error for dedicated rerank-API models**

A natural mistake in the reranking section is picking a provider's dedicated rerank model (e.g. Cohere Rerank on Foundry). Those deployments only serve their own rerank route — the chat-completions probe gets a bare 404, surfacing as "Raw error: Not Found". Verification now appends an explanation when the model name looks like a rerank-API model, pointing the user at a chat-capable LLM instead. (Supporting native rerank APIs as a reranker backend is a possible follow-up, deliberately out of scope here.)

## Native Cohere Rerank support

Dedicated rerank-API models are now first-class reranker choices instead of failing verification:

- New `native-rerank` client speaking the Cohere v2 wire format: `<base>/v2/rerank` on Cohere keys, `<origin>/providers/cohere/v2/rerank` on Azure AI Foundry keys. The Azure route is served on every host alias of a Foundry resource (`cognitiveservices`/`services.ai`/`openai` hosts — all verified live), so the origin of the key's stored base URL is enough; `model` is the deployment name.
- Detection is a name heuristic (model name contains `rerank`) scoped to providers with a native rerank surface (`cohere`, `azure`) — same spirit as the existing Azure first-party model-name heuristic.
- `resolveRerankerConfig` now returns a discriminated `llm` / `native-rerank` config. The query-time reranker sorts by native relevance scores and floors them at `RERANKER_NATIVE_MIN_RELEVANCE_SCORE` (0.1, conservative — Cohere scores are query-relative), degrading to original order on any failure, same as the LLM path.
- Query expansion (which reuses the reranker LLM for rephrasings) skips expansion for a native rerank model — it can only score documents — instead of failing the query.
- Verification (`test-reranker` + save) probes the native route for these models; the chat-model hint from earlier in this PR now only fires for providers *without* a native rerank surface.
- Settings copy + docs updated.

Verified live against a real Azure AI Foundry `Cohere-rerank-v4.0-fast` deployment: verification passes end-to-end through the settings endpoints, the save route accepts the configuration, and the shipped client correctly ranks a relevance test set (relevant doc 0.92, filler ~0.10). Cohere-direct is covered by wire-level tests (identical v2 format, confirmed by Azure's passthrough responses).
