### PR TITLE
fix(oauth): stop relaying better-auth's bodyless responses as the JSON literal `null`

### DIFF
--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -1424,6 +1424,30 @@ describe("auth routes", () => {
       expect(response.body).toBe("");
     });
 
+    test("a bodyless response does not claim to carry JSON", async () => {
+      // better-call turns an `APIError` thrown without a body — better-auth's
+      // admin plugin and authorization middleware both do this — into a
+      // bodyless response that still declares `content-type: application/json`.
+      // Relaying that header with an empty body hands the client a response
+      // that contradicts itself, so `.json()` throws a parse error.
+      vi.mocked(betterAuth.handler).mockResolvedValue(
+        new Response(null, {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/admin/has-permission",
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.body).toBe("");
+      expect(response.headers["content-type"]).toBeUndefined();
+    });
+
     test("a real better-auth body is still relayed verbatim", async () => {
       const tokenError = JSON.stringify({
         error: "invalid_grant",

--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -1318,6 +1318,139 @@ describe("auth routes", () => {
       expect(lastForwardedOrigin()).toBeNull();
     });
   });
+
+  /**
+   * better-auth's router (better-call) answers with a *bodyless* `Response`
+   * whenever it cannot dispatch a request — an unknown path, a path that only
+   * exists under another method, a trailing-slash or double-slash mismatch —
+   * and whenever it turns an unhandled error into a 500.
+   *
+   * Relaying that through `reply.send(null)` does not forward "no body":
+   * Fastify serializes the JSON literal `null`, a four-byte `application/json`
+   * body. It is valid JSON but not an object, so an OAuth client decoding a
+   * token response reports a type error against its own schema instead of the
+   * HTTP failure that actually happened — the Codex CLI aborts an MCP gateway
+   * login with `invalid type: null, expected struct StandardTokenResponse at
+   * line 1 column 4`, naming neither the status nor the cause.
+   */
+  describe("bodyless better-auth responses", () => {
+    test("the token endpoint never answers with the JSON literal `null`", async () => {
+      // Exactly what better-call returns when no route matches the request.
+      vi.mocked(betterAuth.handler).mockResolvedValue(
+        new Response(null, { status: 404, statusText: "Not Found" }),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/oauth2/token",
+        payload: {
+          grant_type: "authorization_code",
+          client_id: "some-client",
+          code: "auth-code",
+          code_verifier: "a-code-verifier",
+        },
+      });
+
+      // The regression itself: a 4-byte `null` body is what breaks the client.
+      expect(response.body).not.toBe("null");
+      expect(response.rawPayload).toHaveLength(response.body.length);
+
+      // RFC 6749 §5.2 — a token-endpoint failure is a JSON *object*.
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toMatchObject({ error: "invalid_request" });
+      expect(response.headers["cache-control"]).toBe("no-store");
+    });
+
+    test("an unhandled better-auth error becomes an OAuth server_error", async () => {
+      vi.mocked(betterAuth.handler).mockResolvedValue(
+        new Response(null, {
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/oauth2/token",
+        payload: {
+          grant_type: "authorization_code",
+          client_id: "some-client",
+          code: "auth-code",
+          code_verifier: "a-code-verifier",
+        },
+      });
+
+      expect(response.body).not.toBe("null");
+      expect(response.statusCode).toBe(500);
+      expect(response.json()).toMatchObject({ error: "server_error" });
+    });
+
+    test("a bodyless response is never reported as success", async () => {
+      // A token endpoint must not claim success without a token, so a bodyless
+      // 2xx is surfaced as a server error rather than relayed as one.
+      vi.mocked(betterAuth.handler).mockResolvedValue(
+        new Response(null, { status: 200 }),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/oauth2/token",
+        payload: {
+          grant_type: "authorization_code",
+          client_id: "some-client",
+          code: "auth-code",
+          code_verifier: "a-code-verifier",
+        },
+      });
+
+      expect(response.body).not.toBe("null");
+      expect(response.statusCode).toBe(500);
+      expect(response.json()).toMatchObject({ error: "server_error" });
+    });
+
+    test("the /api/auth catch-all forwards no body as no body", async () => {
+      vi.mocked(betterAuth.handler).mockResolvedValue(
+        new Response(null, { status: 404, statusText: "Not Found" }),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/definitely-not-a-route",
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.body).not.toBe("null");
+      expect(response.body).toBe("");
+    });
+
+    test("a real better-auth body is still relayed verbatim", async () => {
+      const tokenError = JSON.stringify({
+        error: "invalid_grant",
+        error_description: "invalid code",
+      });
+      vi.mocked(betterAuth.handler).mockResolvedValue(
+        new Response(tokenError, {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/oauth2/token",
+        payload: {
+          grant_type: "authorization_code",
+          client_id: "some-client",
+          code: "auth-code",
+          code_verifier: "a-code-verifier",
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.body).toBe(tokenError);
+    });
+  });
 });
 
 async function createAuthTestApp(): Promise<FastifyInstanceWithZod> {

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -268,13 +268,11 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
         }
       }
 
-      reply.status(response.status);
-
-      response.headers.forEach((value: string, key: string) => {
-        reply.header(key, value);
+      relayBetterAuthResponse({
+        reply,
+        response,
+        body: await readBetterAuthResponseBody(response),
       });
-
-      reply.send(response.body ? await response.text() : null);
     },
   });
 
@@ -418,11 +416,11 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
       const response = await betterAuth.handler(req);
 
-      reply.status(response.status);
-      response.headers.forEach((value: string, key: string) => {
-        reply.header(key, value);
+      relayBetterAuthResponse({
+        reply,
+        response,
+        body: await readBetterAuthResponseBody(response),
       });
-      reply.send(response.body ? await response.text() : null);
     },
   });
 
@@ -630,7 +628,7 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
       });
 
       const response = await betterAuth.handler(req);
-      const rawResponseBody = response.body ? await response.text() : null;
+      const rawResponseBody = await readBetterAuthResponseBody(response);
 
       // Bind a shareable-App connector token to its canonical resource URI
       // (RFC 8707) so it is accepted only at its own connector — before deriving
@@ -691,14 +689,38 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
         );
       }
 
-      reply.status(response.status);
-      response.headers.forEach((value: string, key: string) => {
-        if (key.toLowerCase() === "content-length") {
-          return;
-        }
-        reply.header(key, value);
+      // better-auth answers bodyless whenever its router cannot dispatch the
+      // request (unknown path, wrong method, path-shape mismatch) or turns an
+      // unhandled error into a 500. RFC 6749 §5.2 requires a JSON object here,
+      // so translate rather than forward the empty body: a client that gets
+      // nothing — or the JSON literal `null` this used to send — can only
+      // report a parse failure against its own token-response schema, naming
+      // neither the status nor the cause.
+      if (responseBody === null) {
+        const tokenError = oauthTokenErrorForBodylessResponse(response.status);
+        logger.error(
+          {
+            grantType: body?.grant_type,
+            clientId: body?.client_id,
+            betterAuthStatus: response.status,
+            status: tokenError.status,
+          },
+          "[auth:oauth2/token] better-auth returned no response body; answering with an OAuth error",
+        );
+        return reply
+          .status(tokenError.status)
+          .header("content-type", "application/json; charset=utf-8")
+          .header("cache-control", "no-store")
+          .header("pragma", "no-cache")
+          .send(tokenError.body);
+      }
+
+      relayBetterAuthResponse({
+        reply,
+        response,
+        body: responseBody,
+        skipContentLength: true,
       });
-      reply.send(responseBody);
     },
   });
 
@@ -764,16 +786,12 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
           body: serializedBody,
         }),
       );
-      const responseBody = response.body ? await response.text() : null;
-
-      reply.status(response.status);
-      response.headers.forEach((value: string, key: string) => {
-        if (key.toLowerCase() === "content-length") {
-          return;
-        }
-        reply.header(key, value);
+      relayBetterAuthResponse({
+        reply,
+        response,
+        body: await readBetterAuthResponseBody(response),
+        skipContentLength: true,
       });
-      reply.send(responseBody);
     },
   });
 
@@ -967,11 +985,11 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
         return;
       }
 
-      reply.status(response.status);
-      response.headers.forEach((value: string, key: string) => {
-        reply.header(key, value);
+      relayBetterAuthResponse({
+        reply,
+        response,
+        body: await readBetterAuthResponseBody(response),
       });
-      reply.send(response.body ? await response.text() : null);
     },
   });
 
@@ -999,11 +1017,11 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
         requestBody: request.body as Record<string, unknown> | undefined,
       });
 
-      reply.status(response.status);
-      response.headers.forEach((value: string, key: string) => {
-        reply.header(key, value);
+      relayBetterAuthResponse({
+        reply,
+        response,
+        body: await readBetterAuthResponseBody(response),
       });
-      reply.send(response.body ? await response.text() : null);
     },
   });
   // SPDX-SnippetEnd
@@ -1076,13 +1094,11 @@ const authRoutes: FastifyPluginAsyncZod = async (fastify) => {
         return reply.send(responseText);
       }
 
-      reply.status(response.status);
-
-      response.headers.forEach((value: string, key: string) => {
-        reply.header(key, value);
+      relayBetterAuthResponse({
+        reply,
+        response,
+        body: await readBetterAuthResponseBody(response),
       });
-
-      reply.send(response.body ? await response.text() : null);
     },
   });
 };
@@ -1328,6 +1344,96 @@ async function issueMcpOauthClientAccessToken(params: {
       expires_in: expiresIn,
       scope: MCP_GATEWAY_OAUTH_SCOPE,
     },
+  };
+}
+
+/**
+ * Minimal shape of the Fastify reply used by `relayBetterAuthResponse`, kept
+ * structural so the helper works with every route's zod-typed reply.
+ */
+type BetterAuthRelayReply = {
+  status: (statusCode: number) => unknown;
+  header: (name: string, value: string) => unknown;
+  send: (payload?: string) => unknown;
+};
+
+/**
+ * Copy a better-auth `Response` onto a Fastify reply.
+ *
+ * better-auth's router (better-call) answers with a *bodyless* `Response`
+ * whenever it cannot dispatch a request — an unknown path, a path that only
+ * exists under a different method, a trailing-slash or double-slash mismatch —
+ * and whenever it turns an unhandled error into a 500.
+ *
+ * That missing body must not be handed to `reply.send(null)`. Fastify does not
+ * read `null` as "no body": it serializes the JSON literal `null`, a four-byte
+ * body sent as `application/json`. It parses as valid JSON but is not an
+ * object, so a client decoding a typed response reports a *type* error against
+ * its own schema instead of the HTTP failure that actually happened. On the
+ * OAuth token endpoint that is the difference between a diagnosable error and
+ * none at all: the Codex CLI aborts the whole MCP gateway login with
+ * `OAuth token exchange failed: invalid type: null, expected struct
+ * StandardTokenResponse at line 1 column 4`, which names neither the status nor
+ * the cause.
+ *
+ * A bodyless upstream response therefore stays bodyless.
+ */
+function relayBetterAuthResponse(params: {
+  reply: BetterAuthRelayReply;
+  response: Response;
+  body: string | null;
+  skipContentLength?: boolean;
+}): void {
+  const { reply, response, body, skipContentLength } = params;
+
+  reply.status(response.status);
+  response.headers.forEach((value: string, key: string) => {
+    if (skipContentLength && key.toLowerCase() === "content-length") {
+      return;
+    }
+    reply.header(key, value);
+  });
+
+  reply.send(body ?? undefined);
+}
+
+/**
+ * Read a better-auth response body, preserving the distinction between "empty
+ * body" and "no body at all" — `null` means the response carried no body.
+ */
+async function readBetterAuthResponseBody(
+  response: Response,
+): Promise<string | null> {
+  return response.body ? await response.text() : null;
+}
+
+/**
+ * Status and body for a token-endpoint response that better-auth answered
+ * without one. RFC 6749 §5.2 requires a JSON object carrying an `error`
+ * member, so the bodyless response is translated instead of forwarded.
+ *
+ * A token endpoint must never report success without a token, so anything that
+ * is not an explicit client error is reported as `server_error` with a 5xx.
+ */
+function oauthTokenErrorForBodylessResponse(betterAuthStatus: number): {
+  status: number;
+  body: string;
+} {
+  const isClientError = betterAuthStatus >= 400 && betterAuthStatus < 500;
+  return {
+    status: isClientError ? betterAuthStatus : 500,
+    body: JSON.stringify(
+      isClientError
+        ? {
+            error: "invalid_request",
+            error_description: `The authorization server rejected the token request (HTTP ${betterAuthStatus}).`,
+          }
+        : {
+            error: "server_error",
+            error_description:
+              "The authorization server did not return a token response.",
+          },
+    ),
   };
 }
 

--- a/platform/backend/src/routes/auth.ts
+++ b/platform/backend/src/routes/auth.ts
@@ -1388,7 +1388,22 @@ function relayBetterAuthResponse(params: {
 
   reply.status(response.status);
   response.headers.forEach((value: string, key: string) => {
-    if (skipContentLength && key.toLowerCase() === "content-length") {
+    const name = key.toLowerCase();
+    if (skipContentLength && name === "content-length") {
+      return;
+    }
+    // A response with no body must not claim to carry one. better-call builds
+    // its router misses with `new Response(null, …)`, which has no headers at
+    // all — but an `APIError` thrown without a body (better-auth's admin plugin
+    // and authorization middleware both do this) is turned into a bodyless
+    // response that still declares `content-type: application/json`. Forwarding
+    // that pairs an empty body with a JSON content type, so a client that
+    // trusts the header and calls `.json()` gets a parse error — the same class
+    // of failure this whole change exists to remove.
+    if (
+      body === null &&
+      (name === "content-type" || name === "content-length")
+    ) {
       return;
     }
     reply.header(key, value);


### PR DESCRIPTION
## The bug

Registering an MCP gateway with the Codex CLI dies at the OAuth callback:

```
Error: failed to handle OAuth callback

Caused by:
    OAuth token exchange failed: invalid type: null, expected struct StandardTokenResponse at line 1 column 4
```

The message names neither the status nor the cause, which is the whole problem — it is a client-side *schema* complaint standing in for a server-side failure nobody can see.

## What that message actually means

It means the token endpoint returned the **4-byte JSON literal `null`**.

I pinned this against a stub authorization server driving the real `codex mcp add` flow, and two properties matter:

- A `null` body reproduces the message **verbatim at any status** — 200 and 400 both. So the status code is invisible to the client.
- An **empty** body produces a *different* message (`Other error: server returned empty response body`). So `null` specifically was on the wire, not "nothing".

## Root cause

`routes/auth.ts` relayed better-auth to Fastify with `response.body ? await response.text() : null` at six sites. Two facts collide:

1. **`reply.send(null)` is not "no body" in Fastify.** Measured directly: `send(null)` → `len=4`, `content-type: application/json`, body `null`. `send(undefined)` and `send()` → `len=0`.
2. **better-auth's router (`better-call`) answers bodyless.** It returns `new Response(null, …)` for every route miss — unknown path, a path that only exists under another method, a trailing-slash or double-slash mismatch — and for any unhandled error it converts to a 500.

So every bodyless better-auth response reached clients as a body that is valid JSON but is not an object. A client decoding a typed response reports a type error against its own schema instead of the HTTP failure that happened.

This was reproducible on `main` before this change — `GET /api/auth/oauth2/token` returned **404 with a 4-byte `null` body**, on a dev stack and on the staging environment alike.

## Fix

- A bodyless upstream response now stays bodyless (`relayBetterAuthResponse`), across all six relay sites — the six near-identical blocks collapse into one helper that documents the trap.
- The **token endpoint** goes further and synthesizes an RFC 6749 §5.2 error object, because an empty body leaves an OAuth client with nothing to report either. A bodyless 4xx becomes `invalid_request`; anything else becomes `server_error`, since a token endpoint must never report success without a token.
- The bodyless case is logged at error level with the upstream status, so the underlying condition is diagnosable rather than silent.

Codex now reports:

```
OAuth token exchange failed: Server returned error response: server_error: The authorization server did not return a token response.
```

## Tests

Five tests in `auth.test.ts` pinning the exact root cause. I verified they bite by temporarily restoring the old behaviour — four fail with `expected 'null' not to be 'null'`, the precise byte sequence that broke the client:

- the token endpoint never answers with the JSON literal `null` (bodyless 404 → `invalid_request`)
- an unhandled better-auth error becomes an OAuth `server_error`
- a bodyless response is never reported as success (bodyless 2xx → 500)
- the `/api/auth` catch-all forwards no body as no body
- a real better-auth body is still relayed verbatim

## Verified

- 48/48 in `auth.test.ts`; `oauth-cors` and `oauth-server` suites green. (`oauth.test.ts` has 7 network-dependent timeouts that fail identically on an untouched checkout — pre-existing, unrelated.)
- `tsc --noEmit` clean, `biome check` clean, `knip --production` clean.
- Full `codex mcp add` OAuth login completes end to end against a dev stack with the fix applied, and the gateway is usable afterwards.

## Note for reviewers

Which bodyless branch the original report hit upstream was **not** determined: the pods had been recycled by the time I looked, and that cluster's request logs are not in Cloud Logging. That is precisely the failure mode this change fixes — after it, the real status and a proper OAuth error reach the client and the log, so a recurrence is self-diagnosing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>