### PR TITLE
fix(llm-proxy): record and report token usage that streaming and Responses turns were dropping

### DIFF
--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -137,6 +137,32 @@ interface A2AManagerConfig {
 }
 
 /**
+ * Out-of-band execution parameters passed through to `executeA2AMessage`.
+ *
+ * Named (rather than inlined on `sendMessage`) so callers that build it as an
+ * intermediate `const` can annotate it: TypeScript only applies
+ * excess-property checking to object literals assigned directly to a typed
+ * target, so an unannotated intermediate silently swallows a misspelled key.
+ * That is not hypothetical — chatops passed `route:` for a while and every
+ * ChatOps run was traced as `a2a` because nothing reads that key.
+ */
+export interface A2ASystemParams {
+  sessionId?: string;
+  source?: InteractionSource;
+  routeCategory?: RouteCategory;
+  chatOpsBindingId?: string;
+  chatOpsThreadId?: string;
+  /**
+   * Per-turn framing prepended to the executed user turn but NOT
+   * persisted with it. Callers with server-side sessions (chatops) put
+   * situational context here — "(Telegram conversation, thread id: …)",
+   * group framing — so the stored history stays clean instead of
+   * repeating the frame on every persisted turn.
+   */
+  ephemeralExecutionPrefix?: string;
+}
+
+/**
  * How a full-task-mode send executes its run.
  * - "blocking": awaited; the response carries the settled outcome.
  * - "detached": the task handle returns immediately and the run continues in
@@ -159,21 +185,7 @@ export class A2AManager {
     agentId: string;
     request: A2AProtocolSendMessageRequest;
     // systemParams are currently used for passing through to executeA2AMessage(...)
-    systemParams?: {
-      sessionId?: string;
-      source?: InteractionSource;
-      routeCategory?: RouteCategory;
-      chatOpsBindingId?: string;
-      chatOpsThreadId?: string;
-      /**
-       * Per-turn framing prepended to the executed user turn but NOT
-       * persisted with it. Callers with server-side sessions (chatops) put
-       * situational context here — "(Telegram conversation, thread id: …)",
-       * group framing — so the stored history stays clean instead of
-       * repeating the frame on every persisted turn.
-       */
-      ephemeralExecutionPrefix?: string;
-    };
+    systemParams?: A2ASystemParams;
     /**
      * Fired when loading the context's history triggered a persisted
      * cross-turn compaction (stateful mode only), before the agent executes.

--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -35,6 +35,7 @@ import {
   LlmProviderApiKeyModelLinkModel,
   ModelModel,
 } from "@/models";
+import { RouteCategory } from "@/observability/tracing";
 import { ProviderError } from "@/routes/chat/errors";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type {
@@ -1661,6 +1662,127 @@ describe("ChatOpsManager security validation", () => {
         userId: user.id, // Real user ID, not "chatops-ms-teams-xxx"
       }),
     );
+  });
+
+  // Both ChatOps entry points must tag their run with the ChatOps route
+  // category. `sendMessage` falls back to RouteCategory.A2A when the key is
+  // absent, so a misspelled or omitted key is silently swallowed and every
+  // ChatOps run gets traced as plain A2A. That is exactly what happened: the
+  // initial send passed `route:` (a key nothing reads) and the approval-resume
+  // path passed no route category at all.
+  test("a ChatOps message is routed with the ChatOps route category", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const sendMessageSpy = vi
+      .spyOn(A2AManager.prototype, "sendMessage")
+      .mockResolvedValue({});
+
+    const user = await makeUser({ email: "verified@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: agent.id,
+    });
+
+    const mockProvider = createMockProvider({
+      getUserEmail: async () => "verified@example.com",
+    });
+    const manager = makeManagerWith(mockProvider);
+
+    try {
+      await manager.processMessage({
+        message: createMockMessage(),
+        provider: mockProvider,
+      });
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemParams: expect.objectContaining({
+            routeCategory: RouteCategory.CHATOPS,
+          }),
+        }),
+      );
+    } finally {
+      sendMessageSpy.mockRestore();
+    }
+  });
+
+  test("resuming after an approval decision keeps the ChatOps route category", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const sendMessageSpy = vi
+      .spyOn(A2AManager.prototype, "sendMessage")
+      .mockResolvedValue({});
+
+    const user = await makeUser({ email: "approver@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: agent.id,
+    });
+
+    const mockProvider = createMockProvider();
+    const manager = new ChatOpsManager();
+
+    const decision: ChatOpsApprovalDecision = {
+      taskId: "task-1",
+      approvalId: "approval-1",
+      approved: true,
+      toolName: "some_tool",
+      messageTs: "msg-ts",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      userId: "teams-aad-id",
+      userName: "Approver",
+      responseUrl: "",
+      approverEmail: "approver@example.com",
+      originalMessage: createMockMessage({
+        senderEmail: "approver@example.com",
+      }),
+    };
+
+    try {
+      await manager.handleInteractiveApprovalDecision(mockProvider, decision);
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemParams: expect.objectContaining({
+            routeCategory: RouteCategory.CHATOPS,
+          }),
+        }),
+      );
+    } finally {
+      sendMessageSpy.mockRestore();
+    }
   });
 
   test("Teams approver mixed-case email is accepted", async ({

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -5,7 +5,7 @@ import {
   providerDisplayNames,
   type ResourceVisibilityScope,
 } from "@archestra/shared";
-import { A2AManager } from "@/agents/a2a/a2a-manager";
+import { A2AManager, type A2ASystemParams } from "@/agents/a2a/a2a-manager";
 import type { A2AAttachment } from "@/agents/a2a-executor";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { resolveRunToolTarget } from "@/archestra-mcp-server/run-tool-target";
@@ -2215,10 +2215,10 @@ export class ChatOpsManager {
     });
     const source: InteractionSource =
       CHATOPS_PROVIDER_SOURCES[provider.providerId];
-    const systemParams = {
+    const systemParams: A2ASystemParams = {
       sessionId,
       source,
-      route: RouteCategory.CHATOPS,
+      routeCategory: RouteCategory.CHATOPS,
       chatOpsBindingId: binding.id,
       chatOpsThreadId: effectiveThreadId,
       ephemeralExecutionPrefix,
@@ -2401,6 +2401,9 @@ export class ChatOpsManager {
             originalMessage.threadId,
           ),
           source: CHATOPS_PROVIDER_SOURCES[provider.providerId],
+          // Resuming after an approval is still a ChatOps run; without this it
+          // would fall back to the A2A route category like the initial send did.
+          routeCategory: RouteCategory.CHATOPS,
         },
       });
 

--- a/platform/backend/src/observability/metrics/llm.test.ts
+++ b/platform/backend/src/observability/metrics/llm.test.ts
@@ -168,6 +168,66 @@ describe("getObservableFetch", () => {
     });
   });
 
+  // `openai`, `azure` and `perplexity` each serve two wire shapes, and the
+  // Responses one names its counts `input_tokens`/`output_tokens`. Read with
+  // the chat-completions extractor, `prompt_tokens` is undefined, the uncached
+  // subtraction yields NaN, and the reporter's falsy guard then drops the turn
+  // from the token metric altogether — silently, since nothing is ever wrong,
+  // only missing. So every provider that serves both shapes must sniff.
+  for (const provider of ["openai", "azure", "perplexity"] as const) {
+    test(`${provider}: counts tokens on a Responses-shaped body`, async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        clone: () => ({
+          json: async () => ({
+            usage: {
+              input_tokens: 4321,
+              input_tokens_details: { cached_tokens: 4000 },
+              output_tokens: 77,
+              output_tokens_details: { reasoning_tokens: 11 },
+              total_tokens: 4398,
+            },
+            model: "gpt-4o",
+          }),
+        }),
+      } as Response;
+
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const observableFetch = getObservableFetch(provider, testAgent, "api");
+      await observableFetch("https://api.openai.com/v1/responses", {
+        method: "POST",
+      });
+
+      const labels = {
+        provider,
+        agent_id: testAgent.id,
+        agent_name: testAgent.name,
+        agent_type: testAgent.agentType,
+        source: "api",
+        model: "gpt-4o",
+      };
+      // Cached reads are a subset of input_tokens, so uncached input = 321.
+      expect(counterInc).toHaveBeenCalledWith({
+        labels: { ...labels, type: "input" },
+        value: 321,
+        exemplarLabels: expect.any(Object),
+      });
+      expect(counterInc).toHaveBeenCalledWith({
+        labels: { ...labels, type: "output" },
+        value: 77,
+        exemplarLabels: expect.any(Object),
+      });
+      expect(counterInc).toHaveBeenCalledWith({
+        labels: { ...labels, cache_type: "read" },
+        value: 4000,
+        exemplarLabels: expect.any(Object),
+      });
+    });
+  }
+
   test("records duration with 4xx status code", async () => {
     const mockResponse = {
       ok: false,

--- a/platform/backend/src/observability/metrics/llm.ts
+++ b/platform/backend/src/observability/metrics/llm.ts
@@ -23,7 +23,7 @@ import { getUsageTokens as getGeminiUsage } from "@/routes/proxy/adapters/gemini
 import { getUsageTokens as getMinimaxUsage } from "@/routes/proxy/adapters/minimax";
 import { getUsageTokens as getOllamaNativeUsage } from "@/routes/proxy/adapters/ollama-native";
 import { getUsageTokens as getOpenAIUsage } from "@/routes/proxy/adapters/openai";
-import { getUsageTokens as getPerplexityResponsesUsage } from "@/routes/proxy/adapters/perplexity-responses";
+import { responsesUsageTokens } from "@/routes/proxy/adapters/responses-usage";
 import { getUsageTokens as getZhipuaiUsage } from "@/routes/proxy/adapters/zhipuai";
 import type { GatewayAgent } from "@/types";
 import { getExemplarLabels, sanitizeLabelKey } from "./utils";
@@ -39,13 +39,30 @@ type UsageExtractor =
   | null;
 
 /**
+ * Extractor for a provider that serves BOTH the chat-completions and the
+ * Responses wire shape, whose usage objects name their fields differently
+ * (`prompt_tokens` vs `input_tokens`). It sniffs which body arrived rather than
+ * assuming one.
+ *
+ * Assuming one is not a near miss: run the chat extractor on a Responses body
+ * and it subtracts from `undefined`, so `input` comes back NaN and `output`
+ * undefined. `reportLLMTokens` skips falsy counts, so the turn is not reported
+ * wrong — it vanishes from the token metric entirely.
+ */
+function getChatOrResponsesUsage(usage: Record<string, unknown>) {
+  return "input_tokens" in usage
+    ? responsesUsageTokens(usage as Parameters<typeof responsesUsageTokens>[0])
+    : getOpenAIUsage(usage as Parameters<typeof getOpenAIUsage>[0]);
+}
+
+/**
  * Maps each provider to its usage token extraction function for fetch-based observability.
  * Providers mapped to `null` use their own observability wrappers (e.g. Gemini uses getObservableGenAI,
  * Bedrock uses its own client) and should not extract tokens here to avoid double-reporting.
  * Using Record<SupportedProvider, ...> ensures TypeScript enforces adding new providers here.
  */
 const fetchUsageExtractors: Record<SupportedProvider, UsageExtractor> = {
-  openai: getOpenAIUsage,
+  openai: getChatOrResponsesUsage,
   archestra: getOpenAIUsage,
   cerebras: getOpenAIUsage,
   vllm: getOpenAIUsage,
@@ -54,19 +71,12 @@ const fetchUsageExtractors: Record<SupportedProvider, UsageExtractor> = {
   // `rootUsageExtractors` below, which handles it before the `data.usage` guard.
   "ollama-native": null,
   mistral: getOpenAIUsage,
-  // The provider serves two wire shapes — chat completions for the `sonar*`
-  // models and Responses for the Agent API models — whose usage objects differ
-  // (`prompt_tokens` vs `input_tokens`), so the extractor sniffs which body
-  // arrived rather than assuming one.
-  perplexity: (usage) =>
-    "input_tokens" in usage
-      ? getPerplexityResponsesUsage(usage)
-      : getOpenAIUsage(usage),
+  perplexity: getChatOrResponsesUsage,
   groq: getOpenAIUsage,
   xai: getOpenAIUsage,
   openrouter: getOpenAIUsage,
   anthropic: getAnthropicUsage,
-  azure: getOpenAIUsage,
+  azure: getChatOrResponsesUsage,
   cohere: getCohereUsage,
   zhipuai: getZhipuaiUsage,
   minimax: getMinimaxUsage,

--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai.ts
@@ -14,6 +14,7 @@ import {
   anthropicResponseToOpenai,
   mapStopReason,
 } from "./anthropic-openai-translator";
+import { formatOpenAiChunkSse, toOpenAiStreamUsage } from "./openai-sse-chunk";
 
 type AnthropicRequest = Anthropic.Types.MessagesRequest;
 type AnthropicResponse = Anthropic.Types.MessagesResponse;
@@ -194,6 +195,7 @@ class AnthropicOpenaiStreamAdapter
     return `${this.formatChunk({
       delta: {},
       finishReason,
+      usage: this.state.usage,
     })}data: [DONE]\n\n`;
   }
 
@@ -274,21 +276,17 @@ class AnthropicOpenaiStreamAdapter
   private formatChunk(params: {
     delta: Record<string, unknown>;
     finishReason: string | null;
+    /** Only the final chunk passes this; delta chunks must stay usage-free. */
+    usage?: UsageView | null;
   }): string {
-    return `data: ${JSON.stringify({
+    return formatOpenAiChunkSse({
       id: this.ctx.chatcmplId,
-      object: "chat.completion.chunk",
       created: this.ctx.createdUnix,
       model: this.ctx.requestedModel,
-      choices: [
-        {
-          index: 0,
-          delta: params.delta,
-          finish_reason: params.finishReason,
-          logprobs: null,
-        },
-      ],
-    })}\n\n`;
+      delta: params.delta,
+      finishReason: params.finishReason,
+      usage: toOpenAiStreamUsage(params.usage),
+    });
   }
 }
 

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.test.ts
@@ -221,6 +221,8 @@ describe("azureResponsesAdapterFactory", () => {
     expect(adapter.getUsage()).toEqual({
       inputTokens: 12,
       outputTokens: 7,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       reasoningTokens: 0,
     });
     expect(adapter.getFinishReasons()).toEqual(["tool_calls"]);

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.ts
@@ -43,6 +43,7 @@ import {
   extractCommonToolCallArguments,
 } from "@/types";
 import { formatResponsesStreamErrorFrame } from "./responses-stream-error-frame";
+import { fromResponsesUsage, toResponsesUsage } from "./responses-usage";
 import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 type AzureResponsesRequest = Azure.Types.ResponsesRequest;
@@ -400,16 +401,7 @@ class AzureResponsesResponseAdapter
   }
 
   getUsage(): UsageView {
-    return {
-      inputTokens: this.response.usage?.input_tokens ?? 0,
-      outputTokens: this.response.usage?.output_tokens ?? 0,
-      reasoningTokens:
-        (
-          this.response.usage?.output_tokens_details as
-            | { reasoning_tokens?: number }
-            | undefined
-        )?.reasoning_tokens ?? 0,
-    };
+    return fromResponsesUsage(this.response.usage);
   }
 
   getOriginalResponse(): AzureResponsesResponse {
@@ -482,16 +474,7 @@ class AzureResponsesStreamAdapter
       this.state.responseId = chunk.response.id;
       this.state.model = chunk.response.model;
       if (chunk.response.usage) {
-        this.state.usage = {
-          inputTokens: chunk.response.usage.input_tokens ?? 0,
-          outputTokens: chunk.response.usage.output_tokens ?? 0,
-          reasoningTokens:
-            (
-              chunk.response.usage.output_tokens_details as
-                | { reasoning_tokens?: number }
-                | undefined
-            )?.reasoning_tokens ?? 0,
-        };
+        this.state.usage = fromResponsesUsage(chunk.response.usage);
       }
     }
 
@@ -655,13 +638,9 @@ class AzureResponsesStreamAdapter
               ],
             },
           ],
-          usage: {
-            input_tokens: 0,
-            input_tokens_details: { cached_tokens: 0 },
-            output_tokens: 0,
-            output_tokens_details: { reasoning_tokens: 0 },
-            total_tokens: 0,
-          },
+          // Always numeric, and the tokens actually observed: this is the
+          // client's only usage report for a replaced turn.
+          usage: toResponsesUsage(this.state.usage),
         },
       }),
     ].join("");
@@ -738,16 +717,7 @@ class AzureResponsesStreamAdapter
       model: this.state.model,
       status: "completed",
       output: outputItems,
-      usage: this.state.usage
-        ? {
-            input_tokens: this.state.usage.inputTokens,
-            input_tokens_details: { cached_tokens: 0 },
-            output_tokens: this.state.usage.outputTokens,
-            output_tokens_details: { reasoning_tokens: 0 },
-            total_tokens:
-              this.state.usage.inputTokens + this.state.usage.outputTokens,
-          }
-        : undefined,
+      usage: this.state.usage ? toResponsesUsage(this.state.usage) : undefined,
     } as unknown as AzureResponsesResponse;
   }
 

--- a/platform/backend/src/routes/proxy/adapters/cohere-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere-openai.ts
@@ -14,6 +14,7 @@ import {
   cohereResponseToOpenai,
   mapCohereFinishReason,
 } from "./cohere-openai-translator";
+import { formatOpenAiChunkSse, toOpenAiStreamUsage } from "./openai-sse-chunk";
 
 type CohereRequest = Cohere.Types.ChatRequest;
 type CohereResponse = Cohere.Types.ChatResponse;
@@ -162,6 +163,7 @@ class CohereOpenaiStreamAdapter
       finishReason: this.responseReplacedWithText
         ? "stop"
         : mapCohereFinishReason(this.inner.state.stopReason),
+      usage: this.state.usage,
     })}data: [DONE]\n\n`;
   }
 
@@ -193,21 +195,17 @@ class CohereOpenaiStreamAdapter
   private formatChunk(params: {
     delta: Record<string, unknown>;
     finishReason: string | null;
+    /** Only the final chunk passes this; delta chunks must stay usage-free. */
+    usage?: UsageView | null;
   }): string {
-    return `data: ${JSON.stringify({
+    return formatOpenAiChunkSse({
       id: this.ctx.chatcmplId,
-      object: "chat.completion.chunk",
       created: this.ctx.createdUnix,
       model: this.ctx.requestedModel,
-      choices: [
-        {
-          index: 0,
-          delta: params.delta,
-          finish_reason: params.finishReason,
-          logprobs: null,
-        },
-      ],
-    })}\n\n`;
+      delta: params.delta,
+      finishReason: params.finishReason,
+      usage: toOpenAiStreamUsage(params.usage),
+    });
   }
 }
 

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { Gemini, OpenAi } from "@/types";
+import type { Gemini, OpenAi, UsageView } from "@/types";
 import { sanitizeGeminiToolSchema } from "./gemini-schema";
 import {
   type NormalizedContentPart,
@@ -178,6 +178,64 @@ export function openaiToGemini(req: OpenAiRequest): {
   };
 }
 
+/**
+ * Same mapping as `geminiUsageToOpenai`, but from the stream accumulator.
+ *
+ * The accumulator normalizes `inputTokens` to *uncached* input and keeps the
+ * cache and thinking counts alongside, so the gross figures OpenAI's wire
+ * format expects are reassembled here: `prompt_tokens` adds the cache reads
+ * back, and `total_tokens` adds the thinking tokens that Gemini counts in
+ * `totalTokenCount` but not in `candidatesTokenCount`.
+ *
+ * Reading the accumulator rather than the streamed adapter's rebuilt response
+ * is deliberate: that rebuild reports `promptTokenCount` net of cache, so it
+ * cannot be the source of truth for the gross number.
+ */
+export function geminiUsageViewToOpenai(
+  usage: UsageView | null | undefined,
+):
+  | { prompt_tokens: number; completion_tokens: number; total_tokens: number }
+  | undefined {
+  if (!usage) {
+    return undefined;
+  }
+  const promptTokens = usage.inputTokens + (usage.cacheReadTokens ?? 0);
+  const completionTokens = usage.outputTokens;
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens:
+      promptTokens + completionTokens + (usage.reasoningTokens ?? 0),
+  };
+}
+
+/**
+ * Map Gemini's `usageMetadata` onto the OpenAI usage fields.
+ *
+ * Deliberately reads the raw metadata rather than the stream accumulator's
+ * `UsageView`: that view normalizes `inputTokens` to *uncached* input
+ * (`promptTokenCount - cachedContentTokenCount`, see the gemini adapter), while
+ * OpenAI's `prompt_tokens` is the gross prompt count. Going through the view
+ * would make a streamed turn report a smaller prompt — and a smaller total,
+ * since `totalTokenCount` also counts thinking tokens — than the non-streaming
+ * reply for the identical request on the same route.
+ */
+export function geminiUsageToOpenai(response: GeminiResponse): {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+} {
+  const promptTokens = response.usageMetadata?.promptTokenCount ?? 0;
+  const completionTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens:
+      response.usageMetadata?.totalTokenCount ??
+      promptTokens + completionTokens,
+  };
+}
+
 export function geminiResponseToOpenai(
   response: GeminiResponse,
   ctx: GeminiOpenaiContext,
@@ -210,8 +268,7 @@ export function geminiResponseToOpenai(
     }
   }
 
-  const promptTokens = response.usageMetadata?.promptTokenCount ?? 0;
-  const completionTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
+  const usage = geminiUsageToOpenai(response);
 
   // A prompt-blocked reply carries only `promptFeedback` — no candidates, so no
   // `finishReason` to map. Without this branch it would report a plain "stop"
@@ -246,13 +303,7 @@ export function geminiResponseToOpenai(
         },
       },
     ],
-    usage: {
-      prompt_tokens: promptTokens,
-      completion_tokens: completionTokens,
-      total_tokens:
-        response.usageMetadata?.totalTokenCount ??
-        promptTokens + completionTokens,
-    },
+    usage,
   } as OpenAiResponse;
 }
 

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
@@ -12,8 +12,13 @@ import { geminiAdapterFactory } from "./gemini";
 import {
   type GeminiOpenaiContext,
   geminiResponseToOpenai,
+  geminiUsageViewToOpenai,
   mapGeminiFinishReason,
 } from "./gemini-openai-translator";
+import {
+  formatOpenAiChunkSse,
+  type OpenAiStreamUsage,
+} from "./openai-sse-chunk";
 
 type GeminiRequest = Gemini.Types.GenerateContentRequest & {
   _model?: string;
@@ -175,6 +180,7 @@ class GeminiOpenaiStreamAdapter
       finishReason: mapGeminiFinishReason(
         this.inner.toProviderResponse().candidates?.[0]?.finishReason,
       ),
+      usage: geminiUsageViewToOpenai(this.state.usage),
     })}data: [DONE]\n\n`;
   }
 
@@ -219,21 +225,17 @@ class GeminiOpenaiStreamAdapter
   private formatChunk(params: {
     delta: Record<string, unknown>;
     finishReason: string | null;
+    /** Only the final chunk passes this; delta chunks must stay usage-free. */
+    usage?: OpenAiStreamUsage;
   }): string {
-    return `data: ${JSON.stringify({
+    return formatOpenAiChunkSse({
       id: this.ctx.chatcmplId,
-      object: "chat.completion.chunk",
       created: this.ctx.createdUnix,
       model: this.ctx.requestedModel,
-      choices: [
-        {
-          index: 0,
-          delta: params.delta,
-          finish_reason: params.finishReason,
-          logprobs: null,
-        },
-      ],
-    })}\n\n`;
+      delta: params.delta,
+      finishReason: params.finishReason,
+      usage: params.usage,
+    });
   }
 }
 

--- a/platform/backend/src/routes/proxy/adapters/openai-responses-from-chat.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses-from-chat.ts
@@ -14,6 +14,7 @@ import {
   type OpenaiResponsesContext,
 } from "./openai-responses-translator";
 import { formatResponsesStreamErrorFrame } from "./responses-stream-error-frame";
+import { toResponsesUsage } from "./responses-usage";
 
 type OpenAiResponse = OpenAi.Types.ChatCompletionsResponse;
 
@@ -337,7 +338,13 @@ class ResponsesFromChatStreamAdapter<TChunk, TResponse>
       this.toSse({
         type: "response.completed",
         sequence_number: this.nextSequenceNumber(),
-        response: this.buildResponsesResponse(),
+        // The builder omits usage entirely for an unobserved turn, which is
+        // fine for the non-streaming body but not here: a terminal frame
+        // without numeric usage is silently dropped by the Responses parser.
+        response: {
+          ...this.buildResponsesResponse(),
+          usage: toResponsesUsage(this.state.usage),
+        },
       }),
     ].join("");
   }

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -39,6 +39,7 @@ import {
 } from "@/types";
 import { createOpenAiCodexResponsesClient } from "./openai-codex-responses-client";
 import { formatResponsesStreamErrorFrame } from "./responses-stream-error-frame";
+import { fromResponsesUsage, toResponsesUsage } from "./responses-usage";
 import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 type OpenAiResponsesRequest = OpenAi.Types.ResponsesRequest;
@@ -404,16 +405,7 @@ class OpenAiResponsesResponseAdapter
   }
 
   getUsage(): UsageView {
-    return {
-      inputTokens: this.response.usage?.input_tokens ?? 0,
-      outputTokens: this.response.usage?.output_tokens ?? 0,
-      reasoningTokens:
-        (
-          this.response.usage?.output_tokens_details as
-            | { reasoning_tokens?: number }
-            | undefined
-        )?.reasoning_tokens ?? 0,
-    };
+    return fromResponsesUsage(this.response.usage);
   }
 
   getOriginalResponse(): OpenAiResponsesResponse {
@@ -487,16 +479,7 @@ class OpenAiResponsesStreamAdapter
       this.state.responseId = chunk.response.id;
       this.state.model = chunk.response.model;
       if (chunk.response.usage) {
-        this.state.usage = {
-          inputTokens: chunk.response.usage.input_tokens ?? 0,
-          outputTokens: chunk.response.usage.output_tokens ?? 0,
-          reasoningTokens:
-            (
-              chunk.response.usage.output_tokens_details as
-                | { reasoning_tokens?: number }
-                | undefined
-            )?.reasoning_tokens ?? 0,
-        };
+        this.state.usage = fromResponsesUsage(chunk.response.usage);
       }
     }
 
@@ -660,13 +643,9 @@ class OpenAiResponsesStreamAdapter
               ],
             },
           ],
-          usage: {
-            input_tokens: 0,
-            input_tokens_details: { cached_tokens: 0 },
-            output_tokens: 0,
-            output_tokens_details: { reasoning_tokens: 0 },
-            total_tokens: 0,
-          },
+          // Always numeric, and the tokens actually observed: this is the
+          // client's only usage report for a replaced turn.
+          usage: toResponsesUsage(this.state.usage),
         },
       }),
     ].join("");
@@ -743,16 +722,7 @@ class OpenAiResponsesStreamAdapter
       model: this.state.model,
       status: "completed",
       output: outputItems,
-      usage: this.state.usage
-        ? {
-            input_tokens: this.state.usage.inputTokens,
-            input_tokens_details: { cached_tokens: 0 },
-            output_tokens: this.state.usage.outputTokens,
-            output_tokens_details: { reasoning_tokens: 0 },
-            total_tokens:
-              this.state.usage.inputTokens + this.state.usage.outputTokens,
-          }
-        : undefined,
+      usage: this.state.usage ? toResponsesUsage(this.state.usage) : undefined,
     } as unknown as OpenAiResponsesResponse;
   }
 

--- a/platform/backend/src/routes/proxy/adapters/openai-sse-chunk.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-sse-chunk.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared encoder for the OpenAI chat-completions streaming wire shape.
+ *
+ * Several adapters translate a non-OpenAI provider into this shape
+ * (anthropic-openai, cohere-openai, gemini-openai) and each carried a private,
+ * byte-identical copy of the envelope. The copies drifted: none of them ever
+ * emitted `usage`, so a client streaming through those surfaces never learned
+ * its token counts even though the accumulator had them. One definition keeps
+ * that from happening again.
+ */
+import type { UsageView } from "@/types";
+
+/** Token counts in the OpenAI chat-completions wire shape. */
+export interface OpenAiStreamUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+/**
+ * Map the internal accumulator's usage onto the OpenAI wire fields, or
+ * `undefined` when the provider never reported any.
+ *
+ * Valid only where `UsageView.inputTokens` already equals the provider's gross
+ * prompt count. It is NOT universal: `inputTokens` is normalized to *uncached*
+ * input, so any adapter whose accumulator subtracts cache reads (gemini) must
+ * map its own numbers instead, or the stream would report a smaller prompt than
+ * the non-streaming reply for the identical turn.
+ */
+export function toOpenAiStreamUsage(
+  usage: UsageView | null | undefined,
+): OpenAiStreamUsage | undefined {
+  if (!usage) {
+    return undefined;
+  }
+  return {
+    prompt_tokens: usage.inputTokens,
+    completion_tokens: usage.outputTokens,
+    total_tokens: usage.inputTokens + usage.outputTokens,
+  };
+}
+
+/**
+ * Format one `chat.completion.chunk` SSE event.
+ *
+ * `usage` is already mapped to the wire shape (via `toOpenAiStreamUsage`, or by
+ * the caller when its provider needs different arithmetic) and is omitted
+ * unless supplied, because it belongs only on the final chunk — a delta chunk
+ * carrying usage would be a protocol error.
+ */
+export function formatOpenAiChunkSse(params: {
+  id: string;
+  created: number;
+  model: string;
+  delta: Record<string, unknown>;
+  finishReason: string | null;
+  usage?: OpenAiStreamUsage;
+}): string {
+  return `data: ${JSON.stringify({
+    id: params.id,
+    object: "chat.completion.chunk",
+    created: params.created,
+    model: params.model,
+    choices: [
+      {
+        index: 0,
+        delta: params.delta,
+        finish_reason: params.finishReason,
+        logprobs: null,
+      },
+    ],
+    ...(params.usage ? { usage: params.usage } : {}),
+  })}\n\n`;
+}

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -53,6 +53,7 @@ import {
 import { stripBrowserToolsResults } from "../utils/summarize-tool-results";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
 import { createOpenAiCodexClient } from "./openai-codex-client";
+import { toOpenAiStreamUsage } from "./openai-sse-chunk";
 import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
@@ -1237,13 +1238,9 @@ export class OpenAIStreamAdapter
     // without it, streaming clients (e.g. the chat route's AI SDK, for OpenRouter and other
     // OpenAI-compatible models) never see token counts. Shape mirrors the non-streaming
     // `toProviderResponse()` below — `prompt_tokens` is net of cache, with no `prompt_tokens_details`.
-    if (this.state.usage !== null) {
-      finalChunk.usage = {
-        prompt_tokens: this.state.usage.inputTokens,
-        completion_tokens: this.state.usage.outputTokens,
-        total_tokens:
-          this.state.usage.inputTokens + this.state.usage.outputTokens,
-      };
+    const usage = toOpenAiStreamUsage(this.state.usage);
+    if (usage) {
+      finalChunk.usage = usage;
     }
     return `data: ${JSON.stringify(finalChunk)}\n\ndata: [DONE]\n\n`;
   }

--- a/platform/backend/src/routes/proxy/adapters/perplexity-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/perplexity-responses.ts
@@ -93,31 +93,3 @@ export const perplexityResponsesAdapterFactory: LLMProvider<
     });
   },
 };
-
-/**
- * Token extractor for the fetch-based metrics wrapper.
- *
- * A Responses body reports `input_tokens`/`output_tokens`, not the
- * `prompt_tokens`/`completion_tokens` the chat-completions extractor reads, so
- * this cannot borrow `getUsageTokens` from adapters/openai — that one would
- * subtract from `undefined` and publish NaN.
- *
- * Cached tokens are reported inside the input total, so they are subtracted out
- * to leave the uncached input, matching how every other extractor here counts.
- */
-export function getUsageTokens(usage: {
-  input_tokens?: number;
-  output_tokens?: number;
-  input_tokens_details?: { cached_tokens?: number };
-  output_tokens_details?: { reasoning_tokens?: number };
-}) {
-  const cacheRead = usage.input_tokens_details?.cached_tokens ?? 0;
-
-  return {
-    input: Math.max(0, (usage.input_tokens ?? 0) - cacheRead),
-    output: usage.output_tokens ?? 0,
-    cacheRead,
-    cacheWrite: 0,
-    reasoning: usage.output_tokens_details?.reasoning_tokens ?? 0,
-  };
-}

--- a/platform/backend/src/routes/proxy/adapters/perplexity.ts
+++ b/platform/backend/src/routes/proxy/adapters/perplexity.ts
@@ -48,6 +48,7 @@ import type {
   UsageView,
 } from "@/types";
 import { extractCommonMessageText } from "@/types";
+import { toOpenAiStreamUsage } from "./openai-sse-chunk";
 import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
@@ -460,6 +461,14 @@ class PerplexityStreamAdapter
         },
       ],
     };
+    // We always ask upstream for usage (`stream_options: { include_usage: true }`),
+    // but the chunk carrying it is not forwarded, so the synthesized final chunk
+    // has to relay it or the client never sees token counts. Shape mirrors
+    // `toProviderResponse()` below.
+    const usage = toOpenAiStreamUsage(this.state.usage);
+    if (usage) {
+      finalChunk.usage = usage;
+    }
     return `data: ${JSON.stringify(finalChunk)}\n\ndata: [DONE]\n\n`;
   }
 

--- a/platform/backend/src/routes/proxy/adapters/responses-usage.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/responses-usage.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "@/test";
+import { azureResponsesAdapterFactory } from "./azure-responses";
+import { openaiAdapterFactory } from "./openai";
+import { openAiResponsesAdapterFactory } from "./openai-responses";
+import { makeResponsesFromChatAdapterFactory } from "./openai-responses-from-chat";
+import { perplexityResponsesAdapterFactory } from "./perplexity-responses";
+import { fromResponsesUsage, toResponsesUsage } from "./responses-usage";
+
+// When the proxy replaces a turn — a tool-invocation refusal, or the dual-LLM
+// guardrail failing closed — it synthesizes the whole Responses stream itself
+// instead of relaying upstream's. That synthesized `response.completed` is the
+// client's only usage report for the turn, and it used to hard-code every token
+// count to zero, so a refused turn always looked free.
+//
+// It also has to stay NUMERIC even when nothing was accumulated: the Responses
+// parser's `response.completed` arm requires numeric `usage.input_tokens` and
+// `usage.output_tokens`, and a frame missing them matches the union's
+// permissive unknown-chunk fallback and is dropped silently — the turn then
+// ends with no tokens and a default finish reason.
+const RESPONSES_CTX = {
+  responseId: "resp_test",
+  createdUnix: 0,
+  requestedModel: "archestra:test",
+};
+
+const FACTORIES = {
+  "openai-responses": () => openAiResponsesAdapterFactory.createStreamAdapter(),
+  "azure-responses": () => azureResponsesAdapterFactory.createStreamAdapter(),
+  // Composes from the OpenAI Responses factory, so it must inherit the fix.
+  "perplexity-responses": () =>
+    perplexityResponsesAdapterFactory.createStreamAdapter(),
+  // The model router's chat -> Responses translation.
+  "responses-from-chat": () =>
+    makeResponsesFromChatAdapterFactory(
+      openaiAdapterFactory,
+      RESPONSES_CTX,
+    ).createStreamAdapter(),
+};
+
+/** The three transports that read and write the Responses wire shape natively. */
+const NATIVE_FACTORIES = {
+  "openai-responses": FACTORIES["openai-responses"],
+  "azure-responses": FACTORIES["azure-responses"],
+  "perplexity-responses": FACTORIES["perplexity-responses"],
+};
+
+/** Pull the `response.completed` frame's usage out of a synthesized stream. */
+function completedUsage(
+  sse: string | Uint8Array | (string | Uint8Array)[],
+): Record<string, unknown> {
+  const decoder = new TextDecoder();
+  const decode = (part: string | Uint8Array) =>
+    typeof part === "string" ? part : decoder.decode(part);
+  const text = Array.isArray(sse) ? sse.map(decode).join("") : decode(sse);
+  const frame = text
+    .split("\n\n")
+    .map((block) => block.replace(/^data: /, "").trim())
+    .filter((block) => block.startsWith("{"))
+    .map((block) => JSON.parse(block) as Record<string, unknown>)
+    .find((event) => event.type === "response.completed");
+
+  expect(frame, "no response.completed frame was emitted").toBeDefined();
+  const response = (frame as { response: { usage?: Record<string, unknown> } })
+    .response;
+  return response.usage as Record<string, unknown>;
+}
+
+describe("Responses adapters report real usage on a synthesized completion", () => {
+  for (const [name, make] of Object.entries(FACTORIES)) {
+    test(`${name}: reports the accumulated tokens, not zeros`, () => {
+      const adapter = make();
+      adapter.state.usage = {
+        inputTokens: 1200,
+        outputTokens: 350,
+        reasoningTokens: 200,
+        cacheReadTokens: 900,
+      };
+
+      const usage = completedUsage(adapter.formatCompleteTextSSE("refused"));
+
+      // The accumulator holds UNCACHED input; the wire field is the gross
+      // prompt count, so the cache read is added back: 1200 + 900.
+      expect(usage).toMatchObject({
+        input_tokens: 2100,
+        output_tokens: 350,
+        total_tokens: 2450,
+      });
+    });
+
+    test(`${name}: still emits numeric usage when nothing was accumulated`, () => {
+      const adapter = make();
+      adapter.state.usage = null;
+
+      const usage = completedUsage(adapter.formatCompleteTextSSE("refused"));
+
+      // Absence is what the parser drops; zero is a value it can read.
+      expect(usage).toBeDefined();
+      expect(typeof usage.input_tokens).toBe("number");
+      expect(typeof usage.output_tokens).toBe("number");
+    });
+  }
+});
+
+// `UsageView.inputTokens` is uncached input only, but the Responses wire counts
+// cache reads INSIDE `input_tokens`. Both directions of that split live in
+// responses-usage.ts, and they have to stay inverse: a refusal reports the same
+// prompt count as the turn it replaced, and the recorded cost prices the cached
+// portion at the provider's read rate instead of the full input rate.
+const UPSTREAM_USAGE = {
+  input_tokens: 4321,
+  input_tokens_details: { cached_tokens: 4000 },
+  output_tokens: 77,
+  output_tokens_details: { reasoning_tokens: 11 },
+  total_tokens: 4398,
+};
+
+describe("Responses usage splits cache reads out of the gross input", () => {
+  test("reading subtracts the cache read and records it", () => {
+    expect(fromResponsesUsage(UPSTREAM_USAGE)).toEqual({
+      inputTokens: 321,
+      outputTokens: 77,
+      cacheReadTokens: 4000,
+      cacheWriteTokens: 0,
+      reasoningTokens: 11,
+    });
+  });
+
+  test("a body with no usage reads as zeros rather than throwing", () => {
+    expect(fromResponsesUsage(undefined)).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningTokens: 0,
+    });
+  });
+
+  test("writing puts the cache read back, so the split round-trips", () => {
+    expect(toResponsesUsage(fromResponsesUsage(UPSTREAM_USAGE))).toEqual(
+      UPSTREAM_USAGE,
+    );
+  });
+
+  for (const [name, make] of Object.entries(NATIVE_FACTORIES)) {
+    test(`${name}: a refusal reports upstream's own prompt count`, () => {
+      const adapter = make();
+      adapter.processChunk({
+        type: "response.completed",
+        response: {
+          id: "resp_1",
+          model: "gpt-4o",
+          status: "completed",
+          output: [],
+          usage: UPSTREAM_USAGE,
+        },
+      } as never);
+
+      // What the interaction row and cost calculation read...
+      expect(adapter.state.usage).toMatchObject({
+        inputTokens: 321,
+        cacheReadTokens: 4000,
+      });
+      // ...and what the client reads, unchanged from what the provider sent.
+      expect(completedUsage(adapter.formatCompleteTextSSE("refused"))).toEqual(
+        UPSTREAM_USAGE,
+      );
+    });
+  }
+});

--- a/platform/backend/src/routes/proxy/adapters/responses-usage.ts
+++ b/platform/backend/src/routes/proxy/adapters/responses-usage.ts
@@ -1,0 +1,98 @@
+/**
+ * Token usage for the OpenAI Responses transport, in both directions.
+ *
+ * Reading (`fromResponsesUsage`): the wire's `input_tokens` is the GROSS prompt
+ * count with cache reads counted inside it, while `UsageView.inputTokens` is
+ * defined as uncached input only. The cache read has to be split back out, or
+ * every cached token is priced at the full input rate and `cacheReadTokens`
+ * stays zero so the provider's read discount is never applied.
+ *
+ * Writing (`toResponsesUsage`): the reverse — the split has to be re-added, so
+ * the client reads the same prompt count its provider reported.
+ *
+ * A synthesized terminal `response.completed` — the frame the client gets when
+ * the proxy replaces the turn (tool-invocation refusal, dual-LLM fail-closed)
+ * rather than relaying upstream's own — must always carry a numeric usage
+ * object. The Responses parser validates every chunk against a discriminated
+ * union whose `response.completed` arm requires `usage.input_tokens` and
+ * `usage.output_tokens` as numbers (`input_tokens_details` /
+ * `output_tokens_details` are nullish, so they may be omitted). A frame without
+ * them does not fail parsing: it matches the union's permissive unknown-chunk
+ * fallback and is dropped, the "response finished" test never fires, and the
+ * turn ends with no tokens and a default finish reason — the same silent-drop
+ * trap documented in responses-stream-error-frame.ts.
+ *
+ * So `toResponsesUsage` returns zeros rather than `undefined` for an unobserved
+ * turn: zero is a wire value the client can read, absence is not.
+ */
+import type { UsageView } from "@/types";
+
+/** A `usage` object as the Responses wire shape reports it. */
+export interface ResponsesWireUsage {
+  input_tokens?: number;
+  input_tokens_details?: { cached_tokens?: number } | null;
+  output_tokens?: number;
+  output_tokens_details?: { reasoning_tokens?: number } | null;
+}
+
+export interface ResponsesUsage {
+  input_tokens: number;
+  input_tokens_details: { cached_tokens: number };
+  output_tokens: number;
+  output_tokens_details: { reasoning_tokens: number };
+  total_tokens: number;
+}
+
+/** Read a Responses usage object into the accumulator's normalized view. */
+export function fromResponsesUsage(
+  usage: ResponsesWireUsage | null | undefined,
+): UsageView {
+  const { input, output, cacheRead, reasoning } = responsesUsageTokens(usage);
+  return {
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: cacheRead,
+    cacheWriteTokens: 0,
+    reasoningTokens: reasoning,
+  };
+}
+
+/**
+ * The same split in the shape the fetch-based metrics wrapper consumes.
+ *
+ * This cannot borrow the chat-completions extractor: that one reads
+ * `prompt_tokens`/`completion_tokens`, which a Responses body does not carry,
+ * so it subtracts from `undefined` and yields NaN — and because the reporter
+ * skips falsy counts, the turn's tokens are then dropped from the metric
+ * entirely rather than reported wrong.
+ */
+export function responsesUsageTokens(
+  usage: ResponsesWireUsage | null | undefined,
+) {
+  const cacheRead = usage?.input_tokens_details?.cached_tokens ?? 0;
+  return {
+    input: Math.max(0, (usage?.input_tokens ?? 0) - cacheRead),
+    output: usage?.output_tokens ?? 0,
+    cacheRead,
+    cacheWrite: 0,
+    reasoning: usage?.output_tokens_details?.reasoning_tokens ?? 0,
+  };
+}
+
+/** Map the accumulator's usage back onto the Responses wire fields. */
+export function toResponsesUsage(
+  usage: UsageView | null | undefined,
+): ResponsesUsage {
+  const cachedTokens = usage?.cacheReadTokens ?? 0;
+  // Back to the gross prompt count the provider reported, so a turn the proxy
+  // replaced reports the same input as the turn it replaced.
+  const inputTokens = (usage?.inputTokens ?? 0) + cachedTokens;
+  const outputTokens = usage?.outputTokens ?? 0;
+  return {
+    input_tokens: inputTokens,
+    input_tokens_details: { cached_tokens: cachedTokens },
+    output_tokens: outputTokens,
+    output_tokens_details: { reasoning_tokens: usage?.reasoningTokens ?? 0 },
+    total_tokens: inputTokens + outputTokens,
+  };
+}

--- a/platform/backend/src/routes/proxy/adapters/streaming-usage.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/streaming-usage.test.ts
@@ -1,17 +1,36 @@
 import { describe, expect, test } from "@/test";
+import { makeAnthropicOpenaiAdapterFactory } from "./anthropic-openai";
 import { cerebrasAdapterFactory } from "./cerebras";
+import { makeCohereOpenaiAdapterFactory } from "./cohere-openai";
+import { makeGeminiOpenaiAdapterFactory } from "./gemini-openai";
+import { geminiResponseToOpenai } from "./gemini-openai-translator";
 import { ollamaAdapterFactory } from "./ollama";
 import { openaiAdapterFactory } from "./openai";
+import { perplexityAdapterFactory } from "./perplexity";
 import { vllmAdapterFactory } from "./vllm";
+import { zhipuaiAdapterFactory } from "./zhipuai";
 
-// These four adapters are OpenAI-compatible and each synthesize their final streaming chunk the same
-// way. They must all carry the provider's accumulated usage into that chunk, otherwise streaming
-// clients see no token counts. One parametrized guard keeps the four copies from drifting apart.
+// Every adapter that synthesizes its final streaming chunk in the OpenAI
+// chat-completions shape must carry the provider's accumulated usage into that
+// chunk, otherwise streaming clients see no token counts — including another
+// Archestra chained to this one through the `archestra` provider, which then
+// records every proxied call with zero tokens and no cost.
+//
+// This roster is the anti-drift mechanism, so it has to stay exhaustive: zhipuai
+// and perplexity were missing from it and both had silently dropped usage. When
+// you add an adapter that builds its own final chunk, add it here too.
+//
+// Deliberately NOT listed: bedrock-openai, which emits usage as a separate
+// `choices: []` chunk gated on the client's own `stream_options.include_usage`
+// (bedrock-openai-translator.ts) rather than on the synthesized final chunk, and
+// is covered by bedrock-openai-sse.test.ts.
 const FACTORIES = {
   openai: openaiAdapterFactory,
   vllm: vllmAdapterFactory,
   ollama: ollamaAdapterFactory,
   cerebras: cerebrasAdapterFactory,
+  zhipuai: zhipuaiAdapterFactory,
+  perplexity: perplexityAdapterFactory,
 };
 
 function usageOf(endSse: string | Uint8Array): unknown {
@@ -68,4 +87,102 @@ describe("OpenAI-compatible stream adapters carry usage into the final SSE", () 
       expect(usageOf(adapter.formatEndSSE())).toBeUndefined();
     });
   }
+});
+
+// The `*-openai` translators expose a non-OpenAI provider through the OpenAI
+// chat-completions surface (this is what the `archestra` provider and the model
+// router speak). They wrap an inner native adapter and share one envelope
+// encoder, so the guard here asserts the invariant directly on the accumulator:
+// whatever the inner adapter accumulated must reach the client's final chunk.
+// All three shipped without it, so a client streaming Claude/Gemini/Cohere
+// through the OpenAI surface saw no token counts at all.
+const TRANSLATOR_CTX = {
+  chatcmplId: "chatcmpl-test",
+  createdUnix: 0,
+  requestedModel: "archestra:test",
+};
+
+const TRANSLATORS = {
+  "anthropic-openai": () =>
+    makeAnthropicOpenaiAdapterFactory(TRANSLATOR_CTX).createStreamAdapter(),
+  "cohere-openai": () =>
+    makeCohereOpenaiAdapterFactory(TRANSLATOR_CTX).createStreamAdapter(),
+  "gemini-openai": () =>
+    makeGeminiOpenaiAdapterFactory(TRANSLATOR_CTX).createStreamAdapter(),
+};
+
+describe("OpenAI-compat translators carry usage into the final SSE", () => {
+  for (const [name, make] of Object.entries(TRANSLATORS)) {
+    test(`${name}: emits accumulated usage`, () => {
+      const adapter = make();
+      adapter.state.usage = { inputTokens: 100, outputTokens: 40 };
+
+      expect(usageOf(adapter.formatEndSSE())).toEqual({
+        prompt_tokens: 100,
+        completion_tokens: 40,
+        total_tokens: 140,
+      });
+    });
+
+    test(`${name}: omits usage when the provider reported none`, () => {
+      const adapter = make();
+      adapter.state.usage = null;
+
+      expect(usageOf(adapter.formatEndSSE())).toBeUndefined();
+    });
+  }
+});
+
+// `UsageView.inputTokens` is normalized to *uncached* input, but OpenAI's
+// `prompt_tokens` is the gross prompt count — so an adapter whose accumulator
+// subtracts cache reads cannot map through the shared helper. Gemini is the one
+// that does (promptTokenCount - cachedContentTokenCount), and its `totalTokenCount`
+// additionally counts thinking tokens. Streaming and non-streaming answer the
+// same route, so they must report the same numbers for the same turn.
+describe("gemini-openai reports the same usage streaming and non-streaming", () => {
+  const geminiResponse = {
+    candidates: [
+      {
+        content: { parts: [{ text: "hi" }], role: "model" },
+        finishReason: "STOP",
+      },
+    ],
+    usageMetadata: {
+      promptTokenCount: 2000,
+      cachedContentTokenCount: 1800,
+      candidatesTokenCount: 100,
+      thoughtsTokenCount: 500,
+      totalTokenCount: 2600,
+    },
+  };
+
+  test("streams the gross prompt count, not the cache-adjusted one", () => {
+    const adapter =
+      makeGeminiOpenaiAdapterFactory(TRANSLATOR_CTX).createStreamAdapter();
+    // What the native Gemini adapter accumulates for the response above.
+    adapter.state.usage = {
+      inputTokens: 200, // 2000 - 1800 cached
+      outputTokens: 100,
+      cacheReadTokens: 1800,
+      cacheWriteTokens: 0,
+      reasoningTokens: 500,
+    };
+    adapter.processChunk(geminiResponse as never);
+
+    expect(usageOf(adapter.formatEndSSE())).toEqual({
+      prompt_tokens: 2000,
+      completion_tokens: 100,
+      total_tokens: 2600,
+    });
+  });
+
+  test("matches the non-streaming translation exactly", () => {
+    const adapter =
+      makeGeminiOpenaiAdapterFactory(TRANSLATOR_CTX).createStreamAdapter();
+    adapter.processChunk(geminiResponse as never);
+
+    expect(usageOf(adapter.formatEndSSE())).toEqual(
+      geminiResponseToOpenai(geminiResponse as never, TRANSLATOR_CTX).usage,
+    );
+  });
 });

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.ts
@@ -30,6 +30,7 @@ import {
   extractCommonToolCallArguments,
 } from "@/types";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
+import { toOpenAiStreamUsage } from "./openai-sse-chunk";
 import { upstreamHttpError } from "./upstream-http-error";
 
 // =============================================================================
@@ -635,9 +636,21 @@ class ZhipuaiStreamAdapter
     this.state.responseId = chunk.id;
     this.state.model = chunk.model;
 
-    const choice = chunk.choices[0];
+    // Capture usage BEFORE the `choices` guard below. Zhipu itself rides usage
+    // on the finish chunk, but an OpenAI-compatible upstream answering an
+    // `include_usage` request sends it on a trailing chunk with `choices: []` —
+    // returning early on that chunk would drop the token counts entirely.
+    if (chunk.usage) {
+      this.state.usage = {
+        inputTokens: chunk.usage.prompt_tokens ?? 0,
+        outputTokens: chunk.usage.completion_tokens ?? 0,
+      };
+    }
+
+    // `choices` is optional-chained for the same reason: some OpenAI-compatible
+    // upstreams omit it entirely on usage-only and error chunks.
+    const choice = chunk.choices?.[0];
     if (!choice) {
-      // Empty chunk (shouldn't happen with Zhipu, but handle it)
       return {
         sseData: null,
         isToolCallChunk: false,
@@ -697,13 +710,6 @@ class ZhipuaiStreamAdapter
     if (choice.finish_reason) {
       this.state.stopReason = choice.finish_reason;
       isFinal = true;
-    }
-
-    if (chunk.usage) {
-      this.state.usage = {
-        inputTokens: chunk.usage.prompt_tokens ?? 0,
-        outputTokens: chunk.usage.completion_tokens ?? 0,
-      };
     }
 
     return { sseData, isToolCallChunk, isFinal };
@@ -780,6 +786,14 @@ class ZhipuaiStreamAdapter
         },
       ],
     };
+    // Zhipu reports usage on its finish chunk, which we never forward (it
+    // carries no streamable content), so without this the synthesized final
+    // chunk is the client's last chance to learn the token counts and it
+    // arrives empty. Shape mirrors `toProviderResponse()` below.
+    const usage = toOpenAiStreamUsage(this.state.usage);
+    if (usage) {
+      finalChunk.usage = usage;
+    }
     return `data: ${JSON.stringify(finalChunk)}\n\ndata: [DONE]\n\n`;
   }
 

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -11,6 +11,8 @@ import {
   CHAT_API_KEY_ID_HEADER,
   DUAL_LLM_PROGRESS_CHANNEL_HEADER,
   PROVIDER_BASE_URL_HEADER,
+  SESSION_ID_HEADER,
+  SOURCE_HEADER,
   UNTRUSTED_CONTEXT_HEADER,
 } from "@archestra/shared";
 import { eq } from "drizzle-orm";
@@ -586,6 +588,63 @@ describe("LLM Proxy Handler Prometheus Metrics", () => {
         .from(schema.interactionsTable)
         .where(eq(schema.interactionsTable.profileId, testAgent.id));
       expect(rows).toHaveLength(1);
+    });
+
+    test("a Slack ChatOps stream without usage keeps its source and shows up in the sessions listing", async () => {
+      // T-953: Slack ChatOps runs reach the proxy as streams tagged
+      // `chatops:slack`, and their upstream (frequently another Archestra,
+      // whose own SSE omits the trailing usage chunk) reports no usage. The
+      // usage-gated persist made those runs vanish from LLM Logs entirely.
+      // Recording the row is not enough — it has to keep `source`, or the
+      // "Slack" entry of the Source filter can never find it again.
+      openAiStubOptions.interruptAtChunk = 2;
+
+      const sessionId = "slack-C0B2AGC0AFQ-1784887557";
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+          [SOURCE_HEADER]: "chatops:slack",
+          [SESSION_ID_HEADER]: sessionId,
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "Hello from Slack!" }],
+          stream: true,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const rows = await db
+        .select()
+        .from(schema.interactionsTable)
+        .where(eq(schema.interactionsTable.profileId, testAgent.id));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].source).toBe("chatops:slack");
+      expect(rows[0].sessionId).toBe(sessionId);
+
+      // The unfiltered listing is the view the bug report screenshotted.
+      const unfiltered = await InteractionModel.getSessions(
+        { limit: 10, offset: 0 },
+        undefined,
+        true,
+        { sessionId },
+      );
+      expect(unfiltered.pagination.total).toBe(1);
+      expect(unfiltered.data[0].source).toBe("chatops:slack");
+      expect(unfiltered.data[0].sources).toContain("chatops:slack");
+
+      // ...and the Source filter's "Slack" entry must keep it.
+      const filtered = await InteractionModel.getSessions(
+        { limit: 10, offset: 0 },
+        undefined,
+        true,
+        { sessionId, source: "chatops:slack" },
+      );
+      expect(filtered.pagination.total).toBe(1);
     });
   });
 

--- a/platform/e2e-tests/playwright.config.ts
+++ b/platform/e2e-tests/playwright.config.ts
@@ -52,6 +52,7 @@ const uiTestMatch = [
   "**/dynamic-credentials.spec.ts",
   "**/identity-providers.ee.spec.ts",
   "**/invitation.spec.ts",
+  "**/llm-logs-slack-source.spec.ts",
   "**/mcp-edit.spec.ts",
   "**/mcp-install.spec.ts",
   "**/quickstart.spec.ts",

--- a/platform/e2e-tests/tests/llm-logs-slack-source.spec.ts
+++ b/platform/e2e-tests/tests/llm-logs-slack-source.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * E2E regression coverage for T-953: "Slack logs are not visible in the LLM Logs".
+ *
+ * A Slack ChatOps run reaches the LLM proxy as a *streaming* request tagged
+ * `X-Archestra-Source: chatops:slack`. Its upstream is frequently another
+ * Archestra instance, whose own SSE output omits the trailing usage chunk, so
+ * the stream completes cleanly and never reports token usage.
+ *
+ * The proxy used to gate its whole finally-block persist on `if (usage)`, so
+ * such a run left no interaction row at all and the LLM Proxy log page was
+ * empty even for an admin with no filters set. The WireMock stub used here
+ * (openai-chatops-slack-no-usage.json) reproduces exactly that upstream: a
+ * complete stream that never sends usage.
+ *
+ * This spec pins the *UI* contract: the run is listed on /llm/logs, it is
+ * labelled with the Slack source, and it survives the "Slack" entry of the
+ * Source filter. The corresponding API/persistence contract is pinned by
+ * backend/src/routes/proxy/llm-proxy-handler.test.ts.
+ */
+import type { APIRequestContext } from "@playwright/test";
+import { mergeTests } from "@playwright/test";
+import { API_BASE_URL } from "../consts";
+import { expect, test as uiTest } from "../fixtures";
+import { test as apiTest } from "./api-fixtures";
+
+const test = mergeTests(uiTest, apiTest);
+
+/** Marker the WireMock stub matches on; also the prompt text. */
+const STUB_MARKER = "chatops-slack-no-usage";
+/** Interaction source ChatOps sets for Slack (CHATOPS_PROVIDER_SOURCES). */
+const SLACK_SOURCE = "chatops:slack";
+/** Label INTERACTION_SOURCE_DISPLAY renders for that source. */
+const SLACK_SOURCE_LABEL = "Slack";
+
+const LOGS_PATH = "/llm/logs";
+
+/**
+ * Drive one Slack-sourced streaming completion through the proxy.
+ *
+ * Returns both the session id (used for the API-level readiness poll) and the
+ * unique prompt text, which is what the log table's Session column actually
+ * renders and is therefore how the row is located in the UI. The session-ID
+ * search box is deliberately not used: it only accepts a UUID, while a ChatOps
+ * session id is a thread-derived string like `slack-<channel>-<ts>`.
+ */
+async function runSlackChatOpsCompletion(
+  request: APIRequestContext,
+  proxyId: string,
+) {
+  const nonce = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const sessionId = `slack-e2e-${nonce}`;
+  // Contains STUB_MARKER so WireMock still matches, plus a nonce so the row is
+  // uniquely identifiable among other runs' rows.
+  const prompt = `${STUB_MARKER} ${nonce}`;
+
+  const response = await request.post(
+    `${API_BASE_URL}/v1/openai/${proxyId}/chat/completions`,
+    {
+      headers: {
+        Authorization: `Bearer ${STUB_MARKER}`,
+        "Content-Type": "application/json",
+        // What chatops-manager -> a2a-manager -> llm-client put on the wire.
+        "X-Archestra-Source": SLACK_SOURCE,
+        // ChatOps derives this from the Slack thread so a whole thread is one
+        // session in the logs (buildChatOpsSessionId).
+        "X-Archestra-Session-Id": sessionId,
+      },
+      data: {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: prompt }],
+      },
+    },
+  );
+
+  const body = await response.text();
+  expect(
+    response.status(),
+    `Expected 200 but got ${response.status()}. A 404 means WireMock matched no ` +
+      `stub for "${STUB_MARKER}". Body: ${body}`,
+  ).toBe(200);
+
+  // The stub IS the failure mode under test: a complete stream, no usage.
+  expect(
+    body,
+    "The stub must not report usage — a usage-less stream is the condition being regression-tested",
+  ).not.toContain("usage");
+  expect(body).toContain("[DONE]");
+
+  // The row is written once the stream drains, so poll rather than sleep.
+  await expect
+    .poll(
+      async () => {
+        const sessions = await request.get(
+          `${API_BASE_URL}/api/interactions/sessions` +
+            `?limit=10&offset=0&sessionId=${encodeURIComponent(sessionId)}`,
+        );
+        if (!sessions.ok()) return -1;
+        return (await sessions.json()).pagination.total;
+      },
+      {
+        timeout: 30_000,
+        message:
+          "A Slack ChatOps stream that reported no usage was never recorded as an interaction",
+      },
+    )
+    .toBe(1);
+
+  return { sessionId, prompt };
+}
+
+test.describe("LLM Logs - Slack (ChatOps) source", {
+  tag: ["@firefox", "@webkit"],
+}, () => {
+  test("lists a Slack ChatOps run and keeps it under the Slack source filter", async ({
+    request,
+    adminPage,
+    goToAdminPage,
+    createLlmProxy,
+    deleteAgent,
+  }) => {
+    const proxyResponse = await createLlmProxy(
+      request,
+      `Slack ChatOps Logs ${Date.now()}`,
+      "personal",
+    );
+    const proxy = await proxyResponse.json();
+    const proxyId = proxy.id;
+
+    try {
+      const { prompt } = await runSlackChatOpsCompletion(request, proxyId);
+      // The Session column renders the run's prompt, so the nonce in it is what
+      // identifies this run's row.
+      const rowFor = () =>
+        adminPage.locator("tbody tr").filter({ hasText: prompt });
+
+      // 1. Unfiltered log page — the view the bug report screenshotted.
+      await goToAdminPage(LOGS_PATH);
+      await adminPage.waitForLoadState("domcontentloaded");
+
+      const row = rowFor();
+      await expect(
+        row,
+        "The Slack ChatOps run is missing from the unfiltered LLM Proxy logs",
+      ).toBeVisible({ timeout: 20_000 });
+
+      // 2. The Source column identifies it as Slack.
+      await expect(
+        row.getByText(SLACK_SOURCE_LABEL, { exact: true }),
+        "The Slack ChatOps run is not labelled with the Slack source",
+      ).toBeVisible();
+
+      // 3. The Source filter is URL-driven (page.client.tsx reads ?source=),
+      //    so this exercises the same path the "Slack" dropdown entry takes.
+      await goToAdminPage(
+        `${LOGS_PATH}?source=${encodeURIComponent(SLACK_SOURCE)}`,
+      );
+      await adminPage.waitForLoadState("domcontentloaded");
+      await expect(
+        rowFor(),
+        `The Slack ChatOps run disappeared under the "${SLACK_SOURCE_LABEL}" source filter`,
+      ).toBeVisible({ timeout: 20_000 });
+
+      // 4. ...and the filter genuinely filters: under a different source the
+      //    same run must be gone, otherwise step 3 proves nothing.
+      await goToAdminPage(`${LOGS_PATH}?source=chat`);
+      await adminPage.waitForLoadState("domcontentloaded");
+      await expect(
+        rowFor(),
+        "The Slack ChatOps run is still listed under a non-Slack source filter",
+      ).toHaveCount(0, { timeout: 20_000 });
+    } finally {
+      await deleteAgent(request, proxyId);
+    }
+  });
+});

--- a/platform/e2e-tests/tests/llm-logs-slack-source.spec.ts
+++ b/platform/e2e-tests/tests/llm-logs-slack-source.spec.ts
@@ -17,6 +17,7 @@
  * Source filter. The corresponding API/persistence contract is pinned by
  * backend/src/routes/proxy/llm-proxy-handler.test.ts.
  */
+import crypto from "node:crypto";
 import type { APIRequestContext } from "@playwright/test";
 import { mergeTests } from "@playwright/test";
 import { API_BASE_URL } from "../consts";
@@ -47,7 +48,8 @@ async function runSlackChatOpsCompletion(
   request: APIRequestContext,
   proxyId: string,
 ) {
-  const nonce = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const nonce = crypto.randomUUID().slice(0, 8);
+  // Prefixed, so it stays a ChatOps-shaped id rather than a bare UUID.
   const sessionId = `slack-e2e-${nonce}`;
   // Contains STUB_MARKER so WireMock still matches, plus a nonce so the row is
   // uniquely identifiable among other runs' rows.

--- a/platform/helm/e2e-tests/mappings/openai-chatops-slack-no-usage.json
+++ b/platform/helm/e2e-tests/mappings/openai-chatops-slack-no-usage.json
@@ -1,0 +1,20 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "POST",
+    "urlPath": "/openai/v1/chat/completions",
+    "bodyPatterns": [
+      {
+        "contains": "chatops-slack-no-usage"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache"
+    },
+    "body": "data: {\"id\":\"chatcmpl-chatops-slack\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-chatops-slack\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Answering the Slack thread.\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-chatops-slack\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+  }
+}


### PR DESCRIPTION
Slack ChatOps runs were missing from the LLM Logs. The reported instance runs a version predating #6896, where the proxy's streaming persist was gated on `if (usage)` with no `else` — a stream that ended without a usage chunk wrote no interaction row at all, and ChatOps always streams. That gate is already fixed on `main` (first released in 1.3.19), so for the reported instance the remedy is an upgrade.

What the investigation turned up is *why* those streams carried no usage, and that part is still live on `main`. Three separate defects, each reproduced on a dev stack.

## 1. Regression tests for the reported symptom

`llm-proxy-handler.test.ts` pins that a Slack-sourced usageless stream keeps `source='chatops:slack'` and is returned by `getSessions` both unfiltered and under the "Slack" source filter. Plus a UI spec (`llm-logs-slack-source.spec.ts`) and its WireMock mapping. Both were validated by reverting the fix — they fail with the intended message — and restoring it.

Note for reviewers: `**/llm-proxy/**/*.spec.ts` is in `apiTestMatch` *and* in `browserTestIgnore`, so a UI spec placed there never runs in a browser. This one lives directly under `tests/` and is registered in `uiTestMatch`.

## 2. ChatOps runs were traced as `a2a`

`chatops-manager.ts` set `route: RouteCategory.CHATOPS` while `a2a-manager.ts` reads `systemParams?.routeCategory`, so every ChatOps run was traced under the wrong category. The object was assigned through an untyped intermediate const, so TypeScript's excess-property check never fired. `systemParams` is now a declared `A2ASystemParams` interface, which makes the mismatch a compile error, and both entry points (`processMessage` and the approval-resume path) set the category.

## 3. Streaming adapters dropped usage on the final chunk

An adapter that synthesizes its own final `chat.completion.chunk` has to carry the accumulated usage into it, or streaming clients see no token counts. zhipuai and perplexity dropped it outright; anthropic-openai / cohere-openai / gemini-openai each carried a private, byte-identical copy of the chunk envelope that never emitted `usage` at all.

This matters most for an Archestra chained to another Archestra through the `archestra` provider — the downstream instance then records every proxied call with zero tokens and no cost. Measured live: a zhipuai stream reported no usage even when the client explicitly sent `stream_options: { include_usage: true }`.

The three envelope copies now share one encoder. The accumulator-to-wire mapping is deliberately **not** universal — `UsageView.inputTokens` is uncached input while OpenAI's `prompt_tokens` is gross — so gemini reassembles its own numbers; mapped through the shared helper it would stream a smaller prompt than the identical non-streaming turn reports. There is a parity test asserting the two agree.

zhipuai also captured usage only after a `choices[0]` guard, so the usage-only trailing chunk (`choices: []`) never reached the accumulator.

## 4. The Responses transport mis-read usage in both directions

Found by driving a real tool-invocation refusal through `/v1/openai/{agentId}/responses` on a dev stack.

**The synthesized terminal frame reported zeros.** When the proxy replaces a turn (tool-invocation refusal, dual-LLM fail-closed) it synthesizes the whole stream itself, and that `response.completed` hard-coded every token count to zero — so a refused turn always looked free. It also has to stay *numeric* when nothing was accumulated: the Responses parser's `response.completed` arm requires numeric `input_tokens`/`output_tokens`, and a frame missing them matches the union's permissive unknown-chunk fallback and is dropped silently, ending the turn with no tokens and a default finish reason. The mapper returns zeros, never `undefined` — the same silent-drop trap `responses-stream-error-frame.ts` exists to avoid.

**Cached tokens were billed at the full input rate.** The adapters stored the wire's `input_tokens` verbatim. That field is the gross prompt count with cache reads counted *inside* it, while `UsageView.inputTokens` is uncached-only — so `cache_read_tokens` stayed null and the provider's read discount never applied. Identical requests before and after, from the stack's own `interactions` table:

| | input | cache_read | cost |
|---|---|---|---|
| before | 4321 | NULL | $0.011573 |
| after | 321 | 4000 | $0.006573 |

The $0.005 difference is exactly 4000 tokens at gpt-4o's $1.25/M cached rate. It reaches all three Responses transports, since `perplexity-responses` composes from the OpenAI factory — its own (correct) metrics extractor disagreed with its own interaction rows.

**Non-streaming Responses turns were missing from `llm_tokens_total`.** The fetch metrics wrapper mapped `openai` and `azure` to the chat-completions extractor, which reads `prompt_tokens`. A Responses body carries neither that nor `completion_tokens`, so the uncached subtraction yields NaN and `reportLLMTokens` skips falsy counts — the turn vanishes from the metric rather than being reported wrong. Measured: a non-streaming Responses call moved the counters by zero. `perplexity` already sniffed the body shape for exactly this reason; the other two serve both shapes too and were left behind.

Both directions of the split now live in `responses-usage.ts` and have to stay inverse: `toResponsesUsage` adds the cache read back, or a refused turn would report a smaller prompt than the turn it replaced.

## Verification

Every fix was proven by reintroducing the defect and watching the intended tests fail: neutering the read split fails 5, the gross reassembly 8, the metrics sniff exactly 3, and reverting only the `openai-responses` accumulator fails exactly the openai + perplexity cases while azure passes.

Live on a dev stack, the synthesized refusal frame is now byte-identical to what upstream reported (`cached_tokens: 200`, previously `0`), and the non-streaming call moves the counters by +321 input / +77 output / +4000 cache-read.

2251 backend proxy/observability/agents tests pass; `tsc`, biome and knip clean.

## Deliberately not in scope

- `interactions` has no `organization_id` column and `getSessions` applies no org predicate.
- `SessionSummarySchema.source`/`sources` are strict enums with no read-fallback (unlike `request`/`response`), so one out-of-enum stored `source` would 500 the whole sessions page.
- The LLM Logs session search box requires a UUID, so a ChatOps session id (`slack-<channel>-<ts>`) can never be searched.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>