### PR TITLE
fix(docker): dial the platform's own API by IPv4 literal, not localhost

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -854,6 +854,104 @@ jobs:
 
           echo "All services are ready!"
 
+      # Everything in this image binds IPv4 only, but `localhost` resolves to
+      # ::1 first — getaddrinfo applies RFC 6724 precedence whatever the order
+      # in /etc/hosts, and musl has no /etc/gai.conf to retune it. So any URL
+      # naming it starts every connection on an address with no listener:
+      # refused outright for a client without Happy Eyeballs, a wasted round
+      # trip for one with it. That is the `ECONNREFUSED ::1:9000` in issues
+      # #4917 and #6933. The host-side curls above cannot see this — they
+      # exercise Docker's port mapping, not in-container name resolution.
+      - name: Assert the container never dials a dead loopback address
+        run: |
+          # Context only — never the reason the step fails.
+          echo "--- container facts ---"
+          docker exec archestra-quickstart node -e '
+            const listening = (f) => require("fs").readFileSync(f, "utf8").trim().split("\n").slice(1)
+              .map((l) => l.trim().split(/\s+/)).filter((c) => c[3] === "0A")
+              .map((c) => c[1].split(":")).map(([a, p]) => parseInt(p, 16)).sort((a, b) => a - b);
+            console.log("  listening on v4:", listening("/proc/net/tcp").join(" "));
+            console.log("  listening on v6:", listening("/proc/net/tcp6").join(" "));
+            require("dns").lookup("localhost", { all: true }, (_, a) =>
+              console.log("  localhost resolves to:", JSON.stringify(a)));
+          ' || true
+
+          # Each assertion records its own result so one failure still reports
+          # the others, rather than aborting the step on the first.
+          rc=0
+
+          # 1. The runtime knob the SSR paths and the generated API client read.
+          echo "1/3 The image's internal API URL is an address, not a name..."
+          docker exec archestra-quickstart node -e '
+            const base = process.env.ARCHESTRA_INTERNAL_API_BASE_URL;
+            if (!base) { console.error("FAILED: ARCHESTRA_INTERNAL_API_BASE_URL is unset in the image"); process.exit(1); }
+            const { hostname } = new URL(base);
+            console.log(`  ARCHESTRA_INTERNAL_API_BASE_URL=${base}`);
+            if (require("net").isIP(hostname) === 0) {
+              console.error(`FAILED: ${hostname} is a name; it resolves to ::1 first, where nothing listens`);
+              process.exit(1);
+            }
+          ' || rc=1
+
+          # 2. The frontend proxies /api, /v1 and /ws to the backend through
+          #    Next.js rewrites. With output: "standalone" those destinations are
+          #    resolved during `next build` and frozen into routes-manifest.json,
+          #    so no runtime environment can retarget them — the shipped manifest
+          #    IS the dial list, and it is what carried `http://localhost:9000`
+          #    into the proxy errors users reported.
+          echo "2/3 No baked proxy destination names localhost..."
+          docker exec archestra-quickstart node -e '
+            const m = require("/app/frontend/.next/routes-manifest.json").rewrites;
+            // Some destinations carry :params in the host (the Sentry tunnel),
+            // which is not a parseable URL and can never be a loopback dial.
+            const parsed = [...(m.beforeFiles ?? []), ...(m.afterFiles ?? []), ...(m.fallback ?? [])]
+              .map((r) => { try { return new URL(r.destination); } catch { return null; } })
+              .filter((u) => u && /^https?:$/.test(u.protocol));
+            const named = parsed.filter((u) => u.hostname === "localhost");
+            console.log(`  ${parsed.length} absolute destinations, ${named.length} naming localhost`);
+            if (named.length) {
+              console.error(`FAILED: these resolve to ::1 first, where nothing listens: ${JSON.stringify(named.map((u) => u.href))}`);
+              process.exit(1);
+            }
+          ' || rc=1
+
+          # 3. The same destinations, actually dialled — with the resolver pinned
+          #    to verbatim order and Happy Eyeballs off, so Node connects to the
+          #    FIRST address only. That is what a non-Node client in the container
+          #    does, and it is what turns an ambiguous name from "slow" into
+          #    "refused". Both flags are passed on argv, which beats NODE_OPTIONS,
+          #    and NODE_OPTIONS itself is overridden here with something an
+          #    operator plausibly sets: the fix must not live anywhere a user's
+          #    `docker run -e NODE_OPTIONS=...` could replace it.
+          echo "3/3 Every proxy destination answers on its first-resolved address..."
+          docker exec \
+            -e NODE_OPTIONS=--max-old-space-size=4096 \
+            archestra-quickstart \
+            node --dns-result-order=verbatim --no-network-family-autoselection -e '
+              const isLoopback = (h) => h === "localhost" || h === "[::1]" || h.startsWith("127.");
+              const m = require("/app/frontend/.next/routes-manifest.json").rewrites;
+              const origins = [...new Set([...(m.beforeFiles ?? []), ...(m.afterFiles ?? []), ...(m.fallback ?? [])]
+                .map((r) => { try { return new URL(r.destination); } catch { return null; } })
+                .filter((u) => u && /^https?:$/.test(u.protocol) && isLoopback(u.hostname))
+                .map((u) => u.origin))];
+              if (!origins.length) { console.error("FAILED: no loopback proxy destination found to test"); process.exit(1); }
+              Promise.all(origins.map((origin) =>
+                fetch(new URL("/health", origin))
+                  .then((r) => r.json())
+                  .then((j) => console.log(`  ${origin} -> ${JSON.stringify(j)}`))
+                  .catch((e) => {
+                    console.error(`FAILED: ${origin} unreachable on its first-resolved address: ${e.cause?.message ?? e.message}`);
+                    process.exitCode = 1;
+                  })
+              ));
+            ' || rc=1
+
+          if [ "$rc" -ne 0 ]; then
+            echo "The container dials an address it does not listen on — see issues #4917 / #6933."
+            exit 1
+          fi
+          echo "The container dials only addresses it actually listens on."
+
       # Assert the embedded Dagger Engine (skill sandbox / code runtime) actually
       # came up. The entrypoint deploys it and gates on readiness, but that gate
       # is non-fatal: on timeout it disables the runtime and the container still

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -854,9 +854,10 @@ jobs:
 
           echo "All services are ready!"
 
-      # Everything in this image binds IPv4 only, but `localhost` resolves to
-      # ::1 first — getaddrinfo applies RFC 6724 precedence whatever the order
-      # in /etc/hosts, and musl has no /etc/gai.conf to retune it. So any URL
+      # The API and the Next.js server both bind IPv4 only, but `localhost`
+      # resolves to ::1 first — getaddrinfo applies RFC 6724 precedence
+      # whatever the order in /etc/hosts, and musl has no /etc/gai.conf to
+      # retune it (the bundled Postgres is dual-stack; nothing else is). Any URL
       # naming it starts every connection on an address with no listener:
       # refused outright for a client without Happy Eyeballs, a wasted round
       # trip for one with it. That is the `ECONNREFUSED ::1:9000` in issues

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -703,8 +703,8 @@ The following environment variables can be used to configure Archestra Platform.
 
 - **`ARCHESTRA_API_BASE_URL`** - Archestra API Base URL(s) for connecting to Archestra's LLM Proxy, MCP Gateway and A2A Gateway.
 
-  This URL is displayed in the UI connection instructions to help users configure their agents. It doesn\'t affect internal routing (Archestra frontend communicates with backend via `http://localhost:9000`).
-  - Default: Falls back to `http://localhost:9000`
+  This URL is displayed in the UI connection instructions to help users configure their agents. It doesn\'t affect internal routing (Archestra frontend communicates with backend via `http://127.0.0.1:9000`).
+  - Default: Falls back to `http://127.0.0.1:9000`
   - Supports multiple comma-separated URLs for different connection options (e.g., internal K8s URL and external ingress)
   - Single URL example: `https://api.archestra.com`
   - Multiple URLs example: `http://archestra.default.svc:9000,https://api.archestra.example.com`

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -192,8 +192,9 @@ ARCHESTRA_A2A_TASK_RETENTION_DAYS=90
 # Example multiple: http://archestra.default.svc:9000,https://api.archestra.example.com
 ARCHESTRA_API_BASE_URL=
 
-# Optional, defaults to "http://localhost:9000". Internal URL where the frontend connects to the backend API server
-ARCHESTRA_INTERNAL_API_BASE_URL="http://localhost:9000"
+# Optional, defaults to "http://127.0.0.1:9000". Internal URL where the frontend connects to the backend API server.
+# Addressed by IPv4 literal rather than `localhost`: the API binds IPv4 only, and `localhost` resolves to ::1 first.
+ARCHESTRA_INTERNAL_API_BASE_URL="http://127.0.0.1:9000"
 
 # Optional dedicated port for the publicly-exposable endpoints — currently the
 # MS Teams incoming webhook (/api/webhooks/chatops/ms-teams). Same handler as

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -292,7 +292,21 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
 ENV ARCHESTRA_VERSION=${VERSION}
-ENV ARCHESTRA_INTERNAL_API_BASE_URL="http://localhost:9000"
+# 127.0.0.1, not `localhost`: the API and the Next.js server both bind IPv4
+# only (backend config.ts pins the API to 0.0.0.0; supervisord starts Next with
+# HOSTNAME=0.0.0.0), while `localhost` resolves to ::1 first — getaddrinfo
+# applies RFC 6724 precedence regardless of /etc/hosts order, and musl has no
+# /etc/gai.conf to retune it. Naming it would start every hop to the backend on
+# an address with no listener. See issues #4917 and #6933, and LOOPBACK_HOST in
+# shared/consts.ts.
+#
+# This is read at runtime by the SSR/API-route consumers (frontend proxy.ts,
+# the generated API client, lib/config/config.ts). The Next.js `rewrites()`
+# destination is NOT one of them: with output "standalone" it is resolved
+# during `pnpm build` in the builder stage — where this variable does not
+# exist — and frozen into .next/routes-manifest.json, so that path is governed
+# by DEFAULT_INTERNAL_API_BASE_URL in shared/consts.ts instead.
+ENV ARCHESTRA_INTERNAL_API_BASE_URL="http://127.0.0.1:9000"
 ENV ARCHESTRA_API_BASE_URL=""
 ENV ARCHESTRA_ANALYTICS="enabled"
 ENV ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED="false"

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -2,6 +2,7 @@ import {
   ApiError,
   isAgentTool,
   isBrowserMcpTool,
+  LOOPBACK_HOST,
   MCP_APPS_CLIENT_EXTENSION_CAPABILITIES,
   TimeInMs,
 } from "@archestra/shared";
@@ -50,8 +51,13 @@ import { buildMcpClientInfo } from "@/utils/mcp-client-info";
  * MCP Gateway base URL (internal)
  * Chat connects to the MCP Gateway endpoint with profile ID in path.
  * Derives from the configured API port to work in multi-pod deployments.
+ *
+ * The gateway is served by this same process — the worker pod registers it on
+ * its own listener too — so the dial never leaves the loopback interface.
+ * Addressed by {@link LOOPBACK_HOST} rather than `localhost`, which resolves to
+ * the `::1` address this IPv4-only server never listens on.
  */
-const MCP_GATEWAY_BASE_URL = `http://localhost:${config.api.port}/v1/mcp`;
+const MCP_GATEWAY_BASE_URL = `http://${LOOPBACK_HOST}:${config.api.port}/v1/mcp`;
 
 /**
  * Build the MCP client transport for the loopback gateway.

--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -131,11 +131,27 @@ vi.mock("ollama-ai-provider-v2", async (importOriginal) => {
 import { buildOllamaNativeProviderOptions } from "@/routes/chat/ollama-native-params";
 import type { ConfiguredParameters } from "@/types/model";
 import {
+  buildProxyBaseUrl,
   createDirectLLMModel,
   createLLMModel,
   createLLMModelForAgent,
   OLLAMA_THINK_EXPLICIT_HEADER,
 } from "./llm-client";
+
+describe("buildProxyBaseUrl", () => {
+  // The proxy this URL points at runs in this very process, and the API binds
+  // IPv4 only (config.api.host is "0.0.0.0" outside development). `localhost`
+  // resolves to ::1 first under RFC 6724 precedence, so naming it would send
+  // every chat turn's first proxy connection to an address with no listener —
+  // refused outright without Happy Eyeballs, and a wasted round trip with it.
+  // See issues #4917 / #6933 and LOOPBACK_HOST in shared/consts.ts.
+  it("addresses the loopback interface by IPv4 literal, never by name", () => {
+    const url = new URL(buildProxyBaseUrl("anthropic", "agent-1"));
+
+    expect(url.hostname).toBe("127.0.0.1");
+    expect(url.pathname).toBe("/v1/anthropic/agent-1");
+  });
+});
 
 describe("createDirectLLMModel", () => {
   it("creates a model for anthropic provider", () => {

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -17,6 +17,7 @@ import {
   DUAL_LLM_PROGRESS_CHANNEL_HEADER,
   EXTERNAL_AGENT_ID_HEADER,
   isProviderApiKeyOptional,
+  LOOPBACK_HOST,
   PROVIDER_BASE_URL_HEADER,
   perplexityAgentApiBaseUrl,
   providerRequiresPerUserCredential,
@@ -1163,8 +1164,14 @@ function takeMarkerHeader(
 }
 
 /**
- * Build the proxy base URL for a provider
+ * Build the proxy base URL for a provider.
+ *
+ * The proxy runs in this very process, so the dial stays on the loopback
+ * interface — addressed by {@link LOOPBACK_HOST} rather than `localhost`,
+ * which resolves to the `::1` address this IPv4-only server never listens on.
+ *
+ * @public — exported for testability
  */
-function buildProxyBaseUrl(provider: string, agentId: string): string {
-  return `http://localhost:${config.api.port}/v1/${provider}/${agentId}`;
+export function buildProxyBaseUrl(provider: string, agentId: string): string {
+  return `http://${LOOPBACK_HOST}:${config.api.port}/v1/${provider}/${agentId}`;
 }

--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  DEFAULT_INTERNAL_API_BASE_URL,
   MCP_CATALOG_API_BASE_URL,
   OAUTH_ISSUER_ROOT_ALIASES,
 } from "@archestra/shared";
@@ -46,6 +47,7 @@ const nextConfig: NextConfig = {
     resolveAlias: {
       "@archestra/shared/access-control": "../shared/access-control.ts",
       "@archestra/shared/api-error": "../shared/api-error.ts",
+      "@archestra/shared/consts": "../shared/consts.ts",
     },
   },
   logging: {
@@ -111,7 +113,8 @@ const nextConfig: NextConfig = {
   },
   async rewrites() {
     const backendUrl =
-      process.env.ARCHESTRA_INTERNAL_API_BASE_URL || "http://localhost:9000";
+      process.env.ARCHESTRA_INTERNAL_API_BASE_URL ||
+      DEFAULT_INTERNAL_API_BASE_URL;
     return [
       {
         source: "/api/archestra-catalog/:path*",

--- a/platform/frontend/src/app/internal-test/msw-handlers/route.ts
+++ b/platform/frontend/src/app/internal-test/msw-handlers/route.ts
@@ -11,6 +11,8 @@
 // this list right after `worker.start()` and replays each descriptor via
 // `worker.use(...)`, so a single POST covers both runtimes.
 
+import { DEFAULT_INTERNAL_API_BASE_URL } from "@archestra/shared/consts";
+
 export const dynamic = "force-dynamic";
 
 type HttpMethod = "get" | "post" | "put" | "patch" | "delete";
@@ -35,7 +37,7 @@ const ENABLED =
   process.env.NEXT_PUBLIC_API_MOCKING === "enabled" &&
   process.env.NODE_ENV !== "production";
 const BACKEND_ORIGIN =
-  process.env.ARCHESTRA_INTERNAL_API_BASE_URL || "http://localhost:9000";
+  process.env.ARCHESTRA_INTERNAL_API_BASE_URL || DEFAULT_INTERNAL_API_BASE_URL;
 
 export async function POST(req: Request): Promise<Response> {
   if (!ENABLED) return notFound();

--- a/platform/frontend/src/lib/config/config.test.ts
+++ b/platform/frontend/src/lib/config/config.test.ts
@@ -30,7 +30,7 @@ describe("getBackendBaseUrl", () => {
 
     const result = getBackendBaseUrl();
 
-    expect(result).toBe("http://localhost:9000");
+    expect(result).toBe("http://127.0.0.1:9000");
   });
 
   it("should return NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL when set", () => {
@@ -62,7 +62,7 @@ describe("getBackendBaseUrl", () => {
 
     const result = getBackendBaseUrl();
 
-    expect(result).toBe("http://localhost:9000");
+    expect(result).toBe("http://127.0.0.1:9000");
   });
 
   it("should handle URLs with ports", () => {
@@ -279,7 +279,7 @@ describe("getWebSocketUrl", () => {
 
       const result = getWebSocketUrl();
 
-      expect(result).toBe("ws://localhost:9000/ws");
+      expect(result).toBe("ws://127.0.0.1:9000/ws");
     });
 
     it("should convert http to ws", () => {
@@ -332,7 +332,7 @@ describe("getWebSocketUrl", () => {
 
       const result = getWebSocketUrl();
 
-      expect(result).toBe("ws://localhost:9000/ws");
+      expect(result).toBe("ws://127.0.0.1:9000/ws");
     });
   });
 });

--- a/platform/frontend/src/lib/config/config.ts
+++ b/platform/frontend/src/lib/config/config.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_INTERNAL_API_BASE_URL } from "@archestra/shared/consts";
 import { env } from "next-runtime-env";
 import type { PostHogConfig } from "posthog-js";
 
@@ -5,16 +6,16 @@ const environment: "development" | "production" =
   (process.env.NODE_ENV?.toLowerCase() as "development" | "production") ??
   "development";
 
-export const DEFAULT_BACKEND_URL = "http://localhost:9000";
+export const DEFAULT_BACKEND_URL = DEFAULT_INTERNAL_API_BASE_URL;
 
 /**
  * Get the backend API base URL.
- * Returns the configured URL or defaults to localhost:9000 for development.
+ * Returns the configured URL or defaults to the loopback API for development.
  *
  * Priority:
  * 1. NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL (runtime env var for client/server)
  * 2. ARCHESTRA_INTERNAL_API_BASE_URL (server-side only, for SSR/API routes)
- * 3. Default: http://localhost:9000
+ * 3. Default: {@link DEFAULT_INTERNAL_API_BASE_URL}
  */
 export const getBackendBaseUrl = (): string => {
   // Try runtime env var first (works in both client and server)
@@ -99,11 +100,7 @@ export const getWebSocketUrl = (): string => {
   }
 
   // Server-side: use absolute URL
-  const backendBaseUrl = getBackendBaseUrl();
-  const wsBaseUrl = backendBaseUrl
-    ? backendBaseUrl.replace(/^http/, "ws")
-    : "ws://localhost:9000";
-  return `${wsBaseUrl}/ws`;
+  return `${getBackendBaseUrl().replace(/^http/, "ws")}/ws`;
 };
 
 /**

--- a/platform/frontend/src/mocks/handlers.ts
+++ b/platform/frontend/src/mocks/handlers.ts
@@ -2,6 +2,7 @@
 // barrel (`@archestra/shared`) transitively imports a JSON module without an
 // import attribute, which the Playwright integration-test ESM loader rejects.
 // `client.ts` depends only on zod.
+import { DEFAULT_INTERNAL_API_BASE_URL } from "@archestra/shared/consts";
 import {
   type ClientFilter,
   ClientFilterSchema,
@@ -52,7 +53,7 @@ import {
 // browser (served via Next.js rewrites). MSW path-to-regexp does not accept
 // `*/...` host wildcards.
 const BACKEND_ORIGIN =
-  process.env.ARCHESTRA_INTERNAL_API_BASE_URL || "http://localhost:9000";
+  process.env.ARCHESTRA_INTERNAL_API_BASE_URL || DEFAULT_INTERNAL_API_BASE_URL;
 
 function paired(path: string): [string, string] {
   return [`${BACKEND_ORIGIN}${path}`, path];

--- a/platform/frontend/src/next-config.test.ts
+++ b/platform/frontend/src/next-config.test.ts
@@ -28,7 +28,7 @@ describe("next config rewrites", () => {
       expect.arrayContaining([
         {
           source: "/.well-known/:path*",
-          destination: "http://localhost:9000/.well-known/:path*",
+          destination: "http://127.0.0.1:9000/.well-known/:path*",
         },
       ]),
     );

--- a/platform/frontend/src/proxy.test.ts
+++ b/platform/frontend/src/proxy.test.ts
@@ -113,7 +113,7 @@ describe("proxy", () => {
       expect(response.headers.get("x-middleware-next")).toBeNull();
       // Should rewrite to backend URL
       expect(response.headers.get("x-middleware-rewrite")).toContain(
-        "localhost:9000",
+        "127.0.0.1:9000",
       );
     });
 
@@ -128,7 +128,7 @@ describe("proxy", () => {
 
       expect(response.headers.get("x-middleware-next")).toBeNull();
       expect(response.headers.get("x-middleware-rewrite")).toContain(
-        "localhost:9000",
+        "127.0.0.1:9000",
       );
     });
 

--- a/platform/frontend/src/proxy.ts
+++ b/platform/frontend/src/proxy.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_INTERNAL_API_BASE_URL } from "@archestra/shared/consts";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
@@ -32,7 +33,8 @@ export function proxy(req: NextRequest) {
 
       // Create the rewritten request with modified headers
       const backendUrl =
-        process.env.ARCHESTRA_INTERNAL_API_BASE_URL || "http://localhost:9000";
+        process.env.ARCHESTRA_INTERNAL_API_BASE_URL ||
+        DEFAULT_INTERNAL_API_BASE_URL;
       const backendRequestUrl = new URL(req.nextUrl.pathname, backendUrl);
       backendRequestUrl.search = req.nextUrl.search;
 

--- a/platform/frontend/vitest.config.ts
+++ b/platform/frontend/vitest.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
         __dirname,
         "../shared/api-error.ts",
       ),
+      "@archestra/shared/consts": path.resolve(
+        __dirname,
+        "../shared/consts.ts",
+      ),
       "@archestra/shared": path.resolve(__dirname, "../shared/index.ts"),
     },
   },

--- a/platform/shared/consts.ts
+++ b/platform/shared/consts.ts
@@ -1,3 +1,41 @@
+/**
+ * Loopback host every self-directed dial names — the frontend server reaching
+ * the backend in the same container, and the backend reaching its own LLM
+ * proxy and MCP gateway.
+ *
+ * It is an address literal, not `localhost`, on purpose. In production the API
+ * binds IPv4 only (`api.host = "0.0.0.0"` in the backend config), so it never
+ * has an IPv6 listener — while `localhost` resolves to `::1` FIRST:
+ * getaddrinfo applies RFC 6724 precedence no matter how /etc/hosts is ordered,
+ * and musl (the Alpine runtime image) compiles that table in with no
+ * /etc/gai.conf to retune it. Dialing the name therefore always targets a dead
+ * address first. Clients with Happy Eyeballs recover on the second attempt but
+ * pay for the refused one (~57ms per new connection, measured in the quickstart
+ * image) and log `ECONNREFUSED ::1:9000`; clients without it — busybox wget, or
+ * Node started with `--no-network-family-autoselection` — simply fail. That is
+ * the `::1` noise reported in issues #4917 and #6933.
+ *
+ * Name the address, not the name: it is unambiguous in every environment the
+ * platform runs in and no resolver can reorder it.
+ */
+export const LOOPBACK_HOST = "127.0.0.1";
+
+/**
+ * Where the backend API is reachable from the frontend server when
+ * `ARCHESTRA_INTERNAL_API_BASE_URL` is not set. Both processes always share a
+ * container — the unified image runs them under one supervisord, and the Helm
+ * chart exposes ports 3000 and 9000 on a single container — so the loopback
+ * literal is correct everywhere.
+ *
+ * That variable moves the runtime consumers (the frontend proxy, the generated
+ * API client, lib/config). It does NOT move the Next.js `rewrites()`
+ * destination, which this constant governs alone: with `output: "standalone"`
+ * the config is evaluated during `next build` and the resolved destination is
+ * frozen into `.next/routes-manifest.json`, where no runtime environment can
+ * reach it.
+ */
+export const DEFAULT_INTERNAL_API_BASE_URL = `http://${LOOPBACK_HOST}:9000`;
+
 /** Default app name used as fallback when organization.appName is not configured */
 export const DEFAULT_APP_NAME = "Archestra";
 export const DEFAULT_APP_FULL_NAME = "Archestra.AI";

--- a/platform/shared/hey-api/clients/api/custom-client.ts
+++ b/platform/shared/hey-api/clients/api/custom-client.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_INTERNAL_API_BASE_URL } from "../../../consts";
 import { createQuerySerializer } from "./client/utils.gen";
 import type { CreateClientConfig } from "./client.gen";
 
@@ -27,7 +28,8 @@ export const createClientConfig: CreateClientConfig = (config) => {
   const isServer = typeof window === "undefined";
 
   const backendUrl =
-    process.env.ARCHESTRA_INTERNAL_API_BASE_URL || "http://localhost:9000";
+    process.env.ARCHESTRA_INTERNAL_API_BASE_URL ||
+    DEFAULT_INTERNAL_API_BASE_URL;
 
   return {
     ...config,

--- a/platform/shared/hey-api/openapi-ts.ts
+++ b/platform/shared/hey-api/openapi-ts.ts
@@ -1,16 +1,19 @@
 import { pathToFileURL } from "node:url";
 import { createClient, defineConfig } from "@hey-api/openapi-ts";
-import { MCP_CATALOG_API_BASE_URL } from "../consts";
+import {
+  DEFAULT_INTERNAL_API_BASE_URL,
+  MCP_CATALOG_API_BASE_URL,
+} from "../consts";
 
 /**
  * During `pnpm codegen` (CODEGEN=true), use the generated docs/openapi.json file
  * which includes all enterprise routes regardless of local .env settings.
- * For manual regeneration with a running dev server, use localhost.
+ * For manual regeneration, read it off a running dev server on the loopback API.
  */
 const archestraApiInput =
   process.env.CODEGEN === "true"
     ? "../../docs/openapi.json"
-    : "http://localhost:9000/openapi.json";
+    : `${DEFAULT_INTERNAL_API_BASE_URL}/openapi.json`;
 
 const archestraApiConfig = await defineConfig({
   input: archestraApiInput,

--- a/platform/shared/loopback-dial.test.ts
+++ b/platform/shared/loopback-dial.test.ts
@@ -1,0 +1,111 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { isIP } from "node:net";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_INTERNAL_API_BASE_URL, LOOPBACK_HOST } from "./consts";
+
+/**
+ * The platform's own API binds IPv4 only in production (`api.host` is
+ * "0.0.0.0" in the backend config), so a URL that reaches it through the name
+ * `localhost` always tries `::1` first — an address with no listener. That is
+ * the `ECONNREFUSED ::1:9000` behind issues #4917 and #6933.
+ *
+ * Every self-directed dial therefore names {@link LOOPBACK_HOST}. This test is
+ * the net under the ones that have their own assertion (`buildProxyBaseUrl` in
+ * llm-client.test.ts, the frontend defaults in config.test.ts): it fails if any
+ * source file grows a new URL pointing at our API port through a name.
+ *
+ * Two spellings are rejected: the API port written out, and a computed port.
+ * `localhost` is the right answer for services on the *user's* machine — an
+ * Ollama server, the OTLP collector, an OAuth callback — and those are always
+ * written with their own literal port (11434, 4318), never a computed one, so
+ * a computed port next to `localhost` in this repo is a self-dial.
+ *
+ * A net, not a proof: a self-dial assembled from variables slips past it. The
+ * per-site assertions in llm-client.test.ts, next-config.test.ts,
+ * config.test.ts and proxy.test.ts are what pin the sites that exist today.
+ */
+const SELF_DIAL_BY_NAME = /["'`](?:https?|wss?):\/\/localhost:(?:9000|\$\{)/;
+
+/**
+ * The code that runs *inside* the image. The whole `frontend` package, not just
+ * its `src`, because next.config.ts is where the /api proxy destination is
+ * baked into routes-manifest.json — the path the bug was actually reported on.
+ *
+ * `e2e-tests/` is deliberately absent: those URLs are dialled from the host by
+ * the runner and the browser, where `localhost` is an origin identity rather
+ * than a route — the lite suite's Keycloak redirect URI depends on it (see
+ * platform-e2e-tests.yml).
+ *
+ * `@archestra/shared#check:ci` declares these trees as turbo inputs, so a
+ * change to any of them re-runs this test instead of restoring a cache entry.
+ */
+const SCANNED_ROOTS = ["backend/src", "frontend", "shared"] as const;
+
+const SKIPPED_DIRS = new Set([
+  "node_modules",
+  "dist",
+  ".next",
+  ".next-pw",
+  ".turbo",
+  "test-results",
+]);
+
+describe("loopback dial hygiene", () => {
+  it("reaches the API through an address, not a name", () => {
+    // The property that matters is resolver-independence: an address literal
+    // has exactly one interpretation, a name has as many as /etc/hosts and
+    // RFC 6724 give it.
+    expect(isIP(LOOPBACK_HOST)).toBe(4);
+    expect(isIP(new URL(DEFAULT_INTERNAL_API_BASE_URL).hostname)).toBe(4);
+  });
+
+  it("has no source file dialling the platform's own API port by name", () => {
+    const platformRoot = resolve(import.meta.dirname, "..");
+    const offenders: string[] = [];
+
+    for (const root of SCANNED_ROOTS) {
+      for (const file of sourceFiles(join(platformRoot, root))) {
+        const contents = readFileSync(file, "utf-8");
+        for (const [index, line] of contents.split("\n").entries()) {
+          if (SELF_DIAL_BY_NAME.test(line)) {
+            offenders.push(
+              `${relative(platformRoot, file)}:${index + 1}: ${line.trim()}`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      "These URLs reach the platform's own API, which listens on IPv4 only, " +
+        `through a name that resolves to ::1 first. Use LOOPBACK_HOST / ` +
+        `DEFAULT_INTERNAL_API_BASE_URL from @archestra/shared/consts:\n` +
+        offenders.join("\n"),
+    ).toEqual([]);
+  });
+});
+
+/** Every non-test TypeScript file under `dir`, recursively. */
+function sourceFiles(dir: string): string[] {
+  const found: string[] = [];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(entry.parentPath, entry.name);
+
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRS.has(entry.name)) found.push(...sourceFiles(path));
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry.name)) continue;
+    // Fixtures and expectations legitimately spell out a user-supplied
+    // `http://localhost:9000` — what is under test there is our handling of an
+    // operator's value, not an address we dial.
+    if (/\.(test|spec)\.tsx?$/.test(entry.name)) continue;
+
+    found.push(path);
+  }
+
+  return found;
+}

--- a/platform/shared/package.json
+++ b/platform/shared/package.json
@@ -8,6 +8,7 @@
     ".": "./index.ts",
     "./access-control": "./access-control.ts",
     "./api-error": "./api-error.ts",
+    "./consts": "./consts.ts",
     "./e2e-test-ids": "./e2e-test-ids.ts",
     "./interactions/client": "./interactions/client.ts",
     "./permission.types": "./permission.types.ts",

--- a/platform/turbo.json
+++ b/platform/turbo.json
@@ -84,6 +84,18 @@
       "dependsOn": ["@backend#codegen"],
       "cache": false
     },
+    "@archestra/shared#check:ci": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "**/*.tsx",
+        "**/*.ts",
+        "./biome.json",
+        "**/knip.config.ts",
+        "**/package.json",
+        "$TURBO_ROOT$/backend/src/**",
+        "$TURBO_ROOT$/frontend/**"
+      ]
+    },
     "db:generate": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Problem

In the quickstart container, `localhost` resolves to `::1` first — and nothing in the image listens there.

Every production listener is IPv4-only by construction: the backend pins `api.host` to `0.0.0.0` outside development ([`config.ts`](../blob/main/platform/backend/src/config.ts)), and supervisord starts the Next.js server with `HOSTNAME=0.0.0.0`. Measured inside a running `archestra/platform:latest` container, against a **healthy** backend:

```
listeners v4   0.0.0.0:3000  0.0.0.0:9000  0.0.0.0:9050 …
listeners v6   [::]:5432                       ← postgres only
dns.lookup("localhost")   [{::1, family 6}, {127.0.0.1, family 4}]     ← ::1 first
```

`getaddrinfo` ranks `::1` above `127.0.0.1` per RFC 6724 whatever the order in `/etc/hosts`, and musl compiles that table in with no `/etc/gai.conf` to retune it. So every `localhost` dial starts on a dead address:

| dial | result |
|---|---|
| `fetch("http://127.0.0.1:9000/health")` | ok, **3.0 ms** |
| `fetch("http://localhost:9000/health")` | ok, **59.6 ms** — a refused `::1` connect first |
| `net.connect({host:"localhost", autoSelectFamily:false})` | **`ECONNREFUSED ::1:9000`** |
| `wget http://localhost:9000/health` (busybox) | **`can't connect to remote host: Connection refused`** |
| `fetch("http://localhost:9000/health")` with `NODE_OPTIONS=--no-network-family-autoselection` | **fails** |

Happy Eyeballs hides this from Node most of the time, which is why it survived so long — it is paid as latency and as the `ECONNREFUSED ::1:9000` noise in #6933 and #4917, and it becomes a hard failure for any client without it.

The reported failure path is the frontend's `/api` proxy, and it is **frozen at build time**. With `output: "standalone"`, `rewrites()` is resolved during `next build` and written into `.next/routes-manifest.json`; the server reads that file and never re-evaluates the config. Read straight out of the published image:

```
$ docker run --rm --entrypoint node archestra/platform:latest -e '…routes-manifest…'
http://localhost:9000/api/:path*      http://localhost:9000/health
http://localhost:9000/v1/:path*       http://localhost:9000/_sandbox/:path*
http://localhost:9000/.well-known/:path*   http://localhost:9000/skills/m/:path*
http://localhost:9000/ws
```

Those are exactly the URLs in the reporter's log (`Failed to proxy http://localhost:9000/api/auth/get-session`, `/health`, `/api/config/public`). Setting `ARCHESTRA_INTERNAL_API_BASE_URL` at runtime does **not** move them — verified.

## Change

Name the address, not the name. Every self-directed dial goes to the IPv4 loopback literal, via one constant:

- `LOOPBACK_HOST` / `DEFAULT_INTERNAL_API_BASE_URL` in `shared/consts.ts`
- frontend → backend: `next.config.ts` rewrites, `proxy.ts`, the generated client's `custom-client.ts`, `lib/config/config.ts`, the MSW handlers (so mocks intercept the same origin the client dials)
- backend → its own LLM proxy: `buildProxyBaseUrl`
- backend → its own MCP gateway: `MCP_GATEWAY_BASE_URL` (the chat tool-call hot path; also served on the worker pod's own listener)
- `Dockerfile` `ENV ARCHESTRA_INTERNAL_API_BASE_URL`, and `.env.example`

Nothing about DNS resolution, listeners, or exposure changes. `::1` is still resolved first, still has the same fallback, and every listener binds exactly what it bound before.

## Why not `--dns-result-order=ipv4first`

That was the previous attempt (#7075) and it is not durable:

```
image default : --dns-result-order=ipv4first
user override : --max-old-space-size=4096      ← docker run -e NODE_OPTIONS=… REPLACES the image ENV
```

Raising the heap is the standard advice for a container under memory pressure, so the fix would evaporate exactly when someone is already debugging. Putting it in the launch scripts instead survives that, but it makes a loopback problem into a process-global resolver policy: it reorders `dns.lookup` for every outbound hostname — LLM providers, the database, OTLP, object storage — including in the worker and renderer pods, and costs an IPv6-only/NAT64 cluster a failed IPv4 attempt on every new connection. An address literal has none of that reach.

## Why not bind dual-stack

Binding `::` instead of `0.0.0.0` would also fix it, and it would additionally help non-Node clients in the container. It is a much larger change: it alters what every listener (API, metrics, public endpoints, health, render) is exposed on in a product whose quickstart deliberately publishes to `127.0.0.1` only, and it depends on the host kernel providing `AF_INET6` at all plus `net.ipv6.bindv6only=0`. Addressing the loopback by literal fixes the reported bug without changing a single listener. If dual-stack is wanted later, it is orthogonal to this change and none of it needs undoing.

## Tests

**`shared/loopback-dial.test.ts`** (new) — the constants must be address literals, and no source file under `backend/src`, `frontend` or `shared` may dial the platform's own API port by name. Verified it goes red on a simulated revert of each of the four self-dials, `next.config.ts` included. Deliberately narrow: `localhost` stays correct for an Ollama server, an OTLP collector, an OAuth callback — services on the *user's* machine, always written with their own literal port — and for the e2e suite, where the host-side URL is an origin identity the Keycloak redirect URI depends on.

A cross-workspace scan only works if it actually runs, and `check:ci` is turbo-cached on the package's own files: a backend-only PR restored shared's cache and skipped the scan entirely (measured — `>>> FULL TURBO`). `@archestra/shared#check:ci` therefore declares the scanned trees as `$TURBO_ROOT$` inputs. Verified all three ways round: unchanged tree stays cached, a backend edit busts it, a frontend edit busts it.

**Unit** — `next-config.test.ts` pins the destination that gets baked into the manifest; `config.test.ts`, `proxy.test.ts` and `llm-client.test.ts` pin the resolved defaults.

**e2e (quickstart job)** — a new step that, inside the running container, asserts (1) the image's `ARCHESTRA_INTERNAL_API_BASE_URL` is an address rather than a name, (2) no baked rewrite destination names `localhost`, and (3) every loopback destination answers when dialled with `node --dns-result-order=verbatim --no-network-family-autoselection` under a hostile `-e NODE_OPTIONS` — so the probe connects to the first resolved address only, on argv, where no ambient resolver setting can rescue it. Each assertion records its own result, so one failure still reports the others.

Run against both images:

```
BEFORE  archestra/platform:latest, backend healthy
  1/3  ARCHESTRA_INTERNAL_API_BASE_URL=http://localhost:9000
       FAILED: localhost is a name; it resolves to ::1 first, where nothing listens
  2/3  8 absolute destinations, 7 naming localhost                        FAILED
  3/3  FAILED: http://localhost:9000 unreachable on its first-resolved address:
       connect ECONNREFUSED ::1:9000
  step exit: 1

AFTER   patched image, fresh quickstart container
  1/3  ARCHESTRA_INTERNAL_API_BASE_URL=http://127.0.0.1:9000
  2/3  8 absolute destinations, 0 naming localhost
  3/3  http://127.0.0.1:9000 -> {"name":"Archestra","status":"ok"}
  step exit: 0
  GET /api/config/public -> HTTP 200 in 0.026s     (frontend proxy end to end)
  ::1 occurrences in container logs: 0
```

## Notes

- The Helm chart never sets `ARCHESTRA_INTERNAL_API_BASE_URL`; it runs frontend and backend as one container exposing 3000 and 9000, so the loopback literal is right there too. An operator who genuinely separates them still sets the variable.
- `/connection` falls back to this URL when no external URL is visible, so that panel now shows `http://127.0.0.1:9000/v1` instead of `http://localhost:9000/v1`. Both work from the host; `127.0.0.1` is what the quickstart actually publishes (`-p 127.0.0.1:9000:9000`).
- `scripts/dev-stack.sh` is deliberately untouched: it sets `ARCHESTRA_INTERNAL_API_BASE_URL` in lockstep with the browser-facing `NEXT_PUBLIC_` mirror on the developer's own machine, where `localhost` is what you type.
- This does not close #6933 on its own. That reporter's backend was refusing on **both** families (`ECONNREFUSED 127.0.0.1:9000` as well), i.e. it was not listening at all — a separate defect. What this removes is the `::1` symptom that made the investigation chase a phantom removal of port 9000, and it finishes the job #5328 started when it fixed only the `HEALTHCHECK`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>