### PR TITLE
fix(frontend): state the concrete 24h freshness window in the stale-session panel

### DIFF
--- a/platform/backend/src/auth/list-sessions-freshness.test.ts
+++ b/platform/backend/src/auth/list-sessions-freshness.test.ts
@@ -4,7 +4,8 @@ import { betterAuth } from "@/auth";
 import config from "@/config";
 import { describe, expect, test } from "@/test";
 
-const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
 
 async function sessionCookieHeaders(sessionToken: string) {
   if (!config.auth.secret) {
@@ -25,15 +26,24 @@ async function sessionCookieHeaders(sessionToken: string) {
  * refused even though it is still valid for everything else. Sessions live 7
  * days, so an account spends most of its life in that state — which is why the
  * Sessions card has a re-authentication state rather than just a list.
+ *
+ * The two tests straddle the 24h boundary because the card's copy promises
+ * that exact window; if a Better Auth upgrade moves the default, these fail
+ * and the copy in sessions-card.tsx must be updated with it.
  */
 describe("listSessions session freshness", () => {
+  test("resolves freshAge to the 24h window the Sessions card copy promises", async () => {
+    const ctx = await betterAuth.$context;
+    expect(ctx.sessionConfig.freshAge).toBe(24 * 60 * 60);
+  });
+
   test("refuses a session older than freshAge", async ({
     makeUser,
     makeSession,
   }) => {
     const user = await makeUser();
     const session = await makeSession(user.id, {
-      createdAt: new Date(Date.now() - 2 * DAY_MS),
+      createdAt: new Date(Date.now() - 25 * HOUR_MS),
       expiresAt: new Date(Date.now() + 5 * DAY_MS),
     });
 
@@ -53,7 +63,7 @@ describe("listSessions session freshness", () => {
   }) => {
     const user = await makeUser();
     const session = await makeSession(user.id, {
-      createdAt: new Date(),
+      createdAt: new Date(Date.now() - 23 * HOUR_MS),
       expiresAt: new Date(Date.now() + 7 * DAY_MS),
     });
 

--- a/platform/frontend/src/app/account/_components/sessions-card.test.tsx
+++ b/platform/frontend/src/app/account/_components/sessions-card.test.tsx
@@ -94,6 +94,11 @@ describe("SessionsCard", () => {
     expect(
       await screen.findByText(/sign in again to manage your sessions/i),
     ).toBeInTheDocument();
+    // The copy must state the concrete freshness window — Better Auth's 24h
+    // freshAge default, pinned by backend/src/auth/list-sessions-freshness.test.ts.
+    expect(
+      screen.getByText(/first 24\s+hours after you sign in/i),
+    ).toBeInTheDocument();
     // The failure must not be presented as "you have no other sessions".
     expect(screen.queryByRole("button", { name: "Revoke" })).toBeNull();
 

--- a/platform/frontend/src/app/account/_components/sessions-card.tsx
+++ b/platform/frontend/src/app/account/_components/sessions-card.tsx
@@ -58,9 +58,11 @@ export function SessionsCard() {
               </EmptyMedia>
               <EmptyTitle>Sign in again to manage your sessions</EmptyTitle>
               <EmptyDescription>
-                For your security, this list is only available shortly after you
-                sign in. Sign out and back in to see where your account is
-                signed in.
+                {/* 24 hours mirrors Better Auth's session.freshAge default,
+                    pinned by backend/src/auth/list-sessions-freshness.test.ts */}
+                For your security, this list is only available for the first 24
+                hours after you sign in. Sign out and back in to see where your
+                account is signed in.
               </EmptyDescription>
             </EmptyHeader>
             <EmptyContent>


### PR DESCRIPTION
## Summary

The stale-session panel on `/account` told users the sessions list is "only available shortly after you sign in" — vague enough that a user can't tell whether signing in again is worth it or when the list went away. The copy now states the actual window: "only available for the first 24 hours after you sign in."

24 hours is Better Auth's `session.freshAge` default (`3600 * 24` in `create-context.mjs`), which our config does not override, measured from the session's `createdAt` — staying active does not extend it. Since the frontend copy now hardcodes a number owned by a library default, `list-sessions-freshness.test.ts` pins it two ways: the fresh/stale cases straddle the boundary at 23h/25h, and a direct assertion pins the resolved `sessionConfig.freshAge` at 86400 with no timing slack. If a Better Auth upgrade moves the default, those tests fail and point back at the copy.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>