### PR TITLE
perf(frontend): collapse the /account identity-loading waterfall

### DIFF
--- a/platform/frontend/src/components/settings/role-permissions-card.test.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.test.tsx
@@ -2,10 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RolePermissionsCard } from "@/components/settings/role-permissions-card";
 import { useAllPermissions, useSession } from "@/lib/auth/auth.query";
-import {
-  useActiveMemberRole,
-  useActiveOrganization,
-} from "@/lib/organization.query";
+import { useActiveMemberRole } from "@/lib/organization.query";
 
 const mockUpdateNameMutateAsync = vi.fn();
 
@@ -28,12 +25,9 @@ describe("RolePermissionsCard", () => {
       data: null,
       isLoading: false,
     } as unknown as ReturnType<typeof useAllPermissions>);
-    vi.mocked(useActiveOrganization).mockReturnValue({
-      data: { id: "org-1" },
-    } as unknown as ReturnType<typeof useActiveOrganization>);
     vi.mocked(useActiveMemberRole).mockReturnValue({
       data: "admin",
-      isLoading: false,
+      isPending: false,
     } as unknown as ReturnType<typeof useActiveMemberRole>);
     vi.mocked(useSession).mockReturnValue({
       data: {
@@ -42,20 +36,19 @@ describe("RolePermissionsCard", () => {
           name: "Original Name",
           email: "admin@example.com",
         },
+        session: { activeOrganizationId: "org-1" },
       },
+      isPending: false,
     } as unknown as ReturnType<typeof useSession>);
   });
 
-  it("keeps the skeleton up while the organization is still resolving", () => {
-    vi.mocked(useActiveOrganization).mockReturnValue({
+  it("keeps the skeleton up while the session is still resolving", () => {
+    vi.mocked(useSession).mockReturnValue({
       data: undefined,
       isPending: true,
-    } as unknown as ReturnType<typeof useActiveOrganization>);
-    // A dependent query that is still disabled reports isLoading false with no
-    // data, so the gate cannot rely on isLoading alone.
+    } as unknown as ReturnType<typeof useSession>);
     vi.mocked(useActiveMemberRole).mockReturnValue({
       data: undefined,
-      isLoading: false,
       isPending: true,
     } as unknown as ReturnType<typeof useActiveMemberRole>);
 
@@ -67,13 +60,9 @@ describe("RolePermissionsCard", () => {
     expect(screen.queryByText("Original Name")).toBeNull();
   });
 
-  it("keeps the skeleton up until the role arrives for a resolved organization", () => {
-    // isLoading false with no data covers both halves of the wait: the query
-    // still disabled, and the moment it enables. Gating on isLoading renders
-    // the card here and then snaps it back to a skeleton.
+  it("keeps the skeleton up until the role arrives when the session has an active organization", () => {
     vi.mocked(useActiveMemberRole).mockReturnValue({
       data: undefined,
-      isLoading: false,
       isPending: true,
     } as unknown as ReturnType<typeof useActiveMemberRole>);
 
@@ -86,15 +75,21 @@ describe("RolePermissionsCard", () => {
   });
 
   it("renders the account details when the user has no active organization", () => {
-    vi.mocked(useActiveOrganization).mockReturnValue({
-      data: null,
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: {
+          id: "user-1",
+          name: "Original Name",
+          email: "admin@example.com",
+        },
+        session: { activeOrganizationId: null },
+      },
       isPending: false,
-    } as unknown as ReturnType<typeof useActiveOrganization>);
-    // With no organization id the role query never enables, so it stays pending
-    // forever — the card must not wait on it.
+    } as unknown as ReturnType<typeof useSession>);
+    // With no active organization the role query never enables, so it stays
+    // pending forever — the card must not wait on it.
     vi.mocked(useActiveMemberRole).mockReturnValue({
       data: undefined,
-      isLoading: false,
       isPending: true,
     } as unknown as ReturnType<typeof useActiveMemberRole>);
 

--- a/platform/frontend/src/components/settings/role-permissions-card.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.tsx
@@ -40,10 +40,7 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUpdateAccountNameMutation } from "@/lib/auth/account.query";
 import { useAllPermissions, useSession } from "@/lib/auth/auth.query";
-import {
-  useActiveMemberRole,
-  useActiveOrganization,
-} from "@/lib/organization.query";
+import { useActiveMemberRole } from "@/lib/organization.query";
 
 const NameFormSchema = z.object({
   name: z.string().trim().min(1, "Name is required"),
@@ -71,21 +68,19 @@ const actionLabels: Record<Action, string> = {
 };
 
 export function RolePermissionsCard() {
-  const { data: session } = useSession();
-  const { data: activeOrg, isPending: isOrgPending } = useActiveOrganization();
-  const { data: role, isPending: isRolePending } = useActiveMemberRole(
-    activeOrg?.id,
-  );
+  const { data: session, isPending: isSessionPending } = useSession();
+  const hasActiveOrganization = !!session?.session?.activeOrganizationId;
+  const { data: role, isPending: isRolePending } = useActiveMemberRole();
   const { data: permissions, isLoading: isPermissionsLoading } =
     useAllPermissions();
 
-  // The role query only enables once the organization resolves, and a disabled
-  // query reports isLoading false with no data — gating on that renders the
-  // card, then snaps it back to a skeleton when the role finally fetches.
-  // isPending stays true across both waits; guard it on the organization id so
-  // a user without one is not stuck on a skeleton the role can never clear.
+  // The role query stays pending forever for a user with no active
+  // organization (it never enables), so its wait only counts when the session
+  // says there is an organization to have a role in.
   const isLoading =
-    isOrgPending || (!!activeOrg?.id && isRolePending) || isPermissionsLoading;
+    isSessionPending ||
+    (hasActiveOrganization && isRolePending) ||
+    isPermissionsLoading;
 
   if (isLoading) {
     return (

--- a/platform/frontend/src/lib/organization.query.test.tsx
+++ b/platform/frontend/src/lib/organization.query.test.tsx
@@ -1,0 +1,136 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authQueryKeys } from "@/lib/auth/auth.query";
+import { authClient } from "@/lib/clients/auth/auth-client";
+import {
+  organizationKeys,
+  useActiveMemberRole,
+} from "@/lib/organization.query";
+
+vi.mock("@/lib/clients/auth/auth-client");
+
+function renderActiveMemberRole() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return {
+    ...renderHook(() => useActiveMemberRole(), { wrapper }),
+    queryClient,
+  };
+}
+
+function sessionWith(activeOrganizationId: string | null) {
+  return {
+    data: {
+      user: { id: "user-1", email: "user@example.com" },
+      session: { id: "session-1", activeOrganizationId },
+    },
+    error: null,
+  };
+}
+
+describe("useActiveMemberRole", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authClient.organization.getActiveMemberRole).mockResolvedValue({
+      data: { role: "admin" },
+      error: null,
+    });
+  });
+
+  it("fetches the role from the session alone, without an organization fetch in front", async () => {
+    vi.mocked(authClient.getSession).mockResolvedValue(sessionWith("org-1"));
+
+    const { result } = renderActiveMemberRole();
+
+    await waitFor(() => {
+      expect(result.current.data).toBe("admin");
+    });
+    // The endpoint derives the organization from the session, so the hook must
+    // not consult the organization store (whose fetch would then gate the role).
+    expect(authClient.useActiveOrganization).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while the session is still resolving", async () => {
+    let resolveSession: (value: unknown) => void = () => {};
+    vi.mocked(authClient.getSession).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSession = resolve;
+      }),
+    );
+
+    const { result } = renderActiveMemberRole();
+
+    expect(authClient.organization.getActiveMemberRole).not.toHaveBeenCalled();
+
+    resolveSession(sessionWith("org-1"));
+
+    await waitFor(() => {
+      expect(result.current.data).toBe("admin");
+    });
+  });
+
+  it("resolves to null, not undefined, when the endpoint reports no role", async () => {
+    vi.mocked(authClient.getSession).mockResolvedValue(sessionWith("org-1"));
+    vi.mocked(authClient.organization.getActiveMemberRole).mockResolvedValue({
+      data: undefined,
+      error: null,
+    });
+
+    const { result } = renderActiveMemberRole();
+
+    // null is the settled "no role" answer; undefined would be
+    // indistinguishable from a query that has not resolved yet.
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it("does not serve one organization's cached role after a switch of the active org", async () => {
+    vi.mocked(authClient.getSession).mockResolvedValue(sessionWith("org-1"));
+
+    const { result, queryClient } = renderActiveMemberRole();
+    await waitFor(() => {
+      expect(result.current.data).toBe("admin");
+    });
+
+    vi.mocked(authClient.organization.getActiveMemberRole).mockResolvedValue({
+      data: { role: "member" },
+      error: null,
+    });
+    act(() => {
+      queryClient.setQueryData(
+        authQueryKeys.session(),
+        sessionWith("org-2").data,
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBe("member");
+    });
+    // Each organization keeps its own cache entry; org-1's was not overwritten.
+    expect(
+      queryClient.getQueryData(organizationKeys.activeMemberRole("org-1")),
+    ).toBe("admin");
+  });
+
+  it("never fires for a session with no active organization", async () => {
+    vi.mocked(authClient.getSession).mockResolvedValue(sessionWith(null));
+
+    const { result } = renderActiveMemberRole();
+
+    // The session settling is the last thing that could enable the query.
+    await waitFor(() => {
+      expect(authClient.getSession).toHaveBeenCalled();
+    });
+    expect(result.current.isPending).toBe(true);
+    expect(authClient.organization.getActiveMemberRole).not.toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -53,8 +53,8 @@ export const organizationKeys = {
   invitations: () => [...organizationKeys.all, "invitations"] as const,
   invitation: (id: string) => [...organizationKeys.invitations(), id] as const,
   activeOrg: () => [...organizationKeys.all, "active"] as const,
-  activeMemberRole: () =>
-    [...organizationKeys.activeOrg(), "member-role"] as const,
+  activeMemberRole: (organizationId: string | undefined) =>
+    [...organizationKeys.activeOrg(), "member-role", organizationId] as const,
   details: () => [...organizationKeys.all, "details"] as const,
   onboardingStatus: () =>
     [...organizationKeys.all, "onboarding-status"] as const,
@@ -88,16 +88,29 @@ export function useActiveOrganization() {
 }
 
 /**
- * Fetch active member role
+ * Fetch the caller's role in their active organization. Resolves to null when
+ * the endpoint reports no role; stays disabled (data undefined) while the
+ * session is unresolved or names no active organization.
+ *
+ * The endpoint resolves the organization from the session itself, so this
+ * gates on the session's activeOrganizationId rather than on
+ * useActiveOrganization() — waiting for the full-organization fetch would put
+ * an extra request in front of the role for no reason.
  */
-export function useActiveMemberRole(organizationId?: string) {
+export function useActiveMemberRole() {
+  const { data: session, isPending: isSessionPending } = useSession();
+  const activeOrganizationId =
+    session?.session?.activeOrganizationId ?? undefined;
+
   return useQuery({
-    queryKey: organizationKeys.activeMemberRole(),
+    // The organization id in the key stops one organization's cached role
+    // from being served for another after a switch of the active org.
+    queryKey: organizationKeys.activeMemberRole(activeOrganizationId),
     queryFn: async () => {
       const { data } = await authClient.organization.getActiveMemberRole();
-      return data?.role;
+      return data?.role ?? null;
     },
-    enabled: !!organizationId,
+    enabled: !isSessionPending && !!activeOrganizationId,
   });
 }
 


### PR DESCRIPTION
## Summary

Loading `/account` serialized three identity requests — `get-session` → `get-full-organization` → `get-active-member-role` — because `useActiveMemberRole` was enabled off `useActiveOrganization()`'s result. Better Auth's `get-active-member-role` endpoint derives the organization from the session itself (`session.session.activeOrganizationId`), so that gate bought nothing and kept the role & permissions card on a skeleton for roughly a second per load.

`useActiveMemberRole` now enables directly off the session's `activeOrganizationId`: the role and permissions requests fire in parallel the moment the session resolves, and the full-organization fetch is out of the card's critical path entirely. The card's loading gate follows the same source of truth — session pending, or role pending when the session names an organization — so a user with no active organization renders immediately instead of waiting on a query that never enables.

The role's cache key now includes the organization id, so a cached role can never be served for a different organization after an active-org switch (unreachable in today's UI, but the static key was a standing hazard flagged in review of #7034).

## Why not SSR, like `/agents`

An `/agents`-style server prefetch (`force-dynamic` + server fetch + `initialData`) was considered and rejected on three grounds:

- **Server-rendered HTML for authenticated pages never paints.** `WithAuthCheck` (`src/app/_parts/with-auth-check.tsx`) returns `null` until the client-side `useSession()` query resolves, on every page — including the existing `force-dynamic` ones, whose server-rendered markup is discarded in the same way. What those pages actually gain is data in the RSC payload that spares one client fetch *below* the gate; they do not paint earlier.
- **The bottleneck this PR removes sat above the gate.** Page-level `initialData` can only feed components below the page, but the serialized chain started with the session query that `WithAuthCheck` itself blocks on. No per-page prefetch reaches it; removing the client-side serialization is the lever that exists.
- **What a prefetch could still cover no longer pays for itself.** With the waterfall collapsed, the card's residual wait is one parallel role + permissions round-trip after the session resolves. A server prefetch of those two would not delete that latency — it would move it into TTFB, paid on every `/account` load even with a warm client cache — while adding identity data to the RSC payload and a `force-dynamic` page for a page that is fully client-interactive.

Making `/account` genuinely paint server-side means moving the session check itself to the server (proxy-level optimistic check plus a server session read feeding a `HydrationBoundary`), plus server-side theming so the first paint is not unthemed — an app-shell change with a blast radius of every route, out of scope here.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
