### PR TITLE
feat(chat): surface context headroom on hover and let users compact on demand

### DIFF
--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -3,7 +3,7 @@ title: Chat
 category: Agents
 order: 2
 description: Built-in Chat interface for working with agents and MCP tools
-lastUpdated: 2026-07-28
+lastUpdated: 2026-08-04
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -48,6 +48,8 @@ The context window visualizer shows how the model's context window is filled for
 
 The indicator ring appears after the first message in a conversation. The ring color escalates as the window fills: green below 50 %, yellow from 50 %, orange from 75 %, red from 90 %.
 
+Hover the ring for a summary: tokens used, and how much of the window is left before auto-compaction runs. Auto-compaction fires at 80 % — a tick on the panel's bar marks that point.
+
 The panel breaks usage down by category:
 
 | Category | What it counts |
@@ -62,7 +64,7 @@ Expand any category to see the largest individual contributors (top tools by sch
 
 **Estimates, not exact counts.** The breakdown is computed before the request is sent, using the same character-per-token and bytes-per-token heuristics that drive auto-compaction. The provider's exact prompt size arrives afterward via per-step token usage and supersedes the estimate for the ring. The visualizer never mutates or truncates the request.
 
-When auto-compaction frees tokens, a note appears in the panel showing how many tokens were recovered. See [Context Compaction](#context-compaction) for how compaction works.
+Use **Compact now** in the panel to summarize earlier turns before auto-compaction does it for you. When a compaction frees tokens, a note appears showing how many were recovered. See [Context Compaction](#context-compaction) for how compaction works.
 
 Ollama models often run with a smaller context window than the model architecturally supports. Archestra detects the effective window and sizes the ring to it — see [Ollama Context Window](/docs/platform-supported-llm-providers#context-window).
 

--- a/platform/backend/src/agents/a2a/a2a-context-compaction.ts
+++ b/platform/backend/src/agents/a2a/a2a-context-compaction.ts
@@ -16,14 +16,16 @@
  * Failures are non-fatal: the uncompacted view is returned and the per-step
  * guard (agents/step-context-guard.ts) remains the in-run safety net.
  */
-import { BUILT_IN_AGENT_IDS } from "@archestra/shared";
+import {
+  BUILT_IN_AGENT_IDS,
+  CONTEXT_COMPACTION_AUTO_THRESHOLD,
+} from "@archestra/shared";
 import type { UIMessage } from "ai";
 import { createLLMModel, isApiKeyRequired } from "@/clients/llm-client";
 import logger from "@/logging";
 import { A2AContextCompactionModel, AgentModel, ModelModel } from "@/models";
 import { TOKEN_ESTIMATE } from "@/routes/chat/normalization/estimate-message-tokens";
 import {
-  CONTEXT_COMPACTION_AUTO_THRESHOLD,
   CONTEXT_COMPACTION_TRANSCRIPT_MAX_CHARS,
   compactionSummaryText,
   composeCompactionPrompt,

--- a/platform/backend/src/agents/step-context-guard.ts
+++ b/platform/backend/src/agents/step-context-guard.ts
@@ -12,13 +12,13 @@
  * summarization is unavailable or fails, it falls back to deterministic
  * trimming so the step still fits.
  */
+import { CONTEXT_COMPACTION_AUTO_THRESHOLD } from "@archestra/shared";
 import type { ModelMessage } from "ai";
 import type { LLMModel } from "@/clients/llm-client";
 import logger from "@/logging";
 import { trimMessagesToTokenLimit } from "@/routes/chat/context-trimming";
 import { TOKEN_ESTIMATE } from "@/routes/chat/normalization/estimate-message-tokens";
 import {
-  CONTEXT_COMPACTION_AUTO_THRESHOLD,
   CONTEXT_COMPACTION_TRANSCRIPT_MAX_CHARS,
   compactionSummaryText,
   composeCompactionPrompt,

--- a/platform/backend/src/routes/chat/context-compaction.ts
+++ b/platform/backend/src/routes/chat/context-compaction.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import {
   BUILT_IN_AGENT_IDS,
+  CONTEXT_COMPACTION_AUTO_THRESHOLD,
   CONTEXT_COMPACTION_SYSTEM_PROMPT,
   getModelReadableMimeTypes,
   type SupportedProvider,
@@ -24,7 +25,6 @@ import {
   ATTR_GENAI_REQUEST_MODEL,
 } from "@/observability/tracing";
 import {
-  CONTEXT_COMPACTION_AUTO_THRESHOLD,
   CONTEXT_COMPACTION_MAX_OUTPUT_TOKENS,
   CONTEXT_COMPACTION_SUMMARY_TAG,
   CONTEXT_COMPACTION_TRANSCRIPT_MAX_CHARS,

--- a/platform/backend/src/services/context-compaction.ts
+++ b/platform/backend/src/services/context-compaction.ts
@@ -19,9 +19,6 @@ import {
   generateTaggedText,
 } from "@/utils/generate-tagged-text";
 
-// Compact once the estimated context reaches this share of the model's window.
-export const CONTEXT_COMPACTION_AUTO_THRESHOLD = 0.8;
-
 export const CONTEXT_COMPACTION_MAX_OUTPUT_TOKENS = 8_192;
 
 // Ceiling for the serialized transcript handed to the summarizer; flows keep

--- a/platform/e2e-tests/playwright.config.ts
+++ b/platform/e2e-tests/playwright.config.ts
@@ -48,6 +48,7 @@ const uiTestMatch = [
   "**/auth-redirect.spec.ts",
   "**/chat-permissions.spec.ts",
   "**/chat.spec.ts",
+  "**/context-window.spec.ts",
   "**/credentials-with-vault.ee.spec.ts",
   "**/dynamic-credentials.spec.ts",
   "**/identity-providers.ee.spec.ts",

--- a/platform/e2e-tests/tests/context-window.spec.ts
+++ b/platform/e2e-tests/tests/context-window.spec.ts
@@ -1,9 +1,9 @@
 import { E2eTestId } from "@archestra/shared";
 import {
-  ensureWireMockAnthropicChatProvider,
   expectChatReady,
+  getRuntimeModelForProviderFromApi,
   goToChat,
-  selectApiKeyById,
+  selectApiKeyForProvider,
   selectRuntimeModelFromDialog,
   sendChatMessage,
 } from "../utils";
@@ -12,6 +12,14 @@ import { expect, test } from "./api-fixtures";
 // Run serially to avoid WireMock stub contention with the main chat suite.
 test.describe.configure({ mode: "serial", retries: 2 });
 
+// OpenRouter, not Anthropic: the ring needs a known context window, and
+// OpenRouter's WireMock model list reports `context_length` directly on the
+// fetched model (highest-priority capability source). Anthropic's real API
+// exposes no such field, so that capability can only ever come from the
+// models.dev enrichment pass — a live external fetch this suite does not
+// stub, which left the ring's gate permanently unmet in CI.
+const CONTEXT_WINDOW_TEST_PROVIDER = "openrouter";
+
 test.describe("Context window visualizer", () => {
   test.setTimeout(120_000);
 
@@ -19,21 +27,22 @@ test.describe("Context window visualizer", () => {
     page,
     request,
     makeApiRequest,
-    syncModels,
   }) => {
-    // Provision a WireMock-backed Anthropic key so the chat backend can stream
-    // a real breakdown event without hitting a live LLM.
-    const { apiKeyId, runtimeModel } =
-      await ensureWireMockAnthropicChatProvider({
-        request,
-        makeApiRequest,
-        syncModels,
-      });
+    const runtimeModel = await getRuntimeModelForProviderFromApi(
+      makeApiRequest,
+      request,
+      CONTEXT_WINDOW_TEST_PROVIDER,
+    );
+    test.skip(
+      !runtimeModel,
+      `${CONTEXT_WINDOW_TEST_PROVIDER} is not configured in this test environment`,
+    );
+    if (!runtimeModel) return;
 
     await goToChat(page);
     await expectChatReady(page);
 
-    await selectApiKeyById(page, apiKeyId);
+    await selectApiKeyForProvider(page, CONTEXT_WINDOW_TEST_PROVIDER);
 
     // Pick the WireMock model so the model-selector dropdown closes cleanly.
     const modelSelectorTrigger = page
@@ -79,8 +88,8 @@ test.describe("Context window visualizer", () => {
     await expect(panel).toBeVisible({ timeout: 5_000 });
 
     // At least one category gauge row must be present — the exact set depends on
-    // what the WireMock Anthropic model returns in the breakdown, but "Messages"
-    // is always populated after one conversation turn.
+    // what the WireMock model returns in the breakdown, but "Messages" is
+    // always populated after one conversation turn.
     await expect(panel.getByText("Messages")).toBeVisible({ timeout: 5_000 });
 
     // The estimate footnote is always rendered at the bottom of the panel.
@@ -93,18 +102,21 @@ test.describe("Context window visualizer", () => {
     page,
     request,
     makeApiRequest,
-    syncModels,
   }) => {
-    const { apiKeyId, runtimeModel } =
-      await ensureWireMockAnthropicChatProvider({
-        request,
-        makeApiRequest,
-        syncModels,
-      });
+    const runtimeModel = await getRuntimeModelForProviderFromApi(
+      makeApiRequest,
+      request,
+      CONTEXT_WINDOW_TEST_PROVIDER,
+    );
+    test.skip(
+      !runtimeModel,
+      `${CONTEXT_WINDOW_TEST_PROVIDER} is not configured in this test environment`,
+    );
+    if (!runtimeModel) return;
 
     await goToChat(page);
     await expectChatReady(page);
-    await selectApiKeyById(page, apiKeyId);
+    await selectApiKeyForProvider(page, CONTEXT_WINDOW_TEST_PROVIDER);
 
     const modelSelectorTrigger = page
       .getByTestId(E2eTestId.ChatModelSelectorTrigger)

--- a/platform/e2e-tests/tests/context-window.spec.ts
+++ b/platform/e2e-tests/tests/context-window.spec.ts
@@ -88,4 +88,78 @@ test.describe("Context window visualizer", () => {
       timeout: 5_000,
     });
   });
+
+  test("explains context headroom on hover and offers manual compaction", async ({
+    page,
+    request,
+    makeApiRequest,
+    syncModels,
+  }) => {
+    const { apiKeyId, runtimeModel } =
+      await ensureWireMockAnthropicChatProvider({
+        request,
+        makeApiRequest,
+        syncModels,
+      });
+
+    await goToChat(page);
+    await expectChatReady(page);
+    await selectApiKeyById(page, apiKeyId);
+
+    const modelSelectorTrigger = page
+      .getByTestId(E2eTestId.ChatModelSelectorTrigger)
+      .or(page.getByRole("button", { name: /select model/i }))
+      .or(page.getByRole("button", { name: /claude|gpt|gemini/i }))
+      .first();
+    await expect(modelSelectorTrigger).toBeVisible({ timeout: 10_000 });
+    await modelSelectorTrigger.click();
+    await expect(
+      page.getByRole("dialog", { name: "Select Model" }),
+    ).toBeVisible({ timeout: 5_000 });
+    await selectRuntimeModelFromDialog(page, runtimeModel);
+
+    const testMessageId = `context-compact-e2e-${Math.random().toString(36).slice(2, 10)}`;
+    await sendChatMessage(
+      page,
+      `Test message ${testMessageId} chat-ui-e2e-test: show context window.`,
+    );
+    await expect(
+      page.getByText("This is a mocked response for the chat UI e2e test."),
+    ).toBeVisible({ timeout: 90_000 });
+
+    const trigger = page.getByTestId(E2eTestId.ChatContextUsageTrigger);
+    await expect(trigger).toBeVisible({ timeout: 15_000 });
+
+    // Hovering the ring explains the number without opening anything: how full
+    // the window is, and how much room is left before auto-compaction fires.
+    await trigger.hover();
+    // Radix renders tooltip content twice — the visible popper plus a
+    // visually-hidden copy for screen readers — so this must not be strict.
+    const tooltip = page.getByTestId(E2eTestId.ChatContextUsageTooltip).first();
+    await expect(tooltip).toBeVisible({ timeout: 5_000 });
+    await expect(tooltip).toContainText(/% used/);
+    await expect(tooltip).toContainText(
+      /remaining until auto-compact|Auto-compact runs on your next message/,
+    );
+
+    // Clicking through, the same surface offers the action.
+    await trigger.click();
+    await expect(
+      page.getByRole("dialog", { name: "Context window" }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    const compactButton = page.getByTestId(E2eTestId.ChatContextCompactButton);
+    await expect(compactButton).toBeVisible({ timeout: 5_000 });
+    await compactButton.click();
+
+    // Compaction is reported in the message stream, whether it summarized or
+    // decided there was nothing worth summarizing yet.
+    await expect(
+      page
+        .getByText(/Compacting conversation context/)
+        .or(page.getByText(/context compacted/i))
+        .or(page.getByText(/nothing to compact|not beneficial|already/i))
+        .first(),
+    ).toBeVisible({ timeout: 60_000 });
+  });
 });

--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -71,6 +71,10 @@ export interface ChatPromptInputToolsProps {
     compactedTokenEstimate?: number;
     trigger?: "auto" | "manual";
   } | null;
+  /** Summarize earlier turns on demand, from the context window panel */
+  onCompactConversation?: () => Promise<void> | void;
+  /** A compaction is already running (manual or automatic) */
+  isContextCompacting?: boolean;
   /** Agent's configured LLM API key ID - passed to LlmProviderApiKeySelector */
   agentLlmApiKeyId?: string | null;
   /** Current agent ID for agent selector */
@@ -137,6 +141,8 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   maxContextLength,
   contextWindow,
   lastCompaction,
+  onCompactConversation,
+  isContextCompacting = false,
   agentLlmApiKeyId,
   selectorAgentId,
   onAgentChange,
@@ -382,18 +388,19 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
                       cachedTokens={cachedTokens}
                       maxTokens={maxContextLength}
                       lastCompaction={lastCompaction}
+                      onCompact={onCompactConversation}
+                      isCompacting={isContextCompacting}
                     >
                       <button
                         type="button"
                         aria-label="Context usage"
                         data-testid={E2eTestId.ChatContextUsageTrigger}
-                        className="inline-flex items-center justify-center rounded-full outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
+                        className="inline-flex cursor-pointer items-center justify-center rounded-full outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         <ContextIndicator
                           tokensUsed={tokensUsed}
                           maxTokens={maxContextLength}
                           size="sm"
-                          hideTooltip
                         />
                       </button>
                     </ContextWindowDialog>
@@ -570,18 +577,19 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
               cachedTokens={cachedTokens}
               maxTokens={maxContextLength}
               lastCompaction={lastCompaction}
+              onCompact={onCompactConversation}
+              isCompacting={isContextCompacting}
             >
               <button
                 type="button"
                 aria-label="Context usage"
                 data-testid={E2eTestId.ChatContextUsageTrigger}
-                className="inline-flex items-center justify-center rounded-full outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
+                className="inline-flex cursor-pointer items-center justify-center rounded-full outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
               >
                 <ContextIndicator
                   tokensUsed={tokensUsed}
                   maxTokens={maxContextLength}
                   size="sm"
-                  hideTooltip
                 />
               </button>
             </ContextWindowDialog>

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -321,10 +321,15 @@ const PromptInputContent = ({
   const hooksDebugEnabled = conversation?.hooksDebugEnabled ?? false;
   const canDebug = Boolean(conversationId && isAgentAdmin && agentHooksEnabled);
 
+  // Compaction needs a persisted conversation to summarize, so both of its
+  // entry points — /compact and the context window panel's action — share this
+  // gate.
+  const compactConversation =
+    conversationId && onCompactConversation ? onCompactConversation : undefined;
+
   // /compact and /debug apply to an existing conversation; skill commands work anywhere.
   const slashCommands = useMemo<SlashCommand[]>(() => {
-    const compact =
-      conversationId && onCompactConversation ? [COMPACT_COMMAND] : [];
+    const compact = compactConversation ? [COMPACT_COMMAND] : [];
     const debug: SlashCommand[] = canDebug
       ? [
           {
@@ -337,13 +342,7 @@ const PromptInputContent = ({
         ]
       : [];
     return [...compact, ...debug, ...skillCommands];
-  }, [
-    conversationId,
-    onCompactConversation,
-    canDebug,
-    hooksDebugEnabled,
-    skillCommands,
-  ]);
+  }, [compactConversation, canDebug, hooksDebugEnabled, skillCommands]);
 
   // Keyed by conversation only — NOT by agentId. Keying the new-chat draft by
   // agent made the restore effect below re-run on every agent switch and clear
@@ -951,6 +950,8 @@ const PromptInputContent = ({
             textareaRef={textareaRef}
             contextWindow={contextWindow}
             lastCompaction={lastCompaction}
+            onCompactConversation={compactConversation}
+            isContextCompacting={isContextCompacting}
           />
           {/* shrink-0: the send/mic cluster is a fixed unit and must never
               compress. When the toolbar runs out of room the collapse hook

--- a/platform/frontend/src/components/chat/context-indicator.tsx
+++ b/platform/frontend/src/components/chat/context-indicator.tsx
@@ -1,109 +1,73 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  usageStrokeColor,
+  usageTextColor,
+} from "@/lib/chat/context-window-status";
 import { cn } from "@/lib/utils";
 
-interface ContextIndicatorProps {
-  /** Current prompt-token estimate or provider count. */
-  tokensUsed: number;
-  /** Maximum context window size for the model. */
-  maxTokens: number | null;
-  /** Input tokens served from the prompt cache on the latest response, a subset of tokensUsed. */
-  cachedTokens?: number;
-  /** Optional className for the container */
-  className?: string;
-  /** Size of the indicator. */
-  size?: "sm" | "md";
-  /**
-   * Hide the built-in hover tooltip. Set when the indicator is a trigger for a
-   * richer surface (e.g. the Context Window dialog) that already explains it.
-   * The ring will also use `cursor-pointer` instead of `cursor-default` in that
-   * case so it signals its clickability without text.
-   */
-  hideTooltip?: boolean;
-}
-
-function formatTokenCount(count: number): string {
-  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
-  return count.toString();
-}
-
-function getUsageColor(percentage: number): string {
-  if (percentage >= 90) return "text-red-500";
-  if (percentage >= 75) return "text-orange-500";
-  if (percentage >= 50) return "text-yellow-500";
-  return "text-emerald-500";
-}
-
-function getStrokeColor(percentage: number): string {
-  if (percentage >= 90) return "stroke-red-500";
-  if (percentage >= 75) return "stroke-orange-500";
-  if (percentage >= 50) return "stroke-yellow-500";
-  return "stroke-emerald-500";
-}
+// ============================================================================
+// Progress ring — the shared circular gauge
+// ============================================================================
 
 /**
- * Circular progress indicator showing context window usage.
- * Used as the trigger for the Context Window dialog in the chat toolbar.
+ * Geometry per size. Kept explicit rather than derived so the composer's ring
+ * stays pixel-identical; `xs` is sized for an inline glyph slot beside
+ * `text-xs` copy, as in the context window panel's notes.
  */
-export function ContextIndicator({
-  tokensUsed,
-  maxTokens,
-  cachedTokens,
-  className,
+const RING_GEOMETRY = {
+  xs: { box: "size-4", viewBox: 16, radius: 6, stroke: 2 },
+  sm: { box: "size-5", viewBox: 20, radius: 8, stroke: 2 },
+  md: { box: "size-6", viewBox: 24, radius: 10, stroke: 2.5 },
+} as const;
+
+export type ProgressRingSize = keyof typeof RING_GEOMETRY;
+
+/**
+ * A circular progress gauge. Used for the composer's context indicator and,
+ * at `xs`, wherever a note needs to show the same value it is talking about
+ * rather than a decorative icon.
+ */
+export function ProgressRing({
+  percent,
   size = "sm",
-  hideTooltip = false,
-}: ContextIndicatorProps) {
-  const cacheHitPercent =
-    cachedTokens && cachedTokens > 0 && tokensUsed > 0
-      ? Math.round((Math.min(cachedTokens, tokensUsed) / tokensUsed) * 100)
-      : null;
-  const { percentage, circumference, strokeDashoffset } = useMemo(() => {
-    if (!maxTokens || maxTokens === 0) {
-      return { percentage: 0, circumference: 0, strokeDashoffset: 0 };
-    }
+  className,
+  arcClassName,
+  trackClassName = "stroke-muted",
+  children,
+}: {
+  /** Fill, 0–100. Clamped. */
+  percent: number;
+  size?: ProgressRingSize;
+  className?: string;
+  /** Stroke color class for the filled arc. */
+  arcClassName?: string;
+  /** Stroke color class for the unfilled track. Override on tinted surfaces,
+   *  where the default disappears into the background. */
+  trackClassName?: string;
+  children?: ReactNode;
+}) {
+  const { box, viewBox, radius, stroke } = RING_GEOMETRY[size];
+  const center = viewBox / 2;
+  const circumference = 2 * Math.PI * radius;
+  const filled = Math.min(Math.max(percent, 0), 100);
+  const strokeDashoffset = circumference - (filled / 100) * circumference;
 
-    const pct = Math.min((tokensUsed / maxTokens) * 100, 100);
-    const radius = size === "sm" ? 8 : 10;
-    const circ = 2 * Math.PI * radius;
-    const offset = circ - (pct / 100) * circ;
-
-    return { percentage: pct, circumference: circ, strokeDashoffset: offset };
-  }, [tokensUsed, maxTokens, size]);
-
-  if (!maxTokens) {
-    return null;
-  }
-
-  const dimensions = size === "sm" ? "size-5" : "size-6";
-  const svgSize = size === "sm" ? 20 : 24;
-  const radius = size === "sm" ? 8 : 10;
-  const strokeWidth = size === "sm" ? 2 : 2.5;
-  const center = svgSize / 2;
-
-  const ring = (
+  return (
     <div
       className={cn(
-        "relative inline-flex items-center justify-center",
-        // When the tooltip is hidden the ring is a dialog trigger — show pointer
-        // cursor so sighted users know it's clickable.
-        hideTooltip ? "cursor-pointer" : "cursor-default",
-        dimensions,
+        "relative inline-flex shrink-0 items-center justify-center",
+        box,
         className,
       )}
     >
       <svg
         className="absolute inset-0 -rotate-90"
-        width={svgSize}
-        height={svgSize}
-        viewBox={`0 0 ${svgSize} ${svgSize}`}
+        width={viewBox}
+        height={viewBox}
+        viewBox={`0 0 ${viewBox} ${viewBox}`}
         aria-hidden="true"
       >
         {/* Track */}
@@ -112,8 +76,8 @@ export function ContextIndicator({
           cy={center}
           r={radius}
           fill="none"
-          strokeWidth={strokeWidth}
-          className="stroke-muted"
+          strokeWidth={stroke}
+          className={trackClassName}
         />
         {/* Progress arc */}
         <circle
@@ -121,53 +85,71 @@ export function ContextIndicator({
           cy={center}
           r={radius}
           fill="none"
-          strokeWidth={strokeWidth}
+          strokeWidth={stroke}
           strokeLinecap="round"
           strokeDasharray={circumference}
           strokeDashoffset={strokeDashoffset}
-          className={cn(
-            "transition-all duration-300",
-            getStrokeColor(percentage),
-          )}
+          className={cn("transition-all duration-300", arcClassName)}
         />
       </svg>
+      {children}
+    </div>
+  );
+}
+
+// ============================================================================
+// Context indicator — the composer's token-aware ring
+// ============================================================================
+
+interface ContextIndicatorProps {
+  /** Current prompt-token estimate or provider count. */
+  tokensUsed: number;
+  /** Maximum context window size for the model. */
+  maxTokens: number | null;
+  /** Optional className for the container */
+  className?: string;
+  /** Size of the indicator. */
+  size?: "sm" | "md";
+}
+
+/**
+ * Circular progress ring showing context-window usage. Purely presentational:
+ * the surfaces that host it own the hover copy and the click behaviour (in
+ * chat, `ContextWindowDialog` supplies both).
+ */
+export function ContextIndicator({
+  tokensUsed,
+  maxTokens,
+  className,
+  size = "sm",
+}: ContextIndicatorProps) {
+  const percentage = useMemo(() => {
+    if (!maxTokens || maxTokens === 0) return 0;
+    return Math.min((tokensUsed / maxTokens) * 100, 100);
+  }, [tokensUsed, maxTokens]);
+
+  if (!maxTokens) {
+    return null;
+  }
+
+  return (
+    <ProgressRing
+      percent={percentage}
+      size={size}
+      className={className}
+      arcClassName={usageStrokeColor(percentage)}
+    >
       {/* Percentage label inside ring — only for md size */}
       {size === "md" && (
         <span
           className={cn(
             "text-[8px] font-medium tabular-nums",
-            getUsageColor(percentage),
+            usageTextColor(percentage),
           )}
         >
           {Math.round(percentage)}
         </span>
       )}
-    </div>
-  );
-
-  if (hideTooltip) {
-    return ring;
-  }
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>{ring}</TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          <div className="flex flex-col gap-0.5">
-            <span className="font-medium">Context usage</span>
-            <span className="tabular-nums text-muted-foreground">
-              {formatTokenCount(tokensUsed)} / {formatTokenCount(maxTokens)}{" "}
-              tokens ({Math.round(percentage)}%)
-            </span>
-            {cacheHitPercent !== null && cacheHitPercent > 0 && (
-              <span className="text-muted-foreground">
-                {cacheHitPercent}% served from cache
-              </span>
-            )}
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    </ProgressRing>
   );
 }

--- a/platform/frontend/src/components/chat/context-window-panel.test.tsx
+++ b/platform/frontend/src/components/chat/context-window-panel.test.tsx
@@ -193,6 +193,33 @@ describe("ContextWindowPanel", () => {
     expect(screen.queryByText(/^Compaction /)).not.toBeInTheDocument();
   });
 
+  it("gives headroom and the last compaction a block each", () => {
+    const { container } = render(
+      <ContextWindowPanel
+        breakdown={makeBreakdown()}
+        lastCompaction={{
+          originalTokenEstimate: 50_000,
+          compactedTokenEstimate: 12_000,
+          trigger: "auto",
+        }}
+      />,
+    );
+
+    // Two separate statements about two separate moments — they must not be
+    // crammed into one note, and each must carry its own icon.
+    const notes = container.querySelectorAll(".rounded-md.border");
+    expect(notes).toHaveLength(2);
+    expect(notes[0]).toHaveTextContent(
+      "71% of context remaining until auto-compact.",
+    );
+    expect(notes[1]).toHaveTextContent(
+      /Auto-compaction summarized earlier turns/,
+    );
+    for (const note of notes) {
+      expect(note.querySelector("svg")).toBeInTheDocument();
+    }
+  });
+
   it("renders the estimate footnote", () => {
     render(<ContextWindowPanel breakdown={makeBreakdown()} />);
     expect(screen.getByText(/Estimated before sending/)).toBeInTheDocument();
@@ -288,5 +315,133 @@ describe("ContextWindowDialog — fallback state", () => {
 
     expect(screen.getByText("claude-opus-4-8")).toBeInTheDocument();
     expect(screen.getByText("Messages")).toBeInTheDocument();
+  });
+});
+
+// ============================================================================
+// ContextWindowDialog — manual compaction
+// ============================================================================
+
+describe("ContextWindowDialog — compact action", () => {
+  async function openDialog(ui: React.ReactElement) {
+    const user = userEvent.setup();
+    render(ui);
+    await user.click(screen.getByRole("button", { name: "Open" }));
+    return user;
+  }
+
+  it("offers no compact action when the conversation cannot be compacted", async () => {
+    await openDialog(
+      <ContextWindowDialog
+        breakdown={makeBreakdown()}
+        tokensUsed={89_000}
+        maxTokens={1_000_000}
+      >
+        <button type="button">Open</button>
+      </ContextWindowDialog>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /compact now/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("compacts on demand", async () => {
+    const onCompact = vi.fn();
+    const user = await openDialog(
+      <ContextWindowDialog
+        breakdown={makeBreakdown()}
+        tokensUsed={89_000}
+        maxTokens={1_000_000}
+        onCompact={onCompact}
+      >
+        <button type="button">Open</button>
+      </ContextWindowDialog>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /compact now/i }));
+
+    expect(onCompact).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks re-entry while a compaction is already running", async () => {
+    const onCompact = vi.fn();
+    await openDialog(
+      <ContextWindowDialog
+        breakdown={makeBreakdown()}
+        tokensUsed={89_000}
+        maxTokens={1_000_000}
+        onCompact={onCompact}
+        isCompacting
+      >
+        <button type="button">Open</button>
+      </ContextWindowDialog>,
+    );
+
+    const button = screen.getByRole("button", { name: /compacting/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("states headroom to auto-compaction in the same words as the indicator", async () => {
+    await openDialog(
+      <ContextWindowDialog
+        breakdown={makeBreakdown()}
+        tokensUsed={89_000}
+        maxTokens={1_000_000}
+        onCompact={vi.fn()}
+      >
+        <button type="button">Open</button>
+      </ContextWindowDialog>,
+    );
+
+    // 8.9% used against an 80% trigger → 71 points of headroom.
+    expect(
+      screen.getByText("71% of context remaining until auto-compact."),
+    ).toBeInTheDocument();
+  });
+
+  it("warns that auto-compaction is imminent once past the threshold", async () => {
+    await openDialog(
+      <ContextWindowDialog
+        breakdown={makeBreakdown({
+          usedTokens: 850_000,
+          freeTokens: 150_000,
+          usedPercent: 85,
+        })}
+        tokensUsed={850_000}
+        maxTokens={1_000_000}
+        onCompact={vi.fn()}
+      >
+        <button type="button">Open</button>
+      </ContextWindowDialog>,
+    );
+
+    expect(
+      screen.getByText("Auto-compact runs on your next message."),
+    ).toBeInTheDocument();
+  });
+
+  it("invents no headroom when the model's window is unknown", async () => {
+    await openDialog(
+      <ContextWindowDialog
+        breakdown={makeBreakdown({ contextLength: null, freeTokens: null })}
+        tokensUsed={89_000}
+        maxTokens={null}
+        onCompact={vi.fn()}
+      >
+        <button type="button">Open</button>
+      </ContextWindowDialog>,
+    );
+
+    // No window means no threshold to count down to, so the note that would
+    // carry both the sentence and the action has nothing to say and is
+    // dropped. The composer cannot reach this state anyway — its context ring
+    // only renders once a window is known — and `/compact` still works.
+    expect(
+      screen.queryByText(/remaining until auto-compact/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /compact now/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/chat/context-window-panel.tsx
+++ b/platform/frontend/src/components/chat/context-window-panel.tsx
@@ -7,10 +7,12 @@ import {
   type ContextWindowItem,
   E2eTestId,
 } from "@archestra/shared";
-import { ChevronRight, Sparkles } from "lucide-react";
+import { ChevronRight, Loader2, Sparkles } from "lucide-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { ProgressRing } from "@/components/chat/context-indicator";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Collapsible,
   CollapsibleContent,
@@ -24,6 +26,21 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  AUTO_COMPACT_PERCENT,
+  autoCompactProgressPercent,
+  type ContextWindowStatus,
+  describeContextHeadroom,
+  formatTokenCount as formatTokens,
+  getContextWindowStatus,
+  usageStrokeColor,
+  usageTextColor,
+} from "@/lib/chat/context-window-status";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { cn } from "@/lib/utils";
 
@@ -85,6 +102,13 @@ interface ContextWindowDialogProps {
   /** Input tokens served from the prompt cache on the latest response. */
   cachedTokens?: number;
   lastCompaction?: LastCompaction | null;
+  /**
+   * Summarize earlier turns on demand. Omitted when the conversation cannot be
+   * compacted (read-only, or not yet persisted), which hides the action.
+   */
+  onCompact?: () => void | Promise<void>;
+  /** A compaction — manual or automatic — is already running. */
+  isCompacting?: boolean;
   /** The trigger element (the circular context indicator). */
   children: ReactNode;
 }
@@ -95,20 +119,46 @@ interface ContextWindowDialogProps {
 
 /**
  * Modal explaining how the model's context window was assembled for the
- * current turn. The trigger (children) is the ring indicator in the toolbar.
+ * current turn. The trigger (children) is the ring indicator in the toolbar,
+ * and this component owns both of its affordances: the hover tooltip that
+ * summarizes headroom, and the click that opens this breakdown.
  */
 export function ContextWindowDialog({
   breakdown,
   tokensUsed,
   maxTokens,
+  cachedTokens,
   lastCompaction,
+  onCompact,
+  isCompacting = false,
   children,
 }: ContextWindowDialogProps) {
   const appName = useAppName();
+  // The breakdown's own percentage wins once it arrives: it is measured on the
+  // same yardstick as the auto-compaction check, whereas tokensUsed/maxTokens
+  // is the pre-response seed.
+  const status = getContextWindowStatus(
+    breakdown?.usedTokens ?? tokensUsed,
+    breakdown?.contextLength ?? maxTokens,
+  );
 
   return (
     <Dialog>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>{children}</DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-[260px]">
+          <ContextUsageTooltip
+            status={status}
+            tokensUsed={breakdown?.usedTokens ?? tokensUsed}
+            maxTokens={breakdown?.contextLength ?? maxTokens}
+            cachedTokens={cachedTokens}
+            isCompacting={isCompacting}
+          />
+        </TooltipContent>
+      </Tooltip>
+
       <DialogContent className="flex max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-[480px]">
         <DialogHeader className="shrink-0 space-y-1 border-b border-border/60 px-5 pb-3 pt-5 text-left">
           <DialogTitle className="text-base">Context window</DialogTitle>
@@ -121,6 +171,8 @@ export function ContextWindowDialog({
           <ContextWindowPanel
             breakdown={breakdown}
             lastCompaction={lastCompaction}
+            onCompact={onCompact}
+            isCompacting={isCompacting}
           />
         ) : (
           <EmptyState
@@ -135,12 +187,92 @@ export function ContextWindowDialog({
 }
 
 // ============================================================================
+// Hover summary — the glanceable half of the indicator
+// ============================================================================
+
+/**
+ * What the ring means, in three lines: how full, how much room is left before
+ * the conversation gets summarized without asking, and where the click goes.
+ */
+function ContextUsageTooltip({
+  status,
+  tokensUsed,
+  maxTokens,
+  cachedTokens,
+  isCompacting,
+}: {
+  status: ContextWindowStatus;
+  tokensUsed: number;
+  maxTokens: number | null;
+  cachedTokens?: number;
+  isCompacting: boolean;
+}) {
+  const cacheHitPercent =
+    cachedTokens && cachedTokens > 0 && tokensUsed > 0
+      ? Math.round((Math.min(cachedTokens, tokensUsed) / tokensUsed) * 100)
+      : null;
+
+  return (
+    <div
+      className="flex flex-col gap-1"
+      data-testid={E2eTestId.ChatContextUsageTooltip}
+    >
+      <span className="font-medium">Context window</span>
+
+      <span className="tabular-nums text-muted-foreground">
+        {maxTokens != null ? (
+          <span>
+            {formatTokens(tokensUsed)} / {formatTokens(maxTokens)} tokens ·{" "}
+            {Math.round(status.usedPercent)}% used
+          </span>
+        ) : (
+          <span>{formatTokens(tokensUsed)} tokens used</span>
+        )}
+      </span>
+
+      {isCompacting ? (
+        <span className="text-muted-foreground">Compacting now…</span>
+      ) : (
+        // Headroom is only meaningful against a known window; without one the
+        // percentages above are already suppressed and a figure here would be
+        // invented.
+        maxTokens != null && (
+          <span
+            className={cn(
+              status.nearAutoCompact
+                ? usageTextColor(status.usedPercent)
+                : "text-muted-foreground",
+            )}
+          >
+            {describeContextHeadroom(status)}
+          </span>
+        )
+      )}
+
+      {cacheHitPercent !== null && cacheHitPercent > 0 && (
+        <span className="text-muted-foreground">
+          {cacheHitPercent}% served from cache
+        </span>
+      )}
+
+      <span className="mt-0.5 border-t border-border/60 pt-1 text-muted-foreground/70">
+        Click for the full breakdown.
+      </span>
+    </div>
+  );
+}
+
+// ============================================================================
 // Panel — exported for standalone use in tests and other surfaces
 // ============================================================================
 
 interface ContextWindowPanelProps {
   breakdown: ContextWindowBreakdown;
   lastCompaction?: LastCompaction | null;
+  /** Summarize earlier turns on demand; omitted when that is not possible. */
+  onCompact?: () => void | Promise<void>;
+  /** A compaction — manual or automatic — is already running. */
+  isCompacting?: boolean;
 }
 
 /**
@@ -151,6 +283,8 @@ interface ContextWindowPanelProps {
 export function ContextWindowPanel({
   breakdown,
   lastCompaction,
+  onCompact,
+  isCompacting = false,
 }: ContextWindowPanelProps) {
   const {
     model,
@@ -163,11 +297,12 @@ export function ContextWindowPanel({
     segments,
   } = breakdown;
 
+  // A real window is what makes headroom — and the auto-compaction tick —
+  // meaningful; without one the bar is only a composition breakdown.
+  const hasRealWindow = contextLength != null && contextLength > 0;
   // Denominator for bar / share math: real window when known, else used total.
-  const denominator =
-    contextLength != null && contextLength > 0
-      ? contextLength
-      : usedTokens || 1;
+  const denominator = hasRealWindow ? contextLength : usedTokens || 1;
+  const status = getContextWindowStatus(usedTokens, contextLength);
 
   const compactionSaved = resolveCompactionSavings(lastCompaction);
 
@@ -233,26 +368,76 @@ export function ContextWindowPanel({
           segmentByCategory={segmentByCategory}
           freeTokens={freeTokens}
           denominator={denominator}
+          showAutoCompactMarker={hasRealWindow}
         />
 
-        {/* Compaction note — only when tokens were actually freed */}
+        {/* Headroom to auto-compaction — shared verbatim with the indicator's
+            hover tooltip, and marked by the tick on the bar above. Its glyph is
+            the composer's own ring, filled by how far this conversation has
+            travelled toward auto-compaction, so the note shows the value it is
+            talking about instead of a decorative icon. Compacting is the answer
+            to that sentence, so the action sits with it rather than after the
+            closing footnote. */}
+        {hasRealWindow && (
+          <PanelNote
+            icon={
+              <ProgressRing
+                percent={autoCompactProgressPercent(status)}
+                size="xs"
+                arcClassName={usageStrokeColor(status.usedPercent)}
+                trackClassName="stroke-muted-foreground/25"
+              />
+            }
+            className={cn(
+              status.nearAutoCompact && usageTextColor(status.usedPercent),
+            )}
+            action={
+              onCompact && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={status.nearAutoCompact ? "default" : "outline"}
+                  className="-my-1 shrink-0"
+                  disabled={isCompacting}
+                  onClick={() => void onCompact()}
+                  data-testid={E2eTestId.ChatContextCompactButton}
+                >
+                  {isCompacting ? (
+                    <>
+                      <Loader2 className="animate-spin" aria-hidden />
+                      <span>Compacting…</span>
+                    </>
+                  ) : (
+                    <span>Compact now</span>
+                  )}
+                </Button>
+              )
+            }
+          >
+            {describeContextHeadroom(status)}
+          </PanelNote>
+        )}
+
+        {/* What the last compaction actually freed — a separate event from the
+            headroom above, so a separate block. */}
         {compactionSaved > 0 && (
-          <div className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-            <Sparkles
-              className="mt-0.5 size-3.5 shrink-0 text-violet-500"
-              aria-hidden
-            />
-            <span>
-              {lastCompaction?.trigger === "manual"
-                ? "Compaction"
-                : "Auto-compaction"}{" "}
-              summarized earlier turns and freed{" "}
-              <span className="font-medium text-foreground">
-                {formatTokens(compactionSaved)} tokens
-              </span>{" "}
-              in this conversation.
-            </span>
-          </div>
+          <PanelNote
+            icon={
+              <Sparkles
+                className="size-3.5 shrink-0 text-violet-500"
+                aria-hidden
+              />
+            }
+          >
+            {lastCompaction?.trigger === "manual"
+              ? "Compaction"
+              : "Auto-compaction"}{" "}
+            summarized earlier turns and freed{" "}
+            <span className="font-medium text-foreground">
+              {formatTokens(compactionSaved)} tokens
+            </span>{" "}
+            in this conversation.
+          </PanelNote>
         )}
       </div>
 
@@ -296,6 +481,43 @@ export function ContextWindowPanel({
 }
 
 // ============================================================================
+// Summary notes
+// ============================================================================
+
+/**
+ * The callout shell used by the summary header's notes. They describe separate
+ * things — headroom before auto-compaction, and what the last compaction freed
+ * — so each gets its own block and its own icon; sharing this shell is what
+ * keeps them reading as siblings rather than two unrelated components.
+ */
+function PanelNote({
+  icon,
+  className,
+  action,
+  children,
+}: {
+  /** A 14px leading glyph — an icon, or a gauge showing the value discussed. */
+  icon: ReactNode;
+  className?: string;
+  /** Optional trailing control, for a note whose statement has an answer. */
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      {icon}
+      <span className="flex-1">{children}</span>
+      {action}
+    </div>
+  );
+}
+
+// ============================================================================
 // Stacked composition bar
 // ============================================================================
 
@@ -304,33 +526,49 @@ function StackedBar({
   segmentByCategory,
   freeTokens,
   denominator,
+  showAutoCompactMarker,
 }: {
   categories: readonly ContextWindowCategory[];
   segmentByCategory: Record<string, { tokens: number } | undefined>;
   freeTokens: number | null;
   denominator: number;
+  showAutoCompactMarker: boolean;
 }) {
   return (
-    <div
-      className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted"
-      aria-hidden
-    >
-      {categories.map((cat) => {
-        const tokens = segmentByCategory[cat]?.tokens ?? 0;
-        if (tokens <= 0) return null;
-        const pct = percentOf(tokens, denominator);
-        return (
-          <div
-            key={cat}
-            className={cn("h-full shrink-0", CATEGORY_META[cat].color)}
-            style={{ width: `${pct}%`, minWidth: "0.125rem" }}
-            title={`${CATEGORY_META[cat].label}: ${formatTokens(tokens)}`}
-          />
-        );
-      })}
-      {/* Remaining free space: transparent, occupies the rest of the bar */}
-      {freeTokens != null && freeTokens > 0 && (
-        <div className="h-full flex-1 bg-transparent" />
+    <div className="relative">
+      <div
+        className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted"
+        aria-hidden
+      >
+        {categories.map((cat) => {
+          const tokens = segmentByCategory[cat]?.tokens ?? 0;
+          if (tokens <= 0) return null;
+          const pct = percentOf(tokens, denominator);
+          return (
+            <div
+              key={cat}
+              className={cn("h-full shrink-0", CATEGORY_META[cat].color)}
+              style={{ width: `${pct}%`, minWidth: "0.125rem" }}
+              title={`${CATEGORY_META[cat].label}: ${formatTokens(tokens)}`}
+            />
+          );
+        })}
+        {/* Remaining free space: transparent, occupies the rest of the bar */}
+        {freeTokens != null && freeTokens > 0 && (
+          <div className="h-full flex-1 bg-transparent" />
+        )}
+      </div>
+
+      {/* Auto-compaction tick — only meaningful against a real window, where
+          the bar's denominator is the context length rather than the total
+          used so far. */}
+      {showAutoCompactMarker && (
+        <span
+          className="absolute -top-0.5 h-3.5 w-px bg-foreground/40"
+          style={{ left: `${AUTO_COMPACT_PERCENT}%` }}
+          title={`Auto-compaction runs at ${AUTO_COMPACT_PERCENT}%`}
+          aria-hidden
+        />
       )}
     </div>
   );
@@ -522,21 +760,6 @@ function resolveCompactionSavings(
 function percentOf(value: number, total: number): number {
   if (total <= 0) return 0;
   return Math.min((value / total) * 100, 100);
-}
-
-/** Header percentage color, escalating as the window fills. */
-function usageTextColor(percent: number): string {
-  if (percent >= 90) return "text-red-500";
-  if (percent >= 75) return "text-orange-500";
-  if (percent >= 50) return "text-yellow-500";
-  return "text-emerald-500";
-}
-
-/** Compact token count: 85_600 → "85.6k", 1_000_000 → "1.0M". */
-function formatTokens(count: number): string {
-  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
-  return count.toString();
 }
 
 /** Share percentage: one decimal under 10% so small slices stay legible. */

--- a/platform/frontend/src/lib/chat/context-window-status.test.ts
+++ b/platform/frontend/src/lib/chat/context-window-status.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTO_COMPACT_PERCENT,
+  autoCompactProgressPercent,
+  getContextWindowStatus,
+} from "./context-window-status";
+
+describe("getContextWindowStatus", () => {
+  it("reports headroom to auto-compaction, not to a full window", () => {
+    // 37% used against an 80% trigger leaves 43 points of the window — the
+    // number the indicator quotes, and deliberately not 63%.
+    const status = getContextWindowStatus(370_000, 1_000_000);
+
+    expect(status.usedPercent).toBeCloseTo(37);
+    expect(status.remainingPercent).toBeCloseTo(43);
+  });
+
+  it("floors remaining headroom at zero once past the trigger", () => {
+    const status = getContextWindowStatus(950_000, 1_000_000);
+
+    expect(status.remainingPercent).toBe(0);
+    expect(status.atAutoCompact).toBe(true);
+  });
+
+  it("treats the trigger itself as at-auto-compact", () => {
+    const status = getContextWindowStatus(800_000, 1_000_000);
+
+    expect(status.usedPercent).toBeCloseTo(AUTO_COMPACT_PERCENT);
+    expect(status.atAutoCompact).toBe(true);
+    expect(status.remainingPercent).toBe(0);
+  });
+
+  it("flags the band where compacting is worth offering before it is forced", () => {
+    const approaching = getContextWindowStatus(760_000, 1_000_000);
+    const comfortable = getContextWindowStatus(400_000, 1_000_000);
+
+    expect(approaching.nearAutoCompact).toBe(true);
+    expect(approaching.atAutoCompact).toBe(false);
+    expect(comfortable.nearAutoCompact).toBe(false);
+  });
+
+  it("caps usage at 100% when the estimate overshoots the window", () => {
+    const status = getContextWindowStatus(1_400_000, 1_000_000);
+
+    expect(status.usedPercent).toBe(100);
+    expect(status.remainingPercent).toBe(0);
+  });
+
+  it("fills the countdown gauge against the trigger, not the whole window", () => {
+    // 40% of a window used is only halfway to an 80% trigger — the gauge
+    // beside the headroom sentence counts down to that event, so it must not
+    // read 40% like the composer's usage ring does.
+    const status = getContextWindowStatus(400_000, 1_000_000);
+
+    expect(status.usedPercent).toBeCloseTo(40);
+    expect(autoCompactProgressPercent(status)).toBeCloseTo(50);
+  });
+
+  it("fills the countdown gauge completely once auto-compaction is due", () => {
+    expect(
+      autoCompactProgressPercent(getContextWindowStatus(800_000, 1_000_000)),
+    ).toBe(100);
+    // And stays full rather than overflowing past the trigger.
+    expect(
+      autoCompactProgressPercent(getContextWindowStatus(990_000, 1_000_000)),
+    ).toBe(100);
+  });
+
+  it("reports no pressure rather than dividing by an unknown window", () => {
+    // Callers suppress the headroom copy entirely in this case; the point here
+    // is that an unknown window never reads as *near* auto-compaction.
+    const status = getContextWindowStatus(50_000, null);
+
+    expect(status.usedPercent).toBe(0);
+    expect(status.atAutoCompact).toBe(false);
+    expect(status.nearAutoCompact).toBe(false);
+  });
+});

--- a/platform/frontend/src/lib/chat/context-window-status.ts
+++ b/platform/frontend/src/lib/chat/context-window-status.ts
@@ -1,0 +1,109 @@
+import { CONTEXT_COMPACTION_AUTO_THRESHOLD } from "@archestra/shared";
+
+// ============================================================================
+// Public interface
+// ============================================================================
+
+/** The share of the window (in percent) at which auto-compaction fires. */
+export const AUTO_COMPACT_PERCENT = Math.round(
+  CONTEXT_COMPACTION_AUTO_THRESHOLD * 100,
+);
+
+/**
+ * How full the context window is, plus the headroom the user actually cares
+ * about: how much is left before auto-compaction takes over, not before the
+ * window is physically full.
+ */
+export interface ContextWindowStatus {
+  /** Share of the window consumed, 0–100. */
+  usedPercent: number;
+  /**
+   * Points of the full window still free before auto-compaction fires, 0–80.
+   * Phrased as "N% of context remaining until auto-compact".
+   */
+  remainingPercent: number;
+  /** Auto-compaction will run on the next turn. */
+  atAutoCompact: boolean;
+  /** Close enough to auto-compaction that compacting now is worth offering. */
+  nearAutoCompact: boolean;
+}
+
+export function getContextWindowStatus(
+  tokensUsed: number,
+  maxTokens: number | null,
+): ContextWindowStatus {
+  const usedPercent =
+    maxTokens && maxTokens > 0
+      ? Math.min((tokensUsed / maxTokens) * 100, 100)
+      : 0;
+
+  return {
+    usedPercent,
+    remainingPercent: Math.max(AUTO_COMPACT_PERCENT - usedPercent, 0),
+    atAutoCompact: usedPercent >= AUTO_COMPACT_PERCENT,
+    nearAutoCompact: usedPercent >= USAGE_BANDS.warning,
+  };
+}
+
+/**
+ * The one sentence describing context headroom, shared by every surface that
+ * mentions it (indicator tooltip, breakdown panel). Keeping it in one place is
+ * what stops the panel and the tooltip drifting into two different numbers for
+ * the same thing.
+ */
+export function describeContextHeadroom(status: ContextWindowStatus): string {
+  return status.atAutoCompact
+    ? "Auto-compact runs on your next message."
+    : `${Math.round(status.remainingPercent)}% of context remaining until auto-compact.`;
+}
+
+/**
+ * How far the conversation has travelled toward auto-compaction, 0–100 — a
+ * full ring means it fires on the next turn. Deliberately *not* the share of
+ * the window used: this drives the gauge beside the headroom sentence, so it
+ * has to count down to the same event that sentence names.
+ */
+export function autoCompactProgressPercent(
+  status: ContextWindowStatus,
+): number {
+  return Math.min((status.usedPercent / AUTO_COMPACT_PERCENT) * 100, 100);
+}
+
+/** Usage-band text color, escalating as the window fills. */
+export function usageTextColor(percent: number): string {
+  if (percent >= USAGE_BANDS.critical) return "text-red-500";
+  if (percent >= USAGE_BANDS.warning) return "text-orange-500";
+  if (percent >= USAGE_BANDS.elevated) return "text-yellow-500";
+  return "text-emerald-500";
+}
+
+/** Usage-band stroke color for the indicator ring's progress arc. */
+export function usageStrokeColor(percent: number): string {
+  if (percent >= USAGE_BANDS.critical) return "stroke-red-500";
+  if (percent >= USAGE_BANDS.warning) return "stroke-orange-500";
+  if (percent >= USAGE_BANDS.elevated) return "stroke-yellow-500";
+  return "stroke-emerald-500";
+}
+
+/** Compact token count: 85_600 → "85.6k", 1_000_000 → "1.0M". */
+export function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  return count.toString();
+}
+
+// ============================================================================
+// Internal
+// ============================================================================
+
+/**
+ * Shared escalation bands for every context-usage surface (ring, headline
+ * percentage, compaction nudge). `warning` deliberately sits just under
+ * {@link AUTO_COMPACT_PERCENT} so the UI turns amber while the user can still
+ * choose to compact on their own terms.
+ */
+const USAGE_BANDS = {
+  elevated: 50,
+  warning: 75,
+  critical: 90,
+} as const;

--- a/platform/helm/e2e-tests/mappings/openrouter-models-list.json
+++ b/platform/helm/e2e-tests/mappings/openrouter-models-list.json
@@ -19,12 +19,14 @@
         {
           "id": "openrouter/auto",
           "created": 1700000000,
-          "owned_by": "openrouter"
+          "owned_by": "openrouter",
+          "context_length": 2000000
         },
         {
           "id": "openrouter/openai/gpt-4o-mini",
           "created": 1700000000,
-          "owned_by": "openrouter"
+          "owned_by": "openrouter",
+          "context_length": 128000
         }
       ]
     }

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -41,6 +41,16 @@ export const CONTEXT_WINDOW_BREAKDOWN_EVENT =
   "data-context-window-breakdown" as const;
 
 /**
+ * Share of the model's context window at which auto-compaction fires.
+ *
+ * Owned here rather than in the backend because the chat UI quotes it: the
+ * context indicator tells the user how much headroom is left *before*
+ * auto-compaction, not before the window is full, so both sides must gate on
+ * exactly the same number.
+ */
+export const CONTEXT_COMPACTION_AUTO_THRESHOLD = 0.8;
+
+/**
  * Canonical display order of context window categories, matching the
  * top-to-bottom stack in the assembled request:
  *   system_prompt → tools → messages → tool_results → files

--- a/platform/shared/e2e-test-ids.ts
+++ b/platform/shared/e2e-test-ids.ts
@@ -119,6 +119,8 @@ export const E2eTestId = {
   ChatDisabledFileUploadButton: "chat-disabled-file-upload-button",
   ChatContextUsageTrigger: "chat-context-usage-trigger",
   ChatContextUsagePanel: "chat-context-usage-panel",
+  ChatContextUsageTooltip: "chat-context-usage-tooltip",
+  ChatContextCompactButton: "chat-context-compact-button",
   ChatApiKeySelectorTrigger: "chat-api-key-selector-trigger",
   ChatApiKeySelectorSearchInput: "chat-api-key-selector-search-input",
   // Chat Model Selector


### PR DESCRIPTION
## Summary
- Context ring in the composer now has a hover tooltip: tokens used, percent of window, and headroom until auto-compaction (`describeContextHeadroom`, shared with the panel so the two surfaces never drift into different numbers).
- The context window panel gains a **Compact now** action, so manual compaction is reachable without typing `/compact`. The button sits inside the headroom note it answers, with a real progress ring (not a static icon) counting down to the 80% auto-compaction trigger.
- The panel's usage bar gets a tick marking the auto-compaction threshold.
- Extracted a reusable `ProgressRing` component and a `context-window-status.ts` module holding the shared math/copy/color so the composer ring, the tooltip, and the panel all read from one source.
- Docs updated (`platform-chat.md`) to describe the hover and the new action.

Design iterated over several rounds against Claude Code's own "X% of context remaining until auto-compact / Click to compact now" pattern, adapted to Archestra's existing dialog-based breakdown panel rather than overloading the ring's click.

Task: T-1014

## Test plan
- [x] `pnpm type-check` clean across all workspaces
- [x] `pnpm lint` clean (frontend/backend/shared/e2e-tests)
- [x] `pnpm knip` clean
- [x] Frontend unit tests: 372 files / 3482 tests passing, including new coverage in `context-window-status.test.ts` and `context-window-panel.test.tsx`
- [x] New Playwright spec case registered in `uiTestMatch` and verified manually against a live dev stack (OpenRouter free-tier model) in a real browser — hover tooltip, panel action, disabled-while-compacting state

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>