### PR TITLE
fix(connection): make disconnect actually reverse connect, for every client

### DIFF
--- a/docs/pages/platform-connection.md
+++ b/docs/pages/platform-connection.md
@@ -3,7 +3,7 @@ title: Connect Your Agents
 category: Archestra Platform
 order: 8
 description: How the one-command setup script connects your AI tools, and how to audit or undo it
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-04
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -65,7 +65,7 @@ You can also read the generator. A deterministic renderer builds the script with
 
 For Claude Code, Codex, and Copilot CLI, the script installs a startup guard — a pre-loader that checks your Archestra remotes each time you launch `claude`, `codex`, or `copilot`. It makes a single health request covering the configured remotes — the LLM proxy and the MCP gateway; the skills marketplace rides on the same origin — then plays each remote's check in turn with a brief spinner. When everything is healthy, the CLI starts in about a second. The guard draws on the terminal's alternate screen, so nothing lingers after the CLI exits.
 
-A remote the platform reports down gets a "Failed to connect to …" line. After the last check, one prompt covers every down remote — "Disconnect MCP gateway (name) from Codex now? (Y/n)", naming your client, or "Disconnect all 3 unreachable resources…" when several are down. Enter or `y` disconnects them all — the same reverse-of-connect steps as the Disconnect panel; `n` keeps them. Later launches skip a remote the guard disconnected. Once no connected remote is left, the guard removes itself — the script and the profile hook — so a stale wrapper can never break a launch. When the platform itself is unreachable, the guard retries its request for up to 15 seconds with a status line, showing the same disconnect prompt below it, then treats every remote as down. Every path ends with the CLI starting; the guard never blocks a launch. Non-interactive runs, `codex exec` or `claude -p` for example, only get a warning on stderr.
+A remote the platform reports down gets a "Failed to connect to …" line. After the last check, one prompt covers every down remote — "Disconnect MCP gateway (name) from Codex now? (Y/n)", naming your client, or "Disconnect all 3 unreachable resources…" when several are down. Enter or `y` disconnects them all — the exact reverse of the connect steps; `n` keeps them. The guard reads the client's config back to confirm each removal landed. A removal it cannot confirm gets a ✗ line with the command to run by hand, and the guard stays installed to try again. Later launches skip a remote the guard disconnected. Once no connected remote is left, the guard removes itself — the script and the profile hook — so a stale wrapper can never break a launch. When the platform itself is unreachable, the guard retries its request for up to 15 seconds with a status line, showing the same disconnect prompt below it, then treats every remote as down. Every path ends with the CLI starting; the guard never blocks a launch. Non-interactive runs, `codex exec` or `claude -p` for example, only get a warning on stderr.
 
 Under the checks the guard always shows a reconfigure entry: "To reconfigure your Archestra connection press [C]". When everything is healthy it waits about a second and a half for that key, then starts the CLI. Press `C` and the rows turn into a numbered menu — one per remote — so you can disconnect any of them, reachable or not, by pressing its number. The row lands on a check, later launches skip it, and removing the last connected remote uninstalls the guard. Press `Esc` to leave the menu and start the CLI.
 
@@ -77,7 +77,7 @@ The guard lives under `~/.archestra/`, hooked in by a marked wrapper block in yo
 | Codex | `~/.archestra/codex-startup-guard.sh` | `~/.archestra/codex-startup-guard.ps1` | `ARCHESTRA_CODEX_GUARD=0` |
 | Copilot CLI | `~/.archestra/copilot-startup-guard.sh` | `~/.archestra/copilot-startup-guard.ps1` | `ARCHESTRA_COPILOT_GUARD=0` |
 
-Set the disable variable to turn the guard off without uninstalling. The Disconnect panel has per-OS one-liners that remove everything the guard installed.
+Set the disable variable to turn the guard off without uninstalling. To remove everything by hand instead, follow your client's Revert steps below.
 
 ## Supported Clients
 
@@ -94,7 +94,7 @@ The `claude` CLI must be on your `PATH`.
 - **Skills** — runs `claude plugin marketplace add` then `claude plugin install`.
 - **Startup guard** — installs a pre-loader that checks your Archestra remotes before every `claude` launch. See [Startup Guard](#startup-guard).
 - **Backup** — `~/.claude/settings.json.archestra-backup`.
-- **Revert** — open the Disconnect panel on the Connection page for the exact reverse steps. Or restore the backup, delete the Archestra env keys, run `claude mcp remove <name>`, and drop the exported Bedrock token from your profile.
+- **Revert** — the startup guard's reconfigure menu (press `C` at launch) disconnects any remote. By hand: restore the backup, delete the Archestra env keys, run `claude mcp remove <name>` and `claude plugin marketplace remove <name>`, and drop the exported Bedrock token from your profile.
 
 ### Codex
 
@@ -105,7 +105,7 @@ The `codex` CLI must be on your `PATH`.
 - **Skills** — runs `codex plugin marketplace add`.
 - **Startup guard** — installs a pre-loader that checks your Archestra remotes before every `codex` launch. See [Startup Guard](#startup-guard).
 - **Backup** — `~/.codex/config.toml.archestra-backup`.
-- **Revert** — restore the backup, or delete the `# >>> archestra:<name> >>>` block; run `codex mcp remove <name>`.
+- **Revert** — the startup guard's reconfigure menu (press `C` at launch) disconnects any remote. By hand: delete the `# >>> archestra:<name> >>>` block, run `codex mcp remove <name>` and `codex plugin marketplace remove <name>`; if the script signed Codex in with a virtual key, run `codex logout`, then `codex login` with your own account.
 
 ### Cursor
 

--- a/platform/backend/src/services/connection-setup-script.test.ts
+++ b/platform/backend/src/services/connection-setup-script.test.ts
@@ -1318,7 +1318,56 @@ describe("idempotent re-runs", () => {
 
     const codex = renderSetupScript(fullContext("codex"));
     expect(codex).toContain(
-      '[ -f "$CONFIG.archestra-backup" ] || cp "$CONFIG" "$CONFIG.archestra-backup"',
+      'if [ -f "$CONFIG" ] && [ ! -f "$CONFIG.archestra-backup" ]; then',
+    );
+  });
+});
+
+describe("codex config backup is genuinely pre-Archestra", () => {
+  // The backup exists so a user (or the docs' restore instructions) can get
+  // back to the config they had before Archestra touched it. `codex mcp add`
+  // and `codex plugin marketplace add` edit the same config.toml the provider
+  // block goes into, so a backup taken inside the proxy section would already
+  // contain the gateway registered a moment earlier — and an mcp/skills-only
+  // connect would take no backup at all.
+  test("bash: the backup is taken before the first codex CLI call", () => {
+    const script = renderSetupScript(fullContext("codex"));
+    const backupAt = script.indexOf(".archestra-backup");
+    expect(backupAt).toBeGreaterThan(-1);
+    expect(backupAt).toBeLessThan(script.indexOf("codex mcp add"));
+    expect(backupAt).toBeLessThan(
+      script.indexOf("codex plugin marketplace add"),
+    );
+  });
+
+  test("bash: an mcp-only connect still takes the backup, honoring CODEX_HOME", async () => {
+    const script = renderSetupScript({
+      ...fullContext("codex"),
+      proxy: null,
+      skills: null,
+    });
+    await expectValidBash(script);
+    expect(script).toContain(
+      'CONFIG="${CODEX_HOME:-$HOME/.codex}/config.toml"',
+    );
+    expect(script).toContain(
+      'if [ -f "$CONFIG" ] && [ ! -f "$CONFIG.archestra-backup" ]; then',
+    );
+    expect(script.indexOf(".archestra-backup")).toBeLessThan(
+      script.indexOf("codex mcp add"),
+    );
+  });
+
+  test("windows: the backup is taken before the first codex CLI call, honoring CODEX_HOME", () => {
+    const script = renderSetupScript(fullContext("codex", "windows"));
+    const backupAt = script.indexOf(".archestra-backup");
+    expect(backupAt).toBeGreaterThan(-1);
+    expect(backupAt).toBeLessThan(script.indexOf("codex mcp add"));
+    expect(backupAt).toBeLessThan(
+      script.indexOf("codex plugin marketplace add"),
+    );
+    expect(script).toContain(
+      "$(if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE '.codex' })",
     );
   });
 });

--- a/platform/backend/src/services/connection-setup-script.ts
+++ b/platform/backend/src/services/connection-setup-script.ts
@@ -768,6 +768,19 @@ function codexSections(ctx: SetupScriptContext): string[] {
 
   startupGuardUnshadowSection(ctx, CODEX_GUARD_CLIENT, sections);
 
+  if (ctx.mcp || ctx.proxy || ctx.skills) {
+    // Codex owns config.toml wherever CODEX_HOME points (default ~/.codex),
+    // and every action below edits that file — the mcp/skills registrations
+    // through the codex CLI just as much as the provider block this script
+    // appends itself. The one-time backup must therefore be taken before the
+    // FIRST of them, or "pristine pre-Archestra config" would already contain
+    // the gateway the CLI registered a moment earlier.
+    sections.push(`CONFIG="\${CODEX_HOME:-$HOME/.codex}/config.toml"
+if [ -f "$CONFIG" ] && [ ! -f "$CONFIG.archestra-backup" ]; then
+  cp "$CONFIG" "$CONFIG.archestra-backup"
+fi`);
+  }
+
   if (ctx.mcp) {
     sections.push(`say ${sh(`Registering MCP gateway "${ctx.mcp.serverName}" (OAuth)`)}
 cli codex mcp remove ${sh(ctx.mcp.serverName)} >/dev/null 2>&1 || true
@@ -787,12 +800,10 @@ requires_openai_auth = true
 ${codexAttributionHeaderLines(ctx.proxy)}
 # <<< ${marker} <<<`;
 
-    sections.push(`say ${sh(`Adding the "${ctx.proxy.proxyName}" provider to ~/.codex/config.toml`)}
-mkdir -p "$HOME/.codex"
-CONFIG="$HOME/.codex/config.toml"
+    sections.push(`say ${sh(`Adding the "${ctx.proxy.proxyName}" provider to Codex's config.toml`)}
+CONFIG="\${CODEX_HOME:-$HOME/.codex}/config.toml"
+mkdir -p "$(dirname "$CONFIG")"
 if [ -f "$CONFIG" ]; then
-  # Back up once so re-runs preserve the pristine pre-Archestra config.
-  [ -f "$CONFIG.archestra-backup" ] || cp "$CONFIG" "$CONFIG.archestra-backup"
   # drop any previous archestra-managed block for this provider (idempotent)
   awk -v start=${sh(`# >>> ${marker} >>>`)} -v end=${sh(`# <<< ${marker} <<<`)} '
     $0 == start {skip=1; next}

--- a/platform/backend/src/services/connection-setup-script.windows.ts
+++ b/platform/backend/src/services/connection-setup-script.windows.ts
@@ -567,6 +567,19 @@ function codexSections(ctx: SetupScriptContext): string[] {
 
   windowsStartupGuardUnshadowSection(ctx, CODEX_GUARD_CLIENT, sections);
 
+  if (ctx.mcp || ctx.proxy || ctx.skills) {
+    // Codex owns config.toml wherever CODEX_HOME points (default ~/.codex),
+    // and every action below edits that file — the mcp/skills registrations
+    // through the codex CLI just as much as the provider block this script
+    // appends itself. The one-time backup must therefore be taken before the
+    // FIRST of them, or "pristine pre-Archestra config" would already contain
+    // the gateway the CLI registered a moment earlier.
+    sections.push(`$arch_config = Join-Path $(if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE '.codex' }) 'config.toml'
+if ((Test-Path $arch_config) -and -not (Test-Path ($arch_config + '.archestra-backup'))) {
+  Copy-Item -Path $arch_config -Destination ($arch_config + '.archestra-backup')
+}`);
+  }
+
   if (ctx.mcp) {
     sections.push(`Say ${psq(`Registering MCP gateway "${ctx.mcp.serverName}" (OAuth)`)}
 try { codex mcp remove ${psq(ctx.mcp.serverName)} 2>$null | Out-Null } catch { }
@@ -586,12 +599,10 @@ requires_openai_auth = true
 ${codexAttributionHeaderLines(ctx.proxy)}
 # <<< ${marker} <<<`;
 
-    sections.push(`Say ${psq(`Adding the "${ctx.proxy.proxyName}" provider to ~/.codex/config.toml`)}
-$arch_config = Join-Path $env:USERPROFILE '.codex\\config.toml'
+    sections.push(`Say ${psq(`Adding the "${ctx.proxy.proxyName}" provider to Codex's config.toml`)}
+$arch_config = Join-Path $(if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE '.codex' }) 'config.toml'
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $arch_config) | Out-Null
 if (Test-Path $arch_config) {
-  # Back up once so re-runs preserve the pristine pre-Archestra config.
-  if (-not (Test-Path ($arch_config + '.archestra-backup'))) { Copy-Item -Path $arch_config -Destination ($arch_config + '.archestra-backup') }
   # Drop any previous archestra-managed block for this provider (idempotent).
   $arch_start = ${psq(`# >>> ${marker} >>>`)}
   $arch_end = ${psq(`# <<< ${marker} <<<`)}

--- a/platform/backend/src/services/startup-guard.clients.test.ts
+++ b/platform/backend/src/services/startup-guard.clients.test.ts
@@ -1,5 +1,12 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -15,6 +22,7 @@ import {
   CODEX_GUARD_CLIENT,
   COPILOT_GUARD_CLIENT,
 } from "@/services/startup-guard.clients";
+import { renderStartupGuardPowerShell } from "@/services/startup-guard.windows";
 
 const execFileAsync = promisify(execFile);
 
@@ -128,14 +136,264 @@ describe.each([
 });
 
 describe("Codex-specific disconnect", () => {
-  test("strips the archestra provider block it wrote to ~/.codex/config.toml", () => {
+  test("strips the archestra provider block it wrote to Codex's config.toml", () => {
     const script = renderStartupGuardScript(CTX, CODEX_GUARD_CLIENT);
-    expect(script).toContain('CONFIG="$HOME/.codex/config.toml"');
+    expect(script).toContain(
+      'CONFIG="${CODEX_HOME:-$HOME/.codex}/config.toml"',
+    );
     // the awk-delimited block is keyed by the proxy slug connect used
     expect(script).toContain("# >>> archestra:acme_proxy >>>");
     expect(script).toContain("# <<< archestra:acme_proxy <<<");
     // `codex exec` is the non-interactive path the guard bows out on
     expect(script).toContain("exec) INTERACTIVE=0");
+  });
+});
+
+/**
+ * Pull one shell function out of the rendered guard so it can be run on its
+ * own. The generator emits every function at column 0 and closes it with a
+ * bare `}`, so the slice is unambiguous.
+ */
+function extractShellFunction(script: string, name: string): string {
+  const lines = script.split("\n");
+  // The opening line may carry a trailing `# $1 kind` comment.
+  const start = lines.findIndex((line) => line.startsWith(`${name}() {`));
+  if (start === -1) throw new Error(`no ${name}() in the rendered guard`);
+  const end = lines.indexOf("}", start);
+  if (end === -1) throw new Error(`${name}() is never closed`);
+  return lines.slice(start, end + 1).join("\n");
+}
+
+/**
+ * Run rendered guard functions for real against a throwaway CODEX_HOME, with a
+ * fake `codex` on PATH that records its argv. Exercising the generated shell
+ * beats asserting on its text: these defects were all "the code ran and did
+ * nothing", which a string match cannot tell from success.
+ */
+async function runCodexGuardSnippet(params: {
+  functions: string[];
+  invoke: string;
+  configToml?: string;
+  authJson?: string;
+}): Promise<{ code: number; stdout: string; codexArgs: string[] }> {
+  const script = renderStartupGuardScript(CTX, CODEX_GUARD_CLIENT);
+  const dir = await mkdtemp(path.join(tmpdir(), "archestra-codex-"));
+  try {
+    const home = path.join(dir, "codex-home");
+    const bin = path.join(dir, "bin");
+    const argvLog = path.join(dir, "codex-argv.log");
+    await mkdir(home, { recursive: true });
+    await mkdir(bin, { recursive: true });
+    if (params.configToml !== undefined) {
+      await writeFile(
+        path.join(home, "config.toml"),
+        params.configToml,
+        "utf8",
+      );
+    }
+    if (params.authJson !== undefined) {
+      await writeFile(path.join(home, "auth.json"), params.authJson, "utf8");
+    }
+    const fakeCodex = path.join(bin, "codex");
+    await writeFile(
+      fakeCodex,
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(argvLog)}\n`,
+      "utf8",
+    );
+    await chmod(fakeCodex, 0o755);
+
+    const harness = path.join(dir, "harness.sh");
+    await writeFile(
+      harness,
+      [
+        "#!/usr/bin/env bash",
+        // Presentation helpers the extracted functions call.
+        "line_reset() { :; }",
+        'C_WARN=""; C_RESET=""; C_DIM=""; C_ERR=""; C_ACCENT=""',
+        `MCP_SERVER_NAME=${JSON.stringify(CTX.mcp?.serverName)}`,
+        `SKILLS_MARKETPLACE_NAME=${JSON.stringify(CTX.skills?.marketplaceName)}`,
+        ...params.functions.map((name) => extractShellFunction(script, name)),
+        params.invoke,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await execFileAsync("bash", [harness], {
+      env: {
+        ...process.env,
+        CODEX_HOME: home,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+      },
+    }).then(
+      (r) => ({ code: 0, stdout: r.stdout }),
+      (e: { code?: number; stdout?: string }) => ({
+        code: e.code ?? 1,
+        stdout: e.stdout ?? "",
+      }),
+    );
+
+    let codexArgs: string[] = [];
+    try {
+      codexArgs = (await readFile(argvLog, "utf8")).split("\n").filter(Boolean);
+    } catch {
+      codexArgs = [];
+    }
+    return { ...result, codexArgs };
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+const GATEWAY_TABLE = [
+  "[mcp_servers.prod_gateway]",
+  'url = "https://archestra.example.com/v1/mcp/prod-gateway"',
+  "",
+  "[mcp_servers.prod_gateway.tools.demo__open]",
+  'approval_mode = "approve"',
+  "",
+].join("\n");
+
+const FOREIGN_TABLES = [
+  "[mcp_servers.node_repl]",
+  'command = "/opt/codex/node"',
+  "",
+  "[marketplaces.openai-bundled]",
+  'source_type = "local"',
+  "",
+].join("\n");
+
+describe("Codex disconnect reports what it could not remove", () => {
+  test("a gateway the CLI failed to remove fails verification and names the fix", async () => {
+    const { code, stdout } = await runCodexGuardSnippet({
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp || exit 7\nexit 0\n",
+      configToml: `${FOREIGN_TABLES}${GATEWAY_TABLE}`,
+    });
+
+    // Before the fix disconnect_verify did not exist and the caller printed
+    // "✓ Disconnected" unconditionally.
+    expect(code).toBe(7);
+    expect(stdout).toContain("[mcp_servers.prod_gateway] is still in");
+    expect(stdout).toContain("run `codex mcp remove prod_gateway` yourself");
+  });
+
+  test("a marketplace the CLI failed to remove fails verification", async () => {
+    const { code, stdout } = await runCodexGuardSnippet({
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify skills || exit 7\nexit 0\n",
+      configToml: '[marketplaces.acme-skills]\nsource_type = "git"\n',
+    });
+
+    expect(code).toBe(7);
+    expect(stdout).toContain("[marketplaces.acme-skills] is still in");
+  });
+
+  test("verification passes once the entries are gone, ignoring foreign ones", async () => {
+    const { code } = await runCodexGuardSnippet({
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp && disconnect_verify skills\n",
+      // node_repl and openai-bundled are the user's own — they must not read
+      // as our leftovers.
+      configToml: FOREIGN_TABLES,
+    });
+
+    expect(code).toBe(0);
+  });
+
+  test("verification reads the config CODEX_HOME points at", async () => {
+    // Seeded only in CODEX_HOME; a guard hardcoding ~/.codex would see no
+    // leftover here and wrongly report success.
+    const { code } = await runCodexGuardSnippet({
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp || exit 7\nexit 0\n",
+      configToml: GATEWAY_TABLE,
+    });
+
+    expect(code).toBe(7);
+  });
+});
+
+describe("Codex disconnect reverses the credential it installed", () => {
+  test("signs Codex out of an archestra virtual key", async () => {
+    const { codexArgs, stdout } = await runCodexGuardSnippet({
+      functions: ["codex_logout_if_ours", "proxy_disconnect_notes"],
+      invoke: "codex_logout_if_ours\nproxy_disconnect_notes\n",
+      authJson: '{"OPENAI_API_KEY":"arch_deadbeef","auth_mode":"apikey"}',
+    });
+
+    // Without this the key outlives the base_url that made it routable, and
+    // every plain `codex` run 401s against api.openai.com.
+    expect(codexArgs).toContain("logout");
+    expect(stdout).toContain("Signed Codex out of the Archestra virtual key");
+  });
+
+  test("leaves a user-owned api key alone", async () => {
+    const { codexArgs, stdout } = await runCodexGuardSnippet({
+      functions: ["codex_logout_if_ours", "proxy_disconnect_notes"],
+      invoke: "codex_logout_if_ours\nproxy_disconnect_notes\n",
+      authJson: '{"OPENAI_API_KEY":"sk-useROwnedKey","auth_mode":"apikey"}',
+    });
+
+    expect(codexArgs).not.toContain("logout");
+    expect(stdout).not.toContain("Signed Codex out");
+  });
+
+  test("leaves a ChatGPT session alone even beside our key", async () => {
+    // `codex logout` deletes auth.json wholesale, so it must never run while
+    // the user has an OAuth session Codex would prefer anyway.
+    const { codexArgs } = await runCodexGuardSnippet({
+      functions: ["codex_logout_if_ours", "proxy_disconnect_notes"],
+      invoke: "codex_logout_if_ours\nproxy_disconnect_notes\n",
+      authJson:
+        '{"OPENAI_API_KEY":"arch_deadbeef","auth_mode":"chatgpt","tokens":{"access_token":"x"}}',
+    });
+
+    expect(codexArgs).not.toContain("logout");
+  });
+
+  test("does nothing when Codex holds no credential at all", async () => {
+    const { code, codexArgs } = await runCodexGuardSnippet({
+      functions: ["codex_logout_if_ours", "proxy_disconnect_notes"],
+      invoke: "codex_logout_if_ours\nproxy_disconnect_notes\n",
+    });
+
+    expect(code).toBe(0);
+    expect(codexArgs).toEqual([]);
+  });
+});
+
+describe("an unverified disconnect is not recorded as done", () => {
+  test("bash: the skip file and the guard uninstall both wait on success", () => {
+    const script = renderStartupGuardScript(CTX, CODEX_GUARD_CLIENT);
+    // Recording an unproven removal would skip the resource on every later
+    // launch, and uninstalling the guard would delete the only thing that
+    // could retry.
+    expect(script).toContain(
+      'if disconnect_resource "${GUARD_KINDS[$i]}" "${GUARD_LABELS[$i]}"; then',
+    );
+    expect(script).toContain("DISCONNECT_FAILED=1");
+    expect(script).toContain(
+      '[ "$DOWN_COUNT" -ge "$ACTIVE_TOTAL" ] && [ "$DISCONNECT_FAILED" = "0" ] && uninstall_guard',
+    );
+    expect(script).toContain(
+      '[ "$DISCONNECT_FAILED" = "0" ] && uninstall_guard',
+    );
+  });
+
+  test("windows: the skip file and the guard uninstall both wait on success", () => {
+    const script = renderStartupGuardPowerShell(CTX, CODEX_GUARD_CLIENT);
+    expect(script).toContain("if (Disconnect-ArchRemote $r.Kind $r.Label) {");
+    expect(script).toContain("$Script:ArchDisconnectFailed = $true");
+    expect(script).toContain(
+      "if ($downRemotes.Count -ge $ActiveRemotes.Count -and -not $Script:ArchDisconnectFailed) { Remove-ArchGuard }",
+    );
+    expect(script).toContain(
+      "if (-not $Script:ArchDisconnectFailed) { Remove-ArchGuard }",
+    );
+    // A missing binary cannot have removed anything.
+    expect(script).toContain("the codex executable could not be found on PATH");
+    // …and Windows reverses the credential too.
+    expect(script).toContain("Invoke-ArchCodexLogoutIfOurs");
   });
 });
 

--- a/platform/backend/src/services/startup-guard.clients.test.ts
+++ b/platform/backend/src/services/startup-guard.clients.test.ts
@@ -19,6 +19,7 @@ import {
   type StartupGuardContext,
 } from "@/services/startup-guard";
 import {
+  CLAUDE_CODE_GUARD_CLIENT,
   CODEX_GUARD_CLIENT,
   COPILOT_GUARD_CLIENT,
 } from "@/services/startup-guard.clients";
@@ -165,42 +166,46 @@ function extractShellFunction(script: string, name: string): string {
 }
 
 /**
- * Run rendered guard functions for real against a throwaway CODEX_HOME, with a
- * fake `codex` on PATH that records its argv. Exercising the generated shell
- * beats asserting on its text: these defects were all "the code ran and did
- * nothing", which a string match cannot tell from success.
+ * Run rendered guard functions for real against a throwaway home directory,
+ * with a fake client binary on PATH that records its argv. Exercising the
+ * generated shell beats asserting on its text: the defects this pins were all
+ * "the code ran and did nothing", which a string match cannot tell from
+ * success.
+ *
+ * `files` are written relative to the temp home; `env` overlays the spawned
+ * bash's environment (HOME always points at the temp home, so verifiers that
+ * default to `$HOME/...` read the fixture, never this machine's real config).
+ * An `env` value may embed `{HOME}`, replaced with the temp home's absolute
+ * path — the only way a caller can point CODEX_HOME/CLAUDE_CONFIG_DIR at a
+ * directory that does not exist until the harness creates it.
  */
-async function runCodexGuardSnippet(params: {
+async function runGuardSnippet(params: {
+  client: StartupGuardClient;
   functions: string[];
   invoke: string;
-  configToml?: string;
-  authJson?: string;
-}): Promise<{ code: number; stdout: string; codexArgs: string[] }> {
-  const script = renderStartupGuardScript(CTX, CODEX_GUARD_CLIENT);
-  const dir = await mkdtemp(path.join(tmpdir(), "archestra-codex-"));
+  files?: Record<string, string>;
+  env?: Record<string, string>;
+}): Promise<{ code: number; stdout: string; cliArgs: string[] }> {
+  const script = renderStartupGuardScript(CTX, params.client);
+  const dir = await mkdtemp(path.join(tmpdir(), "archestra-guard-run-"));
   try {
-    const home = path.join(dir, "codex-home");
+    const home = path.join(dir, "home");
     const bin = path.join(dir, "bin");
-    const argvLog = path.join(dir, "codex-argv.log");
+    const argvLog = path.join(dir, "cli-argv.log");
     await mkdir(home, { recursive: true });
     await mkdir(bin, { recursive: true });
-    if (params.configToml !== undefined) {
-      await writeFile(
-        path.join(home, "config.toml"),
-        params.configToml,
-        "utf8",
-      );
+    for (const [relpath, content] of Object.entries(params.files ?? {})) {
+      const target = path.join(home, relpath);
+      await mkdir(path.dirname(target), { recursive: true });
+      await writeFile(target, content, "utf8");
     }
-    if (params.authJson !== undefined) {
-      await writeFile(path.join(home, "auth.json"), params.authJson, "utf8");
-    }
-    const fakeCodex = path.join(bin, "codex");
+    const fakeCli = path.join(bin, params.client.binary);
     await writeFile(
-      fakeCodex,
+      fakeCli,
       `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(argvLog)}\n`,
       "utf8",
     );
-    await chmod(fakeCodex, 0o755);
+    await chmod(fakeCli, 0o755);
 
     const harness = path.join(dir, "harness.sh");
     await writeFile(
@@ -218,11 +223,23 @@ async function runCodexGuardSnippet(params: {
       "utf8",
     );
 
+    const overlay = Object.fromEntries(
+      Object.entries(params.env ?? {}).map(([key, value]) => [
+        key,
+        value.replaceAll("{HOME}", home),
+      ]),
+    );
     const result = await execFileAsync("bash", [harness], {
       env: {
         ...process.env,
-        CODEX_HOME: home,
+        HOME: home,
+        // Config-relocation vars exported on the machine running the tests
+        // must not leak into the fixture home. Empty string falls through
+        // `${VAR:-default}` to the default, exactly like unset.
+        CLAUDE_CONFIG_DIR: "",
+        CODEX_HOME: "",
         PATH: `${bin}:${process.env.PATH ?? ""}`,
+        ...overlay,
       },
     }).then(
       (r) => ({ code: 0, stdout: r.stdout }),
@@ -232,16 +249,36 @@ async function runCodexGuardSnippet(params: {
       }),
     );
 
-    let codexArgs: string[] = [];
+    let cliArgs: string[] = [];
     try {
-      codexArgs = (await readFile(argvLog, "utf8")).split("\n").filter(Boolean);
+      cliArgs = (await readFile(argvLog, "utf8")).split("\n").filter(Boolean);
     } catch {
-      codexArgs = [];
+      cliArgs = [];
     }
-    return { ...result, codexArgs };
+    return { ...result, cliArgs };
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+}
+
+/** Codex flavor of {@link runGuardSnippet}: CODEX_HOME points at the temp home. */
+async function runCodexGuardSnippet(params: {
+  functions: string[];
+  invoke: string;
+  configToml?: string;
+  authJson?: string;
+}): Promise<{ code: number; stdout: string; codexArgs: string[] }> {
+  const files: Record<string, string> = {};
+  if (params.configToml !== undefined) files["config.toml"] = params.configToml;
+  if (params.authJson !== undefined) files["auth.json"] = params.authJson;
+  const { code, stdout, cliArgs } = await runGuardSnippet({
+    client: CODEX_GUARD_CLIENT,
+    functions: params.functions,
+    invoke: params.invoke,
+    files,
+    env: { CODEX_HOME: "{HOME}" },
+  });
+  return { code, stdout, codexArgs: cliArgs };
 }
 
 const GATEWAY_TABLE = [
@@ -406,5 +443,186 @@ describe("Copilot-specific disconnect", () => {
     expect(script).toContain('"$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"');
     // Copilot's non-interactive one-shot flag
     expect(script).toContain("-p|--prompt) INTERACTIVE=0");
+  });
+});
+
+describe("Claude Code disconnect reports what it could not remove", () => {
+  const GATEWAY_JSON = JSON.stringify({
+    mcpServers: {
+      prod_gateway: { type: "http", url: "https://archestra.example.com" },
+      "user-own-server": { type: "stdio", command: "/usr/bin/thing" },
+    },
+  });
+
+  test("a gateway the CLI failed to remove fails verification and names the fix", async () => {
+    const { code, stdout } = await runGuardSnippet({
+      client: CLAUDE_CODE_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp || exit 7\nexit 0\n",
+      files: { ".claude.json": GATEWAY_JSON },
+    });
+
+    // Before the fix the removal was fire-and-forget: `claude mcp remove` ran
+    // silenced with its result discarded, and the guard printed ✓ regardless.
+    expect(code).toBe(7);
+    expect(stdout).toContain("prod_gateway is still registered in");
+    expect(stdout).toContain(
+      "run `claude mcp remove --scope user prod_gateway` yourself",
+    );
+  });
+
+  test("the name appearing in an unrelated value is not a leftover", async () => {
+    // ~/.claude.json holds per-project state where a server name can occur in
+    // ordinary strings — this is why the check parses JSON instead of grepping.
+    const { code } = await runGuardSnippet({
+      client: CLAUDE_CODE_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp\n",
+      files: {
+        ".claude.json": JSON.stringify({
+          mcpServers: {},
+          projects: {
+            "/home/user/repo": { history: ["please debug prod_gateway"] },
+          },
+        }),
+      },
+    });
+
+    expect(code).toBe(0);
+  });
+
+  test("verification reads the config CLAUDE_CONFIG_DIR points at", async () => {
+    // Seeded only under the relocated config dir; a verifier hardcoding
+    // ~/.claude.json would see no leftover and wrongly report success.
+    const { code } = await runGuardSnippet({
+      client: CLAUDE_CODE_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp || exit 7\nexit 0\n",
+      files: { "claude-cfg/.claude.json": GATEWAY_JSON },
+      env: { CLAUDE_CONFIG_DIR: "{HOME}/claude-cfg" },
+    });
+
+    expect(code).toBe(7);
+  });
+
+  test("a marketplace the CLI failed to remove fails verification; foreign ones never do", async () => {
+    const stillThere = await runGuardSnippet({
+      client: CLAUDE_CODE_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify skills || exit 7\nexit 0\n",
+      files: {
+        ".claude/plugins/known_marketplaces.json": JSON.stringify({
+          "claude-plugins-official": { source: "github" },
+          "acme-skills": { source: "https://archestra.example.com/repo.git" },
+        }),
+      },
+    });
+    expect(stillThere.code).toBe(7);
+    expect(stillThere.stdout).toContain(
+      "run `claude plugin marketplace remove acme-skills` yourself",
+    );
+
+    const foreignOnly = await runGuardSnippet({
+      client: CLAUDE_CODE_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify skills\n",
+      files: {
+        ".claude/plugins/known_marketplaces.json": JSON.stringify({
+          "claude-plugins-official": { source: "github" },
+        }),
+      },
+    });
+    expect(foreignOnly.code).toBe(0);
+  });
+
+  test("an unreadable config passes: presence must be proven, not presumed", async () => {
+    const { code } = await runGuardSnippet({
+      client: CLAUDE_CODE_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp && disconnect_verify skills\n",
+      files: { ".claude.json": "{ this is not json" },
+    });
+
+    expect(code).toBe(0);
+  });
+});
+
+describe("Copilot CLI disconnect reports what it could not remove", () => {
+  test("a gateway the CLI failed to remove fails verification and names the fix", async () => {
+    const { code, stdout } = await runGuardSnippet({
+      client: COPILOT_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp || exit 7\nexit 0\n",
+      files: {
+        ".copilot/mcp-config.json": JSON.stringify({
+          mcpServers: {
+            prod_gateway: { url: "https://archestra.example.com" },
+          },
+        }),
+      },
+    });
+
+    expect(code).toBe(7);
+    expect(stdout).toContain("run `copilot mcp remove prod_gateway` yourself");
+  });
+
+  test("a marketplace the CLI failed to remove fails verification", async () => {
+    const { code, stdout } = await runGuardSnippet({
+      client: COPILOT_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify skills || exit 7\nexit 0\n",
+      files: {
+        ".copilot/settings.json": JSON.stringify({
+          extraKnownMarketplaces: {
+            "acme-skills": { source: "https://archestra.example.com/repo.git" },
+          },
+        }),
+      },
+    });
+
+    expect(code).toBe(7);
+    expect(stdout).toContain(
+      "run `copilot plugin marketplace remove acme-skills` yourself",
+    );
+  });
+
+  test("verification passes once the entries are gone or the files are absent", async () => {
+    const clean = await runGuardSnippet({
+      client: COPILOT_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp && disconnect_verify skills\n",
+      files: {
+        ".copilot/mcp-config.json": JSON.stringify({ mcpServers: {} }),
+        ".copilot/settings.json": JSON.stringify({}),
+      },
+    });
+    expect(clean.code).toBe(0);
+
+    const absent = await runGuardSnippet({
+      client: COPILOT_GUARD_CLIENT,
+      functions: ["disconnect_verify"],
+      invoke: "disconnect_verify mcp && disconnect_verify skills\n",
+    });
+    expect(absent.code).toBe(0);
+  });
+});
+
+describe("windows disconnect verification (string pins — no PS runtime in CI)", () => {
+  test("claude: reads the JSON configs the CLI edits, honoring CLAUDE_CONFIG_DIR", () => {
+    const script = renderStartupGuardPowerShell(CTX, CLAUDE_CODE_GUARD_CLIENT);
+    expect(script).toContain("function Test-ArchDisconnected");
+    expect(script).toContain("ConvertFrom-Json");
+    expect(script).toContain(
+      "$(if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { $env:USERPROFILE }) '.claude.json'",
+    );
+    expect(script).toContain("plugins\\known_marketplaces.json");
+    expect(script).toContain("$archParsed.mcpServers");
+  });
+
+  test("copilot: reads mcp-config.json and settings.json", () => {
+    const script = renderStartupGuardPowerShell(CTX, COPILOT_GUARD_CLIENT);
+    expect(script).toContain(".copilot\\mcp-config.json");
+    expect(script).toContain(".copilot\\settings.json");
+    expect(script).toContain("$archParsed.extraKnownMarketplaces");
   });
 });

--- a/platform/backend/src/services/startup-guard.clients.test.ts
+++ b/platform/backend/src/services/startup-guard.clients.test.ts
@@ -434,6 +434,96 @@ describe("an unverified disconnect is not recorded as done", () => {
   });
 });
 
+// The menu's cursor/spinner choreography, neutralized: the contract under
+// test is verify → record, not the animation. remember_disconnected is
+// re-declared verbatim because the real one is a one-liner
+// extractShellFunction cannot slice.
+const MENU_ROW_PREAMBLE = [
+  "menu_at_row() { :; }",
+  "menu_leave_row() { :; }",
+  "spin_start() { :; }",
+  "spin_tick() { :; }",
+  'remember_disconnected() { printf "%s\\n" "$1" >> "$SKIP_FILE"; }',
+  "MIN_CHECK_FRAMES=0",
+  "FRAME_SLEEP=0",
+  "GUARD_KINDS=(mcp)",
+  'GUARD_LABELS=("MCP gateway")',
+  'SKIP_FILE="$HOME/guard-skip"',
+  "DISCONNECT_FAILED=0",
+].join("\n");
+
+describe("the reconfigure menu obeys the same verify-before-record contract", () => {
+  test("bash: a removal that cannot be proven paints ✗, records nothing, and stays retryable", async () => {
+    const { code, stdout } = await runCodexGuardSnippet({
+      functions: [
+        "menu_disconnect_row",
+        "disconnect_actions",
+        "disconnect_verify",
+      ],
+      invoke: [
+        MENU_ROW_PREAMBLE,
+        "menu_disconnect_row 1 0 && exit 9",
+        '[ "$DISCONNECT_FAILED" = "1" ] || exit 8',
+        '[ ! -f "$SKIP_FILE" ] || exit 7',
+        "exit 0",
+      ].join("\n"),
+      // The fake CLI removes nothing, so the gateway table survives it.
+      configToml: GATEWAY_TABLE,
+    });
+
+    expect(code).toBe(0);
+    expect(stdout).toContain(
+      "✗ Could not disconnect MCP gateway — [1] to retry",
+    );
+    expect(stdout).not.toContain("✓ Disconnected");
+    // The verify hint would corrupt the in-place row; it stays suppressed.
+    expect(stdout).not.toContain("is still in");
+  });
+
+  test("bash: a proven removal lands the check and the skip-file entry", async () => {
+    const { code, stdout } = await runCodexGuardSnippet({
+      functions: [
+        "menu_disconnect_row",
+        "disconnect_actions",
+        "disconnect_verify",
+      ],
+      invoke: [
+        MENU_ROW_PREAMBLE,
+        "menu_disconnect_row 1 0 || exit 9",
+        'grep -qx mcp "$SKIP_FILE" || exit 8',
+        '[ "$DISCONNECT_FAILED" = "0" ] || exit 7',
+        "exit 0",
+      ].join("\n"),
+      // Nothing of ours left behind, so the removal verifies.
+      configToml: FOREIGN_TABLES,
+    });
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("✓ Disconnected MCP gateway");
+  });
+
+  test("bash: the menu's guard uninstall waits on every removal being proven", () => {
+    const script = renderStartupGuardScript(CTX, CODEX_GUARD_CLIENT);
+    expect(script).toContain(
+      'menu_disconnect_row "$key" "$menu_target" || continue',
+    );
+    expect(script).toContain(
+      'if [ "$menu_left" -eq 0 ] && [ "$DISCONNECT_FAILED" = "0" ]; then',
+    );
+  });
+
+  test("windows: same contract — verify, gate the record, gate the uninstall", () => {
+    const script = renderStartupGuardPowerShell(CTX, CODEX_GUARD_CLIENT);
+    expect(script).toContain("$archOk = Invoke-ArchDisconnectActions $r.Kind");
+    expect(script).toContain(
+      "if (-not (Disconnect-ArchMenuRow ($d - 1) $count $baseTop)) { continue }",
+    );
+    expect(script).toContain(
+      "if ($done.Count -ge $count -and -not $Script:ArchDisconnectFailed) { Remove-ArchGuard; break }",
+    );
+  });
+});
+
 describe("Copilot-specific disconnect", () => {
   test("strips the COPILOT_PROVIDER_* export lines from the shell profiles", () => {
     const script = renderStartupGuardScript(CTX, COPILOT_GUARD_CLIENT);

--- a/platform/backend/src/services/startup-guard.clients.ts
+++ b/platform/backend/src/services/startup-guard.clients.ts
@@ -18,8 +18,10 @@ import type { StartupGuardClient, StartupGuardContext } from "./startup-guard";
  * disconnect commands the guard runs when a remote is unreachable.
  *
  * Cursor is deliberately absent: it is a GUI IDE with no wrappable terminal
- * launch command, so its connect is reversed from the Disconnect panel rather
- * than a startup guard.
+ * launch command, so no startup guard can host a disconnect for it. Its
+ * connect currently has no automated reversal at all — the Disconnect panel
+ * that once covered it was removed from the connect flow — so undoing a
+ * Cursor connect means editing `~/.cursor/mcp.json` by hand.
  */
 
 /** Single-quote a value for bash; safe for arbitrary content. */
@@ -48,6 +50,23 @@ export const CLAUDE_CODE_GUARD_CLIENT: StartupGuardClient = {
   mcpDisconnectCommands: `      command claude mcp remove --scope user "$MCP_SERVER_NAME" </dev/null >/dev/null 2>&1 || true
       command claude mcp remove --scope local "$MCP_SERVER_NAME" </dev/null >/dev/null 2>&1 || true`,
   skillsDisconnectCommands: `      command claude plugin marketplace remove "$SKILLS_MARKETPLACE_NAME" </dev/null >/dev/null 2>&1 || true`,
+  // Connect registers the gateway at user scope, which lives in
+  // `~/.claude.json` (or `$CLAUDE_CONFIG_DIR/.claude.json`) under `mcpServers`;
+  // marketplaces are indexed in `plugins/known_marketplaces.json` by name. A
+  // local-scope entry the user added themselves is deliberately not checked.
+  mcpDisconnectVerify: jsonMemberGoneVerify({
+    configPath: '"${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json"',
+    member: "mcpServers",
+    nameVar: "$MCP_SERVER_NAME",
+    manualCommand: "claude mcp remove --scope user",
+  }),
+  skillsDisconnectVerify: jsonMemberGoneVerify({
+    configPath:
+      '"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/known_marketplaces.json"',
+    member: "",
+    nameVar: "$SKILLS_MARKETPLACE_NAME",
+    manualCommand: "claude plugin marketplace remove",
+  }),
   renderProxyDisconnect: claudeProxyDisconnect,
   windows: {
     mcpDisconnect: `      if ($archRealExe) {
@@ -57,6 +76,20 @@ export const CLAUDE_CODE_GUARD_CLIENT: StartupGuardClient = {
     skillsDisconnect: `      if ($archRealExe) {
         try { & $archRealExe.Source plugin marketplace remove $SkillsMarketplaceName 2>$null | Out-Null } catch { }
       }`,
+    mcpDisconnectVerify: windowsJsonMemberGoneVerify({
+      configPath:
+        "Join-Path $(if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { $env:USERPROFILE }) '.claude.json'",
+      member: "mcpServers",
+      nameVar: "$McpServerName",
+      manualCommand: "claude mcp remove --scope user",
+    }),
+    skillsDisconnectVerify: windowsJsonMemberGoneVerify({
+      configPath:
+        "Join-Path $(if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $env:USERPROFILE '.claude' }) 'plugins\\known_marketplaces.json'",
+      member: "",
+      nameVar: "$SkillsMarketplaceName",
+      manualCommand: "claude plugin marketplace remove",
+    }),
     renderProxyDisconnect: claudeWindowsProxyDisconnect,
     proxyDisconnectNote: (ctx) =>
       ctx.proxy?.provider === "bedrock"
@@ -394,10 +427,37 @@ export const COPILOT_GUARD_CLIENT: StartupGuardClient = {
   nonInteractiveArgPatterns: ["-p", "--prompt"],
   mcpDisconnectCommands: `      command copilot mcp remove "$MCP_SERVER_NAME" </dev/null >/dev/null 2>&1 || true`,
   skillsDisconnectCommands: `      command copilot plugin marketplace remove "$SKILLS_MARKETPLACE_NAME" </dev/null >/dev/null 2>&1 || true`,
+  // Copilot CLI keeps MCP servers in `~/.copilot/mcp-config.json` under
+  // `mcpServers` and registered marketplaces in `~/.copilot/settings.json`
+  // under `extraKnownMarketplaces` (both verified against a live install).
+  mcpDisconnectVerify: jsonMemberGoneVerify({
+    configPath: '"$HOME/.copilot/mcp-config.json"',
+    member: "mcpServers",
+    nameVar: "$MCP_SERVER_NAME",
+    manualCommand: "copilot mcp remove",
+  }),
+  skillsDisconnectVerify: jsonMemberGoneVerify({
+    configPath: '"$HOME/.copilot/settings.json"',
+    member: "extraKnownMarketplaces",
+    nameVar: "$SKILLS_MARKETPLACE_NAME",
+    manualCommand: "copilot plugin marketplace remove",
+  }),
   renderProxyDisconnect: copilotProxyDisconnect,
   windows: {
     mcpDisconnect: `      if ($archRealExe) { try { & $archRealExe.Source mcp remove $McpServerName 2>$null | Out-Null } catch { } }`,
     skillsDisconnect: `      if ($archRealExe) { try { & $archRealExe.Source plugin marketplace remove $SkillsMarketplaceName 2>$null | Out-Null } catch { } }`,
+    mcpDisconnectVerify: windowsJsonMemberGoneVerify({
+      configPath: "Join-Path $env:USERPROFILE '.copilot\\mcp-config.json'",
+      member: "mcpServers",
+      nameVar: "$McpServerName",
+      manualCommand: "copilot mcp remove",
+    }),
+    skillsDisconnectVerify: windowsJsonMemberGoneVerify({
+      configPath: "Join-Path $env:USERPROFILE '.copilot\\settings.json'",
+      member: "extraKnownMarketplaces",
+      nameVar: "$SkillsMarketplaceName",
+      manualCommand: "copilot plugin marketplace remove",
+    }),
     renderProxyDisconnect: copilotWindowsProxyDisconnect,
     proxyDisconnectNote: () =>
       "Removed the COPILOT_PROVIDER_* environment variables (User scope and this session). Open a new terminal for the change to fully take effect.",
@@ -449,4 +509,85 @@ proxy_disconnect_notes() {
   printf '%s  Removed any COPILOT_PROVIDER_* export lines from your shell profiles — open a new terminal so the change takes effect.%s\\n' "$C_DIM" "$C_RESET"
   return 0
 }`;
+}
+
+// ===================================================================
+// Shared disconnect-verification helpers
+// ===================================================================
+
+/**
+ * Bash proof that a named member is gone from a client's JSON config, for the
+ * engine's `disconnect_verify()`.
+ *
+ * The removal itself is delegated to the vendor CLI, whose exit status cannot
+ * answer "is it gone?" — a remove of an already-absent entry may exit 0 or 1
+ * depending on the CLI — and a missing binary makes the removal a silent
+ * no-op. Reading the config back is the only honest check, and it is also
+ * what catches the missing-binary case. Prints the manual command and returns
+ * 1 when the entry survived.
+ *
+ * The check needs python3 for a real JSON parse (a plain grep of a JSON file
+ * false-positives on names that appear in unrelated values); without python3
+ * it returns 0, keeping the previous assume-success behaviour rather than
+ * failing disconnects on machines that cannot verify. An unreadable or
+ * corrupt config also passes: presence is unprovable there, and the failure
+ * path must only fire on proof.
+ */
+function jsonMemberGoneVerify(params: {
+  /** Shell expression for the config path, e.g. `"$HOME/.copilot/mcp-config.json"`. */
+  configPath: string;
+  /** Top-level object holding the entries; empty string = the document root. */
+  member: string;
+  /** Shell variable carrying the entry name, e.g. `$MCP_SERVER_NAME`. */
+  nameVar: string;
+  /** Command the user can run by hand when verification fails. */
+  manualCommand: string;
+}): string {
+  const { configPath, member, nameVar, manualCommand } = params;
+  return `      command -v python3 >/dev/null 2>&1 || return 0
+      arch_cfg=${configPath}
+      [ -f "$arch_cfg" ] || return 0
+      if python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+except Exception:
+    sys.exit(0)
+parent = cfg.get(sys.argv[3]) if sys.argv[3] else cfg
+sys.exit(1 if isinstance(parent, dict) and sys.argv[2] in parent else 0)
+' "$arch_cfg" "${nameVar}" "${member}"; then return 0; fi
+      line_reset
+      printf '%s  %s is still registered in %s — run \`${manualCommand} %s\` yourself.%s\\n' "$C_WARN" "${nameVar}" "$arch_cfg" "${nameVar}" "$C_RESET"
+      return 1`;
+}
+
+/**
+ * PowerShell twin of {@link jsonMemberGoneVerify}, for the engine's
+ * `Test-ArchDisconnected`. ConvertFrom-Json is built in, so there is no
+ * python3-style dependency; the unreadable-config case still passes for the
+ * same reason.
+ */
+function windowsJsonMemberGoneVerify(params: {
+  /** PowerShell expression for the config path. */
+  configPath: string;
+  /** Top-level object holding the entries; empty string = the document root. */
+  member: string;
+  /** PowerShell variable carrying the entry name, e.g. `$McpServerName`. */
+  nameVar: string;
+  /** Command the user can run by hand when verification fails. */
+  manualCommand: string;
+}): string {
+  const { configPath, member, nameVar, manualCommand } = params;
+  const parent = member ? `$archParsed.${member}` : "$archParsed";
+  return `    $archCfg = ${configPath}
+    if (Test-Path $archCfg) {
+      $archParsed = $null
+      try { $archParsed = Get-Content -Path $archCfg -Raw | ConvertFrom-Json } catch { }
+      $archParent = if ($archParsed) { ${parent} } else { $null }
+      if ($archParent -and $archParent.PSObject.Properties[${nameVar}]) {
+        $Script:ArchDisconnectReason = ${nameVar} + ' is still registered in ' + $archCfg + ' — run \`${manualCommand} ' + ${nameVar} + '\` yourself.'
+        return $false
+      }
+    }`;
 }

--- a/platform/backend/src/services/startup-guard.clients.ts
+++ b/platform/backend/src/services/startup-guard.clients.ts
@@ -1,4 +1,5 @@
 import {
+  ARCHESTRA_TOKEN_PREFIX,
   CLAUDE_CODE_CUSTOM_HEADERS_ENV_KEY,
   CLAUDE_CODE_PROXY_ENV_KEYS,
   COPILOT_PROVIDER_ENV_KEYS,
@@ -194,15 +195,69 @@ export const CODEX_GUARD_CLIENT: StartupGuardClient = {
   nonInteractiveArgPatterns: ["exec"],
   mcpDisconnectCommands: `      command codex mcp remove "$MCP_SERVER_NAME" </dev/null >/dev/null 2>&1 || true`,
   skillsDisconnectCommands: `      command codex plugin marketplace remove "$SKILLS_MARKETPLACE_NAME" </dev/null >/dev/null 2>&1 || true`,
+  mcpDisconnectVerify: codexVerifyTableGone(
+    "mcp_servers",
+    "$MCP_SERVER_NAME",
+    "codex mcp remove",
+  ),
+  skillsDisconnectVerify: codexVerifyTableGone(
+    "marketplaces",
+    "$SKILLS_MARKETPLACE_NAME",
+    "codex plugin marketplace remove",
+  ),
   renderProxyDisconnect: codexProxyDisconnect,
   windows: {
     mcpDisconnect: `      if ($archRealExe) { try { & $archRealExe.Source mcp remove $McpServerName 2>$null | Out-Null } catch { } }`,
     skillsDisconnect: `      if ($archRealExe) { try { & $archRealExe.Source plugin marketplace remove $SkillsMarketplaceName 2>$null | Out-Null } catch { } }`,
+    mcpDisconnectVerify: codexWindowsVerifyTableGone(
+      "mcp_servers",
+      "$McpServerName",
+      "codex mcp remove",
+    ),
+    skillsDisconnectVerify: codexWindowsVerifyTableGone(
+      "marketplaces",
+      "$SkillsMarketplaceName",
+      "codex plugin marketplace remove",
+    ),
     renderProxyDisconnect: codexWindowsProxyDisconnect,
     proxyDisconnectNote: (ctx) =>
-      `Removed the ${ctx.appName} provider from ~/.codex/config.toml. If you signed Codex in with an ${ctx.appName} virtual key, run codex logout (then log back in) to restore your own credentials.`,
+      `Removed the ${ctx.appName} provider from the Codex config.toml. If Codex was signed in with an ${ctx.appName} virtual key it has been signed out — run codex login to sign back in with your own account.`,
   },
 };
+
+/**
+ * Codex keeps its config where `CODEX_HOME` points, defaulting to `~/.codex`.
+ * The vendor CLI honours that variable, so a guard that hardcoded `~/.codex`
+ * would verify a different file than the one `codex mcp remove` just edited and
+ * report a phantom failure.
+ */
+function codexConfigShellPath(): string {
+  return '"${CODEX_HOME:-$HOME/.codex}/config.toml"';
+}
+
+/**
+ * Prove a `[<section>.<name>]` table is gone from Codex's config, and say what
+ * to run by hand when it is not.
+ *
+ * The removal itself is delegated to the Codex CLI, which is the right owner —
+ * it deletes the parent table together with any nested `[<section>.<name>.*]`
+ * sub-tables (per-tool `approval_mode` entries), which a line-based stripper
+ * here would strand. What the guard must not do is *assume* the delegation
+ * happened: the binary may not resolve, so reading the file back is the only
+ * honest check.
+ */
+function codexVerifyTableGone(
+  section: string,
+  nameVar: string,
+  manualCommand: string,
+): string {
+  return `      arch_cfg=${codexConfigShellPath()}
+      [ -f "$arch_cfg" ] || return 0
+      grep -q "^\\[${section}\\.${nameVar}\\]" "$arch_cfg" 2>/dev/null || return 0
+      line_reset
+      printf '%s  [${section}.%s] is still in %s — run \`${manualCommand} %s\` yourself.%s\\n' "$C_WARN" "${nameVar}" "$arch_cfg" "${nameVar}" "$C_RESET"
+      return 1`;
+}
 
 /**
  * Codex's proxy disconnect on Windows: strip the `# >>> archestra:<proxyName> >>>`
@@ -210,46 +265,116 @@ export const CODEX_GUARD_CLIENT: StartupGuardClient = {
  * ~/.codex/config.toml — the exact reverse of the block the Windows connect
  * script writes. Pure PowerShell, mirroring the connect script's own strip loop.
  */
+/** PowerShell twin of {@link codexConfigShellPath}. */
+function codexHomePs(): string {
+  return "$(if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE '.codex' })";
+}
+
+/** PowerShell twin of {@link codexVerifyTableGone}. */
+function codexWindowsVerifyTableGone(
+  section: string,
+  nameVar: string,
+  manualCommand: string,
+): string {
+  return `    $archCfg = Join-Path ${codexHomePs()} 'config.toml'
+    if (Test-Path $archCfg) {
+      $archHeader = '[${section}.' + ${nameVar} + ']'
+      if (@(Get-Content -Path $archCfg) -contains $archHeader) {
+        $Script:ArchDisconnectReason = $archHeader + ' is still in ' + $archCfg + ' — run \`${manualCommand} ' + ${nameVar} + '\` yourself.'
+        return $false
+      }
+    }`;
+}
+
 function codexWindowsProxyDisconnect(ctx: StartupGuardContext): string {
   const marker = `archestra:${ctx.proxy?.proxyName ?? ""}`;
   return `function Disconnect-ArchProxy {
-  $path = Join-Path $env:USERPROFILE '.codex\\config.toml'
-  if (-not (Test-Path $path)) { return }
-  $start = ${psq(`# >>> ${marker} >>>`)}
-  $end = ${psq(`# <<< ${marker} <<<`)}
-  $kept = New-Object System.Collections.Generic.List[string]
-  $skip = $false
-  foreach ($ln in (Get-Content -Path $path)) {
-    if ($ln -eq $start) { $skip = $true; continue }
-    if ($ln -eq $end) { $skip = $false; continue }
-    if (-not $skip) { $kept.Add($ln) }
+  $path = Join-Path ${codexHomePs()} 'config.toml'
+  if (Test-Path $path) {
+    $start = ${psq(`# >>> ${marker} >>>`)}
+    $end = ${psq(`# <<< ${marker} <<<`)}
+    $kept = New-Object System.Collections.Generic.List[string]
+    $skip = $false
+    foreach ($ln in (Get-Content -Path $path)) {
+      if ($ln -eq $start) { $skip = $true; continue }
+      if ($ln -eq $end) { $skip = $false; continue }
+      if (-not $skip) { $kept.Add($ln) }
+    }
+    Set-Content -Path $path -Value $kept -Encoding utf8
   }
-  Set-Content -Path $path -Value $kept -Encoding utf8
+  Invoke-ArchCodexLogoutIfOurs
+}
+
+# Sign out ONLY when Codex is holding an ${ctx.appName} key. A user-owned key
+# (sk-…) or a ChatGPT session is left untouched: \`codex logout\` deletes the
+# whole credential file, so running it unconditionally would destroy an account
+# login the user established themselves.
+function Invoke-ArchCodexLogoutIfOurs {
+  $Script:ArchLoggedOut = $false
+  $authPath = Join-Path ${codexHomePs()} 'auth.json'
+  if (-not (Test-Path $authPath)) { return }
+  $raw = ''
+  try { $raw = Get-Content -Path $authPath -Raw } catch { return }
+  if ($raw -match '"auth_mode"\\s*:\\s*"chatgpt"') { return }
+  if ($raw -notmatch '"OPENAI_API_KEY"\\s*:\\s*"${ARCHESTRA_TOKEN_PREFIX}') { return }
+  $exe = Get-ArchRealExe
+  if (-not $exe) { return }
+  try { & $exe.Source logout 2>$null | Out-Null } catch { return }
+  $Script:ArchLoggedOut = $true
 }`;
 }
 
 /**
  * Codex's proxy disconnect: strip the `# >>> archestra:<proxyName> >>>` …
- * `# <<< archestra:<proxyName> <<<` block connect appended to
- * ~/.codex/config.toml (awk, no python3 dependency). The Codex login credential
- * is left intact — removing the provider block already stops routing through
- * Archestra — with a note pointing at `codex logout` when a virtual key was used.
+ * `# <<< archestra:<proxyName> <<<` block connect appended to Codex's
+ * config.toml (awk, no python3 dependency), then sign Codex out of the virtual
+ * key connect logged it in with.
+ *
+ * Both halves are required, and dropping only the first is worse than dropping
+ * neither. Connect writes the pair as `base_url` inside that block plus an
+ * `arch_…` key in Codex's own credential store (`codex login --with-api-key`).
+ * The block is inert until the user opts in with `codex -c model_provider=…`;
+ * the credential is global. Removing only the block therefore leaves every
+ * plain `codex` run sending an Archestra virtual key to api.openai.com, which
+ * answers `401 Incorrect API key provided: arch_…` — Codex ends up more broken
+ * than before it was ever connected, and the key leaks to a third party.
+ *
+ * `codex logout` deletes the whole credential file, so it is only safe when the
+ * credential in it is ours. The guard checks for our `arch_` prefix — a prefix
+ * test, so no secret is read — and skips a ChatGPT session (`auth_mode`), which
+ * Codex prefers over any stored key and which the user established themselves.
  */
 function codexProxyDisconnect(ctx: StartupGuardContext): string {
   const marker = `archestra:${ctx.proxy?.proxyName ?? ""}`;
   return `disconnect_proxy() {
-  CONFIG="$HOME/.codex/config.toml"
-  [ -f "$CONFIG" ] || return 0
-  awk -v start=${sh(`# >>> ${marker} >>>`)} -v end=${sh(`# <<< ${marker} <<<`)} '
-    $0 == start {skip=1; next}
-    $0 == end {skip=0; next}
-    !skip {print}
-  ' "$CONFIG" > "$CONFIG.archestra-tmp" 2>/dev/null && mv "$CONFIG.archestra-tmp" "$CONFIG"
+  CONFIG=${codexConfigShellPath()}
+  if [ -f "$CONFIG" ]; then
+    awk -v start=${sh(`# >>> ${marker} >>>`)} -v end=${sh(`# <<< ${marker} <<<`)} '
+      $0 == start {skip=1; next}
+      $0 == end {skip=0; next}
+      !skip {print}
+    ' "$CONFIG" > "$CONFIG.archestra-tmp" 2>/dev/null && mv "$CONFIG.archestra-tmp" "$CONFIG"
+  fi
+  codex_logout_if_ours
+}
+
+# Sign out ONLY when Codex is holding an ${ctx.appName} key. A user-owned
+# key (sk-…) or a ChatGPT session is left untouched: logout would delete it.
+codex_logout_if_ours() {
+  AUTH=${'"${CODEX_HOME:-$HOME/.codex}/auth.json"'}
+  [ -f "$AUTH" ] || return 0
+  grep -q '"auth_mode"[[:space:]]*:[[:space:]]*"chatgpt"' "$AUTH" 2>/dev/null && return 0
+  grep -q '"OPENAI_API_KEY"[[:space:]]*:[[:space:]]*"${ARCHESTRA_TOKEN_PREFIX}' "$AUTH" 2>/dev/null || return 0
+  command codex logout </dev/null >/dev/null 2>&1 || true
+  ARCH_LOGGED_OUT=1
 }
 
 proxy_disconnect_notes() {
   line_reset
-  printf '%s  Removed the ${ctx.appName} provider from ~/.codex/config.toml. If you signed Codex in with an ${ctx.appName} virtual key, run \`codex logout\` (then log back in) to restore your own credentials.%s\\n' "$C_DIM" "$C_RESET"
+  printf '%s  Removed the ${ctx.appName} provider from $CONFIG.%s\\n' "$C_DIM" "$C_RESET"
+  if [ "\${ARCH_LOGGED_OUT:-0}" = "1" ]; then
+    printf '%s  Signed Codex out of the ${ctx.appName} virtual key — run \`codex login\` to sign back in with your own account.%s\\n' "$C_DIM" "$C_RESET"
+  fi
   return 0
 }`;
 }

--- a/platform/backend/src/services/startup-guard.ts
+++ b/platform/backend/src/services/startup-guard.ts
@@ -152,6 +152,21 @@ export interface StartupGuardClient {
    */
   skillsDisconnectCommands: string;
   /**
+   * Optional proof that the `mcp)` removal actually took effect, run in the
+   * foreground after the silenced commands above.
+   *
+   * The removals delegate to the vendor CLI, whose exit status cannot answer
+   * "is it gone?": `codex mcp remove <missing>` exits 0 while
+   * `codex plugin marketplace remove <missing>` exits 1, so a zero exit proves
+   * nothing and a non-zero one may just mean "already absent". These snippets
+   * therefore check the client's config on disk instead. They must print their
+   * own reason and `return 1` when the entry survived; a client that omits
+   * them keeps the previous assume-success behaviour.
+   */
+  mcpDisconnectVerify?: string;
+  /** As `mcpDisconnectVerify`, for the `skills)` case. */
+  skillsDisconnectVerify?: string;
+  /**
    * The `disconnect_proxy()` and `proxy_disconnect_notes()` shell function
    * definitions, fully client-specific (settings.json strip / TOML block strip
    * / shell-profile export strip). Only emitted when a proxy is covered.
@@ -179,6 +194,16 @@ export interface StartupGuardWindowsClient {
    * and `$SkillsMarketplaceName`.
    */
   skillsDisconnect: string;
+  /**
+   * PowerShell body proving the `'mcp'` removal landed, for
+   * `Test-ArchDisconnected`. Must `return $false` (after setting
+   * `$Script:ArchDisconnectReason`) when the entry survived. See
+   * {@link StartupGuardClient.mcpDisconnectVerify} for why the vendor CLI's
+   * exit status cannot be used instead.
+   */
+  mcpDisconnectVerify?: string;
+  /** As `mcpDisconnectVerify`, for the `'skills'` case. */
+  skillsDisconnectVerify?: string;
   /**
    * Defines `function Disconnect-ArchProxy { … }` — the client-specific proxy
    * reversal (settings.json strip / config.toml block strip / env removal).
@@ -473,6 +498,31 @@ ${client.skillsDisconnectCommands}
   esac
 }
 
+# Proof that a removal landed. The vendor CLIs are delegated to with their
+# output silenced and their exit status is not a reliable signal, so the check
+# reads the client's config instead. Runs in the FOREGROUND (unlike
+# disconnect_actions) so a failing check can print why. Default: assume success,
+# which is every client that ships no verifier.
+disconnect_verify() { # $1 kind
+  case "$1" in${
+    ctx.mcp && client.mcpDisconnectVerify
+      ? `
+    mcp)
+${client.mcpDisconnectVerify}
+      ;;`
+      : ""
+  }${
+    ctx.skills && client.skillsDisconnectVerify
+      ? `
+    skills)
+${client.skillsDisconnectVerify}
+      ;;`
+      : ""
+  }
+  esac
+  return 0
+}
+
 # Reversing a connect step animates the same way the probes do: the commands
 # run in the background while the dots grow, then the row lands on a check.
 disconnect_resource() { # $1 kind, $2 label
@@ -487,6 +537,10 @@ disconnect_resource() { # $1 kind, $2 label
   done
   wait "$arch_dp" 2>/dev/null || true
   line_reset
+  if ! disconnect_verify "$1"; then
+    printf '%s✗ Could not disconnect %s%s\\n' "$C_ERR" "$2" "$C_RESET"
+    return 1
+  fi
   printf '%s✓%s Disconnected %s\\n' "$C_ACCENT" "$C_RESET" "$2"${
     ctx.proxy
       ? `
@@ -513,10 +567,20 @@ ${client.renderProxyDisconnect(ctx)}`
       : ""
   }
 
+# Set when any resource failed to disconnect, so the caller keeps the guard
+# installed instead of deleting the only thing that could retry.
+DISCONNECT_FAILED=0
+
 disconnect_and_forget() { # $@ = resource indices: reverse connect, then skip on later launches
   for i in "$@"; do
-    disconnect_resource "\${GUARD_KINDS[$i]}" "\${GUARD_LABELS[$i]}"
-    remember_disconnected "\${GUARD_KINDS[$i]}"
+    # Only a removal we could prove is recorded as done — remembering an
+    # unverified one would skip the resource on every later launch and strand
+    # the leftover permanently.
+    if disconnect_resource "\${GUARD_KINDS[$i]}" "\${GUARD_LABELS[$i]}"; then
+      remember_disconnected "\${GUARD_KINDS[$i]}"
+    else
+      DISCONNECT_FAILED=1
+    fi
   done
 }
 
@@ -654,7 +718,7 @@ prompt_down_all() {
     y|Y|'')
       GUARD_DWELL=1
       disconnect_and_forget $DOWN_IDXS
-      [ "$DOWN_COUNT" -ge "$ACTIVE_TOTAL" ] && uninstall_guard
+      [ "$DOWN_COUNT" -ge "$ACTIVE_TOTAL" ] && [ "$DISCONNECT_FAILED" = "0" ] && uninstall_guard
       ;;
     *)
       line_reset
@@ -798,7 +862,7 @@ if [ "$DISC_ALL" = "1" ]; then
   line_reset
   GUARD_DWELL=1
   disconnect_and_forget $ACTIVE_IDXS
-  uninstall_guard
+  [ "$DISCONNECT_FAILED" = "0" ] && uninstall_guard
   finish_guard
 fi
 if [ "$SKIP_ALL" = "1" ]; then

--- a/platform/backend/src/services/startup-guard.ts
+++ b/platform/backend/src/services/startup-guard.ts
@@ -588,10 +588,12 @@ disconnect_and_forget() { # $@ = resource indices: reverse connect, then skip on
 # Opened with [C] from the prompt under the rows. Every remote is already on
 # screen in a stable block, so the menu just re-decorates those rows in place
 # ([n] label) and reads number keys — no redraw, no layout jump. Pressing a
-# number disconnects that remote (reverse-of-connect, then remembered) and
-# lands its row on the purple check; Esc or Enter leaves and lets claude
-# start. Removing the last connected remote takes the guard with it. Rows
-# list every active remote regardless of reachability.
+# number disconnects that remote (reverse-of-connect, verified, then
+# remembered) and lands its row on the purple check — or on ✗ with its number
+# still live when the removal cannot be proven; Esc or Enter leaves and lets
+# claude start. Removing the last connected remote takes the guard with it,
+# but only when every removal was proven. Rows list every active remote
+# regardless of reachability.
 MENU_DONE=' '
 menu_at_row()    { printf '\\033[%dA\\r\\033[2K' "$((ACTIVE_TOTAL - $1 + 1))"; }
 menu_leave_row() { printf '\\033[%dB\\r' "$((ACTIVE_TOTAL - $1 + 1))"; }
@@ -616,9 +618,20 @@ menu_disconnect_row() { # $1 pos, $2 idx — animate the reversal on its own row
   done
   wait "$arch_dp" 2>/dev/null || true
   line_reset
+  # Same contract as disconnect_resource: only a removal we can prove lands
+  # the check and the skip-file entry. Verify output is suppressed because
+  # this line is repainted in place — the row itself carries the verdict,
+  # and an unproven removal keeps its number so it can be retried.
+  if ! disconnect_verify "\${GUARD_KINDS[$2]}" >/dev/null 2>&1; then
+    DISCONNECT_FAILED=1
+    printf '%s✗ Could not disconnect %s — [%s] to retry%s' "$C_ERR" "\${GUARD_LABELS[$2]}" "$1" "$C_RESET"
+    menu_leave_row "$1"
+    return 1
+  fi
   printf '%s✓%s Disconnected %s' "$C_ACCENT" "$C_RESET" "\${GUARD_LABELS[$2]}"
   menu_leave_row "$1"
   remember_disconnected "\${GUARD_KINDS[$2]}"
+  return 0
 }
 reconfigure_menu() {
   GUARD_DWELL=1
@@ -642,13 +655,13 @@ reconfigure_menu() {
         done
         [ -z "$menu_target" ] && continue
         case "$MENU_DONE" in *" $menu_target "*) continue ;; esac
-        menu_disconnect_row "$key" "$menu_target"
+        menu_disconnect_row "$key" "$menu_target" || continue
         MENU_DONE="$MENU_DONE$menu_target "
         menu_left=0
         for menu_idx in $ACTIVE_IDXS; do
           case "$MENU_DONE" in *" $menu_idx "*) ;; *) menu_left=$((menu_left + 1)) ;; esac
         done
-        if [ "$menu_left" -eq 0 ]; then
+        if [ "$menu_left" -eq 0 ] && [ "$DISCONNECT_FAILED" = "0" ]; then
           uninstall_guard
           break
         fi

--- a/platform/backend/src/services/startup-guard.windows.test.ts
+++ b/platform/backend/src/services/startup-guard.windows.test.ts
@@ -368,8 +368,12 @@ describe.each([
     binary: "codex",
     disableEnvVar: "ARCHESTRA_CODEX_GUARD",
     nonInteractive: "$a -eq 'exec'",
-    proxyConfig: ".codex\\config.toml",
-    proxyNote: "Removed the Archestra provider from ~/.codex/config.toml",
+    // Codex keeps its config wherever CODEX_HOME points, and the vendor CLI
+    // honours that — a hardcoded ~/.codex would edit a different file than the
+    // `codex mcp remove` beside it.
+    proxyConfig:
+      "$(if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE '.codex' })",
+    proxyNote: "Removed the Archestra provider from the Codex config.toml",
   },
   {
     name: "Copilot CLI",

--- a/platform/backend/src/services/startup-guard.windows.ts
+++ b/platform/backend/src/services/startup-guard.windows.ts
@@ -283,7 +283,16 @@ function Show-ArchDown($r) {
 
 function Get-ArchRealExe {
   # The profile wraps \`${client.binary}\` in a function, so resolve the real executable.
-  Get-Command -Name ${client.binary} -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+  # -CommandType Application matches PATHEXT executables only, which misses a
+  # .ps1/.cmd shim — and every delegated removal is a no-op when this returns
+  # nothing, so widen the search before giving up.
+  $found = Get-Command -Name ${client.binary} -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $found) {
+    $found = Get-Command -Name ${client.binary} -ErrorAction SilentlyContinue |
+      Where-Object { $_.CommandType -in @('Application', 'ExternalScript') } |
+      Select-Object -First 1
+  }
+  $found
 }
 
 # The reverse-of-connect commands for one remote, silenced. Shared by the
@@ -291,6 +300,12 @@ function Get-ArchRealExe {
 # per-kind bodies come straight from the client descriptor's \`windows\` half.
 function Invoke-ArchDisconnectActions([string]$Kind) {
   $archRealExe = Get-ArchRealExe
+  if (-not $archRealExe -and $Kind -ne 'proxy') {
+    # Nothing to delegate to: the removal cannot have happened. Say so rather
+    # than falling through the switch and reporting a success we never did.
+    $Script:ArchDisconnectReason = 'the ${client.binary} executable could not be found on PATH'
+    return $false
+  }
   switch ($Kind) {${
     ctx.mcp
       ? `
@@ -312,6 +327,29 @@ ${client.windows.skillsDisconnect}
       : ""
   }
   }
+  return (Test-ArchDisconnected $Kind)
+}
+
+# Proof that a removal landed. The vendor CLI is invoked with its output
+# silenced and its exit status is not a reliable signal — \`mcp remove\` of a
+# missing server exits 0 — so the check reads the config back instead. Clients
+# that ship no verifier keep the previous assume-success behaviour.
+function Test-ArchDisconnected([string]$Kind) {${
+    ctx.mcp && client.windows.mcpDisconnectVerify
+      ? `
+  if ($Kind -eq 'mcp') {
+${client.windows.mcpDisconnectVerify}
+  }`
+      : ""
+  }${
+    ctx.skills && client.windows.skillsDisconnectVerify
+      ? `
+  if ($Kind -eq 'skills') {
+${client.windows.skillsDisconnectVerify}
+  }`
+      : ""
+  }
+  return $true
 }
 
 # Reversing a connect step animates the same way the probes do: the dots
@@ -319,9 +357,18 @@ ${client.windows.skillsDisconnect}
 function Disconnect-ArchRemote([string]$Kind, [string]$Label) {
   Show-ArchSpinStart ('Disconnecting ' + $Label) ''
   for ($pad = 0; $pad -lt 2; $pad++) { Start-Sleep -Milliseconds $FrameSleepMs; Show-ArchSpinTick }
-  Invoke-ArchDisconnectActions $Kind
+  $Script:ArchDisconnectReason = ''
+  $archOk = Invoke-ArchDisconnectActions $Kind
   for ($pad = 0; $pad -lt 2; $pad++) { Start-Sleep -Milliseconds $FrameSleepMs; Show-ArchSpinTick }
   Clear-ArchLine
+  if (-not $archOk) {
+    Write-Arch '✗' Red -NoNewline
+    Write-Host (' Could not disconnect ' + $Label)
+    if ($Script:ArchDisconnectReason) {
+      Write-Arch ('  ' + $Script:ArchDisconnectReason) DarkYellow
+    }
+    return $false
+  }
   Write-Arch '✓' Magenta -NoNewline
   Write-Host (' Disconnected ' + $Label)${
     ctx.proxy && client.windows.proxyDisconnectNote(ctx)
@@ -332,14 +379,22 @@ function Disconnect-ArchRemote([string]$Kind, [string]$Label) {
   }`
       : ""
   }
+  return $true
 }
 
 ${ctx.proxy ? client.windows.renderProxyDisconnect(ctx) : ""}
 
 function Disconnect-ArchRemotes($remotes) { # reverse connect, then skip on later launches
+  $Script:ArchDisconnectFailed = $false
   foreach ($r in $remotes) {
-    Disconnect-ArchRemote $r.Kind $r.Label
-    Add-ArchDisconnected $r.Kind
+    # Only a removal we could prove is recorded as done — remembering an
+    # unverified one would skip the resource on every later launch and strand
+    # the leftover permanently.
+    if (Disconnect-ArchRemote $r.Kind $r.Label) {
+      Add-ArchDisconnected $r.Kind
+    } else {
+      $Script:ArchDisconnectFailed = $true
+    }
   }
 }
 
@@ -522,7 +577,7 @@ function Show-ArchDownSummaryPrompt($downRemotes) {
   if ($choice -eq 'y') {
     $Script:Dwell = $true
     Disconnect-ArchRemotes $downRemotes
-    if ($downRemotes.Count -ge $ActiveRemotes.Count) { Remove-ArchGuard }
+    if ($downRemotes.Count -ge $ActiveRemotes.Count -and -not $Script:ArchDisconnectFailed) { Remove-ArchGuard }
     return
   }
   Clear-ArchLine
@@ -667,7 +722,7 @@ if ($Script:DiscAll) {
   Clear-ArchLine
   $Script:Dwell = $true
   Disconnect-ArchRemotes $ActiveRemotes
-  Remove-ArchGuard
+  if (-not $Script:ArchDisconnectFailed) { Remove-ArchGuard }
   Exit-ArchGuard
 }
 if ($Script:SkipAll) {

--- a/platform/backend/src/services/startup-guard.windows.ts
+++ b/platform/backend/src/services/startup-guard.windows.ts
@@ -402,11 +402,13 @@ function Disconnect-ArchRemotes($remotes) { # reverse connect, then skip on late
 # Opened with [C] from the prompt under the rows. Every remote is already on
 # screen in a stable block, so the menu just re-decorates those rows in place
 # ([n] label) and reads number keys — no redraw, no layout jump. Pressing a
-# number disconnects that remote (reverse-of-connect, then remembered) and
-# lands its row on the purple check; Esc or Enter leaves and lets claude
-# start. Removing the last connected remote takes the guard with it. Rows
-# list every active remote regardless of reachability. VT uses relative
-# cursor moves off the block; legacy consoles use absolute positioning.
+# number disconnects that remote (reverse-of-connect, verified, then
+# remembered) and lands its row on the purple check — or on ✗ with its number
+# still live when the removal cannot be proven; Esc or Enter leaves and lets
+# claude start. Removing the last connected remote takes the guard with it,
+# but only when every removal was proven. Rows list every active remote
+# regardless of reachability. VT uses relative cursor moves off the block;
+# legacy consoles use absolute positioning.
 function Move-ArchRowStart([int]$i, [int]$count, [int]$baseTop) {
   if ($UseVt) { Write-Host -NoNewline ("$Esc[" + ($count - $i) + "A\`r$Esc[2K") }
   else { try { [Console]::SetCursorPosition(0, $baseTop - $count + $i) } catch { }; Clear-ArchLine }
@@ -432,13 +434,24 @@ function Disconnect-ArchMenuRow([int]$i, [int]$count, [int]$baseTop) {
   Move-ArchRowStart $i $count $baseTop
   Show-ArchSpinStart ('Disconnecting ' + $r.Label) ''
   for ($p = 0; $p -lt 2; $p++) { Start-Sleep -Milliseconds $FrameSleepMs; Show-ArchSpinTick }
-  Invoke-ArchDisconnectActions $r.Kind
+  $Script:ArchDisconnectReason = ''
+  $archOk = Invoke-ArchDisconnectActions $r.Kind
   for ($p = 0; $p -lt 2; $p++) { Start-Sleep -Milliseconds $FrameSleepMs; Show-ArchSpinTick }
   Clear-ArchLine
+  if (-not $archOk) {
+    # Same contract as Disconnect-ArchRemote: only a removal we can prove
+    # lands the check and the skip-file entry. The row carries the verdict
+    # (the reason line has no room here) and keeps its number for a retry.
+    $Script:ArchDisconnectFailed = $true
+    Write-Arch ('✗ Could not disconnect ' + $r.Label + ' — [' + ($i + 1) + '] to retry') Red -NoNewline
+    Move-ArchRowEnd $i $count $baseTop
+    return $false
+  }
   Write-Arch '✓' Magenta -NoNewline
   Write-Host -NoNewline (' Disconnected ' + $r.Label)
   Move-ArchRowEnd $i $count $baseTop
   Add-ArchDisconnected $r.Kind
+  return $true
 }
 function Show-ArchMenuRowResult([int]$i, [int]$count, [int]$baseTop) {
   $r = $ActiveRemotes[$i]
@@ -482,9 +495,9 @@ function Invoke-ArchReconfigureMenu {
     if ([int]::TryParse([string]$k.KeyChar, [ref]$d) -and $d -ge 1 -and $d -le $count) {
       $r = $ActiveRemotes[$d - 1]
       if ($done.ContainsKey($r.Kind)) { continue }
-      Disconnect-ArchMenuRow ($d - 1) $count $baseTop
+      if (-not (Disconnect-ArchMenuRow ($d - 1) $count $baseTop)) { continue }
       $done[$r.Kind] = $true
-      if ($done.Count -ge $count) { Remove-ArchGuard; break }
+      if ($done.Count -ge $count -and -not $Script:ArchDisconnectFailed) { Remove-ArchGuard; break }
     }
   }
   Clear-ArchMenuFooter $baseTop


### PR DESCRIPTION
## The bug

Removing the Archestra configuration from a client via the startup guard's disconnect left Archestra behind. The live report: after "remove all" on a Codex install, `[mcp_servers.<gateway>]` and `[marketplaces.<skills>]` survived in `config.toml`, and every plain `codex` run then died with `401 Incorrect API key provided: arch_…` against api.openai.com.

Two independent causes, and the same shape exists in all three guarded clients (Claude Code, Codex, Copilot CLI) on both platforms.

### 1. Fabricated success

The gateway and marketplace removals delegate to the vendor CLI — correctly, since the CLI owns its config (and, verified live, `codex mcp remove` also reaps nested `[mcp_servers.<gw>.tools.*]` sub-tables a hand-rolled stripper would strand). But nothing looked at the result: output discarded, and on Windows an unresolved `$archRealExe` made the whole arm a silent no-op (`Get-Command -CommandType Application` misses `.ps1`/`.cmd` shims). The guard then printed `✓ Disconnected`, recorded the kind in its skip file so later launches never re-check it, and **deleted itself** — reporting success it never checked, then destroying the only mechanism that could retry.

### 2. The credential outlives its base_url

Codex connect writes a pair: `base_url` inside the marker block in `config.toml`, and an `arch_` key into Codex's own credential store via `codex login --with-api-key`. Disconnect removed only the block. That is backwards — the block is **inert** until the user opts in with `codex -c model_provider=…`, while the credential is **global**. So disconnect left Codex more broken than before it was ever connected, shipping an Archestra virtual key to a third party on every launch.

## The fix

**Verify, don't assume.** The guard now reads each client's config back after the delegated removal and refuses to report a removal it cannot prove. Exit codes cannot answer this — measured: `codex mcp remove <missing>` exits 0 while `codex plugin marketplace remove <missing>` exits 1. Per client:

| Client | Gateway check | Marketplace check |
|---|---|---|
| Claude Code | `mcpServers` in `~/.claude.json` (honors `CLAUDE_CONFIG_DIR`) | `plugins/known_marketplaces.json` |
| Codex | `[mcp_servers.<name>]` in `config.toml` (honors `CODEX_HOME`) | `[marketplaces.<name>]` |
| Copilot CLI | `mcpServers` in `~/.copilot/mcp-config.json` | `extraKnownMarketplaces` in `~/.copilot/settings.json` |

JSON configs are parsed (python3 on POSIX, skipped when absent; `ConvertFrom-Json` on Windows), never grepped — `~/.claude.json` carries per-project state where a server name can appear in ordinary strings, and a false "still present" would block the guard's self-uninstall forever. An unreadable config passes: the failure path fires only on proof.

**A failed removal is now a visible failure.** `✗ Could not disconnect …` with the exact command to run by hand; the kind is *not* recorded in the skip file, and the guard does *not* uninstall itself while any removal failed.

**The credential is reversed — carefully.** Verified live: `codex logout` deletes `auth.json` wholesale, so a blanket logout would destroy a user's ChatGPT session. The guard signs out only when the stored key is ours (`arch_` prefix — a prefix test, no secret read) and never when `auth_mode` is `chatgpt`. Windows and POSIX both.

**Windows binary resolution widened** past `-CommandType Application`, and a still-unresolved binary is reported as the failure it is instead of silently skipping the removal.

**Codex's backup is now genuinely pre-Archestra.** It previously ran inside the proxy section, *after* `codex mcp add` had edited the file — so the "pristine" copy already contained an Archestra gateway (confirmed on two live machines), and restoring it would re-install what the user removed. It now runs before the first codex CLI call, covers mcp/skills-only connects, and honors `CODEX_HOME` like the CLI it drives.

**Docs**: three references to the Disconnect panel (removed from the connect flow in an earlier release) now describe the startup guard's reconfigure menu; Codex revert steps include `codex logout` for virtual-key logins; Cursor is documented as having no automated reversal.

## Not in scope, noted

- Each connect overwrites the guard with only the current names, orphaning names from earlier connects — needs a manifest design, filed separately.
- `node_repl` startup failures from the original report are an OpenAI Codex desktop misconfiguration (a `/mnt/c/...` path written by its own WSL integration, present byte-identical in the pre-Archestra backup) — not Archestra's, and unaffected by disconnects.

## Tests

Tests execute the generated shell rather than string-matching it: extracted guard functions run against a throwaway home with fixture configs and a fake client CLI on PATH that logs its argv. Every one of these defects was "the code ran and did nothing", which text assertions cannot distinguish from success.

- 22 executed-shell tests across the three clients (leftover detected + named fix, foreign entries survive, config-relocation honored, unreadable config passes, credential signed out only when ours)
- Ordering pins for the backup on both platforms
- All 22 fail without the fix (11 per commit, verified by reverting)
- 208 green across the guard and connection suites; `tsc`, `biome`, `knip` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>