### PR TITLE
fix(frontend): show searchable select results from the top when the query changes

### DIFF
--- a/platform/frontend/src/components/ui/command.test.tsx
+++ b/platform/frontend/src/components/ui/command.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "./command";
+
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as typeof ResizeObserver;
+  // cmdk reveals its selected item this way; jsdom has no layout, so the call
+  // only needs to exist.
+  Element.prototype.scrollIntoView = () => {};
+});
+
+const MODELS = [
+  "Claude Opus 5",
+  "Claude Opus 4.5",
+  "GPT-5.6 Sol Pro",
+  "Kimi K2 0905",
+  "Step 3.5 Flash",
+];
+
+function renderPicker(options: string[] = MODELS) {
+  const view = render(
+    <Command>
+      <CommandInput placeholder="Search models..." />
+      <CommandList>
+        <CommandEmpty>No models found.</CommandEmpty>
+        {options.map((name) => (
+          <CommandItem key={name} value={name}>
+            {name}
+          </CommandItem>
+        ))}
+      </CommandList>
+    </Command>,
+  );
+  const list = view.container.querySelector("[cmdk-list]") as HTMLElement;
+  const input = view.container.querySelector("[cmdk-input]") as HTMLElement;
+  return { ...view, list, input };
+}
+
+describe("CommandList", () => {
+  // The results a query produces are ranked best-first, so a container left at
+  // its previous offset hides exactly the rows the user searched for.
+  it("returns to the top of the list when the query changes", async () => {
+    const { list, input } = renderPicker();
+    list.scrollTop = 480;
+
+    fireEvent.change(input, { target: { value: "opus" } });
+
+    await waitFor(() => expect(list.scrollTop).toBe(0));
+  });
+
+  it("returns to the top again when the query is cleared", async () => {
+    const { list, input } = renderPicker();
+    fireEvent.change(input, { target: { value: "opus" } });
+    await waitFor(() => expect(list.scrollTop).toBe(0));
+
+    list.scrollTop = 260;
+    fireEvent.change(input, { target: { value: "" } });
+
+    await waitFor(() => expect(list.scrollTop).toBe(0));
+  });
+
+  // Only a new query means a new list. Rerenders that leave the query alone —
+  // options arriving from a fetch, say — must not yank the user's scroll
+  // position back, and neither must the first render, which is when cmdk
+  // reveals an already-selected item.
+  it("leaves the scroll position alone when the query is unchanged", async () => {
+    const { list, input, rerender } = renderPicker();
+    fireEvent.change(input, { target: { value: "claude" } });
+    await waitFor(() => expect(list.scrollTop).toBe(0));
+
+    list.scrollTop = 320;
+    rerender(
+      <Command>
+        <CommandInput placeholder="Search models..." />
+        <CommandList>
+          <CommandEmpty>No models found.</CommandEmpty>
+          {[...MODELS, "Claude Fable Latest"].map((name) => (
+            <CommandItem key={name} value={name}>
+              {name}
+            </CommandItem>
+          ))}
+        </CommandList>
+      </Command>,
+    );
+
+    await waitFor(() =>
+      expect(
+        document.querySelectorAll("[cmdk-item]:not([hidden])").length,
+      ).toBeGreaterThan(0),
+    );
+    expect(list.scrollTop).toBe(320);
+  });
+});

--- a/platform/frontend/src/components/ui/command.tsx
+++ b/platform/frontend/src/components/ui/command.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Command as CommandPrimitive } from "cmdk";
+import { Command as CommandPrimitive, useCommandState } from "cmdk";
 import { SearchIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 import {
   Dialog,
   DialogContent,
@@ -97,11 +97,46 @@ function CommandInput({
 
 function CommandList({
   className,
+  ref,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.List>) {
+  const search = useCommandState((state) => state.search);
+  const listRef = React.useRef<HTMLDivElement | null>(null);
+  const lastSearch = React.useRef(search);
+
+  /**
+   * A new query is a new result list, so show it from the top. cmdk itself
+   * only ever scrolls this container toward the row it has marked selected —
+   * which it reads from the DOM one render behind, so typing either scrolls
+   * to where the *previous* top match landed in the re-ranked list or leaves
+   * the container parked at a stale offset. Either way the best matches
+   * render above the fold and the results read as irrelevant.
+   *
+   * Must stay a passive effect: cmdk performs its scroll in a layout effect,
+   * and this has to run after it to win. Skips the first render so a list
+   * that opens with a selection still reveals it.
+   */
+  React.useEffect(() => {
+    if (lastSearch.current === search) {
+      return;
+    }
+    lastSearch.current = search;
+    if (listRef.current) {
+      listRef.current.scrollTop = 0;
+    }
+  }, [search]);
+
   return (
     <CommandPrimitive.List
       data-slot="command-list"
+      ref={(node) => {
+        listRef.current = node;
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      }}
       className={cn(
         "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
         className,

--- a/platform/frontend/src/components/ui/multi-select-combobox.tsx
+++ b/platform/frontend/src/components/ui/multi-select-combobox.tsx
@@ -47,6 +47,17 @@ export function MultiSelectCombobox({
   const inputRef = React.useRef<HTMLInputElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+
+  // The search input lives in the popover anchor, outside the Command, so
+  // CommandList's own show-from-the-top-on-query-change reset never fires
+  // here (cmdk's search state stays empty). Same rule, applied by hand: a
+  // new query must not keep the old scroll offset.
+  React.useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = 0;
+    }
+  }, [search]);
 
   const selectedOptions = options.filter((opt) => value.includes(opt.value));
 
@@ -170,7 +181,7 @@ export function MultiSelectCombobox({
         onInteractOutside={(e) => e.preventDefault()}
       >
         <Command shouldFilter={false}>
-          <CommandList>
+          <CommandList ref={listRef}>
             <CommandEmpty>{emptyMessage}</CommandEmpty>
             <CommandGroup>
               {options

--- a/platform/frontend/src/components/ui/multi-select-combobox.tsx
+++ b/platform/frontend/src/components/ui/multi-select-combobox.tsx
@@ -53,7 +53,12 @@ export function MultiSelectCombobox({
   // CommandList's own show-from-the-top-on-query-change reset never fires
   // here (cmdk's search state stays empty). Same rule, applied by hand: a
   // new query must not keep the old scroll offset.
+  const lastSearch = React.useRef(search);
   React.useEffect(() => {
+    if (lastSearch.current === search) {
+      return;
+    }
+    lastSearch.current = search;
     if (listRef.current) {
       listRef.current.scrollTop = 0;
     }


### PR DESCRIPTION
## Summary
- Typing in the chat model selector (and other cmdk-based searchable selects) scrolled the option list on its own, hiding the top — most relevant — results.
- Root cause: cmdk only ever scrolls its list toward the row it has marked selected, which it reads from the DOM one render behind its own re-ranking. So typing scrolls toward where the *previous* top match landed in the new order, or not at all, leaving the container parked at a stale offset.
- Fix: reset `CommandList`'s scroll to the top whenever the cmdk search query changes (passive effect, runs after cmdk's own layout-effect scroll so it wins). Lives in the shared `ui/command.tsx`, so every cmdk-based select in the app is covered. `MultiSelectCombobox` keeps its search input outside the `Command` where cmdk can't see it, so it applies the same reset by hand.
- Deliberately minimal: no change to filtering/ranking/relevance, no restructuring of how results are computed — only where the list scrolls to when the results change.

Task: T-1020

## Test plan
- [x] New test (`command.test.tsx`) pins: scroll resets to top on query change, resets again on clearing, and does *not* reset on an unrelated rerender with the query unchanged.
- [x] `pnpm vitest run` (frontend, full suite) green.
- [x] `pnpm type-check` / `pnpm lint` clean on changed files.
- [x] Manually verified on a live dev stack against a 367-model catalog: typing (with or without scrolling the list first) now shows the top match at the top with the list at `scrollTop: 0`; keyboard selection still lands on the first visible result.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>