### PR TITLE
fix(secrets): diagnosable Vault failures + AWS IAM re-auth on 4xx

### DIFF
--- a/platform/backend/src/observability/error-tracking-policy.test.ts
+++ b/platform/backend/src/observability/error-tracking-policy.test.ts
@@ -219,4 +219,18 @@ describe("classifyErrorForTracking", () => {
       secrets_backend_error: "403: permission denied",
     });
   });
+
+  test("truncates unbounded backend error strings in the tag", () => {
+    const error = new ApiError(
+      503,
+      "An error occurred while accessing secrets. Please try again later or contact your administrator.",
+      SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+    );
+    error.cause = {
+      response: { statusCode: 500, body: { errors: ["x".repeat(1000)] } },
+    };
+    const decision = classifyErrorForTracking(error);
+    expect(decision.tags?.secrets_backend_error).toHaveLength(200);
+    expect(decision.tags?.secrets_backend_error).toMatch(/^500: x+$/);
+  });
 });

--- a/platform/backend/src/observability/error-tracking-policy.test.ts
+++ b/platform/backend/src/observability/error-tracking-policy.test.ts
@@ -200,4 +200,23 @@ describe("classifyErrorForTracking", () => {
       SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
     ]);
   });
+
+  test("surfaces the secrets backend's own error from the chained cause", () => {
+    // The user-facing message is generic by design; the tag is what makes a
+    // captured secrets outage diagnosable without access to server logs.
+    const error = new ApiError(
+      503,
+      "An error occurred while accessing secrets. Please try again later or contact your administrator.",
+      SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+    );
+    error.cause = {
+      response: { statusCode: 403, body: { errors: ["permission denied"] } },
+    };
+    const decision = classifyErrorForTracking(error);
+    expect(decision.report).toBe(true);
+    expect(decision.tags).toMatchObject({
+      error_type: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+      secrets_backend_error: "403: permission denied",
+    });
+  });
 });

--- a/platform/backend/src/observability/error-tracking-policy.ts
+++ b/platform/backend/src/observability/error-tracking-policy.ts
@@ -85,8 +85,13 @@ export function classifyErrorForTracking(
       fingerprint: [SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE],
       tags: {
         error_type: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+        // Truncate explicitly: Vault error strings are unbounded, and
+        // exception sinks silently clip over-long tag values.
         ...(error.cause !== undefined && {
-          secrets_backend_error: extractVaultErrorMessage(error.cause),
+          secrets_backend_error: extractVaultErrorMessage(error.cause).slice(
+            0,
+            200,
+          ),
         }),
       },
     };

--- a/platform/backend/src/observability/error-tracking-policy.ts
+++ b/platform/backend/src/observability/error-tracking-policy.ts
@@ -3,6 +3,7 @@ import {
   getTransientDbErrorCode,
   isDbStatementTimeoutError,
 } from "@/database/retry";
+import { extractVaultErrorMessage } from "@/secrets-manager/utils";
 import { ApiError, SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
 import {
   collectErrorCodes,
@@ -72,6 +73,9 @@ export function classifyErrorForTracking(
 
   // A secrets-backend (e.g. Vault) outage fails every route that reads secrets,
   // fragmenting one incident into an issue per endpoint and upstream message.
+  // The user-facing message is deliberately generic, so surface the backend's
+  // actual response (status code + error strings, never secret material) from
+  // the chained cause — otherwise the captured issue is undiagnosable.
   if (
     error instanceof ApiError &&
     error.internalCode === SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE
@@ -79,7 +83,12 @@ export function classifyErrorForTracking(
     return {
       report: true,
       fingerprint: [SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE],
-      tags: { error_type: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE },
+      tags: {
+        error_type: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+        ...(error.cause !== undefined && {
+          secrets_backend_error: extractVaultErrorMessage(error.cause),
+        }),
+      },
     };
   }
 

--- a/platform/backend/src/secrets-manager/secrets-manager.test.ts
+++ b/platform/backend/src/secrets-manager/secrets-manager.test.ts
@@ -32,6 +32,8 @@ describe("SecretsManager", async () => {
   // biome-ignore lint/style/noRestrictedImports: dynamic import
   const ReadonlyVaultSecretManager = (await import("./readonly-vault.ee"))
     .default;
+  // biome-ignore lint/style/noRestrictedImports: dynamic import
+  const { VaultClient } = await import("./vault-client.ee");
 
   describe("getSecretsManagerTypeBasedOnEnvVars", () => {
     const originalEnv = process.env;
@@ -926,12 +928,15 @@ describe("SecretsManager", async () => {
 
         // A secrets-backend failure is an upstream outage, not an app bug:
         // it must surface as a retryable 503 tagged with the internal code
-        // that error tracking uses to group one outage into one issue.
+        // that error tracking uses to group one outage into one issue. The
+        // original error must ride along as `cause` — the user-facing message
+        // is generic, so the cause is the only diagnosable detail.
         await expect(vaultManager.getSecret(created.id)).rejects.toMatchObject({
           statusCode: 503,
           internalCode: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
           message:
             "An error occurred while accessing secrets. Please try again later or contact your administrator.",
+          cause: expect.objectContaining({ message: "Vault unavailable" }),
         });
 
         // Cleanup
@@ -1251,6 +1256,92 @@ describe("SecretsManager", async () => {
         expect(updated).not.toBeNull();
         expect(updated?.isByosVault).toBe(false);
       });
+    });
+  });
+
+  describe("VaultClient token refresh on 4xx", () => {
+    const baseConfig = {
+      address: "http://localhost:8200",
+      kvVersion: "2" as const,
+      secretPath: "secret/data/archestra",
+      k8sTokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+      k8sMountPoint: "kubernetes",
+      awsMountPoint: "aws",
+      awsRegion: "us-east-1",
+      awsStsEndpoint: "https://sts.amazonaws.com",
+    };
+    const vault403 = {
+      response: { statusCode: 403, body: { errors: ["permission denied"] } },
+    };
+
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      // Static env credentials so AWS IAM login resolves credentials from the
+      // environment without touching network credential providers.
+      process.env = {
+        ...originalEnv,
+        AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE",
+        AWS_SECRET_ACCESS_KEY: "test-secret-key",
+      };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    test("re-authenticates and retries once on 4xx with AWS IAM auth", async () => {
+      // A 4xx mid-session typically means the login-issued client token
+      // expired; a fresh login must transparently recover the operation.
+      mockVaultClient.write
+        .mockResolvedValueOnce({ auth: { client_token: "token-1" } })
+        .mockResolvedValueOnce({ auth: { client_token: "token-2" } });
+      mockVaultClient.read
+        .mockRejectedValueOnce(vault403)
+        .mockResolvedValueOnce({ data: { data: { value: "s3cret" } } });
+
+      const client = new VaultClient({
+        ...baseConfig,
+        authMethod: "aws" as const,
+        awsRole: "archestra-role",
+      });
+
+      const result = await client.getSecretFromPath(
+        "secret/data/archestra/foo",
+      );
+
+      expect(result).toEqual({ value: "s3cret" });
+      expect(mockVaultClient.read).toHaveBeenCalledTimes(2);
+      expect(mockVaultClient.write).toHaveBeenCalledTimes(2);
+      expect(mockVaultClient.write).toHaveBeenNthCalledWith(
+        2,
+        "auth/aws/login",
+        expect.anything(),
+      );
+    });
+
+    test("does not retry on 4xx with static token auth", async () => {
+      // A static token cannot be refreshed, so the 4xx must propagate
+      // immediately instead of looping through a pointless retry.
+      mockVaultClient.read.mockRejectedValueOnce(vault403);
+
+      const client = new VaultClient({
+        ...baseConfig,
+        authMethod: "token" as const,
+        token: "dev-root-token",
+      });
+
+      await expect(
+        client.getSecretFromPath("secret/data/archestra/foo"),
+      ).rejects.toMatchObject({
+        statusCode: 503,
+        internalCode: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+        message: "403: permission denied",
+      });
+
+      expect(mockVaultClient.read).toHaveBeenCalledTimes(1);
+      expect(mockVaultClient.write).not.toHaveBeenCalled();
     });
   });
 });

--- a/platform/backend/src/secrets-manager/secrets-manager.test.ts
+++ b/platform/backend/src/secrets-manager/secrets-manager.test.ts
@@ -17,6 +17,7 @@ const mockVaultClient = vi.hoisted(() => ({
   write: vi.fn(),
   read: vi.fn(),
   delete: vi.fn(),
+  list: vi.fn(),
   kubernetesLogin: vi.fn(),
 }));
 
@@ -1048,6 +1049,25 @@ describe("SecretsManager", async () => {
         await SecretModel.delete(created.id);
       });
     });
+
+    describe("checkConnectivity", () => {
+      test("chains the underlying error as cause on failure", async () => {
+        const vaultManager = new VaultSecretManager(vaultConfig);
+
+        mockVaultClient.list.mockRejectedValueOnce({
+          response: { statusCode: 503, body: { errors: ["Vault is sealed"] } },
+        });
+
+        await expect(vaultManager.checkConnectivity()).rejects.toMatchObject({
+          statusCode: 503,
+          internalCode: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+          message: "503: Vault is sealed",
+          cause: expect.objectContaining({
+            response: expect.objectContaining({ statusCode: 503 }),
+          }),
+        });
+      });
+    });
   });
 
   describe("VaultSecretManager with KV v1", () => {
@@ -1332,7 +1352,9 @@ describe("SecretsManager", async () => {
         ...baseConfig,
         authMethod: "kubernetes" as const,
         k8sRole: "archestra-role",
-        // Any readable file works as the SA token for a mocked login.
+        // The SA token file is really read (fs.readFile runs before the
+        // mocked kubernetesLogin call), so it must exist — its content is
+        // then discarded by the mock. Any readable file works.
         k8sTokenPath: "./package.json",
       });
 

--- a/platform/backend/src/secrets-manager/secrets-manager.test.ts
+++ b/platform/backend/src/secrets-manager/secrets-manager.test.ts
@@ -17,6 +17,7 @@ const mockVaultClient = vi.hoisted(() => ({
   write: vi.fn(),
   read: vi.fn(),
   delete: vi.fn(),
+  kubernetesLogin: vi.fn(),
 }));
 
 vi.mock("node-vault", () => {
@@ -1319,6 +1320,29 @@ describe("SecretsManager", async () => {
         "auth/aws/login",
         expect.anything(),
       );
+    });
+
+    test("surfaces the Vault detail when Kubernetes login itself fails", async () => {
+      // The login failure crosses two boundaries (loginWithKubernetes →
+      // ensureInitialized → the operation's error handler); none of them may
+      // flatten the Vault response to a generic "Connection failed".
+      mockVaultClient.kubernetesLogin.mockRejectedValueOnce(vault403);
+
+      const client = new VaultClient({
+        ...baseConfig,
+        authMethod: "kubernetes" as const,
+        k8sRole: "archestra-role",
+        // Any readable file works as the SA token for a mocked login.
+        k8sTokenPath: "./package.json",
+      });
+
+      await expect(
+        client.getSecretFromPath("secret/data/archestra/foo"),
+      ).rejects.toMatchObject({
+        statusCode: 503,
+        internalCode: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+        message: "403: permission denied",
+      });
     });
 
     test("does not retry on 4xx with static token auth", async () => {

--- a/platform/backend/src/secrets-manager/utils.ts
+++ b/platform/backend/src/secrets-manager/utils.ts
@@ -1,3 +1,4 @@
+import { ApiError } from "@archestra/shared";
 import type { SecretStorageType } from "@/types";
 
 /**
@@ -5,6 +6,17 @@ import type { SecretStorageType } from "@/types";
  * Returns only the Vault response details (status code and errors array)
  */
 export function extractVaultErrorMessage(error: unknown): string {
+  // An already-wrapped ApiError carries no Vault `.response`: its detail is
+  // the original error chained as `cause`, or failing that its own message.
+  // Without this, a wrapped error flattens to "Connection failed" at every
+  // boundary that re-extracts (e.g. ensureInitialized re-wrapping a login
+  // failure).
+  if (error instanceof ApiError) {
+    return error.cause !== undefined
+      ? extractVaultErrorMessage(error.cause)
+      : error.message;
+  }
+
   const vaultErr = error as {
     response?: { statusCode?: number; body?: { errors?: string[] } };
   };

--- a/platform/backend/src/secrets-manager/vault-client.ee.ts
+++ b/platform/backend/src/secrets-manager/vault-client.ee.ts
@@ -246,11 +246,13 @@ export class VaultClient {
       this.initialized = true;
     } catch (error) {
       logger.error({ error }, "VaultClient: initialization failed");
-      throw new ApiError(
+      const apiError = new ApiError(
         503,
         extractVaultErrorMessage(error),
         SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
       );
+      apiError.cause = error;
+      throw apiError;
     }
   }
 
@@ -455,11 +457,9 @@ export class VaultClient {
         { error, tokenPath, role: this.config.k8sRole },
         "VaultClient: Kubernetes authentication failed",
       );
-      throw new ApiError(
-        503,
-        extractVaultErrorMessage(error),
-        SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
-      );
+      // Throw raw (like loginWithAws): ensureInitialized owns the single
+      // ApiError wrap, so wrapping here would only bury the Vault detail.
+      throw error;
     }
   }
 

--- a/platform/backend/src/secrets-manager/vault-client.ee.ts
+++ b/platform/backend/src/secrets-manager/vault-client.ee.ts
@@ -83,7 +83,7 @@ export class VaultClient {
     const listPath = this.getListPath(folderPath);
 
     try {
-      const result = await this.executeWithK8sTokenRefresh(
+      const result = await this.executeWithTokenRefresh(
         () => this.client.list(listPath),
         "listSecretsInFolder",
       );
@@ -137,7 +137,7 @@ export class VaultClient {
     }
 
     try {
-      const vaultResponse = await this.executeWithK8sTokenRefresh(
+      const vaultResponse = await this.executeWithTokenRefresh(
         () => this.client.read(vaultPath),
         "getSecretFromPath",
       );
@@ -180,7 +180,7 @@ export class VaultClient {
     const listPath = this.getListPath(folderPath);
 
     try {
-      const result = await this.executeWithK8sTokenRefresh(
+      const result = await this.executeWithTokenRefresh(
         () => this.client.list(listPath),
         "checkFolderConnectivity",
       );
@@ -268,11 +268,13 @@ export class VaultClient {
       throw error;
     }
 
-    throw new ApiError(
+    const apiError = new ApiError(
       503,
       extractVaultErrorMessage(error),
       SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
     );
+    apiError.cause = error;
+    throw apiError;
   }
 
   /**
@@ -289,51 +291,51 @@ export class VaultClient {
   }
 
   /**
-   * Write data to a Vault path with auth and K8s token refresh.
+   * Write data to a Vault path with auth and token refresh.
    */
   protected async writeToPath(
     path: string,
     payload: Record<string, unknown>,
   ): Promise<void> {
     await this.ensureInitialized();
-    await this.executeWithK8sTokenRefresh(
+    await this.executeWithTokenRefresh(
       () => this.client.write(path, payload),
       "writeToPath",
     );
   }
 
   /**
-   * Delete a secret at a Vault path with auth and K8s token refresh.
+   * Delete a secret at a Vault path with auth and token refresh.
    */
   protected async deleteAtPath(path: string): Promise<void> {
     await this.ensureInitialized();
-    await this.executeWithK8sTokenRefresh(
+    await this.executeWithTokenRefresh(
       () => this.client.delete(path),
       "deleteAtPath",
     );
   }
 
   /**
-   * Read a secret from a Vault path with auth and K8s token refresh.
+   * Read a secret from a Vault path with auth and token refresh.
    */
   protected async readFromPath(
     path: string,
   ): Promise<{ data: Record<string, unknown> }> {
     await this.ensureInitialized();
-    return await this.executeWithK8sTokenRefresh(
+    return await this.executeWithTokenRefresh(
       () => this.client.read(path),
       "readFromPath",
     );
   }
 
   /**
-   * List keys at a Vault path with auth and K8s token refresh.
+   * List keys at a Vault path with auth and token refresh.
    * Returns an empty array if the path does not exist (404).
    */
   protected async listKeysAtPath(path: string): Promise<string[]> {
     await this.ensureInitialized();
     try {
-      const result = await this.executeWithK8sTokenRefresh(
+      const result = await this.executeWithTokenRefresh(
         () => this.client.list(path),
         "listKeysAtPath",
       );
@@ -387,27 +389,28 @@ export class VaultClient {
   }
 
   /**
-   * Execute a Vault operation with automatic token refresh for K8s auth.
-   * If a 4xx error occurs and K8s auth is used, re-authenticate and retry once.
+   * Execute a Vault operation with automatic token refresh.
+   * If a 4xx error occurs under an auth method that can mint a fresh client
+   * token (Kubernetes or AWS IAM login), re-authenticate and retry once.
+   * Static token auth has nothing to refresh, so its errors propagate as-is.
    */
-  private async executeWithK8sTokenRefresh<T>(
+  private async executeWithTokenRefresh<T>(
     operation: () => Promise<T>,
     operationName: string,
   ): Promise<T> {
     try {
       return await operation();
     } catch (error) {
-      // Only retry for K8s auth method and 4xx errors
-      if (
-        this.config.authMethod !== "kubernetes" ||
-        !this.isVault4xxError(error)
-      ) {
+      const canReauthenticate =
+        this.config.authMethod === "kubernetes" ||
+        this.config.authMethod === "aws";
+      if (!canReauthenticate || !this.isVault4xxError(error)) {
         throw error;
       }
 
       logger.info(
-        { operationName },
-        "VaultClient: received 4xx error with K8s auth, re-authenticating",
+        { operationName, authMethod: this.config.authMethod },
+        "VaultClient: received 4xx error, re-authenticating",
       );
 
       // Reset initialization state and re-authenticate

--- a/platform/backend/src/secrets-manager/vault.ee.ts
+++ b/platform/backend/src/secrets-manager/vault.ee.ts
@@ -229,11 +229,13 @@ export default class VaultSecretManager
         { error, listBasePath, kvVersion: this.config.kvVersion },
         "VaultSecretManager.checkConnectivity: failed to list secrets",
       );
-      throw new ApiError(
+      const apiError = new ApiError(
         503,
         extractVaultErrorMessage(error),
         SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
       );
+      apiError.cause = error;
+      throw apiError;
     }
   }
 

--- a/platform/backend/src/secrets-manager/vault.ee.ts
+++ b/platform/backend/src/secrets-manager/vault.ee.ts
@@ -54,20 +54,29 @@ export default class VaultSecretManager
     operationName: string,
     context: Record<string, unknown> = {},
   ): never {
+    const vaultError = extractVaultErrorMessage(error);
+    // The Vault detail goes into the message text (not only the structured
+    // fields) because retained log records keep just the message line —
+    // without it, a forwarded log trail only shows a generic failure.
     logger.error(
-      { error, vaultError: extractVaultErrorMessage(error), ...context },
-      `VaultSecretManager.${operationName}: failed`,
+      { error, vaultError, ...context },
+      `VaultSecretManager.${operationName}: failed (${vaultError})`,
     );
 
     if (error instanceof ApiError) {
       throw error;
     }
 
-    throw new ApiError(
+    // The user-facing message stays generic (Vault internals aren't for end
+    // users), but the original error rides along as `cause` so error tracking
+    // can report what the secrets backend actually returned.
+    const apiError = new ApiError(
       503,
       "An error occurred while accessing secrets. Please try again later or contact your administrator.",
       SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
     );
+    apiError.cause = error;
+    throw apiError;
   }
 
   async createSecret(


### PR DESCRIPTION
## What

Two fixes for Vault-backed secrets operations, both motivated by self-hosted deployments hitting the generic `An error occurred while accessing secrets…` 503 during MCP catalog operations with no way to tell what actually failed.

### 1. Re-authenticate and retry on 4xx under AWS IAM auth

The one-shot re-auth-and-retry on a Vault 4xx previously only applied to the Kubernetes auth method. A client token minted by AWS IAM login expires just the same, and when it did, every subsequent secrets read failed until a process restart. `executeWithK8sTokenRefresh` is now `executeWithTokenRefresh` and retries for both login-based auth methods (Kubernetes and AWS IAM). Static token auth has nothing to refresh, so its errors still propagate as-is.

### 2. Make secrets-backend failures diagnosable from error tracking

The user-facing 503 message stays deliberately generic, but previously the underlying Vault error was only visible in the instance's own logs:

- `VaultSecretManager.handleVaultError` / `VaultClient.handleVaultError` now chain the original error as `cause` on the thrown `ApiError`.
- The error-tracking policy surfaces it as a `secrets_backend_error` tag (Vault status code + error strings — never secret material) on captured secrets-outage issues.
- The failure log line now carries the Vault detail in its message text (`VaultSecretManager.getSecret: failed (403: permission denied)`), so message-only retained log trails keep the detail too.

## Tests

- `secrets-manager.test.ts`: new coverage for the AWS IAM re-auth retry and for static-token auth not retrying; the existing read-failure test now also pins the `cause` chaining.
- `error-tracking-policy.test.ts`: new test pinning the `secrets_backend_error` tag derived from the chained cause.

Backend `vitest`, `tsc --noEmit`, `biome check`, and `knip` (dev + production) all pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>