### PR TITLE
fix(llm-logs): stop shipping full request bodies on the logs page; report container OOM kills (T-1015)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -164984,6 +164984,12 @@
                           },
                           "lastUserMessagePreview": {
                             "nullable": true,
+                            "description": "Short preview (max 200 chars) of the session's last user message. Raw request bodies are not returned by this listing.",
+                            "type": "string",
+                            "maxLength": 200
+                          },
+                          "lastInteractionType": {
+                            "nullable": true,
                             "type": "string"
                           },
                           "conversationTitle": {
@@ -165024,6 +165030,7 @@
                           "authenticatedAppNames",
                           "userNames",
                           "lastUserMessagePreview",
+                          "lastInteractionType",
                           "conversationTitle",
                           "claudeCodeTitle"
                         ],

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -164982,10 +164982,7 @@
                               "type": "string"
                             }
                           },
-                          "lastInteractionRequest": {
-                            "nullable": true
-                          },
-                          "lastInteractionType": {
+                          "lastUserMessagePreview": {
                             "nullable": true,
                             "type": "string"
                           },
@@ -165026,8 +165023,7 @@
                           "authMethods",
                           "authenticatedAppNames",
                           "userNames",
-                          "lastInteractionRequest",
-                          "lastInteractionType",
+                          "lastUserMessagePreview",
                           "conversationTitle",
                           "claudeCodeTitle"
                         ],

--- a/platform/backend/src/models/interaction.test.ts
+++ b/platform/backend/src/models/interaction.test.ts
@@ -3952,6 +3952,10 @@ describe("InteractionModel", () => {
       }
       const expectedLength = messages.length; // 1 + 21*2 = 43
 
+      // The writes above warmed the delta manager's caches; drop them so the
+      // preview provably comes from cold DB reconstruction.
+      InteractionDeltaManager.reset();
+
       const sessions = await InteractionModel.getSessions(
         { limit: 100, offset: 0 },
         admin.id,

--- a/platform/backend/src/models/interaction.test.ts
+++ b/platform/backend/src/models/interaction.test.ts
@@ -1286,6 +1286,53 @@ describe("InteractionModel", () => {
     });
   });
 
+  describe("getSessions last-user-message preview (T-1015)", () => {
+    test("returns a truncated preview and never the raw request", async ({
+      makeAdmin,
+    }) => {
+      const admin = await makeAdmin();
+      const agent = await AgentModel.create({
+        name: "Agent",
+        teams: [],
+        scope: "org",
+      });
+
+      const longMessage = "m".repeat(500);
+      await InteractionModel.create({
+        profileId: agent.id,
+        sessionId: "preview-session",
+        request: {
+          model: "gpt-4",
+          messages: [
+            { role: "user", content: "earlier turn" },
+            { role: "assistant", content: "ack" },
+            { role: "user", content: longMessage },
+          ],
+        },
+        response: {
+          id: "r1",
+          object: "chat.completion",
+          created: Date.now(),
+          model: "gpt-4",
+          choices: [],
+        },
+        type: "openai:chatCompletions",
+      });
+
+      const sessions = await InteractionModel.getSessions(
+        { limit: 100, offset: 0 },
+        admin.id,
+        true,
+        { sessionId: "preview-session" },
+      );
+
+      expect(sessions.data).toHaveLength(1);
+      const session = sessions.data[0];
+      expect(session.lastUserMessagePreview).toBe(longMessage.slice(0, 200));
+      expect(session).not.toHaveProperty("lastInteractionRequest");
+    });
+  });
+
   describe("getSessions billing-mode split", () => {
     test("splits session cost into billed and subscription", async ({
       makeAdmin,
@@ -1865,8 +1912,8 @@ describe("InteractionModel", () => {
     });
   });
 
-  describe("getSessions lastInteraction and claudeCodeTitle", () => {
-    test("returns lastInteractionRequest and lastInteractionType for session with single interaction", async ({
+  describe("getSessions last-interaction preview and claudeCodeTitle", () => {
+    test("returns the last-user-message preview for a session with a single interaction", async ({
       makeAdmin,
     }) => {
       const admin = await makeAdmin();
@@ -1918,9 +1965,8 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      expect(sessions.data[0].lastInteractionRequest).not.toBeNull();
-      expect(sessions.data[0].lastInteractionType).toBe(
-        "openai:chatCompletions",
+      expect(sessions.data[0].lastUserMessagePreview).toBe(
+        "This is a meaningful message with more than 20 characters",
       );
     });
 
@@ -1968,11 +2014,10 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      expect(sessions.data[0].lastInteractionRequest).not.toBeNull();
-      expect(sessions.data[0].lastInteractionType).toBe("openai:responses");
+      expect(sessions.data[0].lastUserMessagePreview).toBe("Hi from codex cli");
     });
 
-    test("skips prompt suggestion generator requests when finding lastInteractionRequest", async ({
+    test("skips prompt suggestion generator requests when deriving the preview", async ({
       makeAdmin,
     }) => {
       const admin = await makeAdmin();
@@ -1982,7 +2027,7 @@ describe("InteractionModel", () => {
         scope: "org",
       });
 
-      // First: a real user request (should be the lastInteractionRequest)
+      // First: a real user request (should drive the preview)
       await InteractionModel.create({
         profileId: agent.id,
         sessionId: "session-with-prompt-suggestion",
@@ -2038,13 +2083,12 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      const lastRequest = sessions.data[0].lastInteractionRequest as {
-        messages: Array<{ content: string }>;
-      };
-      expect(lastRequest.messages[0].content).toContain("real user question");
+      expect(sessions.data[0].lastUserMessagePreview).toContain(
+        "real user question",
+      );
     });
 
-    test("skips title generation requests when finding lastInteractionRequest", async ({
+    test("skips title generation requests when deriving the preview", async ({
       makeAdmin,
     }) => {
       const admin = await makeAdmin();
@@ -2078,7 +2122,7 @@ describe("InteractionModel", () => {
         type: "openai:chatCompletions",
       });
 
-      // Second: a title generation request (should be skipped for lastInteractionRequest)
+      // Second: a title generation request (should be skipped for the preview)
       await InteractionModel.create({
         profileId: agent.id,
         sessionId: "session-with-title-gen",
@@ -2120,10 +2164,9 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      const lastRequest = sessions.data[0].lastInteractionRequest as {
-        messages: Array<{ content: string }>;
-      };
-      expect(lastRequest.messages[0].content).toContain("real question");
+      expect(sessions.data[0].lastUserMessagePreview).toContain(
+        "real question",
+      );
     });
 
     test("extracts claudeCodeTitle from title generation response", async ({
@@ -2209,7 +2252,7 @@ describe("InteractionModel", () => {
         scope: "org",
       });
 
-      // Real request (should be returned as lastInteractionRequest)
+      // Real request (should drive the preview)
       await InteractionModel.create({
         profileId: agent.id,
         sessionId: "session-malformed-title",
@@ -2267,14 +2310,12 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      // Should have the main interaction but null for title
-      expect(sessions.data[0].lastInteractionRequest).not.toBeNull();
+      // Should have the main interaction's preview but null for title
+      expect(sessions.data[0].lastUserMessagePreview).not.toBeNull();
       expect(sessions.data[0].claudeCodeTitle).toBeNull();
     });
 
-    test("returns lastInteractionRequest even for short messages", async ({
-      makeAdmin,
-    }) => {
+    test("returns a preview even for short messages", async ({ makeAdmin }) => {
       const admin = await makeAdmin();
       const agent = await AgentModel.create({
         name: "Agent",
@@ -2308,10 +2349,10 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      expect(sessions.data[0].lastInteractionRequest).not.toBeNull();
+      expect(sessions.data[0].lastUserMessagePreview).toBe("hi");
     });
 
-    test("returns lastInteractionRequest for Gemini format (contents[].parts[].text)", async ({
+    test("returns a preview for Gemini format (contents[].parts[].text)", async ({
       makeAdmin,
     }) => {
       const admin = await makeAdmin();
@@ -2358,13 +2399,10 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      expect(sessions.data[0].lastInteractionRequest).not.toBeNull();
-      expect(sessions.data[0].lastInteractionType).toBe(
-        "gemini:generateContent",
-      );
+      expect(sessions.data[0].lastUserMessagePreview).toBe("123");
     });
 
-    test("returns lastInteractionRequest for Gemini with image-only content (no text)", async ({
+    test("returns a descriptive preview for Gemini with image-only content (no text)", async ({
       makeAdmin,
     }) => {
       const admin = await makeAdmin();
@@ -2417,13 +2455,10 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      expect(sessions.data[0].lastInteractionRequest).not.toBeNull();
-      expect(sessions.data[0].lastInteractionType).toBe(
-        "gemini:generateContent",
-      );
+      expect(sessions.data[0].lastUserMessagePreview).toBe("[image/png data]");
     });
 
-    test("returns lastInteractionRequest for Gemini with function response (tool result)", async ({
+    test("returns a descriptive preview for Gemini with function response (tool result)", async ({
       makeAdmin,
     }) => {
       const admin = await makeAdmin();
@@ -2491,9 +2526,8 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      expect(sessions.data[0].lastInteractionRequest).not.toBeNull();
-      expect(sessions.data[0].lastInteractionType).toBe(
-        "gemini:generateContent",
+      expect(sessions.data[0].lastUserMessagePreview).toBe(
+        "[Function response: get_weather]",
       );
     });
 
@@ -2542,7 +2576,9 @@ describe("InteractionModel", () => {
       expect(ourSession).toBeDefined();
       expect(ourSession?.sessionId).toBeNull();
       expect(ourSession?.interactionId).toBe(interaction.id);
-      expect(ourSession?.lastInteractionRequest).not.toBeNull();
+      expect(ourSession?.lastUserMessagePreview).toBe(
+        "This is a standalone interaction without a session ID",
+      );
     });
   });
 
@@ -3875,7 +3911,7 @@ describe("InteractionModel", () => {
       expect(requestTypeOf(main.id)).toBe("main");
     });
 
-    test("getSessions reconstructs the last interaction request, even when the parent is outside the 20-row window", async ({
+    test("getSessions derives the preview from the fully reconstructed chain, even when ancestors are outside the 20-row window", async ({
       makeAdmin,
     }) => {
       const admin = await makeAdmin();
@@ -3891,14 +3927,22 @@ describe("InteractionModel", () => {
       // recent row (defaultNow() can tie within the same millisecond under load,
       // which would make the "last main interaction" selection flaky).
       const baseTime = new Date("2020-01-01T00:00:00.000Z").getTime();
-      const messages: unknown[] = [
-        { role: "user", content: "turn 0 — kick things off with enough text" },
-      ];
+      // Every user turn after the head is tool_result-only, so the preview's
+      // text can only come from the head row — which sits outside the 20-row
+      // window and materializes only through full chain reconstruction. A
+      // suffix-only (unreconstructed) request would yield a null preview.
+      const headText = "turn 0 — kick things off with enough text";
+      const messages: unknown[] = [{ role: "user", content: headText }];
       let tipId = "";
       for (let i = 0; i < 22; i++) {
         if (i > 0) {
           messages.push({ role: "assistant", content: `reply ${i}` });
-          messages.push({ role: "user", content: `turn ${i}` });
+          messages.push({
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: `tu_${i}`, content: "ok" },
+            ],
+          });
         }
         const row = await createClaude(agent.id, [...messages], {
           sessionId: "delta-sessions",
@@ -3916,9 +3960,7 @@ describe("InteractionModel", () => {
       );
 
       expect(sessions.data).toHaveLength(1);
-      expect(messagesOf(sessions.data[0].lastInteractionRequest)).toHaveLength(
-        expectedLength,
-      );
+      expect(sessions.data[0].lastUserMessagePreview).toBe(headText);
       // The reconstructed tip is the most recent interaction.
       const tip = await InteractionModel.findById(tipId);
       expect(messagesOf(tip?.request)).toHaveLength(expectedLength);

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -5,6 +5,7 @@ import type {
 } from "@archestra/shared";
 import {
   clientFilterToAgentIds,
+  DynamicInteraction,
   isClaudeSessionSource,
   LEGACY_CLAUDE_CODE_SESSION_SOURCE,
 } from "@archestra/shared";
@@ -1355,8 +1356,7 @@ class InteractionModel {
         authMethods: parseInteractionAuthMethods(s.authMethods),
         authenticatedAppNames: s.authenticatedAppNames ?? [],
         userNames: s.userNames ?? [],
-        lastInteractionRequest: lastInteraction?.request ?? null,
-        lastInteractionType: lastInteraction?.type ?? null,
+        lastUserMessagePreview: lastInteraction?.lastUserMessagePreview ?? null,
         conversationTitle: s.conversationTitle,
         claudeCodeTitle: lastInteraction?.claudeCodeTitle ?? null,
       };
@@ -1383,7 +1383,7 @@ class InteractionModel {
   ): Promise<
     Map<
       string,
-      { request: unknown; type: string; claudeCodeTitle: string | null }
+      { lastUserMessagePreview: string | null; claudeCodeTitle: string | null }
     >
   > {
     if (sessionKeys.length === 0) {
@@ -1471,7 +1471,7 @@ class InteractionModel {
     // Group by session and find the "last main interaction" and "title interaction"
     const result = new Map<
       string,
-      { request: unknown; type: string; claudeCodeTitle: string | null }
+      { lastUserMessagePreview: string | null; claudeCodeTitle: string | null }
     >();
 
     // Group interactions by session key (sessionId or interaction id for single interactions)
@@ -1562,8 +1562,9 @@ class InteractionModel {
         }
 
         result.set(sessionKey, {
-          request: tipRequest,
-          type: lastMainInteraction?.type ?? "",
+          lastUserMessagePreview: lastMainInteraction
+            ? buildLastUserMessagePreview(tipRequest, lastMainInteraction.type)
+            : null,
           claudeCodeTitle: claudeCodeTitle ?? null,
         });
       }
@@ -1647,6 +1648,34 @@ async function withReconstructedRequests<
         }
       : row;
   });
+}
+
+/** Max length of the sessions listing's last-user-message preview. */
+const LAST_USER_MESSAGE_PREVIEW_MAX_LENGTH = 200;
+
+/**
+ * Derive the short last-user-message preview shown by the sessions listing,
+ * using the same provider-aware parsing as the interaction detail view.
+ * Returns null when the request has no extractable user text or an
+ * unsupported provider shape — the listing renders its fallback instead.
+ */
+function buildLastUserMessagePreview(
+  request: unknown,
+  type: string,
+): string | null {
+  try {
+    const interaction = new DynamicInteraction({
+      request,
+      response: {},
+      type,
+    } as never);
+    const message = interaction.getLastUserMessage().trim();
+    return message
+      ? message.slice(0, LAST_USER_MESSAGE_PREVIEW_MAX_LENGTH)
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function parseInteractionAuthMethods(

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -47,6 +47,7 @@ import type {
 } from "@/types";
 import {
   InteractionAuthMethodSchema,
+  LAST_USER_MESSAGE_PREVIEW_MAX_LENGTH,
   normalizeInteractionResponse,
 } from "@/types";
 import { trackBackgroundWork } from "@/utils/background-work";
@@ -1357,6 +1358,7 @@ class InteractionModel {
         authenticatedAppNames: s.authenticatedAppNames ?? [],
         userNames: s.userNames ?? [],
         lastUserMessagePreview: lastInteraction?.lastUserMessagePreview ?? null,
+        lastInteractionType: lastInteraction?.lastInteractionType ?? null,
         conversationTitle: s.conversationTitle,
         claudeCodeTitle: lastInteraction?.claudeCodeTitle ?? null,
       };
@@ -1383,7 +1385,11 @@ class InteractionModel {
   ): Promise<
     Map<
       string,
-      { lastUserMessagePreview: string | null; claudeCodeTitle: string | null }
+      {
+        lastUserMessagePreview: string | null;
+        lastInteractionType: string | null;
+        claudeCodeTitle: string | null;
+      }
     >
   > {
     if (sessionKeys.length === 0) {
@@ -1471,7 +1477,11 @@ class InteractionModel {
     // Group by session and find the "last main interaction" and "title interaction"
     const result = new Map<
       string,
-      { lastUserMessagePreview: string | null; claudeCodeTitle: string | null }
+      {
+        lastUserMessagePreview: string | null;
+        lastInteractionType: string | null;
+        claudeCodeTitle: string | null;
+      }
     >();
 
     // Group interactions by session key (sessionId or interaction id for single interactions)
@@ -1565,6 +1575,7 @@ class InteractionModel {
           lastUserMessagePreview: lastMainInteraction
             ? buildLastUserMessagePreview(tipRequest, lastMainInteraction.type)
             : null,
+          lastInteractionType: lastMainInteraction?.type ?? null,
           claudeCodeTitle: claudeCodeTitle ?? null,
         });
       }
@@ -1650,9 +1661,6 @@ async function withReconstructedRequests<
   });
 }
 
-/** Max length of the sessions listing's last-user-message preview. */
-const LAST_USER_MESSAGE_PREVIEW_MAX_LENGTH = 200;
-
 /**
  * Derive the short last-user-message preview shown by the sessions listing,
  * using the same provider-aware parsing as the interaction detail view.
@@ -1670,9 +1678,16 @@ function buildLastUserMessagePreview(
       type,
     } as never);
     const message = interaction.getLastUserMessage().trim();
-    return message
-      ? message.slice(0, LAST_USER_MESSAGE_PREVIEW_MAX_LENGTH)
-      : null;
+    if (!message) {
+      return null;
+    }
+    let preview = message.slice(0, LAST_USER_MESSAGE_PREVIEW_MAX_LENGTH);
+    // Don't leave half a surrogate pair at the truncation point.
+    const lastCode = preview.charCodeAt(preview.length - 1);
+    if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+      preview = preview.slice(0, -1);
+    }
+    return preview;
   } catch {
     return null;
   }

--- a/platform/backend/src/observability/previous-termination-report.test.ts
+++ b/platform/backend/src/observability/previous-termination-report.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { reportAbnormalPreviousTermination } from "./previous-termination-report";
+
+vi.mock("@/logging");
+
+const captureExceptionSentry = vi.hoisted(() => vi.fn());
+vi.mock("@sentry/node", () => ({
+  captureException: captureExceptionSentry,
+}));
+
+const capturePosthog = vi.hoisted(() => vi.fn());
+vi.mock("@/services/error-tracking", () => ({
+  posthogErrorTrackingService: { captureException: capturePosthog },
+}));
+
+const readNamespacedPod = vi.hoisted(() => vi.fn());
+const isK8sConfigured = vi.hoisted(() => vi.fn());
+vi.mock("@/k8s/shared", () => ({
+  isK8sConfigured,
+  loadKubeConfig: vi.fn(() => ({
+    kubeConfig: {},
+    namespace: "archestra",
+  })),
+  createK8sClients: vi.fn(() => ({
+    coreApi: { readNamespacedPod },
+  })),
+}));
+
+function podWithLastState(
+  terminated:
+    | {
+        reason?: string;
+        exitCode: number;
+        startedAt?: string;
+        finishedAt?: string;
+      }
+    | undefined,
+) {
+  return {
+    status: {
+      containerStatuses: [
+        {
+          name: "archestra-platform",
+          restartCount: terminated ? 2 : 0,
+          lastState: terminated ? { terminated } : {},
+        },
+      ],
+    },
+  };
+}
+
+describe("reportAbnormalPreviousTermination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isK8sConfigured.mockReturnValue(true);
+  });
+
+  test("reports an OOMKilled previous container as fatal", async () => {
+    readNamespacedPod.mockResolvedValue(
+      podWithLastState({ reason: "OOMKilled", exitCode: 137 }),
+    );
+
+    await reportAbnormalPreviousTermination();
+
+    expect(captureExceptionSentry).toHaveBeenCalledTimes(1);
+    const [error, options] = captureExceptionSentry.mock.calls[0];
+    expect(error.message).toContain("OOMKilled");
+    expect(error.message).toContain("exit code 137");
+    expect(options.level).toBe("fatal");
+    expect(options.tags).toMatchObject({
+      container: "archestra-platform",
+      reason: "OOMKilled",
+      exit_code: "137",
+    });
+
+    expect(capturePosthog).toHaveBeenCalledTimes(1);
+    expect(capturePosthog.mock.calls[0][0].properties).toMatchObject({
+      reason: "OOMKilled",
+      exitCode: 137,
+      container: "archestra-platform",
+    });
+  });
+
+  test("reports a non-zero exit without OOM as error level", async () => {
+    readNamespacedPod.mockResolvedValue(
+      podWithLastState({ reason: "Error", exitCode: 1 }),
+    );
+
+    await reportAbnormalPreviousTermination();
+
+    expect(captureExceptionSentry).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSentry.mock.calls[0][1].level).toBe("error");
+  });
+
+  test("stays silent for a clean previous termination", async () => {
+    readNamespacedPod.mockResolvedValue(
+      podWithLastState({ reason: "Completed", exitCode: 0 }),
+    );
+
+    await reportAbnormalPreviousTermination();
+
+    expect(captureExceptionSentry).not.toHaveBeenCalled();
+    expect(capturePosthog).not.toHaveBeenCalled();
+  });
+
+  test("stays silent when the container never restarted", async () => {
+    readNamespacedPod.mockResolvedValue(podWithLastState(undefined));
+
+    await reportAbnormalPreviousTermination();
+
+    expect(captureExceptionSentry).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when the Kubernetes runtime is not configured", async () => {
+    isK8sConfigured.mockReturnValue(false);
+
+    await reportAbnormalPreviousTermination();
+
+    expect(readNamespacedPod).not.toHaveBeenCalled();
+    expect(captureExceptionSentry).not.toHaveBeenCalled();
+  });
+
+  test("swallows Kubernetes API failures without throwing", async () => {
+    readNamespacedPod.mockRejectedValue(new Error("forbidden"));
+
+    await expect(reportAbnormalPreviousTermination()).resolves.toBeUndefined();
+    expect(captureExceptionSentry).not.toHaveBeenCalled();
+  });
+});

--- a/platform/backend/src/observability/previous-termination-report.test.ts
+++ b/platform/backend/src/observability/previous-termination-report.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { reportAbnormalPreviousTermination } from "./previous-termination-report";
 
@@ -13,24 +15,53 @@ vi.mock("@/services/error-tracking", () => ({
   posthogErrorTrackingService: { captureException: capturePosthog },
 }));
 
-const readNamespacedPod = vi.hoisted(() => vi.fn());
-const isK8sConfigured = vi.hoisted(() => vi.fn());
-vi.mock("@/k8s/shared", () => ({
-  isK8sConfigured,
-  loadKubeConfig: vi.fn(() => ({
-    kubeConfig: {},
-    namespace: "archestra",
-  })),
-  createK8sClients: vi.fn(() => ({
-    coreApi: { readNamespacedPod },
-  })),
+// The service-account namespace file and the marker file are externally-owned
+// storage (kubelet-projected volume / container-local tmp).
+const readFileMock = vi.hoisted(() => vi.fn());
+const writeFileMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs/promises", () => ({
+  readFile: readFileMock,
+  writeFile: writeFileMock,
 }));
+
+const readNamespacedPod = vi.hoisted(() => vi.fn());
+const loadFromCluster = vi.hoisted(() => vi.fn());
+vi.mock("@kubernetes/client-node", () => ({
+  KubeConfig: class {
+    loadFromCluster = loadFromCluster;
+    makeApiClient() {
+      return { readNamespacedPod };
+    }
+  },
+  CoreV1Api: class {},
+}));
+
+const NAMESPACE_PATH =
+  "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+const MARKER_PATH = path.join(
+  os.tmpdir(),
+  "archestra-terminations-reported.json",
+);
+
+/** In-cluster namespace file present; marker file holds `markers` (or none). */
+function primeFs(markers: string[] | null) {
+  readFileMock.mockImplementation(async (file: string) => {
+    if (file === NAMESPACE_PATH) {
+      return "archestra\n";
+    }
+    if (file === MARKER_PATH && markers !== null) {
+      return JSON.stringify(markers);
+    }
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  });
+}
 
 function podWithLastState(
   terminated:
     | {
         reason?: string;
         exitCode: number;
+        containerID?: string;
         startedAt?: string;
         finishedAt?: string;
       }
@@ -52,15 +83,25 @@ function podWithLastState(
 describe("reportAbnormalPreviousTermination", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    isK8sConfigured.mockReturnValue(true);
+    writeFileMock.mockResolvedValue(undefined);
   });
 
-  test("reports an OOMKilled previous container as fatal", async () => {
+  test("reports an OOMKilled previous container as fatal and records a marker", async () => {
+    primeFs(null);
     readNamespacedPod.mockResolvedValue(
-      podWithLastState({ reason: "OOMKilled", exitCode: 137 }),
+      podWithLastState({
+        reason: "OOMKilled",
+        exitCode: 137,
+        containerID: "containerd://abc",
+      }),
     );
 
     await reportAbnormalPreviousTermination();
+
+    expect(readNamespacedPod).toHaveBeenCalledWith({
+      name: os.hostname(),
+      namespace: "archestra",
+    });
 
     expect(captureExceptionSentry).toHaveBeenCalledTimes(1);
     const [error, options] = captureExceptionSentry.mock.calls[0];
@@ -75,13 +116,61 @@ describe("reportAbnormalPreviousTermination", () => {
 
     expect(capturePosthog).toHaveBeenCalledTimes(1);
     expect(capturePosthog.mock.calls[0][0].properties).toMatchObject({
+      $exception_fingerprint:
+        "container-abnormal-termination/archestra-platform/OOMKilled",
       reason: "OOMKilled",
       exitCode: 137,
-      container: "archestra-platform",
     });
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      MARKER_PATH,
+      JSON.stringify(["archestra-platform:containerd://abc"]),
+    );
   });
 
-  test("reports a non-zero exit without OOM as error level", async () => {
+  test("does not re-report a termination already recorded in the marker file", async () => {
+    // supervisord restarts the backend process without restarting the
+    // container, so the same lastState is read again on the next boot.
+    primeFs(["archestra-platform:containerd://abc"]);
+    readNamespacedPod.mockResolvedValue(
+      podWithLastState({
+        reason: "OOMKilled",
+        exitCode: 137,
+        containerID: "containerd://abc",
+      }),
+    );
+
+    await reportAbnormalPreviousTermination();
+
+    expect(captureExceptionSentry).not.toHaveBeenCalled();
+    expect(capturePosthog).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  test("reports a new termination even when an older one is recorded", async () => {
+    primeFs(["archestra-platform:containerd://old"]);
+    readNamespacedPod.mockResolvedValue(
+      podWithLastState({
+        reason: "OOMKilled",
+        exitCode: 137,
+        containerID: "containerd://new",
+      }),
+    );
+
+    await reportAbnormalPreviousTermination();
+
+    expect(captureExceptionSentry).toHaveBeenCalledTimes(1);
+    expect(writeFileMock).toHaveBeenCalledWith(
+      MARKER_PATH,
+      JSON.stringify([
+        "archestra-platform:containerd://old",
+        "archestra-platform:containerd://new",
+      ]),
+    );
+  });
+
+  test("reports a non-zero exit without OOM at error level", async () => {
+    primeFs(null);
     readNamespacedPod.mockResolvedValue(
       podWithLastState({ reason: "Error", exitCode: 1 }),
     );
@@ -93,6 +182,7 @@ describe("reportAbnormalPreviousTermination", () => {
   });
 
   test("stays silent for a clean previous termination", async () => {
+    primeFs(null);
     readNamespacedPod.mockResolvedValue(
       podWithLastState({ reason: "Completed", exitCode: 0 }),
     );
@@ -101,9 +191,11 @@ describe("reportAbnormalPreviousTermination", () => {
 
     expect(captureExceptionSentry).not.toHaveBeenCalled();
     expect(capturePosthog).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
   });
 
   test("stays silent when the container never restarted", async () => {
+    primeFs(null);
     readNamespacedPod.mockResolvedValue(podWithLastState(undefined));
 
     await reportAbnormalPreviousTermination();
@@ -111,16 +203,20 @@ describe("reportAbnormalPreviousTermination", () => {
     expect(captureExceptionSentry).not.toHaveBeenCalled();
   });
 
-  test("does nothing when the Kubernetes runtime is not configured", async () => {
-    isK8sConfigured.mockReturnValue(false);
+  test("does nothing outside Kubernetes (no service-account namespace file)", async () => {
+    readFileMock.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
 
     await reportAbnormalPreviousTermination();
 
+    expect(loadFromCluster).not.toHaveBeenCalled();
     expect(readNamespacedPod).not.toHaveBeenCalled();
     expect(captureExceptionSentry).not.toHaveBeenCalled();
   });
 
   test("swallows Kubernetes API failures without throwing", async () => {
+    primeFs(null);
     readNamespacedPod.mockRejectedValue(new Error("forbidden"));
 
     await expect(reportAbnormalPreviousTermination()).resolves.toBeUndefined();

--- a/platform/backend/src/observability/previous-termination-report.ts
+++ b/platform/backend/src/observability/previous-termination-report.ts
@@ -1,0 +1,94 @@
+import os from "node:os";
+import * as Sentry from "@sentry/node";
+import {
+  createK8sClients,
+  isK8sConfigured,
+  loadKubeConfig,
+} from "@/k8s/shared";
+import logger from "@/logging";
+import { posthogErrorTrackingService } from "@/services/error-tracking";
+
+/**
+ * Report this pod's previous container termination when it was abnormal.
+ *
+ * A memory-limit kill (OOMKilled, exit 137) takes the whole container down —
+ * the process that could have reported the failure dies with it, so the kill
+ * never reaches error tracking and shows up only as a silent RestartCount
+ * bump (T-1015: /llm/logs OOM-killed staging pods for weeks unnoticed). On
+ * boot, the replacement process reads its own pod's `lastState.terminated`
+ * from the Kubernetes API and reports any abnormal termination through the
+ * existing error-tracking integrations.
+ *
+ * Best-effort by design: requires the in-cluster Kubernetes runtime (the pod
+ * name is the container hostname), and any failure is logged at debug level
+ * and never affects startup.
+ */
+export async function reportAbnormalPreviousTermination(): Promise<void> {
+  if (!isK8sConfigured()) {
+    return;
+  }
+
+  try {
+    const podName = os.hostname();
+    const { kubeConfig, namespace } = loadKubeConfig();
+    const { coreApi } = createK8sClients(kubeConfig, namespace);
+    const pod = await coreApi.readNamespacedPod({
+      name: podName,
+      namespace,
+    });
+
+    for (const status of pod.status?.containerStatuses ?? []) {
+      const terminated = status.lastState?.terminated;
+      if (!terminated) {
+        continue;
+      }
+      if (terminated.exitCode === 0 && terminated.reason !== "OOMKilled") {
+        continue;
+      }
+
+      const reason = terminated.reason ?? "unknown";
+      const error = new Error(
+        `Container "${status.name}" in pod "${podName}" restarted after ${reason} (exit code ${terminated.exitCode})`,
+      );
+      error.name = "ContainerAbnormalTermination";
+
+      const context = {
+        podName,
+        namespace,
+        container: status.name,
+        reason,
+        exitCode: terminated.exitCode,
+        restartCount: status.restartCount,
+        startedAt: terminated.startedAt,
+        finishedAt: terminated.finishedAt,
+      };
+
+      logger.error(
+        context,
+        "Previous container instance terminated abnormally",
+      );
+
+      Sentry.captureException(error, {
+        level: reason === "OOMKilled" ? "fatal" : "error",
+        fingerprint: ["container-abnormal-termination", status.name, reason],
+        tags: {
+          container: status.name,
+          reason,
+          exit_code: String(terminated.exitCode),
+        },
+        extra: context,
+      });
+
+      posthogErrorTrackingService.captureException({
+        error,
+        properties: context,
+      });
+    }
+  } catch (error) {
+    // Never let boot-time observability interfere with serving traffic.
+    logger.debug(
+      { err: error },
+      "Skipped previous-termination report (pod status unavailable)",
+    );
+  }
+}

--- a/platform/backend/src/observability/previous-termination-report.ts
+++ b/platform/backend/src/observability/previous-termination-report.ts
@@ -1,10 +1,8 @@
+import { readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
+import path from "node:path";
+import * as k8s from "@kubernetes/client-node";
 import * as Sentry from "@sentry/node";
-import {
-  createK8sClients,
-  isK8sConfigured,
-  loadKubeConfig,
-} from "@/k8s/shared";
 import logger from "@/logging";
 import { posthogErrorTrackingService } from "@/services/error-tracking";
 
@@ -19,23 +17,40 @@ import { posthogErrorTrackingService } from "@/services/error-tracking";
  * from the Kubernetes API and reports any abnormal termination through the
  * existing error-tracking integrations.
  *
- * Best-effort by design: requires the in-cluster Kubernetes runtime (the pod
- * name is the container hostname), and any failure is logged at debug level
- * and never affects startup.
+ * Two deliberate design points:
+ * - The pod is resolved from the service-account namespace file plus an
+ *   in-cluster client — never from the orchestrator's MCP-workload
+ *   configuration, which may point at a different namespace or an external
+ *   cluster.
+ * - Each termination is reported once. supervisord restarts the backend
+ *   *process* without restarting the *container*, so the same lastState is
+ *   re-read on every such restart; a marker file in container-local tmp
+ *   (preserved across process restarts, wiped by a real container restart)
+ *   suppresses the duplicates.
+ *
+ * Best-effort by design: outside Kubernetes the namespace file is absent and
+ * this is a no-op; any failure is logged at debug level and never affects
+ * startup.
  */
 export async function reportAbnormalPreviousTermination(): Promise<void> {
-  if (!isK8sConfigured()) {
-    return;
-  }
-
   try {
+    const namespace = (
+      await readFile(SERVICE_ACCOUNT_NAMESPACE_PATH, "utf8")
+    ).trim();
+
+    const kubeConfig = new k8s.KubeConfig();
+    kubeConfig.loadFromCluster();
+    const coreApi = kubeConfig.makeApiClient(k8s.CoreV1Api);
+
+    // The pod name is the container hostname in Kubernetes.
     const podName = os.hostname();
-    const { kubeConfig, namespace } = loadKubeConfig();
-    const { coreApi } = createK8sClients(kubeConfig, namespace);
     const pod = await coreApi.readNamespacedPod({
       name: podName,
       namespace,
     });
+
+    const alreadyReported = await readReportedMarkers();
+    const newlyReported: string[] = [];
 
     for (const status of pod.status?.containerStatuses ?? []) {
       const terminated = status.lastState?.terminated;
@@ -45,6 +60,14 @@ export async function reportAbnormalPreviousTermination(): Promise<void> {
       if (terminated.exitCode === 0 && terminated.reason !== "OOMKilled") {
         continue;
       }
+
+      const marker = `${status.name}:${
+        terminated.containerID ?? String(terminated.finishedAt ?? "unknown")
+      }`;
+      if (alreadyReported.includes(marker)) {
+        continue;
+      }
+      newlyReported.push(marker);
 
       const reason = terminated.reason ?? "unknown";
       const error = new Error(
@@ -68,9 +91,15 @@ export async function reportAbnormalPreviousTermination(): Promise<void> {
         "Previous container instance terminated abnormally",
       );
 
+      const fingerprint = [
+        "container-abnormal-termination",
+        status.name,
+        reason,
+      ];
+
       Sentry.captureException(error, {
         level: reason === "OOMKilled" ? "fatal" : "error",
-        fingerprint: ["container-abnormal-termination", status.name, reason],
+        fingerprint,
         tags: {
           container: status.name,
           reason,
@@ -81,14 +110,58 @@ export async function reportAbnormalPreviousTermination(): Promise<void> {
 
       posthogErrorTrackingService.captureException({
         error,
-        properties: context,
+        properties: {
+          $exception_fingerprint: fingerprint.join("/"),
+          ...context,
+        },
       });
+    }
+
+    if (newlyReported.length > 0) {
+      await writeReportedMarkers([...alreadyReported, ...newlyReported]);
     }
   } catch (error) {
     // Never let boot-time observability interfere with serving traffic.
     logger.debug(
       { err: error },
-      "Skipped previous-termination report (pod status unavailable)",
+      "Skipped previous-termination report (not in a cluster, or pod status unavailable)",
     );
+  }
+}
+
+// === Internal helpers
+
+/** Present exactly when this process runs inside a Kubernetes pod. */
+const SERVICE_ACCOUNT_NAMESPACE_PATH =
+  "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+/**
+ * Container-local record of terminations already reported by this container
+ * instance — preserved across supervisord-level process restarts, wiped by a
+ * real container restart.
+ */
+const REPORTED_MARKER_PATH = path.join(
+  os.tmpdir(),
+  "archestra-terminations-reported.json",
+);
+
+async function readReportedMarkers(): Promise<string[]> {
+  try {
+    const parsed: unknown = JSON.parse(
+      await readFile(REPORTED_MARKER_PATH, "utf8"),
+    );
+    return Array.isArray(parsed)
+      ? parsed.filter((m): m is string => typeof m === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeReportedMarkers(markers: string[]): Promise<void> {
+  try {
+    await writeFile(REPORTED_MARKER_PATH, JSON.stringify(markers));
+  } catch (error) {
+    logger.debug({ err: error }, "Could not persist termination-report marker");
   }
 }

--- a/platform/backend/src/routes/interaction.test.ts
+++ b/platform/backend/src/routes/interaction.test.ts
@@ -9,6 +9,7 @@ import {
 import ConversationModel from "@/models/conversation";
 import ConversationChatErrorModel from "@/models/conversation-chat-error";
 import InteractionModel from "@/models/interaction";
+import InteractionDeltaManager from "@/models/interaction-delta-manager";
 import KnowledgeBaseConnectorModel from "@/models/knowledge-base-connector";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
@@ -476,6 +477,21 @@ describe("interaction routes", () => {
       response: anthropicResp,
     });
 
+    // Sessions endpoint derives its preview from the reconstructed request —
+    // the raw request body itself is never returned by the listing (T-1015:
+    // shipping full bodies OOM-killed the platform container). Runs FIRST, on
+    // a cold delta cache, so the preview provably comes from DB
+    // reconstruction rather than tip state warmed by the writes above.
+    InteractionDeltaManager.reset();
+    const sessions = await app.inject({
+      method: "GET",
+      url: "/api/interactions/sessions?limit=10&offset=0&sessionId=route-delta-session",
+    });
+    expect(sessions.statusCode).toBe(200);
+    const sessionRow = sessions.json().data[0];
+    expect(sessionRow.lastUserMessagePreview).toBe("second message");
+    expect(sessionRow).not.toHaveProperty("lastInteractionRequest");
+
     // Detail endpoint reconstructs the full request and passes response schema.
     const detail = await app.inject({
       method: "GET",
@@ -494,18 +510,6 @@ describe("interaction routes", () => {
       .json()
       .data.find((i: { id: string }) => i.id === tip.id);
     expect(tipRow.request.messages).toEqual(fullMessages);
-
-    // Sessions endpoint derives its preview from the reconstructed request —
-    // the raw request body itself is never returned by the listing (T-1015:
-    // shipping full bodies OOM-killed the platform container).
-    const sessions = await app.inject({
-      method: "GET",
-      url: "/api/interactions/sessions?limit=10&offset=0&sessionId=route-delta-session",
-    });
-    expect(sessions.statusCode).toBe(200);
-    const sessionRow = sessions.json().data[0];
-    expect(sessionRow.lastUserMessagePreview).toBe("second message");
-    expect(sessionRow).not.toHaveProperty("lastInteractionRequest");
   });
 
   test("filters the sessions endpoint by client (external_agent_id)", async ({

--- a/platform/backend/src/routes/interaction.test.ts
+++ b/platform/backend/src/routes/interaction.test.ts
@@ -495,15 +495,17 @@ describe("interaction routes", () => {
       .data.find((i: { id: string }) => i.id === tip.id);
     expect(tipRow.request.messages).toEqual(fullMessages);
 
-    // Sessions endpoint reconstructs the last interaction request.
+    // Sessions endpoint derives its preview from the reconstructed request —
+    // the raw request body itself is never returned by the listing (T-1015:
+    // shipping full bodies OOM-killed the platform container).
     const sessions = await app.inject({
       method: "GET",
       url: "/api/interactions/sessions?limit=10&offset=0&sessionId=route-delta-session",
     });
     expect(sessions.statusCode).toBe(200);
-    expect(sessions.json().data[0].lastInteractionRequest.messages).toEqual(
-      fullMessages,
-    );
+    const sessionRow = sessions.json().data[0];
+    expect(sessionRow.lastUserMessagePreview).toBe("second message");
+    expect(sessionRow).not.toHaveProperty("lastInteractionRequest");
   });
 
   test("filters the sessions endpoint by client (external_agent_id)", async ({

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -83,6 +83,7 @@ import OrganizationModel from "@/models/organization";
 import { ngrokTunnelManager } from "@/ngrok-tunnel-manager";
 import { initializeObservabilityMetrics, metrics } from "@/observability";
 import { classifyErrorForTracking } from "@/observability/error-tracking-policy";
+import { reportAbnormalPreviousTermination } from "@/observability/previous-termination-report";
 import { enrichOpenApiWithRbac } from "@/openapi/enrich-openapi-with-rbac";
 import { activeChatRunService } from "@/services/active-chat-run";
 import { warmRenderRuntime } from "@/services/apps/app-recording-render-runtime";
@@ -1490,6 +1491,10 @@ const startWebServer = async () => {
 
     await fastify.listen({ port, host });
     fastify.log.info(`${name} started on port ${port}`);
+
+    // If the previous container instance died abnormally (e.g. OOMKilled),
+    // it could not report its own death — surface it now. Fire-and-forget.
+    void reportAbnormalPreviousTermination();
 
     // Optional dedicated listener aliasing the MS Teams webhook on its own
     // port (see startPublicEndpointsServer).

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -634,8 +634,13 @@ export const SessionSummarySchema = z.object({
   authMethods: z.array(InteractionAuthMethodSchema),
   authenticatedAppNames: z.array(z.string()),
   userNames: z.array(z.string()),
-  lastInteractionRequest: z.unknown().nullable(),
-  lastInteractionType: z.string().nullable(),
+  /**
+   * Short preview (≤200 chars) of the session's last user message, computed
+   * server-side from the reconstructed request. The raw request body is
+   * intentionally never returned by the listing — shipping full bodies
+   * OOM-killed the platform container (T-1015).
+   */
+  lastUserMessagePreview: z.string().nullable(),
   conversationTitle: z.string().nullable(),
   claudeCodeTitle: z.string().nullable(),
 });

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -600,6 +600,9 @@ export const ToonSkipReasonCountsSchema = z.object({
   noToolResults: z.number(),
 });
 
+/** Max length of `lastUserMessagePreview` on session summaries. */
+export const LAST_USER_MESSAGE_PREVIEW_MAX_LENGTH = 200;
+
 /**
  * Session summary schema for the sessions endpoint
  */
@@ -635,12 +638,20 @@ export const SessionSummarySchema = z.object({
   authenticatedAppNames: z.array(z.string()),
   userNames: z.array(z.string()),
   /**
-   * Short preview (≤200 chars) of the session's last user message, computed
-   * server-side from the reconstructed request. The raw request body is
-   * intentionally never returned by the listing — shipping full bodies
-   * OOM-killed the platform container (T-1015).
+   * Short preview of the session's last user message, computed server-side
+   * from the reconstructed request. The raw request body is intentionally
+   * never returned by the listing — shipping full bodies OOM-killed the
+   * platform container (T-1015). Fetch bodies per interaction via
+   * GET /api/interactions when needed.
    */
-  lastUserMessagePreview: z.string().nullable(),
+  lastUserMessagePreview: z
+    .string()
+    .max(LAST_USER_MESSAGE_PREVIEW_MAX_LENGTH)
+    .nullable()
+    .describe(
+      "Short preview (max 200 chars) of the session's last user message. Raw request bodies are not returned by this listing.",
+    ),
+  lastInteractionType: z.string().nullable(),
   conversationTitle: z.string().nullable(),
   claudeCodeTitle: z.string().nullable(),
 });

--- a/platform/frontend/src/app/llm/logs/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.tsx
@@ -4,7 +4,6 @@ import {
   type archestraApiTypes,
   type ClientFilter,
   clientForExternalAgentIds,
-  DynamicInteraction,
   INTERACTION_SOURCE_DISPLAY,
   type InteractionSource,
 } from "@archestra/shared";
@@ -98,22 +97,9 @@ function getSessionDisplayData(session: SessionData) {
   // not the session-id provenance.
   const clientSource = clientForExternalAgentIds(session.externalAgentIds);
 
-  let lastUserMessage = "";
-  if (session.lastInteractionRequest && session.lastInteractionType) {
-    try {
-      const mockInteraction = {
-        request: session.lastInteractionRequest,
-        response: {},
-        type: session.lastInteractionType,
-      };
-      const interaction = new DynamicInteraction(
-        mockInteraction as archestraApiTypes.GetInteractionResponses["200"],
-      );
-      lastUserMessage = interaction.getLastUserMessage();
-    } catch {
-      lastUserMessage = "";
-    }
-  }
+  // Server-computed preview — the sessions API never returns raw request
+  // bodies (shipping them OOM-killed the platform container, T-1015).
+  const lastUserMessage = session.lastUserMessagePreview ?? "";
 
   const displayText = claudeCodeTitle || lastUserMessage;
 

--- a/platform/frontend/src/app/llm/logs/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.tsx
@@ -131,7 +131,6 @@ export default function LlmProxyLogsPage({
   initialData,
 }: {
   initialData?: {
-    interactions: archestraApiTypes.GetInteractionsResponses["200"];
     agents: archestraApiTypes.GetAllAgentsResponses["200"];
   };
 }) {
@@ -148,7 +147,6 @@ function SessionsTable({
   initialData,
 }: {
   initialData?: {
-    interactions: archestraApiTypes.GetInteractionsResponses["200"];
     agents: archestraApiTypes.GetAllAgentsResponses["200"];
   };
 }) {

--- a/platform/frontend/src/app/llm/logs/page.test.tsx
+++ b/platform/frontend/src/app/llm/logs/page.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import LlmProxyLogsPageServer from "./page";
+
+// The interactions prefetch used to serialize ~10 full LLM request/response
+// bodies into the RSC payload that no client code read — enough to OOM the
+// platform container on a busy instance (T-1015). This pins the server
+// component to prefetching the agents list only.
+
+const getAllAgents = vi.hoisted(() => vi.fn());
+const getInteractions = vi.hoisted(() => vi.fn());
+vi.mock("@archestra/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@archestra/shared")>();
+  return {
+    ...actual,
+    archestraApiSdk: {
+      ...actual.archestraApiSdk,
+      getAllAgents,
+      getInteractions,
+    },
+  };
+});
+
+vi.mock("@/lib/utils/server", () => ({
+  getServerApiHeaders: vi.fn(async () => ({})),
+}));
+
+vi.mock("./page.client", () => ({
+  default: () => null,
+}));
+
+describe("LlmProxyLogsPageServer (T-1015)", () => {
+  it("prefetches only the agents list — never the interactions list", async () => {
+    getAllAgents.mockResolvedValue({ data: [] });
+    getInteractions.mockResolvedValue({ data: { data: [] } });
+
+    await LlmProxyLogsPageServer();
+
+    expect(getAllAgents).toHaveBeenCalledTimes(1);
+    expect(getInteractions).not.toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/app/llm/logs/page.tsx
+++ b/platform/frontend/src/app/llm/logs/page.tsx
@@ -5,7 +5,6 @@ import {
 } from "@archestra/shared";
 
 import { ServerErrorFallback } from "@/components/error-fallback";
-import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { handleApiError } from "@/lib/utils";
 import { getServerApiHeaders } from "@/lib/utils/server";
 import LlmProxyLogsPage from "./page.client";
@@ -13,58 +12,26 @@ import LlmProxyLogsPage from "./page.client";
 export const dynamic = "force-dynamic";
 
 export default async function LlmProxyLogsPageServer() {
+  // Only the agent list is prefetched. The table is session-based
+  // (useInteractionSessions in page.client.tsx) and has never read an
+  // interactions prop, so prefetching /api/interactions here only served to
+  // serialize ~10 fully reconstructed LLM request/response bodies into the RSC
+  // payload that nothing consumes — tens of MB per render on a busy instance.
   let initialData: {
-    interactions: archestraApiTypes.GetInteractionsResponses["200"];
     agents: archestraApiTypes.GetAllAgentsResponses["200"];
   } = {
-    interactions: {
-      data: [],
-      pagination: {
-        currentPage: 1,
-        limit: DEFAULT_TABLE_LIMIT,
-        total: 0,
-        totalPages: 0,
-        hasNext: false,
-        hasPrev: false,
-      },
-    },
     agents: [],
   };
   try {
     const headers = await getServerApiHeaders();
-    const [interactionsResponse, agentsResponse] = await Promise.all([
-      archestraApiSdk.getInteractions({
-        headers,
-        query: {
-          limit: DEFAULT_TABLE_LIMIT,
-          offset: 0,
-          sortBy: "createdAt",
-          sortDirection: "desc",
-        },
-      }),
-      archestraApiSdk.getAllAgents({
-        headers,
-        query: { excludeBuiltIn: true, agentTypes: ["agent", "llm_proxy"] },
-      }),
-    ]);
-    if (interactionsResponse.error) {
-      handleApiError(interactionsResponse.error);
-    }
+    const agentsResponse = await archestraApiSdk.getAllAgents({
+      headers,
+      query: { excludeBuiltIn: true, agentTypes: ["agent", "llm_proxy"] },
+    });
     if (agentsResponse.error) {
       handleApiError(agentsResponse.error);
     }
     initialData = {
-      interactions: interactionsResponse.data || {
-        data: [],
-        pagination: {
-          currentPage: 1,
-          limit: DEFAULT_TABLE_LIMIT,
-          total: 0,
-          totalPages: 0,
-          hasNext: false,
-          hasPrev: false,
-        },
-      },
       agents: agentsResponse.data || [],
     };
   } catch (error) {

--- a/platform/frontend/src/mocks/data/interactions.ts
+++ b/platform/frontend/src/mocks/data/interactions.ts
@@ -66,6 +66,7 @@ export function makeSessionSummary(
     authenticatedAppNames: [],
     userNames: [],
     lastUserMessagePreview: null,
+    lastInteractionType: null,
     conversationTitle: null,
     claudeCodeTitle: null,
     ...overrides,
@@ -163,6 +164,7 @@ export const llmLogsSessionsSeed = [
     sessionSource: null,
     source: "api",
     lastUserMessagePreview: "Plain API session message",
+    lastInteractionType: "openai:chatCompletions",
   }),
 ];
 

--- a/platform/frontend/src/mocks/data/interactions.ts
+++ b/platform/frontend/src/mocks/data/interactions.ts
@@ -65,8 +65,7 @@ export function makeSessionSummary(
     authMethods: [],
     authenticatedAppNames: [],
     userNames: [],
-    lastInteractionRequest: null,
-    lastInteractionType: null,
+    lastUserMessagePreview: null,
     conversationTitle: null,
     claudeCodeTitle: null,
     ...overrides,
@@ -163,11 +162,7 @@ export const llmLogsSessionsSeed = [
     sessionId: "api-session",
     sessionSource: null,
     source: "api",
-    lastInteractionType: "openai:chatCompletions",
-    lastInteractionRequest: {
-      model: "gpt-4o",
-      messages: [{ role: "user", content: "Plain API session message" }],
-    },
+    lastUserMessagePreview: "Plain API session message",
   }),
 ];
 

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -43636,7 +43636,11 @@ export type GetInteractionSessionsResponses = {
             authMethods: Array<'provider_key' | 'virtual_key' | 'passthrough_virtual_key' | 'jwks' | 'oauth_client_credentials' | 'oauth_user' | 'internal' | 'unknown'>;
             authenticatedAppNames: Array<string>;
             userNames: Array<string>;
+            /**
+             * Short preview (max 200 chars) of the session's last user message. Raw request bodies are not returned by this listing.
+             */
             lastUserMessagePreview: string | null;
+            lastInteractionType: string | null;
             conversationTitle: string | null;
             claudeCodeTitle: string | null;
         }>;

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -43636,8 +43636,7 @@ export type GetInteractionSessionsResponses = {
             authMethods: Array<'provider_key' | 'virtual_key' | 'passthrough_virtual_key' | 'jwks' | 'oauth_client_credentials' | 'oauth_user' | 'internal' | 'unknown'>;
             authenticatedAppNames: Array<string>;
             userNames: Array<string>;
-            lastInteractionRequest: unknown;
-            lastInteractionType: string | null;
+            lastUserMessagePreview: string | null;
             conversationTitle: string | null;
             claudeCodeTitle: string | null;
         }>;


### PR DESCRIPTION
## Problem

Opening **LLM Logs** on staging OOM-killed the platform container (exit 137; backend ~1.9 GiB + Next.js ~1.1 GiB against the shared 3 Gi cgroup). The kill severs the RSC stream (browser shows `ERR_QUIC_PROTOCOL_ERROR` + the global "Application error" page) and takes `/health` down with it. Kernel kill records go back to Jul 16 — nothing ever surfaced them.

For a **ten-row** listing the route moved ~52 MB twice:

1. `page.tsx` server-prefetched `GET /api/interactions?limit=10` into `initialData.interactions` — dead weight nothing has read since the sessions redesign (`0024c69fc`, #2013), serialized into the RSC payload every render.
2. `GET /api/interactions/sessions` returned each session's fully delta-reconstructed `lastInteractionRequest` — **99.98% of the response by bytes** — so the client could derive an ~80-char preview.

This is a threshold crossing from data growth (Claude Code contexts), not a recent regression; reverting recent commits does not help.

## Changes

- **Drop the dead SSR prefetch.** The page keeps prefetching only the agents list (pinned by a new server-component test).
- **Sessions API returns a server-computed `lastUserMessagePreview`** (`≤200` chars, `z.string().max(200)`, documented in OpenAPI) using the same provider-aware parsing the client used (`DynamicInteraction.getLastUserMessage`), and never returns the raw request. Delta reconstruction still runs before the preview is derived; tests exercise it on a **cold** cache with the only user text in a chain ancestor outside the 20-row fetch window.
- **Report abnormal previous-container terminations on boot.** A killed container can't report its own death; on startup the backend resolves its own pod via the service-account namespace + in-cluster client (deliberately not the orchestrator's MCP-workload config, which may point elsewhere), reports OOMKilled (`fatal`) / non-zero exits (`error`) through the existing error-tracking integrations, and dedupes via a container-local marker file so supervisord-level process restarts don't re-emit stale kills. No-ops outside Kubernetes; never affects startup.

## ⚠️ Breaking change (sessions listing only)

`GET /api/interactions/sessions` no longer returns `lastInteractionRequest` (raw LLM request bodies). This is deliberate and is the fix — any consumer reading it should fetch bodies per interaction via `GET /api/interactions?sessionId=…` or the interaction detail endpoint. `lastInteractionType` **is retained** (restored during review to minimize the breaking surface). Two smaller behavior notes: a whitespace-only last message now renders the "No message" fallback instead of a blank cell, and a failing interactions fetch no longer blanks the whole page server-side (the table shows its retry state instead).

## Measured (dev stack pinned to the deployed commit, 10 × 5 MB seeded interactions)

| Surface | Before | After |
|---|---|---|
| `/llm/logs` HTML | 52,605,068 B / ~5 s | 148,745 B |
| `GET /api/interactions/sessions?limit=10` | 52,439,732 B | **9,350 B** |

## Review

Adversarially cross-reviewed (external `codex` + independent internal pass); fixes landed in `4424be418`: restored `lastInteractionType`, schema-level preview bound, surrogate-safe truncation, reporter namespace/cluster resolution, marker-file dedupe, PostHog exception fingerprint, cold-cache reconstruction tests, SSR no-prefetch regression test. Known deferrals (tracked on T-1015): delta-manager cache is entry-bounded not byte-bounded (pre-existing), worker/renderer processes don't run the termination reporter, and the session detail page still fetches full rows (`limit ≤ 100`) pending the list-projection redesign.

Fixes T-1015.