### PR TITLE
feat(skills): guard a skill update with a compare-and-set on its head

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -295004,6 +295004,12 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "baseVersion": {
+                    "description": "The skill's `latestVersion` when this edit was composed. Rejected with 409 if the skill has moved past it. Omit only when the payload owes nothing to a prior read of the skill.",
+                    "type": "integer",
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991
                   }
                 },
                 "required": [

--- a/docs/pages/platform-agent-skills.md
+++ b/docs/pages/platform-agent-skills.md
@@ -3,7 +3,7 @@ title: Skills
 category: Agents
 order: 3
 description: Reusable SKILL.md instruction sets that agents load on demand
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-05
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -130,6 +130,14 @@ A synced skill can lose its GitHub token while it sits in the trash. It still re
 Every edit that changes a skill's `SKILL.md` or resource files creates a new immutable version. An edit that changes nothing does not. Version numbers count up from 1, and the full history is kept.
 
 `GET /api/skills/:id/versions` lists versions as metadata, newest first. `GET /api/skills/:id/versions/:version` returns one version's body and file snapshots. Sandboxes mount a pinned version, so a running skill never changes mid-conversation.
+
+### Concurrent Edits
+
+An edit can be anchored to the version it started from. If someone changes the skill's content first, the save is refused. Their edit is never overwritten.
+
+`PUT /api/skills/:id` takes `baseVersion` — the skill's `latestVersion` when you composed the edit. The request fails with 409 if the skill has moved past it. Omit `baseVersion` and the save is not guarded. The `edit_skill` tool takes the same field.
+
+Only content is versioned. A change to the name, scope, teams, or environments is not caught.
 
 ## Environments
 

--- a/platform/backend/src/archestra-mcp-server/skills.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.ts
@@ -609,7 +609,16 @@ const registry = defineArchestraTools([
           expectedLatestVersion: args.baseVersion,
         });
       } catch (error) {
-        if (error instanceof ApiError) return errorResult(error.message);
+        if (error instanceof ApiError) {
+          // The model's conflict message is client-neutral, so the way back is
+          // added here — `load_skill` is this caller's re-read, not the REST
+          // route's.
+          return errorResult(
+            error.internalCode === "skill_version_conflict"
+              ? `${error.message} Reload the skill with load_skill and retry.`
+              : error.message,
+          );
+        }
         throw error;
       }
       if (!updated) {

--- a/platform/backend/src/models/skill.ts
+++ b/platform/backend/src/models/skill.ts
@@ -346,11 +346,12 @@ class SkillModel {
    * change can never be committed with a team set that leaves the skill
    * orphaned.
    *
-   * When `expectedLatestVersion` is set, the update is a compare-and-set: it
-   * throws `ApiError(409)` (rolling back) if the skill's head has already moved
-   * past that version, so an edit computed from a stale snapshot cannot clobber
-   * a concurrent update. Omit it to keep last-write-wins (the full-manifest
-   * `update_skill` path, whose payload is self-contained).
+   * `expectedLatestVersion` anchors the edit to the head it was computed from:
+   * the update is a compare-and-set that throws `ApiError(409)` (rolling back)
+   * if the skill has already moved past it, so a stale snapshot cannot clobber
+   * a concurrent write. Every caller that read the skill before editing it
+   * passes one. Omit it only when the payload owes nothing to a prior read —
+   * `update_skill`, which composes a whole manifest from its arguments.
    */
   static async updateWithFiles(params: {
     id: string;
@@ -382,9 +383,16 @@ class SkillModel {
         params.expectedLatestVersion !== undefined &&
         skill.latestVersion !== params.expectedLatestVersion
       ) {
+        // Carries an internal code because the update route raises other 409s
+        // (a name collision, a read-only GitHub-synced skill) and a client that
+        // has to offer a reload cannot tell them apart on the status alone.
+        // The message stays client-neutral: it reaches both the REST route and
+        // `edit_skill`, so the caller appends its own way back rather than
+        // being named here.
         throw new ApiError(
           409,
-          `Skill "${skill.name}" has moved to version ${skill.latestVersion}; the edit was based on version ${params.expectedLatestVersion}. Reload the skill with load_skill and retry.`,
+          `Skill "${skill.name}" has moved to version ${skill.latestVersion}; the edit was based on version ${params.expectedLatestVersion}.`,
+          "skill_version_conflict",
         );
       }
 

--- a/platform/backend/src/models/skill.ts
+++ b/platform/backend/src/models/skill.ts
@@ -349,9 +349,10 @@ class SkillModel {
    * `expectedLatestVersion` anchors the edit to the head it was computed from:
    * the update is a compare-and-set that throws `ApiError(409)` (rolling back)
    * if the skill has already moved past it, so a stale snapshot cannot clobber
-   * a concurrent write. Every caller that read the skill before editing it
-   * passes one. Omit it only when the payload owes nothing to a prior read —
-   * `update_skill`, which composes a whole manifest from its arguments.
+   * a concurrent write. It is opt-in per caller: `edit_skill` always passes one
+   * (its schema requires `baseVersion`), the REST update route forwards one only
+   * when the client sends it, and `update_skill` never does — it composes a whole
+   * manifest from its arguments and owes nothing to a prior read.
    */
   static async updateWithFiles(params: {
     id: string;

--- a/platform/backend/src/routes/skill/skill.routes.ts
+++ b/platform/backend/src/routes/skill/skill.routes.ts
@@ -261,9 +261,11 @@ const SkillManifestInputSchema = SkillManifestFieldsSchema.superRefine(
 
 /**
  * Update payload: the manifest fields plus `baseVersion`, the compare-and-set
- * the `edit_skill` MCP tool already takes under the same name. A caller that
- * read the skill before editing it anchors on what it read, so a write landing
- * in between is rejected (409) instead of silently buried.
+ * the `edit_skill` MCP tool already takes under the same name. Optional, and
+ * not sent by any in-repo caller yet — the skill editor dialog still saves
+ * last-write-wins. For now it guards API clients that opt in: a write landing
+ * between their read and their save is rejected (409) rather than silently
+ * buried.
  *
  * Split from {@link SkillManifestInputSchema} because `.superRefine()` yields a
  * `ZodEffects`, which cannot be `.extend()`ed — the shared fields have to live

--- a/platform/backend/src/routes/skill/skill.routes.ts
+++ b/platform/backend/src/routes/skill/skill.routes.ts
@@ -230,32 +230,57 @@ const ConvertAgentToSkillInputSchema = z.object({
  * files untouched; passing `[]` clears them. `scope` defaults to `personal`;
  * `teamIds` is only meaningful for `scope = 'team'`.
  */
-const SkillManifestInputSchema = z
-  .object({
-    content: SkillManifestContentSchema,
-    files: z.array(SkillFileInputSchema).max(MAX_FILES_PER_SKILL).optional(),
-    scope: ResourceVisibilityScopeSchema.optional(),
-    teamIds: z.array(z.string()).optional(),
-    /** Only meaningful for `scope = 'personal'`; ignored for team/org skills. */
-    userIds: z.array(z.string()).optional(),
-    environmentIds: z
-      .array(UuidIdSchema)
-      .optional()
-      .describe(
-        "Environments the skill is restricted to. Empty (or omitted on " +
-          "create) makes the skill available to agents in every " +
-          "environment; otherwise only agents in one of the listed " +
-          "environments see it.",
-      ),
-    allowedTools: z
-      .array(z.string())
-      .optional()
-      .describe(
-        "Tools the skill expects, overriding the SKILL.md `allowed-tools` " +
-          "frontmatter. Omit to use the frontmatter; pass [] to clear.",
-      ),
-  })
-  .superRefine((data, ctx) => refineUniqueFilePaths(data.files, ctx));
+const SkillManifestFieldsSchema = z.object({
+  content: SkillManifestContentSchema,
+  files: z.array(SkillFileInputSchema).max(MAX_FILES_PER_SKILL).optional(),
+  scope: ResourceVisibilityScopeSchema.optional(),
+  teamIds: z.array(z.string()).optional(),
+  /** Only meaningful for `scope = 'personal'`; ignored for team/org skills. */
+  userIds: z.array(z.string()).optional(),
+  environmentIds: z
+    .array(UuidIdSchema)
+    .optional()
+    .describe(
+      "Environments the skill is restricted to. Empty (or omitted on " +
+        "create) makes the skill available to agents in every " +
+        "environment; otherwise only agents in one of the listed " +
+        "environments see it.",
+    ),
+  allowedTools: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Tools the skill expects, overriding the SKILL.md `allowed-tools` " +
+        "frontmatter. Omit to use the frontmatter; pass [] to clear.",
+    ),
+});
+
+const SkillManifestInputSchema = SkillManifestFieldsSchema.superRefine(
+  (data, ctx) => refineUniqueFilePaths(data.files, ctx),
+);
+
+/**
+ * Update payload: the manifest fields plus `baseVersion`, the compare-and-set
+ * the `edit_skill` MCP tool already takes under the same name. A caller that
+ * read the skill before editing it anchors on what it read, so a write landing
+ * in between is rejected (409) instead of silently buried.
+ *
+ * Split from {@link SkillManifestInputSchema} because `.superRefine()` yields a
+ * `ZodEffects`, which cannot be `.extend()`ed — the shared fields have to live
+ * in a plain object for the update schema to add to them.
+ */
+const SkillManifestUpdateSchema = SkillManifestFieldsSchema.extend({
+  baseVersion: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      "The skill's `latestVersion` when this edit was composed. Rejected " +
+        "with 409 if the skill has moved past it. Omit only when the payload " +
+        "owes nothing to a prior read of the skill.",
+    ),
+}).superRefine((data, ctx) => refineUniqueFilePaths(data.files, ctx));
 
 /** A comma-separated query param parsed into a string[] (mirrors the agents list). */
 const CommaSeparatedIds = z.preprocess(
@@ -812,7 +837,7 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         description: "Update a skill's SKILL.md, resource files, and scope",
         tags: ["Skills"],
         params: z.object({ id: z.string() }),
-        body: SkillManifestInputSchema,
+        body: SkillManifestUpdateSchema,
         response: constructResponseSchema(SkillDetailSchema),
       },
     },
@@ -915,11 +940,16 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
               body.files === undefined ? undefined : toSkillFiles(body.files),
             teamIds: scopeChanged || teamsChanged ? newTeamIds : undefined,
             environmentIds: environmentsChanged ? newEnvironmentIds : undefined,
+            // Compare-and-set against the head the caller composed from; the
+            // transaction rejects (409) rather than burying a concurrent edit.
+            expectedLatestVersion: body.baseVersion,
           }),
         );
       } catch (error) {
         // Name conflict within the skill's visibility namespace — not a team FK
         // (mapped above) or a duplicate resource-file path (rejected at input).
+        // The version-conflict 409 raised inside the transaction is an ApiError,
+        // not a unique violation, so it passes through this check untouched.
         if (isSkillNameConflict(error)) {
           throw skillNameConflict(parsed.name);
         }

--- a/platform/backend/src/routes/skill/update.skill.route.test.ts
+++ b/platform/backend/src/routes/skill/update.skill.route.test.ts
@@ -96,6 +96,97 @@ describe("PUT /api/skills/:id", () => {
     expect(body.files[0].path).toBe("references/NEW.md");
   });
 
+  test("baseVersion rejects an edit composed from a superseded head", async () => {
+    const created = (
+      await ctx.app.inject({
+        method: "POST",
+        url: "/api/skills",
+        payload: { content: MANIFEST },
+      })
+    ).json();
+
+    // someone else's edit moves the head past what our caller read
+    const theirs = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/skills/${created.id}`,
+      payload: { content: `${MANIFEST}\nTheir edit.` },
+    });
+    expect(theirs.statusCode).toBe(200);
+    expect(theirs.json().latestVersion).toBeGreaterThan(created.latestVersion);
+
+    const stale = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/skills/${created.id}`,
+      payload: {
+        content: `${MANIFEST}\nOur edit.`,
+        baseVersion: created.latestVersion,
+      },
+    });
+
+    expect(stale.statusCode).toBe(409);
+    // machine-readable so a client can offer a reload, which it cannot do off
+    // the status alone — this route's other 409s are not reload-able
+    expect(stale.json().error.internal_code).toBe("skill_version_conflict");
+
+    // the rejected edit rolled back: their content survives intact
+    const after = await ctx.app.inject({
+      method: "GET",
+      url: `/api/skills/${created.id}`,
+    });
+    expect(after.json().content).toContain("Their edit.");
+    expect(after.json().content).not.toContain("Our edit.");
+  });
+
+  test("a name-collision 409 carries no version-conflict code", async () => {
+    const created = (
+      await ctx.app.inject({
+        method: "POST",
+        url: "/api/skills",
+        payload: { content: manifestNamed("first-skill") },
+      })
+    ).json();
+    await ctx.app.inject({
+      method: "POST",
+      url: "/api/skills",
+      payload: { content: manifestNamed("second-skill") },
+    });
+
+    const renamed = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/skills/${created.id}`,
+      payload: { content: manifestNamed("second-skill") },
+    });
+
+    expect(renamed.statusCode).toBe(409);
+    expect(renamed.json().error.internal_code).toBeUndefined();
+  });
+
+  test("omitting baseVersion keeps last-write-wins", async () => {
+    const created = (
+      await ctx.app.inject({
+        method: "POST",
+        url: "/api/skills",
+        payload: { content: MANIFEST },
+      })
+    ).json();
+
+    await ctx.app.inject({
+      method: "PUT",
+      url: `/api/skills/${created.id}`,
+      payload: { content: `${MANIFEST}\nTheir edit.` },
+    });
+
+    // same stale starting point as above, but unguarded — the write lands
+    const unguarded = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/skills/${created.id}`,
+      payload: { content: `${MANIFEST}\nOur edit.` },
+    });
+
+    expect(unguarded.statusCode).toBe(200);
+    expect(unguarded.json().content).toContain("Our edit.");
+  });
+
   test("explicit allowedTools overrides the frontmatter on update", async () => {
     const created = (
       await ctx.app.inject({

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -76030,6 +76030,10 @@ export type UpdateSkillData = {
          * Tools the skill expects, overriding the SKILL.md `allowed-tools` frontmatter. Omit to use the frontmatter; pass [] to clear.
          */
         allowedTools?: Array<string>;
+        /**
+         * The skill's `latestVersion` when this edit was composed. Rejected with 409 if the skill has moved past it. Omit only when the payload owes nothing to a prior read of the skill.
+         */
+        baseVersion?: number;
     };
     path: {
         id: string;


### PR DESCRIPTION
## What

`PUT /api/skills/:id` now accepts an optional `baseVersion` — the skill's `latestVersion` at the moment the edit was composed. When it is present the update becomes a compare-and-set: if the skill's head moved in between, the request is rejected with `409` and the transaction rolls back, instead of silently burying whoever wrote first. Omitted, the route keeps its current last-write-wins behavior.

The `edit_skill` MCP tool already took a required `baseVersion` and drove the same model-level guard. This extends it to the REST route and makes the resulting 409 machine-readable.

## Changes

- **`models/skill.ts`** — the version-conflict 409 now carries `internalCode: "skill_version_conflict"`. The update route raises other 409s (name collision within the visibility namespace, read-only GitHub-synced skill) that a client cannot tell apart on status alone. The message itself was made client-neutral: it reaches both the REST route and `edit_skill`, so the recovery hint moved out to the caller.
- **`archestra-mcp-server/skills.ts`** — `edit_skill` appends its own way back ("Reload the skill with `load_skill` and retry") when it sees that internal code. `load_skill` is *its* re-read, not a REST client's.
- **`routes/skill/skill.routes.ts`** — `SkillManifestUpdateSchema` adds `baseVersion` and forwards it as `expectedLatestVersion`. The shared manifest fields had to be split out of `SkillManifestInputSchema` first: `.superRefine()` yields a `ZodEffects`, which cannot be `.extend()`ed. `refineUniqueFilePaths` is re-applied to the new schema.
- **Docs** — new *Concurrent Edits* section under Version History in `platform-agent-skills.md`; `openapi.json` and the generated API client regenerated.

## Scope and limits

Two things are deliberate and are called out in the code so they don't read as oversights:

- **No in-repo caller sends `baseVersion` yet.** The skill editor dialog still saves last-write-wins; wiring it up is a follow-up PR. Until then the guard serves API clients that opt in. Noted in the JSDoc on the schema, at the exact place a reader asks the question.
- **Only the SKILL.md body and resource files are versioned.** `computeContentHash` covers those two and nothing else, so a change to frontmatter fields, scope, teams, environments, or sharing does not move `latestVersion` and is not caught by the guard. Documented in the same docs section.

## Tests

Three new cases in `update.skill.route.test.ts`: a stale `baseVersion` is rejected with the internal code and the first writer's content survives the rollback; a name-collision 409 carries no version-conflict code (so a client can still distinguish them); omitting `baseVersion` keeps last-write-wins.

`pnpm vitest run src/routes/skill/update.skill.route.test.ts` (13 passed) and `src/archestra-mcp-server/skills.test.ts` (58 passed) green; `pnpm type-check` clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
