### PR TITLE
test(llm-logs): prove cold-path delta reconstruction at the route boundary; crash-safe termination marker

### DIFF
--- a/platform/backend/src/observability/previous-termination-report.test.ts
+++ b/platform/backend/src/observability/previous-termination-report.test.ts
@@ -19,9 +19,11 @@ vi.mock("@/services/error-tracking", () => ({
 // storage (kubelet-projected volume / container-local tmp).
 const readFileMock = vi.hoisted(() => vi.fn());
 const writeFileMock = vi.hoisted(() => vi.fn());
+const renameMock = vi.hoisted(() => vi.fn());
 vi.mock("node:fs/promises", () => ({
   readFile: readFileMock,
   writeFile: writeFileMock,
+  rename: renameMock,
 }));
 
 const readNamespacedPod = vi.hoisted(() => vi.fn());
@@ -84,6 +86,7 @@ describe("reportAbnormalPreviousTermination", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     writeFileMock.mockResolvedValue(undefined);
+    renameMock.mockResolvedValue(undefined);
   });
 
   test("reports an OOMKilled previous container as fatal and records a marker", async () => {
@@ -122,10 +125,12 @@ describe("reportAbnormalPreviousTermination", () => {
       exitCode: 137,
     });
 
+    // Write-then-rename keeps the marker file crash-safe.
     expect(writeFileMock).toHaveBeenCalledWith(
-      MARKER_PATH,
+      `${MARKER_PATH}.tmp`,
       JSON.stringify(["archestra-platform:containerd://abc"]),
     );
+    expect(renameMock).toHaveBeenCalledWith(`${MARKER_PATH}.tmp`, MARKER_PATH);
   });
 
   test("does not re-report a termination already recorded in the marker file", async () => {
@@ -161,7 +166,7 @@ describe("reportAbnormalPreviousTermination", () => {
 
     expect(captureExceptionSentry).toHaveBeenCalledTimes(1);
     expect(writeFileMock).toHaveBeenCalledWith(
-      MARKER_PATH,
+      `${MARKER_PATH}.tmp`,
       JSON.stringify([
         "archestra-platform:containerd://old",
         "archestra-platform:containerd://new",

--- a/platform/backend/src/observability/previous-termination-report.ts
+++ b/platform/backend/src/observability/previous-termination-report.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, rename, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import * as k8s from "@kubernetes/client-node";
@@ -160,7 +160,11 @@ async function readReportedMarkers(): Promise<string[]> {
 
 async function writeReportedMarkers(markers: string[]): Promise<void> {
   try {
-    await writeFile(REPORTED_MARKER_PATH, JSON.stringify(markers));
+    // Write-then-rename: an interrupted in-place write would leave corrupt
+    // JSON, which reads back as "no markers" and re-reports stale kills.
+    const tmpPath = `${REPORTED_MARKER_PATH}.tmp`;
+    await writeFile(tmpPath, JSON.stringify(markers));
+    await rename(tmpPath, REPORTED_MARKER_PATH);
   } catch (error) {
     logger.debug({ err: error }, "Could not persist termination-report marker");
   }

--- a/platform/backend/src/routes/interaction.test.ts
+++ b/platform/backend/src/routes/interaction.test.ts
@@ -445,10 +445,16 @@ describe("interaction routes", () => {
       },
     };
     const m0 = { role: "user", content: "first message in the claude session" };
+    // The tip's own delta suffix carries no user TEXT (tool_result-only), so
+    // the preview's text exists only in the head row — a suffix-only
+    // (unreconstructed) read would yield a null preview.
     const fullMessages = [
       m0,
       { role: "assistant", content: "ack" },
-      { role: "user", content: "second message" },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "tu_1", content: "ok" }],
+      },
     ];
 
     const anthropicReq = (messages: unknown[]) =>
@@ -489,10 +495,14 @@ describe("interaction routes", () => {
     });
     expect(sessions.statusCode).toBe(200);
     const sessionRow = sessions.json().data[0];
-    expect(sessionRow.lastUserMessagePreview).toBe("second message");
+    expect(sessionRow.lastUserMessagePreview).toBe(
+      "first message in the claude session",
+    );
     expect(sessionRow).not.toHaveProperty("lastInteractionRequest");
 
-    // Detail endpoint reconstructs the full request and passes response schema.
+    // Detail endpoint reconstructs the full request and passes response
+    // schema. Cold cache again: the sessions call above warmed the tip.
+    InteractionDeltaManager.reset();
     const detail = await app.inject({
       method: "GET",
       url: `/api/interactions/${tip.id}`,
@@ -500,7 +510,9 @@ describe("interaction routes", () => {
     expect(detail.statusCode).toBe(200);
     expect(detail.json().request.messages).toEqual(fullMessages);
 
-    // Session-filtered list reconstructs every interaction's request.
+    // Session-filtered list reconstructs every interaction's request — also
+    // from a cold cache.
+    InteractionDeltaManager.reset();
     const list = await app.inject({
       method: "GET",
       url: "/api/interactions?limit=10&offset=0&sortBy=createdAt&sortDirection=desc&sessionId=route-delta-session",

--- a/platform/backend/src/routes/interaction.test.ts
+++ b/platform/backend/src/routes/interaction.test.ts
@@ -473,6 +473,10 @@ describe("interaction routes", () => {
       type: "anthropic:messages",
       request: anthropicReq([m0]),
       response: anthropicResp,
+      // Explicit distinct timestamps: defaultNow() can tie within the same
+      // millisecond, and the last-interaction window ranks by created_at
+      // alone — a tie could select the head row and dodge tip reconstruction.
+      createdAt: new Date("2020-01-01T00:00:00.000Z"),
     });
     const tip = await InteractionModel.create({
       profileId: agent.id,
@@ -481,6 +485,7 @@ describe("interaction routes", () => {
       type: "anthropic:messages",
       request: anthropicReq(fullMessages),
       response: anthropicResp,
+      createdAt: new Date("2020-01-01T00:00:01.000Z"),
     });
 
     // Sessions endpoint derives its preview from the reconstructed request —


### PR DESCRIPTION
Follow-up to #7095 — the two round-2 findings from the adversarial cross-review landed after that PR entered the merge queue:

- **Route delta test now proves cold reconstruction.** The expected preview text previously lived in the tip row's own stored delta suffix, so the sessions path could have skipped chain reconstruction and still passed. The tip's suffix now carries no user text (tool_result-only turn), the preview text exists only in the chain head, and each of the three reads (sessions, detail, list) runs on a freshly reset delta cache.
- **Termination-report marker is written via write-then-rename.** An interrupted in-place write would leave corrupt JSON, which reads back as "no markers" and would re-report stale kills on the next backend process restart.

Tests: 29/29 across the two touched files; lint clean.

Part of T-1015.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>