### PR TITLE
fix(mcp-registry): stop a teammate's pending install from hiding the Install button — top merge-queue flakes

### DIFF
--- a/.github/actions/scan-docker-image/action.yml
+++ b/.github/actions/scan-docker-image/action.yml
@@ -29,7 +29,26 @@ inputs:
 runs:
   using: composite
   steps:
+    # First attempt is allowed to fail so a transient infrastructure error
+    # (e.g. a 403 downloading the Scout binary release asset, which has kicked
+    # PRs out of the merge queue) gets one retry. A genuine CVE finding fails
+    # the retry identically, so real findings still fail the job.
     - name: Docker Scout CVE Check
+      id: scout-first-attempt
+      continue-on-error: true
+      uses: docker/scout-action@7520205ff60037fdc436b40b6a1d1e55a839ec2d # v1.22.0
+      with:
+        command: cves
+        image: ${{ inputs.image }}
+        dockerhub-user: ${{ inputs.dockerhub-user }}
+        dockerhub-password: ${{ inputs.dockerhub-password }}
+        only-severities: ${{ inputs.only-severities }}
+        only-fixed: ${{ inputs.only-fixed }}
+        write-comment: false
+        exit-code: ${{ inputs.exit-code }}
+
+    - name: Docker Scout CVE Check (retry)
+      if: steps.scout-first-attempt.outcome == 'failure'
       uses: docker/scout-action@7520205ff60037fdc436b40b6a1d1e55a839ec2d # v1.22.0
       with:
         command: cves

--- a/platform/e2e-tests/tests/static-credentials-management.spec.ts
+++ b/platform/e2e-tests/tests/static-credentials-management.spec.ts
@@ -185,14 +185,20 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
           gatewayName: gatewayNameForAssignment,
         });
         const expectedAssignableCredentials = expectedCredentials;
-        const visibleStaticCredentials =
-          await getVisibleStaticCredentials(page);
-        for (const credential of expectedAssignableCredentials) {
-          await expect(visibleStaticCredentials).toContain(credential);
-        }
-        await expect(visibleStaticCredentials).toHaveLength(
-          expectedAssignableCredentials.length,
-        );
+        // Poll instead of a one-shot read: the dropdown renders from a
+        // TanStack Query result that can transiently miss a just-created
+        // credential until the mount-time refetch lands (observed in merge
+        // queue as "expected admin@example.com, received [Default Team]").
+        // The options re-render in place once fresh data arrives, so
+        // re-reading converges; a thrown read (options briefly unmounted
+        // mid-re-render) counts as "not yet" rather than aborting the poll.
+        await expect
+          .poll(
+            async () =>
+              (await getVisibleStaticCredentials(page).catch(() => [])).sort(),
+            { timeout: 30_000, intervals: [500, 1000, 2000, 4000] },
+          )
+          .toEqual([...expectedAssignableCredentials].sort());
         await selectCredentialOption(
           page,
           page.getByRole("option", {

--- a/platform/e2e-tests/utils/mcp-registry.ts
+++ b/platform/e2e-tests/utils/mcp-registry.ts
@@ -212,7 +212,10 @@ async function openCatalogItemConnectDialog(
   catalogItemName: string,
   options?: { timeoutMs?: number },
 ): Promise<void> {
-  const timeoutMs = options?.timeoutMs ?? 30_000;
+  // 60s, not 30s: on standard GitHub-hosted runners the card can spend a
+  // while with its Install button legitimately absent (e.g. the viewer's own
+  // just-triggered install still settling) before it renders.
+  const timeoutMs = options?.timeoutMs ?? 60_000;
   const connectButton = page.getByTestId(
     `${E2eTestId.ConnectCatalogItemButton}-${catalogItemName}`,
   );

--- a/platform/e2e-tests/utils/tool-assignments.ts
+++ b/platform/e2e-tests/utils/tool-assignments.ts
@@ -161,7 +161,10 @@ export async function assignCatalogCredentialToGateway(params: {
   const credentialOption = params.page.getByRole("option", {
     name: params.credentialName,
   });
-  await expect(credentialOption).toBeVisible({ timeout: 10_000 });
+  // 30s, not 10s: the option list renders from a query result that can
+  // transiently miss a just-created credential until the mount-time refetch
+  // lands; the options re-render in place once fresh data arrives.
+  await expect(credentialOption).toBeVisible({ timeout: 30_000 });
   await selectCredentialOption(params.page, credentialOption);
   await saveOpenProfileDialog(params.page);
 }

--- a/platform/frontend/src/app/mcp/registry/_parts/card-install-state.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/card-install-state.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { isCardShowingInstallInProgress } from "./card-install-state";
+
+describe("isCardShowingInstallInProgress", () => {
+  it("does NOT treat another user's pending install as installing (the merge-queue flake: teammate's pending connection hid the viewer's Install button)", () => {
+    expect(
+      isCardShowingInstallInProgress({
+        deploymentFailed: false,
+        viewerTriggeredInstall: false,
+        variant: "local",
+        installationStatus: "pending",
+        hasInstalledServer: true,
+        installationOwnedByViewer: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does NOT treat another user's tool discovery as installing", () => {
+    expect(
+      isCardShowingInstallInProgress({
+        deploymentFailed: false,
+        viewerTriggeredInstall: false,
+        variant: "local",
+        installationStatus: "discovering-tools",
+        hasInstalledServer: true,
+        installationOwnedByViewer: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats the viewer's own pending install as installing", () => {
+    expect(
+      isCardShowingInstallInProgress({
+        deploymentFailed: false,
+        viewerTriggeredInstall: false,
+        variant: "local",
+        installationStatus: "pending",
+        hasInstalledServer: true,
+        installationOwnedByViewer: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats the viewer's own tool discovery as installing", () => {
+    expect(
+      isCardShowingInstallInProgress({
+        deploymentFailed: false,
+        viewerTriggeredInstall: false,
+        variant: "local",
+        installationStatus: "discovering-tools",
+        hasInstalledServer: true,
+        installationOwnedByViewer: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats an install the viewer just triggered as installing regardless of ownership data", () => {
+    expect(
+      isCardShowingInstallInProgress({
+        deploymentFailed: false,
+        viewerTriggeredInstall: true,
+        variant: "local",
+        installationStatus: null,
+        hasInstalledServer: false,
+        installationOwnedByViewer: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("is not installing once the viewer's install succeeded", () => {
+    expect(
+      isCardShowingInstallInProgress({
+        deploymentFailed: false,
+        viewerTriggeredInstall: false,
+        variant: "local",
+        installationStatus: "success",
+        hasInstalledServer: true,
+        installationOwnedByViewer: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows the failure state, not a spinner, when the deployment failed while still pending", () => {
+    expect(
+      isCardShowingInstallInProgress({
+        deploymentFailed: true,
+        viewerTriggeredInstall: false,
+        variant: "local",
+        installationStatus: "pending",
+        hasInstalledServer: true,
+        installationOwnedByViewer: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("never derives installing from backend status on non-local variants", () => {
+    expect(
+      isCardShowingInstallInProgress({
+        deploymentFailed: false,
+        viewerTriggeredInstall: false,
+        variant: "remote",
+        installationStatus: "pending",
+        hasInstalledServer: true,
+        installationOwnedByViewer: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/card-install-state.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/card-install-state.ts
@@ -1,0 +1,59 @@
+import type { McpServerCardVariant } from "./mcp-server-card";
+
+/**
+ * Decides whether an MCP registry card is in its "installing" state — which
+ * hides the Install button and shows install progress.
+ *
+ * `installationStatus` comes from the aggregated installation for the catalog
+ * item, and that aggregation falls back to ANOTHER user's server when the
+ * viewer has no install of their own (`getAggregatedInstallation` prefers the
+ * viewer's server but settles for any). A teammate's pending install must not
+ * put the viewer's card into the installing state: it would hide the viewer's
+ * Install button for the whole pod-startup + tool-discovery window of a
+ * connection that isn't theirs, locking them out of adding their own
+ * credential (and intermittently failing e2e installs queued right after a
+ * teammate's).
+ *
+ * So a backend `pending` / `discovering-tools` status only counts when the
+ * aggregated installation belongs to the viewer; an install the viewer just
+ * triggered in this session (`viewerTriggeredInstall`) always counts.
+ */
+export function isCardShowingInstallInProgress({
+  deploymentFailed,
+  viewerTriggeredInstall,
+  variant,
+  installationStatus,
+  hasInstalledServer,
+  installationOwnedByViewer,
+}: {
+  /** The K8s deployment already failed (e.g. CrashLoopBackOff): show the error, not a spinner. */
+  deploymentFailed: boolean;
+  /** The viewer started an install for this item in this session (`installingItemId === item.id`). */
+  viewerTriggeredInstall: boolean;
+  variant: McpServerCardVariant;
+  installationStatus:
+    | "error"
+    | "pending"
+    | "success"
+    | "idle"
+    | "discovering-tools"
+    | null
+    | undefined;
+  /** An aggregated installation exists for this catalog item. */
+  hasInstalledServer: boolean;
+  /** The aggregated installation's `ownerId` is the viewing user. */
+  installationOwnedByViewer: boolean;
+}): boolean {
+  if (deploymentFailed) {
+    return false;
+  }
+  if (viewerTriggeredInstall) {
+    return true;
+  }
+  return (
+    variant === "local" &&
+    installationOwnedByViewer &&
+    (installationStatus === "pending" ||
+      (installationStatus === "discovering-tools" && hasInstalledServer))
+  );
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -65,6 +65,7 @@ import { useReinstallInternalMcpCatalogItem } from "@/lib/mcp/internal-mcp-catal
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { useDefaultEnvironment } from "@/lib/organization.query";
 import { useAssignableTeams } from "@/lib/teams/team.query";
+import { isCardShowingInstallInProgress } from "./card-install-state";
 import { useCanModifyCatalogItem } from "./catalog-edit-access";
 import { clearCatalogEditParam } from "./catalog-edit-link";
 import { resolveCatalogEnvironmentLabel } from "./catalog-environment-label";
@@ -375,13 +376,15 @@ export function McpServerCard({
     />
   ) : null;
 
-  const isInstalling = Boolean(
-    !isDeploymentFailed &&
-      (installingItemId === item.id ||
-        (variant === "local" &&
-          (installationStatus === "pending" ||
-            (installationStatus === "discovering-tools" && installedServer)))),
-  );
+  const isInstalling = isCardShowingInstallInProgress({
+    deploymentFailed: isDeploymentFailed,
+    viewerTriggeredInstall: installingItemId === item.id,
+    variant,
+    installationStatus,
+    hasInstalledServer: !!installedServer,
+    installationOwnedByViewer:
+      !!currentUserId && installedServer?.ownerId === currentUserId,
+  });
 
   const isCurrentUserAuthenticated =
     currentUserId && installedServer?.users


### PR DESCRIPTION
## Why

Merge-queue kicks felt way up lately, so this PR starts from the data: of the **1000 `merge_group` CI runs in the past week, 82 failed** (~8% of queue runs, 54 distinct PR queue entries kicked). Ranked by run count:

| Cause | Failed runs | Status |
|---|---|---|
| `static-credentials-management.spec.ts:48` (gateway credential dropdown) | 33 | **fixed here** |
| `mcp-gateway-jwks.ee.spec.ts:30` | 32 | already fixed by #7058's api+idp matrix split — zero failures in ~250 runs since Aug 2 |
| `static-credentials-management.spec.ts:281` (Install button never appears) | 21 — and in nearly **every** failed queue run since Aug 3 | **fixed here** |
| `chat.spec.ts` provider matrix (mocked response not visible in 90s) | 24 | not fixed — needs trace-level investigation, see below |
| Docker Image Scanning | 15 runs | CVE part fixed by #7079 this morning; transient-403 part **fixed here** |
| `static-credentials-management.spec.ts:351` | 8 | **fixed here** |

The `:281` spike is a regression that started exactly when CI moved to GitHub-hosted runners (#7058, Aug 2): slower pod startup + tool discovery widened a pre-existing race past the test's 30s budget, after which it failed ~14 different PRs' queue runs in two days (e.g. #7072 was kicked twice yesterday alone by `:48`/`:281` plus once by the Docker-scan 403).

## What

**1. Product fix (root cause of `:281`): a teammate's pending install no longer hides your Install button.**
`McpServerCard` derived its installing state from the *aggregated* installation for the catalog item, which falls back to another user's server when the viewer has none. So while user A's team credential was mid-pod-startup/tool-discovery, user B's card hid its Install button entirely — in the e2e, the next user polls 30s for a button that stays hidden until the pod settles. Backend `pending`/`discovering-tools` now only counts when the aggregated installation belongs to the viewer (in-session installs the viewer triggered still count). Logic extracted to `card-install-state.ts` with unit tests, following the `_parts` pure-helper pattern.

**2. E2E hardening for `:48`/`:351`:** the gateway-assignment credential dropdown renders from a query result that can transiently miss a just-created credential until the mount-time refetch lands (queue signature: expected `admin@example.com`, received `[Default Team]`). The one-shot read + assert is now a converging poll; the option-visibility wait in `assignCatalogCredentialToGateway` widened 10s→30s; `openCatalogItemConnectDialog` default budget 30s→60s for standard-runner headroom.

**3. CI: retry the Docker Scout scan once.** The scout-action intermittently 403s downloading its own 174MB release asset, failing the scan with no retry. Transient failures get one retry; genuine CVE findings fail the retry identically, so nothing gets softer. (zizmor clean.)

## Not fixed here (known remaining flake)

`chat.spec.ts:205/214` — the mocked streaming response intermittently never renders within 90s, across many providers (so it's pipeline-wide, not provider-specific), ~24 runs this week. Every failure log carries zero server-side signal; root-causing this needs a failing run's Playwright trace + backend logs correlated at failure time. Two providers (cerebras, cohere) are already skip-listed for the same signature.

## Validation

- New unit tests: `card-install-state.test.ts` (8/8 pass)
- `pnpm type-check` clean (frontend + e2e-tests), `biome check` clean, frontend `knip` clean, `zizmor` clean on the action
- Full e2e suite runs on this PR's CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>