### PR TITLE
feat(apps): silent app builds with user-facing language in chat

### DIFF
--- a/platform/backend/src/agents/agent-system-prompt.test.ts
+++ b/platform/backend/src/agents/agent-system-prompt.test.ts
@@ -20,6 +20,7 @@ import type { OpenedApp } from "@/services/apps/opened-app-context";
 import { SKILL_SANDBOX_ATTACHMENTS_DIR } from "@/skills-sandbox/runtime-image";
 import { describe, expect, test } from "@/test";
 import {
+  APP_BUILD_CONDUCT_INSTRUCTION,
   buildAgentSystemPrompt,
   OPENED_APP_PREFIX,
   PROJECT_FILES_PREFIX,
@@ -295,6 +296,53 @@ describe("buildAgentSystemPrompt", () => {
     expect(
       await buildAgentSystemPrompt({ ...common, mcpTools: {} }),
     ).not.toContain(TOOL_UI_RESULT_INSTRUCTION);
+  });
+
+  test("adds the app-build conduct instruction when the agent can build apps", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const agent = await makeAgent({
+      systemPrompt: "Base.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId);
+    const common = {
+      agent,
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    };
+
+    // Direct exposure: keyed off the scaffold_app tool being assigned.
+    const withScaffoldApp: Record<string, Tool> = {
+      [brand(TOOL_SCAFFOLD_APP_SHORT_NAME)]: {} as Tool,
+    };
+    expect(
+      await buildAgentSystemPrompt({ ...common, mcpTools: withScaffoldApp }),
+    ).toContain(APP_BUILD_CONDUCT_INSTRUCTION);
+    expect(
+      await buildAgentSystemPrompt({ ...common, mcpTools: someTool }),
+    ).not.toContain(APP_BUILD_CONDUCT_INSTRUCTION);
+
+    // search_and_run_only can dispatch scaffold_app without it being listed,
+    // so the mode alone qualifies.
+    const searchAgent = await makeAgent({
+      systemPrompt: "Base.",
+      toolExposureMode: "search_and_run_only",
+    });
+    await makeMember(user.id, searchAgent.organizationId);
+    expect(
+      await buildAgentSystemPrompt({
+        agent: searchAgent,
+        mcpTools: {},
+        organizationId: searchAgent.organizationId,
+        userId: user.id,
+        agentId: searchAgent.id,
+      }),
+    ).toContain(APP_BUILD_CONDUCT_INSTRUCTION);
   });
 
   test("adds the tool-loading instruction only in search_and_run_only mode", async ({

--- a/platform/backend/src/agents/agent-system-prompt.ts
+++ b/platform/backend/src/agents/agent-system-prompt.ts
@@ -54,6 +54,20 @@ export const TOOL_UI_RESULT_INSTRUCTION =
   "When a tool result includes a UI resource, it means an interactive UI was rendered for the user. Respond with at most one brief sentence. Never describe, list, or explain what the UI shows.";
 
 /**
+ * Response-shaping rule for app building, emitted whenever the agent can reach
+ * the app-authoring tools (assigned directly, or discoverable in
+ * search_and_run_only mode). The model's habit of writing a transition sentence
+ * before each tool call turns an app build into a stream of internals-flavored
+ * status bubbles; a system-prompt rule is the only reliable counterweight — the
+ * Build App skill restates it, but skill text arrives as a tool result and
+ * loses to the habit on its own.
+ *
+ * @public — canonical instruction text, asserted by the assembler tests.
+ */
+export const APP_BUILD_CONDUCT_INSTRUCTION =
+  'While you are building or changing an app, your responses contain tool calls ONLY — no text. This applies from the user\'s build request onward, including your very first response and any skill loading or tool discovery before the first app tool call. Not an acknowledgment of the request, not a plan, not status lines between calls, not commentary on what a search returned. If you are about to write "I\'ll build…", "Let me…", or "Now I\'ll…" ahead of a tool call: stop, and make the call with no text at all. The user sees every word you emit as a chat message and watches the app itself render as you work, so the whole build reads as: (optionally) your clarifying questions, then silence, then the finished app. Exactly three kinds of message may contain text: (1) clarifying questions about what to build; (2) a blocker, stated as the action the user can take in product terms — never internal tool or SDK names, and no account of the searches or checks you ran; (3) the final delivery.';
+
+/**
  * The sentence that accompanies every {@link quoteUntrusted} span, telling the
  * model what the quotes mean. Kept as one constant so each block that carries
  * user-authored text says the same thing.
@@ -158,6 +172,14 @@ export async function buildAgentSystemPrompt(params: {
   const toolResultInstructions =
     Object.keys(mcpTools).length > 0 ? TOOL_UI_RESULT_INSTRUCTION : null;
 
+  // In search_and_run_only mode scaffold_app is dispatchable without being
+  // listed, so the mode alone qualifies; otherwise key off the assigned tools.
+  const appBuildConductInstruction =
+    agent.toolExposureMode === "search_and_run_only" ||
+    archestraMcpBranding.getToolName(TOOL_SCAFFOLD_APP_SHORT_NAME) in mcpTools
+      ? APP_BUILD_CONDUCT_INSTRUCTION
+      : null;
+
   // eagerly list the agent's skills in the prompt (like Claude Code /
   // opencode), but only when the agent can actually load them.
   const skillCatalogPrompt =
@@ -194,6 +216,7 @@ export async function buildAgentSystemPrompt(params: {
       fileHandlingInstruction,
       TOOL_DENIAL_INSTRUCTION,
       toolResultInstructions,
+      appBuildConductInstruction,
       hookSessionContext,
     ]
       .filter(Boolean)
@@ -552,5 +575,5 @@ function buildLoadToolsWhenNeededSystemPrompt(): string {
 
   return `${base}
 
-When the user asks to make, build, or create an app or interactive UI, never write the app's code in your chat reply: start by calling \`${runToolName}\` with \`tool_name: "${scaffoldAppName}"\`, and find the follow-up app tools with \`${searchToolsName}\`.`;
+When the user asks to make, build, or create an app or interactive UI, never write the app's code in your chat reply: start by calling \`${runToolName}\` with \`tool_name: "${scaffoldAppName}"\`, and find the follow-up app tools with \`${searchToolsName}\`. Open with the tool call itself — no lead-in sentence first.`;
 }

--- a/platform/backend/src/archestra-mcp-server/app-authoring-guidance.ts
+++ b/platform/backend/src/archestra-mcp-server/app-authoring-guidance.ts
@@ -5,7 +5,7 @@ import { APP_PLATFORM_CSP_RESOURCE_DOMAINS } from "@/services/apps/app-ui-policy
 // drift. Names what the inline SDK summary omits so the model knows when to
 // load the full Build App skill.
 export const BUILD_APP_SKILL_POINTER =
-  'For tool-calling apps (the assign→preview→diagnostics build loop), the CDN allowlist, or platform theming, load the "Build App" skill (in your available skills) for the full authoring playbook.';
+  'For tool-calling apps (the assign→preview→diagnostics build loop), the CDN allowlist, or platform theming, load the "Build App" skill (in your available skills) for the full authoring playbook — its references/apps-sdk.md file carries the full SDK contract.';
 
 // The recurring "no render has happened yet, and that is fine" directive shared
 // by validate_app / get_app_diagnostics result text, so the guidance stays
@@ -49,4 +49,4 @@ export const ARCHESTRA_APP_SDK_SUMMARY = `window.archestra is injected at render
 - File tools, called through archestra.tools.call by their full built-in names (archestra__save_file, archestra__read_file, archestra__read_file_raw, archestra__search_files, archestra__edit_file, archestra__delete_file, archestra__upload_file, archestra__download_file) — a persistent file store private to each viewer of this app (its own namespace: never the chat's or a project's files, and never another viewer's). archestra__read_file_raw resolves to {contentBase64, mimeType, sizeBytes} — the exact bytes for parsing, any type including binary; archestra__read_file is the model-shaped paged text window. Use the store for documents the app produces or the viewer keeps; use archestra.storage for structured app state.
 - archestra.llm.complete(prompt, {system, jsonMode}) — one host LLM completion over data the app already has (not a data source).
 - archestra.ui.openLink(url) — the ONLY way to open an external link (the sandbox blocks popups, so <a target="_blank"> silently does nothing); archestra.ui.requestDisplayMode(mode) also reaches the host; archestra.context is the running app's {appId, version}.
-All external data must come through assigned MCP tools (the sandbox blocks network access). This is the condensed SDK surface — for tool-calling apps (the assign→preview_app_tool→get_app_diagnostics build loop), the CSP/CDN allowlist, or theming against the platform stylesheet, load the Build App skill for the full contract.`;
+All external data must come through assigned MCP tools (the sandbox blocks network access). This is the condensed SDK surface — for tool-calling apps (the assign→preview_app_tool→get_app_diagnostics build loop), the CSP/CDN allowlist, or theming against the platform stylesheet, load the Build App skill for the full contract (its references/apps-sdk.md file). These identifiers are build internals: when talking to the user, describe the app and any gap in their product terms (the feature, the server to connect) — never SDK calls, tool names, or assignment mechanics.`;

--- a/platform/backend/src/database/seed.test.ts
+++ b/platform/backend/src/database/seed.test.ts
@@ -606,7 +606,20 @@ describe("syncBuiltInSkills", () => {
       sourceRef: buildAppRef,
     });
     expect(seeded).not.toBeNull();
-    expect(seeded?.content).toContain("window.archestra");
+
+    // SKILL.md carries the flow and chat-conduct rules; the SDK contract is
+    // bundled as a reference file instead of embedded in the body, so loading
+    // the skill front-loads how to build and talk, not the API surface.
+    expect(seeded?.content).toContain("references/apps-sdk.md");
+    expect(seeded?.content).not.toContain("connect-src");
+
+    const files = await SkillFileModel.findBySkillId(seeded?.id ?? "");
+    const sdkReference = files.find(
+      (file) => file.path === "references/apps-sdk.md",
+    );
+    expect(sdkReference?.kind).toBe("reference");
+    expect(sdkReference?.content).toContain("window.archestra");
+    expect(sdkReference?.content).toContain("connect-src");
   });
 });
 

--- a/platform/backend/src/skills/built-in-skills.ts
+++ b/platform/backend/src/skills/built-in-skills.ts
@@ -289,12 +289,28 @@ permission error means the caller's role lacks the required
 retrying.
 `;
 
-// The build-app playbook embeds the SDK/CSP/storage contract and build-loop
-// guidance verbatim from the authoring tools' shared source, so the skill is the
-// single place those conventions live (the tool descriptions stay short).
+// The build-app playbook keeps SKILL.md focused on the build flow and how to
+// talk to the user; the SDK/CSP/storage contract and build-loop guidance are
+// bundled as a reference file (embedded verbatim from the authoring tools'
+// shared source, so the skill package is the single place those conventions
+// live and the tool descriptions stay short).
 const BUILD_APP_SKILL = `# Building Archestra Apps
 
-You build interactive single-file HTML/JS apps for users from chat — dashboards, forms, trackers, games, any custom UI. An app runs in a sandboxed iframe and talks to the platform through the injected window.archestra SDK. Build it up through the staged flow below — each tool's result tells you the next step — never write a whole app in one shot, and never paste app HTML into the chat reply or hand it back as a chat artifact. The app exists only as the versioned HTML these app tools manage; change it exclusively with \`archestra__edit_app\` — the \`run_command\` code sandbox is a separate scratch filesystem and cannot alter the app itself. When the document already exists as a file you can reach — a chat attachment, or something you assembled and saved — pass that file's id to \`archestra__edit_app\` as \`replacementHtmlSource\` instead of reproducing its bytes in a tool call: that is the only way to build an app from content too large to retype in one turn.
+You build interactive single-file HTML/JS apps for users from chat — dashboards, forms, trackers, games, any custom UI. An app runs in a sandboxed iframe and talks to the platform through the Archestra Apps SDK, injected at render time. Build it up through the staged flow below — each tool's result tells you the next step — never write a whole app in one shot, and never paste app HTML into the chat reply or hand it back as a chat artifact. The app exists only as the versioned HTML these app tools manage; change it exclusively with \`archestra__edit_app\` — the \`run_command\` code sandbox is a separate scratch filesystem and cannot alter the app itself. When the document already exists as a file you can reach — a chat attachment, or something you assembled and saved — pass that file's id to \`archestra__edit_app\` as \`replacementHtmlSource\` instead of reproducing its bytes in a tool call: that is the only way to build an app from content too large to retype in one turn.
+
+## Work silently — this rule comes first
+
+While building an app, every response you produce MUST begin directly with a tool call and contain no prose at all. Your habit is to write a sentence before each tool call — "Let me read the reference…", "Now I'll search for the tool…", "That didn't surface it, let me try…" — and here that habit is a bug: every such sentence is shown to the user as a chat message, and a build that narrates itself reads as broken. Do the step instead of announcing it — the user watches the app itself take shape as it renders inline. During a build, exactly three responses may contain prose:
+
+1. **Refining** — asking the (up to 3) clarifying questions via \`archestra__refine_app\`.
+2. **Blocked** — the build cannot continue without something only the user can provide or decide.
+3. **Delivery** — the app passed validation (and any requested publish is done) and you are handing it over.
+
+Everything you do say is in the user's terms. Never surface build internals in chat: tool names (\`set_app_tools\`, \`preview_app_tool\`), SDK identifiers (\`window.archestra\`, \`archestra.tools.call()\`), tool ids, version numbers, assignment/validation mechanics, or accounts of searches and checks you ran along the way ("the search only surfaced…", "I checked which servers…"). When you need to name the platform's app layer at all, call it the Archestra Apps SDK. Describe a gap or blocker by the action the user can take — one sentence naming the action, not an explanation of the platform's plumbing: "Connect Jira to enable submitting tickets from the app", never "the jira__create_issue tool could not be assigned".
+
+## The SDK reference
+
+The full Archestra Apps SDK contract (the injected surface, storage, file tools, the CSP/CDN allowlist, theming) and the tool-calling build loop live in this skill's \`references/apps-sdk.md\` — read it (load this skill again, passing that path) before your first \`archestra__edit_app\`, and code against it rather than from memory.
 
 ## Flow
 1. \`archestra__scaffold_app\` — **only when the request is for a brand-new app that does not exist yet.** This is the sole app-creating tool: every call writes a new app entity to the DB, so call it at most once per app and never for a change to an app that already exists. First decide whether the app is already there: if you are holding an app id from earlier in this conversation, or the user is asking to change, extend, fix, restyle, or add to an app you already built, that app exists — skip scaffolding and make the change with \`archestra__edit_app\` on its id (read_app first if its current HTML is not already in context). If you are unsure whether a matching app already exists, call \`archestra__list_apps\`. Reuse an existing app ONLY when the user is clearly referring to it — same purpose, or they named it as theirs to change. Never rework an app that serves a different purpose just because its name or theme is close: apps can be built from other conversations, and overwriting one destroys work the user still relies on. When in doubt — including on a name collision from scaffold_app — ask the user whether to modify the existing app or create a new one under a different name; only if nothing matches is it a new app. Only when it is genuinely a new app, create it from the single starter template (a minimal scaffold is fine). Pass the tools it needs via the tools param if you already know them (this is the initial assignment set; replace it at any time afterward with \`archestra__set_app_tools\`, never edit_app/refine_app). Returns the new app's id and the seeded HTML — carry that id through every later step and any follow-up request for the same app; do not scaffold it again (each later change is an edit_app on that id).
@@ -303,12 +319,19 @@ You build interactive single-file HTML/JS apps for users from chat — dashboard
 4. \`archestra__validate_app\` — run static structural checks plus the live render diagnostics (\`archestra__get_app_diagnostics\` reads those render diagnostics on their own). Fix any errors with \`archestra__edit_app\` and re-validate until it passes.
 5. \`archestra__publish_app\` — only if the user wants others to run the app: promote it to a team or the whole organization (publishing is for sharing, not a required build step).
 
-Once the app passes validation (and any requested publish is done), the build is complete: stop calling app tools — do not re-read, re-validate, or re-check an app you have not changed — and close the loop with the user: name the app and link to its standalone page by reproducing, verbatim, the markdown link the scaffold_app/edit_app result returned (it is already labeled with the app's name) — never rebuild the link from the id or surface the raw /a/<id> path as the link text, say in plain product terms what it does, and carry out whatever completion the user's request asked for. Describe the app the way its user thinks about it, not how it is wired — keep build-time mechanics out of the summary unless the user has to act on one (e.g. "connect the GitHub server to enable search"). Be honest about what actually works — if a tool could not be assigned or a feature is not wired up, say so plainly instead of implying it works. Do not tack on a menu of extra features you could build next.
+Once the app passes validation (and any requested publish is done), the build is complete: stop calling app tools — do not re-read, re-validate, or re-check an app you have not changed — and close the loop with the user: name the app and link to its standalone page by reproducing, verbatim, the markdown link the scaffold_app/edit_app result returned (it is already labeled with the app's name) — never rebuild the link from the id or surface the raw /a/<id> path as the link text, say in plain product terms what it does, and carry out whatever completion the user's request asked for. Describe the app the way its user thinks about it, not how it is wired — per "Working in chat" above, build-time mechanics stay out of the summary, and anything the user must act on is named as their action in product terms (e.g. "Connect the GitHub server to enable search"). Be honest about what actually works — if a tool could not be assigned or a feature is not wired up, say so plainly in those same user terms instead of implying it works. Do not tack on a menu of extra features you could build next.
+`;
 
-## SDK and authoring conventions
+// The SDK contract and build loop, bundled as the build-app skill's reference
+// file. Embedded verbatim from the authoring tools' shared source
+// (app-authoring-guidance.ts) so the reference can never drift from what the
+// tools enforce; SKILL.md points the model here before its first edit_app.
+const BUILD_APP_SDK_REFERENCE = `# Archestra Apps SDK and authoring conventions
+
 ${APP_AUTHORING_CONTRACT}
 
 ## Build loop
+
 ${APP_BUILD_LOOP_GUIDANCE}
 `;
 
@@ -340,8 +363,14 @@ export const BUILT_IN_SKILLS: BuiltInSkill[] = [
     builtInSkillId: "build-app",
     name: "Build App",
     description:
-      "Build an interactive app for a user (dashboard, form, tracker, game, or custom UI): the staged scaffold → refine → edit → validate → publish flow and the window.archestra SDK, storage, tools, and CSP conventions. Use whenever the user asks to make, build, or create an app or interactive UI, authoring it through that flow.",
+      "Build an interactive app for a user (dashboard, form, tracker, game, or custom UI): the staged scaffold → refine → edit → validate → publish flow, the window.archestra SDK, storage, tools, and CSP conventions, and the silent-build chat conduct. Use whenever the user asks to make, build, or create an app or interactive UI, authoring it through that flow.",
     content: BUILD_APP_SKILL,
-    files: [],
+    files: [
+      {
+        path: "references/apps-sdk.md",
+        kind: "reference",
+        content: BUILD_APP_SDK_REFERENCE,
+      },
+    ],
   },
 ];


### PR DESCRIPTION
## Problem

Building an app in chat narrated its own internals: a transition sentence before every tool call ("Let me search for the tool…", "Now I'll…"), play-by-play of tool searches and checks, and gaps/blockers explained in SDK and tool vocabulary (`archestra.tools.call()`, tool names, assignment mechanics) instead of something the user can act on. The intended experience is the opposite: the user asks for an app, optionally answers a couple of clarifying questions, watches the app render as it's built, and gets a product-terms summary at the end.

## Changes

**Build App skill** (`skills/built-in-skills.ts`)
- SKILL.md now leads with chat-conduct rules: app builds run as a silent tool loop; prose is allowed at exactly three moments — refine questions, a blocker stated as the action the user can take, and the final delivery — always in the user's terms, never internal tool/SDK identifiers. When the app layer must be named at all, it's "the Archestra Apps SDK" (rewritten to the org's white-label brand like all built-in skill text).
- The SDK/CSP/storage contract and the tool-calling build loop move out of the SKILL.md body into a bundled `references/apps-sdk.md` (still embedded verbatim from `app-authoring-guidance.ts` so it can't drift from what the tools enforce). Loading the skill now front-loads flow and conduct; the model reads the reference before its first `edit_app`.
- The skill's catalog description stays purely descriptive — the catalog frame explicitly tells the model not to follow directives inside descriptions, so conduct rules there would be dead text.

**Agent system prompt** (`agents/agent-system-prompt.ts`)
- New `APP_BUILD_CONDUCT_INSTRUCTION`, emitted whenever the agent can reach the app-authoring tools (scaffold_app assigned, or `search_and_run_only` mode where it's always dispatchable). Skill text arrives as a tool result mid-conversation and reliably loses to the model's narrate-before-tool-calls habit; the system prompt is the effective counterweight. The app pointer in the progressive-tool-loading block also now says to open with the tool call itself.

**SDK summary in tool results** (`archestra-mcp-server/app-authoring-guidance.ts`)
- The condensed SDK surface carried in scaffold/refine results now flags its identifiers as build internals to keep out of user-facing text (that summary is exactly where a model that never loaded the skill picks up `archestra.tools.list()` vocabulary), and points at the skill's `references/apps-sdk.md` for the full contract.

## Testing

- Unit: assembler test for the new instruction's emission conditions; seed test pins that the SDK contract lives in the seeded `references/apps-sdk.md` file and no longer in the SKILL.md body. Full affected suites green (skills, seed, apps tools, agent prompt, chat context, A2A executor — 898 tests), plus type-check, biome, knip.
- Live, against a local dev stack in the chat UI (Claude Opus 4.8), iterating on the wording until behavior matched:
  - Tool-gap scenario (app needing a server that isn't connected): clarifying questions → silent tool activity → blocker phrased as the action to take ("connect a GitHub MCP server", with options), zero SDK identifiers, no narration bubbles between tool calls.
  - Happy path (storage-backed team standup app): brief acknowledgment, fully silent scaffold→edit→validate with the app rendering inline, delivery in product terms with the verbatim app link.
- Residual: a model may still occasionally open with a one-line acknowledgment before its first tool call; internals vocabulary and mid-build play-by-play are gone in repeated runs.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>