### PR TITLE
fix(frontend): stop MCP catalog icons stretching on non-square SVGs

### DIFF
--- a/platform/frontend/src/components/mcp-catalog-icon.test.tsx
+++ b/platform/frontend/src/components/mcp-catalog-icon.test.tsx
@@ -1,0 +1,44 @@
+import { ARCHESTRA_MCP_CATALOG_ID } from "@archestra/shared";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAppIconLogo } from "@/lib/hooks/use-app-name";
+
+vi.mock("next/image", () => ({
+  default: ({
+    alt,
+    src,
+    className,
+    style,
+  }: {
+    alt: string;
+    src: string;
+    className?: string;
+    style?: React.CSSProperties;
+  }) => <img alt={alt} src={src} className={className} style={style} />,
+}));
+
+vi.mock("@/lib/hooks/use-app-name");
+
+import { McpCatalogIcon } from "./mcp-catalog-icon";
+
+describe("McpCatalogIcon", () => {
+  it("pins the rendered image to the requested size, overriding Tailwind's img height:auto reset", () => {
+    const { container } = render(
+      <McpCatalogIcon icon="data:image/svg+xml;base64,abc" size={16} />,
+    );
+
+    const img = container.querySelector("img");
+    expect(img).toHaveStyle({ width: "16px", height: "16px" });
+  });
+
+  it("pins the default Archestra logo to the requested size too", () => {
+    vi.mocked(useAppIconLogo).mockReturnValue("/logo-icon.svg");
+
+    const { container } = render(
+      <McpCatalogIcon catalogId={ARCHESTRA_MCP_CATALOG_ID} size={24} />,
+    );
+
+    const img = container.querySelector("img");
+    expect(img).toHaveStyle({ width: "24px", height: "24px" });
+  });
+});

--- a/platform/frontend/src/components/mcp-catalog-icon.tsx
+++ b/platform/frontend/src/components/mcp-catalog-icon.tsx
@@ -31,6 +31,7 @@ export function McpCatalogIcon({
         width={size}
         height={size}
         className={cn("shrink-0 rounded-sm object-contain", className)}
+        style={{ width: size, height: size }}
       />
     );
   }
@@ -52,6 +53,7 @@ export function McpCatalogIcon({
         width={size}
         height={size}
         className={cn("shrink-0 rounded-sm object-contain", className)}
+        style={{ width: size, height: size }}
       />
     );
   }


### PR DESCRIPTION
## Summary

MCP catalog icons whose source image isn't square (e.g. MongoDB's tall SVG mark) rendered stretched wherever `McpCatalogIcon` is used — the Guardrails sources filter, the tools table's Source column, and anywhere else a catalog icon appears. Tailwind's preflight `img { height: auto }` reset was overriding the `width`/`height` attributes on the component's `next/image` elements, so the browser fell back to the image's intrinsic aspect ratio instead of the requested square size.

Icons are now pinned to size via an inline style, the same approach the component's `Server` icon fallback already used — inline styles beat the element-selector reset regardless of an icon's native proportions.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>