### PR TITLE
feat(environments): rename egress mode labels to Block all/Allowlist/Allow all

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -493,13 +493,13 @@ Archestra protects every MCP server pod from Server-Side Request Forgery (SSRF) 
 
 Each pod gets one policy, chosen by its environment's egress mode:
 
-- **Unrestricted** (the default) — a reserved-range floor: DNS and the public internet are allowed; private, link-local, and metadata ranges are blocked.
-- **Restricted** — only the CIDRs and domains the environment allow-lists, plus DNS.
+- **Denylist** (`unrestricted`, the default) — a reserved-range floor: DNS and the public internet are allowed; private, link-local, and metadata ranges are blocked.
+- **Allowlist** (`restricted`) — only the CIDRs and domains the environment allow-lists, plus DNS.
 - **Off** — all egress is denied.
 
 A namespace-wide default-deny baseline also selects every MCP pod, so a pod that is still starting up is denied by default rather than left open.
 
-**Blocked reserved ranges** (the unrestricted floor):
+**Blocked reserved ranges** (the Denylist floor):
 
 - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` - RFC 1918 private ranges (cluster pods, services, nodes)
 - `169.254.0.0/16` - Link-local / cloud metadata endpoints (AWS IMDSv1, GCP, Azure)
@@ -511,7 +511,7 @@ A namespace-wide default-deny baseline also selects every MCP pod, so a pod that
 
 **Prerequisite**: your cluster must use a CNI that enforces network policies. Calico, Cilium, and GKE Dataplane V2 enforce standard `NetworkPolicy` objects; on EKS Auto Mode, where `ApplicationNetworkPolicy` is the enforcement mechanism, the policy is emitted as an `ApplicationNetworkPolicy` instead. Where no enforcing dataplane is present, the policies are created but not enforced.
 
-To let a server reach a specific internal service — a Grafana instance in the `monitoring` namespace, for example — set its environment's network policy to `restricted` and add that CIDR or domain to the allow-list. See [Network Policies](/docs/platform-private-registry#network-policies).
+To let a server reach a specific internal service — a Grafana instance in the `monitoring` namespace, for example — set its environment's egress mode to **Allowlist** (`restricted`) and add that CIDR or domain to the allow-list. See [Network Policies](/docs/platform-private-registry#network-policies).
 
 ### Accessing the Platform
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -493,13 +493,13 @@ Archestra protects every MCP server pod from Server-Side Request Forgery (SSRF) 
 
 Each pod gets one policy, chosen by its environment's egress mode:
 
-- **Denylist** (`unrestricted`, the default) — a reserved-range floor: DNS and the public internet are allowed; private, link-local, and metadata ranges are blocked.
+- **Allow all** (`unrestricted`, the default) — a reserved-range floor: DNS and the public internet are allowed; private, link-local, and metadata ranges are blocked.
 - **Allowlist** (`restricted`) — only the CIDRs and domains the environment allow-lists, plus DNS.
-- **Off** — all egress is denied.
+- **Block all** (`off`) — all egress is denied.
 
 A namespace-wide default-deny baseline also selects every MCP pod, so a pod that is still starting up is denied by default rather than left open.
 
-**Blocked reserved ranges** (the Denylist floor):
+**Blocked reserved ranges** (the Allow all floor):
 
 - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` - RFC 1918 private ranges (cluster pods, services, nodes)
 - `169.254.0.0/16` - Link-local / cloud metadata endpoints (AWS IMDSv1, GCP, Azure)

--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -3,7 +3,7 @@ title: "Environments"
 category: Administration
 description: "Isolate tools, knowledge, skills, subagents, runtimes, and cost limits across deployment environments"
 order: 3
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-05
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -69,9 +69,9 @@ This applies to both explicitly assigned resources and the implicit **Auto** acc
 
 ## Network egress policies
 
-An environment can define a Kubernetes **namespace** and a **network egress policy**. Both MCP server pods and agent [code sandboxes](/docs/platform-code-sandbox) for that environment run in its namespace and inherit its egress policy, so their outbound network reach is contained. Policies can disable internet egress, allow all egress, or restrict egress to selected IP/CIDR ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
+An environment can define a Kubernetes **namespace** and a **network egress policy**. Both MCP server pods and agent [code sandboxes](/docs/platform-code-sandbox) for that environment run in its namespace and inherit its egress policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Off** (`off`) blocks all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Denylist** (`unrestricted`) allows all egress — cluster-hosted workloads still get a fixed floor of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
 
-When a workload runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in unrestricted policy.
+When a workload runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in Denylist policy (`unrestricted`).
 
 How a policy applies depends on the workload. A **self-hosted MCP server** (or agent code sandbox) runs as a pod in your cluster, so the policy is enforced continuously at the network layer — a workload that needs broad outbound access (for example one that visits arbitrary sites) fails under a restrictive policy unless its destinations are allowlisted.
 

--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -69,9 +69,9 @@ This applies to both explicitly assigned resources and the implicit **Auto** acc
 
 ## Network egress policies
 
-An environment can define a Kubernetes **namespace** and a **network egress policy**. Both MCP server pods and agent [code sandboxes](/docs/platform-code-sandbox) for that environment run in its namespace and inherit its egress policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Off** (`off`) blocks all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Denylist** (`unrestricted`) allows all egress — cluster-hosted workloads still get a fixed floor of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
+An environment can define a Kubernetes **namespace** and a **network egress policy**. Both MCP server pods and agent [code sandboxes](/docs/platform-code-sandbox) for that environment run in its namespace and inherit its egress policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Block all** (`off`) denies all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Allow all** (`unrestricted`) permits everything — cluster-hosted workloads still get a fixed floor of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
 
-When a workload runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in Denylist policy (`unrestricted`).
+When a workload runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in Allow all policy (`unrestricted`).
 
 How a policy applies depends on the workload. A **self-hosted MCP server** (or agent code sandbox) runs as a pod in your cluster, so the policy is enforced continuously at the network layer — a workload that needs broad outbound access (for example one that visits arbitrary sites) fails under a restrictive policy unless its destinations are allowlisted.
 

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -974,18 +974,20 @@ export function NetworkPolicyFields({
           label="Egress"
           description={
             <>
-              Controls outbound internet access. Off blocks all egress,
-              Allowlist (
+              Controls outbound internet access. Block all (
+              <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
+                off
+              </code>{" "}
+              in the API) denies all egress, Allowlist (
               <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
                 restricted
-              </code>{" "}
-              in the API) permits only the CIDR/domain rules below, and Denylist
-              (
+              </code>
+              ) permits only the CIDR/domain rules below, and Allow all (
               <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
                 unrestricted
               </code>
-              ) allows all egress — workloads hosted in your cluster still get a
-              fixed floor of blocked reserved ranges.
+              ) permits everything — workloads hosted in your cluster still get
+              a fixed floor of blocked reserved ranges.
             </>
           }
         />
@@ -1111,9 +1113,9 @@ function FieldLabel({
 }
 
 const EGRESS_MODE_LABELS: Record<EgressMode, string> = {
-  off: "Off",
+  off: "Block all",
   restricted: "Allowlist",
-  unrestricted: "Denylist",
+  unrestricted: "Allow all",
 };
 
 function formatEgressMode(mode: EgressMode) {

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -972,7 +972,22 @@ export function NetworkPolicyFields({
       <div className="space-y-2">
         <FieldLabel
           label="Egress"
-          description="Controls outbound internet access. Off blocks egress, Restricted allows only the CIDR/domain rules below, and Unrestricted allows all egress."
+          description={
+            <>
+              Controls outbound internet access. Off blocks all egress,
+              Allowlist (
+              <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
+                restricted
+              </code>{" "}
+              in the API) permits only the CIDR/domain rules below, and Denylist
+              (
+              <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
+                unrestricted
+              </code>
+              ) allows all egress — workloads hosted in your cluster still get a
+              fixed floor of blocked reserved ranges.
+            </>
+          }
         />
         <Select
           value={egressMode}
@@ -983,9 +998,13 @@ export function NetworkPolicyFields({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="off">Off</SelectItem>
-            <SelectItem value="restricted">Restricted</SelectItem>
-            <SelectItem value="unrestricted">Unrestricted</SelectItem>
+            <SelectItem value="off">{EGRESS_MODE_LABELS.off}</SelectItem>
+            <SelectItem value="restricted">
+              {EGRESS_MODE_LABELS.restricted}
+            </SelectItem>
+            <SelectItem value="unrestricted">
+              {EGRESS_MODE_LABELS.unrestricted}
+            </SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -994,7 +1013,7 @@ export function NetworkPolicyFields({
         <FieldLabel
           htmlFor="network-policy-cidrs"
           label="Allowed CIDRs"
-          description="IPv4 or IPv6 CIDR ranges that restricted workloads may reach. These rules are enforced by standard Kubernetes NetworkPolicy."
+          description="IPv4 or IPv6 CIDR ranges that workloads in Allowlist mode may reach. These rules are enforced by standard Kubernetes NetworkPolicy."
         />
         <Textarea
           id="network-policy-cidrs"
@@ -1044,7 +1063,7 @@ export function NetworkPolicyFields({
         <FieldLabel
           htmlFor="network-policy-domains"
           label="Allowed domains"
-          description="Domain names or wildcard domains that restricted workloads may reach. Requires a supported FQDN policy provider."
+          description="Domain names or wildcard domains that workloads in Allowlist mode may reach. Requires a supported FQDN policy provider."
         />
         <Textarea
           id="network-policy-domains"
@@ -1091,15 +1110,14 @@ function FieldLabel({
   );
 }
 
+const EGRESS_MODE_LABELS: Record<EgressMode, string> = {
+  off: "Off",
+  restricted: "Allowlist",
+  unrestricted: "Denylist",
+};
+
 function formatEgressMode(mode: EgressMode) {
-  switch (mode) {
-    case "off":
-      return "Off";
-    case "restricted":
-      return "Restricted";
-    case "unrestricted":
-      return "Unrestricted";
-  }
+  return EGRESS_MODE_LABELS[mode];
 }
 
 function formatPolicySummary(policy: NetworkPolicy) {


### PR DESCRIPTION
## Summary

The environments table showed two unrelated "Restricted" values side by side: the egress mode and the RBAC deploy-gate badge. Neither egress name said what the mode does, and "Off" could be read as "no policy enforced" — the opposite of its actual effect (all egress denied). The egress modes now display as a fully parallel trio, each label stating its effect: **Block all** (`off` — all egress denied), **Allowlist** (`restricted` — only the listed CIDRs/domains pass), and **Allow all** (`unrestricted` — everything passes, with the fixed reserved-range floor still applied to cluster-hosted pods). The RBAC badge keeps "Restricted" and is now the only use of the word on the screen.

Wire, API, and stored values (`off`/`restricted`/`unrestricted`) are unchanged — this is a display-name and docs rename only, so no migration and no API break. Because the raw values still surface in audit-log diffs and the `archestra.io/network-policy-egress-mode` pod annotation, the editor's help popover and the docs name each mode together with its wire value ("**Allowlist** (`restricted`)") so the two vocabularies stay traceable to each other.

The Allow all copy is deliberately scoped: the reserved-range floor is enforced by Kubernetes NetworkPolicy for cluster-hosted workloads only — the remote-MCP-server URL host check (`isHostAllowedByNetworkPolicy`) allows every host under `unrestricted`, so the copy avoids claiming the floor applies there.