### PR TITLE
fix: prevent horizontal overflow in agent editor

### DIFF
--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -1718,7 +1718,7 @@ export function AgentDialog({
             onSubmit={handleSave}
           >
             <fieldset disabled={readOnly} className="contents">
-              <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 pb-4 space-y-4">
+              <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-4 py-4 pb-4 space-y-4">
                 {agentType === "profile" && (
                   <Alert variant="warning">
                     <AlertTriangle className="h-4 w-4" />

--- a/platform/frontend/src/components/mcp-server-pill-shell.tsx
+++ b/platform/frontend/src/components/mcp-server-pill-shell.tsx
@@ -58,14 +58,14 @@ export function McpServerPillShell({
 }: McpServerPillShellProps) {
   return (
     <Popover open={open} onOpenChange={onOpenChange} modal>
-      <div className="flex items-center">
+      <div className="flex max-w-full min-w-0 items-center">
         <PopoverTrigger asChild>
           <Button
             type="button"
             variant="outline"
             size="sm"
             className={cn(
-              "h-8 px-3 gap-1.5 text-xs",
+              "h-8 min-w-0 max-w-full flex-1 gap-1.5 px-3 text-xs",
               isEmpty && "border-dashed opacity-50",
               isEmpty && "rounded-r-none border-r-0",
               highlighted && "border-primary opacity-100",
@@ -73,8 +73,8 @@ export function McpServerPillShell({
             data-testid={triggerTestId}
           >
             {icon}
-            <span className="font-medium">{displayName}</span>
-            <span className="text-muted-foreground">({count})</span>
+            <span className="min-w-0 truncate font-medium">{displayName}</span>
+            <span className="shrink-0 text-muted-foreground">({count})</span>
             {note ? (
               <span className="shrink-0 font-normal text-muted-foreground">
                 {note}
@@ -100,18 +100,18 @@ export function McpServerPillShell({
         )}
       </div>
       <PopoverContent
-        className="w-[420px] max-h-[min(500px,var(--radix-popover-content-available-height))] p-0 flex flex-col overflow-hidden"
+        className="flex max-h-[min(500px,var(--radix-popover-content-available-height))] w-[420px] max-w-[calc(100vw-2rem)] min-w-0 flex-col overflow-hidden p-0"
         side="bottom"
         align="start"
         sideOffset={8}
         avoidCollisions
         collisionPadding={16}
       >
-        <div className="p-4 border-b flex items-start justify-between gap-2 shrink-0">
-          <div>
-            <h4 className="font-semibold">{displayName}</h4>
+        <div className="flex min-w-0 shrink-0 items-start justify-between gap-2 border-b p-4">
+          <div className="min-w-0 flex-1">
+            <h4 className="truncate font-semibold">{displayName}</h4>
             {description && (
-              <p className="text-sm text-muted-foreground mt-1">
+              <p className="mt-1 [overflow-wrap:anywhere] text-sm text-muted-foreground">
                 {description}
                 {docsUrl ? (
                   <>

--- a/platform/frontend/src/components/ui/assignment-combobox.tsx
+++ b/platform/frontend/src/components/ui/assignment-combobox.tsx
@@ -105,7 +105,7 @@ export function AssignmentCombobox({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="w-96 max-h-72 flex flex-col"
+        className="flex max-h-72 w-96 max-w-[calc(100vw-2rem)] min-w-0 flex-col"
         align="start"
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
@@ -124,8 +124,8 @@ export function AssignmentCombobox({
             }
           />
         </div>
-        <div className="overflow-y-auto flex-1">
-          <DropdownMenuGroup>
+        <div className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto">
+          <DropdownMenuGroup className="min-w-0">
             {filteredItems.length === 0 ? (
               <div className="px-2 py-4 text-center text-sm text-muted-foreground">
                 {emptyMessage}
@@ -138,7 +138,7 @@ export function AssignmentCombobox({
                     <DropdownMenuItem
                       key={item.id}
                       disabled
-                      className="cursor-pointer opacity-50"
+                      className="min-w-0 cursor-pointer opacity-50"
                       data-testid={
                         testId
                           ? getAssignmentComboboxDisabledOptionTestId(
@@ -148,12 +148,12 @@ export function AssignmentCombobox({
                           : undefined
                       }
                     >
-                      <div className="flex items-center gap-3 min-w-0 pl-6">
+                      <div className="flex w-full min-w-0 items-center gap-3 pl-6">
                         {item.icon}
-                        <div className="min-w-0">
-                          <span className="truncate">{item.name}</span>
+                        <div className="min-w-0 flex-1">
+                          <span className="block truncate">{item.name}</span>
                           {item.disabledReason && (
-                            <p className="text-xs text-muted-foreground">
+                            <p className="truncate text-xs text-muted-foreground">
                               {item.disabledReason}
                             </p>
                           )}
@@ -166,7 +166,7 @@ export function AssignmentCombobox({
                   <DropdownMenuCheckboxItem
                     key={item.id}
                     checked={isSelected}
-                    className="cursor-pointer"
+                    className="min-w-0 cursor-pointer"
                     data-testid={
                       testId
                         ? getAssignmentComboboxOptionTestId(testId, item.name)
@@ -181,18 +181,18 @@ export function AssignmentCombobox({
                       if (isSelected) e.preventDefault();
                     }}
                   >
-                    <div className="flex items-center justify-between gap-2 w-full">
-                      <div className="flex items-center gap-3 min-w-0">
+                    <div className="flex w-full min-w-0 items-center justify-between gap-2">
+                      <div className="flex min-w-0 flex-1 items-center gap-3">
                         {item.icon}
-                        <div className="min-w-0">
-                          <span className="truncate">{item.name}</span>
+                        <div className="min-w-0 flex-1">
+                          <span className="block truncate">{item.name}</span>
                           {item.description && (
                             <ItemDescription description={item.description} />
                           )}
                         </div>
                       </div>
                       {item.badge && (
-                        <span className="text-xs text-muted-foreground shrink-0">
+                        <span className="max-w-[40%] shrink-0 truncate text-xs text-muted-foreground">
                           {item.badge}
                         </span>
                       )}
@@ -250,8 +250,11 @@ function ItemDescription({ description }: { description: string }) {
   }, [description]);
 
   return (
-    <div className="text-xs text-muted-foreground mt-0.5">
-      <p ref={ref} className={cn(!expanded && "line-clamp-1")}>
+    <div className="min-w-0 text-xs text-muted-foreground mt-0.5">
+      <p
+        ref={ref}
+        className={cn("[overflow-wrap:anywhere]", !expanded && "line-clamp-1")}
+      >
         {description}
       </p>
       {(isTruncated || expanded) && (


### PR DESCRIPTION
## Summary
- prevent the Edit Agent form from scrolling horizontally
- constrain assignment picker rows and metadata independently of content length
- keep MCP server pills and popovers within their available width

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>