### PR TITLE
fix(chat): stop nesting the clear control inside the model selector trigger

### DIFF
--- a/platform/frontend/src/components/chat/model-selector.test.tsx
+++ b/platform/frontend/src/components/chat/model-selector.test.tsx
@@ -130,6 +130,46 @@ beforeEach(() => {
   setQuery({});
 });
 
+describe("clear control", () => {
+  // The trigger is itself a <button>. A clear control nested inside it is
+  // invalid HTML: React reports it, hydration breaks, and keyboard users
+  // cannot reach it separately from the trigger.
+  it.each([
+    "outline",
+    "default",
+  ] as const)("renders the clear control outside the trigger button (%s variant)", (variant) => {
+    setQuery({ modelsByProvider: { openai: [model()] } });
+    renderSelector({ selectedModel: "m1", onClear: vi.fn(), variant });
+
+    const clear = screen.getByRole("button", { name: /clear model/i });
+    expect(clear.parentElement?.closest("button")).toBeNull();
+    expect(document.querySelector("button button")).toBeNull();
+  });
+
+  it("clears without opening the model dialog", () => {
+    const onClear = vi.fn();
+    setQuery({ modelsByProvider: { openai: [model()] } });
+    renderSelector({ selectedModel: "m1", onClear, variant: "outline" });
+
+    fireEvent.click(screen.getByRole("button", { name: /clear model/i }));
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("dialog-content")).not.toBeInTheDocument();
+  });
+
+  it("does not offer the clear control while the selector is disabled", () => {
+    setQuery({ modelsByProvider: { openai: [model()] } });
+    renderSelector({
+      selectedModel: "m1",
+      onClear: vi.fn(),
+      variant: "outline",
+      disabled: true,
+    });
+
+    expect(screen.getByRole("button", { name: /clear model/i })).toBeDisabled();
+  });
+});
+
 describe("ModelSelector coverage matrix", () => {
   it("shows the loading spinner while a real fetch is in flight", () => {
     setQuery({ isPending: true, isFetching: true, isLoading: true });

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -718,8 +718,13 @@ export const ModelSelector = memo(function ModelSelector({
     );
   }
 
+  // The clear control is a sibling of the trigger, not a child: the trigger is
+  // itself a <button>, and a nested one is invalid HTML that breaks hydration
+  // and cannot be reached by keyboard on its own.
+  const showClear = Boolean(onClear && selectedModel);
+
   return (
-    <div>
+    <div className="relative inline-flex min-w-0 items-center">
       <ModelSelectorRoot open={open} onOpenChange={handleOpenChange}>
         <ModelSelectorTrigger asChild>
           {variant === "outline" ? (
@@ -727,7 +732,10 @@ export const ModelSelector = memo(function ModelSelector({
               variant="outline"
               size="sm"
               disabled={disabled}
-              className="h-8 px-3 gap-1.5 text-xs max-w-[280px] min-w-0"
+              className={cn(
+                "h-8 px-3 gap-1.5 text-xs max-w-[280px] min-w-0",
+                showClear && "pr-7",
+              )}
               data-testid={E2eTestId.ChatModelSelectorTrigger}
             >
               {selectedModelLogo && (
@@ -745,24 +753,11 @@ export const ModelSelector = memo(function ModelSelector({
                   Best available model
                 </span>
               )}
-              {onClear && selectedModel && (
-                <button
-                  type="button"
-                  aria-label="Clear model"
-                  className="ml-1 shrink-0 rounded-sm opacity-50 hover:opacity-100"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onClear();
-                  }}
-                >
-                  <XIcon className="size-3" />
-                </button>
-              )}
             </Button>
           ) : (
             <PromptInputButton
               disabled={disabled}
-              className="max-w-[280px] min-w-0"
+              className={cn("max-w-[280px] min-w-0", showClear && "pr-7")}
               data-testid={E2eTestId.ChatModelSelectorTrigger}
             >
               {selectedModelLogo && (
@@ -774,19 +769,6 @@ export const ModelSelector = memo(function ModelSelector({
               <ModelSelectorName className="truncate flex-1 text-left">
                 {selectedModelDisplayName || "Select model"}
               </ModelSelectorName>
-              {onClear && selectedModel && (
-                <button
-                  type="button"
-                  aria-label="Clear model"
-                  className="ml-1 shrink-0 rounded-sm opacity-50 hover:opacity-100"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onClear();
-                  }}
-                >
-                  <XIcon className="size-3" />
-                </button>
-              )}
             </PromptInputButton>
           )}
         </ModelSelectorTrigger>
@@ -813,6 +795,17 @@ export const ModelSelector = memo(function ModelSelector({
           </ModelSelectorContent>
         )}
       </ModelSelectorRoot>
+      {showClear && (
+        <button
+          type="button"
+          aria-label="Clear model"
+          disabled={disabled}
+          className="absolute right-2 top-1/2 -translate-y-1/2 shrink-0 rounded-sm opacity-50 hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
+          onClick={onClear}
+        >
+          <XIcon className="size-3" />
+        </button>
+      )}
     </div>
   );
 });


### PR DESCRIPTION
## Summary

The model selector's trigger is a `<button>` — `ModelSelectorTrigger asChild` renders it through `Button` or `PromptInputButton` — and the "Clear model" control sat inside it. A button inside a button is invalid HTML: React reports `In HTML, <button> cannot be a descendant of <button>. This will cause a hydration error.` on every render where a model is selected, and the browser gives the inner control no independent focus, so keyboard and screen-reader users could reach the trigger but never the clear action. It fired on the agent dialog and anywhere else the selector shows a chosen model.

The clear control is now a sibling of the trigger, positioned over padding the trigger reserves for it (`pr-7`) only while the control is shown. Two behaviours change as a result: clicking clear no longer needs `stopPropagation` to avoid opening the dialog, because it is no longer inside the trigger, and the control now honours the selector's `disabled` prop — nesting had left it clickable while the selector it belonged to was disabled.

Both trigger variants carried their own copy of the nested markup, so both are covered.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>