### PR TITLE
fix(skills): show the personal badge on a user's own skills

### DIFF
--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -352,6 +352,7 @@ function SkillsList() {
           authorId={row.original.authorId}
           authorName={row.original.authorName}
           currentUserId={currentUserId}
+          showSelfAsMe
         />
       ),
     },


### PR DESCRIPTION
The Skills table's Visibility column already used `ResourceVisibilityBadge` — the same component as Agents, MCP Gateways and LLM Proxies — but was missing the `showSelfAsMe` prop those three pass. The component hides the badge by default for the viewer's own unshared resource, so your own personal skills rendered no badge at all, while other users' skills already showed their name correctly.

Adds `showSelfAsMe` so an owner's personal skills show the blue "Me" badge, consistent with the other three pages.

No test added: the `showSelfAsMe` → "Me" behavior is already pinned by `resource-visibility-badge.test.tsx`, and this change is prop plumbing, which `platform/CLAUDE.md` says to skip testing. None of the three sibling adopters assert the badge at page level either.

Task: T-1024

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>