### PR TITLE
fix(frontend): make visibility scope badges consistent across the app

### DIFF
--- a/platform/frontend/src/app/connection/connect-command-panel.test.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { CONNECT_CLIENTS } from "./clients";
@@ -131,6 +131,9 @@ beforeEach(() => {
   vi.mocked(useHasPermissions).mockReturnValue({
     data: true,
   } as ReturnType<typeof useHasPermissions>);
+  vi.mocked(useSession).mockReturnValue({
+    data: { user: { id: "user-1" } },
+  } as ReturnType<typeof useSession>);
   availableKeysMock.mockReturnValue({
     data: [{ provider: "anthropic" }, { provider: "bedrock" }],
   });
@@ -138,8 +141,17 @@ beforeEach(() => {
   modelsByProviderMock.mockReturnValue({});
   allSkillsMock.mockReturnValue({
     data: [
-      { id: "s1", name: "warehouse-postgres" },
-      { id: "s2", name: "billing-pipeline" },
+      { id: "s1", name: "warehouse-postgres", scope: "org", teams: [] },
+      // A colleague's personal skill: the picker lists these for skill admins
+      // and preselects them, so the row must name whose it is.
+      {
+        id: "s2",
+        name: "billing-pipeline",
+        scope: "personal",
+        authorId: "user-2",
+        authorName: "Dana",
+        teams: [],
+      },
     ],
   });
   createSetupMock.mockResolvedValue({
@@ -294,7 +306,12 @@ describe("ConnectCommandPanel", () => {
     ).toBeInTheDocument();
 
     await user.click(screen.getByTestId("connect-change-skills"));
-    await user.click(screen.getByLabelText("billing-pipeline"));
+    // The picker preselects skills an admin can see, including other people's
+    // personal ones, so each row must say whose it is before it is installed.
+    expect(screen.getByText("Dana")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("checkbox", { name: /billing-pipeline/ }),
+    );
 
     await waitFor(() =>
       expect(createSetupMock).toHaveBeenLastCalledWith(

--- a/platform/frontend/src/app/connection/connect-command-panel.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.tsx
@@ -25,6 +25,7 @@ import { CreditWarningNotice } from "@/components/connection/credit-warning-noti
 import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
 import { GithubCopilotSignIn } from "@/components/github-copilot-sign-in";
 import { ProviderIcon } from "@/components/provider-icon";
+import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -37,7 +38,7 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { WizardStep } from "@/components/wizard-step";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { copyToClipboard } from "@/lib/clipboard";
 import {
   type CreateConnectionSetupBody,
@@ -161,6 +162,9 @@ export function ConnectCommandPanel({
 }: ConnectCommandPanelProps) {
   const { eligible: skillsEligible, skills: allSkills } =
     useConnectSkills(llmProxyId);
+  // The skill picker labels each row's owner, so it needs the viewer's id.
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
   // Skill selection: `null` means "all skills" (the default, and it keeps
   // including skills created later). Once the user touches any checkbox it
   // becomes an explicit snapshot of chosen ids — so an opt-out (empty set)
@@ -687,7 +691,16 @@ export function ConnectCommandPanel({
                   toggleSkill(skill.id, checked === true)
                 }
               />
-              {skill.name}
+              <span>{skill.name}</span>
+              <ResourceVisibilityBadge
+                scope={skill.scope}
+                teams={skill.teams}
+                users={skill.users}
+                authorId={skill.authorId}
+                authorName={skill.authorName}
+                currentUserId={currentUserId}
+                showSelfAsMe
+              />
             </label>
           </li>
         ))}

--- a/platform/frontend/src/app/connection/skills-marketplace-step.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { archestraApiSdk } from "@archestra/shared";
+import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
 import {
   AlertTriangle,
@@ -502,15 +502,18 @@ function firstActiveLink(links: SkillShareLink[]): SkillShareLink | null {
   return links.find((l) => l.status === "active") ?? null;
 }
 
-/** The slice of a skill the connection flow needs to list and share it. */
-export interface ConnectSkill {
-  id: string;
-  name: string;
-}
+/**
+ * The slice of a skill the connection flow needs to list, attribute, and share
+ * it. Derived from the API response so the fields can't drift from it.
+ */
+export type ConnectSkill = Pick<
+  archestraApiTypes.GetSkillsResponses["200"]["data"][number],
+  "id" | "name" | "scope" | "authorId" | "authorName" | "teams" | "users"
+>;
 
 /**
- * Query over the org's full skill set (id + name), for the connect-command
- * step's per-skill picker. Soft-fails to an empty list (with the API-error
+ * Query over the org's full skill set, for the connect-command step's
+ * per-skill picker. Soft-fails to an empty list (with the API-error
  * toast) so a skills outage degrades to "no skills ride along" instead of
  * blocking command generation.
  *
@@ -547,7 +550,15 @@ async function fetchAllSkills(
     }
     if (!data) break;
     for (const skill of data.data) {
-      skills.push({ id: skill.id, name: skill.name });
+      skills.push({
+        id: skill.id,
+        name: skill.name,
+        scope: skill.scope,
+        authorId: skill.authorId,
+        authorName: skill.authorName,
+        teams: skill.teams,
+        users: skill.users,
+      });
     }
     if (data.data.length < limit) break;
     offset += limit;

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-access-badge.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-access-badge.tsx
@@ -59,6 +59,9 @@ export function ConnectorAccessBadge({
       authorId={undefined}
       authorName={undefined}
       currentUserId={undefined}
+      // Inert here: a connector is only ever org- or team-scoped, so the
+      // personal-scope branch this flag controls is unreachable.
+      showSelfAsMe={false}
     />
   );
 }

--- a/platform/frontend/src/app/llm/model-providers/page.test.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.test.tsx
@@ -354,7 +354,9 @@ describe("ApiKeysPage", () => {
 
     // The owner is the point: the backend already joins userName, and before
     // this column showed only a generic scope word for every personal key.
-    expect(screen.getByText("Me")).toBeInTheDocument();
+    // "Me" appears four times — the viewer's own key plus the three
+    // subscription rows, which are the viewer's own accounts by definition.
+    expect(screen.getAllByText("Me")).toHaveLength(4);
     expect(screen.getByText("Dana")).toBeInTheDocument();
     expect(screen.getByText("Organization")).toBeInTheDocument();
   });

--- a/platform/frontend/src/app/llm/model-providers/page.test.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.test.tsx
@@ -144,15 +144,21 @@ vi.mock("@/components/ui/data-table", () => ({
     data: Array<{ id: string; name: string }>;
     columns: Array<{
       id?: string;
+      accessorKey?: string;
       cell?: (context: { row: { original: unknown } }) => React.ReactNode;
     }>;
   }) => {
     const actions = columns.find((column) => column.id === "actions");
+    // The Access cell is rendered too: it is the only column besides actions
+    // whose contents are asserted, and dropping it would let a blank
+    // ownership cell pass unnoticed.
+    const access = columns.find((column) => column.accessorKey === "scope");
     return (
       <div data-loading={isLoading}>
         {data.map((row) => (
           <div key={row.id}>
             <span>{row.name}</span>
+            {access?.cell?.({ row: { original: row } })}
             {actions?.cell?.({ row: { original: row } })}
           </div>
         ))}
@@ -204,7 +210,7 @@ vi.mock("@/components/ui/select", () => ({
 }));
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { useOrganization } from "@/lib/organization.query";
 import ApiKeysPage from "./page";
@@ -305,6 +311,52 @@ describe("ApiKeysPage", () => {
       screen.queryByText("Existing ChatGPT credential"),
     ).not.toBeInTheDocument();
     expect(screen.getAllByText("Connect")).toHaveLength(2);
+  });
+
+  it("names who each scoped credential is accessible to", () => {
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+      isPending: false,
+    } as unknown as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "user-me" } },
+    } as ReturnType<typeof useSession>);
+    mockUseLlmProviderApiKeys.mockReturnValue({
+      data: [
+        {
+          id: "k1",
+          name: "My key",
+          provider: "anthropic",
+          scope: "personal",
+          userId: "user-me",
+          userName: "My Name",
+        },
+        {
+          id: "k2",
+          name: "Colleague key",
+          provider: "anthropic",
+          scope: "personal",
+          userId: "user-other",
+          userName: "Dana",
+        },
+        {
+          id: "k3",
+          name: "Shared key",
+          provider: "anthropic",
+          scope: "org",
+          userId: null,
+        },
+      ],
+      isPending: false,
+    });
+
+    render(<ApiKeysPage />);
+
+    // The owner is the point: the backend already joins userName, and before
+    // this column showed only a generic scope word for every personal key.
+    expect(screen.getByText("Me")).toBeInTheDocument();
+    expect(screen.getByText("Dana")).toBeInTheDocument();
+    expect(screen.getByText("Organization")).toBeInTheDocument();
   });
 
   it("opens Connect with provider-specific subscription defaults", () => {

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -16,7 +16,6 @@ import {
   Plus,
   Server,
   Trash2,
-  User,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -38,6 +37,7 @@ import {
 import { LlmProviderSelectItems } from "@/components/llm-provider-select-items";
 import { PageLayout } from "@/components/page-layout";
 import {
+  platformOwnedStyles,
   SCOPE_META,
   scopeLabel,
   scopeStyles,
@@ -486,16 +486,26 @@ export default function ApiKeysPage() {
         cell: ({ row }) => {
           const credential = row.original;
           if (credential.kind === "subscription") {
+            // A subscription is one person's own account, so it is coloured as
+            // the personal scope it is rather than left as a bare pill beside
+            // the scoped rows.
+            const PersonalIcon = SCOPE_META.personal.icon;
             return (
-              <Badge variant="outline" className="max-w-full gap-1">
-                <User className="h-3 w-3" />
+              <Badge
+                variant="outline"
+                className={cn(scopeStyles.personal, "max-w-full gap-1")}
+              >
+                <PersonalIcon className="h-3 w-3" />
                 <span className="truncate">Personal account</span>
               </Badge>
             );
           }
           if (credential.isSystem) {
             return (
-              <Badge variant="secondary" className="max-w-full gap-1">
+              <Badge
+                variant="outline"
+                className={cn(platformOwnedStyles, "max-w-full gap-1")}
+              >
                 <Server className="h-3 w-3" />
                 <span className="truncate">System</span>
               </Badge>

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -5,7 +5,6 @@ import {
   E2eTestId,
   formatSecretStorageType,
   isProviderApiKeyOptional,
-  type ResourceVisibilityScope,
 } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
@@ -36,12 +35,8 @@ import {
 } from "@/components/llm-provider-api-key-form";
 import { LlmProviderSelectItems } from "@/components/llm-provider-select-items";
 import { PageLayout } from "@/components/page-layout";
-import {
-  platformOwnedStyles,
-  SCOPE_META,
-  scopeLabel,
-  scopeStyles,
-} from "@/components/scope-vocabulary";
+import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
+import { platformOwnedStyles } from "@/components/scope-vocabulary";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -62,6 +57,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { DialogCancelButton } from "@/components/unsaved-changes-guard";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
@@ -486,49 +487,64 @@ export default function ApiKeysPage() {
         cell: ({ row }) => {
           const credential = row.original;
           if (credential.kind === "subscription") {
-            // A subscription is one person's own account, so it is coloured as
-            // the personal scope it is rather than left as a bare pill beside
-            // the scoped rows.
-            const PersonalIcon = SCOPE_META.personal.icon;
+            // A subscription is a personal credential of whoever connected it
+            // (today the endpoint only returns the viewer's own, so this reads
+            // "Me"); the Name column's "Subscription" tag already says what
+            // kind of credential it is, so the Access cell answers only whose.
             return (
-              <Badge
-                variant="outline"
-                className={cn(scopeStyles.personal, "max-w-full gap-1")}
-              >
-                <PersonalIcon className="h-3 w-3" />
-                <span className="truncate">Personal account</span>
-              </Badge>
+              <ResourceVisibilityBadge
+                scope="personal"
+                teams={undefined}
+                authorId={credential.credential?.userId ?? currentUserId}
+                authorName={credential.credential?.userName ?? null}
+                currentUserId={currentUserId}
+                showSelfAsMe
+              />
             );
           }
           if (credential.isSystem) {
+            // Not a visibility scope: nobody in the org owns this row. It is
+            // auto-provisioned because the deployment authenticates with cloud
+            // credentials, so it borrows the platform-owned styling that the
+            // built-in agent badge uses.
             return (
-              <Badge
-                variant="outline"
-                className={cn(platformOwnedStyles, "max-w-full gap-1")}
-              >
-                <Server className="h-3 w-3" />
-                <span className="truncate">System</span>
-              </Badge>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        platformOwnedStyles,
+                        "max-w-full cursor-help gap-1",
+                      )}
+                    >
+                      <Server className="h-3 w-3" />
+                      <span className="truncate">System</span>
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    Provisioned automatically because this deployment
+                    authenticates with cloud credentials instead of an API key.
+                    Managed through environment configuration and usable by the
+                    whole organization.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             );
           }
-          const { scope } = credential;
-          const ScopeIcon = SCOPE_META[scope].icon;
           return (
-            <Badge
-              variant="outline"
-              className={cn(scopeStyles[scope], "max-w-full gap-1")}
-            >
-              <ScopeIcon className="h-3 w-3" />
-              <span className="truncate">
-                {accessLabel({
-                  scope,
-                  userId: credential.userId,
-                  userName: credential.userName,
-                  teamName: credential.teamName,
-                  currentUserId,
-                })}
-              </span>
-            </Badge>
+            <ResourceVisibilityBadge
+              scope={credential.scope}
+              teams={
+                credential.teamId && credential.teamName
+                  ? [{ id: credential.teamId, name: credential.teamName }]
+                  : undefined
+              }
+              authorId={credential.userId}
+              authorName={credential.userName}
+              currentUserId={currentUserId}
+              showSelfAsMe
+            />
           );
         },
       },
@@ -834,42 +850,6 @@ export default function ApiKeysPage() {
       </div>
     </PageLayout>
   );
-}
-
-/**
- * What the Access badge says for a stored credential.
- *
- * A personal key names its owner instead of repeating the scope word. The list
- * endpoint only ever returns the caller's own personal keys (admins included),
- * so in practice that row reads "Me", matching how the rest of the app labels
- * the current user; the `userName` branch — the name the endpoint already
- * joins onto every row — is what a key owned by somebody else would say if
- * that visibility ever widens. A team key names its team, and the scope label
- * is the fallback whenever no name came back.
- */
-function accessLabel({
-  scope,
-  userId,
-  userName,
-  teamName,
-  currentUserId,
-}: {
-  scope: ResourceVisibilityScope;
-  userId: string | null;
-  userName?: string | null;
-  teamName?: string | null;
-  currentUserId?: string;
-}): string {
-  if (scope === "personal") {
-    if (currentUserId && userId === currentUserId) {
-      return "Me";
-    }
-    return userName || scopeLabel(scope);
-  }
-  if (scope === "team") {
-    return teamName || scopeLabel(scope);
-  }
-  return scopeLabel(scope);
 }
 
 function DeleteApiKeyDescription({

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -10,7 +10,6 @@ import {
 import type { ColumnDef } from "@tanstack/react-table";
 import {
   AlertTriangle,
-  Building2,
   CheckCircle2,
   Loader2,
   Pencil,
@@ -18,7 +17,6 @@ import {
   Server,
   Trash2,
   User,
-  Users,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -39,6 +37,11 @@ import {
 } from "@/components/llm-provider-api-key-form";
 import { LlmProviderSelectItems } from "@/components/llm-provider-select-items";
 import { PageLayout } from "@/components/page-layout";
+import {
+  SCOPE_META,
+  scopeLabel,
+  scopeStyles,
+} from "@/components/scope-vocabulary";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -60,7 +63,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { DialogCancelButton } from "@/components/unsaved-changes-guard";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
@@ -73,6 +76,7 @@ import {
   useUpdateLlmProviderApiKey,
 } from "@/lib/llm-provider-api-keys.query";
 import { useOrganization } from "@/lib/organization.query";
+import { cn } from "@/lib/utils";
 import { useAllVirtualApiKeys } from "@/lib/virtual-api-keys.query";
 import { MODEL_NAV_TABS } from "../model-nav-tabs";
 import { isEditApiKeyFormValid } from "./edit-key-form.utils";
@@ -95,12 +99,6 @@ type ModelProviderRow =
       credential: LlmProviderApiKeyResponse | null;
       defaultValues: Partial<LlmProviderApiKeyFormValues>;
     };
-
-const SCOPE_ICONS: Record<ResourceVisibilityScope, React.ReactNode> = {
-  personal: <User className="h-3 w-3" />,
-  team: <Users className="h-3 w-3" />,
-  org: <Building2 className="h-3 w-3" />,
-};
 
 const DEFAULT_FORM_VALUES: LlmProviderApiKeyFormValues = {
   name: "",
@@ -176,6 +174,10 @@ export default function ApiKeysPage() {
     enabled: apiKeyQueriesEnabled,
   });
   const { data: organization } = useOrganization();
+  // Read defensively: suites that render this page mock the auth query module
+  // wholesale, and the Access column should fall back to the scope label
+  // rather than crash the table (same convention as `user-share-field.tsx`).
+  const currentUserId = useSession()?.data?.user?.id;
   const updateMutation = useUpdateLlmProviderApiKey();
   const deleteMutation = useDeleteLlmProviderApiKey();
   const byosEnabled = useFeature("byosEnabled");
@@ -481,33 +483,44 @@ export default function ApiKeysPage() {
         header: "Access",
         size: 210,
         minSize: 170,
-        cell: ({ row }) =>
-          row.original.kind === "subscription" ? (
-            <Badge variant="outline" className="max-w-full gap-1">
-              <User className="h-3 w-3" />
-              <span className="truncate">Personal account</span>
-            </Badge>
-          ) : (
-            <Badge
-              variant={row.original.isSystem ? "secondary" : "outline"}
-              className="max-w-full gap-1"
-            >
-              {row.original.isSystem ? (
+        cell: ({ row }) => {
+          const credential = row.original;
+          if (credential.kind === "subscription") {
+            return (
+              <Badge variant="outline" className="max-w-full gap-1">
+                <User className="h-3 w-3" />
+                <span className="truncate">Personal account</span>
+              </Badge>
+            );
+          }
+          if (credential.isSystem) {
+            return (
+              <Badge variant="secondary" className="max-w-full gap-1">
                 <Server className="h-3 w-3" />
-              ) : (
-                SCOPE_ICONS[row.original.scope as ResourceVisibilityScope]
-              )}
+                <span className="truncate">System</span>
+              </Badge>
+            );
+          }
+          const { scope } = credential;
+          const ScopeIcon = SCOPE_META[scope].icon;
+          return (
+            <Badge
+              variant="outline"
+              className={cn(scopeStyles[scope], "max-w-full gap-1")}
+            >
+              <ScopeIcon className="h-3 w-3" />
               <span className="truncate">
-                {row.original.isSystem
-                  ? "System"
-                  : row.original.scope === "team"
-                    ? row.original.teamName
-                    : row.original.scope === "personal"
-                      ? "Personal"
-                      : "Organization"}
+                {accessLabel({
+                  scope,
+                  userId: credential.userId,
+                  userName: credential.userName,
+                  teamName: credential.teamName,
+                  currentUserId,
+                })}
               </span>
             </Badge>
-          ),
+          );
+        },
       },
       {
         accessorKey: "secretStorageType",
@@ -648,6 +661,7 @@ export default function ApiKeysPage() {
       getKeyUsage,
       azureOpenAiEntraIdEnabled,
       anthropicWifEnabled,
+      currentUserId,
     ],
   );
 
@@ -810,6 +824,42 @@ export default function ApiKeysPage() {
       </div>
     </PageLayout>
   );
+}
+
+/**
+ * What the Access badge says for a stored credential.
+ *
+ * A personal key names its owner instead of repeating the scope word. The list
+ * endpoint only ever returns the caller's own personal keys (admins included),
+ * so in practice that row reads "Me", matching how the rest of the app labels
+ * the current user; the `userName` branch — the name the endpoint already
+ * joins onto every row — is what a key owned by somebody else would say if
+ * that visibility ever widens. A team key names its team, and the scope label
+ * is the fallback whenever no name came back.
+ */
+function accessLabel({
+  scope,
+  userId,
+  userName,
+  teamName,
+  currentUserId,
+}: {
+  scope: ResourceVisibilityScope;
+  userId: string | null;
+  userName?: string | null;
+  teamName?: string | null;
+  currentUserId?: string;
+}): string {
+  if (scope === "personal") {
+    if (currentUserId && userId === currentUserId) {
+      return "Me";
+    }
+    return userName || scopeLabel(scope);
+  }
+  if (scope === "team") {
+    return teamName || scopeLabel(scope);
+  }
+  return scopeLabel(scope);
 }
 
 function DeleteApiKeyDescription({

--- a/platform/frontend/src/app/mcp/registry/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/registry/[id]/page.client.tsx
@@ -23,6 +23,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { PageLayout } from "@/components/page-layout";
+import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -599,6 +600,22 @@ function CatalogItemDetails({ item }: { item: CatalogItem }) {
                       {environmentLabel ?? defaultEnvironment.name}
                     </OverviewField>
                   )}
+                  <OverviewField label="Accessible to">
+                    {/*
+                      `showSelfAsMe` because this is a labelled field rather
+                      than one badge among many in a list: the viewer's own
+                      personal server must still say "Me" instead of leaving
+                      the field blank.
+                    */}
+                    <ResourceVisibilityBadge
+                      scope={item.scope}
+                      teams={item.teams}
+                      authorId={item.authorId}
+                      authorName={item.authorName}
+                      currentUserId={currentUserId}
+                      showSelfAsMe
+                    />
+                  </OverviewField>
                   {endpoint && (
                     <OverviewField
                       label={variant === "remote" ? "Server URL" : "Command"}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -567,9 +567,10 @@ export function McpServerCard({
   const extraCount = connectionAvatars.length - MAX_AVATARS;
 
   // Who can reach this catalog item. Personal items of the viewer's own say
-  // nothing new — the grid already groups them under a "Personal" heading, and
-  // the badge renders null for that case anyway, so the gate mirrors it to keep
-  // the row (and its separator) from reserving space for an empty badge.
+  // nothing new — the grid already groups them under a "Personal" heading, so
+  // the badge is asked not to label them "Me" (`showSelfAsMe={false}`) and
+  // renders null for that case; the gate mirrors it to keep the row (and its
+  // separator) from reserving space for an empty badge.
   const showScopeBadge =
     item.scope !== "personal" ||
     Boolean(item.authorId && item.authorId !== currentUserId);
@@ -598,6 +599,7 @@ export function McpServerCard({
             authorId={item.authorId}
             authorName={item.authorName}
             currentUserId={currentUserId}
+            showSelfAsMe={false}
           />
           {hasCompactInfoAfterScopeBadge && (
             <div className="h-4 w-px bg-border" />

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -27,6 +27,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
+import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import {
   Avatar,
   AvatarFallback,
@@ -565,11 +566,18 @@ export function McpServerCard({
   }
   const extraCount = connectionAvatars.length - MAX_AVATARS;
 
-  const showAuthorAvatar =
-    item.scope === "personal" && Boolean(item.authorName);
+  // Who can reach this catalog item. Personal items of the viewer's own say
+  // nothing new — the grid already groups them under a "Personal" heading, and
+  // the badge renders null for that case anyway, so the gate mirrors it to keep
+  // the row (and its separator) from reserving space for an empty badge.
+  const showScopeBadge =
+    item.scope !== "personal" ||
+    Boolean(item.authorId && item.authorId !== currentUserId);
 
-  const hasCompactInfoContent =
-    showAuthorAvatar ||
+  // Whether anything follows the badge in the row. Shared by the row's "is there
+  // anything at all to show" gate and the badge's trailing divider so the two
+  // can't drift and leave a divider hanging at the end of the row.
+  const hasCompactInfoAfterScopeBadge =
     toolsCount > 0 ||
     totalAgentCount > 0 ||
     (variant === "local" && deploymentServerIds.length > 0) ||
@@ -578,26 +586,20 @@ export function McpServerCard({
         hasOrgConnection ||
         Boolean(oauthReauthIndicator)));
 
+  const hasCompactInfoContent = showScopeBadge || hasCompactInfoAfterScopeBadge;
+
   const compactInfoRow = hasCompactInfoContent ? (
     <div className="flex items-center gap-3 text-sm text-muted-foreground">
-      {showAuthorAvatar && (
+      {showScopeBadge && (
         <>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Avatar className="size-6 border-2 border-background">
-                  <AvatarFallback className="text-[10px]">
-                    {item.authorName?.slice(0, 2).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-              </TooltipTrigger>
-              <TooltipContent>Author: {item.authorName}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          {(toolsCount > 0 ||
-            (variant === "local" && deploymentServerIds.length > 0) ||
-            (!isBuiltinVariant &&
-              (connectionAvatars.length > 0 || hasOrgConnection))) && (
+          <ResourceVisibilityBadge
+            scope={item.scope}
+            teams={item.teams}
+            authorId={item.authorId}
+            authorName={item.authorName}
+            currentUserId={currentUserId}
+          />
+          {hasCompactInfoAfterScopeBadge && (
             <div className="h-4 w-px bg-border" />
           )}
         </>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
@@ -15,6 +15,7 @@ import {
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
+import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import {
   type TableRowAction,
   TableRowActions,
@@ -65,6 +66,8 @@ export function McpServerTable({
   onCancelInstallation,
 }: McpServerTableProps) {
   const router = useRouter();
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
 
   const columns: ColumnDef<CatalogItem>[] = [
     {
@@ -111,11 +114,16 @@ export function McpServerTable({
     {
       id: "author",
       size: 140,
-      header: "Author",
+      header: "Accessible to",
       cell: ({ row }) => (
-        <span className="line-clamp-1 text-sm text-muted-foreground">
-          {row.original.authorName ?? "—"}
-        </span>
+        <ResourceVisibilityBadge
+          scope={row.original.scope}
+          teams={row.original.teams}
+          authorId={row.original.authorId}
+          authorName={row.original.authorName}
+          currentUserId={currentUserId}
+          showSelfAsMe
+        />
       ),
     },
     {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-usage-tab.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-usage-tab.test.tsx
@@ -56,6 +56,21 @@ describe("McpServerUsageTab", () => {
     expect(screen.getByText("bob@example.com")).toBeInTheDocument();
   });
 
+  it("spells out the scope of an ownerless agent instead of the raw enum", () => {
+    render(
+      <McpServerUsageTab
+        serversForCatalog={[
+          server([agent({ id: "1", name: "Org Agent", scope: "org" })]),
+        ]}
+      />,
+    );
+
+    const row = screen.getByText("Org Agent").closest("tr") as HTMLElement;
+
+    expect(within(row).getByText("Organization")).toBeInTheDocument();
+    expect(within(row).queryByText("org")).not.toBeInTheDocument();
+  });
+
   it("labels how each agent reaches the server", () => {
     render(
       <McpServerUsageTab

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-usage-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-usage-tab.tsx
@@ -2,6 +2,7 @@
 
 import type { archestraApiTypes } from "@archestra/shared";
 import { Bot } from "lucide-react";
+import { scopeLabel } from "@/components/scope-badge";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -74,9 +75,15 @@ export function McpServerUsageTab({
                     {/*
                       Personal agents are seeded per member and share a name, so
                       the owner is what tells them apart. Org- and team-scoped
-                      agents belong to everyone, hence the scope label instead.
+                      agents belong to everyone, hence the scope label instead —
+                      spelled out the way every scope pill spells it, so this
+                      column never shows the raw `org` enum.
                     */}
-                    {owner ?? <span className="capitalize">{agent.scope}</span>}
+                    {owner ? (
+                      <span>{owner}</span>
+                    ) : (
+                      <span>{scopeLabel(agent.scope)}</span>
+                    )}
                   </TableCell>
                   <TableCell>
                     {agent.access === "assigned" ? (

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-usage-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-usage-tab.tsx
@@ -2,7 +2,7 @@
 
 import type { archestraApiTypes } from "@archestra/shared";
 import { Bot } from "lucide-react";
-import { scopeLabel } from "@/components/scope-badge";
+import { scopeLabel } from "@/components/scope-vocabulary";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,

--- a/platform/frontend/src/app/messaging-channels/a2a/page.tsx
+++ b/platform/frontend/src/app/messaging-channels/a2a/page.tsx
@@ -4,6 +4,7 @@ import { Bot } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import { A2AConnectionInstructions } from "@/components/a2a-connection-instructions";
+import { AgentBadge } from "@/components/agent-badge";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -59,6 +60,7 @@ export default function A2APage() {
                 <div className="flex items-center gap-2 min-w-0">
                   <Bot className="h-4 w-4 shrink-0" />
                   <span className="truncate">{selectedAgent.name}</span>
+                  <AgentBadge type={selectedAgent.scope} className="ml-auto" />
                 </div>
               )}
             </SelectValue>
@@ -69,6 +71,7 @@ export default function A2APage() {
                 <div className="flex items-center gap-2 min-w-0">
                   <Bot className="h-4 w-4 shrink-0" />
                   <span className="truncate">{agent.name}</span>
+                  <AgentBadge type={agent.scope} className="ml-auto" />
                 </div>
               </SelectItem>
             ))}

--- a/platform/frontend/src/app/messaging-channels/email/page.tsx
+++ b/platform/frontend/src/app/messaging-channels/email/page.tsx
@@ -418,9 +418,11 @@ function EmailAgentRow({
           <ResourceVisibilityBadge
             scope={agent.scope}
             teams={agent.teams}
+            users={agent.users}
             authorId={agent.authorId}
             authorName={agent.authorName}
             currentUserId={currentUserId}
+            showSelfAsMe
           />
         </div>
       </TableCell>

--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -42,8 +42,10 @@ import { SelectableFileList } from "@/components/chat/selectable-file-list";
 import { FileDropZone } from "@/components/files/file-drop-zone";
 import { PageLayout } from "@/components/page-layout";
 import { EditProjectDialog } from "@/components/projects/edit-project-dialog";
+import { projectVisibilityToScope } from "@/components/projects/project-visibility";
 import { QueryLoadError } from "@/components/query-load-error";
 import { useResolveRunChat } from "@/components/scheduled-tasks/use-resolve-run-chat";
+import { ScopeBadge } from "@/components/scope-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -168,6 +170,15 @@ function ProjectDetail() {
           description={project.description ?? ""}
           actionButton={
             <div className="flex items-center gap-2">
+              {/* The same scope pill (personal/team/org) the list and card views
+                  show, so a project's sharing doesn't disappear when you open
+                  it. The administrator badge below says something different —
+                  why the composer, chats and pin are missing. */}
+              <ScopeBadge
+                scope={projectVisibilityToScope(project.visibility)}
+                teamNames={project.shareTeamNames}
+                userNames={project.shareUserNames}
+              />
               {isAdminView && (
                 <Badge variant="secondary">
                   Viewing as administrator

--- a/platform/frontend/src/components/agent-badge.tsx
+++ b/platform/frontend/src/components/agent-badge.tsx
@@ -1,23 +1,22 @@
 import type { AgentScope } from "@archestra/shared";
+import { SCOPE_META } from "@/components/scope-vocabulary";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
-// Light-mode text uses the 700/800 palette steps: the 600 steps fall below the
-// 4.5:1 contrast minimum (WCAG 1.4.3) on the tinted /10 fills. Dark mode's 400
-// steps already pass. Keep in sync with scopeStyles in
-// resource-visibility-badge.tsx.
+// The three visibility scopes speak the shared vocabulary. "builtIn" is not a
+// scope — it marks an agent Archestra ships rather than one an org created — so
+// its colour and label stay local to this badge.
 const styles = {
-  personal:
-    "bg-blue-500/10 text-blue-700 border-blue-500/30 dark:text-blue-400 dark:border-blue-400/30",
-  team: "bg-green-500/10 text-green-800 border-green-500/30 dark:text-green-400 dark:border-green-400/30",
-  org: "bg-amber-500/10 text-amber-800 border-amber-500/30 dark:text-amber-400 dark:border-amber-400/30",
+  personal: SCOPE_META.personal.styles,
+  team: SCOPE_META.team.styles,
+  org: SCOPE_META.org.styles,
   builtIn:
     "bg-purple-500/10 text-purple-700 border-purple-500/30 dark:text-purple-400 dark:border-purple-400/30",
 } as const;
 const labels = {
-  personal: "Personal",
-  team: "Team",
-  org: "Organization",
+  personal: SCOPE_META.personal.label,
+  team: SCOPE_META.team.label,
+  org: SCOPE_META.org.label,
   builtIn: "Built-in",
 } as const;
 const commonClasses =

--- a/platform/frontend/src/components/agent-badge.tsx
+++ b/platform/frontend/src/components/agent-badge.tsx
@@ -1,17 +1,17 @@
 import type { AgentScope } from "@archestra/shared";
-import { SCOPE_META } from "@/components/scope-vocabulary";
+import { platformOwnedStyles, SCOPE_META } from "@/components/scope-vocabulary";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 // The three visibility scopes speak the shared vocabulary. "builtIn" is not a
-// scope — it marks an agent Archestra ships rather than one an org created — so
-// its colour and label stay local to this badge.
+// scope — it marks an agent the platform ships rather than one an org created —
+// so it borrows the shared platform-owned styling instead, which the system
+// credential badge uses too.
 const styles = {
   personal: SCOPE_META.personal.styles,
   team: SCOPE_META.team.styles,
   org: SCOPE_META.org.styles,
-  builtIn:
-    "bg-purple-500/10 text-purple-700 border-purple-500/30 dark:text-purple-400 dark:border-purple-400/30",
+  builtIn: platformOwnedStyles,
 } as const;
 const labels = {
   personal: SCOPE_META.personal.label,

--- a/platform/frontend/src/components/agent-connect-instructions-dialog.tsx
+++ b/platform/frontend/src/components/agent-connect-instructions-dialog.tsx
@@ -34,13 +34,14 @@ import {
   type CreatedCredentials,
   OAuthClientCreatedDialog,
 } from "@/components/oauth-client-created-dialog";
+import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { SECRET_PLACEHOLDER_TOKEN } from "@/components/secret-copy-button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { VirtualKeyManagement } from "@/components/virtual-key-management";
 import { useProfile, useProfiles } from "@/lib/agent.query";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useIdentityProviders } from "@/lib/auth/identity-provider-read.query";
 import { copyToClipboard } from "@/lib/clipboard";
 import config from "@/lib/config/config";
@@ -551,6 +552,8 @@ function OauthClientTable({
   proxyId: string;
   clients: LlmOauthClientRow[] | undefined;
 }) {
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
   const { data: canDelete } = useHasPermissions({
     llmOauthClient: ["delete"],
   });
@@ -596,6 +599,7 @@ function OauthClientTable({
             <th className="px-3 py-1.5 font-medium">Name</th>
             <th className="px-3 py-1.5 font-medium">Client ID</th>
             <th className="px-3 py-1.5 font-medium">Providers</th>
+            <th className="px-3 py-1.5 font-medium">Accessible to</th>
             {(canUpdate || canDelete) && <th className="w-8 px-2 py-1.5" />}
           </tr>
         </thead>
@@ -635,6 +639,16 @@ function OauthClientTable({
                       .map((mapping) => providerDisplayNames[mapping.provider])
                       .join(", ")
                   : "—"}
+              </td>
+              <td className="max-w-[180px] px-3 py-1.5">
+                <ResourceVisibilityBadge
+                  scope={client.scope}
+                  teams={client.teams}
+                  authorId={client.authorId}
+                  authorName={client.authorName}
+                  currentUserId={currentUserId}
+                  showSelfAsMe
+                />
               </td>
               {(canUpdate || canDelete) && (
                 <td className="px-2 py-1.5">

--- a/platform/frontend/src/components/agent-selector.tsx
+++ b/platform/frontend/src/components/agent-selector.tsx
@@ -3,6 +3,7 @@
 import { Check, ChevronDown, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { AgentIcon } from "@/components/agent-icon";
+import { ScopeBadge } from "@/components/scope-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -491,7 +492,15 @@ function AgentSelectorRow({
         className="text-muted-foreground"
       />
       <span className="min-w-0 flex-1">
-        <span className="block truncate">{agent.name}</span>
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate">{agent.name}</span>
+          {agent.scope ? (
+            <ScopeBadge
+              scope={agent.scope}
+              teamNames={agent.teams?.map((team) => team.name)}
+            />
+          ) : null}
+        </span>
         {description && (
           <span className="block truncate text-xs text-muted-foreground">
             {description}
@@ -537,16 +546,14 @@ function agentSearchText(agent: AgentSelectorAgent) {
     .join(" ");
 }
 
+// Identity only — scope (personal/team/org, with the team names in its tooltip)
+// is carried by the ScopeBadge beside the name. The email still disambiguates
+// other users' personal gateways/proxies, which an admin genuinely sees in the
+// connect settings picker.
 function getOwnerLabel(agent: AgentSelectorAgent) {
-  if (agent.scope !== "personal") {
-    if (agent.scope === "team" && agent.teams?.length) {
-      return agent.teams.map((team) => team.name).join(", ");
-    }
-
-    return null;
-  }
-
-  return agent.authorEmail ?? agent.authorName ?? "Personal";
+  return agent.scope === "personal"
+    ? (agent.authorEmail ?? agent.authorName ?? null)
+    : null;
 }
 
 function matchesSearch(value: string, search: string) {

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -819,15 +819,14 @@ function AgentSettingsView({
       </div>
 
       <div className="p-4 space-y-4 flex-1 min-h-0 overflow-y-auto">
-        {agent.scope === "org" ||
-          (agent.scope === "team" && (
-            <Alert variant="info" className="border-0 py-2 text-xs">
-              <Info className="size-3.5" />
-              <AlertDescription className="text-xs">
-                You are editing a shared agent
-              </AlertDescription>
-            </Alert>
-          ))}
+        {(agent.scope === "org" || agent.scope === "team") && (
+          <Alert variant="info" className="border-0 py-2 text-xs">
+            <Info className="size-3.5" />
+            <AlertDescription className="text-xs">
+              You are editing a shared agent
+            </AlertDescription>
+          </Alert>
+        )}
         <SystemPromptEditor
           value={instructions}
           onChange={setInstructions}

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -346,8 +346,14 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
                         <AgentIcon icon={agent.icon} size={14} />
                       </div>
                       <div className="flex-1 min-w-0">
-                        <div className="text-sm font-medium truncate">
-                          {agent.name}
+                        <div className="flex items-center gap-1.5 min-w-0">
+                          <span className="text-sm font-medium truncate">
+                            {agent.name}
+                          </span>
+                          <AgentBadge
+                            type={agent.scope}
+                            className="text-[10px] px-1.5 py-0 shrink-0"
+                          />
                         </div>
                         {agent.description && (
                           <div className="text-[11px] text-muted-foreground truncate">

--- a/platform/frontend/src/components/executed-as-badge.test.tsx
+++ b/platform/frontend/src/components/executed-as-badge.test.tsx
@@ -2,7 +2,7 @@ import type { McpExecutedAs } from "@archestra/shared";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { scopeStyles } from "@/components/resource-visibility-badge";
+import { scopeStyles } from "@/components/scope-vocabulary";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { ExecutedAsBadge } from "./executed-as-badge";
 

--- a/platform/frontend/src/components/executed-as-badge.tsx
+++ b/platform/frontend/src/components/executed-as-badge.tsx
@@ -3,7 +3,7 @@
 import type { McpExecutedAs, McpExecutedAsKind } from "@archestra/shared";
 import type { LucideIcon } from "lucide-react";
 import { Globe, User, Users } from "lucide-react";
-import { scopeStyles } from "@/components/resource-visibility-badge";
+import { scopeStyles } from "@/components/scope-vocabulary";
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,

--- a/platform/frontend/src/components/llm-provider-api-key-dropdown.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-dropdown.tsx
@@ -9,18 +9,12 @@ import {
   type ResourceVisibilityScope,
   type SupportedProvider,
 } from "@archestra/shared";
-import {
-  Building2,
-  CheckIcon,
-  ChevronDown,
-  Key,
-  User,
-  Users,
-} from "lucide-react";
+import { CheckIcon, ChevronDown, Key } from "lucide-react";
 import Image from "next/image";
 import { useMemo } from "react";
 import { PromptInputButton } from "@/components/ai-elements/prompt-input";
 import { PROVIDER_CONFIG } from "@/components/llm-provider-api-key-form";
+import { SCOPE_META, scopeLabel } from "@/components/scope-vocabulary";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -72,12 +66,6 @@ interface LlmProviderApiKeyDropdownProps {
   organizationDefaultSelected?: boolean;
   onSelectOrganizationDefault?: () => void;
 }
-
-const SCOPE_ICONS: Record<ResourceVisibilityScope, React.ReactNode> = {
-  personal: <User className="h-3 w-3" />,
-  team: <Users className="h-3 w-3" />,
-  org: <Building2 className="h-3 w-3" />,
-};
 
 export function LlmProviderApiKeyDropdown({
   availableKeys,
@@ -316,7 +304,7 @@ export function LlmProviderApiKeyDropdown({
                     className="cursor-pointer"
                   >
                     <div className="flex min-w-0 flex-1 items-center gap-2">
-                      {key.scope ? SCOPE_ICONS[key.scope] : null}
+                      {key.scope ? <ScopeIcon scope={key.scope} /> : null}
                       <span className="truncate">{key.name}</span>
                       {key.scope === "team" && key.teamName ? (
                         <Badge
@@ -389,6 +377,23 @@ function ProviderIcon({ provider }: { provider: SupportedProvider }) {
       height={14}
       className="shrink-0 rounded dark:invert"
     />
+  );
+}
+
+/**
+ * The scope glyph next to a key's name. It is the only thing distinguishing a
+ * personal key from an organization one here, and there is no room for text in
+ * this popover, so it carries the scope label as its accessible name (and as a
+ * hover title) rather than being a mute 12px decoration.
+ */
+function ScopeIcon({ scope }: { scope: ResourceVisibilityScope }) {
+  const Icon = SCOPE_META[scope].icon;
+  const label = scopeLabel(scope);
+
+  return (
+    <span role="img" aria-label={label} title={label} className="inline-flex">
+      <Icon className="h-3 w-3" />
+    </span>
   );
 }
 

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -13,20 +13,14 @@ import {
   isSelfHostedProvider,
   providerRequiresPerUserCredential,
 } from "@archestra/shared";
-import {
-  Building2,
-  CheckCircle2,
-  ChevronDown,
-  Trash2,
-  User,
-  Users,
-} from "lucide-react";
+import { CheckCircle2, ChevronDown, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { type UseFormReturn, useFieldArray } from "react-hook-form";
 import { GithubCopilotSignIn } from "@/components/github-copilot-sign-in";
 import { Microsoft365CopilotSignIn } from "@/components/microsoft-365-copilot-sign-in";
 import { OpenaiCodexSignIn } from "@/components/openai-codex-sign-in";
+import { SCOPE_META, scopeLabel } from "@/components/scope-vocabulary";
 import {
   type VisibilityOption,
   VisibilitySelector,
@@ -611,15 +605,15 @@ export function LlmProviderApiKeyForm({
     > => [
       {
         value: "personal",
-        label: "Personal",
+        label: scopeLabel("personal"),
         description: "Only you can use this key",
-        icon: User,
+        icon: SCOPE_META.personal.icon,
       },
       {
         value: "team",
-        label: "Team",
+        label: scopeLabel("team"),
         description: "Available to members of one selected team",
-        icon: Users,
+        icon: SCOPE_META.team.icon,
         disabled: isPerUserCredential || !canReadTeams || teams.length === 0,
         disabledReason: isPerUserCredential
           ? perUserScopeReason
@@ -631,9 +625,9 @@ export function LlmProviderApiKeyForm({
       },
       {
         value: "org",
-        label: "Organization",
+        label: scopeLabel("org"),
         description: "Available to everyone in the organization",
-        icon: Building2,
+        icon: SCOPE_META.org.icon,
         disabled: isPerUserCredential || !isLlmProviderApiKeyAdmin,
         disabledReason: isPerUserCredential
           ? perUserScopeReason

--- a/platform/frontend/src/components/mcp-oauth-management.test.tsx
+++ b/platform/frontend/src/components/mcp-oauth-management.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useProfiles } from "@/lib/agent.query";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import {
   useCreateMcpOauthClient,
   useDeleteMcpOauthClient,
@@ -63,6 +63,9 @@ beforeEach(() => {
   vi.mocked(useHasPermissions).mockReturnValue({ data: true } as ReturnType<
     typeof useHasPermissions
   >);
+  vi.mocked(useSession).mockReturnValue({
+    data: { user: { id: "user-1" } },
+  } as ReturnType<typeof useSession>);
   vi.mocked(useProfiles).mockReturnValue({ data: [] } as ReturnType<
     typeof useProfiles
   >);

--- a/platform/frontend/src/components/mcp-oauth-management.tsx
+++ b/platform/frontend/src/components/mcp-oauth-management.tsx
@@ -15,9 +15,10 @@ import {
   OAuthClientCreatedDialog,
 } from "@/components/oauth-client-created-dialog";
 import { QueryLoadError } from "@/components/query-load-error";
+import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { Button } from "@/components/ui/button";
 import { useProfiles } from "@/lib/agent.query";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { copyToClipboard } from "@/lib/clipboard";
 import {
   useCreateMcpOauthClient,
@@ -46,6 +47,8 @@ export function McpOauthManagement({
   resourceId: string;
   resourceKind: "agent" | "gateway";
 }) {
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
   const { data: canRead } = useHasPermissions({ mcpOauthClient: ["read"] });
   const { data: canCreate } = useHasPermissions({ mcpOauthClient: ["create"] });
   const { data: canUpdate } = useHasPermissions({ mcpOauthClient: ["update"] });
@@ -97,6 +100,7 @@ export function McpOauthManagement({
               <tr className="border-b bg-muted/40 text-left text-[10px] uppercase tracking-wider text-muted-foreground">
                 <th className="px-3 py-1.5">Name</th>
                 <th className="px-3 py-1.5">Client ID</th>
+                <th className="px-3 py-1.5">Accessible to</th>
                 <th className="w-24 px-2 py-1.5" />
               </tr>
             </thead>
@@ -124,6 +128,16 @@ export function McpOauthManagement({
                         <Copy className="h-3.5 w-3.5" />
                       </Button>
                     </span>
+                  </td>
+                  <td className="max-w-[180px] px-3 py-1.5">
+                    <ResourceVisibilityBadge
+                      scope={client.scope}
+                      teams={client.teams}
+                      authorId={client.authorId}
+                      authorName={client.authorName}
+                      currentUserId={currentUserId}
+                      showSelfAsMe
+                    />
                   </td>
                   <td className="px-2 py-1.5">
                     <div className="flex">

--- a/platform/frontend/src/components/projects/edit-project-dialog.tsx
+++ b/platform/frontend/src/components/projects/edit-project-dialog.tsx
@@ -110,7 +110,7 @@ function EditProjectDialogForm({
   const visibilityOptions: Array<VisibilityOption<ProjectVisibility>> = [
     {
       value: "none",
-      label: "Only me",
+      label: "Personal",
       description: "No one else can see this project.",
       icon: Lock,
       disabled: shareLocked,

--- a/platform/frontend/src/components/resource-scope-filter.tsx
+++ b/platform/frontend/src/components/resource-scope-filter.tsx
@@ -12,6 +12,7 @@ import {
   serializeLabels,
 } from "@/components/label-select";
 import { PermissionRequirementHint } from "@/components/permission-requirement-hint";
+import { scopeStyles } from "@/components/resource-visibility-badge";
 import { Badge } from "@/components/ui/badge";
 import { MultiSelect } from "@/components/ui/multi-select";
 import {
@@ -27,6 +28,7 @@ import { useLabelKeys, useLabelValues } from "@/lib/agent.query";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useOrganizationMembers } from "@/lib/organization.query";
 import { useTeams } from "@/lib/teams/team.query";
+import { cn } from "@/lib/utils";
 
 const SHARED_SCOPES = ["personal", "team", "org"] as const;
 
@@ -498,7 +500,7 @@ export function ActiveFilterBadges({
             <Badge
               key={team.id}
               variant="outline"
-              className="gap-1 pr-1 bg-green-500/10 text-green-600 border-green-500/30"
+              className={cn(scopeStyles.team, "gap-1 pr-1")}
             >
               {team.name}
               <button
@@ -528,7 +530,7 @@ export function ActiveFilterBadges({
             <Badge
               key={user.id}
               variant="outline"
-              className="gap-1 pr-1 bg-blue-500/10 text-blue-600 border-blue-500/30"
+              className={cn(scopeStyles.personal, "gap-1 pr-1")}
             >
               {user.name || user.email}
               <button

--- a/platform/frontend/src/components/resource-scope-filter.tsx
+++ b/platform/frontend/src/components/resource-scope-filter.tsx
@@ -12,7 +12,7 @@ import {
   serializeLabels,
 } from "@/components/label-select";
 import { PermissionRequirementHint } from "@/components/permission-requirement-hint";
-import { scopeStyles } from "@/components/resource-visibility-badge";
+import { scopeStyles } from "@/components/scope-vocabulary";
 import { Badge } from "@/components/ui/badge";
 import { MultiSelect } from "@/components/ui/multi-select";
 import {

--- a/platform/frontend/src/components/resource-visibility-badge.test.tsx
+++ b/platform/frontend/src/components/resource-visibility-badge.test.tsx
@@ -5,7 +5,24 @@ import { ResourceVisibilityBadge } from "./resource-visibility-badge";
 const ME = "user-me";
 
 describe("ResourceVisibilityBadge", () => {
-  it("hides the badge for the current user's own personal resource by default", () => {
+  it("renders nothing rather than guessing when the scope is unknown", () => {
+    const { container } = render(
+      <ResourceVisibilityBadge
+        scope={undefined}
+        teams={[]}
+        authorId="user-other"
+        authorName="Someone"
+        currentUserId={ME}
+        showSelfAsMe
+      />,
+    );
+
+    // Never fall through to "Team": a badge asserting the wrong audience is
+    // believed, whereas a missing one gets questioned.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("hides the badge for the current user's own personal resource when showSelfAsMe is false", () => {
     const { container } = render(
       <ResourceVisibilityBadge
         scope="personal"
@@ -13,6 +30,7 @@ describe("ResourceVisibilityBadge", () => {
         authorId={ME}
         authorName="My Name"
         currentUserId={ME}
+        showSelfAsMe={false}
       />,
     );
 
@@ -106,6 +124,7 @@ describe("ResourceVisibilityBadge per-user shares", () => {
         authorId={ME}
         authorName="My Name"
         currentUserId={ME}
+        showSelfAsMe={false}
       />,
     );
 
@@ -124,6 +143,7 @@ describe("ResourceVisibilityBadge per-user shares", () => {
         authorId={ME}
         authorName="My Name"
         currentUserId={ME}
+        showSelfAsMe={false}
       />,
     );
 

--- a/platform/frontend/src/components/resource-visibility-badge.tsx
+++ b/platform/frontend/src/components/resource-visibility-badge.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { ResourceVisibilityScope } from "@archestra/shared";
-import { Globe, User, UserRoundCheck, Users } from "lucide-react";
+import { UserRoundCheck } from "lucide-react";
+import { SCOPE_META, scopeStyles } from "@/components/scope-vocabulary";
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
@@ -11,17 +12,6 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
-// Scope colors mirror AgentBadge so apps/MCP/proxies/skills share one language.
-// Light-mode text uses the 700/800 palette steps: the 600 steps fall below the
-// 4.5:1 contrast minimum (WCAG 1.4.3) on the tinted /10 fills. Dark mode's 400
-// steps already pass.
-export const scopeStyles = {
-  personal:
-    "bg-blue-500/10 text-blue-700 border-blue-500/30 dark:text-blue-400 dark:border-blue-400/30",
-  team: "bg-green-500/10 text-green-800 border-green-500/30 dark:text-green-400 dark:border-green-400/30",
-  org: "bg-amber-500/10 text-amber-800 border-amber-500/30 dark:text-amber-400 dark:border-amber-400/30",
-} as const;
-
 export function ResourceVisibilityBadge({
   scope,
   teams,
@@ -29,7 +19,7 @@ export function ResourceVisibilityBadge({
   authorId,
   authorName,
   currentUserId,
-  showSelfAsMe = false,
+  showSelfAsMe,
 }: {
   scope: ResourceVisibilityScope | undefined;
   teams: TeamInfo[] | undefined;
@@ -44,18 +34,32 @@ export function ResourceVisibilityBadge({
   authorName: string | null | undefined;
   currentUserId: string | undefined;
   /**
-   * Controls how a personal resource owned by the current user is labelled. By
-   * default that badge is hidden. Set this to render a "Me" badge instead: when
-   * the same column also lists team- and organization-scoped resources, a blank
-   * cell on the user's own row is confusing, so labelling it "Me" keeps every
-   * row consistently attributed.
+   * How to label a personal resource the current user owns. Required, with no
+   * default, because either answer is silently invisible if you guess wrong and
+   * the wrong one renders an empty cell — which is exactly how two shipped bugs
+   * got in. Deciding is one line; noticing a blank cell in review is not.
+   *
+   * Pass `true` when one column mixes personal, team and organization rows: a
+   * blank cell on the viewer's own row among labelled ones reads as missing
+   * data, so "Me" keeps every row attributed.
+   *
+   * Pass `false` when the surface already segregates owners — a grid split
+   * under "Personal" and "Shared" headings, or a list scoped to one user —
+   * where a "Me" pill on every row is noise.
    */
-  showSelfAsMe?: boolean;
+  showSelfAsMe: boolean;
 }) {
+  // An unknown scope says nothing rather than guessing. Falling through to the
+  // team branch would label a resource "Team" on no evidence, which is worse
+  // than an empty cell: a wrong badge is believed, a missing one is queried.
+  if (!scope) {
+    return null;
+  }
+
   if (scope === "org") {
     return (
       <Badge variant="outline" className={cn(scopeStyles.org, "gap-1 text-xs")}>
-        <Globe className="h-3 w-3" />
+        <OrgIcon className="h-3 w-3" />
         Organization
       </Badge>
     );
@@ -85,7 +89,7 @@ export function ResourceVisibilityBadge({
             "inline-flex max-w-[180px] items-center gap-1 overflow-hidden text-xs",
           )}
         >
-          <User className="h-3 w-3 shrink-0" />
+          <PersonalIcon className="h-3 w-3 shrink-0" />
           <span className="min-w-0 flex-1 truncate">
             {truncateBadgeText(displayName ?? "", MAX_BADGE_TEXT_LENGTH)}
           </span>
@@ -131,7 +135,7 @@ export function ResourceVisibilityBadge({
         variant="outline"
         className={cn(scopeStyles.team, "gap-1 text-xs")}
       >
-        <Users className="h-3 w-3" />
+        <TeamIcon className="h-3 w-3" />
         Team
       </Badge>
     );
@@ -142,16 +146,20 @@ export function ResourceVisibilityBadge({
       pills={teams.map((team) => ({
         key: `team:${team.id}`,
         name: team.name,
-        icon: Users,
+        icon: TeamIcon,
       }))}
       style={scopeStyles.team}
     />
   );
 }
 
+const OrgIcon = SCOPE_META.org.icon;
+const PersonalIcon = SCOPE_META.personal.icon;
+const TeamIcon = SCOPE_META.team.icon;
+
 type TeamInfo = { id: string; name: string };
 type UserInfo = { id: string; name: string };
-type Pill = { key: string; name: string; icon: typeof User };
+type Pill = { key: string; name: string; icon: typeof TeamIcon };
 
 const MAX_PILLS_TO_SHOW = 3;
 const MAX_BADGE_TEXT_LENGTH = 15;

--- a/platform/frontend/src/components/resource-visibility-badge.tsx
+++ b/platform/frontend/src/components/resource-visibility-badge.tsx
@@ -90,9 +90,7 @@ export function ResourceVisibilityBadge({
           )}
         >
           <PersonalIcon className="h-3 w-3 shrink-0" />
-          <span className="min-w-0 flex-1 truncate">
-            {truncateBadgeText(displayName ?? "", MAX_BADGE_TEXT_LENGTH)}
-          </span>
+          <span className="min-w-0 flex-1 truncate">{displayName}</span>
         </Badge>
       );
     }
@@ -115,10 +113,7 @@ export function ResourceVisibilityBadge({
             >
               <UserRoundCheck className="h-3 w-3 shrink-0" />
               <span className="min-w-0 truncate">
-                {truncateBadgeText(
-                  displayName ?? sharedWith[0].name,
-                  MAX_BADGE_TEXT_LENGTH,
-                )}
+                {displayName ?? sharedWith[0].name}
               </span>
               <span className="shrink-0 opacity-70">+{sharedWith.length}</span>
             </Badge>
@@ -162,7 +157,6 @@ type UserInfo = { id: string; name: string };
 type Pill = { key: string; name: string; icon: typeof TeamIcon };
 
 const MAX_PILLS_TO_SHOW = 3;
-const MAX_BADGE_TEXT_LENGTH = 15;
 
 /** A row of name pills, overflowing into a "+N more" tooltip. */
 function PillRow({ pills, style }: { pills: Pill[]; style: string }) {
@@ -181,9 +175,7 @@ function PillRow({ pills, style }: { pills: Pill[]; style: string }) {
           )}
         >
           <Icon className="h-3 w-3 shrink-0" />
-          <span className="min-w-0 flex-1 truncate">
-            {truncateBadgeText(name, MAX_BADGE_TEXT_LENGTH)}
-          </span>
+          <span className="min-w-0 flex-1 truncate">{name}</span>
         </Badge>
       ))}
       {remaining.length > 0 && (
@@ -208,10 +200,4 @@ function PillRow({ pills, style }: { pills: Pill[]; style: string }) {
       )}
     </div>
   );
-}
-
-function truncateBadgeText(value: string, maxLength: number): string {
-  return value.length > maxLength
-    ? `${value.slice(0, maxLength - 3)}...`
-    : value;
 }

--- a/platform/frontend/src/components/scope-badge.tsx
+++ b/platform/frontend/src/components/scope-badge.tsx
@@ -18,6 +18,15 @@ const SCOPE_META: Record<
   org: { label: "Organization", icon: Globe },
 };
 
+/**
+ * The human label for a scope, read from the same table the pill uses, so
+ * surfaces that spell the scope out in text ("Organization", not the raw `org`
+ * enum) cannot drift from what the pill says.
+ */
+export function scopeLabel(scope: ResourceVisibilityScope): string {
+  return SCOPE_META[scope].label;
+}
+
 // Icon-only scope pill (personal/team/org) with the label in the tooltip +
 // aria-label. Shared across the apps and projects cards so scope reads the same
 // everywhere. A team scope folds its team names into the label ("Team: London
@@ -46,7 +55,7 @@ export function ScopeBadge({
     return null;
   }
 
-  const { label: scopeLabel, icon: scopeIcon } = SCOPE_META[scope];
+  const { icon: scopeIcon } = SCOPE_META[scope];
   const Icon = sharedWithUsers ? UserRoundCheck : scopeIcon;
 
   const names = teamNames?.filter(Boolean) ?? [];
@@ -54,7 +63,7 @@ export function ScopeBadge({
     ? `Shared with: ${sharedWith.join(", ")}`
     : scope === "team" && names.length > 0
       ? `Team: ${names.join(", ")}`
-      : scopeLabel;
+      : scopeLabel(scope);
 
   return (
     <Tooltip>

--- a/platform/frontend/src/components/scope-badge.tsx
+++ b/platform/frontend/src/components/scope-badge.tsx
@@ -1,6 +1,10 @@
 import type { ResourceVisibilityScope } from "@archestra/shared";
-import { Globe, User, UserRoundCheck, Users } from "lucide-react";
-import { scopeStyles } from "@/components/resource-visibility-badge";
+import { UserRoundCheck } from "lucide-react";
+import {
+  SCOPE_META,
+  scopeLabel,
+  scopeStyles,
+} from "@/components/scope-vocabulary";
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
@@ -8,24 +12,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-
-const SCOPE_META: Record<
-  ResourceVisibilityScope,
-  { label: string; icon: typeof User }
-> = {
-  personal: { label: "Personal", icon: User },
-  team: { label: "Team", icon: Users },
-  org: { label: "Organization", icon: Globe },
-};
-
-/**
- * The human label for a scope, read from the same table the pill uses, so
- * surfaces that spell the scope out in text ("Organization", not the raw `org`
- * enum) cannot drift from what the pill says.
- */
-export function scopeLabel(scope: ResourceVisibilityScope): string {
-  return SCOPE_META[scope].label;
-}
 
 // Icon-only scope pill (personal/team/org) with the label in the tooltip +
 // aria-label. Shared across the apps and projects cards so scope reads the same

--- a/platform/frontend/src/components/scope-badge.tsx
+++ b/platform/frontend/src/components/scope-badge.tsx
@@ -58,7 +58,11 @@ export function ScopeBadge({
           variant="outline"
           aria-label={label}
           className={cn(
-            scopeStyles[sharedWithUsers ? "team" : scope],
+            // A shared personal resource stays personal-coloured — the grants
+            // change who can reach it, not its scope class. The distinct icon
+            // and tooltip carry the "shared" part, exactly as
+            // resource-visibility-badge renders the same case.
+            scopeStyles[scope],
             "px-1.5",
           )}
         >

--- a/platform/frontend/src/components/scope-vocabulary.ts
+++ b/platform/frontend/src/components/scope-vocabulary.ts
@@ -1,0 +1,58 @@
+import type { ResourceVisibilityScope } from "@archestra/shared";
+import { Globe, User, Users } from "lucide-react";
+
+/**
+ * The one definition of how a visibility scope is spoken, drawn and coloured.
+ *
+ * Every surface that names a scope reads it from here, so a new table, card or
+ * picker cannot invent a fourth vocabulary. The copies this replaced had
+ * already drifted in both directions: two private `SCOPE_ICONS` maps drew the
+ * organization scope as a building while the shared badges drew a globe, and a
+ * table printing the raw enum through `capitalize` said "Org" where every badge
+ * said "Organization".
+ *
+ * Light-mode text uses the 700/800 palette steps: the 600 steps fall below the
+ * 4.5:1 contrast minimum (WCAG 1.4.3) on the tinted /10 fills. Dark mode's 400
+ * steps already pass.
+ */
+export const SCOPE_META: Record<
+  ResourceVisibilityScope,
+  { label: string; icon: typeof User; styles: string }
+> = {
+  personal: {
+    label: "Personal",
+    icon: User,
+    styles:
+      "bg-blue-500/10 text-blue-700 border-blue-500/30 dark:text-blue-400 dark:border-blue-400/30",
+  },
+  team: {
+    label: "Team",
+    icon: Users,
+    styles:
+      "bg-green-500/10 text-green-800 border-green-500/30 dark:text-green-400 dark:border-green-400/30",
+  },
+  org: {
+    label: "Organization",
+    icon: Globe,
+    styles:
+      "bg-amber-500/10 text-amber-800 border-amber-500/30 dark:text-amber-400 dark:border-amber-400/30",
+  },
+};
+
+/**
+ * The human label for a scope, so surfaces that spell the scope out in text
+ * cannot drift from what the badges say.
+ */
+export function scopeLabel(scope: ResourceVisibilityScope): string {
+  return SCOPE_META[scope].label;
+}
+
+/**
+ * Badge classes per scope, for surfaces that render their own pill shell rather
+ * than one of the shared badge components.
+ */
+export const scopeStyles: Record<ResourceVisibilityScope, string> = {
+  personal: SCOPE_META.personal.styles,
+  team: SCOPE_META.team.styles,
+  org: SCOPE_META.org.styles,
+};

--- a/platform/frontend/src/components/scope-vocabulary.ts
+++ b/platform/frontend/src/components/scope-vocabulary.ts
@@ -56,3 +56,13 @@ export const scopeStyles: Record<ResourceVisibilityScope, string> = {
   team: SCOPE_META.team.styles,
   org: SCOPE_META.org.styles,
 };
+
+/**
+ * For things the platform provides rather than a person or org owning them —
+ * a built-in agent, a system-managed credential. Not a visibility scope, but it
+ * sits in the same column as one, so it needs to be deliberately distinct from
+ * all three rather than falling back to an uncoloured pill that reads as
+ * "nobody filled this in".
+ */
+export const platformOwnedStyles =
+  "bg-purple-500/10 text-purple-700 border-purple-500/30 dark:text-purple-400 dark:border-purple-400/30";

--- a/platform/frontend/src/components/virtual-key-management.tsx
+++ b/platform/frontend/src/components/virtual-key-management.tsx
@@ -8,6 +8,7 @@ import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EditVirtualKeyDialog } from "@/components/edit-virtual-key-dialog";
 import { formatProviderKeySummary } from "@/components/provider-key-mappings-field";
 import { QueryLoadError } from "@/components/query-load-error";
+import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { Button } from "@/components/ui/button";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { copyToClipboard } from "@/lib/clipboard";
@@ -80,7 +81,7 @@ export function VirtualKeyManagement({
             {keyType === "standard" && (
               <th className="px-3 py-1.5 font-medium">Providers</th>
             )}
-            <th className="px-3 py-1.5 font-medium">Owner</th>
+            <th className="px-3 py-1.5 font-medium">Accessible to</th>
             {(canUpdate || canDelete) && <th className="w-8 px-2 py-1.5" />}
           </tr>
         </thead>
@@ -102,10 +103,15 @@ export function VirtualKeyManagement({
                   {formatProviderKeySummary(key.providerApiKeys)}
                 </td>
               )}
-              <td className="px-3 py-1.5 text-muted-foreground">
-                {key.authorId === currentUserId
-                  ? "Me"
-                  : (key.authorName ?? "—")}
+              <td className="max-w-[180px] px-3 py-1.5">
+                <ResourceVisibilityBadge
+                  scope={key.scope}
+                  teams={key.teams}
+                  authorId={key.authorId}
+                  authorName={key.authorName}
+                  currentUserId={currentUserId}
+                  showSelfAsMe
+                />
               </td>
               {(canUpdate || canDelete) && (
                 <td className="px-2 py-1.5">


### PR DESCRIPTION
Follow-up to #7118, which fixed one missing personal badge on the Skills table. An audit of all 90 list/table/card surfaces found the same class of gap in 16 more places, plus **six** independent definitions of the scope vocabulary that had already drifted apart.

## Missing or wrong badges

- **Email agents table** — identical to the #7118 bug: omitted `showSelfAsMe` (own agents rendered a blank cell) *and* `users` (per-user shares never rendered).
- **Virtual keys, MCP OAuth clients, LLM OAuth clients** — three tables with `scope`/`authorId`/`teams` on every row and no column showing them. Adds an "Accessible to" column.
- **Agent pickers** (chat, A2A, shared selector) — personal, team and org agents were pixel-identical; the chat picker even sorts by scope without showing it.
- **MCP registry** — showed the same resource four different ways (initials avatar / bare name / nothing / raw enum "Org"). Unified.
- **Connect wizard skill picker** — lists other users' *personal* skills to skill admins and preselects them all, with nothing indicating whose they are.
- **Project detail page** — the sharing pill shown in list and card views vanished on open.
- **Model providers** — hand-rolled `Building2` for org, no scope colour, and it never rendered the owner despite the backend already joining `userName`.

## Preventing recurrence

The root cause is that a new surface asking "how do I show who can see this?" found four competing answers. `scope-vocabulary.ts` is now the single source of label, icon and colour; the three badge components and every hand-rolled site read from it. `AgentBadge`'s duplicated palette and its "keep in sync by hand" comment are gone, as are both private `SCOPE_ICONS` maps. Org is `Globe` everywhere.

`showSelfAsMe` is now **required** with no default. Omitting it is what silently rendered nothing in both shipped bugs; the compiler now forces every call site to decide, and every existing one has been made explicit with no behaviour change. `ResourceVisibilityBadge` also returns `null` for an unknown scope instead of falling through to "Team" — a wrong badge is believed, a missing one gets questioned.

## Verification

`tsc`, biome and knip clean; full frontend suite green (3604 passing). The email fix was A/B verified in the browser (blank cell before, "Me" badge after) and the registry and scope-selector changes were confirmed on a dev stack. New tests pin the model-providers owner column and the unknown-scope guard.

Deliberately unchanged, per the audit: chat sidebar share icons (the payload lacks the names `ScopeBadge` needs, so it would render a blue "Personal" pill for a shared chat), the registry card's segregated Personal/Shared grid, and `Building2` on cost limits and email security, which are different enums rather than visibility scopes.

Task: T-1024

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>