### PR TITLE
fix(frontend): registry a11y follow-ups — contrast and accessible names

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
@@ -348,6 +348,7 @@ function ServerCard({
                 target="_blank"
                 rel="noopener noreferrer"
                 title="Docs"
+                aria-label={`Documentation for ${server.display_name || server.name} (opens in new tab)`}
               >
                 <BookOpen className="h-4 w-4" />
               </a>
@@ -365,6 +366,7 @@ function ServerCard({
                 target="_blank"
                 rel="noopener noreferrer"
                 title="GitHub"
+                aria-label={`GitHub repository for ${server.display_name || server.name} (opens in new tab)`}
               >
                 <Github className="h-4 w-4" />
               </a>
@@ -380,6 +382,13 @@ function ServerCard({
                 ? "Added"
                 : userAllowedToCreateCatalogItem
                   ? "Use as template"
+                  : "Ask an administrator to add this server to the registry"
+            }
+            aria-label={
+              isInCatalog
+                ? `${server.display_name || server.name} already added`
+                : userAllowedToCreateCatalogItem
+                  ? `Use ${server.display_name || server.name} as template`
                   : "Ask an administrator to add this server to the registry"
             }
             onClick={() => onSelectServer(server)}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
@@ -654,6 +654,7 @@ export function McpLogsContent({
                     variant="ghost"
                     size="sm"
                     onClick={handleCopyCommand}
+                    aria-label="Copy command"
                     className="absolute top-1/2 -translate-y-1/2 right-1 text-slate-400 hover:text-slate-200 hover:bg-slate-800"
                   >
                     <Copy className="h-3 w-3" />

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -697,7 +697,7 @@ export function McpServerCard({
                         onClick={() => goToItemPage("credentials")}
                       >
                         <Avatar className="size-6 border-2 border-background cursor-pointer">
-                          <AvatarFallback className="bg-amber-500/10 text-amber-600 dark:text-amber-400">
+                          <AvatarFallback className="bg-amber-500/10 text-amber-800 dark:text-amber-400">
                             <Globe className="h-3 w-3" />
                           </AvatarFallback>
                         </Avatar>
@@ -993,7 +993,7 @@ export function McpServerCard({
       <CardContent className="flex flex-col gap-4 flex-grow">
         {showApprovalPanel && (
           <div className="space-y-1 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2.5">
-            <div className="flex items-center gap-2 text-sm font-medium text-amber-600 dark:text-amber-500">
+            <div className="flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-500">
               <span>
                 {isInstallAdmin
                   ? "Image needs approval"

--- a/platform/frontend/src/app/mcp/registry/_parts/oauth-reauth-indicator.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/oauth-reauth-indicator.tsx
@@ -15,8 +15,10 @@ export function OAuthReauthIndicator({
   onActivate?: () => void;
   className?: string;
 }) {
+  // amber-800 in light mode: amber-600 measures ~3.1:1 on the card background,
+  // below the 4.5:1 minimum for small text (WCAG 1.4.3).
   const containerClassName = cn(
-    "inline-flex items-center gap-1 text-xs text-amber-600",
+    "inline-flex items-center gap-1 text-xs text-amber-800 dark:text-amber-400",
     className,
   );
 
@@ -41,7 +43,7 @@ export function OAuthReauthIndicator({
       onClick={onActivate}
       className={cn(
         containerClassName,
-        "cursor-pointer rounded-sm underline-offset-2 hover:text-amber-700 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500",
+        "cursor-pointer rounded-sm underline-offset-2 hover:text-amber-900 dark:hover:text-amber-300 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500",
       )}
       data-testid="oauth-reauth-state"
       aria-label="Needs re-authentication, open credentials"

--- a/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
@@ -79,7 +79,9 @@ export function RegistrySortMenu({
       <DropdownMenuTrigger asChild>
         <Button variant="outline" className="gap-2 font-normal">
           <ArrowDownUp className="h-4 w-4" />
-          <span className="text-muted-foreground">Sort:</span>
+          {/* Inherits the button's foreground: muted-foreground dips below the
+              4.5:1 contrast minimum on some themes (WCAG 1.4.3). */}
+          <span>Sort:</span>
           {current.label}
         </Button>
       </DropdownMenuTrigger>
@@ -231,15 +233,16 @@ export function RegistryFilterChips({
           variant="secondary"
           className="gap-1.5 py-1 font-normal"
         >
-          <span className="text-muted-foreground">
-            {GROUP_LABELS[entry.group]}:
-          </span>
+          {/* The chip's prefix and dismiss icon inherit secondary-foreground —
+              muted-foreground on the secondary fill falls below the 4.5:1
+              contrast minimum on some themes (WCAG 1.4.3). */}
+          <span>{GROUP_LABELS[entry.group]}:</span>
           {entry.label}
           <button
             type="button"
             aria-label={`Remove ${entry.label} filter`}
             onClick={() => onRemove(entry.group, entry.value)}
-            className="ml-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-background/60 hover:text-foreground"
+            className="ml-0.5 rounded-full p-0.5 hover:bg-background/60"
           >
             <X className="h-3 w-3" />
           </button>
@@ -248,7 +251,7 @@ export function RegistryFilterChips({
       <button
         type="button"
         onClick={onClearAll}
-        className="text-sm text-muted-foreground hover:text-foreground"
+        className="text-sm text-foreground underline-offset-2 hover:underline"
       >
         Clear all
       </button>

--- a/platform/frontend/src/components/label-select.tsx
+++ b/platform/frontend/src/components/label-select.tsx
@@ -180,6 +180,11 @@ export function LabelKeyRowBase({
           {selectedValues.length > 0 && (
             <Badge variant="secondary" className="ml-2 h-5 px-1.5 text-xs">
               {selectedValues.length}
+              <span className="sr-only">
+                {selectedValues.length === 1
+                  ? "value selected"
+                  : "values selected"}
+              </span>
             </Badge>
           )}
         </button>


### PR DESCRIPTION
## Summary

Follow-up to #7073 covering the MCP registry page specifically — contrast and accessible-name gaps that the earlier passes missed.

### Contrast (WCAG 1.4.3)

- The **needs-reauthentication marker** (alert icon + small text on server cards), the **org-wide credential avatar icon**, and the **approval panel heading** used `amber-600`, which measures ~3.1:1 against the card background in light mode — below the 4.5:1 minimum for small text. They move to `amber-800` in light mode with explicit dark-mode steps (`amber-400`/`amber-500`) that already passed.
- The **registry filter chips** put `muted-foreground` text (the group prefix and the dismiss icon) on the `secondary` fill, which lands below 4.5:1 on some themes. They now inherit the badge's paired `secondary-foreground`, and the "Clear all" button and "Sort:" prefix use the page foreground instead of muted.

### Accessible names (WCAG 2.4.6 / 4.1.2)

- The catalog browser's icon-only **Docs** and **GitHub** link buttons had only `title` attributes; they gain descriptive `aria-label`s naming the server and the new-tab behavior. The icon-only **add-as-template** button gets a matching per-server label.
- The **manual-command copy** button in the logs dialog (icon-only until clicked) gains a name.
- The label filter's per-key **count indicators** read as "N values selected" to assistive tech instead of a bare number.

## Testing

Validated with lint, type-check, and the registry + label-select test files (29 files / 326 tests passing) before extraction to this branch; CI runs the full suite here.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>