### PR TITLE
fix(mcp): don't overwrite custom static Authorization headers with the caller's IdP JWT

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -6275,6 +6275,171 @@ describe("McpClient", () => {
         );
       });
 
+      // Regression: a connection whose only credential is a custom userConfig
+      // field mapped to the `Authorization` header (common for hand-configured
+      // remote servers) does not populate the canonical access_token secret
+      // fields. The external-IdP fallback used to read that as "no stored
+      // authorization" and overwrite the working header with the caller's JWT,
+      // so every JWKS-authenticated gateway call failed upstream auth while
+      // the same connection kept working for session-authenticated callers.
+      test("JWKS auth with a custom-field Authorization credential uses the stored header, not the JWT (remote server)", async () => {
+        const customAuthCatalog = await InternalMcpCatalogModel.create({
+          name: "custom-auth-field-server",
+          serverType: "remote",
+          serverUrl: "https://custom-auth-field.example.com/mcp",
+          userConfig: {
+            api_token: {
+              type: "string",
+              title: "Authorization",
+              description: 'Sent as Authorization with a "Bearer " prefix',
+              required: true,
+              sensitive: true,
+              headerName: "Authorization",
+              valuePrefix: "Bearer ",
+            },
+          },
+        });
+
+        const customAuthSecret = await secretManager().createSecret(
+          { api_token: "stored-custom-field-key" },
+          "custom-auth-field-secret",
+        );
+
+        const customAuthServer = await McpServerModel.create({
+          name: "custom-auth-field-server",
+          secretId: customAuthSecret.id,
+          catalogId: customAuthCatalog.id,
+          serverType: "remote",
+          scope: "org",
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "custom-auth-field-server__query",
+          description: "Query with a custom auth field",
+          parameters: {},
+          catalogId: customAuthCatalog.id,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: customAuthServer.id,
+        });
+
+        mockCallTool.mockResolvedValueOnce({
+          content: [{ type: "text", text: "upstream ok" }],
+          isError: false,
+        });
+
+        const result = await mcpClient.executeToolCallForOwner(
+          {
+            id: "call_custom_auth_field",
+            name: "custom-auth-field-server__query",
+            arguments: {},
+          },
+          agentOwner(agentId),
+          {
+            tokenId: "ext-token",
+            teamId: null,
+            isOrganizationToken: false,
+            isExternalIdp: true,
+            rawToken: "caller-jwt-must-not-be-sent",
+            userId: "ext-user-custom-field",
+          },
+        );
+
+        expect(result.isError).toBe(false);
+        const { StreamableHTTPClientTransport } = await import(
+          "@modelcontextprotocol/sdk/client/streamableHttp.js"
+        );
+        const lastCall = vi
+          .mocked(StreamableHTTPClientTransport)
+          .mock.calls.at(-1);
+        const headers = lastCall?.[1]?.requestInit?.headers as Headers;
+        expect(headers.get("authorization")).toBe(
+          "Bearer stored-custom-field-key",
+        );
+        // The call ran under the org connection's stored credential, so the
+        // executed-as identity names the connection — not IdP passthrough.
+        expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
+          kind: "org",
+        });
+      });
+
+      // The canonical token fields also cover non-Authorization header names;
+      // an external-IdP caller's JWT must not ride along as an extra
+      // Authorization header next to such a credential.
+      test("JWKS auth does not add the JWT alongside a canonical credential bound to a non-Authorization header", async () => {
+        const apiKeyCatalog = await InternalMcpCatalogModel.create({
+          name: "api-key-header-server",
+          serverType: "remote",
+          serverUrl: "https://api-key-header.example.com/mcp",
+          userConfig: {
+            access_token: {
+              type: "string",
+              title: "Access Token",
+              description: "API key",
+              required: true,
+              sensitive: true,
+              headerName: "x-api-key",
+            },
+          },
+        });
+
+        const apiKeySecret = await secretManager().createSecret(
+          { access_token: "api-key-secret-value" },
+          "api-key-header-secret",
+        );
+
+        const apiKeyServer = await McpServerModel.create({
+          name: "api-key-header-server",
+          secretId: apiKeySecret.id,
+          catalogId: apiKeyCatalog.id,
+          serverType: "remote",
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "api-key-header-server__list_items",
+          description: "List items with API key auth",
+          parameters: {},
+          catalogId: apiKeyCatalog.id,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: apiKeyServer.id,
+        });
+
+        mockCallTool.mockResolvedValueOnce({
+          content: [{ type: "text", text: "api key response" }],
+          isError: false,
+        });
+
+        await mcpClient.executeToolCallForOwner(
+          {
+            id: "call_api_key_jwks",
+            name: "api-key-header-server__list_items",
+            arguments: {},
+          },
+          agentOwner(agentId),
+          {
+            tokenId: "ext-token",
+            teamId: null,
+            isOrganizationToken: false,
+            isExternalIdp: true,
+            rawToken: "caller-jwt-must-not-ride-along",
+            userId: "ext-user-api-key",
+          },
+        );
+
+        const { StreamableHTTPClientTransport } = await import(
+          "@modelcontextprotocol/sdk/client/streamableHttp.js"
+        );
+        const lastCall = vi
+          .mocked(StreamableHTTPClientTransport)
+          .mock.calls.at(-1);
+        const headers = lastCall?.[1]?.requestInit?.headers as Headers;
+        expect(headers.get("x-api-key")).toBe("api-key-secret-value");
+        expect(headers.get("authorization")).toBeNull();
+      });
+
       test("uses a custom header name for static bearer credentials", async () => {
         const customHeaderCatalog = await InternalMcpCatalogModel.create({
           name: "custom-header-server",

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -596,6 +596,7 @@ class McpClient {
       resolvedServer,
       tokenAuth,
       enterpriseTransportCredential,
+      catalogItem,
       secrets,
     });
     if (executedAs) {
@@ -2116,7 +2117,7 @@ class McpClient {
             enterpriseTransportCredential,
           );
         } else if (
-          !hasStaticAuthorizationCredential(secrets) &&
+          !staticCredentialsProvideAuthorization({ catalogItem, secrets }) &&
           tokenAuth?.isExternalIdp &&
           tokenAuth.rawToken
         ) {
@@ -2170,7 +2171,7 @@ class McpClient {
             enterpriseTransportCredential,
           );
         } else if (
-          !hasStaticAuthorizationCredential(secrets) &&
+          !staticCredentialsProvideAuthorization({ catalogItem, secrets }) &&
           tokenAuth?.isExternalIdp &&
           tokenAuth.rawToken
         ) {
@@ -3064,12 +3065,14 @@ class McpClient {
     resolvedServer: ResolvedInstallIdentity | null;
     tokenAuth: TokenAuthContext | undefined;
     enterpriseTransportCredential: ResolvedEnterpriseTransportCredential | null;
+    catalogItem: InternalMcpCatalog;
     secrets: Record<string, unknown>;
   }): Promise<McpExecutedAs | null> {
     const {
       resolvedServer,
       tokenAuth,
       enterpriseTransportCredential,
+      catalogItem,
       secrets,
     } = params;
 
@@ -3081,7 +3084,7 @@ class McpClient {
       return { kind: "idp_exchange", callerUserId };
     }
 
-    if (!hasStaticAuthorizationCredential(secrets)) {
+    if (!staticCredentialsProvideAuthorization({ catalogItem, secrets })) {
       if (tokenAuth?.isExternalIdp && tokenAuth.rawToken) {
         return { kind: "idp_passthrough", callerUserId };
       }
@@ -4793,6 +4796,27 @@ function hasStaticAuthorizationCredential(
   }
 
   return false;
+}
+
+/**
+ * True when the install's stored static credentials already settle the
+ * outbound authorization — either via the canonical token secret fields, or
+ * via a custom userConfig field mapped to the `Authorization` header. The
+ * external-IdP JWT fallback (end-to-end JWKS pattern) must never fire in that
+ * case: it would overwrite a working stored credential with the caller's JWT
+ * and the upstream would reject the call.
+ */
+function staticCredentialsProvideAuthorization(params: {
+  catalogItem: InternalMcpCatalog;
+  secrets: Record<string, unknown>;
+}): boolean {
+  if (hasStaticAuthorizationCredential(params.secrets)) {
+    return true;
+  }
+
+  return Object.keys(buildStaticCredentialHeaders(params)).some(
+    (name) => name.toLowerCase() === "authorization",
+  );
 }
 
 function getStaticCredentialHeaderValue(params: {

--- a/platform/backend/src/routes/mcp-gateway/external-idp-static-header.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/external-idp-static-header.test.ts
@@ -1,0 +1,274 @@
+/**
+ * MCP Gateway — external-IdP callers vs. stored static header credentials.
+ *
+ * Full-stack regression test for the credential clobber where a caller who
+ * authenticates via an external IdP (JWKS/JWT) called a tool on a remote
+ * connection whose stored credential is a custom userConfig field mapped to
+ * the `Authorization` header (how hand-configured remote servers commonly
+ * store their key). Those installs don't populate the canonical
+ * `access_token`/`raw_access_token` secret fields, so the transport's
+ * IdP-JWT fallback misread them as "no stored authorization" and overwrote
+ * the working header with the caller's JWT — the upstream rejected every
+ * gateway call while the same connection kept working for
+ * session-authenticated callers, and the resulting error blamed the (valid)
+ * stored credential.
+ *
+ * Like the sibling `external-idp-install-guard.test.ts`, this drives a real
+ * JWKS-authenticated HTTP request through the gateway route so the
+ * `isExternalIdp` flag is produced by the auth layer, and it fakes the remote
+ * MCP server at the network boundary (MSW) so the assertion is on the actual
+ * Authorization header that reached the wire.
+ */
+
+import { MCP_EXECUTED_AS_META_KEY } from "@archestra/shared";
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { HttpResponse, http } from "msw";
+import { vi } from "vitest";
+import mcpClient from "@/clients/mcp-client";
+import { secretManager } from "@/secrets-manager";
+import type { JwksValidationResult } from "@/services/jwks-validator";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
+
+const mockValidateJwt = vi.fn<() => Promise<JwksValidationResult | null>>();
+
+vi.mock("@/services/jwks-validator", () => ({
+  jwksValidator: {
+    validateJwt: (...args: unknown[]) => mockValidateJwt(...(args as [])),
+  },
+}));
+
+const { default: mcpGatewayRoutes } = await import("./index");
+
+// A JWT-shaped bearer token that is NOT an Archestra token, so the gateway
+// routes it through external-IdP JWKS validation instead of the token tables.
+const FAKE_JWT = "eyJhbGciOiJSUzI1NiJ9.fake.jwt";
+const CATALOG_NAME = "static-header-remote";
+const FULL_TOOL_NAME = `${CATALOG_NAME}__query`;
+const UPSTREAM_URL = "https://static-header-upstream.example.com/mcp";
+const STORED_HEADER_VALUE = "Bearer stored-static-header-key";
+
+function makeMcpHeaders(token: string): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    authorization: `Bearer ${token}`,
+  };
+}
+
+describe("MCP Gateway - external IdP with stored static-header credential", () => {
+  const mswServer = useMswServer();
+  let app: FastifyInstance;
+  // Authorization header of every request the fake upstream MCP server saw.
+  let upstreamAuthHeaders: Array<string | null>;
+
+  beforeEach(async () => {
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    await app.register(mcpGatewayRoutes);
+    mockValidateJwt.mockReset();
+    upstreamAuthHeaders = [];
+
+    // A minimal stateless streamable-http MCP server at the network boundary:
+    // enough of the protocol for connect + tools/list + tools/call, recording
+    // the Authorization header on every request.
+    mswServer.use(
+      http.post(UPSTREAM_URL, async ({ request }) => {
+        upstreamAuthHeaders.push(request.headers.get("authorization"));
+        const body = (await request.json()) as {
+          id?: number | string;
+          method: string;
+          params?: { protocolVersion?: string };
+        };
+        if (body.method === "initialize") {
+          return HttpResponse.json({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              protocolVersion: body.params?.protocolVersion ?? "2025-03-26",
+              capabilities: { tools: {} },
+              serverInfo: { name: "static-header-upstream", version: "1.0.0" },
+            },
+          });
+        }
+        if (body.id === undefined) {
+          // Notifications (e.g. notifications/initialized) expect 202.
+          return new HttpResponse(null, { status: 202 });
+        }
+        if (body.method === "tools/list") {
+          return HttpResponse.json({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              tools: [{ name: "query", inputSchema: { type: "object" } }],
+            },
+          });
+        }
+        if (body.method === "tools/call") {
+          return HttpResponse.json({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              content: [{ type: "text", text: "upstream says hi" }],
+              isError: false,
+            },
+          });
+        }
+        return HttpResponse.json({
+          jsonrpc: "2.0",
+          id: body.id,
+          error: { code: -32601, message: "Method not found" },
+        });
+      }),
+      // The SDK probes for a standalone SSE stream; 405 means "not offered".
+      http.get(UPSTREAM_URL, () => new HttpResponse(null, { status: 405 })),
+      http.delete(UPSTREAM_URL, () => new HttpResponse(null, { status: 200 })),
+    );
+  });
+
+  afterEach(async () => {
+    // The gateway caches upstream connections; drop them so the next test's
+    // MSW handlers see a fresh connect instead of a reused session.
+    await mcpClient.disconnectAll();
+    await app.close();
+  });
+
+  test("sends the stored custom-field Authorization header upstream, not the caller's JWT", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeAgentTool,
+    makeIdentityProvider,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    await makeMember(caller.id, org.id, { role: "admin" });
+
+    const idp = await makeIdentityProvider(org.id, {
+      oidcConfig: {
+        clientId: "test-client",
+        jwksEndpoint: "https://idp.example.com/.well-known/jwks.json",
+      },
+    });
+
+    // Remote catalog entry whose only credential is a custom userConfig field
+    // mapped to the Authorization header — no canonical access_token field.
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: CATALOG_NAME,
+      serverType: "remote",
+      serverUrl: UPSTREAM_URL,
+      scope: "org",
+      userConfig: {
+        api_token: {
+          type: "string",
+          title: "Authorization",
+          description: 'Sent as Authorization with a "Bearer " prefix',
+          required: true,
+          sensitive: true,
+          headerName: "Authorization",
+          valuePrefix: "Bearer ",
+        },
+      },
+    });
+    const tool = await makeTool({
+      catalogId: catalog.id,
+      name: FULL_TOOL_NAME,
+    });
+
+    // Organization-wide connection holding the working static credential.
+    const secret = await secretManager().createSecret(
+      { api_token: "stored-static-header-key" },
+      "static-header-org-secret",
+    );
+    await makeMcpServer({
+      catalogId: catalog.id,
+      serverType: "remote",
+      scope: "org",
+      secretId: secret.id,
+    });
+
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      identityProviderId: idp.id,
+      toolExposureMode: "full",
+      accessAllTools: false,
+    });
+    await makeAgentTool(agent.id, tool.id, {
+      credentialResolutionMode: "dynamic",
+    });
+
+    mockValidateJwt.mockResolvedValue({
+      sub: caller.email,
+      email: caller.email,
+      name: "Caller",
+      rawClaims: { sub: caller.email },
+    });
+
+    // Stateless mode requires an initialize before a tools/call.
+    const initResponse = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders(FAKE_JWT),
+      payload: {
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "1.0.0" },
+        },
+        id: 1,
+      },
+    });
+    expect(initResponse.statusCode).toBe(200);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders(FAKE_JWT),
+      payload: {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: FULL_TOOL_NAME, arguments: {} },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const result = response.json();
+
+    // The call succeeded through the org connection's stored credential —
+    // no "expired or invalid authentication" error blaming a valid key.
+    expect(result).toHaveProperty("result");
+    expect(result.result.isError).toBeFalsy();
+    const textContent = result.result.content.find(
+      (c: { type: string }) => c.type === "text",
+    );
+    expect(textContent?.text).toBe("upstream says hi");
+
+    // Every request that reached the upstream carried the stored credential;
+    // the caller's IdP JWT never replaced it.
+    expect(upstreamAuthHeaders.length).toBeGreaterThan(0);
+    for (const header of upstreamAuthHeaders) {
+      expect(header).toBe(STORED_HEADER_VALUE);
+    }
+
+    // And the executed-as identity names the org connection — not an IdP
+    // passthrough of the caller's own token.
+    expect(result.result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
+      kind: "org",
+    });
+  });
+});


### PR DESCRIPTION
## What happened

The MCP gateway supports an end-to-end JWKS pattern: when a caller authenticates with an external IdP JWT and the resolved connection stores no authorization of its own, the caller's JWT is forwarded upstream as the `Authorization` header.

The "stores no authorization of its own" check only looked at the canonical `access_token` / `raw_access_token` secret fields. But a remote connection configured with a **custom userConfig field mapped to the `Authorization` header** (a common shape for hand-configured remote servers, e.g. a field with `headerName: "Authorization"` + `valuePrefix: "Bearer "`) stores its key under a custom field name — so the check misread it as "no stored credential" and **overwrote the working header with the caller's JWT**.

Result for affected setups:

- Every JWKS-authenticated gateway call to such a server failed upstream auth and surfaced the actionable `auth_expired` ("Expired or invalid authentication…") error — blaming a perfectly valid stored credential, so re-authenticating never helped.
- The same connection kept working for session-authenticated callers (chat/UI), making the failure look gateway-specific and hard to diagnose.
- The tool-call log reported `executedAs: idp_passthrough` even though the operator expected the connection's stored credential to be used.

## The fix

New `staticCredentialsProvideAuthorization` guard: the stored static credentials settle the outbound authorization when either the canonical token fields are present **or** any userConfig field maps to the `Authorization` header. The external-IdP JWT fallback (both the remote and local streamable-http transport paths) and the `executedAs` classifier now share this guard, so the wire behavior and the reported identity stay in agreement.

Deliberately narrow: a canonical credential bound to a non-`Authorization` header (e.g. `x-api-key`) still suppresses the JWT fallback exactly as before — the caller's JWT must never ride along to an upstream that didn't ask for it.

## Tests

- **Route-level full stack** (`routes/mcp-gateway/external-idp-static-header.test.ts`): a real JWKS-authenticated HTTP request through the gateway route (the `isExternalIdp` flag produced by the auth layer, not hand-set), with the remote MCP server faked at the network boundary via MSW — asserts the `Authorization` header that actually reached the wire is the stored credential, the call succeeds, and `executedAs` names the org connection. Fails pre-fix with the caller's JWT on the wire.
- **Client-level** (`clients/mcp-client.test.ts`): stored custom-field `Authorization` credential wins over the JWT (+ correct `executedAs`), and the JWT does not get added alongside a canonical credential bound to a non-`Authorization` header.

Both regression tests were verified to fail against the pre-fix code.