### PR TITLE
fix(bench): stop sending transient githubToken on skill imports

### DIFF
--- a/ai-labs/runner/src/client.rs
+++ b/ai-labs/runner/src/client.rs
@@ -927,7 +927,8 @@ impl EvalClient {
             JsonValue::Array(skill_paths.iter().map(|s| JsonValue::String(s.clone())).collect()),
         );
         body.insert("scope".to_string(), JsonValue::String(scope.to_string()));
-        with_github_token(&mut body);
+        // No githubToken here: the import route rejects transient tokens (scheduled
+        // sync pulls could not reuse them), and the benchmark's skill repos are public.
 
         let prev_timeout = self.timeout();
         self.set_timeout(Duration::from_secs_f64(600.0));


### PR DESCRIPTION
## Summary

The platform's `POST /api/skills/github/import` route rejects transient `githubToken` values (a never-stored token cannot authenticate the scheduled sync pulls that keep imports fresh), but `import_github_skills` in the bench runner still attached one whenever `GITHUB_TOKEN`/`GH_TOKEN` was set or `gh` was authenticated. On such machines every benchmark run failed env seeding with a 400 before any task could start; CI never hit it because no token is discoverable there.

The import call now sends no token. The benchmark's skill repos are public, so the import needs none; `discover_github_skills` keeps sending it, since the discovery route accepts it and it raises the GitHub rate limit for repo listing. If a future env ever needs a private skill repo, the route's sanctioned path is a stored PAT or GitHub App configuration, not a transient token.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>