### PR TITLE
fix(auth): let SSO sign-in link onto existing unverified password accounts

### DIFF
--- a/docs/pages/platform-sso.md
+++ b/docs/pages/platform-sso.md
@@ -4,7 +4,7 @@ category: Administration
 subcategory: Identity Providers
 description: "Sign users in with their existing identity provider via OIDC or SAML"
 order: 4
-lastUpdated: 2026-07-16
+lastUpdated: 2026-08-06
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -151,7 +151,7 @@ The IdP didn't return the required user attributes. For GitHub, the user must ha
 
 ### `account not linked` error
 
-The SSO provider is not trusted for automatic account linking, or the provider returned an email that doesn't match the existing account. Verify the provider is configured in Identity Providers and the user is signing in with the same email as their existing account.
+The IdP returned an email that doesn't match the existing account, or reported the email as unverified. Verify the user signs in with the same email as their existing Archestra account and that the IdP marks the email verified.
 
 ### `invalid_dpop_proof` error (Okta)
 

--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -7,6 +7,7 @@ import { allAvailableActions } from "@archestra/shared/access-control";
 import type { HookEndpointContext } from "@better-auth/core";
 import { APIError } from "better-auth";
 import { eq } from "drizzle-orm";
+import { HttpResponse, http } from "msw";
 import { vi } from "vitest";
 import { cacheManager } from "@/cache-manager";
 import type * as originalConfigModule from "@/config";
@@ -29,6 +30,7 @@ import InvitationModel from "@/models/invitation";
 import McpServerModel from "@/models/mcp-server";
 import SecretModel from "@/models/secret";
 import { beforeEach, describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
 
 // Create a hoisted ref to control disableInvitations in tests
 const mockDisableInvitations = vi.hoisted(() => ({ value: false }));
@@ -4200,5 +4202,137 @@ describe("membership removal cleanup", () => {
       .from(schema.usersTable)
       .where(eq(schema.usersTable.id, leaver.id));
     expect(userRow).toBeUndefined();
+  });
+});
+
+describe("SSO account linking onto existing password users", () => {
+  // Regression guard for instances that switch to SSO sign-in after users
+  // already exist with email/password accounts. Archestra never sends
+  // verification email, so those local users stay emailVerified=false
+  // forever; without accountLinking.requireLocalEmailVerified: false,
+  // better-auth refuses to implicitly link their first SSO login
+  // (redirecting with error=account_not_linked), which permanently locks
+  // them out once basic auth is disabled.
+  const IDP_ORIGIN = "https://sso-idp.archestra-test.invalid";
+
+  const mswServer = useMswServer();
+
+  test("OIDC callback links onto an existing email/password user whose email was never verified", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeAccount,
+    makeIdentityProvider,
+  }) => {
+    const user = await makeUser({
+      email: "unverified-password-user@example.com",
+      emailVerified: false,
+    });
+    const org = await makeOrganization();
+    await makeMember(user.id, org.id, { role: "member" });
+    await makeAccount(user.id, {
+      providerId: CREDENTIAL_PROVIDER_ID,
+      accountId: user.id,
+    });
+
+    const provider = await makeIdentityProvider(org.id, {
+      providerId: "oidc-unverified-link",
+      issuer: IDP_ORIGIN,
+      domain: "example.com",
+      oidcConfig: {
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        authorizationEndpoint: `${IDP_ORIGIN}/authorize`,
+        tokenEndpoint: `${IDP_ORIGIN}/token`,
+        userInfoEndpoint: `${IDP_ORIGIN}/userinfo`,
+        jwksEndpoint: `${IDP_ORIGIN}/jwks`,
+        pkce: false,
+      },
+    });
+
+    // Initiate SSO sign-in to mint the server-side state row and the signed
+    // state cookie the callback validates.
+    const signInResponse = await auth.handler(
+      new Request("http://localhost:3000/api/auth/sign-in/sso", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          providerId: provider.providerId,
+          callbackURL: "http://localhost:3000/chat",
+        }),
+      }),
+    );
+    expect(signInResponse.status).toBe(200);
+    const { url: authorizationUrl } = (await signInResponse.json()) as {
+      url: string;
+    };
+    const state = new URL(authorizationUrl).searchParams.get("state");
+    expect(state).toBeTruthy();
+    const stateCookies = signInResponse.headers
+      .getSetCookie()
+      .map((cookie) => cookie.split(";")[0])
+      .join("; ");
+
+    // Fake the IdP: code exchange + userinfo with a verified email that
+    // matches the existing local user.
+    mswServer.use(
+      http.post(`${IDP_ORIGIN}/token`, () =>
+        HttpResponse.json({
+          access_token: "sso-access-token",
+          token_type: "Bearer",
+        }),
+      ),
+      http.get(`${IDP_ORIGIN}/userinfo`, () =>
+        HttpResponse.json({
+          sub: "external-subject-1",
+          email: user.email,
+          email_verified: true,
+          name: "Unverified Password User",
+        }),
+      ),
+    );
+
+    const callbackResponse = await auth.handler(
+      new Request(
+        `http://localhost:3000/api/auth/sso/callback/${provider.providerId}?code=fake-code&state=${state}`,
+        { headers: { cookie: stateCookies } },
+      ),
+    );
+
+    expect(callbackResponse.status).toBe(302);
+    const location = callbackResponse.headers.get("location") ?? "";
+    // Without requireLocalEmailVerified: false this redirect carries
+    // ?error=account_not_linked instead of completing the sign-in.
+    expect(location).not.toContain("error=");
+    expect(location).toContain("http://localhost:3000/chat");
+
+    // The SSO account is linked to the pre-existing user...
+    const linkedAccounts = await db
+      .select()
+      .from(schema.accountsTable)
+      .where(eq(schema.accountsTable.userId, user.id));
+    const ssoAccount = linkedAccounts.find(
+      (account) => account.providerId === provider.providerId,
+    );
+    expect(ssoAccount).toBeDefined();
+    expect(ssoAccount?.accountId).toBe("external-subject-1");
+
+    // ...a session was created for that user (not a duplicate user)...
+    const [sessionRow] = await db
+      .select()
+      .from(schema.sessionsTable)
+      .where(eq(schema.sessionsTable.userId, user.id));
+    expect(sessionRow).toBeDefined();
+
+    // ...and the verified IdP assertion flipped the local flag, so the
+    // account self-heals on first SSO login.
+    const [userRow] = await db
+      .select()
+      .from(schema.usersTable)
+      .where(eq(schema.usersTable.id, user.id));
+    expect(userRow.emailVerified).toBe(true);
   });
 });

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -322,9 +322,12 @@ export const auth = betterAuth({
     accountLinking: {
       enabled: true,
       /**
-       * Trust built-in SSO providers plus any identity providers configured by users.
-       * This allows existing users to sign in with built-in providers and custom
-       * generic OIDC/SAML providers without an env var override.
+       * Trust built-in SSO providers plus any identity providers configured by
+       * users. Note this list only affects better-auth's built-in social
+       * providers: the SSO plugin calls handleOAuthUserInfo with
+       * `trustProviderByName: false` and instead derives trust from the
+       * provider's `domainVerified` flag, so custom OIDC/SAML providers are
+       * NOT trusted through this list.
        */
       trustedProviders: getTrustedAccountLinkingProviderIds,
       /**
@@ -335,6 +338,27 @@ export const auth = betterAuth({
        */
       allowDifferentEmails: false,
       allowUnlinkingAll: true,
+      /**
+       * Let an SSO/social sign-in implicitly link onto an existing local
+       * account whose email was never marked verified.
+       *
+       * better-auth's default (true) guards against pre-registration account
+       * takeover: an attacker self-registers an unverified password account
+       * at the victim's email and waits for the victim's first SSO login to
+       * link onto it, keeping the planted password. That attack needs open
+       * self-registration, which Archestra does not have — accounts are only
+       * created by operators or through admin-issued invitations that fix the
+       * email address — and no verification email is ever sent, so every
+       * password-created user stays emailVerified=false forever. Under the
+       * default, switching an instance to SSO sign-in (especially with
+       * ARCHESTRA_AUTH_DISABLE_BASIC_AUTH) permanently locks those users out
+       * with "Account Not Linked" on their first SSO login.
+       *
+       * Linking still requires an email-verified assertion from the IdP (or a
+       * domain-verified provider) and an exact email match
+       * (allowDifferentEmails: false).
+       */
+      requireLocalEmailVerified: false,
     },
   },
 


### PR DESCRIPTION
## Problem

On instances that enable SSO after users already exist with email/password accounts, those users' first SSO login fails with **"Account Not Linked"** and redirects back to the sign-in page with `error=account_not_linked`. If basic authentication is also disabled (`ARCHESTRA_AUTH_DISABLE_BASIC_AUTH=true`), those users are permanently locked out — no password fallback, and no way to reach the explicit account-linking flow without a session.

Root cause: better-auth's `accountLinking.requireLocalEmailVerified` defaults to `true`, refusing to implicitly link an SSO identity onto an existing local user whose email was never marked verified. Archestra never sends verification email, so every password-created user has `emailVerified = false` forever — the refusal fires for effectively every pre-existing password user.

## Fix

Set `accountLinking.requireLocalEmailVerified: false`.

The pre-registration-takeover scenario the default guards against (attacker plants an unverified password account at the victim's email, victim's first SSO login links onto it) requires open self-registration, which Archestra does not have: accounts are only created by operators or through admin-issued invitations that fix the email address. The remaining linking guards are unchanged — the IdP must assert the email as verified (or the provider must be domain-verified), and the email must exactly match (`allowDifferentEmails: false`).

**Self-healing:** no data migration needed. On the first successful SSO login after rollout, better-auth links the account and flips the local `emailVerified` flag.

Also:

- Corrects the stale `trustedProviders` comment — the SSO plugin passes `trustProviderByName: false` and derives trust from the provider's `domainVerified` flag, not from that list.
- Updates the `account not linked` troubleshooting entry in the SSO docs to the two causes that remain.