### PR TITLE
fix(deps): pin js-yaml 4.3.1 for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -55,7 +55,7 @@ overrides:
   express: 5.2.0
   express-rate-limit: 8.3.1
   jws: 4.0.1
-  js-yaml: '>=4.3.0 <5'
+  js-yaml: 4.3.1
   qs: 6.15.2
   d3-path: 3.1.0
   hono: 4.12.25
@@ -443,8 +443,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.1
       js-yaml:
-        specifier: '>=4.3.0 <5'
-        version: 4.3.0
+        specifier: 4.3.1
+        version: 4.3.1
       jsdom:
         specifier: ^29.0.0
         version: 29.0.0(@noble/hashes@2.0.1)
@@ -8361,8 +8361,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.0.0:
@@ -12528,7 +12528,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@hey-api/openapi-ts@0.97.3(@typescript/typescript6@6.0.1)':
     dependencies:
@@ -12902,7 +12902,7 @@ snapshots:
       form-data: 4.0.6
       hpagent: 1.2.0
       isomorphic-ws: 5.0.0(ws@8.21.0)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonpath-plus: 10.3.0
       node-fetch: 2.7.0
       openid-client: 6.8.1
@@ -13098,7 +13098,7 @@ snapshots:
       colorette: 2.0.20
       emnapi: 1.10.0
       es-toolkit: 1.45.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       obug: 2.1.1
       semver: 7.7.4
       typanion: 3.14.0
@@ -19080,7 +19080,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -76,7 +76,11 @@ overrides:
   # CVE-2026-59869 (HIGH, uncontrolled resource consumption) affects >=4.0.0,
   # fixed in 4.3.0. Bounded to <5 so consumers expecting the 4.x API aren't
   # force-jumped onto the js-yaml 5 major.
-  js-yaml: '>=4.3.0 <5'
+  # Then GHSA-5p4m-2wfm-xmqj (HIGH, quadratic CPU in !!omap resolution) fixed
+  # in 4.3.1, published 2026-08-06 — inside the 7-day window, so excluded from
+  # minimumReleaseAge below and pinned exact so a floor can't pull an
+  # unvetted release.
+  js-yaml: 4.3.1
   qs: 6.15.2
   d3-path: 3.1.0
   # CVE-2026-54290 (HIGH, permissive cross-domain policy) fixed in 4.12.25.
@@ -194,6 +198,10 @@ minimumReleaseAgeExclude:
   # 2026-07-21 and clears the 7-day window on 2026-07-28. Remove on/after that
   # date — the lockfile stays pinned at 9.7.0 regardless.
   - find-my-way
+  # TEMPORARY: js-yaml 4.3.1 (fix GHSA-5p4m-2wfm-xmqj, HIGH) was published
+  # 2026-08-06 and clears the 7-day window on 2026-08-13. Remove on/after that
+  # date — the lockfile stays pinned at 4.3.1 regardless.
+  - js-yaml
   # TEMPORARY: brace-expansion 5.0.9 (fix CVE-2026-69152, HIGH) was published
   # 2026-07-30 and clears the 7-day window on 2026-08-06. Remove on/after that
   # date — the lockfile stays pinned at 5.0.9 regardless.


### PR DESCRIPTION
GHSA-5p4m-2wfm-xmqj (HIGH, quadratic CPU consumption in js-yaml `!!omap` resolution) entered the advisory feed at 2026-08-06T20:27Z and now fails the required Docker Image Scanning gate for every PR in the merge queue.

Raises the existing js-yaml override from `>=4.3.0 <5` to an exact `4.3.1` pin. The fix release is inside the 7-day `minimumReleaseAge` window, so js-yaml joins `minimumReleaseAgeExclude` with the standing removal note (window clears 2026-08-13; the lockfile stays pinned regardless).

Unblocks the queue for every open PR, including #7134.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>