### PR TITLE
fix(helm): stop the enforcement probe reporting a verdict it never measured

### DIFF
--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -520,15 +520,16 @@ args:
     done
     printf '%s' "$result" > /dev/termination-log
     {{- /*
-      Silent when the target answers: a working check should cost the operator
-      one line, and that line is the treatment arm's.
+      Silent when the target answers: a healthy release should cost the operator
+      no output at all.
 
-      When the target never answers, the treatment arm is blocked for the same
-      reason and reports enforcement it did not observe — so this says so, and
+      When the target never answers, the treatment arm is blocked for that same
+      reason rather than by any policy, and cannot tell the two apart. This arm
+      is the only one that can, so it reports the run measured nothing — and
       says it without depending on which line Helm printed first.
     */}}
     if [ "$result" = blocked ]; then
-      echo "[archestra] ⚠️ ⚠️ ⚠️  NETWORK POLICY CHECK INCONCLUSIVE  ⚠️ ⚠️ ⚠️  Could not reach {{ .host }}:9000, so enforcement was never measured — environment egress rules (MCP servers, code sandboxes) may be accepted and then silently ignored. Disregard any enforcement result reported for this release"
+      echo "[archestra] ⚠️ ⚠️ ⚠️  NETWORK POLICY CHECK INCONCLUSIVE  ⚠️ ⚠️ ⚠️  Could not reach {{ .host }}:9000, so enforcement was never measured — environment egress rules (MCP servers, code sandboxes) may be accepted and then silently ignored. Re-run once the platform is up to get a verdict"
     fi
     exit 0
 {{- end }}
@@ -572,15 +573,18 @@ args:
     fi
     printf '%s' "$result" > /dev/termination-log
     {{- /*
-      One line per outcome. Helm emits a pod's whole log as a single `level=...
-      msg="..."` record, so an embedded newline arrives as a literal \n inside one
-      quoted string — a stacked banner renders as garbage. Emoji survive intact,
-      which is what carries the emphasis instead.
+      Speaks only to warn. Being blocked is also what a target that never came up
+      looks like from inside this pod, so an all-clear here would sometimes
+      announce enforcement nobody measured. The verdict still leaves in the
+      termination message, where the platform resolves it against the control arm
+      and can claim enforcement holding both halves of the evidence.
+
+      Helm emits a pod's whole log as a single `level=... msg="..."` record, so an
+      embedded newline arrives as a literal \n inside one quoted string — a
+      stacked banner renders as garbage. Emoji carry the emphasis instead.
     */}}
     if [ "$result" = reachable ]; then
       echo "[archestra] 🚨 🚨 🚨  NETWORK POLICY NOT ENFORCED  🚨 🚨 🚨  Environment egress rules (MCP servers, code sandboxes) are accepted and then silently ignored — see https://archestra.ai/docs/platform-environments#network-egress-policies"
-    else
-      echo "[archestra] ✅ Network policy enforced"
     fi
     exit 0
 {{- end }}

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -579,9 +579,11 @@ args:
       termination message, where the platform resolves it against the control arm
       and can claim enforcement holding both halves of the evidence.
 
-      Helm emits a pod's whole log as a single `level=... msg="..."` record, so an
-      embedded newline arrives as a literal \n inside one quoted string — a
-      stacked banner renders as garbage. Emoji carry the emphasis instead.
+      One line, because the two supported Helm majors disagree about hook output:
+      Helm 4 routes it through its structured logger, where the whole pod log
+      becomes one `level=... msg="..."` record and every newline arrives as a
+      literal \n, while Helm 3 copies the stream verbatim. A stacked banner
+      renders on 3 and reaches 4 as a row of escapes. Emoji survive both.
     */}}
     if [ "$result" = reachable ]; then
       echo "[archestra] 🚨 🚨 🚨  NETWORK POLICY NOT ENFORCED  🚨 🚨 🚨  Environment egress rules (MCP servers, code sandboxes) are accepted and then silently ignored — see https://archestra.ai/docs/platform-environments#network-egress-policies"

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -528,7 +528,7 @@ args:
       says it without depending on which line Helm printed first.
     */}}
     if [ "$result" = blocked ]; then
-      echo "[archestra] ⚠️ ⚠️ ⚠️  NETWORK POLICY CHECK INCONCLUSIVE  ⚠️ ⚠️ ⚠️  Could not reach {{ .host }}:9000 — disregard any enforcement result reported for this release"
+      echo "[archestra] ⚠️ ⚠️ ⚠️  NETWORK POLICY CHECK INCONCLUSIVE  ⚠️ ⚠️ ⚠️  Could not reach {{ .host }}:9000, so enforcement was never measured — environment egress rules (MCP servers, code sandboxes) may be accepted and then silently ignored. Disregard any enforcement result reported for this release"
     fi
     exit 0
 {{- end }}
@@ -578,7 +578,7 @@ args:
       which is what carries the emphasis instead.
     */}}
     if [ "$result" = reachable ]; then
-      echo "[archestra] 🚨 🚨 🚨  NETWORK POLICY NOT ENFORCED  🚨 🚨 🚨  Egress rules are accepted and then silently ignored — see https://archestra.ai/docs/platform-environments#network-egress-policies"
+      echo "[archestra] 🚨 🚨 🚨  NETWORK POLICY NOT ENFORCED  🚨 🚨 🚨  Environment egress rules (MCP servers, code sandboxes) are accepted and then silently ignored — see https://archestra.ai/docs/platform-environments#network-egress-policies"
     else
       echo "[archestra] ✅ Network policy enforced"
     fi

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -528,7 +528,7 @@ args:
       says it without depending on which line Helm printed first.
     */}}
     if [ "$result" = blocked ]; then
-      echo "[archestra] network policy check: INCONCLUSIVE, could not reach {{ .host }}:9000 — disregard any enforcement result reported for this release"
+      echo "[archestra] ⚠️ ⚠️ ⚠️  NETWORK POLICY CHECK INCONCLUSIVE  ⚠️ ⚠️ ⚠️  Could not reach {{ .host }}:9000 — disregard any enforcement result reported for this release"
     fi
     exit 0
 {{- end }}
@@ -572,14 +572,15 @@ args:
     fi
     printf '%s' "$result" > /dev/termination-log
     {{- /*
-      One line per outcome: Helm wraps each log record in its own `level=... msg=`
-      envelope, so a multi-line banner would arrive as a column of quoted
-      fragments.
+      One line per outcome. Helm emits a pod's whole log as a single `level=...
+      msg="..."` record, so an embedded newline arrives as a literal \n inside one
+      quoted string — a stacked banner renders as garbage. Emoji survive intact,
+      which is what carries the emphasis instead.
     */}}
     if [ "$result" = reachable ]; then
-      echo "[archestra] network policy check: WARNING, network policy not enforced. See https://archestra.ai/docs/platform-environments#network-egress-policies"
+      echo "[archestra] 🚨 🚨 🚨  NETWORK POLICY NOT ENFORCED  🚨 🚨 🚨  Egress rules are accepted and then silently ignored — see https://archestra.ai/docs/platform-environments#network-egress-policies"
     else
-      echo "[archestra] network policy check: OK, enforcement enabled"
+      echo "[archestra] ✅ Network policy enforced"
     fi
     exit 0
 {{- end }}

--- a/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
+++ b/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
@@ -230,9 +230,9 @@ tests:
 
   - it: warns in one self-contained line and stays silent otherwise
     asserts:
-      # Helm emits a pod's whole log as one record and the two arms arrive in no
-      # guaranteed order, so a message that refers to the other arm, or spans
-      # lines, arrives unreadable.
+      # The two arms arrive in no guaranteed order, and Helm 4 collapses each
+      # pod's log into one record, so a message that refers to the other arm, or
+      # spans lines, arrives unreadable.
       - matchRegex:
           path: spec.containers[0].args[0]
           pattern: 'NETWORK POLICY NOT ENFORCED'
@@ -261,9 +261,13 @@ tests:
           pattern: 'https://archestra\.ai/docs/platform-environments#network-egress-policies'
         documentIndex: 2
 
-  # Helm renders an embedded newline as a literal \n inside the single quoted
-  # record, so a stacked banner reaches the operator as one line of escapes. The
-  # emphasis has to come from emoji on one line instead.
+  # Helm 4 routes hook output through its structured logger, so a stacked banner
+  # reaches the operator as one record of \n escapes; Helm 3 copies the stream
+  # verbatim and renders it. One line is the only shape correct on both.
+  #
+  # Guarded from both directions, because a banner can be built two ways: a
+  # newline inside one echo, or consecutive echoes. The second is the shape
+  # someone reaches for first, and it leaves every quoted run newline-free.
   - it: keeps every operator-facing message on one line
     asserts:
       - notMatchRegex:
@@ -273,6 +277,14 @@ tests:
       - notMatchRegex:
           path: spec.containers[0].args[0]
           pattern: 'echo "[^"]*\n[^"]*"'
+        documentIndex: 2
+      - notMatchRegex:
+          path: spec.containers[0].args[0]
+          pattern: 'echo "[^"]*"[\s\S]*echo "'
+        documentIndex: 1
+      - notMatchRegex:
+          path: spec.containers[0].args[0]
+          pattern: 'echo "[^"]*"[\s\S]*echo "'
         documentIndex: 2
       - matchRegex:
           path: spec.containers[0].args[0]

--- a/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
+++ b/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
@@ -230,15 +230,16 @@ tests:
 
   - it: states each outcome in a single self-contained line
     asserts:
-      # Helm emits one log record per line and in no guaranteed order, so a
-      # message that refers to the other arm, or spans lines, arrives unreadable.
+      # Helm emits a pod's whole log as one record and the two arms arrive in no
+      # guaranteed order, so a message that refers to the other arm, or spans
+      # lines, arrives unreadable.
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: 'OK, enforcement enabled'
+          pattern: 'Network policy enforced'
         documentIndex: 2
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: 'WARNING, network policy not enforced'
+          pattern: 'NETWORK POLICY NOT ENFORCED'
         documentIndex: 2
       # The warning is one line with nowhere to explain itself, so it has to
       # carry the way out.
@@ -246,6 +247,32 @@ tests:
           path: spec.containers[0].args[0]
           pattern: 'https://archestra\.ai/docs/platform-environments#network-egress-policies'
         documentIndex: 2
+
+  # Helm renders an embedded newline as a literal \n inside the single quoted
+  # record, so a stacked banner reaches the operator as one line of escapes. The
+  # emphasis has to come from emoji on one line instead.
+  - it: keeps every operator-facing message on one line
+    asserts:
+      - notMatchRegex:
+          path: spec.containers[0].args[0]
+          pattern: 'echo "[^"]*\n[^"]*"'
+        documentIndex: 1
+      - notMatchRegex:
+          path: spec.containers[0].args[0]
+          pattern: 'echo "[^"]*\n[^"]*"'
+        documentIndex: 2
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: '🚨'
+        documentIndex: 2
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: '✅'
+        documentIndex: 2
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: '⚠️'
+        documentIndex: 1
 
   # A working cluster should cost one line. The control arm speaks only to void
   # a result the treatment arm cannot know is meaningless: with the target down
@@ -258,7 +285,7 @@ tests:
         documentIndex: 1
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: 'INCONCLUSIVE, could not reach'
+          pattern: 'NETWORK POLICY CHECK INCONCLUSIVE'
         documentIndex: 1
       - matchRegex:
           path: spec.containers[0].args[0]

--- a/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
+++ b/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
@@ -228,18 +228,26 @@ tests:
           value: hook-succeeded,hook-failed
         documentIndex: 2
 
-  - it: states each outcome in a single self-contained line
+  - it: warns in one self-contained line and stays silent otherwise
     asserts:
       # Helm emits a pod's whole log as one record and the two arms arrive in no
       # guaranteed order, so a message that refers to the other arm, or spans
       # lines, arrives unreadable.
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: 'Network policy enforced'
+          pattern: 'NETWORK POLICY NOT ENFORCED'
+        documentIndex: 2
+      # No all-clear from this arm. Blocked is also how an unreachable target
+      # looks from inside the policy, so a pod holding half the evidence would
+      # sometimes announce enforcement nobody measured. The termination message
+      # still carries the verdict to the platform, which holds both halves.
+      - notMatchRegex:
+          path: spec.containers[0].args[0]
+          pattern: 'echo "\[archestra\][^"]*(enforced|OK|✅)'
         documentIndex: 2
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: 'NETWORK POLICY NOT ENFORCED'
+          pattern: "printf '%s' \"\\$result\" > /dev/termination-log"
         documentIndex: 2
       # The warning is one line with nowhere to explain itself, so it has to
       # carry both what silently stops working and the way out. Helm output
@@ -272,17 +280,13 @@ tests:
         documentIndex: 2
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: '✅'
-        documentIndex: 2
-      - matchRegex:
-          path: spec.containers[0].args[0]
           pattern: '⚠️'
         documentIndex: 1
 
-  # A working cluster should cost one line. The control arm speaks only to void
-  # a result the treatment arm cannot know is meaningless: with the target down
-  # it is blocked for the wrong reason and would report enforcement regardless.
-  - it: says nothing when the target answers, and voids the result when it does not
+  # A healthy cluster should cost no output at all. This arm speaks only when the
+  # target never came up, which is the one state the treatment arm cannot detect:
+  # it is blocked for the wrong reason and measures nothing.
+  - it: says nothing when the target answers, and reports why when it does not
     asserts:
       - notMatchRegex:
           path: spec.containers[0].args[0]
@@ -292,9 +296,16 @@ tests:
           path: spec.containers[0].args[0]
           pattern: 'NETWORK POLICY CHECK INCONCLUSIVE'
         documentIndex: 1
+      # Never tells the operator to discount a result. With no all-clear from the
+      # treatment arm, the only line that can accompany this one is the warning,
+      # and that is the direction it is safe to believe.
+      - notMatchRegex:
+          path: spec.containers[0].args[0]
+          pattern: '[Dd]isregard'
+        documentIndex: 1
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: '[Dd]isregard any enforcement result reported for this release'
+          pattern: 'Re-run once the platform is up'
         documentIndex: 1
       # Unmeasured and unenforced leave the operator equally exposed, so this
       # arm names the same consequence rather than only reporting that the

--- a/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
+++ b/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
@@ -242,7 +242,12 @@ tests:
           pattern: 'NETWORK POLICY NOT ENFORCED'
         documentIndex: 2
       # The warning is one line with nowhere to explain itself, so it has to
-      # carry the way out.
+      # carry both what silently stops working and the way out. Helm output
+      # reaches an operator who has no environment editor in front of them.
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: 'MCP servers, code sandboxes'
+        documentIndex: 2
       - matchRegex:
           path: spec.containers[0].args[0]
           pattern: 'https://archestra\.ai/docs/platform-environments#network-egress-policies'
@@ -289,7 +294,14 @@ tests:
         documentIndex: 1
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: 'disregard any enforcement result reported for this release'
+          pattern: '[Dd]isregard any enforcement result reported for this release'
+        documentIndex: 1
+      # Unmeasured and unenforced leave the operator equally exposed, so this
+      # arm names the same consequence rather than only reporting that the
+      # probe could not run.
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: 'MCP servers, code sandboxes'
         documentIndex: 1
 
   # The platform looks for the verdict in the namespace it manages workloads in.


### PR DESCRIPTION
## Summary

The NetworkPolicy enforcement probe printed its result in the same register as every other line Helm emits, and one of those lines could be false.

The treatment pod is blocked both when a policy denies it and when the target never came up, and by construction cannot tell those apart — it has no network and no API access, which is the whole point of it. It reported the first case as `OK, enforcement enabled`, so a release where the platform never answered printed enforcement nobody had measured, immediately beside the control arm's line saying to discount it. Whichever Helm happened to print first decided what the operator believed.

That all-clear is gone. The verdict still leaves in the container termination message, so the platform resolves both arms and reports the healthy case in the UI while holding evidence this pod does not have. Helm output becomes exception-only: a release that prints nothing is one where the probe ran and found nothing wrong, and a probe that cannot run fails the release rather than passing quietly.

The two remaining messages lead with emoji and name what silently stops working — environment egress rules governing MCP server pods and agent code sandboxes. Helm output reaches whoever ran the release, who may never open an environment editor, so "egress rules" on its own had no referent. The inconclusive arm no longer tells anyone to disregard the enforcement result: there is none left to disregard, and the only line that can now accompany it is the warning, which is the direction it is safe to believe.

Every message stays on one line, because the two supported Helm majors disagree about hook output. Helm 4 routes it through its structured logger, where a pod's entire log becomes one `level=... msg="..."` record and every newline arrives as a literal `\n`; Helm 3 copies the stream verbatim. A stacked banner renders on 3 and reaches 4 as a row of escapes, so one line is the only shape correct on both. Emoji survive either, which is what carries the emphasis instead.

## Behaviour

| Cluster state | Helm install/upgrade output |
| --- | --- |
| Enforces NetworkPolicy | *(nothing)* |
| Does not enforce | 🚨 warning naming the affected workloads, linking the docs |
| Target never reachable | ⚠️ inconclusive, naming the same consequence |

No change to `enforcementStatus`, the `/api/k8s/capabilities` response, or the environments UI — the probe's machine-readable channel is untouched.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>