### PR TITLE
test(backend): pin credential-stripping invariants for connector config and Zod error text

### DIFF
--- a/platform/backend/src/archestra-mcp-server/helpers.test.ts
+++ b/platform/backend/src/archestra-mcp-server/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   deduplicateLabels,
   fencedBlock,
   formatAssignmentSummary,
+  formatZodError,
   formatZodErrorWithSchema,
   isAbortLikeError,
 } from "./helpers";
@@ -292,5 +293,80 @@ describe("formatZodErrorWithSchema", () => {
     expect(formatZodErrorWithSchema(error, schema)).toContain(
       'nested: unrecognized key "timeout"',
     );
+  });
+});
+
+/**
+ * `catchError` gives every failure a generic message except a ZodError, whose
+ * text it forwards to the model verbatim as the tool result. A tool argument
+ * can hold a credential, so the rejected value must never appear in the
+ * message. Zod's own formatting is what keeps it out — a Zod upgrade, a custom
+ * error map, or a `.refine()` message that interpolates its input would put it
+ * back.
+ */
+describe("Zod error text never echoes the rejected value", () => {
+  const rejected = "sk-rejected-secret-value";
+
+  function errorFor(schema: z.ZodType, value: unknown): z.ZodError {
+    const result = schema.safeParse(value);
+    if (result.success) throw new Error("expected a validation failure");
+    return result.error;
+  }
+
+  test.each([
+    [
+      "enum",
+      z.object({ mode: z.enum(["a", "b"]) }),
+      { mode: rejected },
+      "mode",
+    ],
+    [
+      "literal",
+      z.object({ kind: z.literal("fixed") }),
+      { kind: rejected },
+      "kind",
+    ],
+    [
+      "string length",
+      z.object({ token: z.string().max(3) }),
+      { token: rejected },
+      "token",
+    ],
+    [
+      "url format",
+      z.object({ endpoint: z.url() }),
+      { endpoint: rejected },
+      "endpoint",
+    ],
+    ["number type", z.object({ port: z.number() }), { port: rejected }, "port"],
+  ])("formatZodError on a %s failure", (_label, schema, value, path) => {
+    const message = formatZodError(errorFor(schema, value));
+    expect(message).not.toContain(rejected);
+    // names the offending field, so the assertion above is not passing on an
+    // empty message.
+    expect(message).toContain(path);
+  });
+
+  test("formatZodErrorWithSchema on an unrecognized key holding a credential", () => {
+    const schema = z.strictObject({ ok: z.string() });
+    const message = formatZodErrorWithSchema(
+      errorFor(schema, { ok: "x", extra: rejected }),
+      schema,
+    );
+    expect(message).not.toContain(rejected);
+    expect(message).toContain('unrecognized key "extra"');
+  });
+
+  test("formatZodErrorWithSchema on a discriminator holding a credential", () => {
+    const schema = z.discriminatedUnion("type", [
+      z.strictObject({ type: z.literal("base64"), data: z.string() }),
+      z.strictObject({ type: z.literal("text"), data: z.string() }),
+    ]);
+    const message = formatZodErrorWithSchema(
+      errorFor(schema, { type: rejected, data: "x" }),
+      schema,
+    );
+    expect(message).not.toContain(rejected);
+    expect(message).toContain('set "type" to one of: "base64", "text"');
   });
 });

--- a/platform/backend/src/types/knowledge-connector.test.ts
+++ b/platform/backend/src/types/knowledge-connector.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "@/test";
 import {
+  InsertKnowledgeBaseConnectorSchema,
+  UpdateKnowledgeBaseConnectorSchema,
+} from "./knowledge-base-connector";
+import {
   ConfluenceConfigSchema,
   ConnectorConfigSchema,
+  ConnectorCredentialsSchema,
   GithubConfigSchema,
   GitlabConfigSchema,
   JiraConfigSchema,
@@ -232,6 +237,86 @@ describe("knowledge-connector schemas", () => {
       if (result.type === "confluence") {
         expect(result.confluenceUrl).toBe("https://mycompany.atlassian.net");
       }
+    });
+  });
+
+  /**
+   * Credentials belong in the connector's vaulted secret bag, never in `config`
+   * — which is persisted as jsonb and echoed back verbatim by the
+   * create/update knowledge connector MCP tools. The tools take `config` as a
+   * free-form object and expose no credentials field, so a model has nowhere
+   * else to put a token it invents; only these schemas keep it out of the
+   * database and the tool result. A `.passthrough()`/`.loose()`/`.catchall()`
+   * on any member of the union would silently reopen that path.
+   */
+  describe("credential fields never survive into config", () => {
+    const credentialKeys = Object.keys(ConnectorCredentialsSchema.shape);
+    const smuggled = "smuggled-credential-value";
+    const smuggledCredentials = Object.fromEntries(
+      credentialKeys.map((key) => [key, smuggled]),
+    );
+
+    function expectStripped(parsed: unknown) {
+      expect(JSON.stringify(parsed)).not.toContain(smuggled);
+      for (const key of credentialKeys) {
+        expect(parsed).not.toHaveProperty(key);
+      }
+    }
+
+    // Guards the assertions below: an empty key list would make every
+    // stripping check pass without testing anything, and deriving the list
+    // means a newly added credential field is covered without editing this.
+    test("derives a non-empty key list from the credentials bag", () => {
+      expect(credentialKeys).toContain("apiToken");
+      expect(credentialKeys.length).toBeGreaterThan(1);
+    });
+
+    test.each([
+      [
+        "jira",
+        { type: "jira", jiraBaseUrl: "mycompany.atlassian.net", isCloud: true },
+      ],
+      [
+        "github",
+        { type: "github", githubUrl: "api.github.com", owner: "test-org" },
+      ],
+      [
+        "web_crawler",
+        { type: "web_crawler", startUrl: "https://docs.example.com" },
+      ],
+    ])("ConnectorConfigSchema strips them from a %s config", (_type, base) => {
+      expectStripped(
+        ConnectorConfigSchema.parse({ ...base, ...smuggledCredentials }),
+      );
+    });
+
+    test("the connector create write path strips them", () => {
+      const parsed = InsertKnowledgeBaseConnectorSchema.parse({
+        organizationId: "org-1",
+        name: "connector",
+        connectorType: "jira",
+        config: {
+          type: "jira",
+          jiraBaseUrl: "mycompany.atlassian.net",
+          isCloud: true,
+          ...smuggledCredentials,
+        },
+      });
+      expect(JSON.stringify(parsed)).not.toContain(smuggled);
+      expectStripped(parsed.config);
+    });
+
+    test("the connector update write path strips them", () => {
+      const parsed = UpdateKnowledgeBaseConnectorSchema.partial().parse({
+        config: {
+          type: "jira",
+          jiraBaseUrl: "mycompany.atlassian.net",
+          isCloud: true,
+          ...smuggledCredentials,
+        },
+      });
+      expect(JSON.stringify(parsed)).not.toContain(smuggled);
+      expectStripped(parsed.config);
     });
   });
 


### PR DESCRIPTION
Two properties keep credentials out of model-visible surfaces, and both currently hold only as a side effect of Zod's defaults — nothing asserts them, so an unrelated schema edit or a dependency bump can retire either one silently.

The create/update knowledge connector MCP tools accept `config` as a free-form object and expose no credentials field, so a model that invents a token has nowhere to put it but `config` — which is persisted as jsonb and echoed back verbatim in the tool result. Key stripping on the members of `ConnectorConfigSchema` is the only thing keeping that token out of the database and out of the model's context; a `.passthrough()`, `.loose()`, or `.catchall()` added to any member for an unrelated reason would reopen the path. The connector test derives its credential key list from `ConnectorCredentialsSchema`, so a newly added credential field is covered without touching the test.

`catchError` gives every failure a generic message except a `ZodError`, whose text it forwards to the model verbatim so validation problems stay actionable. Tool arguments can carry credentials, which makes the rejected value's absence from Zod's message text load-bearing. Zod 4 keeps the input off the issue object entirely (`code`, `values`, `path`, `message`), so today nothing can echo it even by accident — a version whose message formatting changes would end that quietly.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>