### PR TITLE
fix(frontend): correct connect summary plural spacing

### DIFF
--- a/platform/frontend/src/app/connection/gateway-servers-summary.test.tsx
+++ b/platform/frontend/src/app/connection/gateway-servers-summary.test.tsx
@@ -85,8 +85,7 @@ describe("GatewayServersSummary", () => {
     render(<GatewayServersSummary gatewayId="g1" />);
 
     // header count: 2 servers, 3 tools total
-    expect(screen.getByRole("button")).toHaveTextContent(/2 MCP servers/);
-    expect(screen.getByRole("button")).toHaveTextContent(/3 tools/);
+    expect(screen.getByText("2 MCP servers · 3 tools")).toBeInTheDocument();
 
     await expandList();
 

--- a/platform/frontend/src/app/connection/gateway-servers-summary.tsx
+++ b/platform/frontend/src/app/connection/gateway-servers-summary.tsx
@@ -90,6 +90,7 @@ export function GatewayServersSummary({
   const totalTools = accessAll
     ? servers.reduce((sum, s) => sum + s.toolCount, 0)
     : (gateway.tools?.length ?? 0);
+  const summaryLabel = `${accessAll ? "All " : ""}${servers.length} MCP ${servers.length === 1 ? "server" : "servers"} · ${totalTools} ${totalTools === 1 ? "tool" : "tools"}`;
 
   const editLink =
     canManage && gatewayId ? (
@@ -137,12 +138,7 @@ export function GatewayServersSummary({
               !expanded && "-rotate-90",
             )}
           />
-          {accessAll ? <span>All </span> : null}
-          <span>{servers.length} MCP server</span>
-          {servers.length === 1 ? null : <span>s</span>}
-          <span> · </span>
-          <span>{totalTools} tool</span>
-          {totalTools === 1 ? null : <span>s</span>}
+          <span>{summaryLabel}</span>
         </button>
         {accessAll && (
           <span className="text-muted-foreground/70">


### PR DESCRIPTION
Fix the Connect review summary’s spaced plural suffixes (`server s`, `tool s`) by rendering the complete count label inside one translation-safe span.

Adds exact-text coverage for plural server and tool counts.

Task: https://slack.com/archives/C0B2AGC0AFQ/p1786024187364719?thread_ts=1786024149.061439&cid=C0B2AGC0AFQ

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>