### PR TITLE
fix(llm-cost): reclassify a proxy-discovered model once its provider lists it

### DIFF
--- a/platform/backend/src/models/model.test.ts
+++ b/platform/backend/src/models/model.test.ts
@@ -590,6 +590,103 @@ describe("ModelModel", () => {
       );
       expect(updated?.defaultParameters).toEqual({ num_ctx: 8192 });
     });
+
+    test("clears the proxy-discovery flag when a provider catalog returns the model", async () => {
+      // The proxy saw this id before any key had synced it, so the row exists
+      // as proxy-discovered.
+      await ModelModel.ensureModelExists("claude-opus-4-7", "anthropic");
+      const discovered = await ModelModel.findByProviderAndModelId(
+        "anthropic",
+        "claude-opus-4-7",
+      );
+      expect(discovered?.discoveredViaLlmProxy).toBe(true);
+
+      // A configured provider's own catalog now returns it, which makes it a
+      // synced model that key deletion should be able to clean up.
+      await ModelModel.bulkUpsert(
+        [
+          {
+            externalId: "anthropic/claude-opus-4-7",
+            provider: "anthropic",
+            modelId: "claude-opus-4-7",
+            inputModalities: ["text"],
+            outputModalities: ["text"],
+            promptPricePerToken: "0.000005",
+            completionPricePerToken: "0.000025",
+            lastSyncedAt: new Date(),
+          },
+        ],
+        { fromProviderCatalog: true },
+      );
+
+      const synced = await ModelModel.findByProviderAndModelId(
+        "anthropic",
+        "claude-opus-4-7",
+      );
+      expect(synced?.discoveredViaLlmProxy).toBe(false);
+    });
+
+    test("keeps the proxy-discovery flag when the registry import names the model", async () => {
+      // The models.dev import upserts the whole registry regardless of which
+      // providers are configured, so a model appearing there is no evidence the
+      // caller can actually reach it. Only a configured provider's own catalog
+      // is, so this path must leave the row's protection alone.
+      await ModelModel.ensureModelExists("gpt-4o", "openai");
+
+      await ModelModel.bulkUpsert([
+        {
+          externalId: "openai/gpt-4o",
+          provider: "openai",
+          modelId: "gpt-4o",
+          inputModalities: ["text"],
+          outputModalities: ["text"],
+          promptPricePerToken: "0.0000025",
+          completionPricePerToken: "0.00001",
+          lastSyncedAt: new Date(),
+        },
+      ]);
+
+      const stillProxyDiscovered = await ModelModel.findByProviderAndModelId(
+        "openai",
+        "gpt-4o",
+      );
+      expect(stillProxyDiscovered?.discoveredViaLlmProxy).toBe(true);
+    });
+
+    test("preserves custom price overrides on conflict", async () => {
+      const created = await ModelModel.create({
+        externalId: "openai/custom-priced",
+        provider: "openai",
+        modelId: "custom-priced",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        lastSyncedAt: new Date(),
+      });
+      await ModelModel.update(created.id, {
+        customPricePerMillionInput: "12.00",
+        customPricePerMillionOutput: "36.00",
+      });
+
+      await ModelModel.bulkUpsert([
+        {
+          externalId: "openai/custom-priced",
+          provider: "openai",
+          modelId: "custom-priced",
+          inputModalities: ["text"],
+          outputModalities: ["text"],
+          promptPricePerToken: "0.000001",
+          completionPricePerToken: "0.000002",
+          lastSyncedAt: new Date(),
+        },
+      ]);
+
+      const after = await ModelModel.findByProviderAndModelId(
+        "openai",
+        "custom-priced",
+      );
+      expect(after?.customPricePerMillionInput).toBe("12.00");
+      expect(after?.customPricePerMillionOutput).toBe("36.00");
+    });
   });
 
   describe("bulkUpsertFull", () => {
@@ -645,6 +742,69 @@ describe("ModelModel", () => {
         "llama3-full",
       );
       expect(refreshed?.defaultParameters).toEqual({ num_ctx: 8192 });
+    });
+
+    test("clears the proxy-discovery flag when a catalog sync returns the model", async () => {
+      await ModelModel.ensureModelExists("gpt-4o-full", "openai");
+      const discovered = await ModelModel.findByProviderAndModelId(
+        "openai",
+        "gpt-4o-full",
+      );
+      expect(discovered?.discoveredViaLlmProxy).toBe(true);
+
+      await ModelModel.bulkUpsertFull([
+        {
+          externalId: "openai/gpt-4o-full",
+          provider: "openai",
+          modelId: "gpt-4o-full",
+          inputModalities: ["text"],
+          outputModalities: ["text"],
+          promptPricePerToken: "0.0000025",
+          completionPricePerToken: "0.00001",
+          lastSyncedAt: new Date(),
+        },
+      ]);
+
+      const synced = await ModelModel.findByProviderAndModelId(
+        "openai",
+        "gpt-4o-full",
+      );
+      expect(synced?.discoveredViaLlmProxy).toBe(false);
+    });
+
+    test("resets custom price overrides on full refresh", async () => {
+      const created = await ModelModel.create({
+        externalId: "openai/full-custom-priced",
+        provider: "openai",
+        modelId: "full-custom-priced",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        lastSyncedAt: new Date(),
+      });
+      await ModelModel.update(created.id, {
+        customPricePerMillionInput: "12.00",
+        customPricePerMillionOutput: "36.00",
+      });
+
+      await ModelModel.bulkUpsertFull([
+        {
+          externalId: "openai/full-custom-priced",
+          provider: "openai",
+          modelId: "full-custom-priced",
+          inputModalities: ["text"],
+          outputModalities: ["text"],
+          promptPricePerToken: "0.000001",
+          completionPricePerToken: "0.000002",
+          lastSyncedAt: new Date(),
+        },
+      ]);
+
+      const after = await ModelModel.findByProviderAndModelId(
+        "openai",
+        "full-custom-priced",
+      );
+      expect(after?.customPricePerMillionInput).toBeNull();
+      expect(after?.customPricePerMillionOutput).toBeNull();
     });
   });
 

--- a/platform/backend/src/models/model.ts
+++ b/platform/backend/src/models/model.ts
@@ -378,8 +378,17 @@ class ModelModel {
    * PostgreSQL has a 65535 parameter limit, so we batch to stay well under.
    * All batches are wrapped in a transaction to ensure atomicity.
    * NOTE: Does NOT overwrite customPricePerMillionInput/Output on conflict.
+   *
+   * `fromProviderCatalog` marks the rows as models a configured provider's own
+   * catalog returned, which clears `discoveredViaLlmProxy`. The models.dev
+   * registry import must leave it unset: it upserts the whole registry
+   * regardless of which providers are configured, so a row appearing there is
+   * no evidence anyone can reach the model.
    */
-  static async bulkUpsert(dataArray: CreateModel[]): Promise<Model[]> {
+  static async bulkUpsert(
+    dataArray: CreateModel[],
+    { fromProviderCatalog = false }: { fromProviderCatalog?: boolean } = {},
+  ): Promise<Model[]> {
     if (dataArray.length === 0) {
       return [];
     }
@@ -433,6 +442,14 @@ class ModelModel {
               defaultParameters: sql`COALESCE(excluded.default_parameters, ${schema.modelsTable.defaultParameters})`,
               lastSyncedAt: sql`excluded.last_synced_at`,
               updatedAt: sql`NOW()`,
+              // The proxy marks a row it creates for an id no catalog had
+              // listed, which exempts it from deleteOrphanedModels so a custom
+              // price survives having no API key link. A configured provider's
+              // catalog returning the id makes it an ordinary synced model, and
+              // leaving the mark set would exempt it from that cleanup forever.
+              ...(fromProviderCatalog
+                ? { discoveredViaLlmProxy: sql`false` }
+                : {}),
               // NOTE: custom price overrides (input/output/cache) intentionally NOT updated
               // NOTE: capability fields only backfill when the existing DB value is null
               // to preserve user-edited values while still populating missing metadata
@@ -457,6 +474,11 @@ class ModelModel {
   /**
    * Bulk upsert models, overwriting ALL fields including user-edited values.
    * Used by the "full refresh" flow to reset models to provider defaults.
+   *
+   * Resetting a row to provider defaults is only meaningful for a model the
+   * provider actually serves, so this path is always a provider-catalog sync
+   * and clears `discoveredViaLlmProxy` unconditionally — unlike
+   * {@link ModelModel.bulkUpsert}, which the registry import also uses.
    */
   static async bulkUpsertFull(dataArray: CreateModel[]): Promise<Model[]> {
     if (dataArray.length === 0) {
@@ -506,6 +528,7 @@ class ModelModel {
               customPricePerMillionOutput: sql`NULL`,
               customPricePerMillionCacheRead: sql`NULL`,
               customPricePerMillionCacheWrite: sql`NULL`,
+              discoveredViaLlmProxy: sql`false`,
               lastSyncedAt: sql`excluded.last_synced_at`,
               updatedAt: sql`NOW()`,
             },

--- a/platform/backend/src/services/model-sync.test.ts
+++ b/platform/backend/src/services/model-sync.test.ts
@@ -114,6 +114,53 @@ describe("ModelSyncService", () => {
     expect(linkedModels.every((m) => m.model.provider === "openai")).toBe(true);
   });
 
+  test("reclassifies a proxy-discovered model once the provider's catalog returns it", async ({
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const org = await makeOrganization();
+    const secret = await makeSecret({ secret: { apiKey: "test-key" } });
+    const apiKey = await makeLlmProviderApiKey(org.id, secret.id, {
+      provider: "openai",
+    });
+
+    // Both rows exist because the proxy saw the ids before any key synced them.
+    await ModelModel.ensureModelExists("gpt-4o", "openai");
+    // A client-invented id no catalog lists, so the sync below never names it.
+    await ModelModel.ensureModelExists("gpt-4o[1m]", "openai");
+
+    modelFetchers.openai = async () => [
+      {
+        id: "gpt-4o",
+        displayName: "GPT-4o",
+        provider: "openai" as SupportedProvider,
+      },
+    ];
+
+    await modelSyncService.syncModelsForApiKey({
+      apiKeyId: apiKey.id,
+      provider: "openai",
+      apiKeyValue: "test-key",
+    });
+
+    // The catalog returned it, so it is an ordinary synced model now and
+    // deleting the key can clean it up.
+    const synced = await ModelModel.findByProviderAndModelId(
+      "openai",
+      "gpt-4o",
+    );
+    expect(synced?.discoveredViaLlmProxy).toBe(false);
+
+    // Nothing returned this one, so it keeps the protection that lets a custom
+    // price survive having no API key link.
+    const untouched = await ModelModel.findByProviderAndModelId(
+      "openai",
+      "gpt-4o[1m]",
+    );
+    expect(untouched?.discoveredViaLlmProxy).toBe(true);
+  });
+
   test("forceRefresh resets custom pricing, normal sync preserves it", async ({
     makeOrganization,
     makeSecret,

--- a/platform/backend/src/services/model-sync.ts
+++ b/platform/backend/src/services/model-sync.ts
@@ -122,7 +122,9 @@ class ModelSyncService {
 
       const upsertedModels = forceRefresh
         ? await ModelModel.bulkUpsertFull(modelsToUpsert)
-        : await ModelModel.bulkUpsert(modelsToUpsert);
+        : await ModelModel.bulkUpsert(modelsToUpsert, {
+            fromProviderCatalog: true,
+          });
 
       logger.info(
         { provider, apiKeyId, upsertedCount: upsertedModels.length },

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -255,7 +255,9 @@ class SystemKeyManager {
       modelsDevData,
     });
 
-    const upsertedModels = await ModelModel.bulkUpsert(modelsToUpsert);
+    const upsertedModels = await ModelModel.bulkUpsert(modelsToUpsert, {
+      fromProviderCatalog: true,
+    });
 
     logger.info(
       { provider, apiKeyId, upsertedCount: upsertedModels.length },


### PR DESCRIPTION
`discovered_via_llm_proxy` marks a row the LLM proxy created for a model id no catalog had listed. It exempts that row from `deleteOrphanedModels`, so a custom price set for cost metrics survives the row having no API key link.

Nothing ever cleared it. The column is written in exactly one place — `ensureModelExists`, on insert — so a row the proxy created before any key had synced that model kept the mark for good, even after a provider's own catalog returned it with real prices and linked API keys. On staging, `claude-opus-4-7` carries a models.dev price and three linked keys and is still marked proxy-discovered. Two things follow: deleting the last API key leaves the row behind instead of cleaning it up the way it does for every other synced model, and anything reading the column to mean "no catalog lists this" gets the wrong answer.

Clearing it is scoped to the flows that fetch a *configured provider's own catalog*, since that is what actually evidences the model is reachable. The models.dev registry import shares `bulkUpsert` but upserts the entire registry regardless of which providers are configured — so it keeps the current behavior, and a genuinely proxy-only row stays protected rather than losing that protection merely because the registry happens to list its id. `bulkUpsertFull` clears unconditionally: resetting a row to provider defaults is only meaningful for a model the provider serves.

Affected rows self-heal on their next sync, so this needs no backfill. It also does not fix the mispriced `…[1m]` context-variant rows — those are a separate row whose id no catalog lists, addressed on its own.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>