### PR TITLE
feat(frontend): warn in the sidebar when the cluster does not enforce network policy

### DIFF
--- a/platform/frontend/src/app/_parts/rum-tracker.ee.tsx
+++ b/platform/frontend/src/app/_parts/rum-tracker.ee.tsx
@@ -22,7 +22,7 @@ export function RumTracker() {
   const { data: session } = useSession();
   const pathname = usePathname();
 
-  const enabled = Boolean(publicConfig?.rum.enabled);
+  const enabled = Boolean(publicConfig?.rum?.enabled);
   const userId = session?.user?.id;
   const isSignedIn = Boolean(userId);
 
@@ -43,9 +43,9 @@ export function RumTracker() {
       rumClient.stop();
       return;
     }
-    rumClient.start({ sampleRate: publicConfig?.rum.sampleRate });
+    rumClient.start({ sampleRate: publicConfig?.rum?.sampleRate });
     return () => rumClient.stop();
-  }, [enabled, isSignedIn, publicConfig?.rum.sampleRate]);
+  }, [enabled, isSignedIn, publicConfig?.rum?.sampleRate]);
 
   // Sign-in detection lives on the RUM client (not the analytics taxonomy)
   // because the analytics call site requires PostHog to be initialized —

--- a/platform/frontend/src/components/sidebar-warnings-accordion.test.tsx
+++ b/platform/frontend/src/components/sidebar-warnings-accordion.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import {
+  useDefaultCredentialsEnabled,
+  useHasPermissions,
+  useSession,
+} from "@/lib/auth/auth.query";
+import { useDisableBasicAuth } from "@/lib/config/config.query";
+import { useK8sCapabilities } from "@/lib/environment.query";
+import { SidebarWarningsAccordion } from "./sidebar-warnings-accordion";
+
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/config/config.query");
+vi.mock("@/lib/environment.query", () => ({
+  useK8sCapabilities: vi.fn(),
+}));
+
+type EnforcementStatus =
+  | "verified-enforced"
+  | "verified-not-enforced"
+  | "unknown";
+
+function setup({
+  enforcementStatus,
+  canUpdateEnvironment = true,
+}: {
+  enforcementStatus?: EnforcementStatus;
+  canUpdateEnvironment?: boolean;
+}) {
+  vi.mocked(useHasPermissions).mockImplementation(
+    (permissions: Record<string, unknown>) =>
+      ({
+        data: "environment" in permissions ? canUpdateEnvironment : false,
+      }) as ReturnType<typeof useHasPermissions>,
+  );
+  // Kept off so the network policy warning is the only one under test.
+  vi.mocked(useSession).mockReturnValue({
+    data: { user: { email: "someone@example.org" } },
+  } as ReturnType<typeof useSession>);
+  vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
+    data: false,
+    isLoading: false,
+  } as ReturnType<typeof useDefaultCredentialsEnabled>);
+  vi.mocked(useDisableBasicAuth).mockReturnValue(true);
+
+  vi.mocked(useK8sCapabilities).mockReturnValue({
+    data: enforcementStatus
+      ? { networkPolicy: { enforcementStatus } }
+      : undefined,
+  } as ReturnType<typeof useK8sCapabilities>);
+
+  return render(
+    <SidebarProvider>
+      <SidebarWarningsAccordion />
+    </SidebarProvider>,
+  );
+}
+
+describe("SidebarWarningsAccordion network policy warning", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom ships no matchMedia, which SidebarProvider needs to decide mobile.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        onchange: null,
+        dispatchEvent: vi.fn(),
+      })),
+    );
+  });
+
+  it("warns when a probe measured the cluster as not enforcing", () => {
+    setup({ enforcementStatus: "verified-not-enforced" });
+
+    expect(screen.getByText("Network policy not enforced")).toBeVisible();
+  });
+
+  it("stays silent when a probe measured the cluster as enforcing", () => {
+    setup({ enforcementStatus: "verified-enforced" });
+
+    expect(screen.queryByText("Network policy not enforced")).toBeNull();
+  });
+
+  // Nothing tested the cluster, which is not evidence that egress rules are
+  // inert — warning here would nag every deployment without a probe result.
+  it("stays silent when enforcement was never measured", () => {
+    setup({ enforcementStatus: "unknown" });
+
+    expect(screen.queryByText("Network policy not enforced")).toBeNull();
+  });
+
+  it("stays silent while capabilities are still loading", () => {
+    setup({});
+
+    expect(screen.queryByText("Network policy not enforced")).toBeNull();
+  });
+
+  // Reading capabilities needs environment:update; without it the query is
+  // disabled and returns nothing rather than 403-ing on every page.
+  it("does not query capabilities without environment update permission", () => {
+    setup({ canUpdateEnvironment: false });
+
+    expect(vi.mocked(useK8sCapabilities)).toHaveBeenCalledWith(false);
+  });
+
+  it("links to the network egress policies docs in a new tab", () => {
+    setup({ enforcementStatus: "verified-not-enforced" });
+
+    const link = screen.getByRole("link", {
+      name: /Network policy not enforced/,
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      expect.stringContaining("platform-environments#network-egress-policies"),
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+});

--- a/platform/frontend/src/components/sidebar-warnings-accordion.test.tsx
+++ b/platform/frontend/src/components/sidebar-warnings-accordion.test.tsx
@@ -102,6 +102,34 @@ describe("SidebarWarningsAccordion network policy warning", () => {
     expect(screen.queryByText("Network policy not enforced")).toBeNull();
   });
 
+  // This renders in the layout, so throwing on an unexpected payload blanks
+  // every page rather than one component.
+  it("survives a response without the network policy section", () => {
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { email: "someone@example.org" } },
+    } as ReturnType<typeof useSession>);
+    vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
+      data: false,
+      isLoading: false,
+    } as ReturnType<typeof useDefaultCredentialsEnabled>);
+    vi.mocked(useDisableBasicAuth).mockReturnValue(true);
+    vi.mocked(useK8sCapabilities).mockReturnValue({
+      data: { error: { message: "Unauthenticated" } },
+    } as unknown as ReturnType<typeof useK8sCapabilities>);
+
+    expect(() =>
+      render(
+        <SidebarProvider>
+          <SidebarWarningsAccordion />
+        </SidebarProvider>,
+      ),
+    ).not.toThrow();
+    expect(screen.queryByText("Network policy not enforced")).toBeNull();
+  });
+
   // Reading capabilities needs environment:update; without it the query is
   // disabled and returns nothing rather than 403-ing on every page.
   it("does not query capabilities without environment update permission", () => {

--- a/platform/frontend/src/components/sidebar-warnings-accordion.tsx
+++ b/platform/frontend/src/components/sidebar-warnings-accordion.tsx
@@ -62,8 +62,13 @@ export function SidebarWarningsAccordion() {
 
   // Only a measured verdict warns. "unknown" means nothing tested the cluster,
   // which is not evidence that egress rules are inert.
+  //
+  // networkPolicy is optional-chained despite being required in the response
+  // type: a payload that does not match — an error envelope, an older backend —
+  // would otherwise throw here and blank every page, since this renders in the
+  // layout rather than on one screen.
   const showNetworkPolicyWarning =
-    capabilities?.networkPolicy.enforcementStatus === "verified-not-enforced";
+    capabilities?.networkPolicy?.enforcementStatus === "verified-not-enforced";
 
   // Null under full white-labeling, where the environments screen carries the
   // same explanation and stays reachable.

--- a/platform/frontend/src/components/sidebar-warnings-accordion.tsx
+++ b/platform/frontend/src/components/sidebar-warnings-accordion.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DEFAULT_ADMIN_EMAIL } from "@archestra/shared";
+import { DEFAULT_ADMIN_EMAIL, DocsPage } from "@archestra/shared";
 import { AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import {
@@ -23,7 +23,15 @@ import {
   useSession,
 } from "@/lib/auth/auth.query";
 import { useDisableBasicAuth } from "@/lib/config/config.query";
+import { getFrontendDocsUrl } from "@/lib/docs/docs";
+import { useK8sCapabilities } from "@/lib/environment.query";
 import { cn } from "@/lib/utils";
+
+interface Warning {
+  label: string;
+  href: string;
+  external: boolean;
+}
 
 export function SidebarWarningsAccordion() {
   const { data: session } = useSession();
@@ -34,6 +42,14 @@ export function SidebarWarningsAccordion() {
   const { data: canUpdateOrg } = useHasPermissions({
     organization: ["update"],
   });
+  // Reading capabilities needs environment:update, so gating the query on the
+  // same permission keeps it from 403-ing for everyone else on every page.
+  const { data: canUpdateEnvironment } = useHasPermissions({
+    environment: ["update"],
+  });
+  const { data: capabilities } = useK8sCapabilities(
+    canUpdateEnvironment === true,
+  );
   const { state: sidebarState } = useSidebar();
 
   const showDefaultCredsWarning =
@@ -44,12 +60,30 @@ export function SidebarWarningsAccordion() {
     defaultCredentialsEnabled &&
     userEmail === DEFAULT_ADMIN_EMAIL;
 
+  // Only a measured verdict warns. "unknown" means nothing tested the cluster,
+  // which is not evidence that egress rules are inert.
+  const showNetworkPolicyWarning =
+    capabilities?.networkPolicy.enforcementStatus === "verified-not-enforced";
+
+  // Null under full white-labeling, where the environments screen carries the
+  // same explanation and stays reachable.
+  const networkPolicyDocsUrl = getFrontendDocsUrl(
+    DocsPage.PlatformEnvironments,
+    "network-egress-policies",
+  );
+
   const warnings = [
     showDefaultCredsWarning && {
       label: "Change default credentials",
       href: "/account?highlight=change-password",
+      external: false,
     },
-  ].filter((w): w is { label: string; href: string } => Boolean(w));
+    showNetworkPolicyWarning && {
+      label: "Network policy not enforced",
+      href: networkPolicyDocsUrl ?? "/settings/environments",
+      external: networkPolicyDocsUrl !== null,
+    },
+  ].filter((w): w is Warning => Boolean(w));
 
   if (warnings.length === 0) {
     return null;
@@ -77,7 +111,12 @@ export function SidebarWarningsAccordion() {
                       key={w.label}
                       className="cursor-pointer"
                     >
-                      <Link href={w.href}>{w.label}</Link>
+                      <Link
+                        href={w.href}
+                        {...externalLinkProps(w.label, w.external)}
+                      >
+                        <span>{w.label}</span>
+                      </Link>
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuContent>
@@ -114,7 +153,7 @@ export function SidebarWarningsAccordion() {
   );
 }
 
-function WarningItem({ label, href }: { label: string; href: string }) {
+function WarningItem({ label, href, external }: Warning) {
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
@@ -122,11 +161,24 @@ function WarningItem({ label, href }: { label: string; href: string }) {
         tooltip={label}
         className="text-destructive hover:text-destructive"
       >
-        <Link href={href}>
+        <Link href={href} {...externalLinkProps(label, external)}>
           <AlertTriangle className="shrink-0" />
           <span>{label}</span>
         </Link>
       </SidebarMenuButton>
     </SidebarMenuItem>
   );
+}
+
+// The new-tab hint rides on aria-label rather than an sr-only sibling, because
+// SidebarMenuButton truncates its last span child and a second span would take
+// that rule off the label, wrapping it to two lines.
+function externalLinkProps(label: string, external: boolean) {
+  return external
+    ? ({
+        target: "_blank",
+        rel: "noopener noreferrer",
+        "aria-label": `${label} (opens in new tab)`,
+      } as const)
+    : {};
 }


### PR DESCRIPTION
## Summary

A cluster that accepts `NetworkPolicy` objects without acting on them only said so inside the environment editor. Anyone who never opens that screen — which is most people, most days — had no signal that the egress rules containing MCP server pods and agent code sandboxes were inert. The chart's enforcement probe already measures this on every install and upgrade; the verdict just had nowhere to surface.

The sidebar now carries it beside **Change default credentials**, which is the same kind of claim: a standing security property of the deployment rather than a problem with the screen in front of you. It links to the network egress policy docs, falling back to the environments screen where full white-labeling hides docs links.

Only a measured verdict warns. `enforcementStatus: "unknown"` means nothing tested the cluster, which is not evidence that rules are ignored — warning on it would nag every deployment the probe never ran against, and the whole point of splitting that field out was to stop treating "unmeasured" as an answer.

Reading capabilities requires `environment:update`, so the query is gated on that permission rather than returning 403 for every other member on every page load.

## Layout-level crash guard

This renders in the sidebar, which every screen mounts, so a response that does not match its declared type throws into a blank page rather than a broken component. Two reads had that exposure and now guard the section as well as the object:

- `publicConfig?.rum.enabled` — a backend whose `/api/config` predates the `rum` block returns a defined config with an undefined section, which is the ordinary state for the length of a rolling upgrade.
- `capabilities?.networkPolicy.enforcementStatus` — same shape, same consequence.

Both response types mark those sections required, which is exactly why neither guard was there: the compiler reads the optional chain as redundant. The types describe the contract, not what a mismatched or older peer actually returns.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>