### PR TITLE
fix(frontend): don't show the browser setup card while the install check is in flight

### DIFF
--- a/platform/frontend/src/components/chat/playwright-install-dialog.test.tsx
+++ b/platform/frontend/src/components/chat/playwright-install-dialog.test.tsx
@@ -1,0 +1,187 @@
+import { PLAYWRIGHT_MCP_CATALOG_ID } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseMcpServers = vi.fn();
+const mockUseProfileToolsWithIds = vi.fn();
+const mockUseConversationEnabledTools = vi.fn();
+const mockUseAgentDelegations = vi.fn();
+const mockUseSession = vi.fn();
+
+vi.mock("@/lib/mcp/mcp-server.query", () => ({
+  useMcpServers: (...args: unknown[]) => mockUseMcpServers(...args),
+}));
+
+vi.mock("@/lib/chat/chat.query", () => ({
+  useProfileToolsWithIds: (...args: unknown[]) =>
+    mockUseProfileToolsWithIds(...args),
+  useConversationEnabledTools: (...args: unknown[]) =>
+    mockUseConversationEnabledTools(...args),
+  fetchAgentMcpTools: vi.fn(async () => []),
+  useHasPlaywrightMcpTools: vi.fn(() => ({})),
+  useUpdateConversationEnabledTools: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/lib/agent-tools.query", () => ({
+  useAgentDelegations: (...args: unknown[]) => mockUseAgentDelegations(...args),
+}));
+
+vi.mock("@/lib/auth/auth.query", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+import { usePlaywrightSetupRequired } from "./playwright-install-dialog";
+
+const USER_ID = "user-1";
+const AGENT_ID = "agent-1";
+const CONVERSATION_ID = "conversation-1";
+
+const PLAYWRIGHT_TOOL = {
+  id: "tool-playwright",
+  name: "microsoft__playwright-mcp__browser_navigate",
+  catalogId: PLAYWRIGHT_MCP_CATALOG_ID,
+  delegateToAgentId: null,
+};
+
+const PLAYWRIGHT_SERVER_OWNED_BY_USER = {
+  id: "server-1",
+  catalogId: PLAYWRIGHT_MCP_CATALOG_ID,
+  ownerId: USER_ID,
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+/**
+ * @param installState "loading" models the window where the user's Playwright
+ * install has not come back yet; "installed"/"not-installed" are resolved.
+ */
+function setup(options: {
+  installState: "loading" | "installed" | "not-installed";
+  agentTools?: Array<Record<string, unknown>>;
+  isLoadingAgentTools?: boolean;
+  enabledTools?: {
+    hasCustomSelection: boolean;
+    enabledToolIds: string[];
+  } | null;
+}) {
+  const {
+    installState,
+    agentTools = [PLAYWRIGHT_TOOL],
+    isLoadingAgentTools = false,
+    enabledTools = { hasCustomSelection: false, enabledToolIds: [] },
+  } = options;
+
+  mockUseSession.mockReturnValue({ data: { user: { id: USER_ID } } });
+
+  mockUseMcpServers.mockReturnValue(
+    installState === "loading"
+      ? { data: undefined, isLoading: true }
+      : {
+          data:
+            installState === "installed"
+              ? [PLAYWRIGHT_SERVER_OWNED_BY_USER]
+              : [],
+          isLoading: false,
+        },
+  );
+
+  mockUseProfileToolsWithIds.mockReturnValue({
+    data: agentTools,
+    isLoading: isLoadingAgentTools,
+  });
+  mockUseConversationEnabledTools.mockReturnValue({ data: enabledTools });
+  mockUseAgentDelegations.mockReturnValue({ data: [], isLoading: false });
+
+  return renderHook(
+    () => usePlaywrightSetupRequired(AGENT_ID, CONVERSATION_ID),
+    { wrapper },
+  );
+}
+
+describe("usePlaywrightSetupRequired", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not report setup required while the user's install state is still loading", () => {
+    const { result } = setup({ installState: "loading" });
+
+    expect(result.current.isRequired).toBe(false);
+  });
+
+  it("reports setup required once the install state resolves to not-installed", () => {
+    const { result } = setup({ installState: "not-installed" });
+
+    expect(result.current.isRequired).toBe(true);
+  });
+
+  it("does not report setup required once the install state resolves to installed", () => {
+    const { result } = setup({ installState: "installed" });
+
+    expect(result.current.isRequired).toBe(false);
+  });
+
+  it("does not report setup required when the agent has no Playwright tools", () => {
+    const { result } = setup({
+      installState: "not-installed",
+      agentTools: [
+        {
+          id: "tool-other",
+          name: "some__other__tool",
+          catalogId: "another-catalog",
+          delegateToAgentId: null,
+        },
+      ],
+    });
+
+    expect(result.current.isRequired).toBe(false);
+  });
+
+  it("does not report setup required while the conversation's enabled tools are unknown", () => {
+    const { result } = setup({
+      installState: "not-installed",
+      enabledTools: null,
+    });
+
+    expect(result.current.isRequired).toBe(false);
+  });
+
+  it("excludes a Playwright tool the conversation has explicitly disabled", () => {
+    const { result } = setup({
+      installState: "not-installed",
+      enabledTools: { hasCustomSelection: true, enabledToolIds: [] },
+    });
+
+    expect(result.current.isRequired).toBe(false);
+  });
+
+  it("reports loading while the agent's tools are still being fetched", () => {
+    const { result } = setup({
+      installState: "not-installed",
+      isLoadingAgentTools: true,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("does not report loading once the user has Playwright installed", () => {
+    const { result } = setup({
+      installState: "installed",
+      isLoadingAgentTools: true,
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/platform/frontend/src/components/chat/playwright-install-dialog.tsx
+++ b/platform/frontend/src/components/chat/playwright-install-dialog.tsx
@@ -58,7 +58,10 @@ export function usePlaywrightSetupRequired(
 
   // Check if current user has Playwright installed using lightweight queries only
   // (no mutations) to avoid interfering with install state in the dialog/right panel
-  const { data: playwrightServers = [] } = useMcpServers({
+  const {
+    data: playwrightServers = [],
+    isLoading: isLoadingPlaywrightServers,
+  } = useMcpServers({
     catalogId: PLAYWRIGHT_MCP_CATALOG_ID,
     enabled: options?.enabled,
   });
@@ -151,7 +154,11 @@ export function usePlaywrightSetupRequired(
   // defaults that may not reflect the user's custom selection.
   const isAwaitingEnabledTools = !!conversationId && !enabledToolsData;
 
+  // Until the user's Playwright servers come back, an empty list is
+  // indistinguishable from "not installed" — claiming setup is required off that
+  // shows the setup card to users who already have a browser.
   const isRequired =
+    !isLoadingPlaywrightServers &&
     !isPlaywrightInstalledByCurrentUser &&
     !isAwaitingEnabledTools &&
     (hasEnabledPlaywrightTool || enabledSubAgentHasPlaywrightTools);


### PR DESCRIPTION
`usePlaywrightSetupRequired` derived the current user's Playwright install state from a `useMcpServers` query whose pending state was left out of the hook's loading gate. While that request was in flight, the empty-list default was indistinguishable from "no browser installed", so `isRequired` came back true and the composer swapped the message input for the "Browser Setup Required" card — then swapped it back once the server list arrived.

Anyone opening a chat on an agent carrying Playwright tools (directly or through a sub-agent) saw that card flash in the prompt input, offering to install a browser they already had, and lost the text input for as long as it was up. The window is exactly as long as the `/api/mcp_server` lookup takes, so it widens precisely where that call is slowest.

`isRequired` now stays false until the install lookup resolves. Users who genuinely need a browser still get the card, one render later; users who already have one never see it.

The gate reads the query's `isLoading` rather than `isPending` on purpose: a permanently disabled query — a user without `mcpServerInstallation:read`, for whom the servers request never runs — keeps its current behavior instead of silently losing the card.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>