### PR TITLE
fix(backend): prevent OpenAPI saturation from OOM-killing web pods

### DIFF
--- a/platform/backend/scripts/calculate-node-max-old-space-size.sh
+++ b/platform/backend/scripts/calculate-node-max-old-space-size.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -eu
+
+# An operator-supplied Node heap limit always wins.
+case " ${NODE_OPTIONS:-} " in
+  *" --max-old-space-size="* | *" --max_old_space_size="* | *" --max-old-space-size "* | *" --max_old_space_size "*)
+    exit 0
+    ;;
+esac
+
+# This explicit override supports a positive MiB value, or 0 to disable the
+# automatically calculated CLI flag.
+if [ "${ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB+x}" = "x" ]; then
+  override=$ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB
+  case "$override" in
+    "" | *[!0-9]*)
+      echo "ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB must be a non-negative integer" >&2
+      exit 1
+      ;;
+  esac
+
+  awk -v value="$override" 'BEGIN { if (value > 0) printf "%d\n", value }'
+  exit 0
+fi
+
+calculate_percentage() {
+  value=$1
+  percentage=$2
+  case "$value" in
+    "" | *[!0-9]*) return 1 ;;
+  esac
+
+  awk -v value="$value" -v percentage="$percentage" \
+    'BEGIN { result = int(value * percentage / 100); if (result > 0) printf "%d\n", result }'
+}
+
+# Prefer the cgroup hard limit. Keep 40% outside V8 old-space for young-space,
+# native/external allocations, thread stacks, and the other web-container
+# processes. If no limit exists, use the request with Node's documented 75%
+# example ratio; requests guide scheduling but are not an OOM boundary.
+if calculated=$(calculate_percentage "${ARCHESTRA_NODE_MEMORY_LIMIT_MIB:-}" 60); then
+  if [ -n "$calculated" ]; then
+    printf "%s\n" "$calculated"
+    exit 0
+  fi
+fi
+
+if calculated=$(calculate_percentage "${ARCHESTRA_NODE_MEMORY_REQUEST_MIB:-}" 75); then
+  if [ -n "$calculated" ]; then
+    printf "%s\n" "$calculated"
+  fi
+fi

--- a/platform/backend/scripts/start-production.sh
+++ b/platform/backend/scripts/start-production.sh
@@ -25,11 +25,21 @@ export ARCHESTRA_NODE_DIAGNOSTIC_DIR="${ARCHESTRA_NODE_DIAGNOSTIC_DIR:-/app/data
 
 mkdir -p "$ARCHESTRA_NODE_DIAGNOSTIC_DIR"
 
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+node_max_old_space_size_mib=$(
+  "$script_dir/calculate-node-max-old-space-size.sh"
+)
+
 set -- \
   --enable-source-maps \
   --report-on-fatalerror \
   --report-uncaught-exception \
   --diagnostic-dir="$ARCHESTRA_NODE_DIAGNOSTIC_DIR"
+
+if [ -n "$node_max_old_space_size_mib" ]; then
+  echo "Configuring Node old-space limit: ${node_max_old_space_size_mib} MiB"
+  set -- "$@" "--max-old-space-size=${node_max_old_space_size_mib}"
+fi
 
 if [ -n "${ARCHESTRA_NODE_HEAPSNAPSHOT_NEAR_HEAP_LIMIT:-}" ]; then
   set -- "$@" "--heapsnapshot-near-heap-limit=${ARCHESTRA_NODE_HEAPSNAPSHOT_NEAR_HEAP_LIMIT}"

--- a/platform/backend/src/openapi/cached-openapi-route.test.ts
+++ b/platform/backend/src/openapi/cached-openapi-route.test.ts
@@ -1,0 +1,81 @@
+import Fastify from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { createCachedOpenApiRouteHandler } from "./cached-openapi-route";
+
+const createApp = (
+  buildDocument: () => unknown,
+  getCacheKey: () => string = () => "default",
+) => {
+  const app = Fastify();
+  app.get(
+    "/openapi.json",
+    createCachedOpenApiRouteHandler({ buildDocument, getCacheKey }),
+  );
+  return app;
+};
+
+describe("createCachedOpenApiRouteHandler", () => {
+  it("serializes the document once and reuses the response", async () => {
+    const buildDocument = vi.fn(() => ({ openapi: "3.1.0" }));
+    const app = createApp(buildDocument);
+
+    const first = await app.inject("/openapi.json");
+    const second = await app.inject("/openapi.json");
+
+    expect(first.statusCode).toBe(200);
+    expect(first.json()).toEqual({ openapi: "3.1.0" });
+    expect(second.body).toBe(first.body);
+    expect(buildDocument).toHaveBeenCalledTimes(1);
+    await app.close();
+  });
+
+  it("adds shared-cache headers and a strong ETag", async () => {
+    const app = createApp(() => ({ openapi: "3.1.0" }));
+
+    const response = await app.inject("/openapi.json");
+
+    expect(response.headers["cache-control"]).toBe(
+      "public, max-age=60, stale-while-revalidate=300",
+    );
+    expect(response.headers.etag).toMatch(/^"[a-f0-9]{64}"$/);
+    expect(response.headers["content-type"]).toContain("application/json");
+    await app.close();
+  });
+
+  it.each([
+    "strong",
+    "weak",
+    "wildcard",
+  ])("returns 304 for a matching %s validator", async (validator) => {
+    const app = createApp(() => ({ openapi: "3.1.0" }));
+    const first = await app.inject("/openapi.json");
+    const etag = first.headers.etag as string;
+    const ifNoneMatch =
+      validator === "strong" ? etag : validator === "weak" ? `W/${etag}` : "*";
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/openapi.json",
+      headers: { "if-none-match": ifNoneMatch },
+    });
+
+    expect(response.statusCode).toBe(304);
+    expect(response.body).toBe("");
+    await app.close();
+  });
+
+  it("rebuilds when the branding cache key changes", async () => {
+    let key = "Archestra:false";
+    const buildDocument = vi.fn(() => ({ key }));
+    const app = createApp(buildDocument, () => key);
+
+    const first = await app.inject("/openapi.json");
+    key = "Example:true";
+    const second = await app.inject("/openapi.json");
+
+    expect(first.json()).toEqual({ key: "Archestra:false" });
+    expect(second.json()).toEqual({ key: "Example:true" });
+    expect(buildDocument).toHaveBeenCalledTimes(2);
+    await app.close();
+  });
+});

--- a/platform/backend/src/openapi/cached-openapi-route.ts
+++ b/platform/backend/src/openapi/cached-openapi-route.ts
@@ -1,0 +1,62 @@
+import { createHash } from "node:crypto";
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+const CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
+
+type CachedOpenApiRouteOptions = {
+  buildDocument: () => unknown;
+  getCacheKey: () => string;
+};
+
+type CachedResponse = {
+  body: Buffer;
+  etag: string;
+  key: string;
+};
+
+const matchesEtag = (
+  header: string | string[] | undefined,
+  etag: string,
+): boolean => {
+  if (!header) return false;
+
+  const values = Array.isArray(header) ? header : [header];
+  return values.some((value) =>
+    value.split(",").some((candidate) => {
+      const normalized = candidate.trim();
+      return normalized === "*" || normalized.replace(/^W\//i, "") === etag;
+    }),
+  );
+};
+
+export const createCachedOpenApiRouteHandler = ({
+  buildDocument,
+  getCacheKey,
+}: CachedOpenApiRouteOptions) => {
+  let cached: CachedResponse | undefined;
+
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    const key = getCacheKey();
+    if (!cached || cached.key !== key) {
+      const serialized = JSON.stringify(buildDocument());
+      if (serialized === undefined) {
+        throw new Error("OpenAPI document cannot be serialized as JSON");
+      }
+      const body = Buffer.from(serialized);
+
+      cached = {
+        body,
+        etag: `"${createHash("sha256").update(body).digest("hex")}"`,
+        key,
+      };
+    }
+
+    reply.header("Cache-Control", CACHE_CONTROL).header("ETag", cached.etag);
+
+    if (matchesEtag(request.headers["if-none-match"], cached.etag)) {
+      return reply.code(304).send();
+    }
+
+    return reply.type("application/json; charset=utf-8").send(cached.body);
+  };
+};

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -86,6 +86,7 @@ import { classifyErrorForTracking } from "@/observability/error-tracking-policy"
 import { reportAbnormalPreviousTermination } from "@/observability/previous-termination-report";
 // biome-ignore lint/style/noRestrictedImports: dual-licensed, self-guards on the license flag
 import { rumExporter } from "@/observability/rum/exporter.ee";
+import { createCachedOpenApiRouteHandler } from "@/openapi/cached-openapi-route";
 import { enrichOpenApiWithRbac } from "@/openapi/enrich-openapi-with-rbac";
 import { activeChatRunService } from "@/services/active-chat-run";
 import { warmRenderRuntime } from "@/services/apps/app-recording-render-runtime";
@@ -1480,8 +1481,12 @@ const startWebServer = async () => {
     await registerSwaggerPlugin(fastify);
 
     // Register routes
-    fastify.get("/openapi.json", async () =>
-      enrichOpenApiWithRbac(fastify.swagger()),
+    fastify.get(
+      "/openapi.json",
+      createCachedOpenApiRouteHandler({
+        buildDocument: () => enrichOpenApiWithRbac(fastify.swagger()),
+        getCacheKey: () => JSON.stringify(archestraMcpBranding.identity),
+      }),
     );
 
     if (enableE2eTestEndpoints) {

--- a/platform/backend/src/standalone-scripts/calculate-node-max-old-space-size.test.ts
+++ b/platform/backend/src/standalone-scripts/calculate-node-max-old-space-size.test.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const script = fileURLToPath(
+  new URL(
+    "../../scripts/calculate-node-max-old-space-size.sh",
+    import.meta.url,
+  ),
+);
+
+const run = (env: Record<string, string> = {}) =>
+  spawnSync(script, [], {
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH ?? "/usr/bin:/bin",
+      ...env,
+    },
+  });
+
+describe("calculate-node-max-old-space-size.sh", () => {
+  it.each([
+    ["3072", "1843"],
+    ["2048", "1228"],
+  ])("uses 60%% of a %s MiB memory limit", (limit, expected) => {
+    const result = run({ ARCHESTRA_NODE_MEMORY_LIMIT_MIB: limit });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(expected);
+  });
+
+  it("falls back to 75% of the memory request", () => {
+    const result = run({ ARCHESTRA_NODE_MEMORY_REQUEST_MIB: "2048" });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("1536");
+  });
+
+  it("prefers an explicit override and supports disabling with zero", () => {
+    const overridden = run({
+      ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB: "1700",
+      ARCHESTRA_NODE_MEMORY_LIMIT_MIB: "3072",
+    });
+    const disabled = run({
+      ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB: "0",
+      ARCHESTRA_NODE_MEMORY_LIMIT_MIB: "3072",
+    });
+
+    expect(overridden.stdout.trim()).toBe("1700");
+    expect(disabled.stdout).toBe("");
+  });
+
+  it.each([
+    "--max-old-space-size=1600",
+    "--max_old_space_size 1600",
+  ])("preserves an existing NODE_OPTIONS limit: %s", (nodeOptions) => {
+    const result = run({
+      NODE_OPTIONS: nodeOptions,
+      ARCHESTRA_NODE_MEMORY_LIMIT_MIB: "3072",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+
+  it("fails fast for an invalid explicit override", () => {
+    const result = run({ ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB: "large" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("must be a non-negative integer");
+  });
+
+  it("ignores malformed discovered values", () => {
+    const result = run({
+      ARCHESTRA_NODE_MEMORY_LIMIT_MIB: "not-a-number",
+      ARCHESTRA_NODE_MEMORY_REQUEST_MIB: "also-invalid",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+});

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -278,6 +278,33 @@ genuinely missing key loudly at startup.
 {{- end }}
 
 {{/*
+Expose declared memory resources in MiB so the production Node launcher can
+derive a V8 old-space ceiling. Only emit fields that are explicitly configured:
+resourceFieldRef otherwise falls back to node allocatable memory.
+*/}}
+{{- define "archestra-platform.nodeMemoryEnv" -}}
+{{- $resources := .resources | default dict -}}
+{{- $requests := get $resources "requests" | default dict -}}
+{{- $limits := get $resources "limits" | default dict -}}
+{{- if get $requests "memory" }}
+- name: ARCHESTRA_NODE_MEMORY_REQUEST_MIB
+  valueFrom:
+    resourceFieldRef:
+      containerName: {{ .containerName }}
+      resource: requests.memory
+      divisor: 1Mi
+{{- end }}
+{{- if get $limits "memory" }}
+- name: ARCHESTRA_NODE_MEMORY_LIMIT_MIB
+  valueFrom:
+    resourceFieldRef:
+      containerName: {{ .containerName }}
+      resource: limits.memory
+      divisor: 1Mi
+{{- end }}
+{{- end }}
+
+{{/*
 Auth secret name for the Archestra Platform
 */}}
 {{- define "archestra-platform.authSecretName" -}}

--- a/platform/helm/archestra/templates/archestra-platform.yaml
+++ b/platform/helm/archestra/templates/archestra-platform.yaml
@@ -148,6 +148,7 @@ spec:
             {{- end }}
           env:
             {{- include "archestra-platform.env" . | nindent 12 }}
+            {{- include "archestra-platform.nodeMemoryEnv" (dict "resources" .Values.archestra.resources "containerName" .Chart.Name) | nindent 12 }}
             {{- if .Values.archestra.worker.enabled }}
             - name: ARCHESTRA_PROCESS_TYPE
               value: "web"

--- a/platform/helm/archestra/templates/archestra-renderer.yaml
+++ b/platform/helm/archestra/templates/archestra-renderer.yaml
@@ -14,6 +14,7 @@ neither this Deployment nor the URL.
 */}}
 {{- if and .Values.archestra.renderer.enabled (ne (include "archestra-platform.maintenanceModeEnabled" .) "true") }}
 {{- $rendererPodAnnotations := mergeOverwrite (dict) (.Values.archestra.podAnnotations | default dict) (.Values.archestra.renderer.podAnnotations | default dict) }}
+{{- $rendererResources := .Values.archestra.renderer.resources | default .Values.archestra.resources }}
 {{- if hasKey $rendererPodAnnotations "prometheus.io/scrape" }}
 {{- $rendererPodAnnotations = mergeOverwrite $rendererPodAnnotations (dict "prometheus.io/port" "9000" "prometheus.io/path" "/metrics") }}
 {{- end }}
@@ -82,13 +83,14 @@ spec:
               protocol: TCP
           env:
             {{- include "archestra-platform.env" . | nindent 12 }}
+            {{- include "archestra-platform.nodeMemoryEnv" (dict "resources" $rendererResources "containerName" (printf "%s-renderer" .Chart.Name)) | nindent 12 }}
             - name: ARCHESTRA_PROCESS_TYPE
               value: "renderer"
           {{- with .Values.archestra.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (.Values.archestra.renderer.resources | default .Values.archestra.resources) }}
+          {{- with $rendererResources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/platform/helm/archestra/templates/archestra-worker.yaml
+++ b/platform/helm/archestra/templates/archestra-worker.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.archestra.worker.enabled (ne (include "archestra-platform.maintenanceModeEnabled" .) "true") }}
 {{- $workerPodAnnotations := mergeOverwrite (dict) (.Values.archestra.podAnnotations | default dict) (.Values.archestra.worker.podAnnotations | default dict) }}
+{{- $workerResources := .Values.archestra.worker.resources | default .Values.archestra.resources }}
 {{- if hasKey $workerPodAnnotations "prometheus.io/scrape" }}
 {{- $workerPodAnnotations = mergeOverwrite $workerPodAnnotations (dict "prometheus.io/port" "9000" "prometheus.io/path" "/metrics") }}
 {{- end }}
@@ -51,13 +52,14 @@ spec:
               protocol: TCP
           env:
             {{- include "archestra-platform.env" . | nindent 12 }}
+            {{- include "archestra-platform.nodeMemoryEnv" (dict "resources" $workerResources "containerName" (printf "%s-worker" .Chart.Name)) | nindent 12 }}
             - name: ARCHESTRA_PROCESS_TYPE
               value: "worker"
           {{- with .Values.archestra.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (.Values.archestra.worker.resources | default .Values.archestra.resources) }}
+          {{- with $workerResources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -465,6 +465,18 @@ tests:
               value: "true"
             - name: ARCHESTRA_CODE_RUNTIME_ENABLED
               value: "true"
+            - name: ARCHESTRA_NODE_MEMORY_REQUEST_MIB
+              valueFrom:
+                resourceFieldRef:
+                  containerName: archestra-platform
+                  resource: requests.memory
+                  divisor: 1Mi
+            - name: ARCHESTRA_NODE_MEMORY_LIMIT_MIB
+              valueFrom:
+                resourceFieldRef:
+                  containerName: archestra-platform
+                  resource: limits.memory
+                  divisor: 1Mi
             - name: ARCHESTRA_PROCESS_TYPE
               value: "web"
 
@@ -1686,6 +1698,24 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: "3Gi"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_NODE_MEMORY_REQUEST_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: archestra-platform
+                resource: requests.memory
+                divisor: 1Mi
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_NODE_MEMORY_LIMIT_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: archestra-platform
+                resource: limits.memory
+                divisor: 1Mi
 
   - it: should allow overriding resource requests and limits
     documentIndex: 1

--- a/platform/helm/archestra/tests/archestra_renderer_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_renderer_deployment_test.yaml
@@ -1,0 +1,35 @@
+suite: archestra renderer deployment
+templates:
+  - archestra-renderer.yaml
+values:
+  - ../ci/test-values.yaml
+tests:
+  - it: renderer deployment exposes its memory budget to the Node launcher
+    documentIndex: 1
+    set:
+      archestra.renderer.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "2Gi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "8Gi"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_NODE_MEMORY_REQUEST_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: archestra-platform-renderer
+                resource: requests.memory
+                divisor: 1Mi
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_NODE_MEMORY_LIMIT_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: archestra-platform-renderer
+                resource: limits.memory
+                divisor: 1Mi

--- a/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
@@ -23,6 +23,24 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: "2Gi"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_NODE_MEMORY_REQUEST_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: archestra-platform-worker
+                resource: requests.memory
+                divisor: 1Mi
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_NODE_MEMORY_LIMIT_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: archestra-platform-worker
+                resource: limits.memory
+                divisor: 1Mi
 
   - it: worker deployment uses percentage-based rolling update defaults
     asserts:


### PR DESCRIPTION
Originating task: [T-1033 — investigate staging backend connection stalls](https://slack.com/archives/C0B2AGC0AFQ/p1786028428325379?thread_ts=1786028363.235449&cid=C0B2AGC0AFQ)

## Summary

- cache the fully serialized `/openapi.json` response as a `Buffer`, keyed by branding identity
- add a strong ETag, conditional `304` handling, and shared-cache headers
- expose configured web, worker, and renderer memory requests/limits through the Kubernetes Downward API
- derive a V8 old-space ceiling before launching Node so garbage collection starts before the container OOM boundary
- preserve operator control through `NODE_OPTIONS` and `ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB`

## Root cause and reproduced mechanism

Staging had four web pods repeatedly OOMKilled at the 3 GiB container limit. The kernel OOM event at `2026-08-06T14:58:21Z` killed the backend process with approximately 2,976,628 KiB anonymous RSS plus 74,984 KiB file RSS.

`/openapi.json` was public, approximately 4.2 MB, uncached, and rebuilt/enriched/serialized for every request. Heap sampling during VM reproduction attributed the dominant allocations to OpenAPI RBAC enrichment, object entry traversal, Fastify serialization, and socket writes.

Retained access logs do not identify the original production caller, so this is a high-confidence reproduced OOM mechanism rather than proof of the historical caller.

## Runtime memory policy

The production launcher now chooses the old-space ceiling in this order:

1. preserve an existing `--max-old-space-size` in `NODE_OPTIONS`
2. use `ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB` when explicitly configured (`0` disables automatic calculation)
3. use 60% of the Kubernetes container memory limit
4. otherwise use 75% of the configured memory request

The 60% limit ratio intentionally leaves room for V8 young-generation memory, Buffers and other native/external allocations, thread stacks, and other processes in the container. With the current defaults this gives:

- web: 3,072 MiB limit -> 1,843 MiB old-space
- worker: 2,048 MiB limit -> 1,228 MiB old-space

The Downward API fields are emitted only when the corresponding resource is explicitly configured, avoiding Kubernetes' node-allocatable fallback for omitted fields.

References: [Node `--max-old-space-size`](https://nodejs.org/download/release/v22.17.0/docs/api/cli.html#--max-old-space-sizesize-in-mib), [Kubernetes Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/), [Kubernetes container resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).

## Final VM saturation report

Identical workload against `/openapi.json`: 200 requests at concurrency 40, zero errors in both runs.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Wall time | 30.716 s | 0.546 s | 56.3x faster |
| Throughput | 6.5 req/s | 366.1 req/s | 56.3x higher |
| p50 latency | 6,308 ms | 69 ms | -98.9% |
| p95 latency | 11,240 ms | 275 ms | -97.6% |
| p99 latency | 13,096 ms | 541 ms | -95.9% |
| Sampled peak RSS | 2,980,928 KiB | 989,192 KiB | -66.8% |
| Errors | 0 | 0 | unchanged |

The after result closely matches the cached-static control. A sustained after test of 2,000 requests at concurrency 40 completed in 4.773 s at 419 req/s, with p50/p95/p99 of 86/121/291 ms, zero errors, and only a 344 KiB sampled RSS increase. Backend health remained `200` after saturation.

Response behavior was also verified directly:

- `200` response, 4,216,117-byte JSON body
- `Cache-Control: public, max-age=60, stale-while-revalidate=300`
- strong SHA-256 ETag
- matching `If-None-Match` returns `304` with a zero-byte body

## Validation

- full backend `check:ci`: passed
  - type-check: passed
  - Vitest: 870/870 files passed; 14,500 tests passed; 62 skipped
  - Knip: passed
  - Biome: passed (2,071 files checked)
  - migration journal/lint: passed
  - sandbox-base synchronization: passed
- post-rebase focused backend tests: 3 files, 20/20 tests passed
- Helm unit tests: 15 suites, 410/410 tests passed
- Helm lint and package: passed
- shell syntax and `git diff --check`: passed

