### PR TITLE
fix(netpol): point the unenforced warning at what it exposes

### DIFF
--- a/platform/frontend/src/components/sidebar-warnings-accordion.test.tsx
+++ b/platform/frontend/src/components/sidebar-warnings-accordion.test.tsx
@@ -138,7 +138,9 @@ describe("SidebarWarningsAccordion network policy warning", () => {
     expect(vi.mocked(useK8sCapabilities)).toHaveBeenCalledWith(false);
   });
 
-  it("links to the network egress policies docs in a new tab", () => {
+  // The SSRF section, not the policy model: it names what an unenforced
+  // cluster exposes and states the enforcing-dataplane prerequisite.
+  it("links to the SSRF protection docs in a new tab", () => {
     setup({ enforcementStatus: "verified-not-enforced" });
 
     const link = screen.getByRole("link", {
@@ -146,7 +148,9 @@ describe("SidebarWarningsAccordion network policy warning", () => {
     });
     expect(link).toHaveAttribute(
       "href",
-      expect.stringContaining("platform-environments#network-egress-policies"),
+      expect.stringContaining(
+        "platform-deployment#ssrf-protection-for-mcp-server-pods",
+      ),
     );
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));

--- a/platform/frontend/src/components/sidebar-warnings-accordion.test.tsx
+++ b/platform/frontend/src/components/sidebar-warnings-accordion.test.tsx
@@ -138,8 +138,6 @@ describe("SidebarWarningsAccordion network policy warning", () => {
     expect(vi.mocked(useK8sCapabilities)).toHaveBeenCalledWith(false);
   });
 
-  // The SSRF section, not the policy model: it names what an unenforced
-  // cluster exposes and states the enforcing-dataplane prerequisite.
   it("links to the SSRF protection docs in a new tab", () => {
     setup({ enforcementStatus: "verified-not-enforced" });
 

--- a/platform/frontend/src/components/sidebar-warnings-accordion.tsx
+++ b/platform/frontend/src/components/sidebar-warnings-accordion.tsx
@@ -70,11 +70,6 @@ export function SidebarWarningsAccordion() {
   const showNetworkPolicyWarning =
     capabilities?.networkPolicy?.enforcementStatus === "verified-not-enforced";
 
-  // The SSRF section rather than the policy model: someone who just learned
-  // enforcement is off needs what is now reachable — cloud metadata endpoints,
-  // private cluster ranges — not how to configure egress modes. It also states
-  // the enforcing-dataplane prerequisite, which is this reader's situation.
-  //
   // Null under full white-labeling, where the environments screen carries the
   // same explanation and stays reachable.
   const networkPolicyDocsUrl = getFrontendDocsUrl(

--- a/platform/frontend/src/components/sidebar-warnings-accordion.tsx
+++ b/platform/frontend/src/components/sidebar-warnings-accordion.tsx
@@ -70,11 +70,16 @@ export function SidebarWarningsAccordion() {
   const showNetworkPolicyWarning =
     capabilities?.networkPolicy?.enforcementStatus === "verified-not-enforced";
 
+  // The SSRF section rather than the policy model: someone who just learned
+  // enforcement is off needs what is now reachable — cloud metadata endpoints,
+  // private cluster ranges — not how to configure egress modes. It also states
+  // the enforcing-dataplane prerequisite, which is this reader's situation.
+  //
   // Null under full white-labeling, where the environments screen carries the
   // same explanation and stays reachable.
   const networkPolicyDocsUrl = getFrontendDocsUrl(
-    DocsPage.PlatformEnvironments,
-    "network-egress-policies",
+    DocsPage.PlatformDeployment,
+    "ssrf-protection-for-mcp-server-pods",
   );
 
   const warnings = [

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -556,7 +556,7 @@ args:
       says it without depending on which line Helm printed first.
     */}}
     if [ "$result" = blocked ]; then
-      echo "[archestra] ⚠️ ⚠️ ⚠️  NETWORK POLICY CHECK INCONCLUSIVE  ⚠️ ⚠️ ⚠️  Could not reach {{ .host }}:9000, so enforcement was never measured — environment egress rules (MCP servers, code sandboxes) may be accepted and then silently ignored. Re-run once the platform is up to get a verdict"
+      echo "[archestra] ⚠️ ⚠️ ⚠️  NETWORK POLICY CHECK INCONCLUSIVE  ⚠️ ⚠️ ⚠️  Could not reach {{ .host }}:9000, so enforcement was never measured — environment egress rules (MCP servers, code sandboxes) may be accepted and then silently ignored, leaving pods able to reach cloud metadata endpoints and private cluster ranges. Re-run once the platform is up to get a verdict — see https://archestra.ai/docs/platform-deployment#ssrf-protection-for-mcp-server-pods"
     fi
     exit 0
 {{- end }}

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -613,7 +613,7 @@ args:
       renders on 3 and reaches 4 as a row of escapes. Emoji survive both.
     */}}
     if [ "$result" = reachable ]; then
-      echo "[archestra] 🚨 🚨 🚨  NETWORK POLICY NOT ENFORCED  🚨 🚨 🚨  Environment egress rules (MCP servers, code sandboxes) are accepted and then silently ignored — see https://archestra.ai/docs/platform-environments#network-egress-policies"
+      echo "[archestra] 🚨 🚨 🚨  NETWORK POLICY NOT ENFORCED  🚨 🚨 🚨  Environment egress rules (MCP servers, code sandboxes) are accepted and then silently ignored, so pods reach cloud metadata endpoints and private cluster ranges — see https://archestra.ai/docs/platform-deployment#ssrf-protection-for-mcp-server-pods"
     fi
     exit 0
 {{- end }}

--- a/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
+++ b/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
@@ -258,7 +258,7 @@ tests:
         documentIndex: 2
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: 'https://archestra\.ai/docs/platform-environments#network-egress-policies'
+          pattern: 'https://archestra\.ai/docs/platform-deployment#ssrf-protection-for-mcp-server-pods'
         documentIndex: 2
 
   # Helm 4 routes hook output through its structured logger, so a stacked banner

--- a/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
+++ b/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
@@ -308,6 +308,12 @@ tests:
           path: spec.containers[0].args[0]
           pattern: 'NETWORK POLICY CHECK INCONCLUSIVE'
         documentIndex: 1
+      # Unmeasured leaves the same exposure open as unenforced, so this arm
+      # carries the same reference rather than only naming the failed check.
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: 'https://archestra\.ai/docs/platform-deployment#ssrf-protection-for-mcp-server-pods'
+        documentIndex: 1
       # Never tells the operator to discount a result. With no all-clear from the
       # treatment arm, the only line that can accompany this one is the warning,
       # and that is the direction it is safe to believe.


### PR DESCRIPTION
## Summary

Both "network policy not enforced" warnings — the one Helm prints on install and upgrade, and the one in the sidebar — linked the network egress policy section. That section teaches the policy model: the three egress modes, the provider support matrix, domain presets. It is written for someone about to configure a policy.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>