### PR TITLE
docs(mcp): label the built-in tool group Code Sandbox

### DIFF
--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -213,7 +213,7 @@ Required RBAC permission: `agent:update`
 
 Required RBAC permission: `agent:read`
 
-Availability: Served only when the code runtime is enabled (the same prerequisite as the [Skill Sandbox](#skill-sandbox) tools), because a hook executes in the conversation sandbox.
+Availability: Served only when the code runtime is enabled (the same prerequisite as the [Code Sandbox](#code-sandbox) tools), because a hook executes in the conversation sandbox.
 
 ##### Input
 
@@ -240,7 +240,7 @@ Availability: Served only when the code runtime is enabled (the same prerequisit
 
 Required RBAC permission: `agent:update`
 
-Availability: Served only when the code runtime is enabled (the same prerequisite as the [Skill Sandbox](#skill-sandbox) tools), because a hook executes in the conversation sandbox.
+Availability: Served only when the code runtime is enabled (the same prerequisite as the [Code Sandbox](#code-sandbox) tools), because a hook executes in the conversation sandbox.
 
 ##### Input
 
@@ -272,7 +272,7 @@ Availability: Served only when the code runtime is enabled (the same prerequisit
 
 Required RBAC permission: `agent:update`
 
-Availability: Served only when the code runtime is enabled (the same prerequisite as the [Skill Sandbox](#skill-sandbox) tools), because a hook executes in the conversation sandbox.
+Availability: Served only when the code runtime is enabled (the same prerequisite as the [Code Sandbox](#code-sandbox) tools), because a hook executes in the conversation sandbox.
 
 ##### Input
 
@@ -304,7 +304,7 @@ Availability: Served only when the code runtime is enabled (the same prerequisit
 
 Required RBAC permission: `agent:update`
 
-Availability: Served only when the code runtime is enabled (the same prerequisite as the [Skill Sandbox](#skill-sandbox) tools), because a hook executes in the conversation sandbox.
+Availability: Served only when the code runtime is enabled (the same prerequisite as the [Code Sandbox](#code-sandbox) tools), because a hook executes in the conversation sandbox.
 
 ##### Input
 
@@ -2190,9 +2190,9 @@ Required RBAC permission: `skill:update`
 | `replacementContent` | `string` | No | The complete new content of the target, replacing it outright with no old_str matching — use it for a small file or a full rewrite. Prefer edits for the SKILL.md body so you don't resend the whole thing. Pass either edits or replacementContent, never both. |
 
 
-### Skill Sandbox
+### Code Sandbox
 
-These tools are served only when the code runtime is enabled — set `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`, or `ARCHESTRA_CODE_RUNTIME_ENABLED=true` together with an orchestrator kubeconfig. Without it they do not appear in `tools/list`. See [Code Sandbox](/docs/platform-code-sandbox).
+These tools are served only when the code runtime is enabled — set `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`, or `ARCHESTRA_CODE_RUNTIME_ENABLED=true` together with an orchestrator kubeconfig. Without it they do not appear in `tools/list`. The [Code Sandbox](/docs/platform-code-sandbox) page covers what the runtime is and how an agent uses it.
 
 | Tool | Description | Required RBAC Permission |
 |------|-------------|--------------------------|

--- a/platform/backend/src/standalone-scripts/codegen-archestra-mcp-server-docs.ts
+++ b/platform/backend/src/standalone-scripts/codegen-archestra-mcp-server-docs.ts
@@ -79,11 +79,11 @@ const toolAccessNotes: Partial<Record<ArchestraToolShortName, string>> = {
  */
 const groupAvailabilityNotes: Partial<Record<ArchestraToolGroupId, string>> = {
   skill_sandbox:
-    "These tools are served only when the code runtime is enabled — set `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`, or `ARCHESTRA_CODE_RUNTIME_ENABLED=true` together with an orchestrator kubeconfig. Without it they do not appear in `tools/list`. See [Code Sandbox](/docs/platform-code-sandbox).",
+    "These tools are served only when the code runtime is enabled — set `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`, or `ARCHESTRA_CODE_RUNTIME_ENABLED=true` together with an orchestrator kubeconfig. Without it they do not appear in `tools/list`. The [Code Sandbox](/docs/platform-code-sandbox) page covers what the runtime is and how an agent uses it.",
 };
 
 const HOOK_RUNTIME_NOTE =
-  "Served only when the code runtime is enabled (the same prerequisite as the [Skill Sandbox](#skill-sandbox) tools), because a hook executes in the conversation sandbox.";
+  "Served only when the code runtime is enabled (the same prerequisite as the [Code Sandbox](#code-sandbox) tools), because a hook executes in the conversation sandbox.";
 
 /**
  * Availability notes for individual tools whose group is otherwise

--- a/platform/shared/archestra-mcp-server.ts
+++ b/platform/shared/archestra-mcp-server.ts
@@ -331,7 +331,9 @@ export const ARCHESTRA_TOOL_GROUPS = [
   { id: "chat", label: "Chat" },
   { id: "meta", label: "Meta" },
   { id: "skills", label: "Skills" },
-  { id: "skill_sandbox", label: "Skill Sandbox" },
+  // `id` keeps the original spelling so the taxonomy keys stay stable; the
+  // label follows the feature's user-facing name (docs page "Code Sandbox").
+  { id: "skill_sandbox", label: "Code Sandbox" },
   { id: "apps", label: "Apps" },
 ] as const;
 


### PR DESCRIPTION
## Summary

The built-in tool group rendered as "Skill Sandbox" is named for where the feature started — a sandbox built to run an Agent Skill's bundled scripts — but that stopped describing it. The enablement flag is `ARCHESTRA_CODE_RUNTIME_ENABLED`, the page users are sent to is titled "Code Sandbox" ("A private Linux container where an agent runs code during a chat"), and the sandbox now backs agent code execution generally rather than skills specifically.

The mismatch misdirects readers about what the group contains. Six of its nine tools — `search_files`, `read_file`, `save_file`, `edit_file`, `delete_file`, `copy_file` — are the persistent file store ("My Files" / Projects); they never touch the Dagger runtime and have nothing to do with skills, and `copy_file` exists to exchange files with an open MCP App. They sit in this group because they share an enablement flag, which is a deployment coupling rather than a domain one. Someone reading "Skill Sandbox" and finding `delete_file` there has no way to tell which feature it belongs to.

The group `id` stays `skill_sandbox`, so the taxonomy keys, the tool-to-group mapping, and the `/api/skill-sandbox/*` routes are untouched. Only the display label changes, which both the generated tools reference and the agent tool picker read from the same constant — the picker's section heading and its "Select all … tools" / "Clear … tools" controls pick it up automatically.

The section anchor moves with the heading, so the four hook tools' cross-reference now points at `#code-sandbox`. That anchor first shipped earlier today, so nothing external depends on the old one.

## Not addressed

Splitting the persistent-file tools into their own group is the more complete fix — sharing a feature flag is a weak reason to share a section. That changes how the tool picker groups things, so it belongs in its own change rather than riding along with a label rename.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>