### PR TITLE
feat(projects): expose project context to MCP clients

### DIFF
--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -1937,6 +1937,8 @@ Required RBAC permission: `knowledgeSource:update`
 | `todo_write` | Write todos to the current conversation. | None (no additional RBAC permission required) |
 | `create_project_from_conversation` | Turn the current chat into a project. | `project:create` |
 | `set_project_share` | Change who can see a project: the whole organization ("organization"), specific teams ("team"), or only the owner ("none"). | `project:update` † |
+| `list_projects` | List the projects the caller can reach — the ones they own plus those shared with them. | `project:read` † |
+| `get_project` | Read one project's context in a single call: its metadata, its instructions (the `instructions.md` that steers every chat in the project), and the list of files it owns. | `project:read` † |
 
 † This tool enforces an additional access requirement beyond its RBAC permission — see its details below.
 
@@ -2003,6 +2005,65 @@ Additional access requirement: Beyond `project:update`, the caller must own the 
 | `project_id` | `string` | Yes | The affected project's id. |
 | `project_name` | `string` | Yes | The affected project's name. |
 | `visibility` | `"organization" \| "team" \| "none"` | Yes | The project's sharing after the update. |
+
+#### list_projects
+
+Required RBAC permission: `project:read`
+
+Additional access requirement: Returns only projects the caller owns or that are shared with them. `project:admin` oversight of other members' projects does **not** extend to this tool.
+
+##### Input
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | `string` | No | Case-insensitive substring matched against the project name and description. Omit to list everything the caller can reach. |
+
+##### Output
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `projects` | `object[]` | Yes | Projects the caller can reach. |
+| `projects[].id` | `string` | Yes | The project's id — pass it to get_project. |
+| `projects[].name` | `string` | Yes | The project's name. |
+| `projects[].description` | `string \| null` | Yes | The project's description. |
+| `projects[].visibility` | `"organization" \| "team" \| "user" \| null` | Yes | Who the project is shared with; null = owner-only. |
+| `projects[].viewer_role` | `"owner" \| "shared" \| "admin"` | Yes | The caller's relationship to the project. |
+| `projects[].owner_name` | `string \| null` | Yes | Display name of the owner. |
+| `projects[].conversation_count` | `integer` | Yes | How many chats live in the project. |
+| `projects[].created_at` | `string` | Yes | ISO 8601 creation timestamp. |
+
+#### get_project
+
+Required RBAC permission: `project:read`
+
+Additional access requirement: Readable only for projects the caller owns or that are shared with them. `project:admin` oversight of other members' projects does **not** extend to this tool.
+
+##### Input
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_id` | `string` | Yes | Id of the project to read (from list_projects). |
+
+##### Output
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes | The project's id — pass it to get_project. |
+| `name` | `string` | Yes | The project's name. |
+| `description` | `string \| null` | Yes | The project's description. |
+| `visibility` | `"organization" \| "team" \| "user" \| null` | Yes | Who the project is shared with; null = owner-only. |
+| `viewer_role` | `"owner" \| "shared" \| "admin"` | Yes | The caller's relationship to the project. |
+| `owner_name` | `string \| null` | Yes | Display name of the owner. |
+| `conversation_count` | `integer` | Yes | How many chats live in the project. |
+| `created_at` | `string` | Yes | ISO 8601 creation timestamp. |
+| `instructions` | `string` | Yes | The project's instructions markdown; empty when never saved. Truncated when `instructions_truncated` is true. |
+| `instructions_truncated` | `boolean` | Yes | Whether `instructions` was cut short at the inline limit. |
+| `files` | `object[]` | Yes | Files the project owns. Read one with read_file, passing the same project_id and this `ref`. |
+| `files[].id` | `string` | Yes | The file's id. |
+| `files[].ref` | `string` | Yes | Stable reference to pass to read_file. |
+| `files[].filename` | `string` | Yes | The file's name. |
+| `files[].mime_type` | `string` | Yes | The file's MIME type. |
+| `files[].size_bytes` | `integer` | Yes | Size in bytes. |
 
 ### Meta
 
@@ -2241,6 +2302,7 @@ Required RBAC permission: `file:manage`
 |-----------|------|----------|-------------|
 | `query` | `string` | No | Case-insensitive substring matched against filenames only. Omit it (or pass empty) to list the files (the first 200). |
 | `scope` | `"chat" \| "app"` | No | "chat" (default) = this chat's files; "app" = the files of the app the user has open, which is how you find what the app has produced before copying one out with copy_file. |
+| `project_id` | `string` | No | Read this project's files instead of the current chat's — how you reach project files when working outside a chat (get_project returns the id). Only projects you own or that are shared with you can be read. Cannot be used from a chat that already belongs to a different project, nor combined with scope: "app". |
 
 ##### Output
 
@@ -2266,6 +2328,7 @@ Required RBAC permission: `file:manage`
 | `filename` | `string` | No | Filename to read instead of `id`; rejected as ambiguous if more than one file shares the name. |
 | `offset` | `integer` | No | 1-based line number to start reading from. Defaults to 1. |
 | `limit` | `integer` | No | Maximum number of lines to read. Defaults to 2000. |
+| `project_id` | `string` | No | Read this project's files instead of the current chat's — how you reach project files when working outside a chat (get_project returns the id). Only projects you own or that are shared with you can be read. Cannot be used from a chat that already belongs to a different project, nor combined with scope: "app". |
 
 ##### Output
 

--- a/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
+++ b/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
@@ -400,11 +400,11 @@ exports[`skill and sandbox tool text > archestra__load_skill 1`] = `
 
 exports[`skill and sandbox tool text > archestra__read_file 1`] = `
 {
-  "description": "Read a persistent file directly, without copying it into the sandbox. Text files come back as numbered lines; images (PNG, JPEG, WebP, GIF) are returned inline so you can view them. Identify the file by \`id\` (the \`id\` or \`ref\` from search_files / save_file) or by \`filename\`. Page large text files with \`offset\`/\`limit\`. For other binary types, copy the file into the sandbox with upload_file and inspect it with run_command.",
+  "description": "Read a persistent file directly, without copying it into the sandbox. Text files come back as numbered lines; images (PNG, JPEG, WebP, GIF) are returned inline so you can view them. Identify the file by \`id\` (the \`id\` or \`ref\` from search_files / save_file) or by \`filename\`. Page large text files with \`offset\`/\`limit\`. Pass project_id to read a project's file — including its instructions.md — which is how you reach them outside a chat. For other binary types, copy the file into the sandbox with upload_file and inspect it with run_command.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Read a persistent file directly, without copying it into the sandbox. Text files come back as numbered lines (\`<n>\\t<line>\`); images (PNG, JPEG, WebP, GIF) are returned inline so you can view them. Identify the file by \`id\` (the \`id\` or \`ref\` from search_files / save_file) or by \`filename\`. Page large text files with \`offset\`/\`limit\`. For other binary types (PDF, archives, …), copy the file into the sandbox with upload_file + run_command.",
+    "description": "Read a persistent file directly, without copying it into the sandbox. Text files come back as numbered lines (\`<n>\\t<line>\`); images (PNG, JPEG, WebP, GIF) are returned inline so you can view them. Identify the file by \`id\` (the \`id\` or \`ref\` from search_files / save_file) or by \`filename\`. Page large text files with \`offset\`/\`limit\`. Pass project_id to read a project's file (e.g. its instructions.md) instead of the chat's. For other binary types (PDF, archives, …), copy the file into the sandbox with upload_file + run_command.",
     "properties": {
       "filename": {
         "description": "Filename to read instead of \`id\`; rejected as ambiguous if more than one file shares the name.",
@@ -427,6 +427,10 @@ exports[`skill and sandbox tool text > archestra__read_file 1`] = `
         "maximum": 9007199254740991,
         "minimum": 1,
         "type": "integer",
+      },
+      "project_id": {
+        "description": "Read this project's files instead of the current chat's — how you reach project files when working outside a chat (get_project returns the id). Only projects you own or that are shared with you can be read. Cannot be used from a chat that already belongs to a different project, nor combined with scope: "app".",
+        "type": "string",
       },
     },
     "type": "object",
@@ -558,12 +562,16 @@ exports[`skill and sandbox tool text > archestra__save_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__search_files 1`] = `
 {
-  "description": "List or search the conversation's persistent files. The query is a case-insensitive substring matched against filenames only, not contents — omit it (or pass empty) to list the files (the first 200; narrow with a substring if there are more). Returns metadata only — each result carries a stable \`ref\` you pass to read_file, edit_file, or delete_file, or to upload_file to copy the file into the sandbox. Pass scope: "app" to list the files of the app the user has open instead — the only way to see what an app holds, and the discovery step before copying one of its files out with copy_file.",
+  "description": "List or search the conversation's persistent files. The query is a case-insensitive substring matched against filenames only, not contents — omit it (or pass empty) to list the files (the first 200; narrow with a substring if there are more). Returns metadata only — each result carries a stable \`ref\` you pass to read_file, edit_file, or delete_file, or to upload_file to copy the file into the sandbox. Pass scope: "app" to list the files of the app the user has open instead — the only way to see what an app holds, and the discovery step before copying one of its files out with copy_file. Pass project_id to list a project's files instead, which is how you reach them outside a chat.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "List or search persistent files by filename substring; omit the query to list them (the first 200). Filenames only, not contents. Lists this chat's files, or the open app's files with scope: "app".",
+    "description": "List or search persistent files by filename substring; omit the query to list them (the first 200). Filenames only, not contents. Lists this chat's files, the open app's files with scope: "app", or a project's files with project_id.",
     "properties": {
+      "project_id": {
+        "description": "Read this project's files instead of the current chat's — how you reach project files when working outside a chat (get_project returns the id). Only projects you own or that are shared with you can be read. Cannot be used from a chat that already belongs to a different project, nor combined with scope: "app".",
+        "type": "string",
+      },
       "query": {
         "description": "Case-insensitive substring matched against filenames only. Omit it (or pass empty) to list the files (the first 200).",
         "type": "string",

--- a/platform/backend/src/archestra-mcp-server/index.ts
+++ b/platform/backend/src/archestra-mcp-server/index.ts
@@ -115,30 +115,58 @@ interface ArchestraValidationMeta {
   issues: Array<{ code: string; path: string }>;
 }
 
-const toolEntries: Partial<
+/**
+ * The aggregations below are built on FIRST USE, not at module scope.
+ *
+ * This module sits in an import cycle: a group module (e.g. `./sandbox`) pulls
+ * the `@/models` barrel, which reaches `models/agent.ts` →
+ * `clients/chat-mcp-client.ts` → back here. Whichever side is entered first
+ * leaves the other's exports uninitialized while it evaluates, so spreading the
+ * group modules at module scope made correctness depend on import order: any
+ * entrypoint that reached a group module before this one (a test importing
+ * `./sandbox` directly, for instance) got `undefined` here and threw
+ * "tools is not iterable".
+ *
+ * Deferring to first call removes the eval-time dependency entirely — by the
+ * time anything asks for a tool, every group module has finished loading. Each
+ * result is memoized, so callers still see one stable array/object identity.
+ */
+
+let toolEntriesCache:
+  | Partial<Record<ArchestraToolFullName, ArchestraRuntimeToolEntry>>
+  | undefined;
+
+function getToolEntries(): Partial<
   Record<ArchestraToolFullName, ArchestraRuntimeToolEntry>
-> = {
-  ...identityToolEntries,
-  ...agentToolEntries,
-  ...hookToolEntries,
-  ...llmProxyToolEntries,
-  ...mcpGatewayToolEntries,
-  ...mcpServerToolEntries,
-  ...teamToolEntries,
-  ...limitToolEntries,
-  ...policyToolEntries,
-  ...toolAssignmentToolEntries,
-  ...knowledgeManagementToolEntries,
-  ...chatToolEntries,
-  ...projectToolEntries,
-  ...searchToolEntries,
-  ...runToolEntries,
-  ...skillToolEntries,
-  ...sandboxToolEntries,
-  ...appToolEntries,
-  ...appDataToolEntries,
-  ...appLlmToolEntries,
-};
+> {
+  if (!toolEntriesCache) {
+    toolEntriesCache = {
+      ...identityToolEntries,
+      ...agentToolEntries,
+      ...hookToolEntries,
+      ...llmProxyToolEntries,
+      ...mcpGatewayToolEntries,
+      ...mcpServerToolEntries,
+      ...teamToolEntries,
+      ...limitToolEntries,
+      ...policyToolEntries,
+      ...toolAssignmentToolEntries,
+      ...knowledgeManagementToolEntries,
+      ...chatToolEntries,
+      ...projectToolEntries,
+      ...searchToolEntries,
+      ...runToolEntries,
+      ...skillToolEntries,
+      ...sandboxToolEntries,
+      ...appToolEntries,
+      ...appDataToolEntries,
+      ...appLlmToolEntries,
+    };
+  }
+  return toolEntriesCache;
+}
+
+let allToolsCache: (typeof identityTools)[number][] | undefined;
 
 /**
  * Every built-in, in registration order, with no deployment-config filtering.
@@ -146,39 +174,53 @@ const toolEntries: Partial<
  * `getArchestraMcpTools`; keeping one array means a tool can never be reachable
  * for dispatch while missing from the list a caller enumerates.
  */
-const ALL_ARCHESTRA_MCP_TOOLS = [
-  ...identityTools,
-  ...agentTools,
-  ...llmProxyTools,
-  ...mcpGatewayTools,
-  ...mcpServerTools,
-  ...teamTools,
-  ...limitTools,
-  ...policyTools,
-  ...toolAssignmentTools,
-  ...knowledgeManagementTools,
-  ...chatTools,
-  ...projectTools,
-  ...searchToolTools,
-  ...runToolTools,
-  ...skillTools,
-  ...sandboxTools,
-  ...hookTools,
-  ...appTools,
-  ...appDataTools,
-  ...appLlmTools,
-];
+function getAllTools(): (typeof identityTools)[number][] {
+  if (!allToolsCache) {
+    allToolsCache = [
+      ...identityTools,
+      ...agentTools,
+      ...llmProxyTools,
+      ...mcpGatewayTools,
+      ...mcpServerTools,
+      ...teamTools,
+      ...limitTools,
+      ...policyTools,
+      ...toolAssignmentTools,
+      ...knowledgeManagementTools,
+      ...chatTools,
+      ...projectTools,
+      ...searchToolTools,
+      ...runToolTools,
+      ...skillTools,
+      ...sandboxTools,
+      ...hookTools,
+      ...appTools,
+      ...appDataTools,
+      ...appLlmTools,
+    ];
+  }
+  return allToolsCache;
+}
 
-const sandboxToolNames: ReadonlySet<string> = new Set(
-  sandboxTools.map((tool) => tool.name),
-);
-const hookToolNames: ReadonlySet<string> = new Set(
-  hookTools.map((tool) => tool.name),
-);
+let sandboxToolNamesCache: ReadonlySet<string> | undefined;
+function getSandboxToolNames(): ReadonlySet<string> {
+  if (!sandboxToolNamesCache) {
+    sandboxToolNamesCache = new Set(sandboxTools.map((tool) => tool.name));
+  }
+  return sandboxToolNamesCache;
+}
+
+let hookToolNamesCache: ReadonlySet<string> | undefined;
+function getHookToolNames(): ReadonlySet<string> {
+  if (!hookToolNamesCache) {
+    hookToolNamesCache = new Set(hookTools.map((tool) => tool.name));
+  }
+  return hookToolNamesCache;
+}
 
 export function getArchestraMcpTools() {
   return brandTools(
-    ALL_ARCHESTRA_MCP_TOOLS.filter((tool) => isToolRuntimeEnabled(tool.name)),
+    getAllTools().filter((tool) => isToolRuntimeEnabled(tool.name)),
   );
 }
 
@@ -189,7 +231,7 @@ export function getArchestraMcpTools() {
  * that serves or dispatches tools wants `getArchestraMcpTools`.
  */
 export function getAllArchestraMcpTools() {
-  return brandTools(ALL_ARCHESTRA_MCP_TOOLS);
+  return brandTools(getAllTools());
 }
 
 /**
@@ -206,7 +248,7 @@ export function getArchestraToolInputSchema(
   if (!shortName) {
     return undefined;
   }
-  const entry = toolEntries[getArchestraToolFullName(shortName)];
+  const entry = getToolEntries()[getArchestraToolFullName(shortName)];
   if (!entry) {
     return undefined;
   }
@@ -264,11 +306,11 @@ export async function executeArchestraTool(
   if (assignmentDenied) return assignmentDenied;
 
   const resolvedToolName =
-    toolEntries[toolName as ArchestraToolFullName] != null
+    getToolEntries()[toolName as ArchestraToolFullName] != null
       ? toolName
       : resolveArchestraToolName(toolName);
   const toolEntry = resolvedToolName
-    ? toolEntries[resolvedToolName as ArchestraToolFullName]
+    ? getToolEntries()[resolvedToolName as ArchestraToolFullName]
     : undefined;
   if (!toolEntry) {
     throw {
@@ -339,8 +381,9 @@ export async function executeArchestraTool(
  * would promise the model a capability the call cannot deliver.
  */
 function isToolRuntimeEnabled(canonicalName: string): boolean {
-  if (sandboxToolNames.has(canonicalName)) return config.skillsSandbox.enabled;
-  if (hookToolNames.has(canonicalName)) return config.hooks.enabled;
+  if (getSandboxToolNames().has(canonicalName))
+    return config.skillsSandbox.enabled;
+  if (getHookToolNames().has(canonicalName)) return config.hooks.enabled;
   return true;
 }
 
@@ -349,7 +392,7 @@ function isToolRuntimeEnabled(canonicalName: string): boolean {
 // been loaded. Rebranding here, where the tool list is built per reconcile, is
 // what lets a white-labeled deployment advertise built-ins under its own name.
 // `brandBuiltInText` is a no-op for non-branded orgs.
-function brandTools(tools: typeof ALL_ARCHESTRA_MCP_TOOLS) {
+function brandTools(tools: ReturnType<typeof getAllTools>) {
   return tools.map((tool) => {
     const shortName = getArchestraToolShortName(tool.name);
     const description =

--- a/platform/backend/src/archestra-mcp-server/projects.test.ts
+++ b/platform/backend/src/archestra-mcp-server/projects.test.ts
@@ -15,6 +15,8 @@ import { type ArchestraContext, executeArchestraTool } from ".";
 
 const TOOL_NAME = `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}create_project_from_conversation`;
 const SHARE_TOOL_NAME = `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}set_project_share`;
+const LIST_TOOL_NAME = `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}list_projects`;
+const GET_TOOL_NAME = `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}get_project`;
 
 describe("create_project_from_conversation tool", () => {
   let agent: Agent;
@@ -286,5 +288,208 @@ describe("set_project_share tool", () => {
       "organization-wide project sharing",
     );
     expect(await ProjectShareModel.findByProjectId(project.id)).toBeNull();
+  });
+});
+
+describe("project read tools (list_projects, get_project)", () => {
+  let agent: Agent;
+  let userId: string;
+  let organizationId: string;
+  let baseContext: ArchestraContext;
+
+  beforeEach(async ({ makeAgent, makeUser, makeOrganization, makeMember }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id);
+    userId = user.id;
+    organizationId = org.id;
+    agent = await makeAgent({ organizationId });
+    baseContext = {
+      agent: { id: agent.id, name: agent.name },
+      userId,
+      organizationId,
+    };
+  });
+
+  /** A second member's project, optionally shared with the whole org. */
+  async function makeForeignProject(
+    makeUser: any,
+    makeMember: any,
+    name: string,
+    shareWithOrg: boolean,
+  ) {
+    const stranger = await makeUser();
+    await makeMember(stranger.id, organizationId, { role: "admin" });
+    const project = await projectService.create({
+      organizationId,
+      userId: stranger.id,
+      name,
+      description: null,
+    });
+    if (shareWithOrg) {
+      await projectService.setShare({
+        id: project.id,
+        organizationId,
+        userId: stranger.id,
+        visibility: "organization",
+        teamIds: [],
+      });
+    }
+    return { project, strangerId: stranger.id as string };
+  }
+
+  test("lists own and shared projects but not another member's private one", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const mine = await projectService.create({
+      organizationId,
+      userId,
+      name: "mine",
+      description: null,
+    });
+    const { project: shared } = await makeForeignProject(
+      makeUser,
+      makeMember,
+      "shared-with-org",
+      true,
+    );
+    const { project: hidden } = await makeForeignProject(
+      makeUser,
+      makeMember,
+      "strangers-private",
+      false,
+    );
+
+    const result = await executeArchestraTool(LIST_TOOL_NAME, {}, baseContext);
+
+    expect(result.isError).toBe(false);
+    const ids = (
+      result.structuredContent as { projects: { id: string }[] }
+    ).projects.map((p) => p.id);
+    expect(ids).toContain(mine.id);
+    expect(ids).toContain(shared.id);
+    expect(ids).not.toContain(hidden.id);
+  });
+
+  test("narrows the list by query", async () => {
+    await projectService.create({
+      organizationId,
+      userId,
+      name: "quarterly-planning",
+      description: null,
+    });
+    await projectService.create({
+      organizationId,
+      userId,
+      name: "unrelated",
+      description: null,
+    });
+
+    const result = await executeArchestraTool(
+      LIST_TOOL_NAME,
+      { query: "quarterly" },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(
+      (
+        result.structuredContent as { projects: { name: string }[] }
+      ).projects.map((p) => p.name),
+    ).toEqual(["quarterly-planning"]);
+  });
+
+  test("returns a project's instructions and files in one call", async () => {
+    const project = await projectService.create({
+      organizationId,
+      userId,
+      name: "with-context",
+      description: null,
+    });
+    await projectService.setInstructions({
+      id: project.id,
+      organizationId,
+      userId,
+      content: "# House rules\nAlways cite sources.",
+    });
+    await fileStore.put({
+      organizationId,
+      userId,
+      projectId: project.id,
+      conversationId: null,
+      filename: "spec.md",
+      mimeType: "text/plain",
+      sizeBytes: 4,
+      data: Buffer.from("spec"),
+    });
+
+    const result = await executeArchestraTool(
+      GET_TOOL_NAME,
+      { project_id: project.id },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const out = result.structuredContent as {
+      id: string;
+      instructions: string;
+      instructions_truncated: boolean;
+      files: { filename: string }[];
+    };
+    expect(out.id).toBe(project.id);
+    expect(out.instructions).toContain("Always cite sources.");
+    expect(out.instructions_truncated).toBe(false);
+    expect(out.files.map((f) => f.filename)).toContain("spec.md");
+  });
+
+  test("flags truncation instead of inlining very long instructions", async () => {
+    const project = await projectService.create({
+      organizationId,
+      userId,
+      name: "verbose",
+      description: null,
+    });
+    await projectService.setInstructions({
+      id: project.id,
+      organizationId,
+      userId,
+      content: "x".repeat(20_001),
+    });
+
+    const result = await executeArchestraTool(
+      GET_TOOL_NAME,
+      { project_id: project.id },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const out = result.structuredContent as {
+      instructions: string;
+      instructions_truncated: boolean;
+    };
+    expect(out.instructions_truncated).toBe(true);
+    expect(out.instructions).toHaveLength(20_000);
+  });
+
+  test("refuses a project the caller cannot access", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const { project } = await makeForeignProject(
+      makeUser,
+      makeMember,
+      "off-limits",
+      false,
+    );
+
+    const result = await executeArchestraTool(
+      GET_TOOL_NAME,
+      { project_id: project.id },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain("Project not found");
   });
 });

--- a/platform/backend/src/archestra-mcp-server/projects.ts
+++ b/platform/backend/src/archestra-mcp-server/projects.ts
@@ -1,11 +1,15 @@
 import {
+  PROJECT_INSTRUCTIONS_FILENAME,
   TOOL_CREATE_PROJECT_FROM_CONVERSATION_SHORT_NAME,
+  TOOL_GET_PROJECT_SHORT_NAME,
+  TOOL_LIST_PROJECTS_SHORT_NAME,
   TOOL_SET_PROJECT_SHARE_SHORT_NAME,
 } from "@archestra/shared";
 import { z } from "zod";
 import logger from "@/logging";
 import { ConversationModel, ProjectModel, TeamModel } from "@/models";
 import { projectService } from "@/services/project";
+import type { ProjectListItem } from "@/types";
 import { ApiError } from "@/types";
 import {
   catchError,
@@ -34,6 +38,69 @@ const CreateProjectFromConversationOutputSchema = z.object({
     .int()
     .nonnegative()
     .describe("How many of the chat's files were moved into the project."),
+});
+
+/**
+ * How much of the instructions `get_project` inlines. Instructions may be up to
+ * `PROJECT_INSTRUCTIONS_MAX_LENGTH` (100k chars) — far more than belongs in a
+ * single tool result — so a long one is cut here and the caller is told to page
+ * the rest through `read_file`, which reads the same underlying file.
+ */
+const MAX_INLINED_INSTRUCTIONS_CHARS = 20_000;
+
+/** Cap on `list_projects` rows, so a large org cannot flood the caller. */
+const MAX_LISTED_PROJECTS = 100;
+
+const ProjectSummarySchema = z.object({
+  id: z.string().describe("The project's id — pass it to get_project."),
+  name: z.string().describe("The project's name."),
+  description: z.string().nullable().describe("The project's description."),
+  visibility: z
+    .enum(["organization", "team", "user"])
+    .nullable()
+    .describe("Who the project is shared with; null = owner-only."),
+  viewer_role: z
+    .enum(["owner", "shared", "admin"])
+    .describe("The caller's relationship to the project."),
+  owner_name: z.string().nullable().describe("Display name of the owner."),
+  conversation_count: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe("How many chats live in the project."),
+  created_at: z.string().describe("ISO 8601 creation timestamp."),
+});
+
+const ListProjectsOutputSchema = z.object({
+  projects: z
+    .array(ProjectSummarySchema)
+    .describe("Projects the caller can reach."),
+});
+
+const GetProjectOutputSchema = ProjectSummarySchema.extend({
+  instructions: z
+    .string()
+    .describe(
+      "The project's instructions markdown; empty when never saved. " +
+        "Truncated when `instructions_truncated` is true.",
+    ),
+  instructions_truncated: z
+    .boolean()
+    .describe("Whether `instructions` was cut short at the inline limit."),
+  files: z
+    .array(
+      z.object({
+        id: z.string().describe("The file's id."),
+        ref: z.string().describe("Stable reference to pass to read_file."),
+        filename: z.string().describe("The file's name."),
+        mime_type: z.string().describe("The file's MIME type."),
+        size_bytes: z.number().int().nonnegative().describe("Size in bytes."),
+      }),
+    )
+    .describe(
+      "Files the project owns. Read one with read_file, passing the same " +
+        "project_id and this `ref`.",
+    ),
 });
 
 const registry = defineArchestraTools([
@@ -235,7 +302,174 @@ const registry = defineArchestraTools([
       );
     },
   }),
+  defineArchestraTool({
+    shortName: TOOL_LIST_PROJECTS_SHORT_NAME,
+    title: "List Projects",
+    description:
+      "List the projects the caller can reach — the ones they own plus those " +
+      "shared with them. Use this to find a project's id before calling " +
+      "get_project. Optionally narrow by a case-insensitive substring of the " +
+      "name or description. Works outside a chat, so an external MCP client " +
+      "can discover projects on its own.",
+    schema: z
+      .object({
+        query: z
+          .string()
+          .optional()
+          .describe(
+            "Case-insensitive substring matched against the project name and " +
+              "description. Omit to list everything the caller can reach.",
+          ),
+      })
+      .strict(),
+    outputSchema: ListProjectsOutputSchema,
+    async handler({ args, context }) {
+      if (!context.userId || !context.organizationId) {
+        return errorResult(
+          "This tool requires an authenticated user context. Call it with a user token.",
+        );
+      }
+      const { userId, organizationId } = context;
+
+      try {
+        // `isProjectAdmin` is deliberately not passed: without a scope filter
+        // the service drops admin-oversight rows anyway, so a project admin
+        // sees exactly what they can access — same as everyone else. Oversight
+        // of other members' private projects stays a UI concern.
+        const projects = await projectService.list({
+          organizationId,
+          userId,
+          search: args.query,
+        });
+        const shown = projects.slice(0, MAX_LISTED_PROJECTS);
+        const summary =
+          shown.length === 0
+            ? "No projects matched."
+            : shown
+                .map(
+                  (p) =>
+                    `${p.name} (id=${p.id}, ${p.conversationCount} chat(s))`,
+                )
+                .join("\n") +
+              (projects.length > MAX_LISTED_PROJECTS
+                ? `\n(showing the first ${MAX_LISTED_PROJECTS} of ${projects.length}; narrow with query.)`
+                : "");
+        return structuredSuccessResult(
+          { projects: shown.map(toProjectSummary) },
+          summary,
+        );
+      } catch (error) {
+        return catchError(error, "listing projects");
+      }
+    },
+  }),
+  defineArchestraTool({
+    shortName: TOOL_GET_PROJECT_SHORT_NAME,
+    title: "Get Project",
+    description:
+      "Read one project's context in a single call: its metadata, its " +
+      `instructions (the \`${PROJECT_INSTRUCTIONS_FILENAME}\` that steers every ` +
+      "chat in the project), and the list of files it owns. Use list_projects " +
+      "to find the id. To read a file's contents, call read_file with the same " +
+      "project_id and the `ref` from the files list. Works outside a chat, so " +
+      "an external MCP client can pull a project's context into its own session.",
+    schema: z
+      .object({
+        project_id: z
+          .string()
+          .describe("Id of the project to read (from list_projects)."),
+      })
+      .strict(),
+    outputSchema: GetProjectOutputSchema,
+    async handler({ args, context }) {
+      if (!context.userId || !context.organizationId) {
+        return errorResult(
+          "This tool requires an authenticated user context. Call it with a user token.",
+        );
+      }
+      const { userId, organizationId } = context;
+
+      try {
+        // Admin oversight is deliberately NOT enabled here. It would let a
+        // project admin list a foreign project's files that the file tools then
+        // refuse to read (they authorize on owner/share alone), so the whole
+        // headless project surface stays on one access rule.
+        const project = await projectService.get({
+          id: args.project_id,
+          organizationId,
+          userId,
+        });
+        const [{ content }, files] = await Promise.all([
+          projectService.getInstructions({
+            id: project.id,
+            organizationId,
+            userId,
+          }),
+          projectService.listFiles({ id: project.id, organizationId, userId }),
+        ]);
+
+        const truncated = content.length > MAX_INLINED_INSTRUCTIONS_CHARS;
+        const instructions = truncated
+          ? content.slice(0, MAX_INLINED_INSTRUCTIONS_CHARS)
+          : content;
+
+        const result = {
+          ...toProjectSummary(project),
+          instructions,
+          instructions_truncated: truncated,
+          files: files.map((f) => ({
+            id: f.id,
+            ref: f.downloadRef,
+            filename: f.filename,
+            mime_type: f.mimeType,
+            size_bytes: f.sizeBytes,
+          })),
+        };
+        const instructionsLine = content
+          ? truncated
+            ? `Instructions (first ${MAX_INLINED_INSTRUCTIONS_CHARS} of ${content.length} chars — page the rest with read_file on ${PROJECT_INSTRUCTIONS_FILENAME}):\n${instructions}`
+            : `Instructions:\n${instructions}`
+          : "Instructions: (none saved yet)";
+        const filesLine =
+          files.length === 0
+            ? "Files: (none)"
+            : `Files:\n${files
+                .map(
+                  (f) =>
+                    `${f.filename} (${f.mimeType}, ${f.sizeBytes} bytes) ref=${f.downloadRef}`,
+                )
+                .join("\n")}`;
+        return structuredSuccessResult(
+          result,
+          `Project "${project.name}" (id=${project.id})\n\n${instructionsLine}\n\n${filesLine}`,
+        );
+      } catch (error) {
+        // "Project not found" (the 404 that also covers "no access") is the
+        // actionable answer; surface it verbatim.
+        if (error instanceof ApiError) {
+          return errorResult(error.message);
+        }
+        return catchError(error, "reading the project");
+      }
+    },
+  }),
 ]);
 
 export const toolEntries = registry.toolEntries;
 export const tools = registry.tools;
+
+// === Internal helpers ===
+
+/** Project row → the compact shape both project read tools return. */
+function toProjectSummary(project: ProjectListItem) {
+  return {
+    id: project.id,
+    name: project.name,
+    description: project.description,
+    visibility: project.visibility,
+    viewer_role: project.viewerRole,
+    owner_name: project.ownerName,
+    conversation_count: project.conversationCount,
+    created_at: project.createdAt.toISOString(),
+  };
+}

--- a/platform/backend/src/archestra-mcp-server/rbac.ts
+++ b/platform/backend/src/archestra-mcp-server/rbac.ts
@@ -151,6 +151,11 @@ export const TOOL_PERMISSIONS: Record<
   // restricts to the owner/project-admin and gates org-wide visibility behind
   // project:share-org.
   set_project_share: { resource: "project", action: "update" },
+  // Reads mirror the GetProjects/GetProject routes. The permission is only the
+  // floor: both handlers narrow to what the caller can actually reach (owner or
+  // shared-with), so `project:read` never widens visibility past their own set.
+  list_projects: { resource: "project", action: "read" },
+  get_project: { resource: "project", action: "read" },
 
   // Meta — permission is enforced on the target tool, not on run_tool itself
   search_tools: null,

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -2193,6 +2193,130 @@ describe("project file scope (save_file, scoped search/my_file)", () => {
     expect(denied.isError).toBe(true);
     expect(textOf(denied)).toContain("project");
   });
+
+  describe("explicit project_id (headless project reads)", () => {
+    test("reads a project's instructions with no conversation at all", async () => {
+      const project = await ProjectModel.create({
+        organizationId,
+        userId,
+        name: "headless-read",
+        description: null,
+      });
+      await fileStore.writeProjectInstructions({
+        organizationId,
+        userId,
+        projectId: project.id,
+        content: "# House rules\nAlways cite sources.",
+      });
+
+      // No conversationId: exactly what an external MCP client on a gateway has.
+      const result = await executeArchestraTool(
+        TOOL_READ_FILE_FULL_NAME,
+        { filename: PROJECT_INSTRUCTIONS_FILENAME, project_id: project.id },
+        context,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(textOf(result)).toContain("Always cite sources.");
+    });
+
+    test("search_files lists the project's files with no conversation", async () => {
+      const project = await ProjectModel.create({
+        organizationId,
+        userId,
+        name: "headless-list",
+        description: null,
+      });
+      await fileStore.put({
+        organizationId,
+        userId,
+        projectId: project.id,
+        conversationId: null,
+        filename: "spec.md",
+        mimeType: "text/plain",
+        sizeBytes: 4,
+        data: Buffer.from("spec"),
+      });
+
+      const result = await executeArchestraTool(
+        TOOL_SEARCH_FILES_FULL_NAME,
+        { project_id: project.id },
+        context,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(
+        structuredOf<{ files: { filename: string }[] }>(result).files.map(
+          (f) => f.filename,
+        ),
+      ).toContain("spec.md");
+    });
+
+    test("denies a project the caller cannot access, without revealing it exists", async ({
+      makeUser,
+      makeMember,
+    }) => {
+      const stranger = await makeUser();
+      await makeMember(stranger.id, organizationId);
+      const theirs = await ProjectModel.create({
+        organizationId,
+        userId: stranger.id,
+        name: "not-mine",
+        description: null,
+      });
+      await fileStore.writeProjectInstructions({
+        organizationId,
+        userId: stranger.id,
+        projectId: theirs.id,
+        content: "secret rules",
+      });
+
+      const result = await executeArchestraTool(
+        TOOL_READ_FILE_FULL_NAME,
+        { filename: PROJECT_INSTRUCTIONS_FILENAME, project_id: theirs.id },
+        context,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).not.toContain("secret rules");
+      // Same wording a nonexistent id gets, so ids cannot be probed.
+      const missingId = crypto.randomUUID();
+      const missing = await executeArchestraTool(
+        TOOL_READ_FILE_FULL_NAME,
+        { filename: PROJECT_INSTRUCTIONS_FILENAME, project_id: missingId },
+        context,
+      );
+      expect(textOf(missing).replace(missingId, "<id>")).toBe(
+        textOf(result).replace(theirs.id, "<id>"),
+      );
+    });
+
+    test("refuses to escape a project chat into another project", async () => {
+      const { ctx } = await makeProjectChatCtx("confined");
+      const other = await ProjectModel.create({
+        organizationId,
+        userId,
+        name: "the-other-one",
+        description: null,
+      });
+      await fileStore.writeProjectInstructions({
+        organizationId,
+        userId,
+        projectId: other.id,
+        content: "other project rules",
+      });
+
+      const result = await executeArchestraTool(
+        TOOL_READ_FILE_FULL_NAME,
+        { filename: PROJECT_INSTRUCTIONS_FILENAME, project_id: other.id },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain("drop project_id");
+      expect(textOf(result)).not.toContain("other project rules");
+    });
+  });
 });
 
 describe("read_file", () => {

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -41,6 +41,7 @@ import {
 } from "@/skills-sandbox/mime-sniff";
 import {
   type ProjectFileScope,
+  resolveExplicitProjectFileScope,
   resolveProjectFileScope,
 } from "@/skills-sandbox/project-file-scope";
 import {
@@ -370,6 +371,23 @@ const UploadFileOutputSchema = z.object({
   sizeBytes: z.number(),
 });
 
+/**
+ * Opt a read tool out of the chat-derived scope and onto a named project. The
+ * point is headless use: a client with no conversation (an external MCP client
+ * on a gateway) has nothing to derive scope from, so it names the project it
+ * found via `list_projects` / `get_project`.
+ */
+const PROJECT_ID_FILE_ARG = z
+  .string()
+  .optional()
+  .describe(
+    "Read this project's files instead of the current chat's — how you reach " +
+      "project files when working outside a chat (get_project returns the id). " +
+      "Only projects you own or that are shared with you can be read. Cannot " +
+      "be used from a chat that already belongs to a different project, nor " +
+      'combined with scope: "app".',
+  );
+
 const SearchFilesSchema = z
   .strictObject({
     query: z
@@ -386,11 +404,13 @@ const SearchFilesSchema = z
           "the user has open, which is how you find what the app has produced " +
           "before copying one out with copy_file.",
       ),
+    project_id: PROJECT_ID_FILE_ARG,
   })
   .describe(
     "List or search persistent files by filename substring; omit the query to " +
       "list them (the first 200). Filenames only, not contents. Lists this " +
-      "chat's files, or the open app's files with scope: \"app\".",
+      "chat's files, the open app's files with scope: \"app\", or a project's " +
+      "files with project_id.",
   );
 
 const SearchFilesOutputSchema = z.object({
@@ -446,6 +466,7 @@ const ReadFileSchema = z
       .describe(
         `Maximum number of lines to read. Defaults to ${READ_FILE_DEFAULT_LINES}.`,
       ),
+    project_id: PROJECT_ID_FILE_ARG,
   })
   .refine((v) => (v.id != null) !== (v.filename != null), {
     message: "provide exactly one of `id` or `filename`",
@@ -455,8 +476,10 @@ const ReadFileSchema = z
       "files come back as numbered lines (`<n>\\t<line>`); images (PNG, JPEG, " +
       "WebP, GIF) are returned inline so you can view them. Identify the file by " +
       "`id` (the `id` or `ref` from search_files / save_file) or by `filename`. Page " +
-      "large text files with `offset`/`limit`. For other binary types (PDF, archives, " +
-      "…), copy the file into the sandbox with upload_file + run_command.",
+      "large text files with `offset`/`limit`. Pass project_id to read a project's " +
+      "file (e.g. its instructions.md) instead of the chat's. For other binary types " +
+      "(PDF, archives, …), copy the file into the sandbox with upload_file + " +
+      "run_command.",
   );
 
 const ReadFileOutputSchema = z.object({
@@ -964,7 +987,8 @@ const registry = defineArchestraTools([
       "pass to read_file, edit_file, or delete_file, or to upload_file to copy the file " +
       'into the sandbox. Pass scope: "app" to list the files of the app the user has ' +
       "open instead — the only way to see what an app holds, and the discovery step " +
-      "before copying one of its files out with copy_file.",
+      "before copying one of its files out with copy_file. Pass project_id to list a " +
+      "project's files instead, which is how you reach them outside a chat.",
     schema: SearchFilesSchema,
     outputSchema: SearchFilesOutputSchema,
     async handler({ args, context }) {
@@ -983,13 +1007,19 @@ const registry = defineArchestraTools([
           "No app is open in this chat, so there are no app files to list. Ask the user to open the app first, then retry.",
         );
       }
+      if (args.scope === "app" && args.project_id) {
+        return errorResult(
+          "project_id cannot be combined with scope: \"app\" — ask for the project's files or the open app's, not both.",
+        );
+      }
 
-      let scope: ProjectFileScope | null;
+      let fileScope: MyFileScope | null;
       try {
-        scope = await resolveProjectFileScope({
+        fileScope = await resolveReadFileScope({
+          projectId: args.project_id,
           conversationId: context.conversationId,
-          userId: guard.userCtx.userId,
-          organizationId: guard.userCtx.organizationId,
+          appId,
+          userCtx: guard.userCtx,
         });
       } catch (error) {
         if (error instanceof SkillSandboxError)
@@ -997,11 +1027,6 @@ const registry = defineArchestraTools([
         throw error;
       }
 
-      const fileScope = resolveChatFileScope(
-        scope,
-        context.conversationId,
-        appId,
-      );
       // A headless no-project call has no conversation to scope to — no files.
       if (!fileScope) {
         return structuredSuccessResult(
@@ -1054,20 +1079,24 @@ const registry = defineArchestraTools([
       "files come back as numbered lines; images (PNG, JPEG, WebP, GIF) are " +
       "returned inline so you can view them. Identify the file by `id` (the `id` or " +
       "`ref` from search_files / save_file) or by `filename`. Page large text files " +
-      "with `offset`/`limit`. For other binary types, copy the file into the sandbox " +
-      "with upload_file and inspect it with run_command.",
+      "with `offset`/`limit`. Pass project_id to read a project's file — including " +
+      "its instructions.md — which is how you reach them outside a chat. For other " +
+      "binary types, copy the file into the sandbox with upload_file and inspect it " +
+      "with run_command.",
     schema: ReadFileSchema,
     outputSchema: ReadFileOutputSchema,
     async handler({ args, context }) {
       const guard = ensureUsable(context);
       if ("error" in guard) return errorResult(guard.error);
 
-      let scope: ProjectFileScope | null;
+      const ref = args.id ?? args.filename ?? "";
+      let fileScope: MyFileScope | null;
       try {
-        scope = await resolveProjectFileScope({
+        fileScope = await resolveReadFileScope({
+          projectId: args.project_id,
           conversationId: context.conversationId,
-          userId: guard.userCtx.userId,
-          organizationId: guard.userCtx.organizationId,
+          appId: context.appId,
+          userCtx: guard.userCtx,
         });
       } catch (error) {
         if (error instanceof SkillSandboxError)
@@ -1075,12 +1104,6 @@ const registry = defineArchestraTools([
         throw error;
       }
 
-      const ref = args.id ?? args.filename ?? "";
-      const fileScope = resolveChatFileScope(
-        scope,
-        context.conversationId,
-        context.appId,
-      );
       if (!fileScope) {
         return errorResult(describeMyFileError("not_found", ref));
       }
@@ -2370,6 +2393,64 @@ function resolveChatFileScope(
     };
   }
   return conversationId ? { kind: "conversation", conversationId } : null;
+}
+
+/** A resolved My Files scope (the non-null result of {@link resolveChatFileScope}). */
+type MyFileScope = NonNullable<ReturnType<typeof resolveChatFileScope>>;
+
+/**
+ * Scope for the two READ tools, which additionally accept an explicit
+ * `project_id`. Without one this is exactly the chat scope; with one the named
+ * project is used after re-verifying the caller's access to it.
+ *
+ * The explicit id is REFUSED, never silently ignored, when it cannot apply — a
+ * caller told it read a project must not have been served something else:
+ *  - an app runtime is confined to its own (app, viewer) namespace;
+ *  - a chat that already belongs to a project stays confined to THAT project,
+ *    so content inside a project chat cannot steer the model into a second
+ *    project the user happens to have access to.
+ *
+ * Only reads take this argument. Writes stay chat-derived, so nothing can be
+ * created in or deleted from a project the caller is not actually working in.
+ */
+async function resolveReadFileScope(params: {
+  projectId: string | undefined;
+  conversationId: string | undefined;
+  appId: string | undefined;
+  userCtx: UserContext;
+}): Promise<MyFileScope | null> {
+  const { projectId, conversationId, appId, userCtx } = params;
+
+  const chatScope = await resolveProjectFileScope({
+    conversationId,
+    userId: userCtx.userId,
+    organizationId: userCtx.organizationId,
+  });
+  if (!projectId) {
+    return resolveChatFileScope(chatScope, conversationId, appId);
+  }
+
+  if (appId) {
+    throw new SkillSandboxError(
+      "project_id cannot be used here — an app can only reach its own files",
+    );
+  }
+  if (chatScope && chatScope.projectId !== projectId) {
+    throw new SkillSandboxError(
+      `this chat belongs to project "${chatScope.projectName}"; only its files can be used here — drop project_id`,
+    );
+  }
+
+  const scope = await resolveExplicitProjectFileScope({
+    projectId,
+    userId: userCtx.userId,
+    organizationId: userCtx.organizationId,
+  });
+  return {
+    kind: "project",
+    projectId: scope.projectId,
+    projectName: scope.projectName,
+  };
 }
 
 function describeMyFileError(

--- a/platform/backend/src/skills-sandbox/project-file-scope.ts
+++ b/platform/backend/src/skills-sandbox/project-file-scope.ts
@@ -68,3 +68,52 @@ export async function resolveProjectFileScope(params: {
 
   return { projectId: project.id, projectName: project.name };
 }
+
+/**
+ * Resolve the file scope of an explicitly named project — the headless path for
+ * callers with no conversation to derive scope from (an external MCP client on a
+ * gateway, which finds the id via `list_projects` / `get_project`).
+ *
+ * Authorization is identical to {@link resolveProjectFileScope}: the project
+ * must live in the caller's organization, not be soft-deleted, and be reachable
+ * by them (owner, or shared with them / a team they are in). Re-checked on EVERY
+ * call, and fails CLOSED.
+ *
+ * `project:admin` oversight deliberately does NOT apply. Reading another
+ * member's project files is an oversight action that belongs to the REST/UI
+ * surface; an agent tool grants only the caller's own reach.
+ *
+ * "Missing" and "no access" raise the SAME error on purpose, so probing ids
+ * cannot be used to discover which projects exist.
+ */
+export async function resolveExplicitProjectFileScope(params: {
+  projectId: string;
+  userId: string;
+  organizationId: string;
+}): Promise<ProjectFileScope> {
+  const { projectId, userId, organizationId } = params;
+
+  const denied = new SkillSandboxError(
+    `no project ${projectId} exists, or you do not have access to it`,
+  );
+
+  const [project] = await db
+    .select()
+    .from(schema.projectsTable)
+    .where(eq(schema.projectsTable.id, projectId));
+  if (
+    !project ||
+    project.organizationId !== organizationId ||
+    project.deletedAt
+  )
+    throw denied;
+
+  const canAccess = await ProjectShareModel.userCanAccessProject({
+    project,
+    userId,
+    organizationId,
+  });
+  if (!canAccess) throw denied;
+
+  return { projectId: project.id, projectName: project.name };
+}

--- a/platform/backend/src/standalone-scripts/codegen-archestra-mcp-server-docs.ts
+++ b/platform/backend/src/standalone-scripts/codegen-archestra-mcp-server-docs.ts
@@ -62,6 +62,12 @@ const toolAccessNotes: Partial<Record<ArchestraToolShortName, string>> = {
   // callers holding `project:share-org`.
   set_project_share:
     "Beyond `project:update`, the caller must own the project (or hold `project:admin`), and moving a project into or out of organization-wide visibility additionally requires `project:share-org`.",
+  // The read tools stay on the caller's own reach: `project:admin` oversight of
+  // a foreign project is a REST/UI capability and does not extend to them.
+  list_projects:
+    "Returns only projects the caller owns or that are shared with them. `project:admin` oversight of other members' projects does **not** extend to this tool.",
+  get_project:
+    "Readable only for projects the caller owns or that are shared with them. `project:admin` oversight of other members' projects does **not** extend to this tool.",
 };
 
 /**

--- a/platform/shared/archestra-mcp-server.ts
+++ b/platform/shared/archestra-mcp-server.ts
@@ -131,6 +131,12 @@ export const TOOL_CREATE_PROJECT_FROM_CONVERSATION_SHORT_NAME =
   "create_project_from_conversation";
 // Change who can see a project (org-wide, teams, or owner-only).
 export const TOOL_SET_PROJECT_SHARE_SHORT_NAME = "set_project_share";
+// Discover the projects the caller can reach, and read one project's context
+// (its instructions plus the files it owns). Both work headlessly — unlike the
+// two tools above they never consult the current chat — so an external MCP
+// client on a gateway can pull a project's context into its own session.
+export const TOOL_LIST_PROJECTS_SHORT_NAME = "list_projects";
+export const TOOL_GET_PROJECT_SHORT_NAME = "get_project";
 export const TOOL_SEARCH_TOOLS_SHORT_NAME = "search_tools";
 export const TOOL_RUN_TOOL_SHORT_NAME = "run_tool";
 export const TOOL_LIST_SKILLS_SHORT_NAME = "list_skills";
@@ -257,6 +263,8 @@ export const ARCHESTRA_TOOL_SHORT_NAMES = [
   TOOL_TODO_WRITE_SHORT_NAME,
   TOOL_CREATE_PROJECT_FROM_CONVERSATION_SHORT_NAME,
   TOOL_SET_PROJECT_SHARE_SHORT_NAME,
+  TOOL_LIST_PROJECTS_SHORT_NAME,
+  TOOL_GET_PROJECT_SHORT_NAME,
   TOOL_SEARCH_TOOLS_SHORT_NAME,
   TOOL_RUN_TOOL_SHORT_NAME,
   TOOL_LIST_SKILLS_SHORT_NAME,
@@ -425,6 +433,8 @@ export const ARCHESTRA_TOOL_GROUP_BY_SHORT_NAME: Record<
   todo_write: "chat",
   create_project_from_conversation: "chat",
   set_project_share: "chat",
+  list_projects: "chat",
+  get_project: "chat",
 
   search_tools: "meta",
   run_tool: "meta",


### PR DESCRIPTION
## Problem

A project's context — its `instructions.md` and its files — is reachable today only from **inside a chat that belongs to the project**, or through the authenticated `/api/projects/*` REST routes.

An MCP client connected to a gateway can call Archestra's built-in tools, but it cannot get at any of that. The gateway's tool-execution context carries no conversation, and the persistent-file tools derive their project scope solely from `conversationId`. The result is a silent dead end: `search_files` returns an empty list and `read_file` reports not-found, with nothing explaining why.

There is also no tool that maps a project name to an id, so a client has no entry point even in principle.

## What this adds

**Two read tools** (`project:read`):

- **`list_projects`** — the projects the caller can reach, optionally narrowed by a name/description substring. Discovery, so a client can find an id.
- **`get_project`** — one project's metadata, its instructions, and its file list in a single call. Instructions longer than the inline cap are truncated and flagged (`instructions_truncated`) rather than dumped whole, with the remainder pageable through `read_file`.

**A headless path into the existing file tools:**

`search_files` and `read_file` take an optional `project_id`, so the bytes behind that file list are actually readable without a conversation. Without the argument, both behave exactly as before.

## Authorization

Nothing here widens what anyone can see.

- `project:read` is only the floor. Every path re-resolves the caller's *real* access — owner, or shared with them / a team they belong to — on **every call**, and fails closed. A project soft-deleted or unshared mid-session stops resolving immediately.
- `project:admin` oversight of another member's project deliberately does **not** extend to these tools. Oversight stays a REST/UI capability, which keeps the whole headless surface on a single rule and avoids `get_project` listing files that `read_file` would then refuse.
- A missing project and an inaccessible one return the **same** error, so ids cannot be probed for existence.
- `project_id` is **refused, not silently ignored**, where it cannot apply — a caller told it read a project must never be served something else:
  - an app runtime stays confined to its own `(app, viewer)` namespace;
  - a chat that already belongs to a project stays confined to *that* project, so content inside a project chat cannot steer the model into a second project the user happens to have access to;
  - it cannot be combined with `scope: "app"`.
- **Only reads take the argument.** Writes (`save_file`, `edit_file`, `delete_file`, `copy_file`) remain chat-derived, so nothing can be created in or deleted from a project the caller is not actually working in.