### PR TITLE
fix(helm): use one warning sign across both probe outcomes

### DIFF
--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -613,7 +613,7 @@ args:
       renders on 3 and reaches 4 as a row of escapes. Emoji survive both.
     */}}
     if [ "$result" = reachable ]; then
-      echo "[archestra] 🚨 🚨 🚨  NETWORK POLICY NOT ENFORCED  🚨 🚨 🚨  Environment egress rules (MCP servers, code sandboxes) are accepted and then silently ignored, so pods reach cloud metadata endpoints and private cluster ranges — see https://archestra.ai/docs/platform-deployment#ssrf-protection-for-mcp-server-pods"
+      echo "[archestra] ⚠️ ⚠️ ⚠️  NETWORK POLICY NOT ENFORCED  ⚠️ ⚠️ ⚠️  Environment egress rules (MCP servers, code sandboxes) are accepted and then silently ignored, so pods reach cloud metadata endpoints and private cluster ranges — see https://archestra.ai/docs/platform-deployment#ssrf-protection-for-mcp-server-pods"
     fi
     exit 0
 {{- end }}

--- a/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
+++ b/platform/helm/archestra/tests/archestra_network_policy_probe_test.yaml
@@ -286,9 +286,11 @@ tests:
           path: spec.containers[0].args[0]
           pattern: 'echo "[^"]*"[\s\S]*echo "'
         documentIndex: 2
+      # Each arm leads with the warning sign, which is the only emphasis Helm 4
+      # leaves once it collapses a pod's log into one escaped record.
       - matchRegex:
           path: spec.containers[0].args[0]
-          pattern: '🚨'
+          pattern: '⚠️'
         documentIndex: 2
       - matchRegex:
           path: spec.containers[0].args[0]


### PR DESCRIPTION
Update Help warning

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>