### PR TITLE
fix(staging): stop the web-tier OOMKill loop

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -10,6 +10,26 @@ archestra:
   resources:
     requests:
       cpu: "500m"
+    # The chart's default 3Gi limit is too tight for this container, which runs
+    # two Node processes under supervisord (backend + the Next.js server). A
+    # freshly-booted web pod already sits at ~2.0Gi of the 3Gi limit (backend
+    # ~1.15Gi RSS, next-server ~0.14Gi, plus slab and page cache), so ordinary
+    # traffic walked it into the limit and the kernel OOM-killed the container
+    # every few minutes. Raising the limit restores real headroom; requests are
+    # unchanged, so scheduling and the node-pool budget are unaffected.
+    #
+    # This also fixes the ordering that made the crash undiagnosable. The Node
+    # launcher derives the V8 old-space ceiling as 60% of the container limit,
+    # so this moves it from 1843 MiB to ~2457 MiB while the container gains a
+    # full extra gigabyte. Projected peak (heap + native/external + the Next.js
+    # server + slab) now lands under 4Gi, so V8 reaches its own heap ceiling
+    # before the cgroup does: the process exits with a JS heap OOM and a
+    # fatal-error report instead of being SIGKILLed with no stack. Note the
+    # ceiling is deliberately left to that formula rather than pinned via
+    # ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB, because that env var would also
+    # apply to the worker, whose limit is 2Gi.
+    limits:
+      memory: "4Gi"
 
   worker:
     replicaCount: 3
@@ -129,7 +149,15 @@ archestra:
     storageClassName: "archestra-diagnostics-rwx"
     accessModes:
       - ReadWriteMany
-    heapSnapshotsNearHeapLimit: 1
+    # Deliberately off (matching the chart default). Writing a heap snapshot as
+    # V8 approaches its limit needs extra memory and stalls the event loop at
+    # exactly the moment memory is tightest, so the container hit its cgroup
+    # limit mid-write: the volume accumulated 783 snapshots and every one was
+    # 0 bytes, i.e. the process was killed before a single byte landed. It also
+    # converted a diagnosable JS heap OOM into an opaque SIGKILL and made the
+    # readiness/liveness probes fail during the stall. Turn this back on only
+    # for a targeted investigation, with headroom to actually write the file.
+    heapSnapshotsNearHeapLimit: 0
 
   # Orchestrator configuration with Workload Identity for Vertex AI
   orchestrator:


### PR DESCRIPTION
## What was happening

Opening a chat on staging hung. All four `archestra-platform` web pods were in an OOMKill loop — roughly one kill every five minutes — so requests landed on a pod that was stalled or about to be killed, and two of four replicas were `NotReady` at any given moment. Caught live, one pod sat at `memory.current=3070MiB` against `memory.max=3072MiB`.

This is not cluster capacity: nodes were at 2–24% CPU and ~50% memory, and the database was healthy (25/200 connections, zero blocked queries).

## Why

**The container limit was sized for one process, but hosts two.** The web container runs the backend *and* the Next.js server under supervisord. A freshly booted pod already occupies ~2.0Gi of the 3Gi limit (backend ~1.15Gi RSS, next-server ~0.14Gi, plus slab and page cache), so ordinary traffic walked it into the wall.

**Heap snapshots made it worse and destroyed the evidence.** Serializing a snapshot needs extra memory and stalls the event loop at exactly the moment memory is tightest, so the container hit its cgroup limit mid-write. The diagnostics volume holds **783 snapshots and every single one is 0 bytes** — the process was killed before a byte landed. It also converted a diagnosable JS heap OOM into an opaque SIGKILL, and the stalls are what produced the readiness/liveness probe failures. `heapSnapshotsNearHeapLimit` was a staging-only override; the chart default is already `0`.

## What this changes

- Platform memory limit 3Gi → 4Gi. Requests are unchanged, so scheduling and the node-pool budget are unaffected.
- `heapSnapshotsNearHeapLimit` back to the chart default of `0`.

This also fixes the failure *ordering*. The old-space ceiling scales to ~2457 MiB while the container gains a full extra gigabyte, so V8 now reaches its own heap ceiling before the cgroup does — Node exits with a JS heap OOM and a fatal-error report instead of vanishing without a stack.

The ceiling is deliberately left to the existing 60%-of-limit formula rather than pinned via `ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB`: that env var would also apply to the worker, whose limit is only 2Gi, where it would have meant a heap ceiling equal to 100% of the container.

## This is mitigation, not the cure

The backend still climbs from ~1.15Gi to ~1.85Gi over minutes of ordinary traffic. The likely source is `InteractionDeltaManager.reconstructCache` (`platform/backend/src/models/interaction-delta-manager.ts:103`): an LRU bounded by **entry count (5000), never by bytes**, whose `commitTip` stores two full request copies per entry (`:225-228`). With multi-MB proxy requests the heap ceiling is reached at a few hundred entries — a few percent of nominal capacity.

That cache was inert on staging until the content-encryption gate was removed from `isEligible()` on Aug 5, after which it populates on every eligible proxy write. Kills went 2/day → 80 (Aug 5) → 407 (Aug 6). Filing that as a separate change; it wants byte-bounding, dropping the second copy, and a cap on ancestor memoization in `foldFor`, plus tests.

## Validation

`helm template` against the staging values renders platform `limits.memory: 4Gi` with the heapsnapshot env var absent, and leaves worker (2Gi) and renderer (8Gi) untouched. The equivalent change is already applied live to unblock staging; merging makes it durable, since the next commit-to-main deploy would otherwise revert it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>