### PR TITLE
fix(interactions): bound the delta reconstruct cache by bytes, not entry count

### DIFF
--- a/platform/archestra-rs/image-rs/index.d.ts
+++ b/platform/archestra-rs/image-rs/index.d.ts
@@ -7,7 +7,11 @@
  * a decompression bomb) or cannot be made to fit. Prefers lossless PNG, falling
  * back to JPEG and progressive downscaling.
  */
-export declare function shrinkImageToFit(input: Buffer, maxBytes: number, maxDimension: number): Promise<ShrunkImage | null>
+export declare function shrinkImageToFit(
+  input: Buffer,
+  maxBytes: number,
+  maxDimension: number,
+): Promise<ShrunkImage | null>;
 
 /**
  * A shrunk image produced by `shrinkImageToFit`. `bytes` is guaranteed to be at
@@ -15,6 +19,6 @@ export declare function shrinkImageToFit(input: Buffer, maxBytes: number, maxDim
  * `"image/jpeg"`.
  */
 export interface ShrunkImage {
-  bytes: Buffer
-  contentType: string
+  bytes: Buffer;
+  contentType: string;
 }

--- a/platform/archestra-rs/image-rs/index.d.ts
+++ b/platform/archestra-rs/image-rs/index.d.ts
@@ -7,11 +7,7 @@
  * a decompression bomb) or cannot be made to fit. Prefers lossless PNG, falling
  * back to JPEG and progressive downscaling.
  */
-export declare function shrinkImageToFit(
-  input: Buffer,
-  maxBytes: number,
-  maxDimension: number,
-): Promise<ShrunkImage | null>;
+export declare function shrinkImageToFit(input: Buffer, maxBytes: number, maxDimension: number): Promise<ShrunkImage | null>
 
 /**
  * A shrunk image produced by `shrinkImageToFit`. `bytes` is guaranteed to be at
@@ -19,6 +15,6 @@ export declare function shrinkImageToFit(
  * `"image/jpeg"`.
  */
 export interface ShrunkImage {
-  bytes: Buffer;
-  contentType: string;
+  bytes: Buffer
+  contentType: string
 }

--- a/platform/backend/src/cache-manager.test.ts
+++ b/platform/backend/src/cache-manager.test.ts
@@ -432,4 +432,93 @@ describe("LRUCacheManager", () => {
     expect(cache.has("C")).toBe(true);
     expect(cache.has("D")).toBe(true);
   });
+
+  test("evicts oldest entries until the retained total fits maxBytes", () => {
+    // Entry count is deliberately generous — bytes are what should bind here.
+    const cache = new LRUCacheManager<string>({
+      maxSize: 100,
+      maxBytes: 30,
+      sizeOf: (value) => value.length,
+    });
+
+    cache.set("A", "a".repeat(10));
+    cache.set("B", "b".repeat(10));
+    cache.set("C", "c".repeat(10));
+    expect(cache.retainedBytes).toBe(30);
+    expect(cache.size).toBe(3);
+
+    // Pushes the total to 40 against a 30 budget, so the oldest entry goes even
+    // though the cache is nowhere near its 100-entry ceiling.
+    cache.set("D", "d".repeat(10));
+
+    expect(cache.retainedBytes).toBe(30);
+    expect(cache.has("A")).toBe(false);
+    expect(cache.has("B")).toBe(true);
+    expect(cache.has("C")).toBe(true);
+    expect(cache.has("D")).toBe(true);
+  });
+
+  test("byte eviction is oldest-written-first and ignores read recency", () => {
+    const cache = new LRUCacheManager<string>({
+      maxSize: 100,
+      maxBytes: 30,
+      sizeOf: (value) => value.length,
+    });
+
+    cache.set("A", "a".repeat(10));
+    cache.set("B", "b".repeat(10));
+    cache.set("C", "c".repeat(10));
+    // Reading A does NOT protect it. QuickLRU only reorders when an entry is
+    // promoted out of its older generation, which cannot happen while the cache
+    // is far below maxSize — so within a generation, reads are invisible to
+    // eviction order. This mirrors QuickLRU's own count-based eviction rather
+    // than adding a second, stricter policy on top of it.
+    expect(cache.get("A")).toBe("a".repeat(10));
+
+    cache.set("D", "d".repeat(10));
+
+    expect(cache.has("A")).toBe(false);
+    expect(cache.has("D")).toBe(true);
+  });
+
+  test("drops a value that is larger than the whole budget", () => {
+    const onEviction = vi.fn();
+    const cache = new LRUCacheManager<string>({
+      maxSize: 100,
+      maxBytes: 30,
+      sizeOf: (value) => value.length,
+      onEviction,
+    });
+
+    cache.set("huge", "x".repeat(100));
+
+    // A cache that cannot retain a value must not pretend it did, so callers
+    // cannot treat set() as making the value readable afterwards.
+    expect(cache.get("huge")).toBeUndefined();
+    expect(cache.retainedBytes).toBe(0);
+    expect(onEviction).toHaveBeenCalledWith("huge", "x".repeat(100));
+  });
+
+  test("leaves entry-count eviction alone when maxBytes is not configured", () => {
+    const cache = new LRUCacheManager<string>({ maxSize: 3 });
+
+    cache.set("A", "a".repeat(10_000));
+    cache.set("B", "b".repeat(10_000));
+
+    // No budget configured: sizes are not measured and nothing is byte-evicted.
+    expect(cache.retainedBytes).toBe(0);
+    expect(cache.size).toBe(2);
+    expect(cache.get("A")).toBe("a".repeat(10_000));
+  });
+
+  test("ignores maxBytes when no sizeOf is supplied", () => {
+    // Without a way to measure values a byte budget cannot be enforced, so the
+    // cache must fall back to entry-count behavior rather than evict blindly.
+    const cache = new LRUCacheManager<string>({ maxSize: 10, maxBytes: 1 });
+
+    cache.set("A", "a".repeat(10_000));
+
+    expect(cache.get("A")).toBe("a".repeat(10_000));
+    expect(cache.size).toBe(1);
+  });
 });

--- a/platform/backend/src/cache-manager.ts
+++ b/platform/backend/src/cache-manager.ts
@@ -356,13 +356,36 @@ export const cacheManager = new CacheManager();
 /**
  * Configuration options for LRU cache instances.
  */
-interface LRUCacheOptions {
+interface LRUCacheOptions<T = unknown> {
   /** Maximum number of entries in the cache (required) */
   maxSize: number;
   /** Default TTL in milliseconds for cache entries (optional, defaults to 1 hour) */
   defaultTtl?: number;
   /** Callback fired when an entry is evicted from the cache */
   onEviction?: (key: string, value: unknown) => void;
+  /**
+   * Optional ceiling on total retained bytes, measured with `sizeOf`.
+   *
+   * An entry count only approximates memory when entries are of similar size.
+   * For a cache holding values whose size varies by orders of magnitude it is
+   * not a bound at all — a few hundred large entries can exhaust the heap while
+   * the cache still looks nearly empty against `maxSize`. Setting this evicts
+   * oldest-written entries until the total fits, making `maxSize` a coarse
+   * backstop and this the real bound.
+   *
+   * Eviction order is QuickLRU's approximation, the same one its count-based
+   * eviction uses: reads do not reorder entries within a generation, so this is
+   * oldest-written-first rather than strictly least-recently-used.
+   *
+   * Requires `sizeOf`. Enforcement walks the retained entries on write, so
+   * callers that set this should keep `maxSize` modest.
+   */
+  maxBytes?: number;
+  /**
+   * Approximate retained size of a value, in bytes. Called once per write, and
+   * only when `maxBytes` is set.
+   */
+  sizeOf?: (value: T) => number;
 }
 
 /**
@@ -371,6 +394,8 @@ interface LRUCacheOptions {
 interface LRUCacheEntry<T> {
   value: T;
   expiresAt: number;
+  /** Size recorded at write time. Always 0 when the cache is not byte-bounded. */
+  bytes: number;
 }
 
 /**
@@ -394,10 +419,14 @@ export class LRUCacheManager<T = unknown> {
   private lruStore: QuickLRU<string, LRUCacheEntry<T>>;
   private defaultTtl: number;
   private onEviction?: (key: string, value: unknown) => void;
+  private maxBytes?: number;
+  private sizeOf?: (value: T) => number;
 
-  constructor(options: LRUCacheOptions) {
+  constructor(options: LRUCacheOptions<T>) {
     this.defaultTtl = options.defaultTtl ?? TimeInMs.Hour;
     this.onEviction = options.onEviction;
+    this.sizeOf = options.sizeOf;
+    this.maxBytes = options.sizeOf ? options.maxBytes : undefined;
 
     this.lruStore = new QuickLRU<string, LRUCacheEntry<T>>({
       maxSize: options.maxSize,
@@ -441,8 +470,10 @@ export class LRUCacheManager<T = unknown> {
     const entry: LRUCacheEntry<T> = {
       value,
       expiresAt: effectiveTtl > 0 ? Date.now() + effectiveTtl : 0,
+      bytes: this.maxBytes === undefined ? 0 : (this.sizeOf?.(value) ?? 0),
     };
     this.lruStore.set(key, entry);
+    this.enforceByteBudget();
   }
 
   /**
@@ -503,10 +534,58 @@ export class LRUCacheManager<T = unknown> {
     return this.lruStore.keys();
   }
 
+  /**
+   * Total bytes recorded at write time across retained entries. Always 0 when
+   * the cache is not byte-bounded.
+   */
+  get retainedBytes(): number {
+    let total = 0;
+    for (const [, entry] of this.lruStore.entriesAscending()) {
+      total += entry.bytes;
+    }
+    return total;
+  }
+
   private evictExpiredEntry(key: string, entry: LRUCacheEntry<T>): void {
     if (this.onEviction) {
       this.onEviction(key, entry.value);
     }
     this.lruStore.delete(key);
+  }
+
+  /**
+   * Evict oldest-written entries until the retained total fits `maxBytes`.
+   *
+   * Sizes are summed from the retained entries rather than tracked incrementally
+   * on purpose: QuickLRU fires `onEviction` for capacity evictions but not for
+   * `delete`, so a running counter would drift out of sync with the store and
+   * silently under- or over-report. At the modest `maxSize` a byte-bounded cache
+   * should use, summing is a handful of integer adds.
+   *
+   * A value larger than the whole budget is evicted immediately, so callers must
+   * not assume a `set` is observable by a later `get` — use the value they wrote.
+   */
+  private enforceByteBudget(): void {
+    const budget = this.maxBytes;
+    if (budget === undefined) {
+      return;
+    }
+
+    const entries = [...this.lruStore.entriesAscending()];
+    let total = 0;
+    for (const [, entry] of entries) {
+      total += entry.bytes;
+    }
+
+    for (const [key, entry] of entries) {
+      if (total <= budget) {
+        break;
+      }
+      total -= entry.bytes;
+      this.lruStore.delete(key);
+      if (this.onEviction) {
+        this.onEviction(key, entry.value);
+      }
+    }
   }
 }

--- a/platform/backend/src/models/interaction-delta-manager.test.ts
+++ b/platform/backend/src/models/interaction-delta-manager.test.ts
@@ -4,6 +4,7 @@ import {
   LEGACY_CLAUDE_DESKTOP_SESSION_SOURCE,
 } from "@archestra/shared";
 import { eq } from "drizzle-orm";
+import { vi } from "vitest";
 import config from "@/config";
 import {
   _resetContentKeys,
@@ -535,6 +536,43 @@ describe("InteractionDeltaManager", () => {
 
     expect(reconstructedMessages(map.get(aTip.id)?.request)).toEqual(aMsgs);
     expect(reconstructedMessages(map.get(bTip.id)?.request)).toEqual(bMsgs);
+  });
+
+  test("reconstructs correctly when the cache retains nothing", async () => {
+    const sessionId = "sess-evicting";
+    const msgs1 = [userMsg("e0")];
+    const msgs2 = [...msgs1, assistantMsg("ea0"), userMsg("e1")];
+    const msgs3 = [...msgs2, assistantMsg("ea1"), userMsg("e2")];
+    await createClaude(msgs1, { sessionId });
+    await createClaude(msgs2, { sessionId });
+    const tip = await createClaude(msgs3, { sessionId });
+
+    InteractionDeltaManager.reset();
+
+    // The reconstruct cache is byte-bounded, so a conversation larger than the
+    // whole budget is evicted the moment it is written. Folding must not depend
+    // on reading its own writes back: if it does, reconstruction silently
+    // returns null here and callers fall back to the stored delta — a partial
+    // request presented as if it were the full one.
+    const cache = (
+      InteractionDeltaManager as unknown as {
+        reconstructCache: { set: (key: string, value: unknown) => void };
+      }
+    ).reconstructCache;
+    const setSpy = vi.spyOn(cache, "set").mockImplementation(() => {});
+
+    try {
+      const full = await InteractionDeltaManager.reconstructRow({
+        id: tip.id,
+        threadId: tip.threadId,
+        request: tip.request,
+        processedRequest: tip.processedRequest,
+      });
+
+      expect(reconstructedMessages(full.request)).toEqual(msgs3);
+    } finally {
+      setSpy.mockRestore();
+    }
   });
 
   test("claude_desktop interactions are delta-encoded too", async () => {

--- a/platform/backend/src/models/interaction-delta-manager.ts
+++ b/platform/backend/src/models/interaction-delta-manager.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { getHeapStatistics } from "node:v8";
 import { isClaudeSessionSource, TimeInMs } from "@archestra/shared";
 import { and, desc, eq, lt, sql } from "drizzle-orm";
 import { LRUCacheManager } from "@/cache-manager";
@@ -92,6 +93,48 @@ interface ReconstructableRow {
 
 const CACHE_MAX_SIZE = 5000;
 
+/**
+ * Entry ceiling for the reconstruct cache.
+ *
+ * Deliberately far below CACHE_MAX_SIZE. A tipCache entry is a few scalars, but
+ * a reconstruct entry is a whole reconstructed request, which for a Claude Code
+ * session runs to megabytes. RECONSTRUCT_CACHE_MAX_BYTES is the real bound; this
+ * is the backstop, kept small so the byte sweep stays cheap.
+ */
+const RECONSTRUCT_CACHE_MAX_ENTRIES = 512;
+
+/**
+ * Share of the V8 heap the reconstruct cache may retain.
+ *
+ * Derived from the heap limit rather than hardcoded so the budget tracks the
+ * container: the production launcher sizes --max-old-space-size from the pod's
+ * memory limit, so a larger pod gets a proportionally larger cache without a
+ * second knob to keep in sync.
+ */
+const RECONSTRUCT_CACHE_HEAP_FRACTION = 0.1;
+
+const RECONSTRUCT_CACHE_MAX_BYTES = Math.floor(
+  getHeapStatistics().heap_size_limit * RECONSTRUCT_CACHE_HEAP_FRACTION,
+);
+
+/**
+ * Approximate retained size of a reconstructed request.
+ *
+ * `.length` counts UTF-16 code units rather than bytes, which understates
+ * multi-byte text. That is fine for a budget whose job is to stop a cache from
+ * consuming the heap, and it avoids a second full pass over the payload.
+ */
+function approximateRetainedBytes(value: FullRequest): number {
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    // Unexpected for these payloads, but a sizing helper must never be the
+    // reason a request fails. Counting it as free is safe — the entry ceiling
+    // still bounds it.
+    return 0;
+  }
+}
+
 class InteractionDeltaManager {
   /** Branch tip per (sessionId, threadId) — write-path parent fast path. */
   private static tipCache = new LRUCacheManager<CachedTip>({
@@ -99,9 +142,19 @@ class InteractionDeltaManager {
     defaultTtl: TimeInMs.Hour,
   });
 
-  /** Reconstructed full request/processedRequest per interaction id — read-path memo. */
+  /**
+   * Reconstructed full request/processedRequest per interaction id — read-path
+   * memo and write-path parent source.
+   *
+   * Bounded by bytes, not entry count. Entries here are whole reconstructed
+   * requests whose size spans orders of magnitude, so a count is not a memory
+   * bound: at Claude Code payload sizes the heap is exhausted by a few hundred
+   * entries, a few percent of a nominal 5000-entry capacity.
+   */
   private static reconstructCache = new LRUCacheManager<FullRequest>({
-    maxSize: CACHE_MAX_SIZE,
+    maxSize: RECONSTRUCT_CACHE_MAX_ENTRIES,
+    maxBytes: RECONSTRUCT_CACHE_MAX_BYTES,
+    sizeOf: approximateRetainedBytes,
     defaultTtl: TimeInMs.Hour,
   });
 
@@ -509,6 +562,12 @@ class InteractionDeltaManager {
     // The previous row's reconstructed full request — the source for inheriting
     // omitted `tools`/`system`. Null at the head (which stores the full envelope).
     let parentFull: FullRequest | null = null;
+    // The fold result, held locally rather than read back out of the cache. The
+    // cache is byte-bounded, so writing an entry does not guarantee it is still
+    // there a moment later: a request larger than the whole budget is evicted
+    // immediately. Reading it back would turn that into a spurious null and send
+    // the caller down the "no delta" path with a partial request.
+    let foldedTarget: FullRequest | null = null;
 
     for (const row of chain) {
       const cached = InteractionDeltaManager.reconstructCache.get(row.id);
@@ -516,6 +575,7 @@ class InteractionDeltaManager {
         requestMessages = getMessages(cached.request) ?? [];
         processedMessages = getMessages(cached.processedRequest);
         parentFull = cached;
+        foldedTarget = cached;
         continue;
       }
 
@@ -544,9 +604,10 @@ class InteractionDeltaManager {
       );
       InteractionDeltaManager.reconstructCache.set(row.id, full);
       parentFull = full;
+      foldedTarget = full;
     }
 
-    return InteractionDeltaManager.reconstructCache.get(id) ?? null;
+    return foldedTarget;
   }
 }
 


### PR DESCRIPTION
Follow-up to #7172, which raised staging's memory limit to stop the web tier being OOM-killed roughly every five minutes. That bought headroom; this addresses what was consuming it.

## The defect

`InteractionDeltaManager.reconstructCache` retains whole reconstructed requests but was bounded only by entry count (5000). An entry count only approximates memory when entries are of similar size. These are not: a Claude Code request runs to megabytes, so the heap is exhausted somewhere around a few hundred entries — a few percent of nominal capacity, at which point the cache still looks nearly empty. Each entry holds two full copies (`request` and `processedRequest`) for a lazily-checked hour.

It was inert while content encryption was on, because `isEligible()` returned false before the tip was ever committed. Once that gate was removed the cache began populating on every eligible proxy write, and near-heap-limit events on staging went from ~2/day to 80, then 407.

## The fix

`LRUCacheManager` gains optional `maxBytes` / `sizeOf`; the reconstruct cache sets a budget derived from the V8 heap limit and drops its entry ceiling to 512 as a backstop.

Deriving the budget from the heap limit rather than hardcoding it means it tracks the container: the production launcher already sizes `--max-old-space-size` from the pod's memory limit, so a larger pod gets a proportionally larger cache with no second knob to keep in sync.

Two implementation notes worth review attention:

- **Sizes are summed from retained entries, not tracked incrementally.** QuickLRU fires `onEviction` for capacity evictions but not for `delete`, so a running counter would silently drift out of sync with the store. At 512 entries this is a handful of integer adds.
- **Eviction order is oldest-*written*-first, not strictly least-recently-used.** QuickLRU is a two-generation LRU, so a `get` does not reorder entries within a generation. This is the same approximation its own count-based eviction already uses, and it suits this workload since the entries worth keeping are the newest branch tips. A test pins this rather than implying a stronger guarantee.

## A latent bug this also fixes

`foldFor` returned its result by reading it back out of the cache. That is safe while eviction is purely count-based, but byte-bounding makes it reachable: a request larger than the whole budget is evicted on write, so the read-back returns `undefined`, `foldFor` returns `null`, and the caller falls back to the stored delta — **a partial request presented as if it were the full one**. `foldFor` now returns the value it built.

## Cost

One `JSON.stringify` per cached write. On the payloads that matter that is ~1-2% of a request which already parses every tool result and runs two tokenizer passes over each — a good trade against unbounded heap growth. Sizing counts UTF-16 code units rather than bytes, which understates multi-byte text; that is fine for a budget whose job is to stop a cache from eating the heap.

## Tests

- `cache-manager.test.ts` — byte eviction, eviction ordering, a value larger than the whole budget being dropped, and two regression guards that a cache without `maxBytes`/`sizeOf` keeps its existing entry-count behavior. 30/30 pass.
- `interaction-delta-manager.test.ts` — reconstruction stays correct when the cache retains nothing, by spying `set` into a no-op. This is the test that fails without the `foldFor` change.

Backend `type-check`, `biome check`, and `knip` (dev + production) are clean.

**Pre-existing failures, not from this change:** `interaction-delta-manager.test.ts` has 8 failures on `main` today. I ran the file on clean `main` first to establish that baseline — it goes 15 passed / 8 failed there, and 16 passed / 8 failed here. Same 8, unrelated to this work, but they should be looked at separately.

## Scope

This reduces memory pressure; it does not resize pods. Whether the chart's 3Gi default and the 60%-of-limit old-space formula are right for a container that hosts both the backend and the Next.js server is a separate question, best settled from a clean baseline once this has been running.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>