### PR TITLE
fix(docker): bump go-git to 5.19.2 for cve-2026-71556

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -72,13 +72,18 @@ RUN git clone --depth 1 --branch "${DAGGER_VERSION}" https://github.com/dagger/d
     # cve-2026-34986: go-jose uncaught exception fixed in >= 4.1.4
     go get github.com/go-jose/go-jose/v4@v4.1.4 && \
     # cve-2026-45022: go-git validation issue fixed in >= 5.19.0
-    go get github.com/go-git/go-git/v5@v5.19.0 && \
+    # cve-2026-71556: go-git link following fixed in >= 5.19.2
+    go get github.com/go-git/go-git/v5@v5.19.2 && \
     # cve-2026-44973: go-billy path traversal fixed in >= 5.9.0
     go get github.com/go-git/go-billy/v5@v5.9.0 && \
-    # cve-2026-39821: x/net CRITICAL fixed in >= 0.55.0
-    go get golang.org/x/net@v0.55.0 && \
+    # cve-2026-39821: x/net CRITICAL fixed in >= 0.55.0.
+    # Pinned to 0.56.0 (not 0.55.0) because go-git 5.19.2 requires >= 0.56.0 — asking for
+    # anything lower here makes `go get` downgrade go-git back below 5.19.2 to satisfy it,
+    # silently reintroducing cve-2026-71556. Do not lower without also lowering go-git.
+    go get golang.org/x/net@v0.56.0 && \
     # cve-2026-46597: x/crypto issue fixed in >= 0.52.0; keep this after x/net.
-    go get golang.org/x/crypto@v0.52.0 && \
+    # Pinned to 0.53.0 for the same go-git 5.19.2 floor reason as x/net above.
+    go get golang.org/x/crypto@v0.53.0 && \
     go get github.com/moby/go-archive@v0.2.0 github.com/moby/profiles/seccomp@v0.2.3 github.com/moby/sys/reexec@v0.1.0 github.com/moby/sys/user@v0.4.0 && \
     # cve-2026-46680: containerd type confusion fixed in >= 2.2.4
     # cve-2026-53488/53492/53489: containerd injection/input-validation/symlink-following fixed in >= 2.2.5


### PR DESCRIPTION
## Problem

The `Docker Image Scanning (Platform)` job fails on `main`, blocking the merge queue:

```
0C  1H  0M  0L  github.com/go-git/go-git/v5 5.19.0
  ✗ HIGH CVE-2026-71556 [Improper Link Resolution Before File Access ('Link Following')]
    Affected range : <=5.19.1
    Fixed version  : 5.19.2
    CVSS Score     : 7.1
```

The image carried go-git 5.19.0, pinned in the Dagger `go-builder` stage for the earlier `cve-2026-45022`.

## Why this isn't a one-line bump

Bumping go-git alone doesn't work, and it fails in a way that looks like the bump didn't take.

go-git 5.19.2 raises its floors to `x/net >= 0.56.0` and `x/crypto >= 0.53.0`. The stage pins those to `0.55.0` / `0.52.0` on the lines immediately after — and those `go get`s run later, so they win. Asking for the lower x/net **exits 0 with no error** and silently downgrades go-git back to **5.19.1**, still inside the vulnerable range. The build succeeds and the scan still fails.

Measured directly:

```
--- go-git after its own pin: v5.19.2
--- now applying the OLD x/net@v0.55.0 pin ---
--- go get x/net@v0.55.0 exit code: 0
--- go-git after old x/net pin: v5.19.1     <-- still vulnerable
```

So this raises all three together and comments the x/net / x/crypto pins as load-bearing for the go-git floor, so a future "tidy-up" lowering them doesn't quietly reintroduce the CVE.

Both new versions are strictly above what their own CVE comments require (x/net `>= 0.55.0` for `cve-2026-39821`, x/crypto `>= 0.52.0` for `cve-2026-46597`), so those fixes are unaffected.

## Scope

go-git is pinned in **only** the Dagger stage, unlike x/net which is pinned in all four (kind, docker-cli, dagger, kubectl). That asymmetry is the existing evidence that the Dagger CLI is the only binary bringing go-git into the image — so one pin site is the right blast radius.

## Verification

Replayed the stage's exact `go get` sequence against dagger `v0.21.7` at the pinned commit (`054f94b…`, verified to match `DAGGER_COMMIT`), then built `./cmd/dagger` with the stage's flags (`CGO_ENABLED=0 GOOS=linux GOARCH=amd64`).

Compiles clean (83M static linux/amd64 ELF). The resulting binary's embedded module metadata — the same data Docker Scout reads — reports:

| module | version |
| --- | --- |
| `github.com/go-git/go-git/v5` | **v5.19.2** ✅ |
| `github.com/go-git/go-billy/v5` | v5.9.0 |
| `golang.org/x/net` | v0.56.0 |
| `golang.org/x/crypto` | v0.53.0 |
| `github.com/go-jose/go-jose/v4` | v4.1.4 |
| `github.com/containerd/containerd/v2` | v2.2.5 |
| `google.golang.org/grpc` | v1.82.1 |

Every other CVE pin in the stage survived — worth checking explicitly here, since the whole failure mode of this stage is later `go get`s silently undoing earlier ones.

The authoritative check is CI's own Scout run on this PR.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>