### PR TITLE
test(mcp): pin the import order that breaks the built-in aggregations

### DIFF
--- a/platform/backend/src/archestra-mcp-server/tool-list-import-cycle.test.ts
+++ b/platform/backend/src/archestra-mcp-server/tool-list-import-cycle.test.ts
@@ -1,0 +1,49 @@
+import { getArchestraToolFullName } from "@archestra/shared";
+import { describe, expect, test, vi } from "vitest";
+
+// Puts this file in the isolated vitest project (see vitest.config.ts: files
+// touching the mock registry get `isolate: true`). `resetModules` below would
+// otherwise clear the module registry the clean project's worker shares with
+// every other file, failing whichever siblings happen to be mid-run.
+vi.mock("@/logging");
+
+/**
+ * `./index` is part of an import cycle: `./sandbox` imports `@/models`, which
+ * reaches `models/agent` → `clients/chat-mcp-client` → back to `./index`.
+ * Entering through `./sandbox` runs `./index`'s body while the group modules it
+ * aggregates are still uninitialized, so anything `./index` builds from them at
+ * module scope reads `undefined`.
+ *
+ * Only one of the two aggregations fails loudly, which is why this pins both:
+ * spreading the tool arrays throws `tools is not iterable`, while spreading the
+ * tool-entry objects silently yields a dispatch map missing whole groups.
+ *
+ * Import order alone decides whether either surfaces, so `resetModules` fixes
+ * the order that breaks rather than leaving it to which file loaded first.
+ */
+describe("built-in aggregations under the @/models import cycle", () => {
+  test("tool lists survive the cycle entered through ./sandbox", async () => {
+    vi.resetModules();
+
+    await import("./sandbox");
+    const index = await import(".");
+
+    expect(index.getAllArchestraMcpTools().length).toBeGreaterThan(0);
+    expect(index.getArchestraMcpTools().length).toBeGreaterThan(0);
+  });
+
+  test("the dispatch map still resolves a sandbox tool's schema", async () => {
+    vi.resetModules();
+
+    await import("./sandbox");
+    const index = await import(".");
+
+    // Resolved through the tool-entry map, so an incomplete one returns
+    // undefined here instead of failing anywhere the model can see.
+    expect(
+      index.getArchestraToolInputSchema(
+        getArchestraToolFullName("run_command"),
+      ),
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`archestra-mcp-server/index.ts` builds two aggregations out of the group modules — the tool arrays and the tool-entry dispatch map — and sits in an import cycle with them: `./sandbox` imports `@/models`, which reaches `models/agent` → `clients/chat-mcp-client` → back to `index`. Entering that cycle through a group module runs `index`'s body while those exports are still uninitialized, so building either aggregation at module scope reads `undefined`.

#7169 made both lazy, which is the right fix. Nothing pins it there. Whether an eager rebuild actually breaks depends on which file loaded `index` first, and mock-free tests share a worker, so the same defect can pass a full run and fail only under a particular shard split — it can return and go green.

These fix the order that breaks instead of leaving it to load order.

They are two tests because the two aggregations fail differently, and only one is visible. Array spread of `undefined` throws `tools is not iterable` and stops everything. Object spread of `undefined` throws nothing — it produces a dispatch map quietly missing whole groups, which surfaces as a built-in that no longer resolves rather than as an error. The map is therefore covered through a tool schema lookup, which returns `undefined` in exactly that case; folding it into the array assertion would have hidden it behind the louder failure.

The file mocks a module so vitest places it in the isolated project. `resetModules` in the shared-worker project clears the registry out from under whichever sibling files are mid-run, which fails them rather than this one.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>