### PR TITLE
fix(deps): pin nanoid to 3.3.17 for CVE-2026-67213

### DIFF
--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -79,6 +79,7 @@ overrides:
   fastify: '>=5.8.5'
   find-my-way: 9.7.0
   postcss: '>=8.5.18'
+  nanoid@<4: 3.3.17
   uuid@^11: '>=11.1.1'
   ip-address: '>=10.3.1'
   brace-expansion: 5.0.9
@@ -8927,8 +8928,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -19897,7 +19898,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   nanoid@5.1.6: {}
 
@@ -20327,7 +20328,7 @@ snapshots:
 
   postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -124,6 +124,13 @@ overrides:
   # carried two postcss copies (8.5.11 and 8.5.17) under the old >=8.5.10
   # floor, so the floor has to clear the higher of the two fixes.
   postcss: '>=8.5.18'
+  # CVE-2026-67213 (GHSA-2v37-7h3g-55p8, HIGH, custom generators loop forever
+  # when size is 0) fixed in 3.3.17 on the v3 line. Transitive via postcss and
+  # points-on-path; scoped to <4 so the frontend's direct nanoid ^5.1.6 (already
+  # past the v5 fix) keeps its own resolution. Pinned exact (not a `>=` floor)
+  # because nanoid is temporarily excluded from minimumReleaseAge below, so a
+  # floor could otherwise pull an unvetted release.
+  nanoid@<4: 3.3.17
   uuid@^11: '>=11.1.1'
   # CVE-2026-69192 (HIGH) affects <=10.3.0, fixed in 10.3.1 — the previous
   # >=10.1.1 floor resolved 10.2.0, inside the vulnerable range.
@@ -210,6 +217,10 @@ minimumReleaseAgeExclude:
   # 2026-07-31 and clears the 7-day window on 2026-08-07. Remove on/after that
   # date — the lockfile stays pinned at 3.1.5 regardless.
   - fast-uri
+  # TEMPORARY: nanoid 3.3.17 (fix CVE-2026-67213, HIGH) was published
+  # 2026-08-03 and clears the 7-day window on 2026-08-10. Remove on/after that
+  # date — the lockfile stays pinned at 3.3.17 regardless.
+  - nanoid
 
 # OpenTelemetry instrumentation requires these packages hoisted to root.
 # @hookform/resolvers/zod statically imports `zod/v4/core` but does not declare


### PR DESCRIPTION
## Summary

Docker Image Scanning in the merge queue rejects every queued PR since 2026-08-08 06:49 UTC because the platform image carries nanoid 3.3.16, inside the range of CVE-2026-67213 / GHSA-2v37-7h3g-55p8 (HIGH): custom nanoid generators loop indefinitely when asked for a size of 0, an unbounded-CPU DoS. The fix on the v3 line is 3.3.17.

nanoid 3.x is transitive here (via `postcss` and `points-on-path`; the frontend's direct dependency is already on the patched 5.1.6), so the bump is a pnpm override scoped to `nanoid@<4` — the v5 resolution is left alone. 3.3.17 was published 2026-08-03, still inside the workspace's 7-day `minimumReleaseAge` quarantine, so the override pins the exact version rather than a `>=` floor and nanoid joins the TEMPORARY release-age exclusions with a removal date of 2026-08-10, matching how form-data/js-yaml/fast-uri handled the same situation.

After this, `pnpm-lock.yaml` resolves only nanoid 3.3.17 and 5.1.6 — both past their line's patched version.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>