### PR TITLE
fix(deps): bump nanoid to 5.1.16 for CVE-2026-67214

### DIFF
--- a/platform/frontend/package.json
+++ b/platform/frontend/package.json
@@ -82,7 +82,7 @@
     "lucide-react": "^0.577.0",
     "mediabunny": "^1.50.8",
     "mermaid": "^11.15.0",
-    "nanoid": "^5.1.6",
+    "nanoid": "^5.1.16",
     "next": "16.3.0-canary.56",
     "next-runtime-env": "^3.3.0",
     "next-themes": "^0.4.6",

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -775,8 +775,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       nanoid:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.1.16
+        version: 5.1.16
       next:
         specifier: 16.3.0-canary.56
         version: 16.3.0-canary.56(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@25.5.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -8933,8 +8933,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -19900,7 +19900,7 @@ snapshots:
 
   nanoid@3.3.17: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.16: {}
 
   nanostores@1.2.0: {}
 


### PR DESCRIPTION
## Summary

Dependabot alert #471 flags the workspace's nanoid 5.1.6 (the frontend's direct dependency) for CVE-2026-67214 / GHSA-28wg-ghj8-5hjv (HIGH): non-secure nanoid generators loop indefinitely when passed a negative size, an unbounded-CPU DoS. The v5 line is affected from 4.0.0 up to the 5.1.16 fix.

This is the sibling advisory of CVE-2026-67213 (the v3-line pin merged in #7178) — same publication day, same bug class, different affected range. The v3 resolution pinned there (3.3.17) is already past its fix for both advisories, so this bump completes the pair: `frontend/package.json` moves its floor from ^5.1.6 to ^5.1.16, and the lockfile now resolves only nanoid 3.3.17 and 5.1.16. 5.1.16 was published 2026-06-24, past the 7-day release quarantine, so no `minimumReleaseAge` exclusion change is involved.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>