### PR TITLE
feat(orchestrator): prototype Dagger MCP service runtime

### DIFF
--- a/platform/archestra-rs/sandbox-core/src/backend.rs
+++ b/platform/archestra-rs/sandbox-core/src/backend.rs
@@ -5,7 +5,10 @@
 //! every match site to handle it.
 
 use crate::backends::dagger::DaggerBackend;
-use crate::{ArtifactBytes, CommandExecution, EngineFault, Limits, ReplayStep, Result};
+use crate::{
+    ArtifactBytes, CommandExecution, DaggerMcpServiceEndpoint, DaggerMcpServiceEnvVar, EngineFault,
+    Limits, ReplayStep, Result, StopDaggerMcpServiceResult,
+};
 
 /// a materialise-and-run request handed to a backend. validated at the public
 /// core entry points before it reaches here. skill files and PYTHONPATH are no
@@ -29,6 +32,21 @@ pub(crate) struct ArtifactRequest {
     pub path: String,
     pub default_cwd: String,
     pub traceparent: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StartMcpServiceRequest {
+    pub service_key: String,
+    pub image: String,
+    pub command: Option<Vec<String>>,
+    pub env: Vec<DaggerMcpServiceEnvVar>,
+    pub port: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StopMcpServiceRequest {
+    pub service_key: String,
+    pub kill: bool,
 }
 
 /// the behaviour every sandbox backend provides. used only via the concrete
@@ -69,6 +87,24 @@ impl Backend {
     pub(crate) async fn check_session(&self, traceparent: Option<String>) -> Result<()> {
         match self {
             Backend::Dagger(b) => b.check_session(traceparent).await,
+        }
+    }
+
+    pub(crate) async fn start_mcp_service(
+        &self,
+        req: StartMcpServiceRequest,
+    ) -> Result<DaggerMcpServiceEndpoint> {
+        match self {
+            Backend::Dagger(b) => b.start_mcp_service(req).await,
+        }
+    }
+
+    pub(crate) async fn stop_mcp_service(
+        &self,
+        req: StopMcpServiceRequest,
+    ) -> Result<StopDaggerMcpServiceResult> {
+        match self {
+            Backend::Dagger(b) => b.stop_mcp_service(req).await,
         }
     }
 

--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -2,6 +2,7 @@
 //! session, and materialises each request into a content-addressed container
 //! chain. all `dagger_sdk` usage is contained in this module.
 
+use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -16,15 +17,19 @@ use dagger_sdk::core::gql_client::GraphQlExtension;
 use dagger_sdk::core::graphql_client::{DefaultGraphQLClient, GraphQLError};
 use dagger_sdk::errors::{ConnectError, DaggerError};
 use dagger_sdk::{
-    Config, Container, ContainerWithExecOpts, ContainerWithFileOpts, ContainerWithNewFileOpts,
-    DaggerConn, Query, ReturnType,
+    Config, Container, ContainerAsServiceOpts, ContainerWithExecOpts, ContainerWithFileOpts,
+    ContainerWithNewFileOpts, DaggerConn, HostTunnelOpts, NetworkProtocol, PortForward, Query,
+    ReturnType, Service, ServiceEndpointOpts, ServiceStopOpts,
 };
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
-use tokio::sync::{OnceCell, broadcast, mpsc, oneshot};
+use tokio::sync::{Mutex, OnceCell, broadcast, mpsc, oneshot};
 use tracing::Span;
 
-use crate::backend::{ArtifactRequest, Backend, RunRequest, SandboxBackend};
+use crate::backend::{
+    ArtifactRequest, Backend, RunRequest, SandboxBackend, StartMcpServiceRequest,
+    StopMcpServiceRequest,
+};
 use crate::session::{self, CHANNEL_CAPACITY, SessionHandle, SessionMsg};
 use crate::supervisor::{
     ARCHESTRA_RUN_PY, SUPERVISOR_PATH, parse_supervisor_output, supervised_argv,
@@ -34,8 +39,9 @@ use crate::validation::{
     skill_root_path, validate_artifact_path, validate_cwd, validate_snapshot_file_path,
 };
 use crate::{
-    ArtifactBytes, CommandExecution, EngineFault, ReplayInputFile, ReplayStep, Result,
-    RuntimeTarget, SandboxError, SnapshotFile,
+    ArtifactBytes, CommandExecution, DAGGER_MCP_SERVICE_KEY_ENV, DaggerMcpServiceEndpoint,
+    EngineFault, ReplayInputFile, ReplayStep, Result, RuntimeTarget, SandboxError, SnapshotFile,
+    StopDaggerMcpServiceResult,
 };
 
 /// debian + python + uv + node + npm + common cli, warmed once per process.
@@ -86,7 +92,6 @@ const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
 /// the dagger SDK message emitted when the engine accepted `/query` but timed
 /// out waiting for this client's session attachables. see [`classify_engine_fault`].
 const SESSION_ATTACHABLES_WAIT_ERROR: &str = "waiting for client session attachables";
-
 const ARTIFACT_TOO_LARGE_EXIT_CODE: isize = 65;
 const ARTIFACT_NOT_FOUND_EXIT_CODE: isize = 66;
 
@@ -111,6 +116,14 @@ const PYPROJECT_SETUP: &str = "printf '[project]\\nname = \"sandbox\"\\nversion 
 pub(crate) struct DaggerBackend {
     client: DaggerConn,
     warm: OnceCell<Container>,
+    mcp_service_slots: Mutex<HashMap<String, Arc<Mutex<Option<RunningMcpService>>>>>,
+}
+
+struct RunningMcpService {
+    spec: StartMcpServiceRequest,
+    source: Service,
+    tunnel: Service,
+    endpoint: DaggerMcpServiceEndpoint,
 }
 
 impl DaggerBackend {
@@ -121,6 +134,157 @@ impl DaggerBackend {
             .await?;
         Ok(container.clone())
     }
+
+    /// Start a container-native MCP server and expose it to the backend through
+    /// a Dagger host tunnel. Holding the per-service slot across the start makes
+    /// concurrent demand a natural single-flight: the second caller observes
+    /// the already-running identical spec and reuses its endpoint, while other
+    /// service keys can wake in parallel.
+    pub(crate) async fn start_mcp_service(
+        &self,
+        req: StartMcpServiceRequest,
+    ) -> Result<DaggerMcpServiceEndpoint> {
+        let slot = {
+            let mut slots = self.mcp_service_slots.lock().await;
+            slots
+                .entry(req.service_key.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(None)))
+                .clone()
+        };
+        // Serialize only this physical service. Different MCP servers can cold
+        // start concurrently and use the actor's normal engine back-pressure.
+        let mut running = slot.lock().await;
+        if let Some(running) = running.as_ref()
+            && running.spec == req
+        {
+            return Ok(running.endpoint.clone());
+        }
+
+        // A catalog edit may reuse the physical key with a different image,
+        // command, env or port. Stop the old graph before replacing it so one
+        // logical MCP server never has two live processes in this session.
+        if let Some(previous) = running.as_ref() {
+            stop_running_mcp_service(previous, true).await?;
+            *running = None;
+        }
+
+        let mut container = self.client.container().from(req.image.clone());
+        for (index, env) in req.env.iter().enumerate() {
+            container = if env.secret.unwrap_or(false) {
+                let secret = self.client.set_secret(
+                    format!("mcp-service-{}-{index}", req.service_key.replace('/', "-")),
+                    env.value.clone(),
+                );
+                container.with_secret_variable(env.name.clone(), secret)
+            } else {
+                container.with_env_variable(env.name.clone(), env.value.clone())
+            };
+        }
+        // Apply after user env so the isolation key cannot be overridden even
+        // if an older caller bypassed the current boundary validation.
+        container =
+            container.with_env_variable(DAGGER_MCP_SERVICE_KEY_ENV, req.service_key.clone());
+        container = container.with_exposed_port(req.port as isize);
+
+        let source = match req.command.as_ref() {
+            Some(command) => {
+                let args = command.iter().map(String::as_str).collect();
+                container.as_service_opts(ContainerAsServiceOpts {
+                    args: Some(args),
+                    // `command` is a full argv override, matching a Kubernetes
+                    // container `command` + `args` pair after TS normalisation.
+                    use_entrypoint: Some(false),
+                    experimental_privileged_nesting: None,
+                    insecure_root_capabilities: None,
+                    expand: None,
+                    no_init: None,
+                })
+            }
+            None => container.as_service(),
+        };
+        let tunnel = self.client.host().tunnel_opts(
+            source.clone(),
+            HostTunnelOpts {
+                native: Some(false),
+                ports: Some(vec![PortForward {
+                    backend: req.port as isize,
+                    // 0 asks Dagger for a collision-free host port.
+                    frontend: 0,
+                    protocol: NetworkProtocol::Tcp,
+                }]),
+            },
+        );
+        // Starting the tunnel starts its source dependency and waits for the
+        // source port health check. That collapses image pull + process start +
+        // readiness + port-forward creation into one engine operation.
+        let started_tunnel = tunnel.start().await.map_err(from_sdk)?;
+        let url = match started_tunnel
+            .endpoint_opts(ServiceEndpointOpts {
+                port: None,
+                scheme: Some("http"),
+            })
+            .await
+        {
+            Ok(url) => url,
+            Err(error) => {
+                // A tunnel that started but could not report its endpoint is
+                // unusable and would otherwise be left running but untracked.
+                let _ = stop_dagger_services(&started_tunnel, &source, true).await;
+                return Err(from_sdk(error));
+            }
+        };
+        let endpoint = DaggerMcpServiceEndpoint { url };
+        *running = Some(RunningMcpService {
+            spec: req,
+            source,
+            tunnel: started_tunnel,
+            endpoint: endpoint.clone(),
+        });
+        Ok(endpoint)
+    }
+
+    /// Stop the host tunnel and its source container. Missing ownership is a
+    /// successful no-op; a Dagger service belongs to its client session, so a
+    /// new backend process must not pretend it can stop a predecessor's graph.
+    pub(crate) async fn stop_mcp_service(
+        &self,
+        req: StopMcpServiceRequest,
+    ) -> Result<StopDaggerMcpServiceResult> {
+        let slot = self
+            .mcp_service_slots
+            .lock()
+            .await
+            .get(&req.service_key)
+            .cloned();
+        let Some(slot) = slot else {
+            return Ok(StopDaggerMcpServiceResult { stopped: false });
+        };
+        let mut running = slot.lock().await;
+        let Some(owned) = running.as_ref() else {
+            return Ok(StopDaggerMcpServiceResult { stopped: false });
+        };
+        stop_running_mcp_service(owned, req.kill).await?;
+        *running = None;
+        Ok(StopDaggerMcpServiceResult { stopped: true })
+    }
+}
+
+async fn stop_running_mcp_service(running: &RunningMcpService, kill: bool) -> Result<()> {
+    stop_dagger_services(&running.tunnel, &running.source, kill).await
+}
+
+async fn stop_dagger_services(tunnel: &Service, source: &Service, kill: bool) -> Result<()> {
+    let opts = ServiceStopOpts { kill: Some(kill) };
+    let tunnel_result = tunnel.stop_opts(opts).await.map_err(from_sdk);
+    // The tunnel owns a dependency on `source`, but stopping it explicitly is
+    // cheap and makes the desired zero-running-container state unambiguous.
+    let source_result = source
+        .stop_opts(ServiceStopOpts { kill: Some(kill) })
+        .await
+        .map_err(from_sdk);
+    tunnel_result?;
+    source_result?;
+    Ok(())
 }
 
 impl SandboxBackend for DaggerBackend {
@@ -546,6 +710,7 @@ pub(crate) async fn spawn(target: RuntimeTarget) -> Result<Arc<SessionHandle>> {
             let backend = Arc::new(Backend::Dagger(DaggerBackend {
                 client,
                 warm: OnceCell::new(),
+                mcp_service_slots: Mutex::new(HashMap::new()),
             }));
             session::run_loop(backend, msg_rx).await;
             Ok(())

--- a/platform/archestra-rs/sandbox-core/src/lib.rs
+++ b/platform/archestra-rs/sandbox-core/src/lib.rs
@@ -354,6 +354,71 @@ pub struct CheckSessionInput {
     pub environment: Option<EnvironmentTarget>,
 }
 
+/// Reserved graph input that keeps otherwise-identical logical MCP workloads
+/// distinct in Dagger's content-addressed service cache.
+pub(crate) const DAGGER_MCP_SERVICE_KEY_ENV: &str = "ARCHESTRA_MCP_SERVICE_KEY";
+
+/// One environment variable supplied to the experimental Dagger MCP service
+/// runtime. Secret values are registered with Dagger as `Secret`s instead of
+/// becoming plain graph arguments (and therefore appearing in traces/cache
+/// metadata).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "napi", napi_derive::napi(object))]
+#[serde(rename_all = "camelCase")]
+pub struct DaggerMcpServiceEnvVar {
+    pub name: String,
+    pub value: String,
+    #[serde(default)]
+    pub secret: Option<bool>,
+}
+
+/// Start (or join) a streamable-HTTP MCP server backed by a Dagger service.
+///
+/// This is deliberately an experimental primitive, not a replacement for the
+/// Kubernetes MCP runtime. It proves the lifecycle seam for catalog entries
+/// that are already container-native and need no Kubernetes-only features.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "napi", napi_derive::napi(object))]
+#[serde(rename_all = "camelCase")]
+pub struct StartDaggerMcpServiceInput {
+    #[cfg_attr(feature = "napi", napi(js_name = "serviceKey"))]
+    pub service_key: String,
+    pub image: String,
+    /// Full argv override. Omit to use the image's entrypoint/CMD.
+    pub command: Option<Vec<String>>,
+    pub env: Vec<DaggerMcpServiceEnvVar>,
+    pub port: u32,
+    pub environment: Option<EnvironmentTarget>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "napi", napi_derive::napi(object))]
+#[serde(rename_all = "camelCase")]
+pub struct DaggerMcpServiceEndpoint {
+    /// Host-reachable URL produced by a Dagger host tunnel.
+    pub url: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "napi", napi_derive::napi(object))]
+#[serde(rename_all = "camelCase")]
+pub struct StopDaggerMcpServiceInput {
+    #[cfg_attr(feature = "napi", napi(js_name = "serviceKey"))]
+    pub service_key: String,
+    #[serde(default)]
+    pub kill: Option<bool>,
+    pub environment: Option<EnvironmentTarget>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "napi", napi_derive::napi(object))]
+#[serde(rename_all = "camelCase")]
+pub struct StopDaggerMcpServiceResult {
+    /// False means this process/session did not own the service; stop is
+    /// intentionally idempotent so a repeated hibernation is harmless.
+    pub stopped: bool,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "napi", napi_derive::napi(object))]
 #[serde(rename_all = "camelCase")]
@@ -425,6 +490,43 @@ pub struct ArtifactBytes {
     pub size_bytes: u32,
 }
 
+#[tracing::instrument(name = "dagger_mcp_service.start.request", skip_all, fields(service_key = %input.service_key, image = %input.image, port = input.port))]
+pub async fn start_dagger_mcp_service(
+    input: StartDaggerMcpServiceInput,
+) -> Result<DaggerMcpServiceEndpoint> {
+    validate_dagger_mcp_service_input(&input)?;
+    let target = runtime_target_from(input.environment.clone())?;
+    let req = backend::StartMcpServiceRequest {
+        service_key: input.service_key,
+        image: input.image,
+        command: input.command,
+        env: input.env,
+        port: input.port as u16,
+    };
+    session::submit(target, move |reply| session::SessionMsg::StartMcpService {
+        req: req.clone(),
+        reply,
+    })
+    .await
+}
+
+#[tracing::instrument(name = "dagger_mcp_service.stop.request", skip_all, fields(service_key = %input.service_key))]
+pub async fn stop_dagger_mcp_service(
+    input: StopDaggerMcpServiceInput,
+) -> Result<StopDaggerMcpServiceResult> {
+    validate_service_key(&input.service_key)?;
+    let target = runtime_target_from(input.environment.clone())?;
+    let req = backend::StopMcpServiceRequest {
+        service_key: input.service_key,
+        kill: input.kill.unwrap_or(false),
+    };
+    session::submit(target, move |reply| session::SessionMsg::StopMcpService {
+        req: req.clone(),
+        reply,
+    })
+    .await
+}
+
 #[tracing::instrument(name = "sandbox.check_session.request", skip_all)]
 pub async fn check_session(input: CheckSessionInput) -> Result<()> {
     let span = tracing::Span::current();
@@ -437,6 +539,79 @@ pub async fn check_session(input: CheckSessionInput) -> Result<()> {
         }
     })
     .await
+}
+
+fn validate_dagger_mcp_service_input(input: &StartDaggerMcpServiceInput) -> Result<()> {
+    validate_service_key(&input.service_key)?;
+    if input.image.trim().is_empty() || input.image.len() > 2048 {
+        return Err(SandboxError::InvalidInput(
+            "Dagger MCP service image must be 1..=2048 characters".to_string(),
+        ));
+    }
+    if !(1..=u16::MAX as u32).contains(&input.port) {
+        return Err(SandboxError::InvalidInput(format!(
+            "Dagger MCP service port must be between 1 and 65535, got {}",
+            input.port
+        )));
+    }
+    if input.command.as_ref().is_some_and(Vec::is_empty) {
+        return Err(SandboxError::InvalidInput(
+            "Dagger MCP service command must be omitted or non-empty".to_string(),
+        ));
+    }
+    if input
+        .command
+        .iter()
+        .flatten()
+        .any(|part| part.is_empty() || part.contains('\0'))
+    {
+        return Err(SandboxError::InvalidInput(
+            "Dagger MCP service command entries must be non-empty and NUL-free".to_string(),
+        ));
+    }
+    for env in &input.env {
+        if !is_env_name(&env.name) {
+            return Err(SandboxError::InvalidInput(format!(
+                "invalid Dagger MCP service environment variable name: {:?}",
+                env.name
+            )));
+        }
+        if env.value.contains('\0') {
+            return Err(SandboxError::InvalidInput(format!(
+                "Dagger MCP service environment variable {:?} contains NUL",
+                env.name
+            )));
+        }
+        if env.name == DAGGER_MCP_SERVICE_KEY_ENV {
+            return Err(SandboxError::InvalidInput(format!(
+                "{DAGGER_MCP_SERVICE_KEY_ENV} is reserved by the Dagger MCP runtime"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_service_key(service_key: &str) -> Result<()> {
+    if service_key.is_empty()
+        || service_key.len() > 200
+        || !service_key
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'/'))
+        || service_key
+            .split('/')
+            .any(|segment| segment.is_empty() || matches!(segment, "." | ".."))
+    {
+        return Err(SandboxError::InvalidInput(format!(
+            "invalid Dagger MCP service key: {service_key:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn is_env_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    matches!(bytes.next(), Some(first) if first.is_ascii_alphabetic() || first == b'_')
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
 }
 
 #[tracing::instrument(
@@ -502,6 +677,77 @@ mod tests {
             environment_id: id.into(),
             namespace: ns.into(),
         }
+    }
+
+    fn valid_mcp_service_input() -> StartDaggerMcpServiceInput {
+        StartDaggerMcpServiceInput {
+            service_key: "namespace/mcp-example".to_string(),
+            image: "ghcr.io/example/mcp:sha-abc".to_string(),
+            command: Some(vec!["node".to_string(), "server.js".to_string()]),
+            env: vec![
+                DaggerMcpServiceEnvVar {
+                    name: "LOG_LEVEL".to_string(),
+                    value: "info".to_string(),
+                    secret: None,
+                },
+                DaggerMcpServiceEnvVar {
+                    name: "API_TOKEN".to_string(),
+                    value: "secret".to_string(),
+                    secret: Some(true),
+                },
+            ],
+            port: 8080,
+            environment: None,
+        }
+    }
+
+    #[test]
+    fn dagger_mcp_service_input_accepts_the_supported_http_shape() {
+        assert!(validate_dagger_mcp_service_input(&valid_mcp_service_input()).is_ok());
+    }
+
+    #[test]
+    fn dagger_mcp_service_input_rejects_unsafe_identity_port_and_env() {
+        let mut input = valid_mcp_service_input();
+        input.service_key = "../../tenant".to_string();
+        assert!(matches!(
+            validate_dagger_mcp_service_input(&input),
+            Err(SandboxError::InvalidInput(_))
+        ));
+
+        let mut input = valid_mcp_service_input();
+        input.port = 0;
+        assert!(matches!(
+            validate_dagger_mcp_service_input(&input),
+            Err(SandboxError::InvalidInput(_))
+        ));
+
+        let mut input = valid_mcp_service_input();
+        input.env[0].name = "BAD-NAME".to_string();
+        assert!(matches!(
+            validate_dagger_mcp_service_input(&input),
+            Err(SandboxError::InvalidInput(_))
+        ));
+
+        let mut input = valid_mcp_service_input();
+        input.env[0].name = "ARCHESTRA_MCP_SERVICE_KEY".to_string();
+        assert!(matches!(
+            validate_dagger_mcp_service_input(&input),
+            Err(SandboxError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn dagger_mcp_service_input_distinguishes_default_command_from_empty_override() {
+        let mut input = valid_mcp_service_input();
+        input.command = None;
+        assert!(validate_dagger_mcp_service_input(&input).is_ok());
+
+        input.command = Some(Vec::new());
+        assert!(matches!(
+            validate_dagger_mcp_service_input(&input),
+            Err(SandboxError::InvalidInput(_))
+        ));
     }
 
     #[test]

--- a/platform/archestra-rs/sandbox-core/src/session.rs
+++ b/platform/archestra-rs/sandbox-core/src/session.rs
@@ -13,8 +13,13 @@ use futures_util::FutureExt;
 use futures_util::future::{BoxFuture, Shared};
 use tokio::sync::{Mutex, OnceCell, Semaphore, mpsc, oneshot};
 
-use crate::backend::{ArtifactRequest, Backend, RunRequest};
-use crate::{ArtifactBytes, CommandExecution, EngineFault, Result, RuntimeTarget, SandboxError};
+use crate::backend::{
+    ArtifactRequest, Backend, RunRequest, StartMcpServiceRequest, StopMcpServiceRequest,
+};
+use crate::{
+    ArtifactBytes, CommandExecution, DaggerMcpServiceEndpoint, EngineFault, Result, RuntimeTarget,
+    SandboxError, StopDaggerMcpServiceResult,
+};
 
 pub(crate) const CHANNEL_CAPACITY: usize = 64;
 // Rust-side cap on concurrent backend handlers. Defense in depth — the TS
@@ -36,6 +41,14 @@ pub(crate) enum SessionMsg {
         traceparent: Option<String>,
         reply: oneshot::Sender<Result<()>>,
     },
+    StartMcpService {
+        req: StartMcpServiceRequest,
+        reply: oneshot::Sender<Result<DaggerMcpServiceEndpoint>>,
+    },
+    StopMcpService {
+        req: StopMcpServiceRequest,
+        reply: oneshot::Sender<Result<StopDaggerMcpServiceResult>>,
+    },
 }
 
 impl SessionMsg {
@@ -44,6 +57,8 @@ impl SessionMsg {
             SessionMsg::Run { .. } => SessionOperation::Run,
             SessionMsg::ReadArtifact { .. } => SessionOperation::ReadArtifact,
             SessionMsg::CheckSession { .. } => SessionOperation::CheckSession,
+            SessionMsg::StartMcpService { .. } => SessionOperation::StartMcpService,
+            SessionMsg::StopMcpService { .. } => SessionOperation::StopMcpService,
         }
     }
 }
@@ -53,6 +68,8 @@ enum SessionOperation {
     Run,
     ReadArtifact,
     CheckSession,
+    StartMcpService,
+    StopMcpService,
 }
 
 impl SessionOperation {
@@ -61,6 +78,8 @@ impl SessionOperation {
             SessionOperation::Run => "run",
             SessionOperation::ReadArtifact => "read_artifact",
             SessionOperation::CheckSession => "check_session",
+            SessionOperation::StartMcpService => "start_mcp_service",
+            SessionOperation::StopMcpService => "stop_mcp_service",
         }
     }
 }
@@ -458,6 +477,14 @@ async fn handle(backend: Arc<Backend>, msg: SessionMsg) {
             let result = catch_panic(&backend, backend.check_session(traceparent)).await;
             let _ = reply.send(result);
         }
+        SessionMsg::StartMcpService { req, reply } => {
+            let result = catch_panic(&backend, backend.start_mcp_service(req)).await;
+            let _ = reply.send(result);
+        }
+        SessionMsg::StopMcpService { req, reply } => {
+            let result = catch_panic(&backend, backend.stop_mcp_service(req)).await;
+            let _ = reply.send(result);
+        }
     }
 }
 
@@ -624,6 +651,8 @@ mod tests {
         // engine error (which may have run some of that history) is not retried.
         assert_eq!(retry_reason(SessionOperation::ReadArtifact, &err), None);
         assert_eq!(retry_reason(SessionOperation::Run, &err), None);
+        assert_eq!(retry_reason(SessionOperation::StartMcpService, &err), None);
+        assert_eq!(retry_reason(SessionOperation::StopMcpService, &err), None);
     }
 
     #[test]
@@ -636,6 +665,8 @@ mod tests {
         assert_eq!(retry_reason(SessionOperation::Run, &err), None);
         assert_eq!(retry_reason(SessionOperation::ReadArtifact, &err), None);
         assert_eq!(retry_reason(SessionOperation::CheckSession, &err), None);
+        assert_eq!(retry_reason(SessionOperation::StartMcpService, &err), None);
+        assert_eq!(retry_reason(SessionOperation::StopMcpService, &err), None);
     }
 
     #[test]
@@ -676,6 +707,14 @@ mod tests {
         );
         assert_eq!(
             retry_reason(SessionOperation::CheckSession, &err),
+            Some(RetryReason::StaleAttachables),
+        );
+        assert_eq!(
+            retry_reason(SessionOperation::StartMcpService, &err),
+            Some(RetryReason::StaleAttachables),
+        );
+        assert_eq!(
+            retry_reason(SessionOperation::StopMcpService, &err),
             Some(RetryReason::StaleAttachables),
         );
     }

--- a/platform/archestra-rs/sandbox-rs/index.d.ts
+++ b/platform/archestra-rs/sandbox-rs/index.d.ts
@@ -23,6 +23,23 @@ export interface CommandExecution {
   truncated: boolean
 }
 
+export interface DaggerMcpServiceEndpoint {
+  /** Host-reachable URL produced by a Dagger host tunnel. */
+  url: string
+}
+
+/**
+ * One environment variable supplied to the experimental Dagger MCP service
+ * runtime. Secret values are registered with Dagger as `Secret`s instead of
+ * becoming plain graph arguments (and therefore appearing in traces/cache
+ * metadata).
+ */
+export interface DaggerMcpServiceEnvVar {
+  name: string
+  value: string
+  secret?: boolean
+}
+
 /**
  * JS input identifying a per-environment isolation target. Omitting it (null)
  * runs on the process-default engine. The Dagger transport address (`kube-pod://…`)
@@ -140,6 +157,37 @@ export interface SnapshotFile {
   encoding: string
   content: string
 }
+
+/**
+ * Start (or join) a streamable-HTTP MCP server backed by a Dagger service.
+ *
+ * This is deliberately an experimental primitive, not a replacement for the
+ * Kubernetes MCP runtime. It proves the lifecycle seam for catalog entries
+ * that are already container-native and need no Kubernetes-only features.
+ */
+export interface StartDaggerMcpServiceInput {
+  serviceKey: string
+  image: string
+  /** Full argv override. Omit to use the image's entrypoint/CMD. */
+  command?: Array<string>
+  env: Array<DaggerMcpServiceEnvVar>
+  port: number
+  environment?: EnvironmentTarget
+}
+
+export interface StopDaggerMcpServiceInput {
+  serviceKey: string
+  kill?: boolean
+  environment?: EnvironmentTarget
+}
+
+export interface StopDaggerMcpServiceResult {
+  /**
+   * False means this process/session did not own the service; stop is
+   * intentionally idempotent so a repeated hibernation is harmless.
+   */
+  stopped: boolean
+}
 export declare function checkSession(input?: CheckSessionInput | undefined | null): Promise<void>
 
 /**
@@ -153,3 +201,12 @@ export declare function flushTelemetry(): void
 export declare function readArtifact(input: ReadArtifactInput): Promise<ArtifactBytes>
 
 export declare function runSandbox(input: RunSandboxInput): Promise<CommandExecution>
+
+/**
+ * Experimental lifecycle primitive used by the MCP/Dagger hibernation spike.
+ * It is intentionally not wired into the production MCP runtime yet.
+ */
+export declare function startDaggerMcpServicePrototype(input: StartDaggerMcpServiceInput): Promise<DaggerMcpServiceEndpoint>
+
+/** Idempotent counterpart to [`start_dagger_mcp_service_prototype`]. */
+export declare function stopDaggerMcpServicePrototype(input: StopDaggerMcpServiceInput): Promise<StopDaggerMcpServiceResult>

--- a/platform/archestra-rs/sandbox-rs/src/lib.rs
+++ b/platform/archestra-rs/sandbox-rs/src/lib.rs
@@ -26,6 +26,25 @@ pub async fn read_artifact(input: core::ReadArtifactInput) -> napi::Result<core:
     catch_core(core::read_artifact(input)).await
 }
 
+/// Experimental lifecycle primitive used by the MCP/Dagger hibernation spike.
+/// It is intentionally not wired into the production MCP runtime yet.
+#[napi(js_name = "startDaggerMcpServicePrototype")]
+pub async fn start_dagger_mcp_service_prototype(
+    input: core::StartDaggerMcpServiceInput,
+) -> napi::Result<core::DaggerMcpServiceEndpoint> {
+    core::telemetry::init();
+    catch_core(core::start_dagger_mcp_service(input)).await
+}
+
+/// Idempotent counterpart to [`start_dagger_mcp_service_prototype`].
+#[napi(js_name = "stopDaggerMcpServicePrototype")]
+pub async fn stop_dagger_mcp_service_prototype(
+    input: core::StopDaggerMcpServiceInput,
+) -> napi::Result<core::StopDaggerMcpServiceResult> {
+    core::telemetry::init();
+    catch_core(core::stop_dagger_mcp_service(input)).await
+}
+
 /// force-flush pending OTLP traces/logs. the backend calls this on graceful
 /// shutdown so the final batch isn't lost. intentionally sync: the blocking
 /// flush runs on the JS thread while the batch-export tasks drain on the tokio

--- a/platform/backend/src/k8s/mcp-server-runtime/DAGGER_HIBERNATION_PROTOTYPE.md
+++ b/platform/backend/src/k8s/mcp-server-runtime/DAGGER_HIBERNATION_PROTOTYPE.md
@@ -1,0 +1,167 @@
+# Dagger-backed MCP hibernation prototype
+
+Status: design spike; native lifecycle primitives exist, but nothing registers
+this runtime with `McpServerRuntimeManager`.
+
+## Result
+
+Dagger can materially simplify idle hibernation for a narrow class of MCP
+servers: single-tenant, `streamable-http`, container-native catalog entries
+that do not depend on custom Kubernetes YAML or Kubernetes-specific identity,
+secret, networking, or ingress features.
+
+For that lane, an MCP server becomes a Dagger `Container.asService()` behind a
+host tunnel:
+
+```text
+first demand -> construct content-addressed container graph
+             -> start tunnel (starts service + waits for port health)
+             -> return host-local HTTP endpoint
+
+idle sweep   -> stop tunnel + service
+
+next demand  -> evaluate the same graph
+             -> reuse engine image/layer cache
+             -> start a new service and tunnel
+```
+
+This replaces the Kubernetes mechanics in PR #7135 for eligible servers:
+
+- no replica-count annotation to remember;
+- no `resourceVersion` compare-and-swap around replica patches;
+- no separate `waking` annotation cleanup;
+- no pod/Deployment readiness polling in the Node process;
+- no per-server Kubernetes Service;
+- no explicit image-cache inspection (the Dagger engine owns its cache);
+- no stale pod/session cleanup after hibernation.
+
+It does **not** replace the hard part of the feature: deciding that a workload
+is idle without racing live demand. The persisted `last_used_at`, active-use
+tracking, organization/install policy, single-flight demand path, and an
+eventual distributed demand lease remain useful regardless of workload runtime.
+
+## Prototype code
+
+The existing `@archestra/sandbox-rs` Dagger session now exposes two deliberately
+named experimental operations:
+
+- `startDaggerMcpServicePrototype`: builds an image/env/command graph, starts a
+  Dagger service through a random-port host tunnel, and returns its HTTP URL;
+- `stopDaggerMcpServicePrototype`: stops the tunnel and source service, with an
+  idempotent `stopped: false` result when this session does not own it.
+
+The native per-target service map gives concurrent starts in one backend
+process a per-physical-service single-flight property while allowing different
+servers to wake concurrently. Supplying the same service key/spec reuses the
+endpoint; supplying a changed spec stops the old graph before starting the
+replacement. Secret env values use Dagger `Secret` nodes rather than plain
+graph arguments. The reserved `ARCHESTRA_MCP_SERVICE_KEY` graph input prevents
+Dagger from de-duplicating two distinct logical workloads that happen to have
+identical image/env/command configuration.
+
+`dagger-mcp-service-prototype.ts` is the TypeScript boundary. Its admission gate
+refuses lossy translations and its builder converts an admitted catalog plus
+already-resolved install env values into the native spec. It is intentionally
+unregistered, so merely shipping the spike cannot move an existing MCP server.
+
+## Why this cannot replace the Kubernetes runtime yet
+
+| Capability | Dagger spike | Existing Kubernetes runtime |
+| --- | --- | --- |
+| HTTP container start/stop | Native service lifecycle | Deployment replicas |
+| Cold-start cache | Dagger/BuildKit graph and image cache | Node image cache + pull policy |
+| HTTP reachability | Client-session host tunnel | Stable Service/pod address |
+| `stdio` MCP | Not modeled | Kubernetes exec/WebSocket |
+| Custom deployment YAML | Not representable safely | First-class |
+| `envFrom`, mounted secrets, ServiceAccount | Not modeled | First-class |
+| Image pull secrets | Not modeled by this primitive | First-class |
+| NodePort/ingress/stable callback address | Not modeled | First-class |
+| Multiple backend replicas | Source service is content-addressed/de-duplicated, but tunnels and Archestra state are session-local | Kubernetes object is shared truth |
+| Backend restart adoption | Session and tunnel are gone; demand restarts | Deployment annotations are adopted |
+| Scheduler/autoscaler visibility | Engine is the scheduled unit | Every MCP pod is visible |
+
+Two constraints are architectural rather than missing fields:
+
+1. Dagger de-duplicates the same content-addressed service requested by multiple
+   clients and keeps it alive while referenced, but each host tunnel and its URL
+   are client-session-local. That is not stable cluster service discovery or a
+   durable Archestra state record.
+2. The current per-environment Dagger engine is one privileged, scheduler-
+   opaque capacity envelope. Moving hundreds of MCP processes into it makes
+   Kubernetes see engine capacity rather than individual MCP requests/limits.
+
+Those trade per-server Kubernetes overhead for a denser shared runtime, but
+they also weaken scheduling isolation and make a single engine a larger failure
+domain. That should be an explicit product/runtime choice, not an incidental
+hibernation refactor.
+
+## Recommended production seam
+
+First separate hibernation policy from workload mechanics. The policy module
+should depend on a small runtime contract rather than `K8sDeployment`:
+
+```ts
+interface McpWorkloadRuntime {
+  key(serverId: string): Promise<string>;
+  observe(serverId: string): Promise<"stopped" | "starting" | "ready" | "failed">;
+  ensureServing(serverId: string): Promise<{ endpoint: string }>;
+  stopIfOwned(serverId: string): Promise<boolean>;
+  hardReset(serverId: string): Promise<void>;
+}
+```
+
+Then keep two implementations:
+
+- `KubernetesMcpWorkloadRuntime`: wraps today's `K8sDeployment`, preserving the
+  full catalog surface and external-scaler compatibility;
+- `DaggerMcpWorkloadRuntime`: wraps the native prototype for admitted HTTP
+  catalogs only.
+
+The idle-policy flow remains shared:
+
+```text
+policy/licence gates
+  -> sibling-group demand lease + fresh last-used check
+  -> runtime.stopIfOwned()
+  -> invalidate MCP client/session pools
+  -> compensate with runtime.ensureServing() if demand crossed the stop
+```
+
+The latest PR wake contract also stays shared: the MCP client waits only
+`wakeResponseBudgetMs()` for `ensureServing()`, then returns the existing
+retryable “still starting” tool result while the runtime single-flight continues
+in the background. A faster Dagger cold start is an optimization, not a reason
+to hold a caller beyond its response budget.
+
+Before production wiring, turn Dagger's reference lifetime into an explicit
+Archestra lease model. Every active tool call should hold a short-lived service
+reference/tunnel; an idle-window keeper holds the warm reference. Hibernation
+drops only the keeper. Dagger then keeps the de-duplicated source service alive
+until active references from every backend replica are gone, directly closing
+the current stop-vs-demand race for the Dagger lane. Persisted ownership/state
+is still needed for observability, restart convergence, and endpoint routing;
+the engine reference count must not be treated as queryable durable state.
+
+## Suggested experiment
+
+1. Run only on a single backend replica and behind a separate prototype flag.
+2. Admit explicit-image, single-tenant streamable-HTTP catalogs through the
+   compatibility gate; everything else stays on Kubernetes.
+3. Route only the MCP client's HTTP endpoint lookup through the Dagger adapter.
+4. Measure warm call latency, cold wake latency, engine RSS, per-service RSS,
+   concurrent wake behavior, image-registry outage behavior, and engine restart
+   blast radius against the same image on the Kubernetes path.
+5. Do not widen eligibility until distributed ownership and stable routing are
+   demonstrated under two backend replicas.
+
+The decision criterion is not merely a faster cold start. The Dagger lane needs
+to save enough standing pod/scheduler overhead to justify a larger shared
+failure domain and the loss of Kubernetes-native customization.
+
+## References
+
+- [PR #7135](https://github.com/archestra-ai/archestra/pull/7135) — current
+  Kubernetes idle-hibernation implementation and its known demand race.
+- [Dagger 0.21.7 service semantics](https://github.com/dagger/dagger/blob/f0a16837a9fb53572f3cdd60c46543bb827efe5d/docs/versioned_docs/version-0.21.7/using-dagger/services.mdx)
+  — content-addressed hostnames, just-in-time lifecycle, cross-client
+  de-duplication, reference-based stop, health checks, and host port tunnels.

--- a/platform/backend/src/sandbox-runtime/dagger-mcp-service-prototype.test.ts
+++ b/platform/backend/src/sandbox-runtime/dagger-mcp-service-prototype.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest";
+import type { InternalMcpCatalog } from "@/types";
+import {
+  assessDaggerMcpCompatibility,
+  buildDaggerMcpServiceInput,
+  DaggerMcpServicePrototype,
+} from "./dagger-mcp-service-prototype";
+
+function candidate(
+  overrides: Partial<InternalMcpCatalog> = {},
+): Pick<
+  InternalMcpCatalog,
+  "serverType" | "multitenant" | "deploymentSpecYaml" | "localConfig"
+> {
+  return {
+    serverType: "local",
+    multitenant: false,
+    deploymentSpecYaml: null,
+    localConfig: {
+      dockerImage: "ghcr.io/example/mcp:sha-abc",
+      command: "node",
+      arguments: ["server.js"],
+      transportType: "streamable-http",
+      httpPort: 8787,
+      httpPath: "/custom-mcp",
+      environment: [],
+      envFrom: [],
+      imagePullSecrets: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("assessDaggerMcpCompatibility", () => {
+  test("admits the narrow container-native HTTP shape", () => {
+    expect(assessDaggerMcpCompatibility(candidate())).toEqual({
+      compatible: true,
+    });
+  });
+
+  test("keeps every Kubernetes-only shape on the Kubernetes runtime", () => {
+    const value = assessDaggerMcpCompatibility(
+      candidate({
+        multitenant: true,
+        deploymentSpecYaml: "apiVersion: apps/v1",
+        localConfig: {
+          transportType: "stdio",
+          arguments: ["server.js"],
+          environment: [
+            {
+              key: "TOKEN",
+              type: "secret",
+              promptOnInstallation: true,
+              mounted: true,
+            },
+          ],
+          envFrom: [{ type: "secret", name: "shared-secret" }],
+          serviceAccount: "mcp-sa",
+          nodePort: 30080,
+          imagePullSecrets: [{ source: "existing", name: "registry" }],
+        },
+      }),
+    );
+
+    expect(value).toEqual({
+      compatible: false,
+      reasons: [
+        "multitenant",
+        "custom-kubernetes-yaml",
+        "stdio-transport",
+        "image-required",
+        "env-from",
+        "image-pull-secrets",
+        "service-account",
+        "node-port",
+        "mounted-secret",
+        "image-entrypoint-with-arguments",
+      ],
+    });
+  });
+});
+
+describe("buildDaggerMcpServiceInput", () => {
+  test("normalizes command and arguments and preserves secret classification", () => {
+    expect(
+      buildDaggerMcpServiceInput({
+        candidate: candidate(),
+        serviceKey: "namespace/mcp-example",
+        resolvedEnv: [
+          { name: "LOG_LEVEL", value: "info" },
+          { name: "API_TOKEN", value: "secret", secret: true },
+        ],
+        environment: {
+          environmentId: "abcdef00-1111-2222-3333-444455556666",
+          namespace: "mcp-runtime",
+        },
+      }),
+    ).toEqual({
+      serviceKey: "namespace/mcp-example",
+      image: "ghcr.io/example/mcp:sha-abc",
+      command: ["node", "server.js"],
+      env: [
+        { name: "LOG_LEVEL", value: "info" },
+        { name: "API_TOKEN", value: "secret", secret: true },
+      ],
+      port: 8787,
+      environment: {
+        environmentId: "abcdef00-1111-2222-3333-444455556666",
+        namespace: "mcp-runtime",
+      },
+    });
+  });
+
+  test("refuses to translate an unsupported catalog", () => {
+    expect(() =>
+      buildDaggerMcpServiceInput({
+        candidate: candidate({
+          localConfig: {
+            command: "node",
+            dockerImage: "node:24",
+            transportType: "stdio",
+          },
+        }),
+        serviceKey: "mcp-example",
+        resolvedEnv: [],
+      }),
+    ).toThrow("stdio-transport");
+  });
+});
+
+test("prototype adapter can be constructed without loading native bindings", () => {
+  expect(new DaggerMcpServicePrototype()).toBeInstanceOf(
+    DaggerMcpServicePrototype,
+  );
+});

--- a/platform/backend/src/sandbox-runtime/dagger-mcp-service-prototype.ts
+++ b/platform/backend/src/sandbox-runtime/dagger-mcp-service-prototype.ts
@@ -1,0 +1,144 @@
+import type {
+  DaggerMcpServiceEndpoint,
+  DaggerMcpServiceEnvVar,
+  EnvironmentTarget,
+  StartDaggerMcpServiceInput,
+  StopDaggerMcpServiceResult,
+} from "@archestra/sandbox-rs";
+import type { InternalMcpCatalog } from "@/types";
+
+type Candidate = Pick<
+  InternalMcpCatalog,
+  "serverType" | "multitenant" | "deploymentSpecYaml" | "localConfig"
+>;
+
+type DaggerMcpIncompatibility =
+  | "custom-kubernetes-yaml"
+  | "env-from"
+  | "image-pull-secrets"
+  | "image-required"
+  | "image-entrypoint-with-arguments"
+  | "mounted-secret"
+  | "multitenant"
+  | "node-port"
+  | "not-local"
+  | "service-account"
+  | "stdio-transport";
+
+type DaggerMcpCompatibility =
+  | { compatible: true }
+  | { compatible: false; reasons: DaggerMcpIncompatibility[] };
+
+/**
+ * Static admission gate for the Dagger MCP service spike.
+ *
+ * The point is to make the prototype an additive runtime lane, never a lossy
+ * translation of Kubernetes behavior. A catalog stays on the existing runtime
+ * whenever its configuration uses a feature the native Dagger primitive does
+ * not model yet.
+ */
+export function assessDaggerMcpCompatibility(
+  candidate: Candidate,
+): DaggerMcpCompatibility {
+  const reasons: DaggerMcpIncompatibility[] = [];
+  const local = candidate.localConfig;
+
+  if (candidate.serverType !== "local") reasons.push("not-local");
+  if (candidate.multitenant) reasons.push("multitenant");
+  if (candidate.deploymentSpecYaml?.trim()) {
+    reasons.push("custom-kubernetes-yaml");
+  }
+  if ((local?.transportType ?? "stdio") !== "streamable-http") {
+    reasons.push("stdio-transport");
+  }
+  if (!local?.dockerImage?.trim()) reasons.push("image-required");
+  if (local?.envFrom?.length) reasons.push("env-from");
+  if (local?.imagePullSecrets?.length) reasons.push("image-pull-secrets");
+  if (local?.serviceAccount) reasons.push("service-account");
+  if (local?.nodePort) reasons.push("node-port");
+  if (local?.environment?.some((entry) => entry.mounted)) {
+    reasons.push("mounted-secret");
+  }
+  if (!local?.command && local?.arguments?.length) {
+    reasons.push("image-entrypoint-with-arguments");
+  }
+
+  return reasons.length > 0
+    ? { compatible: false, reasons }
+    : { compatible: true };
+}
+
+interface BuildDaggerMcpServiceInput {
+  candidate: Candidate;
+  serviceKey: string;
+  resolvedEnv: DaggerMcpServiceEnvVar[];
+  environment?: EnvironmentTarget;
+}
+
+/** Convert an admitted catalog plus already-resolved install secrets to the
+ * small native service spec. Secret resolution remains a TS/DB concern; the
+ * Rust boundary only tells Dagger which values must become graph-safe Secrets.
+ */
+export function buildDaggerMcpServiceInput({
+  candidate,
+  serviceKey,
+  resolvedEnv,
+  environment,
+}: BuildDaggerMcpServiceInput): StartDaggerMcpServiceInput {
+  const compatibility = assessDaggerMcpCompatibility(candidate);
+  if (!compatibility.compatible) {
+    throw new Error(
+      `Catalog is not compatible with the Dagger MCP prototype: ${compatibility.reasons.join(", ")}`,
+    );
+  }
+
+  const local = candidate.localConfig;
+  if (!local?.dockerImage) {
+    throw new Error("Compatible Dagger MCP catalog has no image");
+  }
+  return {
+    serviceKey,
+    image: local.dockerImage,
+    command: local.command
+      ? [local.command, ...(local.arguments ?? [])]
+      : undefined,
+    env: resolvedEnv,
+    port: local.httpPort ?? 8080,
+    environment,
+  };
+}
+
+interface DaggerMcpRunningEndpoint extends DaggerMcpServiceEndpoint {
+  /** Full streamable-HTTP endpoint, including the catalog's MCP path. */
+  mcpUrl: string;
+}
+
+/**
+ * Thin, deliberately unregistered adapter around the native spike. The
+ * production manager can later put this behind an `McpWorkloadRuntime` seam;
+ * keeping it unregistered now guarantees the experiment changes no deployment.
+ */
+export class DaggerMcpServicePrototype {
+  async start(
+    input: StartDaggerMcpServiceInput,
+    httpPath = "/mcp",
+  ): Promise<DaggerMcpRunningEndpoint> {
+    const native = await import("@archestra/sandbox-rs");
+    const endpoint = await native.startDaggerMcpServicePrototype(input);
+    return { ...endpoint, mcpUrl: joinUrlPath(endpoint.url, httpPath) };
+  }
+
+  async stop(params: {
+    serviceKey: string;
+    environment?: EnvironmentTarget;
+    kill?: boolean;
+  }): Promise<StopDaggerMcpServiceResult> {
+    const native = await import("@archestra/sandbox-rs");
+    return native.stopDaggerMcpServicePrototype(params);
+  }
+}
+
+function joinUrlPath(baseUrl: string, path: string): string {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return new URL(path.replace(/^\/+/, ""), base).toString();
+}


### PR DESCRIPTION
## Summary

- prototype native Dagger service and host-tunnel lifecycle primitives for compatible streamable-HTTP MCP servers
- add a strict TypeScript compatibility gate and deliberately unregistered adapter
- document the hybrid Kubernetes/Dagger architecture, lifecycle tradeoffs, and a bounded production experiment

## Relationship to #7135

This is a stacked design spike for #7135. It targets the hibernation feature branch so the diff contains only the Dagger prototype. Nothing registers the adapter with McpServerRuntimeManager, so existing deployment behavior is unchanged.

## Validation

- pnpm --filter @archestra/sandbox-rs build:dev
- cargo check -p sandbox_core -p sandbox_rs --locked
- cargo test -p sandbox_core -p sandbox_rs --locked (63 tests)
- focused backend prototype tests (5 tests)
- pnpm --filter @backend type-check
- Biome, Knip, and git diff --check

A live service start/stop smoke test was not run because no Dagger engine was listening locally.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>