### PR TITLE
fix(helm): stop the web container's heap ceiling from overcommitting its limit

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -248,6 +248,7 @@ Environment network policies require the chart's default MCP manager RBAC so Arc
 - `archestra.tolerations` - Tolerations for scheduling pods on nodes with specific taints (e.g., dedicated nodes, GPU nodes, spot instances). These values are also inherited by MCP server pods as defaults. See [Kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 - `archestra.deploymentStrategy` - Deployment strategy configuration (default: RollingUpdate with `maxUnavailable: 25%` and `maxSurge: 25%`)
 - `archestra.resources` - CPU and memory requests/limits for the container (default: 2 vCPU request, 2Gi memory request, 3Gi memory limit)
+- `archestra.webContainerReservedMemoryMib` - Memory in the web container reserved for the Next.js server instead of the backend's V8 heap (default: 384). The container runs both processes under one limit, so the backend's heap ceiling is a percentage of the limit minus this reservation. Raise it if you run an unusually heavy frontend workload.
 - `archestra.horizontalPodAutoscaler` - Optional HPA for the main `archestra-platform` Deployment. When enabled, the chart defaults to `minReplicas: 2`, `maxReplicas: 10`, a memory utilization target of 70%, immediate scale-up, and a 5-minute scale-down stabilization window.
 - `archestra.worker.replicaCount` - Manual replica count for the separate worker Deployment
 - `archestra.worker.resources` - Resource requests/limits for worker pods (default: 2 vCPU request, 1Gi memory request, 2Gi memory limit)

--- a/platform/backend/scripts/calculate-node-max-old-space-size.sh
+++ b/platform/backend/scripts/calculate-node-max-old-space-size.sh
@@ -24,29 +24,52 @@ if [ "${ARCHESTRA_NODE_MAX_OLD_SPACE_SIZE_MIB+x}" = "x" ]; then
   exit 0
 fi
 
+# Memory inside this container that is NOT available to this Node process,
+# because something else in the container needs it. The web container runs the
+# Next.js server and supervisord alongside the backend; the worker and renderer
+# run a single Node process and set nothing here.
+reserved_mib=${ARCHESTRA_NODE_MEMORY_RESERVED_MIB:-0}
+case "$reserved_mib" in
+  "" | *[!0-9]*)
+    echo "ARCHESTRA_NODE_MEMORY_RESERVED_MIB must be a non-negative integer" >&2
+    exit 1
+    ;;
+esac
+
 calculate_percentage() {
   value=$1
   percentage=$2
+  reserved=${3:-0}
   case "$value" in
     "" | *[!0-9]*) return 1 ;;
   esac
 
-  awk -v value="$value" -v percentage="$percentage" \
-    'BEGIN { result = int(value * percentage / 100); if (result > 0) printf "%d\n", result }'
+  # Subtract the reservation before taking the percentage, so the split is over
+  # the memory this process can actually use. A reservation that swallows the
+  # whole limit is ignored rather than obeyed: emitting nothing would silently
+  # hand the process back Node's cgroup default, which is the opposite of what a
+  # misconfigured reservation is asking for.
+  awk -v value="$value" -v percentage="$percentage" -v reserved="$reserved" \
+    'BEGIN {
+       usable = value - reserved;
+       if (usable <= 0) usable = value;
+       result = int(usable * percentage / 100);
+       if (result > 0) printf "%d\n", result
+     }'
 }
 
-# Prefer the cgroup hard limit. Keep 40% outside V8 old-space for young-space,
-# native/external allocations, thread stacks, and the other web-container
-# processes. If no limit exists, use the request with Node's documented 75%
-# example ratio; requests guide scheduling but are not an OOM boundary.
-if calculated=$(calculate_percentage "${ARCHESTRA_NODE_MEMORY_LIMIT_MIB:-}" 60); then
+# Prefer the cgroup hard limit. Keep 40% of the usable memory outside V8
+# old-space for young-space, native/external allocations, and thread stacks. If
+# no limit exists, use the request with Node's documented 75% example ratio;
+# requests guide scheduling but are not an OOM boundary.
+if calculated=$(calculate_percentage "${ARCHESTRA_NODE_MEMORY_LIMIT_MIB:-}" 60 "$reserved_mib"); then
   if [ -n "$calculated" ]; then
     printf "%s\n" "$calculated"
     exit 0
   fi
 fi
 
-if calculated=$(calculate_percentage "${ARCHESTRA_NODE_MEMORY_REQUEST_MIB:-}" 75); then
+if calculated=$(calculate_percentage "${ARCHESTRA_NODE_MEMORY_REQUEST_MIB:-}" 75 "$reserved_mib"); then
   if [ -n "$calculated" ]; then
     printf "%s\n" "$calculated"
   fi

--- a/platform/backend/src/standalone-scripts/calculate-node-max-old-space-size.test.ts
+++ b/platform/backend/src/standalone-scripts/calculate-node-max-old-space-size.test.ts
@@ -79,4 +79,66 @@ describe("calculate-node-max-old-space-size.sh", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("");
   });
+
+  it("subtracts a reservation from the limit before taking the percentage", () => {
+    // The web container also runs the Next.js server, so 60% of the whole limit
+    // would hand the backend a heap it cannot have: 60% of 3072 is 1843, and
+    // 1843 of heap plus native, the co-located server and slab exceeds 3072
+    // before V8 ever reaches its ceiling. 60% of (3072 - 384) does not.
+    const result = run({
+      ARCHESTRA_NODE_MEMORY_LIMIT_MIB: "3072",
+      ARCHESTRA_NODE_MEMORY_RESERVED_MIB: "384",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("1612");
+  });
+
+  it("applies the reservation to the request fallback too", () => {
+    const result = run({
+      ARCHESTRA_NODE_MEMORY_REQUEST_MIB: "2048",
+      ARCHESTRA_NODE_MEMORY_RESERVED_MIB: "384",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("1248");
+  });
+
+  it("is unchanged when no reservation is set", () => {
+    // Single-process containers (worker, renderer) must keep their existing
+    // ceiling — this change is scoped to containers that co-locate a process.
+    const withoutReservation = run({
+      ARCHESTRA_NODE_MEMORY_LIMIT_MIB: "2048",
+    });
+    const withZero = run({
+      ARCHESTRA_NODE_MEMORY_LIMIT_MIB: "2048",
+      ARCHESTRA_NODE_MEMORY_RESERVED_MIB: "0",
+    });
+
+    expect(withoutReservation.stdout.trim()).toBe("1228");
+    expect(withZero.stdout.trim()).toBe("1228");
+  });
+
+  it("ignores a reservation that would consume the whole limit", () => {
+    // Obeying it would emit no flag at all, silently handing the process back
+    // Node's cgroup default — a bigger heap than either value asked for, which
+    // is the opposite of what a misconfigured reservation intends.
+    const result = run({
+      ARCHESTRA_NODE_MEMORY_LIMIT_MIB: "512",
+      ARCHESTRA_NODE_MEMORY_RESERVED_MIB: "1024",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("307");
+  });
+
+  it("fails fast for an invalid reservation", () => {
+    const result = run({
+      ARCHESTRA_NODE_MEMORY_LIMIT_MIB: "3072",
+      ARCHESTRA_NODE_MEMORY_RESERVED_MIB: "lots",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("must be a non-negative integer");
+  });
 });

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -281,11 +281,20 @@ genuinely missing key loudly at startup.
 Expose declared memory resources in MiB so the production Node launcher can
 derive a V8 old-space ceiling. Only emit fields that are explicitly configured:
 resourceFieldRef otherwise falls back to node allocatable memory.
+
+Callers may pass `reservedMib` for a container that runs something else besides
+this Node process. The launcher subtracts it from the limit before applying its
+percentage, so the split is taken over memory this process can actually use.
+Omit it for single-process containers.
 */}}
 {{- define "archestra-platform.nodeMemoryEnv" -}}
 {{- $resources := .resources | default dict -}}
 {{- $requests := get $resources "requests" | default dict -}}
 {{- $limits := get $resources "limits" | default dict -}}
+{{- if .reservedMib }}
+- name: ARCHESTRA_NODE_MEMORY_RESERVED_MIB
+  value: {{ .reservedMib | quote }}
+{{- end }}
 {{- if get $requests "memory" }}
 - name: ARCHESTRA_NODE_MEMORY_REQUEST_MIB
   valueFrom:

--- a/platform/helm/archestra/templates/archestra-platform.yaml
+++ b/platform/helm/archestra/templates/archestra-platform.yaml
@@ -148,7 +148,7 @@ spec:
             {{- end }}
           env:
             {{- include "archestra-platform.env" . | nindent 12 }}
-            {{- include "archestra-platform.nodeMemoryEnv" (dict "resources" .Values.archestra.resources "containerName" .Chart.Name) | nindent 12 }}
+            {{- include "archestra-platform.nodeMemoryEnv" (dict "resources" .Values.archestra.resources "containerName" .Chart.Name "reservedMib" .Values.archestra.webContainerReservedMemoryMib) | nindent 12 }}
             {{- if .Values.archestra.worker.enabled }}
             - name: ARCHESTRA_PROCESS_TYPE
               value: "web"

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -465,6 +465,8 @@ tests:
               value: "true"
             - name: ARCHESTRA_CODE_RUNTIME_ENABLED
               value: "true"
+            - name: ARCHESTRA_NODE_MEMORY_RESERVED_MIB
+              value: "384"
             - name: ARCHESTRA_NODE_MEMORY_REQUEST_MIB
               valueFrom:
                 resourceFieldRef:
@@ -945,6 +947,31 @@ tests:
           content:
             name: ARCHESTRA_NODE_HEAPSNAPSHOT_NEAR_HEAP_LIMIT
             value: "1"
+
+  # The web container runs the Next.js server alongside the backend under a
+  # single memory limit, so the launcher must take its old-space percentage over
+  # what the backend can actually use. Without the reservation the granted heap
+  # plus the co-located processes exceed the limit, and the cgroup kills the
+  # container before V8 ever reaches its own ceiling.
+  - it: should reserve memory for the co-located frontend on the web container
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_NODE_MEMORY_RESERVED_MIB
+            value: "384"
+
+  - it: should omit the reservation when it is set to zero
+    documentIndex: 1
+    set:
+      archestra.webContainerReservedMemoryMib: 0
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_NODE_MEMORY_RESERVED_MIB
+            value: "0"
 
   - it: should set ARCHESTRA_ORCHESTRATOR_KUBECONFIG env var when kubeconfig volume is mounted
     documentIndex: 1

--- a/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
@@ -181,6 +181,17 @@ tests:
             name: ARCHESTRA_NODE_HEAPSNAPSHOT_NEAR_HEAP_LIMIT
             value: "1"
 
+  # The worker runs a single Node process, so it owns its whole memory limit and
+  # must keep the unreserved old-space ceiling. Reserving here would shrink its
+  # heap to pay for a frontend it does not run.
+  - it: worker does not reserve memory for a co-located frontend
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: ARCHESTRA_NODE_MEMORY_RESERVED_MIB
+
   - it: worker supports overriding the wait-for-postgres image
     set:
       archestra.initContainers.busyboxImage: registry.internal.example.com/platform/busybox:1.36

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -382,6 +382,24 @@ archestra:
     limits:
       memory: "3Gi"
 
+  # Memory inside the web container that is NOT available to the backend's V8
+  # heap, because the same container also runs the Next.js server (and
+  # supervisord) under one memory limit.
+  #
+  # The launcher sizes --max-old-space-size as a percentage of the container's
+  # memory limit. Without this, that percentage is taken over memory the backend
+  # does not solely own, so the heap ceiling it is granted plus the co-located
+  # processes can exceed the limit — and the cgroup kills the container before V8
+  # ever reaches its own ceiling. That turns a diagnosable JS heap OOM into an
+  # opaque SIGKILL, and the stall while it happens fails the probes too.
+  # Subtracting the reservation first restores the intended ordering: V8 reaches
+  # its ceiling, throws, and leaves a stack behind.
+  #
+  # Sized from a measured Next.js server (~150 MiB resident) plus headroom for
+  # growth under load and for supervisord. Only the web container sets this — the
+  # worker and renderer run a single Node process and reserve nothing.
+  webContainerReservedMemoryMib: 384
+
   # Kubernetes probe configuration for the platform and worker containers.
   # See: https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/
   #


### PR DESCRIPTION
## What

The production launcher sizes `--max-old-space-size` as 60% of the container's memory limit. That split assumes the Node process owns the container. **The web container does not** — it runs the Next.js server and supervisord alongside the backend under a single limit.

So the backend is granted a heap it cannot actually have. At the chart's default 3Gi limit it may grow old-space to **1843 MiB**, and 1843 of heap plus native/external allocations, the co-located server and slab exceeds 3Gi before V8 ever reaches its own ceiling. The cgroup wins the race, and a diagnosable JS heap OOM — which would exit with a stack and a fatal-error report — becomes an opaque SIGKILL. The stall while it happens fails the liveness and readiness probes too.

This reserves the co-located memory *before* taking the percentage:

- The launcher gains `ARCHESTRA_NODE_MEMORY_RESERVED_MIB`.
- The chart sets it **only on the web container**, from a new `archestra.webContainerReservedMemoryMib` (default `384`, sized from a measured Next.js server at ~150 MiB resident plus headroom).

At 3Gi the ceiling moves **1843 → 1612**, which leaves roughly a gigabyte of margin for page cache and external Buffers, and restores the intended failure ordering.

## Why not just raise the default limit

Raising `archestra.resources.limits.memory` would cost every deployment a gigabyte per web replica while preserving the same wrong assumption — the percentage would still be taken over memory the backend does not solely own. This fixes the arithmetic instead of paying around it.

## ⚠️ Behavior change for existing installs

This is a **tightening**. A deployment whose backend currently peaks above the new ceiling will start throwing JS heap OOMs where it previously survived. That is the intended trade — the alternative outcome was an undiagnosable SIGKILL — but it's worth calling out in release notes.

Operators who need the old behavior can set `archestra.webContainerReservedMemoryMib: 0`, or raise `archestra.resources.limits.memory` (the reservation scales correctly off a larger limit: at 4Gi the ceiling is 2227).

## Scope

- **Worker and renderer are unchanged.** They run a single Node process, own their whole limit, and set no reservation. A helm test pins that so a future refactor can't quietly shrink their heaps to pay for a frontend they don't run.
- A reservation that would consume the whole limit is **ignored** rather than obeyed: honoring it would emit no flag at all and silently hand the process back Node's cgroup-derived default — a *larger* heap than either value asked for, the opposite of what a misconfigured reservation intends.
- An invalid (non-integer) reservation fails fast rather than being silently dropped.

## Verification

Script behavior, exercised directly:

| limit | reserved | ceiling |
|---|---|---|
| 3072 | 384 | 1612 (was 1843) |
| 2048 | — (worker) | 1228 (unchanged) |
| 2048 (request fallback) | 384 | 1248 |
| 512 | 1024 (over) | 307 (reservation ignored) |
| 4096 | 384 | 2227 |
| any | `lots` | exit 1 |

Rendered chart confirms the split: `archestra-platform` gets `limit=3Gi reserved=384`, `archestra-platform-worker` gets `limit=2Gi` and **no** reservation.

- 13 launcher tests pass (6 new)
- 413/413 helm unittests pass (3 new)
- `helm lint` passes
- docs link check passes

## Related

- #7172 — staging-only mitigation (4Gi + disables the near-heap-limit snapshot flag). Once this lands, staging's 4Gi override is worth revisiting so the two don't compound.
- #7175 — bounds the reconstruct cache by bytes, which is what was actually filling the heap.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>