### PR TITLE
chore(backend): clear the backend biome warnings

### DIFF
--- a/platform/backend/src/agents/a2a/a2a-manager.tasks.test.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.tasks.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "@/test";
 import { type A2AActor, A2AError, A2AErrorKind } from "./a2a-base";
 import { buildApprovalDecisionSendMessageRequest } from "./a2a-helper";
 import { A2AManager } from "./a2a-manager";
-import { A2AContextManager, A2ATaskManager } from "./a2a-model-manager";
+import { A2AContextManager } from "./a2a-model-manager";
 import {
   type A2AProtocolPart,
   A2AProtocolRole,

--- a/platform/backend/src/agents/a2a/a2a-model-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-model-manager.ts
@@ -13,7 +13,6 @@ import { type A2AActor, A2AError, A2AErrorKind } from "./a2a-base";
 import {
   type A2AArchestraApprovalRequest,
   A2AArchestraApprovalRequestSchema,
-  type A2AArchestraTaskApprovalDecision,
   type A2AProtocolArtifact,
   type A2AProtocolMessage,
   type A2AProtocolPart,

--- a/platform/backend/src/agents/a2a/a2a-protocol.ts
+++ b/platform/backend/src/agents/a2a/a2a-protocol.ts
@@ -155,8 +155,6 @@ const A2AProtocolTaskStatusSchema = z.object({
   /** RFC 3339 datetime (protobuf JSON `google.protobuf.Timestamp`). */
   timestamp: z.iso.datetime().optional(),
 });
-type A2AProtocolTaskStatus = z.infer<typeof A2AProtocolTaskStatusSchema>;
-
 export const A2AProtocolTaskSchema = z.object({
   id: z.string(),
   contextId: z.string().optional(),
@@ -342,10 +340,6 @@ const A2AProtocolTaskStatusUpdateEventSchema = z.object({
   final: z.boolean().optional(),
   metadata: z.any().optional(),
 });
-type A2AProtocolTaskStatusUpdateEvent = z.infer<
-  typeof A2AProtocolTaskStatusUpdateEventSchema
->;
-
 /**
  * A2A v1.0 TaskArtifactUpdateEvent: one chunk of a task artifact. Chunked
  * delivery repeats the same `artifact.artifactId` with `append: true`;
@@ -359,10 +353,6 @@ const A2AProtocolTaskArtifactUpdateEventSchema = z.object({
   lastChunk: z.boolean().optional(),
   metadata: z.any().optional(),
 });
-type A2AProtocolTaskArtifactUpdateEvent = z.infer<
-  typeof A2AProtocolTaskArtifactUpdateEventSchema
->;
-
 /**
  * A single event in a SendStreamingMessage / SubscribeToTask stream. Exactly
  * one field is set per event: `statusUpdate` for incremental working/terminal

--- a/platform/backend/src/agents/a2a/a2a-push-notification-service.ts
+++ b/platform/backend/src/agents/a2a/a2a-push-notification-service.ts
@@ -136,16 +136,6 @@ class A2APushNotificationService {
 
 export const a2aPushNotificationService = new A2APushNotificationService();
 
-/**
- * Local development points webhooks at localhost, which the SSRF guard
- * otherwise refuses. Never enabled in production.
- */
-function allowPrivateWebhookHosts(): boolean {
-  return (
-    process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "prod"
-  );
-}
-
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/platform/backend/src/auth/fastify-plugin/middleware.test.ts
+++ b/platform/backend/src/auth/fastify-plugin/middleware.test.ts
@@ -6,7 +6,7 @@ import { vi } from "vitest";
 import config from "@/config";
 import db, { schema } from "@/database";
 import { enterpriseTier } from "@/enterprise-tier";
-import { OrganizationModel, SessionModel } from "@/models";
+import { OrganizationModel } from "@/models";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError } from "@/types";
 import { Authnz } from "./middleware";

--- a/platform/backend/src/clients/mcp-elicitation.ts
+++ b/platform/backend/src/clients/mcp-elicitation.ts
@@ -3,13 +3,10 @@ import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/proto
 import {
   type ClientNotification,
   type ClientRequest,
-  ElicitationCompleteNotificationSchema,
   type ElicitRequest,
   ElicitRequestSchema,
   type ElicitResult,
 } from "@modelcontextprotocol/sdk/types.js";
-
-import logger from "@/logging";
 import type { ClientCapabilitiesWithExtensions } from "@/types/mcp-capabilities";
 
 // =============================================================================

--- a/platform/backend/src/models/a2a/task-approval-request.ts
+++ b/platform/backend/src/models/a2a/task-approval-request.ts
@@ -1,8 +1,5 @@
-import { and, eq, inArray } from "drizzle-orm";
-import type {
-  A2AArchestraApprovalRequest,
-  A2AArchestraTaskApprovalDecision,
-} from "@/agents/a2a/a2a-protocol";
+import { eq, inArray } from "drizzle-orm";
+import type { A2AArchestraApprovalRequest } from "@/agents/a2a/a2a-protocol";
 import db, { schema } from "@/database";
 import type {
   A2ATaskApprovalRequest,

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -18,7 +18,6 @@ import {
   extractGroupsFromClaims,
 } from "@/auth/idp-team-sync-cache.ee";
 import { LRUCacheManager } from "@/cache-manager";
-import config from "@/config";
 import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import { registerProcessLocalCache } from "@/process-local-cache-registry";

--- a/platform/backend/src/models/interaction-delta-manager.ts
+++ b/platform/backend/src/models/interaction-delta-manager.ts
@@ -3,7 +3,6 @@ import { getHeapStatistics } from "node:v8";
 import { isClaudeSessionSource, TimeInMs } from "@archestra/shared";
 import { and, desc, eq, lt, sql } from "drizzle-orm";
 import { LRUCacheManager } from "@/cache-manager";
-// biome-ignore lint/style/noRestrictedImports: dual-licensed; no-ops when the feature is off
 import { readInteractionRow } from "@/content-encryption/audit-rows";
 import db, { schema } from "@/database";
 import type { InsertInteraction } from "@/types";

--- a/platform/backend/src/routes/app-recording/review.app-recording.route.test.ts
+++ b/platform/backend/src/routes/app-recording/review.app-recording.route.test.ts
@@ -61,7 +61,6 @@ function bundleOfAtLeast(bytes: number) {
 
 describe("GET /api/app-recording/review", () => {
   const ctx = useRouteTestApp(appRecordingRoutes);
-  // biome-ignore lint/correctness/useHookAtTopLevel: vitest lifecycle helper (per-test MSW server), not a React hook
   const server = useMswServer();
 
   test("admits a bundle as large as the gallery itself accepts", async () => {

--- a/platform/backend/src/routes/app/mcp-backing.app.route.test.ts
+++ b/platform/backend/src/routes/app/mcp-backing.app.route.test.ts
@@ -146,11 +146,13 @@ describe("MCP backing for apps", () => {
     // The source app owns the launch tool being consumed elsewhere.
     const sourceAppId = await createApp("org");
     await AppModel.setEnabled(sourceAppId, false);
-    const sourceServer = await McpServerModel.findById(
-      (await AppModel.findById(sourceAppId))!.mcpServerId!,
+    const sourceServer = mustExist(
+      await McpServerModel.findById(
+        mustExist(mustExist(await AppModel.findById(sourceAppId)).mcpServerId),
+      ),
     );
     const launchTool = (
-      await ToolModel.findByCatalogIdWithMeta(sourceServer!.catalogId)
+      await ToolModel.findByCatalogIdWithMeta(sourceServer.catalogId)
     )[0];
 
     // A second, unrelated app has the source app's launch tool assigned to it

--- a/platform/backend/src/routes/chat/incognito.route.test.ts
+++ b/platform/backend/src/routes/chat/incognito.route.test.ts
@@ -21,7 +21,6 @@ import {
   randomBytes,
 } from "node:crypto";
 import { sql } from "drizzle-orm";
-import { vi } from "vitest";
 import config from "@/config";
 // biome-ignore lint/style/noRestrictedImports: dual-licensed code under test
 import { runContentEncryptionBackfill } from "@/content-encryption/backfill.ee";
@@ -31,7 +30,6 @@ import {
 } from "@/content-encryption/index.ee";
 import db from "@/database";
 import MessageModel from "@/models/message";
-import { secretManagerCoordinator } from "@/secrets-manager";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";

--- a/platform/backend/src/routes/mcp-gateway/index.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/index.test.ts
@@ -36,7 +36,14 @@ import {
   ToolModel,
   UserTokenModel,
 } from "@/models";
-import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mustExist,
+  test,
+} from "@/test";
 import mcpGatewayRoutes from "./index";
 
 /**
@@ -586,9 +593,11 @@ describe("MCP Gateway (stateless mode)", () => {
       scope: "org",
       enabled: false,
     });
-    const server = await McpServerModel.findById(disabledApp.mcpServerId!);
+    const server = mustExist(
+      await McpServerModel.findById(mustExist(disabledApp.mcpServerId)),
+    );
     const [launchTool] = await ToolModel.findByCatalogIdWithMeta(
-      server!.catalogId,
+      server.catalogId,
     );
     const launchToolName = launchTool.name;
 

--- a/platform/backend/src/routes/mcp-gateway/utils.ts
+++ b/platform/backend/src/routes/mcp-gateway/utils.ts
@@ -121,7 +121,6 @@ import {
   buildGatewayServerCapabilities,
   buildPrivateListCacheHint,
   isResourceUnavailableError,
-  type McpProtocolRevision,
   withCompleteResultEnvelope,
   withPrivateCacheHint,
 } from "./protocol";

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -62,7 +62,6 @@ import config, {
 } from "@/config";
 // biome-ignore lint/style/noRestrictedImports: dual-licensed, self-guards on the license flag
 import { verifyContentEncryptionKey } from "@/content-encryption/guard.ee";
-// biome-ignore lint/style/noRestrictedImports: dual-licensed; no-op when escrow is unconfigured
 import { verifyIncognitoChatConfig } from "@/content-encryption/incognito-escrow";
 // biome-ignore lint/style/noRestrictedImports: dual-licensed, self-guards on the license flag
 import { assertRetentionConfigLicensed } from "@/data-retention/license-gate.ee";

--- a/platform/backend/src/services/connection-setup-script.test.ts
+++ b/platform/backend/src/services/connection-setup-script.test.ts
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: asserts on emitted shell source, where `${VAR}` is shell parameter expansion
+
 import { execFile } from "node:child_process";
 import {
   mkdir,

--- a/platform/backend/src/services/startup-guard.clients.test.ts
+++ b/platform/backend/src/services/startup-guard.clients.test.ts
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: asserts on emitted shell source, where `${VAR}` is shell parameter expansion
+
 import { execFile } from "node:child_process";
 import {
   chmod,

--- a/platform/backend/src/services/startup-guard.clients.ts
+++ b/platform/backend/src/services/startup-guard.clients.ts
@@ -1,3 +1,6 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: these files build bash/PowerShell source as JS strings, so `${VAR}` is shell
+// parameter expansion for the emitted script, not a JS template placeholder
+
 import {
   ARCHESTRA_TOKEN_PREFIX,
   CLAUDE_CODE_CUSTOM_HEADERS_ENV_KEY,

--- a/platform/backend/src/services/startup-guard.test.ts
+++ b/platform/backend/src/services/startup-guard.test.ts
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: asserts on emitted shell source, where `${VAR}` is shell parameter expansion
+
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import {


### PR DESCRIPTION
## Why

Backend carried 32 biome warnings. None of them failed CI, which is exactly the problem: in a list that long a stale suppression is indistinguishable from a live one, and a new warning lands unnoticed. This clears the list so the next one means something.

Backend biome is now **0 errors, 0 warnings**. No behaviour changes.

## What changed

Most of it is unused imports and three dead type aliases in `a2a-protocol.ts` (`A2AProtocolTaskStatus`, `A2AProtocolTaskStatusUpdateEvent`, `A2AProtocolTaskArtifactUpdateEvent` — all local, all with zero references).

Three things needed a decision rather than an autofix:

**`allowPrivateWebhookHosts` is deleted.** It was defined and never called, in a file that contains no SSRF guard for it to relax. Deleting it changes nothing today — but the doc comment says local development points webhooks at localhost and the guard would otherwise refuse them, so **whoever owns A2A push notifications may want to check whether that allowance was meant to be wired up somewhere.** Biome's fix was to rename it to `_allowPrivateWebhookHosts`, which just hides the question.

**Non-null assertions now go through `mustExist`.** Biome rewrites `x!` to `x?.`, which is not equivalent — it hands `undefined` to the next call and fails further downstream with a worse error. Both files already import `mustExist` from `@/test`, which throws with a clear message, so the assertions are genuinely gone rather than suppressed.

**`noTemplateCurlyInString` is a false positive here.** The guard and setup-script renderers build shell source as JS strings, so `${CLAUDE_CONFIG_DIR:-$HOME}` is parameter expansion for the emitted script, not a JS placeholder. Suppressed per file with that reason.

Also drops three suppression comments biome itself reports as having no effect (`suppressions/unused`).

## Testing

`pnpm lint` 8/8, `pnpm type-check` 8/8, `knip` clean (dev + production).

Tests across every touched area: 156 files / 3103 tests pass.

One pre-existing failure remains on this branch: `startup-guard.test.ts` fails on macOS because the guard backgrounds a bare function call, and bash 3.2 (still `/bin/bash` on macOS) execs only the case arm's first command. That is a real product bug — the local-scope MCP entry is never removed while the guard reports success — and it is **fixed in #7185**, not here. It passes on CI either way, since CI runs bash 5.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>