### PR TITLE
feat(bench): daily advised arm becomes mimo-25 + deepseek-flash

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -175,7 +175,7 @@ jobs:
           # Scheduled runs carry no inputs and an empty dispatch field is falsy, so these fallbacks
           # are the single source of the daily selection.
           BENCH_ENVS: ${{ inputs.envs || 'basic' }}
-          BENCH_LANES: ${{ inputs.lanes || 'glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-56-luna,mimo-25,qwen36-35b-a3b,qwen36-27b,qwen36-35b-a3b-adv-deepseek-flash' }}
+          BENCH_LANES: ${{ inputs.lanes || 'glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-56-luna,mimo-25,qwen36-35b-a3b,qwen36-27b,mimo-25-adv-deepseek-flash' }}
         run: |
           set -euo pipefail
           # Dispatch inputs are the only caller-controlled values on the envsubst allowlist, and they

--- a/ai-labs/README.md
+++ b/ai-labs/README.md
@@ -414,7 +414,7 @@ sum of both models' spend — advisor rows are split off by the Advisor agent's 
 advisor lane's slug, the rest at the lane's own — and each advised rollout's `run.json` carries
 `advisor_consult_count`, the advisor token share, and the advisor cost share (aggregated per group in
 `aggregate.json` and the report). The canonical A/B is three arms in one run: cheap alone,
-cheap+advisor, strong alone (e.g. `--lanes qwen36-35b-a3b,qwen36-35b-a3b-adv-deepseek-flash,deepseek-flash`). The
+cheap+advisor, strong alone (e.g. `--lanes mimo-25,mimo-25-adv-deepseek-flash,deepseek-flash`). The
 `--lanes` flag selects lane names from the catalog (default: every lane), so you can define many and run
 one; `--lanes-file` overrides the catalog path. `--max-workers` runs that many lanes concurrently
 (default: one worker per selected lane, capped at 4); tasks within a lane stay serial. On `benchmark`,

--- a/ai-labs/lanes.toml
+++ b/ai-labs/lanes.toml
@@ -104,7 +104,7 @@ api_key_env = "ZAI_API_KEY"
 openrouter_model = "z-ai/glm-5.2"
 
 [[lane]]
-name = "qwen36-35b-a3b-adv-deepseek-flash"
+name = "mimo-25-adv-deepseek-flash"
 provider = "openrouter"
-model = "qwen/qwen3.6-35b-a3b"
+model = "xiaomi/mimo-v2.5"
 advisor = "deepseek-flash"


### PR DESCRIPTION
## Summary

The daily roster's advised arm switches from `qwen36-35b-a3b-adv-deepseek-flash` to `mimo-25-adv-deepseek-flash`. The qwen arm did its job — it carried the causal experiments that established consult-coupled rescues exist where the executor has real headroom — but as a standing daily measurement the arm worth tracking is the economics one: mimo-25 is the roster's cheapest lane, and under the consult mandate (#7191) its advised pairing measured a top-of-band pass rate with roughly half of rollouts consulting and advisor spend under a cent per sweep. Its base lane and its advisor's lane are both already on the roster, so every scheduled report keeps carrying the paired three-way comparison.

A new lane name rather than repointing the old one, because lane names key the artifact directories and TensorBoard series — reusing the qwen arm's name with a different model would splice two models into one trend line. The advised-lane count stays at one, so the bench pod's memory sizing and wall-clock budget are unchanged.

The advised arm's measured behavior depends on the consult-mandate text in #7191: until that merges and deploys, the new arm's daily rows reflect the weaker shipped policy.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>