### PR TITLE
feat(advisor): mark the Advisor beta in the agent dialog and docs

### DIFF
--- a/docs/pages/platform-built-in-subagents.md
+++ b/docs/pages/platform-built-in-subagents.md
@@ -14,6 +14,8 @@ An admin can open a built-in subagent in its settings and change its **system pr
 
 ## Advisor
 
+The Advisor is in beta.
+
 The Advisor is a stronger model an agent consults at the decisions that shape a task: which approach to take, an error that keeps coming back, whether the work is really done. Everything else stays on the agent's own model.
 
 Turn it on per agent or MCP gateway with **Enable Advisor**, under **Subagents**. It works the same in Auto and Custom mode. Pick the Advisor's model in its own settings — a stronger model than the callers use is the point.

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -2524,9 +2524,17 @@ export function AgentDialog({
                       {advisorAgentId && (
                         <div className="flex items-center justify-between gap-4 border-t pt-4">
                           <div className="space-y-0.5">
-                            <Label htmlFor="consult-advisor">
-                              Enable Advisor
-                            </Label>
+                            <div className="flex items-center gap-2">
+                              <Label htmlFor="consult-advisor">
+                                Enable Advisor
+                              </Label>
+                              <Badge
+                                variant="secondary"
+                                className="px-1.5 py-0 text-[10px]"
+                              >
+                                Beta
+                              </Badge>
+                            </div>
                             <p className="text-xs text-muted-foreground">
                               Pairs this{" "}
                               {agentTypeDisplayName[agentType] || "agent"} with


### PR DESCRIPTION
## Summary

The Advisor's consult behavior is still being tuned against benchmark measurement (#7191 landed the current policy), so the surface that enables it should say so: the **Enable Advisor** control in the agent dialog now carries a Beta badge — the same badge pattern the Hooks editor uses — and the docs section opens with the beta note. The dialog is shared between agents and MCP Gateways, so both surfaces get the badge from the one change.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>