### PR TITLE
fix(guardrails): enforce blocked and sanitized tool results in sensitive context

### DIFF
--- a/platform/backend/src/agents/context-trust.test.ts
+++ b/platform/backend/src/agents/context-trust.test.ts
@@ -103,4 +103,53 @@ describe("evaluateToolExecutionContextTrust", () => {
       reason: "agent_configured_untrusted",
     });
   });
+
+  test("reports the preexisting boundary, not a later tool result's, when context starts untrusted", async () => {
+    await TrustedDataPolicyModel.create({
+      toolId,
+      description: "Mark external mail as sensitive",
+      conditions: [
+        { key: "emails[*].from", operator: "contains", value: "@external.com" },
+      ],
+      action: "mark_as_untrusted",
+    });
+
+    const result = await evaluateToolExecutionContextTrust({
+      agentId,
+      organizationId,
+      userId: "user-123",
+      considerContextUntrusted: true,
+      policyContext: {
+        externalAgentId: "chat",
+      },
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Summarize what the email said." }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-email-1",
+              toolName: "read_email",
+              output: {
+                type: "json",
+                value: {
+                  emails: [{ from: "ceo@external.com", subject: "Urgent" }],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.contextIsTrusted).toBe(false);
+    expect(result.unsafeContextBoundary).toEqual({
+      kind: "preexisting_untrusted",
+      reason: "agent_configured_untrusted",
+    });
+  });
 });

--- a/platform/backend/src/agents/context-trust.ts
+++ b/platform/backend/src/agents/context-trust.ts
@@ -1,5 +1,8 @@
 import type { ToolExecutionOptions } from "ai";
-import { evaluateIfContextIsTrusted } from "@/guardrails/trusted-data";
+import {
+  evaluateIfContextIsTrusted,
+  preexistingUntrustedBoundary,
+} from "@/guardrails/trusted-data";
 import { AgentTeamModel } from "@/models";
 import type { PolicyEvaluationContext } from "@/models/tool-invocation-policy";
 import type { CommonMessage, UnsafeContextBoundary } from "@/types";
@@ -18,6 +21,17 @@ export async function evaluateToolExecutionContextTrust(params: {
   contextIsTrusted: boolean;
   unsafeContextBoundary?: UnsafeContextBoundary;
 }> {
+  // This caller discards the result-policy redactions the evaluator computes,
+  // so with the verdict and boundary already settled there is nothing left to
+  // learn — and evaluating would cost a team lookup plus a policy pass over the
+  // whole history on every tool execution.
+  if (params.considerContextUntrusted) {
+    return {
+      contextIsTrusted: false,
+      unsafeContextBoundary: preexistingUntrustedBoundary(),
+    };
+  }
+
   const commonMessages = toCommonMessages(params.messages);
   const teamIds = await AgentTeamModel.getTeamsForAgent(params.agentId);
   const evaluation = await evaluateIfContextIsTrusted({

--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -1323,6 +1323,56 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       ]);
     });
 
+    test("reuses a cached sanitization when context starts untrusted", async () => {
+      await createSanitizePolicy(toolId);
+      stubCacheStore();
+
+      const analysis = {
+        toolCallId: "call_sanitized_cached",
+        conversations: [],
+        result: "Sanitized summary",
+      };
+      const createSpy = vi.spyOn(DualLlmSubagent, "create").mockResolvedValue({
+        processWithMainAgent: vi.fn().mockResolvedValue(analysis),
+      } as unknown as DualLlmSubagent);
+
+      const evaluate = () =>
+        evaluateIfContextIsTrusted({
+          messages: [
+            { role: "user", content: "Summarize the tool results" },
+            {
+              role: "tool",
+              toolCalls: [
+                {
+                  id: "call_sanitized_cached",
+                  name: "get_emails",
+                  content: { source: "external", payload: "raw" },
+                  isError: false,
+                },
+              ],
+            },
+          ],
+          agentId: agentId,
+          organizationId: organizationId,
+          considerContextUntrusted: true,
+          policyContext: { teamIds: [] },
+        });
+
+      await evaluate();
+      const replayed = await evaluate();
+
+      // The agentic loop replays the whole history every turn, so past the
+      // first turn this cached branch is what redacts the result.
+      expect(createSpy).toHaveBeenCalledOnce();
+      expect(replayed.toolResultUpdates).toEqual({
+        call_sanitized_cached: sanitized("Sanitized summary"),
+      });
+      expect(replayed.dualLlmAnalyses).toEqual([analysis]);
+      // The cached branch marks the result trusted; the seeded verdict must
+      // still hold the context untrusted.
+      expect(replayed.contextIsTrusted).toBe(false);
+    });
+
     test("fails closed when sanitization fails and context starts untrusted", async () => {
       await createSanitizePolicy(toolId);
       stubCacheStore();

--- a/platform/backend/src/guardrails/trusted-data.test.ts
+++ b/platform/backend/src/guardrails/trusted-data.test.ts
@@ -1234,6 +1234,212 @@ describe("trusted-data evaluation (provider-agnostic)", () => {
       });
     });
 
+    test("blocks a matching tool result even when context starts untrusted", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [
+          { key: "emails[*].from", operator: "contains", value: "hacker" },
+        ],
+        action: "block_always",
+        description: "Block hacker emails",
+      });
+
+      const result = await evaluateIfContextIsTrusted({
+        messages: [
+          { role: "user" },
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_blocked_untrusted",
+                name: "get_emails",
+                content: {
+                  emails: [{ from: "hacker@evil.com", subject: "Malicious" }],
+                },
+                isError: false,
+              },
+            ],
+          },
+        ],
+        agentId: agentId,
+        organizationId: organizationId,
+        considerContextUntrusted: true,
+        policyContext: { teamIds: [] },
+      });
+
+      expect(result.toolResultUpdates).toEqual({
+        call_blocked_untrusted:
+          "[Content blocked by Archestra security guardrails: Data blocked by policy: Block hacker emails]",
+      });
+      expect(result.contextIsTrusted).toBe(false);
+    });
+
+    test("sanitizes a matching tool result even when context starts untrusted", async () => {
+      await createSanitizePolicy(toolId);
+      stubCacheStore();
+
+      const createSpy = vi.spyOn(DualLlmSubagent, "create").mockResolvedValue({
+        processWithMainAgent: vi.fn().mockResolvedValue({
+          toolCallId: "call_sanitized_untrusted",
+          conversations: [],
+          result: "Sanitized summary",
+        }),
+      } as unknown as DualLlmSubagent);
+
+      const result = await evaluateIfContextIsTrusted({
+        messages: [
+          { role: "user" },
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_sanitized_untrusted",
+                name: "get_emails",
+                content: { source: "external", payload: "raw" },
+                isError: false,
+              },
+            ],
+          },
+        ],
+        agentId: agentId,
+        organizationId: organizationId,
+        considerContextUntrusted: true,
+        policyContext: { teamIds: [] },
+      });
+
+      expect(createSpy).toHaveBeenCalledOnce();
+      expect(result.toolResultUpdates).toEqual({
+        call_sanitized_untrusted: sanitized("Sanitized summary"),
+      });
+      expect(result.contextIsTrusted).toBe(false);
+      // Persisted on the interaction and rendered against the tool part, so an
+      // untrusted-start turn has to carry the analysis like any other.
+      expect(result.dualLlmAnalyses).toEqual([
+        {
+          toolCallId: "call_sanitized_untrusted",
+          conversations: [],
+          result: "Sanitized summary",
+        },
+      ]);
+    });
+
+    test("fails closed when sanitization fails and context starts untrusted", async () => {
+      await createSanitizePolicy(toolId);
+      stubCacheStore();
+
+      vi.spyOn(DualLlmSubagent, "create").mockResolvedValue({
+        processWithMainAgent: vi.fn().mockRejectedValue(
+          new DualLlmAgentCallError({
+            provider: "openai",
+            modelName: "gpt-4",
+            cause: new Error("provider unavailable"),
+          }),
+        ),
+      } as unknown as DualLlmSubagent);
+
+      const rejection = await evaluateIfContextIsTrusted({
+        messages: [
+          { role: "user", content: "Summarize the tool results" },
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_dual",
+                name: "get_emails",
+                content: { source: "external", payload: "raw secret payload" },
+                isError: false,
+              },
+            ],
+          },
+        ],
+        agentId: agentId,
+        organizationId: organizationId,
+        considerContextUntrusted: true,
+        policyContext: { teamIds: [] },
+      }).then(
+        () => null,
+        (error) => error,
+      );
+
+      // An already-untrusted context must not soften the quarantine promise
+      // into "mark untrusted and forward the raw result".
+      expect(rejection).toBeInstanceOf(DualLlmSanitizationError);
+      expect(rejection.message).not.toContain("raw secret payload");
+    });
+
+    test("keeps context untrusted when every tool result is trusted by policy", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [{ key: "source", operator: "equal", value: "trusted" }],
+        action: "mark_as_trusted",
+        description: "Trust internal data",
+      });
+
+      const result = await evaluateIfContextIsTrusted({
+        messages: [
+          { role: "user" },
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_trusted",
+                name: "get_emails",
+                content: { source: "trusted", payload: "internal" },
+                isError: false,
+              },
+            ],
+          },
+        ],
+        agentId: agentId,
+        organizationId: organizationId,
+        considerContextUntrusted: true,
+        policyContext: { teamIds: [] },
+      });
+
+      expect(result.contextIsTrusted).toBe(false);
+      expect(result.toolResultUpdates).toEqual({});
+    });
+
+    test("keeps the preexisting boundary when a later tool result is blocked", async () => {
+      await TrustedDataPolicyModel.create({
+        toolId,
+        conditions: [
+          { key: "emails[*].from", operator: "contains", value: "hacker" },
+        ],
+        action: "block_always",
+        description: "Block hacker emails",
+      });
+
+      const result = await evaluateIfContextIsTrusted({
+        messages: [
+          { role: "user" },
+          {
+            role: "tool",
+            toolCalls: [
+              {
+                id: "call_boundary",
+                name: "get_emails",
+                content: {
+                  emails: [{ from: "hacker@evil.com", subject: "Malicious" }],
+                },
+                isError: false,
+              },
+            ],
+          },
+        ],
+        agentId: agentId,
+        organizationId: organizationId,
+        considerContextUntrusted: true,
+        policyContext: { teamIds: [] },
+        initialUntrustedReason: "inherited_from_parent",
+      });
+
+      expect(result.unsafeContextBoundary).toEqual({
+        kind: "preexisting_untrusted",
+        reason: "inherited_from_parent",
+      });
+    });
+
     test("handles multiple tool calls with mixed trust", async () => {
       // Create policies
       await TrustedDataPolicyModel.create({

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -71,12 +71,36 @@ export class DualLlmSanitizationError extends ApiError {
 /** One tool result's dual LLM analysis, as the progress callbacks report it. */
 type DualLlmAnalysisRef = { toolCallId: string; toolName: string };
 
+/**
+ * Why a context was already unsafe when the turn began. The tool-result reasons
+ * cannot apply: no tool result in this turn is what turned it.
+ */
+type PreexistingUntrustedReason =
+  | typeof UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted
+  | typeof UNSAFE_CONTEXT_BOUNDARY_REASON.inheritedFromParent;
+
+/**
+ * The boundary for a context that was already unsafe when the turn began, so
+ * no single tool result can be named as the point it turned.
+ */
+export function preexistingUntrustedBoundary(
+  reason?: PreexistingUntrustedReason,
+): UnsafeContextBoundary {
+  return {
+    kind: "preexisting_untrusted",
+    reason: reason ?? UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
+  };
+}
+
 export async function evaluateIfContextIsTrusted(params: {
   messages: CommonMessage[];
   agentId: string;
   organizationId: string;
   userId?: string;
-  /** Marks context untrusted from the start, skipping evaluation entirely. */
+  /**
+   * Marks context untrusted from the start. Result policies are still
+   * evaluated: the verdict is predetermined, the redactions are not.
+   */
   considerContextUntrusted?: boolean;
   policyContext: PolicyEvaluationContext;
   onDualLlmStart?: (info: DualLlmAnalysisRef) => void;
@@ -94,7 +118,7 @@ export async function evaluateIfContextIsTrusted(params: {
     analysis: DualLlmAnalysis,
     info: { toolName: string; cached: boolean },
   ) => void;
-  initialUntrustedReason?: UnsafeContextBoundaryReason;
+  initialUntrustedReason?: PreexistingUntrustedReason;
   /**
    * Consult only cached sanitizations: a sanitize-marked result without one
    * counts as untrusted instead of triggering a live (expensive, fallible)
@@ -134,28 +158,14 @@ export async function evaluateIfContextIsTrusted(params: {
 
   const toolResultUpdates: ToolResultUpdates = {};
   const dualLlmAnalyses: DualLlmAnalysis[] = [];
-  let hasUntrustedData = false;
-  let unsafeContextBoundary: UnsafeContextBoundary | undefined;
-
-  // If agent configured to consider context untrusted from the beginning,
-  // mark context as untrusted immediately and skip evaluation
-  if (considerContextUntrusted) {
-    logger.debug(
-      { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: context marked untrusted by agent config",
-    );
-    return {
-      toolResultUpdates: {},
-      contextIsTrusted: false,
-      dualLlmAnalyses: [],
-      unsafeContextBoundary: {
-        kind: "preexisting_untrusted",
-        reason:
-          initialUntrustedReason ??
-          UNSAFE_CONTEXT_BOUNDARY_REASON.agentConfiguredUntrusted,
-      },
-    };
-  }
+  // Result policies still have to run when the context is already untrusted:
+  // `toolResultUpdates` is the only channel that replaces what the model sees,
+  // so skipping evaluation would forward blocked content verbatim.
+  let hasUntrustedData = considerContextUntrusted;
+  let unsafeContextBoundary: UnsafeContextBoundary | undefined =
+    considerContextUntrusted
+      ? preexistingUntrustedBoundary(initialUntrustedReason)
+      : undefined;
 
   // First, collect all tool calls from all messages
   const allToolCalls: Array<{
@@ -215,12 +225,12 @@ export async function evaluateIfContextIsTrusted(params: {
 
   if (allToolCalls.length === 0) {
     logger.debug(
-      { agentId },
-      "[trustedData] evaluateIfContextIsTrusted: no tool calls found, context is trusted",
+      { agentId, contextIsTrusted: !hasUntrustedData },
+      "[trustedData] evaluateIfContextIsTrusted: no tool calls found, nothing to evaluate",
     );
     return {
       toolResultUpdates,
-      contextIsTrusted: true,
+      contextIsTrusted: !hasUntrustedData,
       dualLlmAnalyses: [],
       unsafeContextBoundary,
     };

--- a/platform/backend/src/routes/proxy/llm-proxy-trusted-data.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-trusted-data.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Trusted-data result policies as the model actually receives them.
+ *
+ * These assert on the payload handed to the provider client, not on
+ * `evaluateIfContextIsTrusted`'s return value. A `block_always` policy is only
+ * enforced if `toolResultUpdates` survives all the way into the outgoing
+ * request, and that final hop is invisible to the guardrail's own unit tests.
+ *
+ * The provider is stubbed at the adapter-client boundary, as in
+ * llm-proxy-tool-invocation.test.ts.
+ */
+
+import { UNTRUSTED_CONTEXT_HEADER } from "@archestra/shared";
+import { eq } from "drizzle-orm";
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { vi } from "vitest";
+import db, { schema } from "@/database";
+import { ModelModel, TrustedDataPolicyModel } from "@/models";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { openaiAdapterFactory } from "./adapters";
+import openAiProxyRoutes from "./routes/openai";
+
+/** Distinctive enough to assert on, shaped so secret scanners ignore it. */
+const SECRET = "sentinel-value-the-model-must-never-see";
+
+const READ_EMAIL_TOOL = {
+  type: "function" as const,
+  function: {
+    name: "read_email",
+    description: "Read an email",
+    parameters: {
+      type: "object",
+      properties: { id: { type: "string" } },
+      required: ["id"],
+    },
+  },
+};
+
+describe("LLM Proxy trusted-data result policies (OpenAI)", () => {
+  let app: FastifyInstance;
+  let forwardedMessages: unknown[];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    forwardedMessages = [];
+
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    vi.spyOn(openaiAdapterFactory, "createClient").mockImplementation(
+      () =>
+        ({
+          chat: {
+            completions: {
+              create: async (params: { messages: unknown[] }) => {
+                forwardedMessages = params.messages;
+                return {
+                  id: "chatcmpl-test-openai",
+                  object: "chat.completion",
+                  created: Math.floor(Date.now() / 1000),
+                  model: "gpt-4",
+                  choices: [
+                    {
+                      index: 0,
+                      message: {
+                        role: "assistant",
+                        content: "ok",
+                        refusal: null,
+                        tool_calls: [],
+                      },
+                      finish_reason: "stop",
+                      logprobs: null,
+                    },
+                  ],
+                  usage: {
+                    prompt_tokens: 10,
+                    completion_tokens: 2,
+                    total_tokens: 12,
+                  },
+                };
+              },
+            },
+          },
+        }) as never,
+    );
+
+    await app.register(openAiProxyRoutes);
+    await ModelModel.upsert({
+      externalId: "openai/gpt-4",
+      provider: "openai",
+      modelId: "gpt-4",
+      inputModalities: null,
+      outputModalities: null,
+      customPricePerMillionInput: "10.00",
+      customPricePerMillionOutput: "30.00",
+      lastSyncedAt: new Date(),
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  /**
+   * Mirrors the "Tool Result Policies -> DEFAULT -> Blocked" control, which
+   * updates the empty-conditions policy every tool is seeded with rather than
+   * adding a second one. `evaluateBulk` reads only the first default policy, so
+   * a test that inserts alongside the seeded row is silently shadowed by it and
+   * passes against a broken guardrail.
+   */
+  async function blockAllResults(toolId: string): Promise<void> {
+    const [defaultPolicy] = await db
+      .select()
+      .from(schema.trustedDataPoliciesTable)
+      .where(eq(schema.trustedDataPoliciesTable.toolId, toolId));
+    expect(defaultPolicy?.conditions).toEqual([]);
+    await TrustedDataPolicyModel.update(defaultPolicy.id, {
+      action: "block_always",
+      description: "Blocked by tool result policy",
+    });
+  }
+
+  async function sendTurnWithToolResult(
+    agentId: string,
+    extraHeaders: Record<string, string> = {},
+  ): Promise<string> {
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${agentId}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-key",
+        "user-agent": "test-client",
+        ...extraHeaders,
+      },
+      payload: {
+        model: "gpt-4",
+        messages: [
+          { role: "user", content: "Summarise my latest email" },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: {
+                  name: "read_email",
+                  arguments: JSON.stringify({ id: "1" }),
+                },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "call_1",
+            content: JSON.stringify({ body: `Here is the key: ${SECRET}` }),
+          },
+        ],
+        tools: [READ_EMAIL_TOOL],
+        stream: false,
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    return JSON.stringify(forwardedMessages);
+  }
+
+  test("replaces a blocked tool result whether or not the agent starts untrusted", async ({
+    makeAgent,
+    makeTool,
+  }) => {
+    const agent = await makeAgent({
+      name: "Trusted Data Block Agent",
+      agentType: "llm_proxy",
+      considerContextUntrusted: false,
+    });
+    const tool = await makeTool({ name: "read_email", agentId: agent.id });
+    await blockAllResults(tool.id);
+
+    const trustedStart = await sendTurnWithToolResult(agent.id);
+    expect(trustedStart).toContain("Content blocked by");
+    expect(trustedStart).not.toContain(SECRET);
+
+    await db
+      .update(schema.agentsTable)
+      .set({ considerContextUntrusted: true })
+      .where(eq(schema.agentsTable.id, agent.id));
+
+    const untrustedStart = await sendTurnWithToolResult(agent.id);
+    expect(untrustedStart).toContain("Content blocked by");
+    expect(untrustedStart).not.toContain(SECRET);
+  });
+
+  test("replaces a blocked tool result when untrusted context is inherited from a parent", async ({
+    makeAgent,
+    makeTool,
+  }) => {
+    // A subagent turn reaches the proxy with the parent's header rather than
+    // its own agent flag, so it must be covered independently of the toggle.
+    const agent = await makeAgent({
+      name: "Trusted Data Inherited Agent",
+      agentType: "llm_proxy",
+      considerContextUntrusted: false,
+    });
+    const tool = await makeTool({ name: "read_email", agentId: agent.id });
+    await blockAllResults(tool.id);
+
+    const forwarded = await sendTurnWithToolResult(agent.id, {
+      [UNTRUSTED_CONTEXT_HEADER]: "true",
+    });
+
+    expect(forwarded).toContain("Content blocked by");
+    expect(forwarded).not.toContain(SECRET);
+  });
+});


### PR DESCRIPTION
## Summary

An agent with "Treat context as sensitive from the start of chat" enabled forwarded raw tool results to the model even when the tool's Tool Result Policy was "Blocked" or "Dual LLM". Both policies exist to guarantee the model never sees the original content, so the setting meant to harden an agent was the one that turned the guardrail off.

`evaluateIfContextIsTrusted` computes two unrelated things: a trust verdict, which `considerContextUntrusted` genuinely predetermines, and a set of payload redactions, which it does not. A single early return short-circuited both. `toolResultUpdates` is the only channel that carries a replacement into the outgoing provider request, so with evaluation skipped there was nothing to apply and the raw result went out verbatim — there is no second line of defense behind it.

The flag now seeds `hasUntrustedData` and the `preexisting_untrusted` boundary instead of returning early. Evaluation runs, the verdict still comes out untrusted, and the boundary the UI draws stays where it was. Seeding is what keeps this from coming back: the accumulator is only ever assigned `true`, and every exit derives the verdict from it, so a future return path cannot quietly report a sensitive context as trusted. The no-tool-calls exit hardcoded `contextIsTrusted: true` and now derives it too — left alone it would have flipped a sensitive context to trusted and stopped the tool-invocation default-deny from firing, which is worse than the bug being fixed.

This reaches further than the toggle suggests. The proxy ORs the agent flag with the `X-Archestra-Context-Untrusted` header a parent agent sets, and chat loops back through the same proxy, so delegated and subagent turns hit it with nobody having touched the setting.

Sensitive-start agents with a Dual LLM policy now run live sanitization. That costs latency and tokens, and a failed analysis fails the request closed with a 502 where it previously "succeeded" by handing the model the raw result. That is the documented behavior of a failed sanitization, now applied regardless of the flag.

`evaluateToolExecutionContextTrust` short-circuits locally rather than falling through. It discards the redactions, so with the verdict already settled, evaluating would cost a team lookup and a full history policy pass on every chat tool execution to arrive at the same answer.

Blocked content still reaches tracing and the persisted interaction record — the policy's promise is about what the model sees, not what is stored.

Fixes #4225

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>