### PR TITLE
fix: address the five highest-volume production errors

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -443,6 +443,66 @@ describe("McpClient", () => {
     expect(headers.get("authorization")).toBeNull();
   });
 
+  // Regression: tool calls recover from a session the upstream dropped, but
+  // inspection surfaced it to the operator as a failed server — reading as
+  // "this server is broken" for what a second attempt resolves.
+  test("inspectServer retries once when the upstream dropped the session", async () => {
+    const catalogItem = await InternalMcpCatalogModel.findById(catalogId);
+    if (!catalogItem) throw new Error("expected catalog item");
+
+    const { StreamableHTTPError } = await import(
+      "@modelcontextprotocol/sdk/client/streamableHttp.js"
+    );
+
+    // Both attempts close their client, so this must outlive the first one.
+    mockClose.mockResolvedValue(undefined);
+    mockListTools
+      .mockRejectedValueOnce(
+        new StreamableHTTPError(
+          404,
+          "Error POSTing to endpoint: Session not found",
+        ),
+      )
+      .mockResolvedValueOnce({ tools: [{ name: "list_repos" }] });
+
+    const result = await mcpClient.inspectServer({
+      catalogItem: {
+        ...catalogItem,
+        serverType: "remote",
+        serverUrl: "https://internal.example.com/mcp",
+      },
+      mcpServerId,
+      secrets: {},
+      method: "tools/list",
+    });
+
+    expect(result).toEqual({ tools: [{ name: "list_repos" }] });
+    expect(mockListTools).toHaveBeenCalledTimes(2);
+  });
+
+  test("inspectServer does not retry a genuine inspection failure", async () => {
+    const catalogItem = await InternalMcpCatalogModel.findById(catalogId);
+    if (!catalogItem) throw new Error("expected catalog item");
+
+    mockClose.mockResolvedValue(undefined);
+    mockListTools.mockRejectedValue(new Error("upstream exploded"));
+
+    await expect(
+      mcpClient.inspectServer({
+        catalogItem: {
+          ...catalogItem,
+          serverType: "remote",
+          serverUrl: "https://internal.example.com/mcp",
+        },
+        mcpServerId,
+        secrets: {},
+        method: "tools/list",
+      }),
+    ).rejects.toThrow("upstream exploded");
+
+    expect(mockListTools).toHaveBeenCalledTimes(1);
+  });
+
   test("connectAndGetTools synthesizes read-resource tools when upstream has no tools/list", async () => {
     mockListTools.mockRejectedValueOnce(new Error("Method not found"));
     mockListResources.mockResolvedValueOnce({

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -146,6 +146,27 @@ class StaleSessionError extends Error {
 }
 
 /**
+ * Whether a failure is the upstream rejecting our streamable-HTTP session id
+ * rather than failing the operation itself.
+ *
+ * The MCP SDK skips the `initialize` handshake when the transport already has
+ * a session id, so a session the upstream no longer knows about does not
+ * surface at connect time — it surfaces on the first real RPC. The same is
+ * true for a session established seconds earlier that the upstream then drops
+ * (a restart, a session TTL, or a request landing on a different replica).
+ *
+ * Safe to retry in both cases: the upstream rejects the POST at the transport
+ * layer, before the JSON-RPC message is dispatched, so nothing ran.
+ */
+function isStaleSessionError(error: unknown): boolean {
+  return (
+    error instanceof StaleSessionError ||
+    (error instanceof StreamableHTTPError &&
+      String(error.message).includes("Session not found"))
+  );
+}
+
+/**
  * Token authentication context for dynamic credential resolution
  */
 export type TokenAuthContext = {
@@ -933,10 +954,7 @@ class McpClient {
         // StreamableHTTPError "Session not found" during the first real
         // RPC call (listTools / callTool).  Detect this and retry with a
         // fresh session.
-        const isStaleSession =
-          error instanceof StaleSessionError ||
-          (error instanceof StreamableHTTPError &&
-            String(error.message).includes("Session not found"));
+        const isStaleSession = isStaleSessionError(error);
 
         if (isStaleSession && !isRetry) {
           // Check if another concurrent call is already recovering this
@@ -3610,52 +3628,72 @@ class McpClient {
       enterpriseTransportCredential,
     } = params;
 
-    const transport = await this.getTransport(
-      catalogItem,
-      mcpServerId,
-      secrets,
-      undefined,
-      undefined,
-      undefined,
-      enterpriseTransportCredential,
-    );
+    const runInspection = async (): Promise<unknown> => {
+      const transport = await this.getTransport(
+        catalogItem,
+        mcpServerId,
+        secrets,
+        undefined,
+        undefined,
+        undefined,
+        enterpriseTransportCredential,
+      );
 
-    const client = new Client(buildMcpClientInfo("archestra-inspector"), {
-      capabilities: {},
-    });
+      const client = new Client(buildMcpClientInfo("archestra-inspector"), {
+        capabilities: {},
+      });
+
+      try {
+        await this.raceWithTimeout(
+          client.connect(transport),
+          30000,
+          new McpServerConnectionTimeoutError(),
+        );
+
+        if (method === "tools/list") {
+          return await this.raceWithTimeout(
+            client.listTools(),
+            30000,
+            "List tools timeout",
+          );
+        }
+
+        if (!params.toolName) {
+          throw new Error("toolName is required for tools/call");
+        }
+        return await this.raceWithTimeout(
+          client.callTool(
+            {
+              name: params.toolName,
+              arguments: params.toolArguments ?? {},
+            },
+            undefined,
+            { timeout: config.mcpGateway.toolCallTimeoutMs },
+          ),
+          config.mcpGateway.toolCallTimeoutMs,
+          "Tool call timeout",
+        );
+      } finally {
+        await client.close().catch(() => {});
+      }
+    };
 
     try {
-      await this.raceWithTimeout(
-        client.connect(transport),
-        30000,
-        new McpServerConnectionTimeoutError(),
-      );
-
-      if (method === "tools/list") {
-        return await this.raceWithTimeout(
-          client.listTools(),
-          30000,
-          "List tools timeout",
-        );
+      return await runInspection();
+    } catch (error) {
+      // The upstream dropped the session between connecting and the call.
+      // Tool calls recover from this transparently (see executeToolCall);
+      // inspection used to surface it to the operator as a failed server,
+      // which reads as "this server is broken" for what a second attempt
+      // resolves. Build a fresh transport and try once more.
+      if (!isStaleSessionError(error)) {
+        throw error;
       }
-
-      if (!params.toolName) {
-        throw new Error("toolName is required for tools/call");
-      }
-      return await this.raceWithTimeout(
-        client.callTool(
-          {
-            name: params.toolName,
-            arguments: params.toolArguments ?? {},
-          },
-          undefined,
-          { timeout: config.mcpGateway.toolCallTimeoutMs },
-        ),
-        config.mcpGateway.toolCallTimeoutMs,
-        "Tool call timeout",
+      logger.info(
+        { mcpServerId, method },
+        "Stale session during MCP inspection, retrying with a fresh session",
       );
-    } finally {
-      await client.close().catch(() => {});
+      return await runInspection();
     }
   }
 

--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -232,6 +232,58 @@ describe("getTransientDbErrorCode", () => {
     const aggregate = new AggregateError([new Error("duplicate key")], "");
     expect(getTransientDbErrorCode(aggregate)).toBeNull();
   });
+
+  // Egress to the database rejected or black-holed at the syscall while a
+  // managed cluster reprograms network policy: PostgreSQL is never reached, so
+  // the failure carries an errno and no SQLSTATE.
+  test("detects connection syscall failures that never reach PostgreSQL", () => {
+    expect(
+      getTransientDbErrorCode(
+        new Error("connect EPERM 172.20.81.106:5432 - Local (0.0.0.0:0)"),
+      ),
+    ).toBe("EPERM");
+    expect(
+      getTransientDbErrorCode(new Error("connect EHOSTUNREACH 10.0.0.1:5432")),
+    ).toBe("EHOSTUNREACH");
+    expect(
+      getTransientDbErrorCode(new Error("connect EADDRNOTAVAIL 10.0.0.1:5432")),
+    ).toBe("EADDRNOTAVAIL");
+  });
+
+  test("detects a connection syscall failure reported only on `code`", () => {
+    const error = Object.assign(new AggregateError([], ""), { code: "EPERM" });
+    expect(getTransientDbErrorCode(error)).toBe("EPERM");
+    expect(isTransientDbError(error)).toBe(true);
+  });
+
+  test("unwraps a connection syscall failure the ORM wrapped", () => {
+    const drizzleError = new Error(
+      'Failed query: select "id" from "agents" where "slug" = $1',
+      { cause: new Error("connect EPERM 172.20.81.106:5432") },
+    );
+    expect(getTransientDbErrorCode(drizzleError)).toBe("EPERM");
+    expect(isTransientDbError(drizzleError)).toBe(true);
+  });
+
+  // The ORM interpolates the failing statement's parameters into its message,
+  // so a bare substring match would let user-supplied data mark a permanent
+  // failure (here, a constraint violation) as retryable.
+  test("does not treat an errno inside query parameters as a connection failure", () => {
+    expect(
+      getTransientDbErrorCode(
+        new Error(
+          'Failed query: insert into "agents" ("name") values ($1)\nparams: EPERM_REVIEW_BOT',
+        ),
+      ),
+    ).toBeNull();
+    expect(
+      getTransientDbErrorCode(
+        new Error(
+          'duplicate key value violates unique constraint\nparams: role=EACCES',
+        ),
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("isDbStatementTimeoutError", () => {

--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -279,7 +279,7 @@ describe("getTransientDbErrorCode", () => {
     expect(
       getTransientDbErrorCode(
         new Error(
-          'duplicate key value violates unique constraint\nparams: role=EACCES',
+          "duplicate key value violates unique constraint\nparams: role=EACCES",
         ),
       ),
     ).toBeNull();

--- a/platform/backend/src/database/retry.ts
+++ b/platform/backend/src/database/retry.ts
@@ -77,17 +77,54 @@ const TRANSIENT_ERROR_PATTERNS: ReadonlyArray<{
 ];
 
 /**
+ * Errnos for the connection to the database failing at the syscall, before
+ * PostgreSQL is ever reached (so there is no SQLSTATE to key off).
+ *
+ * In a managed cluster the CNI, a network policy, or a security group can
+ * reject or black-hole egress while nodes, ENIs, or policy rules are being
+ * reprogrammed, and a busy node can momentarily run out of ephemeral source
+ * ports. Each window is short and the next attempt succeeds, which makes these
+ * transient in exactly the way a refused connection is.
+ *
+ * Kept separate from {@link TRANSIENT_ERROR_PATTERNS} because these tokens are
+ * short enough to appear inside unrelated text: the ORM embeds the failing
+ * statement's parameters in the message, so a bare `message.includes("EPERM")`
+ * would let user-supplied data mark a permanent failure as retryable. They are
+ * matched on `error.code`, or on the `<syscall> <ERRNO> <address>` shape Node
+ * uses to render them (see {@link SYSCALL_ERRNO_PATTERN}).
+ */
+const CONNECT_SYSCALL_ERRNOS = [
+  "EPERM",
+  "EACCES",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "EADDRNOTAVAIL",
+  "EADDRINUSE",
+] as const;
+
+/**
+ * Node renders a failed connection syscall as `connect EPERM 10.0.0.1:5432`.
+ * Anchoring on that shape keeps the errno from matching parameter values the
+ * ORM interpolated into the same message.
+ */
+const SYSCALL_ERRNO_PATTERN = new RegExp(
+  `\\b(?:connect|getaddrinfo|read|write)\\s+(${CONNECT_SYSCALL_ERRNOS.join("|")})\\b`,
+);
+
+/**
  * Transient network syscall codes, matched against `error.code` directly.
  * Message matching alone misses Node's multi-address connection failure: when
  * a database host resolves to several addresses (e.g. IPv6 + IPv4) and all
  * fail, net.connect throws an AggregateError whose message is EMPTY — the
  * syscall code lives on `error.code` and the per-address errors in `errors`.
  */
-const TRANSIENT_NETWORK_CODES = new Set(
-  TRANSIENT_ERROR_PATTERNS.filter(({ pattern, code }) => pattern === code).map(
+const TRANSIENT_NETWORK_CODES = new Set<string>([
+  ...TRANSIENT_ERROR_PATTERNS.filter(({ pattern, code }) => pattern === code).map(
     ({ code }) => code,
   ),
-);
+  ...CONNECT_SYSCALL_ERRNOS,
+]);
 
 /** Maximum depth for cause-chain traversal to guard against circular references */
 const MAX_CAUSE_DEPTH = 5;
@@ -172,6 +209,12 @@ export function getTransientDbErrorCode(
     message.includes(pattern),
   );
   if (matched) return matched.code;
+
+  // Connection syscall failures that reached us wrapped (the ORM restates the
+  // cause in its own message), matched on the syscall shape rather than a bare
+  // token so interpolated query parameters cannot trigger them.
+  const syscallErrno = SYSCALL_ERRNO_PATTERN.exec(message)?.[1];
+  if (syscallErrno) return syscallErrno;
 
   // A multi-address connection failure is an AggregateError holding one error
   // per attempted address in `errors` (not `cause`) — check each of them.

--- a/platform/backend/src/database/retry.ts
+++ b/platform/backend/src/database/retry.ts
@@ -120,9 +120,9 @@ const SYSCALL_ERRNO_PATTERN = new RegExp(
  * syscall code lives on `error.code` and the per-address errors in `errors`.
  */
 const TRANSIENT_NETWORK_CODES = new Set<string>([
-  ...TRANSIENT_ERROR_PATTERNS.filter(({ pattern, code }) => pattern === code).map(
-    ({ code }) => code,
-  ),
+  ...TRANSIENT_ERROR_PATTERNS.filter(
+    ({ pattern, code }) => pattern === code,
+  ).map(({ code }) => code),
   ...CONNECT_SYSCALL_ERRNOS,
 ]);
 

--- a/platform/backend/src/models/interaction.test.ts
+++ b/platform/backend/src/models/interaction.test.ts
@@ -4,6 +4,7 @@ import {
   CLAUDE_CLIENT_FILTER,
   CLAUDE_CLIENT_ID,
   CLAUDE_CODE_CLIENT_ID,
+  CLAUDE_METADATA_SESSION_SOURCE,
   CODEX_CLIENT_FILTER,
   CODEX_CLIENT_ID,
 } from "@archestra/shared";
@@ -1330,6 +1331,131 @@ describe("InteractionModel", () => {
       const session = sessions.data[0];
       expect(session.lastUserMessagePreview).toBe(longMessage.slice(0, 200));
       expect(session).not.toHaveProperty("lastInteractionRequest");
+    });
+  });
+
+  describe("getSessions delta-encoded previews across many sessions", () => {
+    // The chosen tip of every session on a page is reconstructed in one batch.
+    // Each session must still get its own reconstructed request back: a batch
+    // that mixed rows up would show one session's message under another.
+    test("reconstructs each session's own last message", async ({
+      makeAdmin,
+    }) => {
+      const admin = await makeAdmin();
+      const agent = await AgentModel.create({
+        name: "Delta Agent",
+        teams: [],
+        scope: "org",
+      });
+
+      const sessionCount = 5;
+      const tipIds: string[] = [];
+      for (let i = 0; i < sessionCount; i++) {
+        // Two turns per session, both delta-eligible: the second stores only
+        // the delta, so its preview is only correct after reconstruction.
+        for (const turn of [1, 2]) {
+          const created = await InteractionModel.create({
+            profileId: agent.id,
+            sessionId: `delta-session-${i}`,
+            sessionSource: CLAUDE_METADATA_SESSION_SOURCE,
+            type: "anthropic:messages",
+            request: {
+              model: "claude-3-5-sonnet",
+              messages: [
+                { role: "user", content: `session ${i} turn 1` },
+                ...(turn === 2
+                  ? [
+                      { role: "assistant", content: "ack" },
+                      { role: "user", content: `session ${i} turn 2` },
+                    ]
+                  : []),
+              ],
+            },
+            response: {
+              id: `r-${i}-${turn}`,
+              type: "message",
+              role: "assistant",
+              model: "claude-3-5-sonnet",
+              content: [],
+            },
+          });
+          if (turn === 2) tipIds.push(created.id);
+        }
+      }
+
+      // Guard the premise: each session's tip must actually be delta-stored,
+      // otherwise the previews below would be correct without reconstruction
+      // and this test would pass while the batch path stayed unexercised.
+      for (const tipId of tipIds) {
+        const tip = await InteractionModel.findById(tipId);
+        expect(tip?.threadId).not.toBeNull();
+      }
+
+      const sessions = await InteractionModel.getSessions(
+        { limit: 100, offset: 0 },
+        admin.id,
+        true,
+      );
+
+      expect(sessions.data).toHaveLength(sessionCount);
+      for (const session of sessions.data) {
+        const index = session.sessionId?.replace("delta-session-", "");
+        expect(session.lastUserMessagePreview).toBe(`session ${index} turn 2`);
+      }
+    });
+  });
+
+  describe("getSessions total", () => {
+    // The total is reused across the pages of one sweep, so it must be keyed by
+    // the filter set — otherwise a filtered page reports the unfiltered count.
+    test("reports a total per filter set, not the first one computed", async ({
+      makeAdmin,
+    }) => {
+      const admin = await makeAdmin();
+      const agent = await AgentModel.create({
+        name: "Total Agent",
+        teams: [],
+        scope: "org",
+      });
+
+      for (const sessionId of ["total-a", "total-b", "total-c"]) {
+        await InteractionModel.create({
+          profileId: agent.id,
+          sessionId,
+          request: { model: "gpt-4", messages: [{ role: "user", content: "x" }] },
+          response: {
+            id: sessionId,
+            object: "chat.completion",
+            created: Date.now(),
+            model: "gpt-4",
+            choices: [],
+          },
+          type: "openai:chatCompletions",
+        });
+      }
+
+      const all = await InteractionModel.getSessions(
+        { limit: 100, offset: 0 },
+        admin.id,
+        true,
+      );
+      expect(all.pagination.total).toBe(3);
+
+      const filtered = await InteractionModel.getSessions(
+        { limit: 100, offset: 0 },
+        admin.id,
+        true,
+        { sessionId: "total-a" },
+      );
+      expect(filtered.pagination.total).toBe(1);
+
+      // Back to the unfiltered sweep: still its own total.
+      const allAgain = await InteractionModel.getSessions(
+        { limit: 100, offset: 1 },
+        admin.id,
+        true,
+      );
+      expect(allAgain.pagination.total).toBe(3);
     });
   });
 

--- a/platform/backend/src/models/interaction.test.ts
+++ b/platform/backend/src/models/interaction.test.ts
@@ -8,6 +8,8 @@ import {
   CODEX_CLIENT_FILTER,
   CODEX_CLIENT_ID,
 } from "@archestra/shared";
+import { inArray } from "drizzle-orm";
+import db, { schema } from "@/database";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { InsertInteraction } from "@/types";
 import { SelectInteractionSchema } from "@/types";
@@ -1373,10 +1375,10 @@ describe("InteractionModel", () => {
             },
             response: {
               id: `r-${i}-${turn}`,
-              type: "message",
-              role: "assistant",
+              object: "chat.completion",
+              created: Date.now(),
               model: "claude-3-5-sonnet",
-              content: [],
+              choices: [],
             },
           });
           if (turn === 2) tipIds.push(created.id);
@@ -1386,15 +1388,26 @@ describe("InteractionModel", () => {
       // Guard the premise: each session's tip must actually be delta-stored,
       // otherwise the previews below would be correct without reconstruction
       // and this test would pass while the batch path stayed unexercised.
-      for (const tipId of tipIds) {
-        const tip = await InteractionModel.findById(tipId);
-        expect(tip?.threadId).not.toBeNull();
+      const storedTips = await db
+        .select({
+          id: schema.interactionsTable.id,
+          threadId: schema.interactionsTable.threadId,
+        })
+        .from(schema.interactionsTable)
+        .where(inArray(schema.interactionsTable.id, tipIds));
+      expect(storedTips).toHaveLength(sessionCount);
+      for (const tip of storedTips) {
+        expect(tip.threadId).not.toBeNull();
       }
 
+      // Scoped to this test's agent: an agent admin's session list is not
+      // otherwise narrowed, so an unfiltered call would also see rows written
+      // by whichever tests ran before this one.
       const sessions = await InteractionModel.getSessions(
         { limit: 100, offset: 0 },
         admin.id,
         true,
+        { profileId: agent.id },
       );
 
       expect(sessions.data).toHaveLength(sessionCount);
@@ -1422,7 +1435,10 @@ describe("InteractionModel", () => {
         await InteractionModel.create({
           profileId: agent.id,
           sessionId,
-          request: { model: "gpt-4", messages: [{ role: "user", content: "x" }] },
+          request: {
+            model: "gpt-4",
+            messages: [{ role: "user", content: "x" }],
+          },
           response: {
             id: sessionId,
             object: "chat.completion",
@@ -1434,10 +1450,12 @@ describe("InteractionModel", () => {
         });
       }
 
+      // Scoped to this test's agent so the totals are this test's rows only.
       const all = await InteractionModel.getSessions(
         { limit: 100, offset: 0 },
         admin.id,
         true,
+        { profileId: agent.id },
       );
       expect(all.pagination.total).toBe(3);
 
@@ -1445,15 +1463,17 @@ describe("InteractionModel", () => {
         { limit: 100, offset: 0 },
         admin.id,
         true,
-        { sessionId: "total-a" },
+        { profileId: agent.id, sessionId: "total-a" },
       );
       expect(filtered.pagination.total).toBe(1);
 
-      // Back to the unfiltered sweep: still its own total.
+      // Back to the broader sweep, on a later page: still its own total, not
+      // the narrower one just computed.
       const allAgain = await InteractionModel.getSessions(
         { limit: 100, offset: 1 },
         admin.id,
         true,
+        { profileId: agent.id },
       );
       expect(allAgain.pagination.total).toBe(3);
     });

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -8,6 +8,7 @@ import {
   DynamicInteraction,
   isClaudeSessionSource,
   LEGACY_CLAUDE_CODE_SESSION_SOURCE,
+  TimeInMs,
 } from "@archestra/shared";
 import {
   and,
@@ -25,6 +26,7 @@ import {
   sql,
   sum,
 } from "drizzle-orm";
+import { LRUCacheManager } from "@/cache-manager";
 import {
   decryptInteractionContent,
   encryptInteractionContent,
@@ -58,6 +60,24 @@ import AgentTeamModel from "./agent-team";
 import ConversationChatErrorModel from "./conversation-chat-error";
 import InteractionDeltaManager from "./interaction-delta-manager";
 import LimitModel from "./limit";
+
+/**
+ * How long a session total stays reusable across pages of the same filter set.
+ * Long enough to cover a client paging through the whole result, short enough
+ * that a total on screen is never meaningfully behind the table.
+ */
+const SESSION_TOTAL_CACHE_TTL_MS = 30 * TimeInMs.Second;
+
+/**
+ * Session totals keyed by filter set (see getSessions). Per-pod and in-process
+ * on purpose: the value is cheap to recompute on a miss, so it is not worth a
+ * round-trip to the distributed cache to share it between pods. Bounded well
+ * above the number of distinct filter combinations in flight at once.
+ */
+const sessionTotalCache = new LRUCacheManager<number>({
+  maxSize: 500,
+  defaultTtl: SESSION_TOTAL_CACHE_TTL_MS,
+});
 
 async function findChatErrorsForSessionId(sessionId: string | null) {
   if (!sessionId || !isUuid(sessionId)) {
@@ -1192,6 +1212,28 @@ class InteractionModel {
     // Cast id to text since session_id is VARCHAR and id is UUID
     const sessionGroupExpr = sql`COALESCE(${schema.interactionsTable.sessionId}, ${schema.interactionsTable.id}::text)`;
 
+    // The session total is the same for every page of one filter set, but the
+    // count it needs scans `interactions` — the largest, write-hot table — so
+    // paying it per page made a client walking the pages re-run a full scan on
+    // every request (the dominant cost of this endpoint, and enough on its own
+    // to push the query into statement timeout as the table grows). Compute it
+    // for the first page of a sweep and reuse it for the rest; a total that
+    // trails new rows by at most SESSION_TOTAL_CACHE_TTL_MS is the intended
+    // trade, since it only sizes the pager.
+    const sessionTotalCacheKey = JSON.stringify([
+      requestingUserId ?? null,
+      isAgentAdmin ?? false,
+      filters?.profileId ?? null,
+      filters?.userId ?? null,
+      filters?.source ?? null,
+      filters?.client ?? null,
+      filters?.externalAgentId ?? null,
+      filters?.sessionId ?? null,
+      filters?.startDate?.toISOString() ?? null,
+      filters?.endDate?.toISOString() ?? null,
+    ]);
+    const cachedTotal = sessionTotalCache.get(sessionTotalCacheKey);
+
     // PHASE 1: Get sessions with lightweight aggregations (no ARRAY_AGG on large JSON)
     // This is the fast path - simple aggregations on indexed columns
     const [sessionsData, [{ total }]] = await Promise.all([
@@ -1295,13 +1337,19 @@ class InteractionModel {
       // filters only touch interactions columns, and joining on the
       // conversations PK can't change the count, so on large tables it only
       // pushed this query into statement timeout.
-      db
-        .select({
-          total: sql<number>`COUNT(DISTINCT ${schema.interactionsTable.sessionId}) + COUNT(*) FILTER (WHERE ${schema.interactionsTable.sessionId} IS NULL)`,
-        })
-        .from(schema.interactionsTable)
-        .where(whereClause),
+      cachedTotal !== undefined
+        ? [{ total: cachedTotal }]
+        : db
+            .select({
+              total: sql<number>`COUNT(DISTINCT ${schema.interactionsTable.sessionId}) + COUNT(*) FILTER (WHERE ${schema.interactionsTable.sessionId} IS NULL)`,
+            })
+            .from(schema.interactionsTable)
+            .where(whereClause),
     ]);
+
+    if (cachedTotal === undefined) {
+      sessionTotalCache.set(sessionTotalCacheKey, Number(total));
+    }
 
     // PHASE 2: Batch fetch "last interaction" info for all sessions
     // This is much faster than ARRAY_AGG because:
@@ -1510,7 +1558,18 @@ class InteractionModel {
       groupedBySession.set(key, existing);
     }
 
-    // For each session, find the last "main" interaction and title
+    // For each session, find the last "main" interaction and title. Selection
+    // is pure, so it runs for every session first and the chosen tips are
+    // reconstructed in one batch below — reconstructing inside this loop issued
+    // a recursive ancestor query per session, i.e. one per row on the page.
+    const selectedPerSession = new Map<
+      string,
+      {
+        lastMainInteraction: (typeof interactions)[0] | null;
+        claudeCodeTitle: string | null | undefined;
+      }
+    >();
+
     for (const [sessionKey, sessionInteractions] of groupedBySession) {
       let lastMainInteraction: (typeof interactions)[0] | null = null;
       // undefined = not yet found, null = found but no text, string = found with text
@@ -1575,27 +1634,44 @@ class InteractionModel {
       }
 
       if (lastMainInteraction || claudeCodeTitle) {
-        // Reconstruct the chosen tip's full request from deltas (no-op for
-        // legacy/non-delta rows). Only one tip per session is reconstructed.
-        let tipRequest: unknown = lastMainInteraction?.request ?? null;
-        if (lastMainInteraction && lastMainInteraction.threadId !== null) {
-          const full = await InteractionDeltaManager.reconstructRow({
-            id: lastMainInteraction.id,
-            threadId: lastMainInteraction.threadId,
-            request: lastMainInteraction.request,
-            processedRequest: null,
-          });
-          tipRequest = full.request;
-        }
-
-        result.set(sessionKey, {
-          lastUserMessagePreview: lastMainInteraction
-            ? buildLastUserMessagePreview(tipRequest, lastMainInteraction.type)
-            : null,
-          lastInteractionType: lastMainInteraction?.type ?? null,
-          claudeCodeTitle: claudeCodeTitle ?? null,
+        selectedPerSession.set(sessionKey, {
+          lastMainInteraction,
+          claudeCodeTitle,
         });
       }
+    }
+
+    // Reconstruct every chosen tip's full request from deltas in one pass (a
+    // no-op for legacy/non-delta rows, which reconstructMany returns as-is).
+    // Still at most one tip per session, now in a single ancestor query.
+    const reconstructed = await InteractionDeltaManager.reconstructMany(
+      [...selectedPerSession.values()]
+        .map(({ lastMainInteraction }) => lastMainInteraction)
+        .filter((tip): tip is (typeof interactions)[0] => tip !== null)
+        .map((tip) => ({
+          id: tip.id,
+          threadId: tip.threadId,
+          request: tip.request,
+          processedRequest: null,
+        })),
+    );
+
+    for (const [
+      sessionKey,
+      { lastMainInteraction, claudeCodeTitle },
+    ] of selectedPerSession) {
+      const tipRequest = lastMainInteraction
+        ? (reconstructed.get(lastMainInteraction.id)?.request ??
+          lastMainInteraction.request)
+        : null;
+
+      result.set(sessionKey, {
+        lastUserMessagePreview: lastMainInteraction
+          ? buildLastUserMessagePreview(tipRequest, lastMainInteraction.type)
+          : null,
+        lastInteractionType: lastMainInteraction?.type ?? null,
+        claudeCodeTitle: claudeCodeTitle ?? null,
+      });
     }
 
     return result;

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -1504,11 +1504,17 @@ class InteractionModel {
       // would be handed to the server-key decryptor.
       incognito_conversation_id: string | null;
     }>(sql`
+      -- id DESC tiebreak: turns within one session commonly land on the same
+      -- millisecond, and created_at alone leaves their order undefined — which
+      -- let an earlier turn be picked as the session's latest, showing a stale
+      -- preview. Ids are monotonic UUIDv7, so they settle the tie by true
+      -- insertion order (the same tiebreak the write path already uses to
+      -- resolve a delta parent).
       WITH ranked AS (
         SELECT
           id, session_id, thread_id, request, response, type, created_at,
           incognito_conversation_id,
-          ROW_NUMBER() OVER (PARTITION BY COALESCE(session_id, id::text) ORDER BY created_at DESC) as rn
+          ROW_NUMBER() OVER (PARTITION BY COALESCE(session_id, id::text) ORDER BY created_at DESC, id DESC) as rn
         FROM interactions
         WHERE ${whereClause}
       )
@@ -1516,7 +1522,7 @@ class InteractionModel {
              incognito_conversation_id
       FROM ranked
       WHERE rn <= ${INTERACTIONS_PER_SESSION}
-      ORDER BY session_id, created_at DESC
+      ORDER BY session_id, created_at DESC, id DESC
     `);
 
     // SPDX-SnippetBegin

--- a/platform/frontend/sentry.edge.config.ts
+++ b/platform/frontend/sentry.edge.config.ts
@@ -4,19 +4,17 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { getFrontendEdgeSentryOptions } from "./sentry.shared";
+import {
+  getFrontendEdgeSentryOptions,
+  shouldEnableFrontendTelemetry,
+} from "./sentry.shared";
 
 // Use process.env directly since config module uses next-runtime-env which is not available during build
 const dsn = process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN || "";
+const environment =
+  process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT?.toLowerCase() ||
+  process.env.NODE_ENV?.toLowerCase();
 
-// Only initialize Sentry if DSN is configured
-if (dsn) {
-  Sentry.init(
-    getFrontendEdgeSentryOptions({
-      dsn,
-      environment:
-        process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT?.toLowerCase() ||
-        process.env.NODE_ENV?.toLowerCase(),
-    }),
-  );
+if (shouldEnableFrontendTelemetry({ dsn, environment })) {
+  Sentry.init(getFrontendEdgeSentryOptions({ dsn, environment }));
 }

--- a/platform/frontend/sentry.server.config.ts
+++ b/platform/frontend/sentry.server.config.ts
@@ -3,19 +3,17 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { getFrontendServerSentryOptions } from "./sentry.shared";
+import {
+  getFrontendServerSentryOptions,
+  shouldEnableFrontendTelemetry,
+} from "./sentry.shared";
 
 // Use process.env directly since config module uses next-runtime-env which is not available during build
 const dsn = process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN || "";
+const environment =
+  process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT?.toLowerCase() ||
+  process.env.NODE_ENV?.toLowerCase();
 
-// Only initialize Sentry if DSN is configured
-if (dsn) {
-  Sentry.init(
-    getFrontendServerSentryOptions({
-      dsn,
-      environment:
-        process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT?.toLowerCase() ||
-        process.env.NODE_ENV?.toLowerCase(),
-    }),
-  );
+if (shouldEnableFrontendTelemetry({ dsn, environment })) {
+  Sentry.init(getFrontendServerSentryOptions({ dsn, environment }));
 }

--- a/platform/frontend/sentry.shared.ts
+++ b/platform/frontend/sentry.shared.ts
@@ -3,6 +3,29 @@ import type { BrowserOptions, EdgeOptions, NodeOptions } from "@sentry/nextjs";
 const FRONTEND_BROWSER_TRACES_SAMPLE_RATE = 0.05;
 const FRONTEND_SERVER_TRACES_SAMPLE_RATE = 0.02;
 
+/**
+ * Environments that mean "someone's laptop". A developer who has the DSN in
+ * their local env file otherwise reports into the same project as the
+ * deployments, and those events are indistinguishable from real ones at a
+ * glance while carrying local absolute paths and a dev-server build's frames.
+ */
+const LOCAL_ENVIRONMENTS = new Set(["development", "test", "local"]);
+
+/**
+ * Whether frontend telemetry should start at all. Every entry point (browser,
+ * server, edge) goes through this so they cannot drift apart.
+ *
+ * To exercise reporting from a local build, set the environment override
+ * (NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT) to something outside this set.
+ */
+export function shouldEnableFrontendTelemetry(params: {
+  dsn: string | undefined;
+  environment: string | undefined;
+}): boolean {
+  if (!params.dsn) return false;
+  return !LOCAL_ENVIRONMENTS.has(params.environment?.toLowerCase() ?? "");
+}
+
 export function getFrontendBrowserSentryOptions(
   params: Pick<BrowserOptions, "dsn" | "environment">,
 ): BrowserOptions {

--- a/platform/frontend/src/instrumentation-client.ts
+++ b/platform/frontend/src/instrumentation-client.ts
@@ -3,14 +3,18 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import config from "@/lib/config/config";
-import { getFrontendBrowserSentryOptions } from "../sentry.shared";
+import {
+  getFrontendBrowserSentryOptions,
+  shouldEnableFrontendTelemetry,
+} from "../sentry.shared";
 
 const {
   sentry: { dsn, environment },
 } = config;
 
-// Only initialize Sentry if DSN is configured
-if (dsn) {
+const telemetryEnabled = shouldEnableFrontendTelemetry({ dsn, environment });
+
+if (telemetryEnabled) {
   void import("@sentry/nextjs").then((Sentry) => {
     const browserOptions = getFrontendBrowserSentryOptions({
       dsn,
@@ -30,7 +34,7 @@ if (dsn) {
 
 export const onRouterTransitionStart: typeof import("@sentry/nextjs").captureRouterTransitionStart =
   (...args) => {
-    if (!dsn) return;
+    if (!telemetryEnabled) return;
 
     void import("@sentry/nextjs").then(({ captureRouterTransitionStart }) => {
       captureRouterTransitionStart(...args);

--- a/platform/frontend/src/instrumentation.test.ts
+++ b/platform/frontend/src/instrumentation.test.ts
@@ -12,6 +12,9 @@ describe("onRequestError filtering", () => {
     captureRequestError.mockClear();
     process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN =
       "https://example.ingest.test";
+    // Reporting is off on local environments, and the test runner is one, so
+    // the deployed case has to say so explicitly.
+    process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT = "staging";
   });
 
   async function loadHook() {
@@ -43,6 +46,22 @@ describe("onRequestError filtering", () => {
 
   it("skips reporting entirely when no DSN is configured", async () => {
     process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN = "";
+    const onRequestError = await loadHook();
+
+    await onRequestError(
+      new Error("Cannot read properties of undefined"),
+      {} as never,
+      {} as never,
+    );
+
+    expect(captureRequestError).not.toHaveBeenCalled();
+  });
+
+  // A developer with the DSN in their local env file otherwise reported into
+  // the same project as the deployments, with their own absolute paths in the
+  // frames.
+  it("skips reporting from a local development environment", async () => {
+    process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT = "development";
     const onRequestError = await loadHook();
 
     await onRequestError(

--- a/platform/frontend/src/instrumentation.ts
+++ b/platform/frontend/src/instrumentation.ts
@@ -1,8 +1,19 @@
+import { shouldEnableFrontendTelemetry } from "../sentry.shared";
+
 const MSW_ENABLED =
   process.env.NEXT_PUBLIC_API_MOCKING === "enabled" &&
   process.env.NODE_ENV !== "production";
 const ERROR_REPORTING_DSN =
   process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN || "";
+
+function errorReportingEnabled(): boolean {
+  return shouldEnableFrontendTelemetry({
+    dsn: process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN || "",
+    environment:
+      process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_ENVIRONMENT?.toLowerCase() ||
+      process.env.NODE_ENV?.toLowerCase(),
+  });
+}
 
 /**
  * Request errors that are benign client disconnects rather than server faults,
@@ -44,7 +55,7 @@ export async function register() {
 
 export const onRequestError: typeof import("@sentry/nextjs").captureRequestError =
   async (...args) => {
-    if (!ERROR_REPORTING_DSN) return;
+    if (!errorReportingEnabled()) return;
     if (isIgnorableRequestError(args[0])) return;
 
     const { captureRequestError } = await import("@sentry/nextjs");

--- a/platform/frontend/src/lib/utils/api.test.ts
+++ b/platform/frontend/src/lib/utils/api.test.ts
@@ -3,6 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner");
 
+const captureException = vi.fn();
+vi.mock("@sentry/nextjs", () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+}));
+
 import { getApiErrorMessage, handleApiError, throwOnApiError } from "./api";
 
 describe("throwOnApiError", () => {
@@ -86,6 +91,47 @@ describe("handleApiError toast dedupe", () => {
       .mocked(toast.error)
       .mock.calls.map(([, options]) => options?.id);
     expect(new Set(ids).size).toBe(2);
+  });
+});
+
+describe("handleApiError exception reporting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  // The dynamic import of the reporting client resolves on the microtask queue.
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it.each([
+    "api_authentication_error",
+    "api_authorization_error",
+    "api_not_found_error",
+    "api_validation_error",
+    "api_conflict_error",
+  ])("does not report an expected %s", async (type) => {
+    handleApiError({ error: { message: "expected failure", type } });
+    await flush();
+
+    expect(captureException).not.toHaveBeenCalled();
+    // Still surfaced to the user — it is expected, not hidden.
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a server-side failure", async () => {
+    handleApiError({
+      error: { message: "boom", type: "api_internal_server_error" },
+    });
+    await flush();
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an error with no recognisable type", async () => {
+    handleApiError(new Error("something unexpected"));
+    await flush();
+
+    expect(captureException).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/platform/frontend/src/lib/utils/api.ts
+++ b/platform/frontend/src/lib/utils/api.ts
@@ -79,8 +79,29 @@ export function toApiError(error: ApiSdkError): Error {
   return new Error(getApiErrorMessage(error));
 }
 
+/**
+ * API error types that describe the request, the caller's session, or their
+ * permissions — not a fault of ours. The backend already drops the matching
+ * 4xx from its own exception reporting (see classifyErrorForTracking); without
+ * the same rule here the client reported them a second time from the other
+ * side of the wire, so an expected "sign in first" on a page opened while
+ * logged out was filed as an application error.
+ *
+ * They are still toasted and logged: the user needs to see them, they just are
+ * not defects to triage.
+ */
+const NON_REPORTABLE_API_ERROR_TYPES = new Set([
+  "api_authentication_error",
+  "api_authorization_error",
+  "api_not_found_error",
+  "api_validation_error",
+  "api_conflict_error",
+  "api_payload_too_large_error",
+]);
+
 export function handleApiError(error: ApiSdkError) {
   const sentryError = toApiError(error);
+  const errorType = getApiErrorType(error);
 
   // Mandatory-2FA lockout: every API call fails with this code until the
   // member enrolls, so route them to the dedicated enrollment page instead of
@@ -103,11 +124,16 @@ export function handleApiError(error: ApiSdkError) {
     toast.error(message, { duration: 12000, id: message });
   }
 
-  void import("@sentry/nextjs")
-    .then(({ captureException }) => {
-      captureException(sentryError, { extra: { originalError: error } });
-    })
-    .catch(() => undefined);
+  if (
+    errorType === undefined ||
+    !NON_REPORTABLE_API_ERROR_TYPES.has(errorType)
+  ) {
+    void import("@sentry/nextjs")
+      .then(({ captureException }) => {
+        captureException(sentryError, { extra: { originalError: error } });
+      })
+      .catch(() => undefined);
+  }
   console.error(sentryError);
 }
 


### PR DESCRIPTION
Addresses the five highest-volume outstanding production errors — ranked by how often they fire and how many people they reach. Each commit is self-contained and can be read on its own.

## What's fixed

**1. Connection failures that never reach PostgreSQL were treated as permanent** (~600 events/week, the single largest source)

A `connect()` to the database can be rejected or black-holed at the syscall while a managed cluster reprograms network policy — the socket never reaches PostgreSQL, so the failure arrives as a bare errno (`EPERM`, `EHOSTUNREACH`, `EADDRNOTAVAIL`, ...) with no SQLSTATE. These fell outside the transient classification, so the request failed outright instead of riding out a window that closes well within the retry budget, and each one was attributed to whichever statement happened to be in flight — fragmenting one connectivity incident into a separate issue per SQL statement.

They are matched on `error.code`, or on the `<syscall> <ERRNO> <address>` shape Node renders them with, rather than as bare message substrings: the ORM interpolates the failing statement's parameters into the message, so a plain `includes()` would let user-supplied data mark a permanent failure as retryable. A test pins that.

**2. The sessions list re-counted and re-walked the whole table on every page** (the highest-frequency slow query, still firing continuously)

Two costs scaled with the `interactions` table rather than with the page:

- The session total ran a `COUNT` over `interactions` on every request, so a client paging through the result re-ran a full scan for each page even though the number is identical across them. It is now computed once per filter set and reused for the rest of the sweep. A total that trails new rows briefly is the intended trade — it only sizes the pager. Keying by filter set is load-bearing (sharing one total across filters would report the unfiltered count on a filtered page), so a test pins it.
- Each session's chosen tip was reconstructed from its deltas inside the grouping loop, issuing one recursive ancestor query per session — one per row on the page. Selection is pure, so it now runs for every session first and the tips are reconstructed in a single batch.

**3. Session previews could show a stale message**

Turns within one session commonly land on the same millisecond, and the window picking a session's most recent interaction ordered on `created_at` alone — leaving same-instant rows undefined, so an earlier turn could win. Added an `id DESC` tiebreak; ids are monotonic UUIDv7, the same property the write path already uses to resolve a delta parent. (Found while writing the test for #2, which was intermittently reading back the wrong turn.)

**4. Inspecting an MCP server failed on a dropped session** (~34 users/month)

A streamable-HTTP session can disappear between connecting and the first RPC — the server restarted, the session aged out, or the request landed on a different replica. Tool calls already recover by retrying with a fresh session; inspection did not, so the operator was told the server had failed for a condition a second attempt clears. The retry is safe for `tools/call` as well as `tools/list`: the upstream rejects the POST at the transport layer, before the JSON-RPC message is dispatched, so nothing ran — the same reasoning the tool-call path already relies on. The stale-session predicate moved out of the tool-call path so both recognise the condition identically.

**5. The frontend filed expected failures and local runs as errors**

The client reported every API failure as an application error, including the ones the backend already classifies as expected and drops: a 401 on a page opened while signed out, a 403 the user lacks permission for, a 404, a validation rejection. Each arrived a second time from the client side and read as a defect to triage. Those types are now skipped — still toasted and logged, since the user needs to see them; they just are not bugs.

Telemetry also started whenever a DSN was present, so a developer with one in their local env file reported into the same project as the deployments, carrying their own absolute paths and dev-server frames. Every entry point (browser, server, edge, and the request-error hook) now shares one predicate that excludes local environments; set the environment override to exercise reporting from a local build.

## Deliberately not changed

Two loud items turned out not to need code:

- A container OOM-kill signal is already resolved on `main` (#7151, #7172, #7175, #7183) — the remaining events predate those.
- A statement timeout on the agents-list connector lookup is collateral from database-wide pressure, not query shape: that table is small and fully indexed on both join sides. It is already classified as an availability signal and grouped by root cause, which is the correct treatment; fixes 1 and 2 reduce the pressure that produces it.

## Testing

- New tests cover connect-errno classification (including the parameter-collision guard), per-session reconstruction across a batched page, per-filter-set totals, and both MCP inspect paths (retry on a dropped session, no retry on a genuine failure) and the frontend reporting policy.
- `pnpm type-check` clean across all 8 workspaces; `biome check` clean on every changed file; backend `knip` (dev + production) clean.
- Full frontend suite green (3,889 passing). Backend suites for every touched file pass; `interaction-delta-manager.test.ts` (8) and `mcp-client.test.ts` (3) carry pre-existing failures also present on `main` at the same counts, untouched by this branch.
- The new sessions tests were run repeatedly under randomized ordering to confirm they are deterministic.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>