### PR TITLE
fix(gemini): key tool-result replacements on position, not the clock

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/gemini.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.test.ts
@@ -1,4 +1,5 @@
 import { FinishReason, type GenerateContentResponse } from "@google/genai";
+import { onTestFinished, vi } from "vitest";
 import { describe, expect, test } from "@/test";
 import type { Gemini } from "@/types";
 import {
@@ -1064,5 +1065,88 @@ describe("restToSdkGenerateContentParams tool-schema sanitization", () => {
     );
 
     expect(fd.parameters).toBeUndefined();
+  });
+});
+
+describe("GeminiRequestAdapter tool result updates", () => {
+  /**
+   * A `functionResponse` without an `id` is the common case — the AI SDK's
+   * Gemini provider never sends one. The id the guardrail reads and the id the
+   * replacement is written under must still agree.
+   */
+  function requestWithUnidentifiedToolResult(): GeminiRequestWithModel {
+    return createMockRequest([
+      { role: "user", parts: [{ text: "Read my mail" }] },
+      {
+        role: "model",
+        parts: [{ functionCall: { name: "read_email", args: {} } }],
+      },
+      {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              name: "read_email",
+              response: { body: "SECRET" },
+            },
+          },
+        ],
+      },
+    ]);
+  }
+
+  test("replaces a tool result whose functionResponse carries no id", () => {
+    vi.useFakeTimers();
+    onTestFinished(() => {
+      vi.useRealTimers();
+    });
+
+    const adapter = geminiAdapterFactory.createRequestAdapter(
+      requestWithUnidentifiedToolResult(),
+    );
+
+    const [toolCall] = adapter
+      .getMessages()
+      .flatMap((message) => message.toolCalls ?? []);
+    expect(toolCall).toBeTruthy();
+
+    // Policy evaluation queries the database between reading the request and
+    // writing the replacement back, so the two passes never share a timestamp.
+    vi.advanceTimersByTime(5);
+    adapter.applyToolResultUpdates({ [toolCall.id]: "[REPLACED]" });
+
+    const contents = adapter.toProviderRequest().contents ?? [];
+    const responses = contents
+      .flatMap((content) => content.parts ?? [])
+      .flatMap((part) =>
+        "functionResponse" in part && part.functionResponse
+          ? [part.functionResponse.response]
+          : [],
+      );
+
+    expect(responses).toEqual([{ sanitizedContent: "[REPLACED]" }]);
+    expect(JSON.stringify(responses)).not.toContain("SECRET");
+  });
+
+  test("resolves the same id from getMessages and getToolResults", () => {
+    vi.useFakeTimers();
+    onTestFinished(() => {
+      vi.useRealTimers();
+    });
+
+    const adapter = geminiAdapterFactory.createRequestAdapter(
+      requestWithUnidentifiedToolResult(),
+    );
+
+    const fromMessages = adapter
+      .getMessages()
+      .flatMap((message) => message.toolCalls ?? [])
+      .map((toolCall) => toolCall.id);
+    vi.advanceTimersByTime(5);
+    const fromToolResults = adapter
+      .getToolResults()
+      .map((toolResult) => toolResult.id);
+
+    expect(fromToolResults).toEqual(fromMessages);
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/gemini.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.test.ts
@@ -1147,6 +1147,10 @@ describe("GeminiRequestAdapter tool result updates", () => {
       .getToolResults()
       .map((toolResult) => toolResult.id);
 
+    // Anchored to the derived value, not just to each other: if the
+    // functionResponse guard stopped matching id-less responses both passes
+    // would return nothing and agree vacuously.
+    expect(fromMessages).toEqual(["gemini-tool-2-0"]);
     expect(fromToolResults).toEqual(fromMessages);
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -103,7 +103,7 @@ class GeminiRequestAdapter
     );
     const commonMessages: CommonMessage[] = [];
 
-    for (const content of contents) {
+    for (const [contentIndex, content] of contents.entries()) {
       const commonMessage: CommonMessage = {
         role: content.role as CommonMessage["role"],
         content: extractCommonMessageText(content),
@@ -113,7 +113,7 @@ class GeminiRequestAdapter
       if (content.parts) {
         const toolCalls: CommonToolResult[] = [];
 
-        for (const part of content.parts) {
+        for (const [partIndex, part] of content.parts.entries()) {
           // Check if this part has the functionResponse property
           if (
             "functionResponse" in part &&
@@ -127,7 +127,7 @@ class GeminiRequestAdapter
               "id" in functionResponse &&
               typeof functionResponse.id === "string"
                 ? functionResponse.id
-                : generateToolCallId(functionResponse.name as string);
+                : syntheticToolCallId(contentIndex, partIndex);
 
             toolCalls.push({
               id,
@@ -163,9 +163,11 @@ class GeminiRequestAdapter
   getToolResults(): CommonToolResult[] {
     const results: CommonToolResult[] = [];
 
-    for (const content of this.request.contents || []) {
+    for (const [contentIndex, content] of (
+      this.request.contents || []
+    ).entries()) {
       if (content.parts) {
-        for (const part of content.parts) {
+        for (const [partIndex, part] of content.parts.entries()) {
           if (
             "functionResponse" in part &&
             part.functionResponse &&
@@ -178,7 +180,7 @@ class GeminiRequestAdapter
               "id" in functionResponse &&
               typeof functionResponse.id === "string"
                 ? functionResponse.id
-                : generateToolCallId(functionResponse.name as string);
+                : syntheticToolCallId(contentIndex, partIndex);
 
             results.push({
               id,
@@ -353,10 +355,10 @@ class GeminiRequestAdapter
         "[adapters/gemini] toProviderRequest: applying updates",
       );
 
-      contents = contents.map((content) => {
+      contents = contents.map((content, contentIndex) => {
         // Only process user messages with parts
         if (content.role === "user" && content.parts) {
-          const updatedParts = content.parts.map((part) => {
+          const updatedParts = content.parts.map((part, partIndex) => {
             // Check if this part is a function response
             if (
               "functionResponse" in part &&
@@ -369,7 +371,7 @@ class GeminiRequestAdapter
                 "id" in functionResponse &&
                 typeof functionResponse.id === "string"
                   ? functionResponse.id
-                  : generateToolCallId(functionResponse.name as string);
+                  : syntheticToolCallId(contentIndex, partIndex);
 
               if (this.toolResultUpdates[id]) {
                 // Update the function response with sanitized content
@@ -1115,11 +1117,14 @@ export function getUsageTokens(usage: {
 // =============================================================================
 
 /**
- * Generate a consistent tool call ID for function responses that don't have one
- * This is needed because Gemini's function responses may not always have an ID
+ * Identifier for a `functionResponse` the client sent without one — optional in
+ * Gemini's API and omitted by the AI SDK, so most requests need it. Trusted-data
+ * policies are evaluated in one pass over the request and their replacements
+ * written back in another, so this has to be derived from something both passes
+ * observe: the response's position in the request.
  */
-function generateToolCallId(functionName: string): string {
-  return `gemini-tool-${functionName}-${Date.now()}`;
+function syntheticToolCallId(contentIndex: number, partIndex: number): string {
+  return `gemini-tool-${contentIndex}-${partIndex}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

On the Gemini surface, a tool whose Tool Result Policy is "Blocked" or "Dual LLM" had its raw output forwarded to the model. The guardrail computed the replacement correctly and then failed to apply it, silently and with no error.

Gemini's `functionResponse.id` is optional, and the AI SDK's Gemini provider never sends one — it builds `functionResponse` from `name` and `response` only. So the proxy synthesizes an identifier, and it did that with `gemini-tool-<name>-${Date.now()}`, minted independently in `getMessages()`, `getToolResults()`, and `toProviderRequest()`.

Trusted-data policies are evaluated in one pass over the request and their replacements written back in another, with database queries in between. The clock advances across that gap, so the id the replacement was filed under is not the id the write-back looks up, `toolResultUpdates[id]` misses, and the original content goes upstream untouched. For any client using the AI SDK this happens on every turn that carries a tool result, so the policy is inert rather than intermittently wrong.

The identifier now derives from the response's position in the request, which both passes observe. Position is stable across them: each walks `request.contents` in order, and TOON compression maps that array one to one rather than reshaping it. The Ollama adapter has always resolved the same problem the same way (`tool_call_id ?? prefix + index`).

Two behaviours are deliberately unchanged: a client-supplied `id` still takes precedence, and the argument lookup still receives `undefined` when there is no real id rather than the synthetic one, so it continues to match by name.

The new tests advance a fake clock between the read and the write. Without that the two passes can land in the same millisecond and the ids agree by accident — the failure only shows up once real work separates them, which is why it survived the existing suite.

## Not addressed

The response-side identifiers at `gemini.ts:545` and `:731` use a similar `gemini-call-<name>-${Date.now()}` fallback. Those are minted once per response and handed to the client rather than round-tripped through two passes, so they do not hit this bug — but two calls to the same tool within one response would collide. That is a separate defect on a separate path.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>