### PR TITLE
feat(llm-proxy): support GitHub Copilot in the model router

### DIFF
--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -31,7 +31,7 @@ GitHub Copilot is routable, with one difference from every other provider: it se
 
 Requesting a Responses-only model on `/chat/completions` returns `400 Bad Request` naming the endpoint to use instead.
 
-A Copilot key is tied to one GitHub account, so it is routable only through your own personal virtual key — never a shared or multi-provider one. See [GitHub Copilot](#github-copilot).
+A Copilot key is tied to one GitHub account, so it is routable only through your own personal virtual key. That key can hold your other providers too, so one router endpoint reaches all of them. See [GitHub Copilot](#github-copilot).
 
 ### Model Router Connection Details
 
@@ -640,7 +640,7 @@ Obtain the token in either way:
 ### Important Notes
 
 - **No static API keys**: access is per-user via a GitHub OAuth token; model availability follows that account's Copilot subscription tier.
-- **Per-user only**: because the token is tied to one GitHub account, Copilot keys are **personal scope only** — they can't be shared via team/org scope or wrapped in a shared (org/team or multi-provider model-router) virtual key. Each user connects their own account. When someone uses an agent with a Copilot model but hasn't connected yet, Archestra resolves *their* key (never the agent owner's) and prompts them to connect: an inline "Connect GitHub Copilot" card in chat, or a message with a Settings link in Slack/Teams. Email and scheduled runs fail with an actionable message.
+- **Per-user only**: because the token is tied to one GitHub account, Copilot keys are **personal scope only** — they can't be shared via team/org scope or wrapped in a team- or org-scoped virtual key. Each user connects their own account. Your own personal virtual key may map Copilot alongside other providers, which is what makes it routable through the model router. When someone uses an agent with a Copilot model but hasn't connected yet, Archestra resolves *their* key (never the agent owner's) and prompts them to connect: an inline "Connect GitHub Copilot" card in chat, or a message with a Settings link in Slack/Teams. Email and scheduled runs fail with an actionable message.
 - **Generative models only**: the `/models` listing covers every model reachable through `/chat/completions` or `/responses`. Copilot also serves an Anthropic `/v1/messages` shim and embedding models, which Archestra does not route to.
 - **GitHub Enterprise**: point the base, token-exchange, and device-auth URLs at your GHE host. Organizations with their own GitHub App can override the client id.
 

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -3,7 +3,7 @@ title: Supported LLM Providers
 category: LLM Proxy
 order: 2
 description: LLM providers supported by Archestra Platform
-lastUpdated: 2026-08-09
+lastUpdated: 2026-08-10
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -23,7 +23,15 @@ The model router exposes one OpenAI-compatible interface for models across confi
 - **Models API** (`/models`) for provider-qualified chat and embedding model IDs
 - **Embeddings API** (`/embeddings`) for embedding models across supported providers
 
-Embedding models use the same provider-qualified IDs as chat models (for example `openai:text-embedding-3-small` or `gemini:gemini-embedding-001`). Anthropic, Bedrock, and Cohere have no compatible embeddings API and return `501 Not Implemented`.
+Embedding models use the same provider-qualified IDs as chat models (for example `openai:text-embedding-3-small` or `gemini:gemini-embedding-001`). Anthropic, Bedrock, Cohere, and GitHub Copilot have no compatible embeddings API and return `501 Not Implemented`.
+
+### GitHub Copilot Through the Model Router
+
+GitHub Copilot is routable, with one difference from every other provider: it serves each model over a single API. The router reads which one from the model and sends the request there. Codex and GPT-5.x models go to the Responses API; the rest go to Chat Completions.
+
+Requesting a Responses-only model on `/chat/completions` returns `400 Bad Request` naming the endpoint to use instead.
+
+A Copilot key is tied to one GitHub account, so it is routable only through your own personal virtual key — never a shared or multi-provider one. See [GitHub Copilot](#github-copilot).
 
 ### Model Router Connection Details
 
@@ -607,6 +615,8 @@ The Models API tells you which one to use. Each entry lists its API in `supporte
 
 - **Base URL**: `http://localhost:9000/v1/github-copilot/{profile-id}`
 - **Authentication**: Pass your **GitHub OAuth token** (the credential below) in the `Authorization` header as `Bearer <token>`
+
+Copilot models are also reachable through the model router as `github-copilot:<model-id>`. See [GitHub Copilot Through the Model Router](#github-copilot-through-the-model-router).
 
 ### Authentication
 

--- a/platform/backend/src/routes/proxy/model-router-resolver.test.ts
+++ b/platform/backend/src/routes/proxy/model-router-resolver.test.ts
@@ -45,6 +45,8 @@ describe("model-router-resolver", () => {
         provider: "anthropic",
         modelId: "claude-haiku-resolver-test",
         requestedModel: "anthropic:claude-haiku-resolver-test",
+        // Single-surface provider: nothing for the router to choose between.
+        supportedEndpoints: null,
       });
     });
 

--- a/platform/backend/src/routes/proxy/model-router-resolver.ts
+++ b/platform/backend/src/routes/proxy/model-router-resolver.ts
@@ -1,6 +1,7 @@
 import {
   isSupportedProvider,
   type SupportedProvider,
+  type SupportedProviderEndpoint,
   SupportedProviders,
 } from "@archestra/shared";
 import { LlmProviderApiKeyModelLinkModel, ModelModel } from "@/models";
@@ -10,6 +11,13 @@ export type ModelRouterResolution = {
   provider: SupportedProvider;
   modelId: string;
   requestedModel: string;
+  /**
+   * The wire surfaces the provider published for this model, carried through so
+   * the router can pick between a provider's chat and Responses surfaces the
+   * same way the chat path does. Null for the providers that serve exactly one
+   * surface, which is all of them but GitHub Copilot.
+   */
+  supportedEndpoints: SupportedProviderEndpoint[] | null;
 };
 
 export async function resolveModelRoute(params: {
@@ -101,6 +109,7 @@ function toResolution(
     provider: model.provider,
     modelId: model.modelId,
     requestedModel,
+    supportedEndpoints: model.supportedEndpoints ?? null,
   };
 }
 

--- a/platform/backend/src/routes/proxy/routes/model-router.test.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.test.ts
@@ -3,6 +3,7 @@ import {
   LLM_PROXY_OAUTH_SCOPE,
   SOURCE_HEADER,
   type SupportedProvider,
+  type SupportedProviderEndpoint,
 } from "@archestra/shared";
 import { eq } from "drizzle-orm";
 import Fastify from "fastify";
@@ -41,6 +42,8 @@ import {
   deepseekAdapterFactory,
   geminiAdapterFactory,
   geminiEmbeddingsAdapterFactory,
+  githubCopilotAdapterFactory,
+  githubCopilotResponsesAdapterFactory,
   groqAdapterFactory,
   minimaxAdapterFactory,
   mistralAdapterFactory,
@@ -92,6 +95,7 @@ async function upsertModel(params: {
   provider: SupportedProvider;
   modelId: string;
   embeddingDimensions?: 768 | 1536 | 3072;
+  supportedEndpoints?: SupportedProviderEndpoint[];
 }) {
   await ModelModel.upsert({
     externalId: `${params.provider}/${params.modelId}`,
@@ -100,6 +104,7 @@ async function upsertModel(params: {
     inputModalities: ["text"],
     outputModalities: ["text"],
     embeddingDimensions: params.embeddingDimensions,
+    supportedEndpoints: params.supportedEndpoints,
     customPricePerMillionInput: "2.50",
     customPricePerMillionOutput: "10.00",
     lastSyncedAt: new Date(),
@@ -165,6 +170,10 @@ const ROUTABLE_PROVIDER_CASES: Array<{
   { provider: "cohere", modelId: "command-a-03-2025" },
   { provider: "deepseek", modelId: "deepseek-chat" },
   { provider: "gemini", modelId: "gemini-2.5-pro" },
+  // A Copilot model that serves chat completions takes the same uniform path
+  // as any other OpenAI-wire provider; its Responses-only siblings are covered
+  // separately below.
+  { provider: "github-copilot", modelId: "gpt-4o" },
   { provider: "groq", modelId: "llama-3.1-8b-instant" },
   { provider: "minimax", modelId: "MiniMax-M1" },
   { provider: "mistral", modelId: "mistral-large-latest" },
@@ -176,6 +185,67 @@ const ROUTABLE_PROVIDER_CASES: Array<{
   { provider: "xai", modelId: "grok-4" },
   { provider: "zhipuai", modelId: "glm-4.5" },
 ];
+
+/**
+ * Stands in for a provider's native Responses surface — the only shape a
+ * Responses-only model can be served over.
+ */
+function createResponsesTestClient() {
+  const completedResponse = {
+    id: "resp-test-copilot",
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    model: "gpt-5.4-codex",
+    status: "completed",
+    output: [
+      {
+        id: "msg-test-copilot",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [
+          {
+            type: "output_text",
+            text: "Hello from Copilot Responses",
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    usage: {
+      input_tokens: 12,
+      output_tokens: 10,
+      total_tokens: 22,
+    },
+  };
+
+  return {
+    responses: {
+      create: async (params: { stream?: boolean }) => {
+        if (params.stream) {
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              yield {
+                type: "response.created",
+                response: {
+                  ...completedResponse,
+                  status: "in_progress",
+                  output: [],
+                },
+              };
+              yield {
+                type: "response.output_text.delta",
+                delta: "Hello from Copilot Responses",
+              };
+              yield { type: "response.completed", response: completedResponse };
+            },
+          };
+        }
+        return completedResponse;
+      },
+    },
+  };
+}
 
 function createCohereTestClient() {
   return {
@@ -387,6 +457,7 @@ describe("model router proxy routes", () => {
       mistralAdapterFactory,
       ollamaAdapterFactory,
       openaiAdapterFactory,
+      githubCopilotAdapterFactory,
       openrouterAdapterFactory,
       perplexityAdapterFactory,
       vllmAdapterFactory,
@@ -396,6 +467,10 @@ describe("model router proxy routes", () => {
         () => createOpenAiTestClient() as never,
       );
     }
+    vi.spyOn(
+      githubCopilotResponsesAdapterFactory,
+      "createClient",
+    ).mockImplementation(() => createResponsesTestClient() as never);
     vi.spyOn(azureAdapterFactory, "createClient").mockImplementation(
       () => createAzureTestClient() as never,
     );
@@ -576,6 +651,206 @@ describe("model router proxy routes", () => {
       );
     });
   }
+
+  test("routes a Responses-only model natively through the provider's Responses surface", async ({
+    makeAgent,
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const app = createFastifyApp();
+    await app.register(modelRouterProxyRoutes);
+    const provider = "github-copilot";
+    const modelId = "gpt-5.4-codex";
+    await upsertModel({
+      provider,
+      modelId,
+      supportedEndpoints: ["/responses"],
+    });
+    const organization = await makeOrganization();
+    const { value } = await createModelRouterVirtualKey({
+      organizationId: organization.id,
+      provider,
+      makeSecret,
+      makeLlmProviderApiKey,
+    });
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      name: "Model Router Responses-only Agent",
+      agentType: "llm_proxy",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/model-router/${agent.id}/responses`,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${value}`,
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: `${provider}:${modelId}`,
+        input: "Hello",
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({ object: "response" });
+    // The native surface must be used verbatim: translating down to chat
+    // completions would hit an endpoint this model does not serve.
+    expect(
+      githubCopilotResponsesAdapterFactory.createClient,
+    ).toHaveBeenCalledOnce();
+    expect(githubCopilotAdapterFactory.createClient).not.toHaveBeenCalled();
+  });
+
+  test("streams a Responses-only model through the provider's Responses surface", async ({
+    makeAgent,
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const app = createFastifyApp();
+    await app.register(modelRouterProxyRoutes);
+    const provider = "github-copilot";
+    const modelId = "gpt-5.4-codex";
+    await upsertModel({
+      provider,
+      modelId,
+      supportedEndpoints: ["/responses"],
+    });
+    const organization = await makeOrganization();
+    const { value } = await createModelRouterVirtualKey({
+      organizationId: organization.id,
+      provider,
+      makeSecret,
+      makeLlmProviderApiKey,
+    });
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      name: "Model Router Responses-only Streaming Agent",
+      agentType: "llm_proxy",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/model-router/${agent.id}/responses`,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${value}`,
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: `${provider}:${modelId}`,
+        stream: true,
+        input: "Hello",
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/event-stream");
+    expect(response.body).toContain("data: [DONE]");
+    expect(
+      githubCopilotResponsesAdapterFactory.createClient,
+    ).toHaveBeenCalledOnce();
+  });
+
+  test("rejects a Responses-only model on chat completions with an actionable error", async ({
+    makeAgent,
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const app = createFastifyApp();
+    await app.register(modelRouterProxyRoutes);
+    const provider = "github-copilot";
+    const modelId = "gpt-5.4-codex";
+    await upsertModel({
+      provider,
+      modelId,
+      supportedEndpoints: ["/responses"],
+    });
+    const organization = await makeOrganization();
+    const { value } = await createModelRouterVirtualKey({
+      organizationId: organization.id,
+      provider,
+      makeSecret,
+      makeLlmProviderApiKey,
+    });
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      name: "Model Router Responses-only Chat Agent",
+      agentType: "llm_proxy",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/model-router/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${value}`,
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: `${provider}:${modelId}`,
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toContain("/responses");
+    // Nothing may reach the provider: the point of the local rejection is that
+    // the request is known-bad before it costs an upstream round trip.
+    expect(githubCopilotAdapterFactory.createClient).not.toHaveBeenCalled();
+    expect(
+      githubCopilotResponsesAdapterFactory.createClient,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("rejects Copilot embedding requests rather than sending the raw token upstream", async ({
+    makeAgent,
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const app = createFastifyApp();
+    await app.register(modelRouterProxyRoutes);
+    // Copilot is an OpenAI-wire chat provider, so a registered embedding model
+    // would otherwise fall into the generic OpenAI-compatible embeddings
+    // adapter — which skips the GitHub-token-to-Copilot-bearer exchange.
+    const provider = "github-copilot";
+    const modelId = "text-embedding-3-small";
+    await upsertModel({ provider, modelId, embeddingDimensions: 1536 });
+    const organization = await makeOrganization();
+    const { value } = await createModelRouterVirtualKey({
+      organizationId: organization.id,
+      provider,
+      makeSecret,
+      makeLlmProviderApiKey,
+    });
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      name: "Model Router Copilot Embedding Agent",
+      agentType: "llm_proxy",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/model-router/${agent.id}/embeddings`,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${value}`,
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: `${provider}:${modelId}`,
+        input: ["first"],
+      },
+    });
+
+    expect(response.statusCode).toBe(501);
+    expect(githubCopilotAdapterFactory.createClient).not.toHaveBeenCalled();
+  });
 
   test("records model router requests with a model router interaction source", async ({
     makeAgent,

--- a/platform/backend/src/routes/proxy/routes/model-router.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.ts
@@ -3,6 +3,7 @@ import {
   LLM_PROXY_OAUTH_SCOPE,
   MODEL_ROUTER_SUPPORTED_PROVIDERS,
   RouteId,
+  requiresResponsesApi,
   type SupportedProvider,
 } from "@archestra/shared";
 import type { FastifyReply, FastifyRequest } from "fastify";
@@ -38,6 +39,8 @@ import {
   cerebrasAdapterFactory,
   deepseekAdapterFactory,
   geminiEmbeddingsAdapterFactory,
+  githubCopilotAdapterFactory,
+  githubCopilotResponsesAdapterFactory,
   groqAdapterFactory,
   makeOpenAiCompatibleEmbeddingsAdapterFactory,
   minimaxAdapterFactory,
@@ -75,6 +78,7 @@ import {
 } from "../llm-proxy-handler";
 import {
   buildRoutableModelId,
+  type ModelRouterResolution,
   resolveModelRoute,
   sortRoutableModels,
 } from "../model-router-resolver";
@@ -204,6 +208,7 @@ const openAiWireProviders = {
   azure: azureAdapterFactory,
   cerebras: cerebrasAdapterFactory,
   deepseek: deepseekAdapterFactory,
+  "github-copilot": githubCopilotAdapterFactory,
   groq: groqAdapterFactory,
   minimax: minimaxAdapterFactory,
   mistral: mistralAdapterFactory,
@@ -468,6 +473,8 @@ async function routeChatCompletion(
     "[ModelRouterProxy] Resolved model route",
   );
 
+  assertModelServesChatCompletions(resolution);
+
   const provider = getOpenAiChatProviderForResolution({
     provider: resolution.provider,
     body: routedBody,
@@ -495,6 +502,26 @@ async function routeResponse(request: FastifyRequest, reply: FastifyReply) {
     allowedProviders: getMappedProviders(auth),
     allowedApiKeyIds: getMappedApiKeyIds(auth),
   });
+
+  // A model its provider serves ONLY over Responses cannot survive the
+  // responses→chat→responses round trip the uniform path uses, so hand the
+  // caller's original Responses body to the provider's native Responses
+  // adapter untouched.
+  const nativeResponsesAdapter = getNativeResponsesAdapter(resolution);
+  if (nativeResponsesAdapter) {
+    await applyModelRouterAuthOverride({
+      request,
+      auth,
+      provider: resolution.provider,
+    });
+    return handleLLMProxy(
+      { ...body, model: resolution.modelId },
+      request,
+      reply,
+      nativeResponsesAdapter,
+    );
+  }
+
   const routedChatBody = {
     ...chatBody,
     model: resolution.modelId,
@@ -573,7 +600,12 @@ function getModelRouterEmbeddingsProvider(
   if (provider === "openai") {
     return openAiEmbeddingsAdapterFactory;
   }
-  if (provider in openAiWireProviders) {
+  // Copilot is an OpenAI-wire chat provider but publishes no embeddings models,
+  // and the generic OpenAI-compatible embeddings adapter would send the raw
+  // GitHub OAuth token upstream instead of exchanging it for a Copilot bearer.
+  // Resolution should never reach here for it; fall through to the 501 if it
+  // somehow does rather than emit a request that leaks the token.
+  if (provider !== "github-copilot" && provider in openAiWireProviders) {
     return makeOpenAiCompatibleEmbeddingsAdapterFactory(provider, () =>
       getProviderConfiguredBaseUrl(provider),
     );
@@ -581,6 +613,44 @@ function getModelRouterEmbeddingsProvider(
   throw new ApiError(
     501,
     `Provider "${provider}" is not yet available through the OpenAI-compatible model router embeddings endpoint.`,
+  );
+}
+
+/**
+ * The provider's native Responses adapter when the resolved model is served
+ * only over Responses, otherwise null.
+ *
+ * Keyed off the model's own published surfaces rather than the provider, so a
+ * provider that serves both wires keeps the uniform chat path for every model
+ * that accepts chat completions, and only its Responses-only models (Copilot's
+ * Codex and GPT-5.x) take the native route.
+ */
+function getNativeResponsesAdapter(resolution: ModelRouterResolution) {
+  if (!requiresResponsesApi(resolution.supportedEndpoints)) {
+    return null;
+  }
+  if (resolution.provider === "github-copilot") {
+    return githubCopilotResponsesAdapterFactory;
+  }
+  return null;
+}
+
+/**
+ * Rejects a Responses-only model on the chat-completions endpoint locally. The
+ * request would otherwise reach a provider that answers with its own opaque
+ * "model not supported" error, which says nothing about the endpoint being the
+ * problem.
+ */
+function assertModelServesChatCompletions(
+  resolution: ModelRouterResolution,
+): void {
+  if (!requiresResponsesApi(resolution.supportedEndpoints)) {
+    return;
+  }
+  throw new ApiError(
+    400,
+    `Model "${resolution.requestedModel}" is only served over the Responses API. ` +
+      `Send this request to the model router's ${RESPONSES_SUFFIX} endpoint instead of ${CHAT_COMPLETIONS_SUFFIX}.`,
   );
 }
 

--- a/platform/backend/src/routes/virtual-api-key/create.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/create.virtual-api-key.route.test.ts
@@ -102,7 +102,7 @@ describe("POST /api/llm-virtual-keys", () => {
     expect(response.statusCode).toBe(200);
   });
 
-  test("per-user provider: rejects org-scoped or model-router virtual keys containing it", async ({
+  test("per-user provider: rejects shared (org-scoped) virtual keys containing it", async ({
     makeLlmProviderApiKey,
     makeSecret,
   }) => {
@@ -113,14 +113,7 @@ describe("POST /api/llm-virtual-keys", () => {
       copilotSecret.id,
       { provider: "github-copilot", scope: "personal", userId: user.id },
     );
-    const openaiSecret = await makeSecret({ secret: { apiKey: "sk-openai" } });
-    const openaiKey = await makeLlmProviderApiKey(
-      organizationId,
-      openaiSecret.id,
-      { provider: "openai", scope: "org" },
-    );
 
-    // Org-scoped (shared) virtual key wrapping the per-user key → rejected
     const orgScoped = await app.inject({
       method: "POST",
       url: "/api/llm-virtual-keys",
@@ -135,9 +128,29 @@ describe("POST /api/llm-virtual-keys", () => {
     });
     expect(orgScoped.statusCode).toBe(400);
     expect(orgScoped.json().error.message).toContain("per-user");
+  });
 
-    // Multi-provider (model-router) bundle containing the per-user key → rejected
-    const bundle = await app.inject({
+  test("per-user provider: allows it alongside other providers in a personal model-router key", async ({
+    makeLlmProviderApiKey,
+    makeSecret,
+  }) => {
+    // Personal scope — not mapping count — is what keeps the token unshared, so
+    // a Copilot key may ride in the owner's own multi-provider router key. That
+    // is the point of the router: one endpoint reaching every provider.
+    const copilotSecret = await makeSecret({ secret: { apiKey: "gho_self" } });
+    const copilotKey = await makeLlmProviderApiKey(
+      organizationId,
+      copilotSecret.id,
+      { provider: "github-copilot", scope: "personal", userId: user.id },
+    );
+    const openaiSecret = await makeSecret({ secret: { apiKey: "sk-openai" } });
+    const openaiKey = await makeLlmProviderApiKey(
+      organizationId,
+      openaiSecret.id,
+      { provider: "openai", scope: "org" },
+    );
+
+    const response = await app.inject({
       method: "POST",
       url: "/api/llm-virtual-keys",
       payload: {
@@ -150,8 +163,49 @@ describe("POST /api/llm-virtual-keys", () => {
         teams: [],
       },
     });
-    expect(bundle.statusCode).toBe(400);
-    expect(bundle.json().error.message).toContain("per-user");
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  test("per-user provider: rejects another user's key in a personal model-router key", async ({
+    makeLlmProviderApiKey,
+    makeSecret,
+    makeUser,
+  }) => {
+    // Ownership is the check that carries the weight once mapping count no
+    // longer does: a personal router key may not wrap someone else's token.
+    const otherUser = await makeUser({ email: "someone-else@test.com" });
+    const copilotSecret = await makeSecret({ secret: { apiKey: "gho_other" } });
+    const otherCopilotKey = await makeLlmProviderApiKey(
+      organizationId,
+      copilotSecret.id,
+      { provider: "github-copilot", scope: "personal", userId: otherUser.id },
+    );
+    const openaiSecret = await makeSecret({ secret: { apiKey: "sk-openai" } });
+    const openaiKey = await makeLlmProviderApiKey(
+      organizationId,
+      openaiSecret.id,
+      { provider: "openai", scope: "org" },
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-virtual-keys",
+      payload: {
+        name: "Borrowed Copilot Router VK",
+        providerApiKeys: [
+          { provider: "github-copilot", providerApiKeyId: otherCopilotKey.id },
+          { provider: "openai", providerApiKeyId: openaiKey.id },
+        ],
+        scope: "personal",
+        teams: [],
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toContain(
+      "your own personal github-copilot key",
+    );
   });
 
   test("ChatGPT-subscription (Codex) openai key: rejected in a shared org-scoped virtual key", async ({

--- a/platform/backend/src/routes/virtual-api-key/virtual-api-key.routes.ts
+++ b/platform/backend/src/routes/virtual-api-key/virtual-api-key.routes.ts
@@ -621,11 +621,13 @@ async function validateProviderApiKeys(params: {
       );
     }
 
-    // Per-user-credential providers (GitHub Copilot) are individual tokens. A
-    // virtual key is itself a shareable secret, so it may only wrap a per-user
-    // key when it is the user's OWN personal key in their OWN personal virtual
-    // key, and never bundled with other providers (a shared model-router key
-    // would expose one user's token to everyone routing through it).
+    // Per-user credentials (GitHub/Microsoft Copilot, or a ChatGPT-subscription
+    // key on `openai`) are one individual's token, so a virtual key may only
+    // wrap one when it is the user's OWN personal key inside their OWN personal
+    // virtual key. Personal scope is what keeps the token unshared — the number
+    // of mappings does not, so a per-user credential may sit alongside other
+    // providers in a personal model-router key. Ownership is re-checked per
+    // mapping at request time in `llm-proxy-auth`.
     const secret = secretsById.get(mapping.providerApiKeyId);
     if (
       credentialRequiresPerUserScope({
@@ -637,10 +639,10 @@ async function validateProviderApiKeys(params: {
         provider: mapping.provider,
         apiKey: secret,
       });
-      if (scope !== "personal" || mappings.length > 1) {
+      if (scope !== "personal") {
         throw new ApiError(
           400,
-          `${label} is per-user: it can only be wrapped in your own personal virtual key on its own, not in a shared or multi-provider (model-router) key.`,
+          `${label} is per-user: it can only be wrapped in your own personal virtual key, not a shared team- or org-scoped one.`,
         );
       }
       if (apiKey.scope !== "personal" || apiKey.userId !== userId) {

--- a/platform/backend/src/services/openai-codex-credentials.ts
+++ b/platform/backend/src/services/openai-codex-credentials.ts
@@ -48,8 +48,8 @@ export function isOpenAiCodexCredential(value: string | undefined): boolean {
 
 /**
  * True when a specific credential must be governed as **per-user** — personal
- * scope only, owner-matched, never shared through team/org or multi-provider
- * (model-router) virtual keys. Two cases collapse here: the provider is
+ * scope only and owner-matched, so it is never shared through a team/org
+ * virtual key. Two cases collapse here: the provider is
  * inherently per-user (GitHub / Microsoft Copilot), or the secret is a
  * ChatGPT-subscription (Codex) credential, which is one person's ChatGPT account
  * and must get the identical treatment on the `openai` provider.

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -281,6 +281,11 @@ export const MODEL_ROUTER_SUPPORTED_PROVIDERS = [
   "vllm",
   "xai",
   "zhipuai",
+  // OpenAI-wire on chat completions, plus a native Responses surface that the
+  // router hands Responses-only models to directly (see
+  // `providerHasMultipleSurfaces`). Its credential is per-user, so it is
+  // routable only through the owner's own personal virtual key.
+  "github-copilot",
   // Translated by the router
   "anthropic",
   "bedrock",


### PR DESCRIPTION
## What

GitHub Copilot models were not reachable through the model router. This makes them routable — and routable from a key that also holds your other providers, which is the whole point of the router.

### 1. Route Copilot models

Copilot was missing from the router's supported-provider list, so `provider:model` ids for it resolved to a 501 and none of its models appeared in `/models`.

Copilot is also the one provider that serves its models over two different wire surfaces, publishing which one applies per model: Codex and GPT-5.x are Responses-only and reject chat completions, while the rest use chat completions. The router now carries `supportedEndpoints` through resolution and dispatches on it:

- A Responses-only model sent to `/responses` goes to Copilot's native Responses surface, with no chat translation in between.
- A Responses-only model sent to `/chat/completions` returns `400` naming the endpoint to use, instead of a confusing upstream rejection.

Copilot is additionally guarded out of the generic OpenAI-compatible **embeddings** dispatch. It publishes no embeddings models, and that adapter would have sent the raw GitHub OAuth token upstream instead of exchanging it for a short-lived Copilot bearer. Resolution should never reach it — the guard makes a 501 the failure mode rather than a leaked token.

### 2. Let a per-user credential share a router key

Creating a virtual key rejected any per-user credential mapped alongside another provider. A Copilot model could therefore only be routed through a key that contained nothing else, which defeats the router.

Mapping count was never the thing keeping the token unshared. Personal scope is, together with the owner match on the mapped provider key, and `llm-proxy-auth` re-checks both per mapping at request time. A personal key with three mappings is shared with nobody. The connection-setup flow already built exactly those keys via `ensureProviderMapping`, so this route was the only place disagreeing with the rest of the product.

The `scope !== "personal"` and ownership checks stay as they were. Only the `mappings.length > 1` clause is gone.

A bug fell out of it: that clause short-circuited **before** the ownership check, so mapping another user's per-user key into a multi-provider key returned a generic `400` rather than the intended `403`. It now returns `403`, pinned by a test.

**Wider than GitHub Copilot:** the same guard governs Microsoft 365 Copilot and ChatGPT-Subscription (Codex) keys on the `openai` provider, so the relaxation applies to those too. What it does not touch is sharing: a per-user credential still cannot go in a team- or org-scoped key.

## Testing

Unit and integration tests cover native Responses routing, streaming, the chat-completions `400`, the embeddings `501` guard, a personal multi-provider key containing a per-user credential, and another user's key being refused with `403`. Each new behavior was verified non-vacuous by neutralizing it and confirming exactly the expected tests fail.

Verified end-to-end locally against a stub Copilot upstream and the development database:

- Personal key mapping Copilot **and** Anthropic → `200` (this same request was `400` before)
- `/models` through that single key → 25 models: 15 Copilot + 10 Anthropic
- `github-copilot:gpt-4o` on `/chat/completions` → `200`
- `github-copilot:gpt-5.3-codex` on `/responses` → `200` natively
- The same Responses-only model on `/chat/completions` → `400`, with no upstream call made
- The token exchange ran, and both inference calls carried the exchanged short-lived bearer — no raw OAuth token reached an inference endpoint
- An org-scoped key containing Copilot → still `400`

Three unrelated failures in the wider proxy suite (OpenAI streaming metrics, tool-invocation policy) were confirmed pre-existing by reverting this change and observing the same failures.

## Docs

`platform-supported-llm-providers.md` documents Copilot in the model router, the two wire surfaces and the `400`, the embeddings behavior, and the corrected per-user key rule.
