### PR TITLE
fix(chatops): give the model the Slack message ts that triggered the run

### DIFF
--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -3902,6 +3902,241 @@ describe("ChatOpsManager attachment passthrough", () => {
   });
 });
 
+// =============================================================================
+// Slack conversation context — which timestamps the model is handed
+// =============================================================================
+
+describe("ChatOpsManager Slack conversation context", () => {
+  // A thread opened by one message and continued by a later reply. The reply is
+  // what triggers the run, so it is the message the agent is answering.
+  const THREAD_ROOT_TS = "1786388787.394499";
+  const REPLY_TS = "1786399123.777111";
+
+  function createSlackProvider(overrides: {
+    getUserEmail: () => Promise<string | null>;
+    getMessagePermalink?: (params: {
+      channelId: string;
+      messageId: string;
+    }) => Promise<string | null>;
+  }): ChatOpsProvider {
+    return {
+      providerId: "slack",
+      displayName: "Slack",
+      isConfigured: () => true,
+      initialize: async () => {},
+      cleanup: async () => {},
+      validateWebhookRequest: async () => true,
+      handleValidationChallenge: () => null,
+      parseWebhookNotification: async () => null,
+      sendReply: async () => "reply-id",
+      parseInteractivePayload: () => null,
+      sendAgentSelectionCard: async () => {},
+      getThreadHistory: async () => [],
+      getUserEmail: overrides.getUserEmail,
+      getChannelName: async () => "test-channel",
+      getWorkspaceId: () => "T_CTX",
+      getWorkspaceName: () => "Test Workspace",
+      hasMissingScopes: () => false,
+      notifyMissingScopes: async () => {},
+      downloadFiles: async () => [],
+      discoverChannels: async () => null,
+      addApprovalRequestForm: async () => {},
+      updateApprovalRequest: async () => {},
+      ...(overrides.getMessagePermalink && {
+        getMessagePermalink: overrides.getMessagePermalink,
+      }),
+    };
+  }
+
+  function slackMessage(
+    overrides: Partial<IncomingChatMessage> = {},
+  ): IncomingChatMessage {
+    return {
+      messageId: REPLY_TS,
+      channelId: "C_CTX",
+      workspaceId: "T_CTX",
+      threadId: THREAD_ROOT_TS,
+      senderId: "U_CTX",
+      senderName: "Slack User",
+      text: "turn this into a task",
+      rawText: "@Bot turn this into a task",
+      timestamp: new Date(),
+      isThreadReply: true,
+      metadata: {
+        eventType: "message",
+        channelType: "im",
+        conversationType: "personal",
+      },
+      ...overrides,
+    };
+  }
+
+  test("hands the model the triggering message ts, not only the thread root", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const executorSpy = vi
+      .spyOn(a2aExecutor, "executeA2AMessage")
+      .mockResolvedValue({
+        text: "Done",
+        messageId: "msg-ctx-1",
+        finishReason: "stop",
+        responseUiMessage: {
+          id: "msg-ctx-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Done" }],
+        },
+      });
+
+    const user = await makeUser({ email: "slack-ctx@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "slack",
+      channelId: "C_CTX",
+      workspaceId: "T_CTX",
+      agentId: agent.id,
+    });
+
+    const provider = createSlackProvider({
+      getUserEmail: async () => "slack-ctx@example.com",
+    });
+
+    await new ChatOpsManager().processMessage({
+      message: slackMessage(),
+      provider,
+    });
+
+    const sent = executorSpy.mock.calls[0][0].message;
+    // The regression: the reply's ts used to be absent entirely, so a tool told
+    // to anchor to "this message" could only be handed the thread opener.
+    expect(sent).toContain(`- Message ts: ${REPLY_TS}`);
+    // The thread root stays available, distinctly labelled.
+    expect(sent).toContain(`- Thread message ts: ${THREAD_ROOT_TS}`);
+  });
+
+  test("links the permalink to the triggering message, not the thread root", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    vi.spyOn(a2aExecutor, "executeA2AMessage").mockResolvedValue({
+      text: "Done",
+      messageId: "msg-ctx-2",
+      finishReason: "stop",
+      responseUiMessage: {
+        id: "msg-ctx-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "Done" }],
+      },
+    });
+
+    const user = await makeUser({ email: "slack-link@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "slack",
+      channelId: "C_CTX",
+      workspaceId: "T_CTX",
+      agentId: agent.id,
+    });
+
+    const permalinkSpy = vi
+      .fn()
+      .mockResolvedValue("https://example.slack.test/archives/C_CTX/p1");
+    const provider = createSlackProvider({
+      getUserEmail: async () => "slack-link@example.com",
+      getMessagePermalink: permalinkSpy,
+    });
+
+    await new ChatOpsManager().processMessage({
+      message: slackMessage(),
+      provider,
+    });
+
+    expect(permalinkSpy).toHaveBeenCalledWith({
+      channelId: "C_CTX",
+      messageId: REPLY_TS,
+    });
+  });
+
+  test("uses the message's own ts as both values for a top-level message", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const executorSpy = vi
+      .spyOn(a2aExecutor, "executeA2AMessage")
+      .mockResolvedValue({
+        text: "Done",
+        messageId: "msg-ctx-3",
+        finishReason: "stop",
+        responseUiMessage: {
+          id: "msg-ctx-3",
+          role: "assistant",
+          parts: [{ type: "text", text: "Done" }],
+        },
+      });
+
+    const user = await makeUser({ email: "slack-root@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "slack",
+      channelId: "C_CTX",
+      workspaceId: "T_CTX",
+      agentId: agent.id,
+    });
+
+    const provider = createSlackProvider({
+      getUserEmail: async () => "slack-root@example.com",
+    });
+
+    // A message that opens a thread: Slack reports no thread_ts, so the
+    // triggering message IS the root and both lines carry the same ts.
+    await new ChatOpsManager().processMessage({
+      message: slackMessage({
+        messageId: THREAD_ROOT_TS,
+        threadId: THREAD_ROOT_TS,
+        isThreadReply: false,
+      }),
+      provider,
+    });
+
+    const sent = executorSpy.mock.calls[0][0].message;
+    expect(sent).toContain(`- Message ts: ${THREAD_ROOT_TS}`);
+    expect(sent).toContain(`- Thread message ts: ${THREAD_ROOT_TS}`);
+  });
+});
+
 describe("buildChatOpsSessionId", () => {
   test("uses threadId when provided", () => {
     expect(buildChatOpsSessionId("slack", "C123", "T456")).toBe(

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -769,25 +769,40 @@ export class ChatOpsManager {
     // Build the full message with context — use cleanedMessageText so
     // the "AgentName >" prefix is stripped from what the LLM sees
     const providerLabel = CHATOPS_PROVIDER_LABELS[provider.providerId];
-    const threadIdForPrefix = message.threadId ?? message.messageId;
-    let systemPrefix = `(${providerLabel} conversation, thread id: ${threadIdForPrefix})`;
+    const threadRootTs = message.threadId ?? message.messageId;
+    let systemPrefix = `(${providerLabel} conversation, thread id: ${threadRootTs})`;
     if (provider.providerId === "slack") {
+      // Link to the message that actually triggered this run rather than the
+      // thread root: Slack builds a reply's permalink with ?thread_ts=<root>,
+      // so one lookup carries both, while the root's permalink loses the reply.
+      const permalinkTs = message.messageId || threadRootTs;
       const permalink = provider.getMessagePermalink
         ? await provider.getMessagePermalink({
             channelId: message.channelId,
-            messageId: threadIdForPrefix,
+            messageId: permalinkTs,
           })
         : null;
+      // Surface BOTH timestamps, each labelled. Only the thread root used to be
+      // here, so a run triggered by a thread reply gave the model no way to name
+      // the message it was actually answering — tools handed a channel+ts pair
+      // then anchored to the thread opener instead of the triggering message.
       const contextLines = [
         `Slack conversation context:`,
         `- Channel ID: ${message.channelId}`,
-        `- Thread message ts: ${threadIdForPrefix}`,
       ];
+      if (message.messageId) {
+        contextLines.push(
+          `- Message ts: ${message.messageId} (the message that triggered this run — use this one to refer to "this message")`,
+        );
+      }
+      contextLines.push(
+        `- Thread message ts: ${threadRootTs} (the first message of the thread)`,
+      );
       if (message.workspaceId) {
         contextLines.push(`- Workspace ID: ${message.workspaceId}`);
       }
       if (permalink) {
-        contextLines.push(`- Thread permalink: ${permalink}`);
+        contextLines.push(`- Message permalink: ${permalink}`);
       }
       systemPrefix = contextLines.join("\n");
     }

--- a/platform/backend/src/types/chatops.ts
+++ b/platform/backend/src/types/chatops.ts
@@ -438,8 +438,10 @@ export interface ChatOpsProvider {
 
   /**
    * Get a permalink to a specific message in the provider's web UI.
-   * Used to surface a clickable thread URL in the LLM context so tools
-   * can reference the originating conversation.
+   * Used to surface a clickable URL in the LLM context so tools can reference
+   * the originating message. Callers pass the message that triggered the run,
+   * not its thread root — Slack encodes the thread in a reply's permalink
+   * (`?thread_ts=`), so the reply link identifies both.
    * @param params.channelId - The channel ID containing the message
    * @param params.messageId - The message ID (Slack ts) to link to
    * @returns Permalink URL, or null if unavailable


### PR DESCRIPTION
## Problem

When a ChatOps agent is asked to act on "this message" in Slack, the only timestamp it has ever been given is the **thread root's**.

`chatops-manager.ts` built the Slack context block from `message.threadId ?? message.messageId`, and pointed the permalink lookup at that same value. `message.messageId` — the ts of the message that actually triggered the run — never reached the prompt at all. Across the whole manager it was used only for dedup keys, logging, and `excludeMessageId`.

So for any thread reply (`thread_ts` set, so `threadId !== messageId`), the model had exactly one ts available and it was the wrong one. A tool asked for a `{channel, ts}` message reference could only be handed the thread opener, and anything that resolves that pair back to message text then read the wrong message — silently, because the ts is well-formed and the message is real.

The parsing layer was never at fault: `slack-provider.ts` keeps both values correctly (`messageId: event.ts`, `threadId: event.thread_ts || event.ts`). Only the prompt builder dropped one.

## Fix

- Surface **both** timestamps in the Slack context block, each labelled, so the model can distinguish the message it is answering from the thread it sits in.
- Point `getMessagePermalink` at the triggering message instead of the thread root. Slack builds a reply's permalink with `?thread_ts=<root>`, so the reply link identifies the thread as well — one lookup, no extra API call. Renamed the line to `- Message permalink:` accordingly.
- Top-level messages are unaffected in substance: `messageId === threadId`, so both lines carry the same ts.

Also refreshed the `getMessagePermalink` docstring on the provider interface to state which message callers are expected to pass.

## Tests

Three behaviour-focused tests in `chatops-manager.test.ts`, all of which fail against the unfixed builder:

- a thread reply puts the triggering ts in the prompt, and keeps the thread root distinctly labelled;
- the permalink is requested for the triggering ts, not the root;
- a top-level message reports its own ts for both.

The pre-fix failure output shows the defect exactly — the prompt contained `- Thread message ts: <root>` and the reply's ts appeared nowhere.

Full `src/agents/chatops/` suite: 466 passed. `pnpm type-check`, `biome ci` on the changed files, and `pnpm knip` (dev + production) are all clean.

## Scope — two related defects are not fixable in this repository

This investigation started from three reported defects. Only the one above lives here.

**A task's description being overwritten** and **a tool schema missing a field the skill asks the model to set** both belong to a runtime-registered MCP server and its skill, not to this codebase:

- Every MCP tool's `inputSchema` is a **database row** — `tools.parameters` (jsonb, `database/schemas/tool.ts`), populated at discovery time by `ToolModel.bulkCreateToolsIfNotExists`. A missing field on a third-party tool's schema is a property of that server's registration in the database, not of any file here.
- The only MCP catalogs seeded from this repo are the Archestra built-in catalog, a browser-preview catalog, and a dev-only test server (`database/seed.ts`). No task-management MCP server is checked in, and none of the tool names involved appear anywhere in the repo.
- Archestra Apps cannot author tool schemas at all: an App contributes one auto-synthesized `open` tool with an empty schema, and the authoring surface only accepts names of tools that already exist. App code is a text column executed client-side in a sandboxed iframe, so there is no server-side path that could perform the overwrite either.
- The skill in question is likewise DB-stored (a `skill_version` record). This repo ships exactly two built-in skills (`skills/built-in-skills.ts`), neither of them this one.

Both need to be fixed where they live — in the external MCP server's own repository and in the stored skill record. Deliberately not papered over with a change here.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>