### PR TITLE
feat(knowledge-base): permission auto-sync for SharePoint and Salesforce connectors

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -190,8 +190,8 @@ Auto-sync permissions works with the connectors marked *Supported* below. The ot
 | GitHub       | Supported             |
 | Jira         | Supported             |
 | Google Drive | Supported             |
-| Salesforce   | Planned               |
-| SharePoint   | Planned               |
+| Salesforce   | Supported             |
+| SharePoint   | Supported             |
 | Asana        | Not supported         |
 | Dropbox      | Not supported         |
 | GitLab       | Not supported         |
@@ -207,6 +207,8 @@ Auto-sync permissions works with the connectors marked *Supported* below. The ot
 
 - **Jira and Confluence Cloud** only return another user's email through the product REST API when that user's Atlassian profile has email visibility set to **"Anyone"**. Add an Atlassian **organization admin API key** to the connector credentials to read managed accounts' emails.
 - **GitHub** only exposes an email the user has made **public on their profile**; no token scope reveals a private email.
+- **SharePoint** returns SharePoint user logins directly. Expanding a Microsoft 365 group or a SharePoint site group to its members needs the extra app permissions listed under [SharePoint](#sharepoint).
+- **Salesforce** reads user emails and group membership through the same login the connector already uses. No extra credential is needed.
 
 **Permission-read access.** The credential must also be able to read the source's permission settings — Jira permission schemes, Confluence space permissions, GitHub repository collaborators. A credential that cannot read them hides that project or space from everyone, because Archestra never assumes an audience it could not verify. Each sync run reports how many it could not read, so a project nobody can find is easy to tell apart from a project nobody is granted.
 
@@ -385,6 +387,20 @@ Where to find each value:
 - **Client Secret** — the secret **Value** from **Certificates & secrets** (not the secret ID).
 - **Site URL** — the exact SharePoint site web URL, not the display name.
 
+**Auto-sync permissions.** Each document library is one permission scope, and an item (file or folder) that breaks permission inheritance becomes its own scope — a document inherits its nearest such ancestor. Site pages follow the site's default library audience; per-page unique sharing is not modeled. Anonymous sharing links map to everyone in your Archestra organization; "people in your organization" links expand to the tenant's active users.
+
+Group grants (Microsoft 365 / Entra groups and SharePoint site groups) carry the group's identity, and each permission sync also snapshots those groups' member rosters — so the connector's **Users** and **Groups** tabs show every member with their assignment status, and an account whose email is hidden upstream (or does not match an Archestra user's email) can be assigned manually from the Users tab. Direct grantees appear there too, under the synthetic `direct-grants` group. The roster covers groups granted on library roots; a group granted only on a single item is listed in the Groups tab but resolves no members until it also holds a library-level grant.
+
+`Sites.Read.All` covers library and item grants. Three more application permissions unlock more, progressively:
+
+| Extra permission | Unlocks |
+| ---------------- | ------- |
+| `User.Read.All` | User grants expand to emails, and organization-wide links expand to the tenant's active users. |
+| `GroupMember.Read.All` | Microsoft 365 / Entra group member rosters (the Users and Groups tabs, and group-based document access). |
+| `Sites.FullControl.All` | SharePoint site-group member rosters through the site's REST API, and permission sync switches to cheaper sharing-aware delta runs. |
+
+Each tier is detected at runtime: without it, that kind of grant or roster drops (fail-closed) and the rest of the sync proceeds.
+
 ### OneDrive
 
 Ingests files from OneDrive for Business (personal drives of specified users) via the Microsoft Graph API. Text is extracted from `.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`, `.htm`, `.yaml`, `.log` files, as well as `.docx`, `.pdf`, and `.pptx` documents. When a multimodal embedding model is configured (see [Image Embedding](#image-embedding)), image files (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`) up to 4 MB are also ingested and embedded directly.
@@ -547,6 +563,10 @@ Example advanced config:
 ```
 
 `Id`, `Name`, and `LastModifiedDate` are always included automatically.
+
+**Auto-sync permissions.** Each object is one permission scope, decided by its organization-wide default: a public object grants every active Salesforce user; a private object resolves each record individually from its owner and its share table (manual, team, and sharing-rule grants). A contact inherits its parent account's audience. Restriction rules, territory hierarchies, and high-volume portal shares are not modeled — they only ever hide content, never over-grant. The same username/password login is used for everything; no extra credential or scope is needed. Private objects on very large orgs resolve per record, so give those connectors a longer permission-sync interval.
+
+Every permission sync also snapshots the org's groups and queues with their (recursively expanded) memberships, plus record owners and per-user share grantees under the synthetic `direct-grants` group — so the connector's **Users** and **Groups** tabs show every grant-holder with their assignment status, and an account whose email is hidden (or matches no Archestra user's email) can be assigned manually from the Users tab. Inactive users stay visible in the roster but never resolve to access.
 
 ### Web Crawler
 

--- a/platform/backend/src/knowledge-base/connectors/salesforce/salesforce-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/salesforce/salesforce-connector.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import type { ConnectorSyncBatch } from "@/types";
+import type { ConnectorSyncBatch, PermissionSnapshotYield } from "@/types";
 import { SalesforceConnector } from "./salesforce-connector";
 
 // ===== jsforce mock (class-based, matching Linear connector test pattern) =====
@@ -7,6 +7,8 @@ import { SalesforceConnector } from "./salesforce-connector";
 const mockLogin = vi.fn();
 const mockQuery = vi.fn();
 const mockQueryMore = vi.fn();
+const mockMetadataRead = vi.fn();
+const mockDeleted = vi.fn();
 
 vi.mock("jsforce", () => {
   class MockConnection {
@@ -14,6 +16,8 @@ vi.mock("jsforce", () => {
     login = mockLogin;
     query = mockQuery;
     queryMore = mockQueryMore;
+    metadata = { read: mockMetadataRead };
+    deleted = mockDeleted;
   }
   return { Connection: MockConnection };
 });
@@ -22,6 +26,8 @@ afterEach(() => {
   mockLogin.mockReset();
   mockQuery.mockReset();
   mockQueryMore.mockReset();
+  mockMetadataRead.mockReset();
+  mockDeleted.mockReset();
 });
 
 const CREDS = { email: "test@example.com", apiToken: "pass+token" };
@@ -698,6 +704,525 @@ describe("SalesforceConnector", () => {
       expect(soql).toContain("Title");
       expect(soql).toContain("Summary");
       expect(soql).toContain("ArticleNumber");
+    });
+  });
+
+  // ----- permission sync -----
+
+  describe("permission sync", () => {
+    type ContainerYield = Extract<
+      PermissionSnapshotYield,
+      { kind: "container" }
+    >;
+    type DocumentYield = Extract<PermissionSnapshotYield, { kind: "document" }>;
+
+    const permConfig = { type: "salesforce", objects: ["Account"] };
+
+    function collectSnapshot(
+      gen: AsyncGenerator<PermissionSnapshotYield> | undefined,
+    ) {
+      const containers = new Map<string, ContainerYield>();
+      const documents: DocumentYield[] = [];
+      return (async () => {
+        for await (const item of gen ??
+          ((async function* () {})() as AsyncGenerator<PermissionSnapshotYield>)) {
+          if (item.kind === "container")
+            containers.set(item.containerKey, item);
+          else documents.push(item);
+        }
+        return { containers, documents };
+      })();
+    }
+
+    function readBack(sourceIds: string[], objectName = "Account") {
+      return vi.fn(async () => ({
+        documents: sourceIds.map((id) => ({
+          sourceId: `salesforce:${objectName}:${id}`,
+          metadata: { objectName },
+        })),
+        nextAfterId: null,
+      }));
+    }
+
+    function syncParams(overrides?: {
+      config?: Record<string, unknown>;
+      sourceIds?: string[];
+      objectName?: string;
+    }) {
+      return {
+        config: overrides?.config ?? permConfig,
+        credentials: CREDS,
+        cursor: null,
+        readIngestedDocuments: readBack(
+          overrides?.sourceIds ?? ["001A"],
+          overrides?.objectName ?? "Account",
+        ),
+      };
+    }
+
+    /** SOQL router: match on FROM/WHERE content. */
+    function stubSoql(routes: Array<{ match: string; records: unknown[] }>) {
+      mockQuery.mockImplementation((soql: string) => {
+        const route = routes.find((r) => soql.includes(r.match));
+        if (!route) throw new Error(`No route for SOQL: ${soql}`);
+        return Promise.resolve({ done: true, records: route.records });
+      });
+    }
+
+    test("supportsPermissionSync is true", () => {
+      expect(new SalesforceConnector().supportsPermissionSync).toBe(true);
+    });
+
+    test("public OWD (Read) → isPublic container, documents assign top-level", async () => {
+      const c = new SalesforceConnector();
+      mockMetadataRead.mockResolvedValue({ sharingModel: "Read" });
+      stubSoql([]); // no SOQL expected on the public path
+
+      const { containers, documents } = await collectSnapshot(
+        c.syncPermissionSnapshot(syncParams()),
+      );
+
+      expect(containers.get("sobject:Account")?.permissions).toEqual({
+        isPublic: true,
+      });
+      expect(documents).toEqual([
+        {
+          kind: "document",
+          sourceId: "salesforce:Account:001A",
+          containerKey: "sobject:Account",
+          cursor: "sobject:Account",
+        },
+      ]);
+    });
+
+    test("private OWD → per-record nested containers with owner + share audience", async () => {
+      const c = new SalesforceConnector();
+      mockMetadataRead.mockResolvedValue({ sharingModel: "Private" });
+      stubSoql([
+        {
+          match: "FROM Account WHERE Id IN",
+          records: [{ Id: "001A", OwnerId: "005OWNER" }],
+        },
+        {
+          match: "FROM AccountShare",
+          records: [
+            {
+              ParentId: "001A",
+              UserOrGroupId: "005SHARED",
+              RowCause: "Manual",
+            },
+            {
+              ParentId: "001A",
+              UserOrGroupId: "00GGROUP",
+              RowCause: "Rule",
+            },
+            // Owner row cause must not duplicate the owner grant.
+            {
+              ParentId: "001A",
+              UserOrGroupId: "005OWNER",
+              RowCause: "Owner",
+            },
+          ],
+        },
+        {
+          match: "FROM User WHERE Id IN",
+          records: [
+            { Id: "005OWNER", Email: "Owner@Example.com", IsActive: true },
+            { Id: "005SHARED", Email: "shared@example.com", IsActive: true },
+          ],
+        },
+      ]);
+
+      const { containers, documents } = await collectSnapshot(
+        c.syncPermissionSnapshot(syncParams()),
+      );
+
+      const nested = containers.get("sobject:Account/record:001A");
+      expect(nested?.permissions).toEqual({
+        isPublic: false,
+        users: ["owner@example.com", "shared@example.com"],
+        groups: ["00GGROUP"],
+      });
+      expect(documents[0]?.containerKey).toBe("sobject:Account/record:001A");
+    });
+
+    test("metadata read failure treats the object as Private (safe direction)", async () => {
+      const c = new SalesforceConnector();
+      mockMetadataRead.mockRejectedValue(new Error("INVALID_TYPE"));
+      stubSoql([
+        {
+          match: "FROM Account WHERE Id IN",
+          records: [{ Id: "001A", OwnerId: "005OWNER" }],
+        },
+        { match: "FROM AccountShare", records: [] },
+        {
+          match: "FROM User WHERE Id IN",
+          records: [
+            { Id: "005OWNER", Email: "owner@example.com", IsActive: true },
+          ],
+        },
+      ]);
+
+      const { containers } = await collectSnapshot(
+        c.syncPermissionSnapshot(syncParams()),
+      );
+
+      expect(containers.get("sobject:Account")?.permissions).toEqual({
+        isPublic: false,
+        users: [],
+        groups: [],
+      });
+      expect(
+        containers.get("sobject:Account/record:001A")?.permissions.users,
+      ).toEqual(["owner@example.com"]);
+    });
+
+    test("unqueryable share table degrades the object to owner-only (fail-closed)", async () => {
+      const c = new SalesforceConnector();
+      mockMetadataRead.mockResolvedValue({ sharingModel: "Private" });
+      mockQuery.mockImplementation((soql: string) => {
+        if (soql.includes("FROM AccountShare")) {
+          return Promise.reject(new Error("INVALID_ENTITY"));
+        }
+        if (soql.includes("FROM Account WHERE Id IN")) {
+          return Promise.resolve({
+            done: true,
+            records: [{ Id: "001A", OwnerId: "005OWNER" }],
+          });
+        }
+        if (soql.includes("FROM User WHERE Id IN")) {
+          return Promise.resolve({
+            done: true,
+            records: [
+              { Id: "005OWNER", Email: "owner@example.com", IsActive: true },
+            ],
+          });
+        }
+        return Promise.reject(new Error(`No route: ${soql}`));
+      });
+
+      const { containers } = await collectSnapshot(
+        c.syncPermissionSnapshot(syncParams()),
+      );
+
+      expect(
+        containers.get("sobject:Account/record:001A")?.permissions,
+      ).toEqual({
+        isPublic: false,
+        users: ["owner@example.com"],
+        groups: [],
+      });
+    });
+
+    test("queue-owned records grant the owning group (00G owner)", async () => {
+      const c = new SalesforceConnector();
+      mockMetadataRead.mockResolvedValue({ sharingModel: "Private" });
+      stubSoql([
+        {
+          match: "FROM Account WHERE Id IN",
+          records: [{ Id: "001A", OwnerId: "00GQUEUE" }],
+        },
+        { match: "FROM AccountShare", records: [] },
+      ]);
+
+      const { containers } = await collectSnapshot(
+        c.syncPermissionSnapshot(syncParams()),
+      );
+
+      expect(
+        containers.get("sobject:Account/record:001A")?.permissions.groups,
+      ).toEqual(["00GQUEUE"]);
+    });
+
+    test("Contact inherits its parent Account's audience; orphan contact is owner-only", async () => {
+      const c = new SalesforceConnector();
+      mockMetadataRead.mockImplementation((_type: string, name: string) =>
+        Promise.resolve({
+          sharingModel: name === "Contact" ? "ControlledByParent" : "Private",
+        }),
+      );
+      stubSoql([
+        {
+          match: "FROM Contact WHERE Id IN",
+          records: [
+            { Id: "003A", AccountId: "001P", OwnerId: "005C" },
+            { Id: "003B", AccountId: null, OwnerId: "005C" },
+          ],
+        },
+        {
+          match: "FROM Account WHERE Id IN",
+          records: [{ Id: "001P", OwnerId: "005P" }],
+        },
+        {
+          match: "FROM AccountShare",
+          records: [
+            { ParentId: "001P", UserOrGroupId: "005TEAM", RowCause: "Team" },
+          ],
+        },
+        {
+          match: "FROM User WHERE Id IN",
+          records: [
+            { Id: "005P", Email: "p@example.com", IsActive: true },
+            { Id: "005TEAM", Email: "team@example.com", IsActive: true },
+            { Id: "005C", Email: "c@example.com", IsActive: true },
+          ],
+        },
+      ]);
+
+      const { containers } = await collectSnapshot(
+        c.syncPermissionSnapshot(
+          syncParams({
+            config: { type: "salesforce", objects: ["Contact"] },
+            sourceIds: ["003A", "003B"],
+            objectName: "Contact",
+          }),
+        ),
+      );
+
+      expect(
+        containers.get("sobject:Contact/record:003A")?.permissions,
+      ).toEqual({
+        isPublic: false,
+        users: ["p@example.com", "team@example.com"],
+        groups: [],
+      });
+      expect(
+        containers.get("sobject:Contact/record:003B")?.permissions.users,
+      ).toEqual(["c@example.com"]);
+    });
+
+    test("syncGroups: recursive expansion, inactive users dropped, byte-matching group ids", async () => {
+      const c = new SalesforceConnector();
+      stubSoql([
+        {
+          match: "FROM GroupMember",
+          records: [
+            { GroupId: "00G1", UserOrGroupId: "00G2" },
+            { GroupId: "00G1", UserOrGroupId: "005A" },
+            { GroupId: "00G2", UserOrGroupId: "005B" },
+            { GroupId: "00G2", UserOrGroupId: "005INACTIVE" },
+          ],
+        },
+        {
+          match: "FROM Group",
+          records: [
+            { Id: "00G1", Name: "Outer", Type: "Regular" },
+            { Id: "00G2", Name: "Inner", Type: "Regular" },
+          ],
+        },
+        {
+          match: "FROM User WHERE Id IN",
+          records: [
+            { Id: "005A", Email: "a@example.com", IsActive: true },
+            { Id: "005B", Email: "b@example.com", IsActive: true },
+            { Id: "005INACTIVE", Email: "gone@example.com", IsActive: false },
+          ],
+        },
+      ]);
+
+      const yields = [];
+      for await (const item of c.syncGroups(syncParams()) ?? []) {
+        yields.push(item);
+      }
+
+      const outer = yields.find((y) => y.groupId === "00G1");
+      const inner = yields.find((y) => y.groupId === "00G2");
+      expect(outer?.members.map((m) => m.email).sort()).toEqual([
+        "a@example.com",
+        "b@example.com",
+        null,
+      ]);
+      expect(inner?.members.map((m) => m.email).sort()).toEqual([
+        "b@example.com",
+        null,
+      ]);
+    });
+
+    test("syncGroups: direct grant-holders roster under direct-grants (owners + user share grantees; hidden emails stay visible)", async () => {
+      const c = new SalesforceConnector();
+      stubSoql([
+        { match: "FROM Group", records: [] },
+        { match: "FROM GroupMember", records: [] },
+        {
+          match: "FROM Account GROUP BY OwnerId",
+          records: [{ OwnerId: "005OWNER" }, { OwnerId: "00GQUEUE" }],
+        },
+        {
+          match: "FROM AccountShare GROUP BY UserOrGroupId",
+          records: [
+            { UserOrGroupId: "005SHAREE", RowCause: "Manual" },
+            // Guest and Owner causes never roster.
+            { UserOrGroupId: "005GUEST", RowCause: "GuestRule" },
+            { UserOrGroupId: "005OWNROW", RowCause: "Owner" },
+            { UserOrGroupId: "00GGRP", RowCause: "Manual" },
+          ],
+        },
+        {
+          match: "FROM User WHERE Id IN",
+          records: [
+            { Id: "005OWNER", Email: "Owner@Example.com", IsActive: true },
+            // No row for 005SHAREE — unresolvable, stays rostered email-less.
+          ],
+        },
+      ]);
+
+      const yields = [];
+      for await (const item of c.syncGroups(syncParams()) ?? []) {
+        yields.push(item);
+      }
+
+      expect(yields).toEqual([
+        {
+          groupId: "direct-grants",
+          members: [
+            {
+              accountId: "005OWNER",
+              displayName: null,
+              email: "owner@example.com",
+            },
+            { accountId: "005SHAREE", displayName: null, email: null },
+          ],
+          cursor: undefined,
+        },
+      ]);
+    });
+
+    test("member override maps a direct grantee whose Salesforce email is hidden", async () => {
+      const c = new SalesforceConnector();
+      mockMetadataRead.mockResolvedValue({ sharingModel: "Private" });
+      stubSoql([
+        {
+          match: "FROM Account WHERE Id IN",
+          records: [{ Id: "001A", OwnerId: "005HIDDEN" }],
+        },
+        {
+          match: "FROM AccountShare",
+          records: [
+            {
+              ParentId: "001A",
+              UserOrGroupId: "005MAPPED",
+              RowCause: "Manual",
+            },
+          ],
+        },
+        // Neither user resolves an email upstream.
+        { match: "FROM User WHERE Id IN", records: [] },
+      ]);
+
+      const { containers } = await collectSnapshot(
+        c.syncPermissionSnapshot({
+          ...syncParams(),
+          resolveMappedEmail: (accountId: string) =>
+            accountId === "005MAPPED" ? "Mapped@Corp.Test" : null,
+        }),
+      );
+
+      // The override materializes the share grant; the unmapped owner stays
+      // dropped fail-closed.
+      expect(
+        containers.get("sobject:Account/record:001A")?.permissions.users,
+      ).toEqual(["mapped@corp.test"]);
+    });
+
+    test("probe: first probe requires full reconcile; share delete dirties the object; Account drift dirties Contact", async () => {
+      const c = new SalesforceConnector();
+
+      const first = await c.probePermissionChanges({
+        config: { type: "salesforce", objects: ["Account", "Contact"] },
+        credentials: CREDS,
+        state: null,
+      });
+      expect(first.fullRequired).toBe(true);
+      expect(typeof first.nextState.soqlCursor).toBe("string");
+
+      // Second probe: no record edits, no share edits, one share deletion
+      // on AccountShare → Account dirty, Contact inherited-dirty.
+      mockQuery.mockResolvedValue({ done: true, records: [] });
+      mockDeleted.mockImplementation((obj: string) =>
+        obj === "AccountShare"
+          ? Promise.resolve({ deletedRecords: [{ id: "00rX" }] })
+          : Promise.resolve({ deletedRecords: [] }),
+      );
+
+      const second = await c.probePermissionChanges({
+        config: { type: "salesforce", objects: ["Account", "Contact"] },
+        credentials: CREDS,
+        state: { soqlCursor: new Date().toISOString() },
+      });
+      expect(second.fullRequired).toBe(false);
+      expect(second.dirtyContainerKeys).toEqual([
+        "sobject:Account",
+        "sobject:Contact",
+      ]);
+    });
+
+    test("probe: getDeleted unsupported → the object is always dirty (deletions invisible)", async () => {
+      const c = new SalesforceConnector();
+      mockQuery.mockResolvedValue({ done: true, records: [] });
+      mockDeleted.mockRejectedValue(new Error("UNSUPPORTED"));
+
+      const result = await c.probePermissionChanges({
+        config: { type: "salesforce", objects: ["Account"] },
+        credentials: CREDS,
+        state: { soqlCursor: new Date().toISOString() },
+      });
+      expect(result.dirtyContainerKeys).toEqual(["sobject:Account"]);
+    });
+
+    test("refreshContainerAudiences re-resolves top-level OWD and nested record audiences", async () => {
+      const c = new SalesforceConnector();
+      mockMetadataRead.mockResolvedValue({ sharingModel: "ReadWrite" });
+      stubSoql([
+        {
+          match: "FROM Account WHERE Id IN",
+          records: [{ Id: "001A", OwnerId: "005OWNER" }],
+        },
+        { match: "FROM AccountShare", records: [] },
+        {
+          match: "FROM User WHERE Id IN",
+          records: [
+            { Id: "005OWNER", Email: "owner@example.com", IsActive: true },
+          ],
+        },
+      ]);
+
+      const yields = [];
+      for await (const item of c.refreshContainerAudiences({
+        config: permConfig,
+        credentials: CREDS,
+        containerKeys: [
+          "sobject:Account",
+          "sobject:Account/record:001A",
+          "bogus:key",
+        ],
+      }) ?? []) {
+        yields.push(item);
+      }
+
+      expect(yields).toEqual([
+        {
+          containerKey: "sobject:Account",
+          permissions: { isPublic: true },
+          audienceResolutionFailed: false,
+        },
+        {
+          containerKey: "sobject:Account/record:001A",
+          permissions: {
+            isPublic: false,
+            users: ["owner@example.com"],
+            groups: [],
+          },
+          audienceResolutionFailed: false,
+        },
+      ]);
+    });
+
+    test("scopeKeyForDocument maps objectName metadata to the object container", () => {
+      const c = new SalesforceConnector();
+      expect(c.scopeKeyForDocument({ objectName: "Account" })).toBe(
+        "sobject:Account",
+      );
+      expect(c.scopeKeyForDocument({})).toBeNull();
     });
   });
 });

--- a/platform/backend/src/knowledge-base/connectors/salesforce/salesforce-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/salesforce/salesforce-connector.ts
@@ -1,9 +1,18 @@
 import { Connection } from "jsforce";
+import * as metrics from "@/observability/metrics";
 import type {
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorItemFailure,
   ConnectorSyncBatch,
+  DocumentPermissions,
+  GroupMembershipYield,
+  GroupMemberYield,
+  PermissionProbeResult,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
+  PermissionSyncState,
+  ResolveMappedEmail,
   SalesforceCheckpoint,
   SalesforceConfig,
 } from "@/types";
@@ -12,6 +21,7 @@ import {
   BaseConnector,
   buildCheckpoint,
   extractErrorMessage,
+  isoCursorWithSkewBuffer,
 } from "../base-connector";
 
 const DEFAULT_BATCH_SIZE = 200;
@@ -167,6 +177,24 @@ type SfRecord = Record<string, unknown> & {
 
 export class SalesforceConnector extends BaseConnector {
   type = "salesforce" as const;
+  supportsPermissionSync = true;
+
+  /** Per-permission-pass state; re-armed by every permission hook entry. */
+  private permConnection: Connection | null = null;
+  /** Object name → OWD sharing model (null = metadata read failed). */
+  private sharingModelCache = new Map<string, string | null>();
+  /** Salesforce user id → email (null = inactive/unresolvable). */
+  private userEmailCache = new Map<string, string | null>();
+  /** Account id → resolved audience (Contact parent-inheritance reuse). */
+  private recordAudienceCache = new Map<
+    string,
+    { permissions: DocumentPermissions; resolutionFailed: boolean }
+  >();
+  /** Objects whose <Obj>Share table is absent/unqueryable this pass. */
+  private shareTableBroken = new Set<string>();
+  private droppedPrincipals = 0;
+  /** Admin member-override lookup, injected by the pass (null = none). */
+  private mappedEmailResolver: ResolveMappedEmail | null = null;
 
   async validateConfig(
     config: Record<string, unknown>,
@@ -354,6 +382,394 @@ export class SalesforceConnector extends BaseConnector {
     }
   }
 
+  // ===== Permission sync =====
+
+  /**
+   * Container model: `sobject:<ObjectName>` per synced object. The object's
+   * org-wide default (OWD) sharing model — read via the Metadata API, no
+   * extra credential tier — decides the shape:
+   *  - Public Read/ReadWrite ⇒ the container is isPublic (every internal
+   *    user) and every document assigns to it. Cheapest possible pass.
+   *  - Private ⇒ per-record nested containers `sobject:<Obj>/record:<id>`
+   *    whose audience is the owner plus the object's share table
+   *    (`<Obj>Share`, RowCause filtered — Owner excluded, guest causes
+   *    excluded), chunked by ParentId. Group grantees become group tokens
+   *    (byte-matching syncGroups' Group.Id); user grantees become emails.
+   *  - ControlledByParent (Contact) ⇒ the record inherits its parent
+   *    Account's resolved audience (owner + AccountShare), materialized as
+   *    its own nested container — cross-container assignment would break
+   *    the cursor-grouping contract.
+   * A metadata read failure treats the object as Private (the safe
+   * direction). UserRecordAccess was rejected for this design: it prices at
+   * O(users × records / 200) per pass and ignores restriction rules anyway.
+   * Known under-grant gaps (documented, never over-grant): restriction
+   * rules, territory hierarchies, and high-volume portal shares.
+   */
+  async *syncPermissionSnapshot(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const config = parseSalesforceConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid Salesforce configuration for permission sync");
+    }
+    const conn = await this.createConnection({
+      credentials: params.credentials,
+      loginUrl: config.loginUrl,
+    });
+    this.initPermissionPass(conn);
+    this.mappedEmailResolver = params.resolveMappedEmail ?? null;
+
+    const specs = buildObjectSyncSpecs({
+      config,
+      advancedConfig: parseAdvancedObjectConfig(
+        config.advancedObjectConfigJson,
+      ),
+    });
+    const containerKeys = specs
+      .map((spec) => `sobject:${spec.objectName}`)
+      .sort();
+    const scope = params.scope ? new Set(params.scope.containerKeys) : null;
+
+    for (const key of containerKeys) {
+      if (scope && !scope.has(key)) continue;
+      // Resume: containers strictly before the cursor are done; the cursor
+      // container is re-processed (idempotent — same audiences).
+      if (params.cursor && key < params.cursor) continue;
+      yield* this.syncObjectSnapshot(conn, key, params);
+    }
+
+    this.reportDroppedPrincipals();
+  }
+
+  /**
+   * Salesforce groups → member emails. Group ids are the 15-char Group.Id,
+   * byte-matching the UserOrGroupId on share rows. Public groups nest, and
+   * Salesforce maintains expanded membership rows for role-hierarchy groups
+   * (Role / RoleAndSubordinates*), so expansion is a recursive walk over one
+   * GroupMember snapshot. The Organization group ("all internal users") has
+   * no membership rows — it expands to every active user. Inactive users
+   * never resolve (a deactivated account holds no access upstream either).
+   */
+  async *syncGroups(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<GroupMembershipYield> {
+    const config = parseSalesforceConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid Salesforce configuration for group sync");
+    }
+    const conn = await this.createConnection({
+      credentials: params.credentials,
+      loginUrl: config.loginUrl,
+    });
+    this.initPermissionPass(conn);
+
+    const groups = await this.queryAll<{
+      Id: string;
+      Name?: string;
+      Type?: string;
+    }>(conn, "SELECT Id, Name, Type FROM Group");
+    const memberRows = await this.queryAll<{
+      GroupId: string;
+      UserOrGroupId: string;
+    }>(conn, "SELECT GroupId, UserOrGroupId FROM GroupMember");
+    const membersByGroup = new Map<string, Set<string>>();
+    for (const row of memberRows) {
+      let set = membersByGroup.get(row.GroupId);
+      if (!set) {
+        set = new Set();
+        membersByGroup.set(row.GroupId, set);
+      }
+      set.add(row.UserOrGroupId);
+    }
+
+    for (const group of groups.sort((a, b) => (a.Id < b.Id ? -1 : 1))) {
+      let members: GroupMemberYield[];
+      try {
+        const userIds = new Set<string>();
+        this.collectGroupUserIds(group.Id, membersByGroup, userIds, new Set());
+        if (group.Type === "Organization") {
+          // "All internal users" has no GroupMember rows — every active user.
+          for (const user of await this.queryAll<{
+            Id: string;
+            IsActive?: boolean;
+          }>(conn, "SELECT Id, IsActive FROM User")) {
+            if (user.IsActive !== false) userIds.add(user.Id);
+          }
+        }
+        members = await this.toMemberYields([...userIds]);
+      } catch (error) {
+        // Per-group failure isolation: one unreadable group fail-closes its
+        // own grants only, never the whole enumeration.
+        this.log.warn(
+          { groupId: group.Id, error: extractErrorMessage(error) },
+          "Could not resolve Salesforce group members; the group's grants stay fail-closed",
+        );
+        members = [];
+      }
+      yield { groupId: group.Id, members, cursor: group.Id };
+    }
+
+    yield* this.syncDirectGrantRoster(conn, config);
+  }
+
+  /**
+   * Direct (non-group) grant-holders — record owners and per-user share
+   * grantees of the synced objects — roster under the synthetic
+   * `direct-grants` group, so an account whose email is hidden or matches no
+   * Archestra user is VISIBLE in the Users tab and override-assignable
+   * (access itself flows through inline `user_email:` tokens, resolved with
+   * the override fallback at audience time, not through this group's token).
+   * One distinct-value SOQL per surface, bounded by distinct grant-holders;
+   * a failed surface skips its contribution (partial roster over none).
+   */
+  private async *syncDirectGrantRoster(
+    conn: Connection,
+    config: SalesforceConfig,
+  ): AsyncGenerator<GroupMembershipYield> {
+    const directIds = new Set<string>();
+    const specs = buildObjectSyncSpecs({
+      config,
+      advancedConfig: parseAdvancedObjectConfig(
+        config.advancedObjectConfigJson,
+      ),
+    });
+    for (const spec of specs) {
+      try {
+        await this.rateLimit();
+        for (const row of await this.queryAll<{ OwnerId?: string }>(
+          conn,
+          `SELECT OwnerId FROM ${spec.objectName} GROUP BY OwnerId`,
+        )) {
+          if (row.OwnerId?.startsWith("005")) directIds.add(row.OwnerId);
+        }
+      } catch (error) {
+        this.log.debug(
+          { objectName: spec.objectName, error: extractErrorMessage(error) },
+          "Could not enumerate record owners for the direct-grants roster",
+        );
+      }
+      const shareObject = shareObjectName(spec.objectName);
+      if (!shareObject) continue;
+      try {
+        await this.rateLimit();
+        for (const row of await this.queryAll<{
+          UserOrGroupId?: string;
+          RowCause?: string;
+        }>(
+          conn,
+          `SELECT UserOrGroupId, RowCause FROM ${shareObject} GROUP BY UserOrGroupId, RowCause`,
+        )) {
+          if (!row.UserOrGroupId?.startsWith("005")) continue;
+          if (row.RowCause && EXCLUDED_SHARE_ROW_CAUSES.has(row.RowCause)) {
+            continue;
+          }
+          if (row.RowCause?.startsWith("Guest")) continue;
+          directIds.add(row.UserOrGroupId);
+        }
+      } catch (error) {
+        this.log.debug(
+          { objectName: spec.objectName, error: extractErrorMessage(error) },
+          "Could not enumerate share grantees for the direct-grants roster",
+        );
+      }
+    }
+    if (directIds.size > 0) {
+      yield {
+        groupId: DIRECT_GRANTS_GROUP_ID,
+        members: await this.toMemberYields([...directIds].sort()),
+      };
+    }
+  }
+
+  /**
+   * Delta-pass probe: per object, three cheap drift checks since the stored
+   * cursor — record edits (ownership changes bump LastModifiedDate), share
+   * rows created/modified, and share rows DELETED via getDeleted (a missed
+   * revocation must never wait for the daily full reconcile). Contact
+   * inherits Account's dirty flag (its audiences are derived from accounts).
+   * An object whose share table does not support getDeleted is always dirty
+   * — deletions there are invisible, so the safe fallback is re-enumeration.
+   */
+  async probePermissionChanges(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+    state: PermissionSyncState | null;
+  }): Promise<PermissionProbeResult> {
+    const config = parseSalesforceConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid Salesforce configuration for permission probe");
+    }
+    const conn = await this.createConnection({
+      credentials: params.credentials,
+      loginUrl: config.loginUrl,
+    });
+
+    const specs = buildObjectSyncSpecs({
+      config,
+      advancedConfig: parseAdvancedObjectConfig(
+        config.advancedObjectConfigJson,
+      ),
+    });
+    const now = new Date().toISOString();
+    const nextState: PermissionSyncState = { soqlCursor: now };
+    const cursor =
+      typeof params.state?.soqlCursor === "string"
+        ? params.state.soqlCursor
+        : null;
+    if (!cursor) {
+      // First probe: no cursor yet — the full pass establishes it.
+      return { dirtyContainerKeys: [], fullRequired: true, nextState };
+    }
+    const since = toSalesforceDateLiteral(isoCursorWithSkewBuffer(cursor));
+    const probeStart = new Date(isoCursorWithSkewBuffer(cursor));
+    const probeEnd = new Date(now);
+
+    const dirty = new Set<string>();
+    for (const spec of specs) {
+      const objectName = spec.objectName;
+      let isDirty = false;
+      try {
+        await this.rateLimit();
+        const records = (await conn.query(
+          `SELECT Id FROM ${objectName} WHERE LastModifiedDate >= ${since} LIMIT 1`,
+        )) as { records: unknown[] };
+        isDirty = records.records.length > 0;
+      } catch (error) {
+        this.log.debug(
+          { objectName, error: extractErrorMessage(error) },
+          "Record drift probe failed for object",
+        );
+      }
+
+      const shareObject = shareObjectName(objectName);
+      if (!isDirty && shareObject) {
+        try {
+          await this.rateLimit();
+          const shares = (await conn.query(
+            `SELECT Id FROM ${shareObject} WHERE LastModifiedDate >= ${since} LIMIT 1`,
+          )) as { records: unknown[] };
+          isDirty = shares.records.length > 0;
+        } catch {
+          // No share table (public OWD, ControlledByParent): no share drift
+          // possible — record drift above is the only signal.
+        }
+      }
+      if (!isDirty && shareObject) {
+        try {
+          await this.rateLimit();
+          const deleted = await conn.deleted(shareObject, probeStart, probeEnd);
+          isDirty = (deleted.deletedRecords ?? []).length > 0;
+        } catch {
+          // getDeleted unsupported here ⇒ share deletions are invisible to
+          // the probe — always re-enumerate this object (safe direction).
+          isDirty = true;
+        }
+      }
+      if (isDirty) dirty.add(`sobject:${objectName}`);
+    }
+    // Contact audiences derive from their parent Account: Account sharing
+    // drift must re-resolve Contacts too.
+    if (
+      dirty.has("sobject:Account") &&
+      specs.some((s) => s.objectName === "Contact")
+    ) {
+      dirty.add("sobject:Contact");
+    }
+
+    return {
+      dirtyContainerKeys: [...dirty].sort(),
+      fullRequired: false,
+      nextState,
+    };
+  }
+
+  /**
+   * Audience verification, run on every delta pass: re-resolve top-level
+   * object containers (the OWD check) AND nested record containers (owner +
+   * shares) without enumerating the corpus. Chunked SOQL, no document
+   * enumeration.
+   */
+  async *refreshContainerAudiences(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+    containerKeys: string[];
+    resolveMappedEmail?: ResolveMappedEmail;
+  }): AsyncGenerator<{
+    containerKey: string;
+    permissions: DocumentPermissions;
+    audienceResolutionFailed?: boolean;
+  }> {
+    const config = parseSalesforceConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid Salesforce configuration for audience refresh");
+    }
+    const conn = await this.createConnection({
+      credentials: params.credentials,
+      loginUrl: config.loginUrl,
+    });
+    this.initPermissionPass(conn);
+    this.mappedEmailResolver = params.resolveMappedEmail ?? null;
+
+    const recordKeysByObject = new Map<string, string[]>();
+    for (const containerKey of params.containerKeys) {
+      const top = containerKey.match(/^sobject:([^/]+)$/);
+      if (top) {
+        const objectName = top[1];
+        const sharing = await this.resolveSharingModel(conn, objectName);
+        yield {
+          containerKey,
+          permissions:
+            sharing === "Read" || sharing === "ReadWrite"
+              ? { isPublic: true }
+              : { isPublic: false, users: [], groups: [] },
+          audienceResolutionFailed: sharing === null,
+        };
+        continue;
+      }
+      const nested = containerKey.match(/^sobject:([^/]+)\/record:([^/]+)$/);
+      if (nested) {
+        const list = recordKeysByObject.get(nested[1]) ?? [];
+        list.push(nested[2]);
+        recordKeysByObject.set(nested[1], list);
+      }
+      // Unknown shapes: skipped, left for the periodic full reconcile.
+    }
+
+    for (const [objectName, recordIds] of recordKeysByObject) {
+      const audiences = await this.resolveRecordAudiences(
+        conn,
+        objectName,
+        recordIds,
+      );
+      for (const recordId of recordIds) {
+        const audience = audiences.get(recordId);
+        yield {
+          containerKey: `sobject:${objectName}/record:${recordId}`,
+          permissions: audience?.permissions ?? {
+            isPublic: false,
+            users: [],
+            groups: [],
+          },
+          audienceResolutionFailed: audience?.resolutionFailed ?? true,
+        };
+      }
+    }
+
+    this.reportDroppedPrincipals();
+  }
+
+  /**
+   * Local-adoption scoping for delta passes: content-sync stamps
+   * `metadata.objectName`. Scoping only — the object enumeration resolves
+   * the authoritative assignment, so this can never over-grant.
+   */
+  scopeKeyForDocument(metadata: Record<string, unknown>): string | null {
+    const objectName = metadata.objectName;
+    return typeof objectName === "string" && objectName.length > 0
+      ? `sobject:${objectName}`
+      : null;
+  }
+
   /**
    * Sync a single Salesforce object, yielding paginated batches.
    *
@@ -516,6 +932,447 @@ export class SalesforceConnector extends BaseConnector {
         );
       }
     }
+  }
+
+  // ===== Permission-sync internals =====
+
+  /** Arm (or re-arm) the per-pass state every permission hook shares. */
+  private initPermissionPass(conn: Connection): void {
+    this.permConnection = conn;
+    this.sharingModelCache = new Map();
+    this.userEmailCache = new Map();
+    this.recordAudienceCache = new Map();
+    this.shareTableBroken = new Set();
+    this.droppedPrincipals = 0;
+    this.mappedEmailResolver = null;
+  }
+
+  private async *syncObjectSnapshot(
+    conn: Connection,
+    containerKey: string,
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const objectName = containerKey.slice("sobject:".length);
+    const recordIds = await this.collectIngestedRecordIds(params, objectName);
+
+    if (recordIds.length === 0) {
+      // Empty corpus: emit the fail-closed boundary container WITHOUT
+      // resolving anything (Jira precedent — not a resolution failure).
+      yield {
+        kind: "container",
+        containerKey,
+        permissions: { isPublic: false, users: [], groups: [] },
+        audienceResolutionFailed: false,
+        cursor: containerKey,
+      };
+      return;
+    }
+
+    const sharing = await this.resolveSharingModel(conn, objectName);
+
+    if (sharing === "Read" || sharing === "ReadWrite") {
+      // Public OWD: every internal user reads every record of this object.
+      yield {
+        kind: "container",
+        containerKey,
+        permissions: { isPublic: true },
+        audienceResolutionFailed: false,
+        cursor: containerKey,
+      };
+      for (const recordId of recordIds) {
+        yield {
+          kind: "document",
+          sourceId: `salesforce:${objectName}:${recordId}`,
+          containerKey,
+          cursor: containerKey,
+        };
+      }
+      return;
+    }
+
+    // Private / ControlledByParent / unknown (failed metadata read): the
+    // top-level container is a pure boundary — audiences live on the nested
+    // record containers.
+    yield {
+      kind: "container",
+      containerKey,
+      permissions: { isPublic: false, users: [], groups: [] },
+      audienceResolutionFailed: false,
+      cursor: containerKey,
+    };
+
+    if (objectName === "Contact" || sharing === "ControlledByParent") {
+      // Contact inherits its parent Account's audience; a contact without
+      // an account is private to its owner.
+      const parents = await this.fetchRecordFields(conn, "Contact", recordIds, [
+        "AccountId",
+      ]);
+      for (const recordId of recordIds) {
+        const accountId = parents.get(recordId)?.AccountId;
+        const audience =
+          typeof accountId === "string" && accountId
+            ? await this.resolveAccountAudienceCached(conn, accountId)
+            : ((
+                await this.resolveRecordAudiences(conn, "Contact", [recordId])
+              ).get(recordId) ?? failedAudience());
+        yield {
+          kind: "container",
+          containerKey: `${containerKey}/record:${recordId}`,
+          permissions: audience.permissions,
+          audienceResolutionFailed: audience.resolutionFailed,
+          cursor: containerKey,
+        };
+        yield {
+          kind: "document",
+          sourceId: `salesforce:Contact:${recordId}`,
+          containerKey: `${containerKey}/record:${recordId}`,
+          cursor: containerKey,
+        };
+      }
+      return;
+    }
+
+    // Private OWD: per-record owner + share-table audiences.
+    const audiences = await this.resolveRecordAudiences(
+      conn,
+      objectName,
+      recordIds,
+    );
+    for (const recordId of recordIds) {
+      const audience = audiences.get(recordId) ?? failedAudience();
+      yield {
+        kind: "container",
+        containerKey: `${containerKey}/record:${recordId}`,
+        permissions: audience.permissions,
+        audienceResolutionFailed: audience.resolutionFailed,
+        cursor: containerKey,
+      };
+      yield {
+        kind: "document",
+        sourceId: `salesforce:${objectName}:${recordId}`,
+        containerKey: `${containerKey}/record:${recordId}`,
+        cursor: containerKey,
+      };
+    }
+  }
+
+  /** Ingested record ids for one object (keyset-paged read-back). */
+  private async collectIngestedRecordIds(
+    params: PermissionSyncParams,
+    objectName: string,
+  ): Promise<string[]> {
+    const prefix = `salesforce:${objectName}:`;
+    const ids: string[] = [];
+    let afterId: string | null = null;
+    for (;;) {
+      const { documents, nextAfterId } = await params.readIngestedDocuments({
+        metadataFilter: { objectName },
+        afterId,
+        limit: PERMISSION_READBACK_PAGE_SIZE,
+      });
+      for (const doc of documents) {
+        if (doc.sourceId.startsWith(prefix)) {
+          ids.push(doc.sourceId.slice(prefix.length));
+        }
+      }
+      if (documents.length < PERMISSION_READBACK_PAGE_SIZE) break;
+      afterId = nextAfterId;
+    }
+    return ids.sort();
+  }
+
+  /**
+   * The object's OWD sharing model via the Metadata API (same session — no
+   * extra credential tier). Cached per pass; a read failure caches null,
+   * which callers treat as Private (the safe direction).
+   */
+  private async resolveSharingModel(
+    conn: Connection,
+    objectName: string,
+  ): Promise<string | null> {
+    const cached = this.sharingModelCache.get(objectName);
+    if (cached !== undefined) return cached;
+    let sharingModel: string | null = null;
+    try {
+      await this.rateLimit();
+      const meta = (await conn.metadata.read("CustomObject", objectName)) as
+        | { sharingModel?: string }
+        | Array<{ sharingModel?: string }>;
+      const entry = Array.isArray(meta) ? meta[0] : meta;
+      sharingModel = entry?.sharingModel ?? null;
+      if (!sharingModel) {
+        this.log.warn(
+          { objectName },
+          "Salesforce metadata read returned no sharingModel; treating the object as Private",
+        );
+      }
+    } catch (error) {
+      this.log.warn(
+        { objectName, error: extractErrorMessage(error) },
+        "Could not read the object's sharing model; treating it as Private (fail-closed)",
+      );
+    }
+    this.sharingModelCache.set(objectName, sharingModel);
+    return sharingModel;
+  }
+
+  /**
+   * Per-record audiences for a private-OWD object: owner + share rows,
+   * chunked (SOQL IN-clause sized). User grantees resolve to emails; group
+   * grantees (00G…) become group tokens byte-matching syncGroups. A missing
+   * or unqueryable share table degrades the object to owner-only for this
+   * pass (fail-closed, logged once per object) — never an over-grant, never
+   * an abort.
+   */
+  private async resolveRecordAudiences(
+    conn: Connection,
+    objectName: string,
+    recordIds: string[],
+  ): Promise<
+    Map<string, { permissions: DocumentPermissions; resolutionFailed: boolean }>
+  > {
+    const out = new Map<
+      string,
+      { permissions: DocumentPermissions; resolutionFailed: boolean }
+    >();
+    const shareObject = shareObjectName(objectName);
+    for (const chunk of chunkArray(recordIds, SOQL_IN_CHUNK_SIZE)) {
+      const owners = await this.fetchRecordFields(conn, objectName, chunk, [
+        "OwnerId",
+      ]);
+      const sharesByParent = new Map<
+        string,
+        Array<{ UserOrGroupId: string }>
+      >();
+      if (shareObject && !this.shareTableBroken.has(objectName)) {
+        try {
+          await this.rateLimit();
+          const shareRows = await this.queryAll<{
+            ParentId: string;
+            UserOrGroupId: string;
+            RowCause?: string;
+          }>(
+            conn,
+            `SELECT ParentId, UserOrGroupId, RowCause FROM ${shareObject} WHERE ParentId IN (${soqlIn(
+              chunk,
+            )})`,
+          );
+          for (const row of shareRows) {
+            if (row.RowCause && EXCLUDED_SHARE_ROW_CAUSES.has(row.RowCause)) {
+              continue;
+            }
+            if (row.RowCause?.startsWith("Guest")) continue;
+            const list = sharesByParent.get(row.ParentId) ?? [];
+            list.push(row);
+            sharesByParent.set(row.ParentId, list);
+          }
+        } catch (error) {
+          this.shareTableBroken.add(objectName);
+          this.log.warn(
+            { objectName, shareObject, error: extractErrorMessage(error) },
+            "Share table unavailable; the object's records resolve owner-only for this pass (fail-closed)",
+          );
+        }
+      }
+
+      const userIds = new Set<string>();
+      for (const recordId of chunk) {
+        const ownerId = owners.get(recordId)?.OwnerId;
+        if (typeof ownerId === "string" && ownerId.startsWith("005")) {
+          userIds.add(ownerId);
+        }
+        for (const row of sharesByParent.get(recordId) ?? []) {
+          if (row.UserOrGroupId.startsWith("005")) {
+            userIds.add(row.UserOrGroupId);
+          }
+        }
+      }
+      const emails = await this.resolveUserEmails(conn, [...userIds]);
+
+      for (const recordId of chunk) {
+        const users = new Set<string>();
+        const groups = new Set<string>();
+        // Direct grants: upstream email, else the admin member-override
+        // mapping (a user id whose email Salesforce hides or that matches no
+        // Archestra account can be assigned from the Users tab).
+        const grantEmail = (userId: string): string | null =>
+          emails.get(userId) ?? this.mappedEmailResolver?.(userId) ?? null;
+        const ownerId = owners.get(recordId)?.OwnerId;
+        if (typeof ownerId === "string") {
+          if (ownerId.startsWith("005")) {
+            const email = grantEmail(ownerId);
+            if (email) users.add(email.toLowerCase());
+          } else if (ownerId.startsWith("00G")) {
+            // Queue/group-owned record: the owning group's members get access.
+            groups.add(ownerId);
+          }
+        }
+        for (const row of sharesByParent.get(recordId) ?? []) {
+          if (row.UserOrGroupId.startsWith("005")) {
+            const email = grantEmail(row.UserOrGroupId);
+            if (email) users.add(email.toLowerCase());
+          } else if (row.UserOrGroupId.startsWith("00G")) {
+            groups.add(row.UserOrGroupId);
+          }
+        }
+        out.set(recordId, {
+          permissions: {
+            isPublic: false,
+            users: [...users],
+            groups: [...groups],
+          },
+          resolutionFailed: false,
+        });
+      }
+    }
+    return out;
+  }
+
+  /** A parent Account's audience, memoized for Contact inheritance. */
+  private async resolveAccountAudienceCached(
+    conn: Connection,
+    accountId: string,
+  ): Promise<{ permissions: DocumentPermissions; resolutionFailed: boolean }> {
+    const cached = this.recordAudienceCache.get(accountId);
+    if (cached) return cached;
+    const audience =
+      (await this.resolveRecordAudiences(conn, "Account", [accountId])).get(
+        accountId,
+      ) ?? failedAudience();
+    this.recordAudienceCache.set(accountId, audience);
+    return audience;
+  }
+
+  /** Chunked field fetch: SELECT Id, <fields> FROM <obj> WHERE Id IN (...). */
+  private async fetchRecordFields(
+    conn: Connection,
+    objectName: string,
+    recordIds: string[],
+    fields: string[],
+  ): Promise<Map<string, Record<string, unknown>>> {
+    const out = new Map<string, Record<string, unknown>>();
+    for (const chunk of chunkArray(recordIds, SOQL_IN_CHUNK_SIZE)) {
+      await this.rateLimit();
+      const rows = await this.queryAll<Record<string, unknown>>(
+        conn,
+        `SELECT Id, ${fields.join(", ")} FROM ${objectName} WHERE Id IN (${soqlIn(chunk)})`,
+      );
+      for (const row of rows) {
+        if (typeof row.Id === "string") out.set(row.Id, row);
+      }
+    }
+    return out;
+  }
+
+  /** Salesforce user ids → emails (inactive users resolve null). Cached. */
+  private async resolveUserEmails(
+    conn: Connection,
+    userIds: string[],
+  ): Promise<Map<string, string | null>> {
+    const out = new Map<string, string | null>();
+    const missing: string[] = [];
+    for (const id of userIds) {
+      const cached = this.userEmailCache.get(id);
+      if (cached !== undefined) out.set(id, cached);
+      else missing.push(id);
+    }
+    for (const chunk of chunkArray(missing, SOQL_IN_CHUNK_SIZE)) {
+      let rows: Array<{ Id: string; Email?: string; IsActive?: boolean }>;
+      try {
+        rows = await this.queryAll(
+          conn,
+          `SELECT Id, Email, IsActive FROM User WHERE Id IN (${soqlIn(chunk)})`,
+        );
+      } catch (error) {
+        this.log.warn(
+          { error: extractErrorMessage(error) },
+          "Could not resolve Salesforce user emails; those principals drop fail-closed",
+        );
+        rows = [];
+      }
+      const seen = new Set<string>();
+      for (const row of rows) {
+        seen.add(row.Id);
+        const email =
+          row.IsActive === false ? null : (row.Email?.toLowerCase() ?? null);
+        this.userEmailCache.set(row.Id, email);
+        out.set(row.Id, email);
+        if (!email) this.droppedPrincipals += 1;
+      }
+      for (const id of chunk) {
+        if (!seen.has(id)) {
+          this.userEmailCache.set(id, null);
+          out.set(id, null);
+          this.droppedPrincipals += 1;
+        }
+      }
+    }
+    return out;
+  }
+
+  /** Expand a group to its user ids, recursing into nested groups. */
+  private collectGroupUserIds(
+    groupId: string,
+    membersByGroup: Map<string, Set<string>>,
+    out: Set<string>,
+    visited: Set<string>,
+  ): void {
+    if (visited.has(groupId)) return;
+    visited.add(groupId);
+    for (const memberId of membersByGroup.get(groupId) ?? []) {
+      if (memberId.startsWith("005")) out.add(memberId);
+      else if (memberId.startsWith("00G")) {
+        this.collectGroupUserIds(memberId, membersByGroup, out, visited);
+      }
+    }
+  }
+
+  private async toMemberYields(userIds: string[]): Promise<GroupMemberYield[]> {
+    const conn = this.permConnection;
+    if (!conn) throw new Error("permission pass not armed");
+    const emails = await this.resolveUserEmails(conn, userIds);
+    return userIds.map((id) => ({
+      accountId: id,
+      displayName: null,
+      email: emails.get(id) ?? null,
+    }));
+  }
+
+  /** query + queryMore loop (jsforce pages large result sets). */
+  private async queryAll<T>(conn: Connection, soql: string): Promise<T[]> {
+    await this.rateLimit();
+    let result = (await conn.query(soql)) as unknown as {
+      done: boolean;
+      records: T[];
+      nextRecordsUrl?: string;
+    };
+    const records = [...result.records];
+    while (!result.done && result.nextRecordsUrl) {
+      await this.rateLimit();
+      result = (await conn.queryMore(result.nextRecordsUrl)) as unknown as {
+        done: boolean;
+        records: T[];
+        nextRecordsUrl?: string;
+      };
+      records.push(...result.records);
+    }
+    return records;
+  }
+
+  /** Surface principals dropped this pass (fail-closed under-grant). */
+  private reportDroppedPrincipals(): void {
+    if (this.droppedPrincipals <= 0) return;
+    const count = this.droppedPrincipals;
+    this.droppedPrincipals = 0;
+    this.log.debug(
+      { count, connectorType: this.type },
+      "Dropped Salesforce principals that could not be resolved (fail-closed)",
+    );
+    metrics.rag.reportPermissionSyncDroppedPrincipals({
+      connectorType: this.type,
+      reason: "no_email",
+      count,
+    });
   }
 
   /** Create an authenticated jsforce Connection. */
@@ -853,4 +1710,55 @@ function subtractSafetyBuffer(isoDate: string): string {
 
 function toSalesforceDateLiteral(isoDate: string): string {
   return new Date(isoDate).toISOString();
+}
+
+// ===== Permission-sync helpers =====
+
+const PERMISSION_READBACK_PAGE_SIZE = 1000;
+/** Conservative IN-clause chunk (SOQL statement-length limits). */
+const SOQL_IN_CHUNK_SIZE = 100;
+
+/**
+ * Share rows that never grant READ access beyond what ownership already
+ * covers. Everything else (Manual, Rule, Team, Sales Team, Implicit*) is
+ * kept — a generous union under-grants nothing; Guest* causes are dropped
+ * (portal guests are never Archestra users).
+ */
+const EXCLUDED_SHARE_ROW_CAUSES = new Set(["Owner"]);
+
+/** Synthetic roster group for direct (non-group) grant-holders. */
+const DIRECT_GRANTS_GROUP_ID = "direct-grants";
+
+/** The share object for an object, or null when none exists. */
+function shareObjectName(objectName: string): string | null {
+  // Contact sharing is ControlledByParent — there is no ContactShare.
+  if (objectName === "Contact") return null;
+  if (objectName.endsWith("__c")) {
+    return `${objectName.slice(0, -"__c".length)}__Share`;
+  }
+  // Standard objects: AccountShare, CaseShare, OpportunityShare, …
+  return `${objectName}Share`;
+}
+
+function failedAudience(): {
+  permissions: DocumentPermissions;
+  resolutionFailed: boolean;
+} {
+  return {
+    permissions: { isPublic: false, users: [], groups: [] },
+    resolutionFailed: true,
+  };
+}
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/** Quote a SOQL IN clause's ids (ids are validated Salesforce identifiers). */
+function soqlIn(ids: string[]): string {
+  return ids.map((id) => `'${id}'`).join(", ");
 }

--- a/platform/backend/src/knowledge-base/connectors/sharepoint/sharepoint-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/sharepoint/sharepoint-connector.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
-import type { ConnectorSyncBatch } from "@/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConnectorSyncBatch, PermissionSnapshotYield } from "@/types";
 import { SharePointConnector } from "./sharepoint-connector";
+
+// The SP REST tier acquires a second-audience token via ClientSecretCredential;
+// keep AAD off the wire in tests.
+vi.mock("@azure/identity", () => ({
+  ClientSecretCredential: class {
+    async getToken() {
+      return { token: "sp-rest-token" };
+    }
+  },
+}));
 
 const credentials = { email: "test-client-id", apiToken: "test-client-secret" };
 
@@ -1169,6 +1179,911 @@ describe("SharePointConnector", () => {
       expect(finalCheckpoint.lastSyncedAt).not.toBe(
         new Date(pageTimestamp).toISOString(),
       );
+    });
+  });
+
+  describe("permission sync", () => {
+    type ContainerYield = Extract<
+      PermissionSnapshotYield,
+      { kind: "container" }
+    >;
+    type DocumentYield = Extract<PermissionSnapshotYield, { kind: "document" }>;
+
+    const permConfig = {
+      type: "sharepoint",
+      tenantId: "tenant-id",
+      siteUrl: "https://tenant.sharepoint.com/sites/test",
+      driveIds: ["D1"],
+      includePages: false,
+    };
+
+    /** Route table: url substring → response body, or a thrown Graph error. */
+    let routes: Array<{
+      match: string;
+      body?: unknown;
+      error?: { statusCode: number };
+      /** Only match when the Prefer header contains this. */
+      prefer?: string;
+    }>;
+    let requestedUrls: string[];
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    function routeFor(url: string, prefer: string | null) {
+      const route = routes.find(
+        (r) =>
+          url.includes(r.match) &&
+          (r.prefer === undefined || (prefer ?? "").includes(r.prefer)),
+      );
+      if (route?.error) {
+        const err = new Error("Graph error") as Error & {
+          statusCode: number;
+        };
+        err.statusCode = route.error.statusCode;
+        throw err;
+      }
+      if (!route) throw new Error(`No route for ${url}`);
+      return route.body;
+    }
+
+    function installClient(connector: SharePointConnector) {
+      const mockApi = vi.fn((url: string) => {
+        let prefer: string | null = null;
+        const chain = {
+          get: () => {
+            requestedUrls.push(url);
+            return Promise.resolve(routeFor(url, prefer));
+          },
+          header: (name: string, value: string) => {
+            if (name === "Prefer") prefer = value;
+            return chain;
+          },
+          responseType: () => chain,
+        };
+        return chain;
+      });
+      vi.spyOn(
+        connector as unknown as { getGraphClient: () => unknown },
+        "getGraphClient",
+      ).mockReturnValue({ api: mockApi } as never);
+    }
+
+    function readBack(docs: Array<{ sourceId: string; driveId?: string }>) {
+      return vi.fn(
+        async (args: {
+          metadataFilter?: Record<string, string>;
+          afterId?: string | null;
+          limit: number;
+        }) => ({
+          documents: docs
+            .filter(
+              (d) =>
+                !args.metadataFilter?.driveId ||
+                d.driveId === args.metadataFilter.driveId,
+            )
+            .map((d) => ({
+              sourceId: d.sourceId,
+              metadata: d.driveId ? { driveId: d.driveId } : null,
+            })),
+          nextAfterId: null,
+        }),
+      );
+    }
+
+    function syncParams(overrides?: {
+      config?: Record<string, unknown>;
+      docs?: Array<{ sourceId: string; driveId?: string }>;
+    }) {
+      return {
+        config: overrides?.config ?? permConfig,
+        credentials,
+        cursor: null,
+        readIngestedDocuments: readBack(
+          overrides?.docs ?? [{ sourceId: "I1", driveId: "D1" }],
+        ),
+      };
+    }
+
+    function collectSnapshot(
+      gen: AsyncGenerator<PermissionSnapshotYield> | undefined,
+    ) {
+      const containers = new Map<string, ContainerYield>();
+      const documents: DocumentYield[] = [];
+      return (async () => {
+        for await (const item of gen ??
+          ((async function* () {})() as AsyncGenerator<PermissionSnapshotYield>)) {
+          if (item.kind === "container")
+            containers.set(item.containerKey, item);
+          else documents.push(item);
+        }
+        return { containers, documents };
+      })();
+    }
+
+    /** The default delta walk: root + one plain file. */
+    function stubDeltaWalk(items: unknown[]) {
+      routes.push({
+        match: "/drives/D1/root/delta",
+        body: { value: items, "@odata.deltaLink": "delta-link-1" },
+      });
+    }
+
+    beforeEach(() => {
+      routes = [
+        {
+          match: "/sites/tenant.sharepoint.com:/sites/test",
+          body: { id: "site-1" },
+        },
+      ];
+      requestedUrls = [];
+      fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+    });
+
+    it("supportsPermissionSync is true", () => {
+      expect(new SharePointConnector().supportsPermissionSync).toBe(true);
+    });
+
+    it("drive container: root audience from the root permission list; plain items assign to it", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" } },
+      ]);
+      routes.push({
+        match: "/drives/D1/root/permissions",
+        body: {
+          value: [
+            {
+              grantedToV2: {
+                siteUser: {
+                  loginName: "i:0#.f|membership|Alice@Example.com",
+                },
+              },
+              roles: ["read"],
+            },
+          ],
+        },
+      });
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      expect(containers.get("drive:D1")?.permissions).toEqual({
+        isPublic: false,
+        users: ["alice@example.com"],
+        groups: [],
+      });
+      expect(documents).toEqual([
+        {
+          kind: "document",
+          sourceId: "I1",
+          containerKey: "drive:D1",
+          cursor: "drive:D1",
+        },
+      ]);
+      // No per-item permission reads for non-exception items.
+      expect(requestedUrls.filter((u) => u.includes("/items/")).length).toBe(0);
+    });
+
+    it("a document under a uniquely-permissioned folder joins that folder's nested container", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "F", parentReference: { id: "root" }, shared: {} },
+        { id: "I1", parentReference: { id: "F" } },
+      ]);
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [
+              {
+                grantedToV2: {
+                  siteUser: {
+                    loginName: "i:0#.f|membership|root@example.com",
+                  },
+                },
+                roles: ["read"],
+              },
+            ],
+          },
+        },
+        {
+          match: "/drives/D1/items/F/permissions",
+          body: {
+            value: [
+              {
+                grantedToV2: {
+                  siteUser: {
+                    loginName: "i:0#.f|membership|folder@example.com",
+                  },
+                },
+                roles: ["read"],
+              },
+            ],
+          },
+        },
+      );
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      expect(containers.get("drive:D1/item:F")?.permissions.users).toEqual([
+        "folder@example.com",
+      ]);
+      expect(documents[0]?.containerKey).toBe("drive:D1/item:F");
+    });
+
+    it("anonymous link → isPublic; organization link expands tenant users (User.Read.All tier)", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" } },
+      ]);
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [
+              { link: { scope: "anonymous" }, roles: ["read"] },
+              { link: { scope: "organization" }, roles: ["read"] },
+            ],
+          },
+        },
+        { match: "/users?$select=id&$top=1", body: { value: [] } },
+        {
+          match: "/users?$select=mail,userPrincipalName,accountEnabled",
+          body: {
+            value: [
+              { mail: "on@example.com", accountEnabled: true },
+              { mail: "off@example.com", accountEnabled: false },
+            ],
+          },
+        },
+      );
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      const audience = containers.get("drive:D1")?.permissions;
+      expect(audience?.isPublic).toBe(true);
+      expect(audience?.users).toEqual(["on@example.com"]);
+    });
+
+    it("organization links drop fail-closed when the users tier is denied", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" } },
+      ]);
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [{ link: { scope: "organization" }, roles: ["read"] }],
+          },
+        },
+        {
+          match: "/users?$select=id&$top=1",
+          error: { statusCode: 403 },
+        },
+      );
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      expect(containers.get("drive:D1")?.permissions.users).toEqual([]);
+    });
+
+    it("Entra group grants emit the group ref; membership resolves via the roster", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" } },
+      ]);
+      routes.push({
+        match: "/drives/D1/root/permissions",
+        body: {
+          value: [
+            {
+              grantedToV2: { group: { id: "g-1" } },
+              roles: ["read"],
+            },
+          ],
+        },
+      });
+
+      const first = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+      // The audience carries the group's IDENTITY at every tier — members
+      // are the roster's concern (syncGroups), not the audience's.
+      expect(first.containers.get("drive:D1")?.permissions).toEqual({
+        isPublic: false,
+        users: [],
+        groups: ["entra:g-1"],
+      });
+    });
+
+    it("SharePoint site-group grants emit the sitegroup ref", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" } },
+      ]);
+      routes.push({
+        match: "/drives/D1/root/permissions",
+        body: {
+          value: [
+            {
+              grantedToV2: { siteGroup: { displayName: "Test Members" } },
+              roles: ["read"],
+            },
+          ],
+        },
+      });
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+      expect(containers.get("drive:D1")?.permissions).toEqual({
+        isPublic: false,
+        users: [],
+        groups: ["sitegroup:Test Members"],
+      });
+      // No expansion happens on the audience path anymore.
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("member override maps a direct grantee whose upstream email is hidden", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" } },
+      ]);
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [
+              { grantedToV2: { user: { id: "u-hidden" } }, roles: ["read"] },
+            ],
+          },
+        },
+        // Users tier probes fine, but the account itself has no email.
+        { match: "/users?", body: { value: [{ id: "probe" }] } },
+        { match: "/users/u-hidden", body: { id: "u-hidden", mail: null } },
+      );
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot({
+          ...syncParams(),
+          resolveMappedEmail: (accountId: string) =>
+            accountId === "u-hidden" ? "Mapped@Corp.Test" : null,
+        }),
+      );
+      expect(containers.get("drive:D1")?.permissions.users).toEqual([
+        "mapped@corp.test",
+      ]);
+    });
+
+    describe("syncGroups", () => {
+      async function collectGroups(connector: SharePointConnector) {
+        const out: Array<{
+          groupId: string;
+          members: Array<{
+            accountId: string;
+            displayName: string | null;
+            email: string | null;
+          }>;
+        }> = [];
+        for await (const g of connector.syncGroups(syncParams())) {
+          out.push({
+            groupId: g.groupId,
+            members: g.members.map((m) => ({
+              accountId: m.accountId,
+              displayName: m.displayName,
+              email: m.email,
+            })),
+          });
+        }
+        return out;
+      }
+
+      it("rosters Entra group members with byte-matching group ids", async () => {
+        const connector = new SharePointConnector();
+        installClient(connector);
+        routes.push(
+          {
+            match: "/drives/D1/root/permissions",
+            body: {
+              value: [
+                { grantedToV2: { group: { id: "g-1" } }, roles: ["read"] },
+              ],
+            },
+          },
+          {
+            match: "/groups/g-1/transitiveMembers",
+            body: {
+              value: [
+                {
+                  id: "m1",
+                  displayName: "Member One",
+                  mail: "member@example.com",
+                },
+                { id: "m2", userPrincipalName: "upn@example.com", mail: null },
+                {
+                  id: "m3",
+                  displayName: "Disabled",
+                  mail: "off@example.com",
+                  accountEnabled: false,
+                },
+              ],
+            },
+          },
+        );
+
+        expect(await collectGroups(connector)).toEqual([
+          {
+            groupId: "entra:g-1",
+            members: [
+              {
+                accountId: "m1",
+                displayName: "Member One",
+                email: "member@example.com",
+              },
+              { accountId: "m2", displayName: null, email: "upn@example.com" },
+              // Disabled accounts stay rostered but never resolve.
+              { accountId: "m3", displayName: "Disabled", email: null },
+            ],
+          },
+        ]);
+      });
+
+      it("expansion denial (403) yields members: [] — memberships fail closed", async () => {
+        const connector = new SharePointConnector();
+        installClient(connector);
+        routes.push(
+          {
+            match: "/drives/D1/root/permissions",
+            body: {
+              value: [
+                { grantedToV2: { group: { id: "g-1" } }, roles: ["read"] },
+              ],
+            },
+          },
+          {
+            match: "/groups/g-1/transitiveMembers",
+            error: { statusCode: 403 },
+          },
+        );
+
+        expect(await collectGroups(connector)).toEqual([
+          { groupId: "entra:g-1", members: [] },
+        ]);
+      });
+
+      it("rosters SP site-group members via SP REST, flattening nested Entra claims", async () => {
+        const connector = new SharePointConnector();
+        installClient(connector);
+        routes.push(
+          {
+            match: "/drives/D1/root/permissions",
+            body: {
+              value: [
+                {
+                  grantedToV2: { siteGroup: { displayName: "Test Members" } },
+                  roles: ["read"],
+                },
+              ],
+            },
+          },
+          {
+            match: "/groups/g-9/transitiveMembers",
+            body: { value: [{ id: "n1", mail: "nested@example.com" }] },
+          },
+        );
+        fetchMock.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            value: [
+              {
+                Email: "Direct@Example.com",
+                LoginName: "i:0#.f|membership|direct@example.com",
+                Title: "Direct User",
+              },
+              { LoginName: "c:0o.c|federateddirectoryclaimprovider|g-9" },
+            ],
+          }),
+        });
+
+        expect(await collectGroups(connector)).toEqual([
+          {
+            groupId: "sitegroup:Test Members",
+            members: [
+              {
+                accountId: "i:0#.f|membership|direct@example.com",
+                displayName: "Direct User",
+                email: "direct@example.com",
+              },
+              {
+                accountId: "n1",
+                displayName: null,
+                email: "nested@example.com",
+              },
+            ],
+          },
+        ]);
+        expect(fetchMock).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "/sites/test/_api/web/sitegroups/getbyname('Test%20Members')/users",
+          ),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              authorization: "Bearer sp-rest-token",
+            }),
+          }),
+        );
+      });
+
+      it("SP REST denial (403) yields members: [] for the site group", async () => {
+        const connector = new SharePointConnector();
+        installClient(connector);
+        routes.push({
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [
+              {
+                grantedToV2: { siteGroup: { displayName: "Test Members" } },
+                roles: ["read"],
+              },
+            ],
+          },
+        });
+        fetchMock.mockResolvedValue({ ok: false, status: 403 });
+
+        expect(await collectGroups(connector)).toEqual([
+          { groupId: "sitegroup:Test Members", members: [] },
+        ]);
+      });
+
+      it("direct grantees roster under direct-grants; hidden emails stay visible for assignment", async () => {
+        const connector = new SharePointConnector();
+        installClient(connector);
+        routes.push(
+          {
+            match: "/drives/D1/root/permissions",
+            body: {
+              value: [
+                {
+                  grantedToV2: {
+                    user: { id: "u-frank", displayName: "Frank NoEmail" },
+                  },
+                  roles: ["read"],
+                },
+                {
+                  grantedToV2: {
+                    siteUser: {
+                      loginName: "i:0#.f|membership|Alice@Example.com",
+                      displayName: "Alice QA",
+                    },
+                  },
+                  roles: ["read"],
+                },
+              ],
+            },
+          },
+          { match: "/users?", body: { value: [{ id: "probe" }] } },
+          { match: "/users/u-frank", body: { id: "u-frank", mail: null } },
+        );
+
+        expect(await collectGroups(connector)).toEqual([
+          {
+            groupId: "direct-grants",
+            members: [
+              {
+                accountId: "i:0#.f|membership|Alice@Example.com",
+                displayName: "Alice QA",
+                email: "alice@example.com",
+              },
+              {
+                accountId: "u-frank",
+                displayName: "Frank NoEmail",
+                email: null,
+              },
+            ],
+          },
+        ]);
+      });
+
+      it("a failed surface read keeps that surface's groups un-yielded (previous roster preserved)", async () => {
+        const connector = new SharePointConnector();
+        installClient(connector);
+        routes.push({
+          match: "/drives/D1/root/permissions",
+          error: { statusCode: 500 },
+        });
+
+        expect(await collectGroups(connector)).toEqual([]);
+      });
+    });
+
+    it("empty corpus emits the boundary container without resolving an audience", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([]);
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams({ docs: [] })),
+      );
+
+      expect(containers.get("drive:D1")).toMatchObject({
+        permissions: { isPublic: false, users: [], groups: [] },
+        audienceResolutionFailed: false,
+      });
+      expect(documents).toEqual([]);
+      expect(
+        requestedUrls.filter((u) => u.includes("/permissions")).length,
+      ).toBe(0);
+    });
+
+    it("root permission read failure fail-closes the container, never aborts", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" } },
+      ]);
+      routes.push({
+        match: "/drives/D1/root/permissions",
+        error: { statusCode: 500 },
+      });
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      expect(containers.get("drive:D1")).toMatchObject({
+        audienceResolutionFailed: true,
+        permissions: { isPublic: false, users: [], groups: [] },
+      });
+      expect(documents[0]?.containerKey).toBe("drive:D1");
+    });
+
+    it("item permission read failure fail-closes the nested container only", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" }, shared: {} },
+      ]);
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [
+              {
+                grantedToV2: {
+                  siteUser: {
+                    loginName: "i:0#.f|membership|root@example.com",
+                  },
+                },
+                roles: ["read"],
+              },
+            ],
+          },
+        },
+        {
+          match: "/drives/D1/items/I1/permissions",
+          error: { statusCode: 429 },
+        },
+      );
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      expect(containers.get("drive:D1/item:I1")).toMatchObject({
+        audienceResolutionFailed: true,
+        permissions: { isPublic: false, users: [], groups: [] },
+      });
+      expect(documents[0]?.containerKey).toBe("drive:D1/item:I1");
+    });
+
+    it("site pages take the default drive's root audience", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      stubDeltaWalk([]); // drive D1: empty
+      routes.push(
+        { match: "/sites/site-1/drive", body: { id: "D0" } },
+        {
+          match: "/drives/D0/root/permissions",
+          body: {
+            value: [
+              {
+                grantedToV2: {
+                  siteUser: {
+                    loginName: "i:0#.f|membership|page@example.com",
+                  },
+                },
+                roles: ["read"],
+              },
+            ],
+          },
+        },
+      );
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(
+          syncParams({
+            config: { ...permConfig, includePages: true },
+            docs: [{ sourceId: "page-9", driveId: undefined }],
+          }),
+        ),
+      );
+
+      expect(containers.get("site:site-1")?.permissions.users).toEqual([
+        "page@example.com",
+      ]);
+      expect(documents.find((d) => d.sourceId === "page-9")?.containerKey).toBe(
+        "site:site-1",
+      );
+    });
+
+    it("probe: first probe captures latest tokens and requires full reconcile", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      routes.push({
+        match: "/drives/D1/root/delta?token=latest",
+        body: { "@odata.deltaLink": "dl-latest" },
+      });
+
+      const result = await connector.probePermissionChanges({
+        config: permConfig,
+        credentials,
+        state: null,
+      });
+
+      expect(result.fullRequired).toBe(true);
+      expect(result.nextState).toEqual({
+        deltaTokens: { "drive:D1": "dl-latest" },
+      });
+    });
+
+    it("probe: sharing-annotated items dirty the container; plain drift does not when elevated", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      routes.push({
+        match: "delta-link-1",
+        body: {
+          value: [{ id: "I1", "@microsoft.graph.sharedChanged": "True" }],
+          "@odata.deltaLink": "delta-link-2",
+        },
+      });
+
+      const dirty = await connector.probePermissionChanges({
+        config: permConfig,
+        credentials,
+        state: { deltaTokens: { "drive:D1": "delta-link-1" } },
+      });
+      expect(dirty).toEqual({
+        dirtyContainerKeys: ["drive:D1"],
+        fullRequired: false,
+        nextState: { deltaTokens: { "drive:D1": "delta-link-2" } },
+      });
+    });
+
+    it("probe: 403 on the sharing preference degrades to coarse probing (any item dirties)", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      routes.push(
+        {
+          match: "delta-link-1",
+          prefer: "deltashowsharingchanges",
+          error: { statusCode: 403 },
+        },
+        {
+          match: "delta-link-1",
+          body: {
+            value: [{ id: "I9" }],
+            "@odata.deltaLink": "delta-link-2",
+          },
+        },
+      );
+
+      const result = await connector.probePermissionChanges({
+        config: permConfig,
+        credentials,
+        state: { deltaTokens: { "drive:D1": "delta-link-1" } },
+      });
+
+      expect(result.fullRequired).toBe(false);
+      expect(result.dirtyContainerKeys).toEqual(["drive:D1"]);
+    });
+
+    it("probe: a rejected token (410) promotes to a full reconcile with fresh tokens", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      routes.push(
+        { match: "delta-link-stale", error: { statusCode: 410 } },
+        {
+          match: "/drives/D1/root/delta?token=latest",
+          body: { "@odata.deltaLink": "dl-fresh" },
+        },
+      );
+
+      const result = await connector.probePermissionChanges({
+        config: permConfig,
+        credentials,
+        state: { deltaTokens: { "drive:D1": "delta-link-stale" } },
+      });
+
+      expect(result.fullRequired).toBe(true);
+      expect(result.nextState).toEqual({
+        deltaTokens: { "drive:D1": "dl-fresh" },
+      });
+    });
+
+    it("refreshContainerAudiences re-resolves drive + site containers and skips nested item keys", async () => {
+      const connector = new SharePointConnector();
+      installClient(connector);
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [
+              {
+                grantedToV2: {
+                  siteUser: {
+                    loginName: "i:0#.f|membership|root@example.com",
+                  },
+                },
+                roles: ["read"],
+              },
+            ],
+          },
+        },
+        { match: "/sites/site-1/drive", body: { id: "D0" } },
+        {
+          match: "/drives/D0/root/permissions",
+          body: { value: [] },
+        },
+      );
+
+      const yields = [];
+      for await (const item of connector.refreshContainerAudiences({
+        config: { ...permConfig, includePages: true },
+        credentials,
+        containerKeys: ["drive:D1", "drive:D1/item:I1", "site:site-1"],
+      }) ?? []) {
+        yields.push(item);
+      }
+
+      expect(yields.map((y) => y.containerKey)).toEqual([
+        "drive:D1",
+        "site:site-1",
+      ]);
+      expect(yields[0]?.permissions.users).toEqual(["root@example.com"]);
+      expect(requestedUrls.filter((u) => u.includes("/items/")).length).toBe(0);
+    });
+
+    it("scopeKeyForDocument maps driveId and siteId metadata to containers", () => {
+      const connector = new SharePointConnector();
+      expect(connector.scopeKeyForDocument({ driveId: "D1" })).toBe("drive:D1");
+      expect(connector.scopeKeyForDocument({ siteId: "S1" })).toBe("site:S1");
+      expect(connector.scopeKeyForDocument({})).toBeNull();
     });
   });
 });

--- a/platform/backend/src/knowledge-base/connectors/sharepoint/sharepoint-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/sharepoint/sharepoint-connector.ts
@@ -6,10 +6,19 @@ import type {
   DriveItem as GraphDriveItem,
   SitePage as GraphSitePage,
 } from "@microsoft/microsoft-graph-types";
+import * as metrics from "@/observability/metrics";
 import type {
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorSyncBatch,
+  DocumentPermissions,
+  GroupMembershipYield,
+  GroupMemberYield,
+  PermissionProbeResult,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
+  PermissionSyncState,
+  ResolveMappedEmail,
   SharePointCheckpoint,
   SharePointConfig,
 } from "@/types";
@@ -82,6 +91,28 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 
 export class SharePointConnector extends BaseConnector {
   type = "sharepoint" as const;
+  supportsPermissionSync = true;
+
+  /** Per-permission-pass state; re-armed by every permission hook entry. */
+  private permCredentials: ConnectorCredentials | null = null;
+  private permConfig: SharePointConfig | null = null;
+  /** Graph user id → email (null = unresolvable this pass). */
+  private userEmailCache = new Map<string, string | null>();
+  /** Entra/M365 group id → member roster (null = tier unavailable/failed). */
+  private entraGroupCache = new Map<string, GroupMemberYield[] | null>();
+  /** SharePoint group title → member roster (null = tier unavailable/failed). */
+  private spGroupCache = new Map<string, GroupMemberYield[] | null>();
+  /** Admin member-override lookup, injected by the pass (null = none). */
+  private mappedEmailResolver: ResolveMappedEmail | null = null;
+  /** All active tenant users (undefined = not fetched this pass). */
+  private tenantUsersCache: string[] | null | undefined;
+  /** Progressive-elevation tiers, probed lazily and cached per pass. */
+  private graphUsersTier: boolean | null = null;
+  private graphGroupsTier: boolean | null = null;
+  private spRestTier: boolean | null = null;
+  private deltaSharingTier: boolean | null = null;
+  private spAccessToken: string | null = null;
+  private droppedPrincipals = 0;
 
   async validateConfig(
     config: Record<string, unknown>,
@@ -284,6 +315,381 @@ export class SharePointConnector extends BaseConnector {
         batchSize,
       });
     }
+  }
+
+  // ===== Permission sync =====
+
+  /**
+   * Container model: `drive:<driveId>` per document library in scope, plus
+   * `site:<siteId>` for site pages. A drive's root audience comes from the
+   * root item's effective permission list. Items that BREAK permission
+   * inheritance (a permission-hierarchy root, surfaced by the delta feed's
+   * `hierarchicalsharing` preference — the mechanism Microsoft's scanning
+   * guidance builds on) become nested `drive:<id>/item:<itemId>` containers;
+   * a document's container is its nearest uniquely-permissioned ancestor,
+   * resolved locally over the buffered walk (the Confluence governing-
+   * restriction pattern). `site:<siteId>` takes the DEFAULT drive's root
+   * audience — SharePoint pages have no v1.0 permission API; site-level
+   * groups govern both (documented approximation; per-page unique sharing
+   * is not modeled).
+   *
+   * Group grants emit GROUP TOKENS (`entra:<guid>` / `sitegroup:<title>` —
+   * byte-matched into `group:sharepoint_…` ACL tokens), and `syncGroups`
+   * persists the membership roster from the same expansions, so the
+   * Users/Groups tabs and member overrides work like every other roster
+   * connector. Direct (non-group) grantees stay inline `user_email:` tokens
+   * — with the pass's `resolveMappedEmail` override fallback — and are
+   * rostered under the synthetic `direct-grants` group so unmatched accounts
+   * are visible and assignable. The roster walks the TOP-LEVEL permission
+   * surfaces (drive roots); a group granted only on a nested
+   * unique-permission item still emits its token (visible in the Groups tab)
+   * but resolves no members until it also appears at top level — bounded
+   * fail-closed, since neither site groups nor granted Entra groups are
+   * globally enumerable. Every pass re-resolves audiences and roster
+   * (revocation latency = pass interval). Tiers are progressive, probed
+   * lazily, cached per pass, and always degrade fail-closed:
+   *  - base (Sites.Read.All): root/item permission lists, siteUser claims,
+   *    group-token emission (identity only — no membership)
+   *  - + User.Read.All: Graph user-id → email, tenant-wide link expansion
+   *  - + GroupMember.Read.All: Entra/M365 roster expansion (syncGroups)
+   *  - + SharePoint Sites.FullControl.All: site-group roster expansion via
+   *    the site's REST API, and sharing-aware delta probing
+   */
+  async *syncPermissionSnapshot(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const config = parseSharePointConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid SharePoint configuration for permission sync");
+    }
+    this.initPermissionPass(params.credentials, config);
+    this.mappedEmailResolver = params.resolveMappedEmail ?? null;
+    const client = this.getGraphClient(params.credentials, config);
+    const siteResolution = await this.resolveSite(client, config.siteUrl);
+    if (!siteResolution.siteId) {
+      throw new Error(buildResolveSiteErrorMessage(siteResolution.error));
+    }
+    const siteId = siteResolution.siteId;
+
+    const containers = await this.topContainers(client, config, siteId);
+    const scope = params.scope ? new Set(params.scope.containerKeys) : null;
+
+    for (const container of containers) {
+      if (scope && !scope.has(container.key)) continue;
+      // Resume: containers strictly before the cursor are done; the cursor
+      // container is re-processed (idempotent — same audiences).
+      if (params.cursor && container.key < params.cursor) continue;
+      if (container.kind === "drive") {
+        yield* this.syncDriveContainerSnapshot(client, container.key, params);
+      } else {
+        yield* this.syncSiteContainerSnapshot(client, container.key, params);
+      }
+    }
+
+    this.reportDroppedPrincipals();
+  }
+
+  /**
+   * Group roster sync (Users/Groups tabs + member overrides). Walks the
+   * TOP-LEVEL permission surfaces (each drive root), collects every granted
+   * group and direct grantee, and expands each group to members. Yielded
+   * groupIds byte-match the refs the audience path emits (`entra:<guid>`,
+   * `sitegroup:<title>`), so query-time group tokens resolve through this
+   * roster. Direct grantees roster under the synthetic `direct-grants`
+   * group — they grant via inline `user_email:` tokens, and the roster row
+   * is what makes an unmatched account visible and override-assignable.
+   * Expansion failure yields `members: []` (fail-closed — the platform
+   * revokes that group's stored memberships; Salesforce precedent). A
+   * surface whose permission read fails is skipped here: the audience phase
+   * owns fail-closing its containers.
+   */
+  async *syncGroups(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<GroupMembershipYield> {
+    const config = parseSharePointConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid SharePoint configuration for group sync");
+    }
+    this.initPermissionPass(params.credentials, config);
+    const client = this.getGraphClient(params.credentials, config);
+    const siteResolution = await this.resolveSite(client, config.siteUrl);
+    if (!siteResolution.siteId) {
+      throw new Error(buildResolveSiteErrorMessage(siteResolution.error));
+    }
+    const containers = await this.topContainers(
+      client,
+      config,
+      siteResolution.siteId,
+    );
+
+    const entraIds = new Set<string>();
+    const spTitles = new Set<string>();
+    const direct = new Map<string, GroupMemberYield>();
+    for (const container of containers) {
+      if (container.kind !== "drive") continue; // site: mirrors a drive root
+      const driveId = container.key.slice("drive:".length);
+      let permissions: SpPermission[];
+      try {
+        permissions = await this.listItemPermissions(
+          client,
+          `/drives/${driveId}/root/permissions`,
+        );
+      } catch (error) {
+        this.log.warn(
+          { driveId, error: extractErrorMessage(error) },
+          "Could not read a drive root's permissions for the group roster; its groups keep their previous roster this pass",
+        );
+        continue;
+      }
+      for (const permission of permissions) {
+        const identitySets = [
+          permission.grantedToV2,
+          ...(permission.grantedToIdentitiesV2 ?? []),
+        ];
+        for (const identitySet of identitySets) {
+          await this.collectRosterIdentity(
+            identitySet,
+            entraIds,
+            spTitles,
+            direct,
+          );
+        }
+      }
+    }
+
+    for (const groupId of [...entraIds].sort()) {
+      const members = await this.expandEntraGroup(groupId);
+      yield { groupId: entraGroupRef(groupId), members: members ?? [] };
+    }
+    for (const title of [...spTitles].sort()) {
+      const members = await this.expandSpGroup(title);
+      yield { groupId: spGroupRef(title), members: members ?? [] };
+    }
+    if (direct.size > 0) {
+      yield {
+        groupId: DIRECT_GRANTS_GROUP_ID,
+        members: [...direct.values()].sort((a, b) =>
+          a.accountId.localeCompare(b.accountId),
+        ),
+      };
+    }
+
+    this.reportDroppedPrincipals();
+  }
+
+  /** Roster-side principal collection (audience-side is applyIdentitySet). */
+  private async collectRosterIdentity(
+    identitySet: SpIdentitySet | undefined,
+    entraIds: Set<string>,
+    spTitles: Set<string>,
+    direct: Map<string, GroupMemberYield>,
+  ): Promise<void> {
+    if (!identitySet) return;
+    if (identitySet.group?.id) entraIds.add(identitySet.group.id);
+    if (identitySet.siteGroup?.displayName) {
+      spTitles.add(identitySet.siteGroup.displayName);
+    }
+    if (identitySet.user?.id) {
+      // Roster the UPSTREAM identity: email stays null when hidden — that is
+      // exactly the row an admin assigns manually.
+      const email = await this.resolveGraphUserEmail(identitySet.user.id);
+      direct.set(identitySet.user.id, {
+        accountId: identitySet.user.id,
+        displayName: identitySet.user.displayName ?? null,
+        email,
+        accountType: "user",
+      });
+      return;
+    }
+    const loginName = identitySet.siteUser?.loginName;
+    if (!loginName) return;
+    const lowered = loginName.toLowerCase();
+    if (lowered.includes("|federateddirectoryclaimprovider|")) {
+      const groupId = loginName.split("|").pop();
+      if (groupId) entraIds.add(groupId);
+      return;
+    }
+    if (
+      lowered.includes("spo-grid-all-users") ||
+      lowered.includes("|rolemanager|") ||
+      lowered === "c:0(.s|true"
+    ) {
+      return; // whole-tenant claims are not rosterable
+    }
+    const claimEmail = lowered.startsWith("i:0#.f|membership|")
+      ? loginName.split("|").pop()?.toLowerCase()
+      : undefined;
+    direct.set(loginName, {
+      accountId: loginName,
+      displayName: identitySet.siteUser?.displayName ?? null,
+      email: claimEmail?.includes("@") ? claimEmail : null,
+      accountType: "siteUser",
+    });
+  }
+
+  /**
+   * Delta-pass probe over each drive's delta feed. With the elevated
+   * `deltashowsharingchanges` preference (requires Sites.FullControl.All),
+   * items whose SHARING changed carry an annotation and only those dirty the
+   * container; without the elevation the preference is dropped and any item
+   * drift dirties it (the feed cannot isolate sharing drift — the safe
+   * coarse fallback). 410 Gone / rejected token ⇒ fullRequired. The pages
+   * container has no change feed — it is always dirty (pages re-verify
+   * cheaply: read-back + the default drive's root audience).
+   */
+  async probePermissionChanges(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+    state: PermissionSyncState | null;
+  }): Promise<PermissionProbeResult> {
+    const config = parseSharePointConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid SharePoint configuration for permission probe");
+    }
+    this.initPermissionPass(params.credentials, config);
+    const client = this.getGraphClient(params.credentials, config);
+    const siteResolution = await this.resolveSite(client, config.siteUrl);
+    if (!siteResolution.siteId) {
+      throw new Error(buildResolveSiteErrorMessage(siteResolution.error));
+    }
+    const containers = await this.topContainers(
+      client,
+      config,
+      siteResolution.siteId,
+    );
+
+    const stored =
+      params.state?.deltaTokens && typeof params.state.deltaTokens === "object"
+        ? (params.state.deltaTokens as Record<string, unknown>)
+        : null;
+    if (!stored) {
+      return {
+        dirtyContainerKeys: [],
+        fullRequired: true,
+        nextState: {
+          deltaTokens: await this.captureDeltaTokens(client, containers),
+        },
+      };
+    }
+
+    const dirty: string[] = [];
+    const nextTokens: Record<string, string> = {};
+    for (const container of containers) {
+      if (container.kind === "site") {
+        dirty.push(container.key);
+        continue;
+      }
+      const token = stored[container.key];
+      if (typeof token !== "string" || !token) {
+        nextTokens[container.key] = await this.getLatestDeltaToken(
+          client,
+          container.key,
+        );
+        dirty.push(container.key);
+        continue;
+      }
+      try {
+        const outcome = await this.walkDriveDelta(client, container.key, {
+          token,
+          forProbe: true,
+        });
+        nextTokens[container.key] = outcome.deltaLink;
+        if (outcome.sawChange) dirty.push(container.key);
+      } catch (error) {
+        // Rejected/expired delta token (410 resync etc.) — the drift window
+        // is lost, so only a full reconcile restores correctness.
+        this.log.warn(
+          { containerKey: container.key, error: extractErrorMessage(error) },
+          "SharePoint delta token rejected; promoting to a full reconcile",
+        );
+        return {
+          dirtyContainerKeys: [],
+          fullRequired: true,
+          nextState: {
+            deltaTokens: await this.captureDeltaTokens(client, containers),
+          },
+        };
+      }
+    }
+
+    return {
+      dirtyContainerKeys: dirty.sort(),
+      fullRequired: false,
+      nextState: { deltaTokens: nextTokens },
+    };
+  }
+
+  /**
+   * Audience verification, run on every delta pass: re-resolve each stored
+   * top-level container's audience without enumerating items. Nested
+   * `.../item:<id>` containers are deliberately NOT yielded — their audiences
+   * follow assignment drift, which the enumerating passes own.
+   */
+  async *refreshContainerAudiences(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+    containerKeys: string[];
+    resolveMappedEmail?: ResolveMappedEmail;
+  }): AsyncGenerator<{
+    containerKey: string;
+    permissions: DocumentPermissions;
+    audienceResolutionFailed?: boolean;
+  }> {
+    const config = parseSharePointConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid SharePoint configuration for audience refresh");
+    }
+    this.initPermissionPass(params.credentials, config);
+    this.mappedEmailResolver = params.resolveMappedEmail ?? null;
+    const client = this.getGraphClient(params.credentials, config);
+
+    for (const containerKey of params.containerKeys) {
+      const driveMatch = containerKey.match(/^drive:([^/]+)$/);
+      if (driveMatch) {
+        const audience = await this.resolveDriveRootAudience(
+          client,
+          driveMatch[1],
+        );
+        yield {
+          containerKey,
+          permissions: audience.permissions,
+          audienceResolutionFailed: audience.resolutionFailed,
+        };
+        continue;
+      }
+      if (/^site:[^/]+$/.test(containerKey)) {
+        const audience = await this.resolveSitePagesAudience(
+          client,
+          containerKey,
+        );
+        yield {
+          containerKey,
+          permissions: audience.permissions,
+          audienceResolutionFailed: audience.resolutionFailed,
+        };
+      }
+      // Nested item containers: skipped (assignment-tier).
+    }
+
+    this.reportDroppedPrincipals();
+  }
+
+  /**
+   * Local-adoption scoping for delta passes: content-sync stamps
+   * `metadata.driveId` on drive items and `metadata.siteId` on pages.
+   * Scoping only — the container enumeration resolves the authoritative
+   * assignment, so this can never over-grant.
+   */
+  scopeKeyForDocument(metadata: Record<string, unknown>): string | null {
+    const driveId = metadata.driveId;
+    if (typeof driveId === "string" && driveId.length > 0) {
+      return `drive:${driveId}`;
+    }
+    const siteId = metadata.siteId;
+    if (typeof siteId === "string" && siteId.length > 0) {
+      return `site:${siteId}`;
+    }
+    return null;
   }
 
   // ===== Private methods =====
@@ -983,6 +1389,823 @@ export class SharePointConnector extends BaseConnector {
 
     return count;
   }
+
+  // ===== Permission-sync internals =====
+
+  /** Arm (or re-arm) the per-pass state every permission hook shares. */
+  private initPermissionPass(
+    credentials: ConnectorCredentials,
+    config: SharePointConfig,
+  ): void {
+    this.permCredentials = credentials;
+    this.permConfig = config;
+    this.userEmailCache = new Map();
+    this.entraGroupCache = new Map();
+    this.spGroupCache = new Map();
+    this.tenantUsersCache = undefined;
+    this.graphUsersTier = null;
+    this.graphGroupsTier = null;
+    this.spRestTier = null;
+    this.deltaSharingTier = null;
+    this.spAccessToken = null;
+    this.droppedPrincipals = 0;
+    this.mappedEmailResolver = null;
+  }
+
+  /** The connector's top-level containers, sorted for a monotonic cursor. */
+  private async topContainers(
+    client: Client,
+    config: SharePointConfig,
+    siteId: string,
+  ): Promise<SpContainer[]> {
+    const driveIds =
+      config.driveIds && config.driveIds.length > 0
+        ? config.driveIds
+        : await this.listDriveIds(client, siteId);
+    const containers: SpContainer[] = driveIds.map((id) => ({
+      key: `drive:${id}`,
+      kind: "drive",
+    }));
+    if (config.includePages !== false) {
+      containers.push({ key: `site:${siteId}`, kind: "site" });
+    }
+    return containers.sort((a, b) =>
+      a.key < b.key ? -1 : a.key > b.key ? 1 : 0,
+    );
+  }
+
+  private async *syncDriveContainerSnapshot(
+    client: Client,
+    containerKey: string,
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const driveId = containerKey.slice("drive:".length);
+    // The corpus enumeration: one delta walk with hierarchicalsharing, which
+    // marks permission-hierarchy roots (items whose permissions no longer
+    // inherit) so unique-permission detection costs no per-item requests.
+    const walk = await this.walkDriveDelta(client, containerKey, {
+      forProbe: false,
+    });
+    const items = walk.items ?? new Map();
+
+    const docIds: string[] = [];
+    let afterId: string | null = null;
+    for (;;) {
+      const { documents, nextAfterId } = await params.readIngestedDocuments({
+        metadataFilter: { driveId },
+        afterId,
+        limit: PERMISSION_READBACK_PAGE_SIZE,
+      });
+      for (const doc of documents) docIds.push(doc.sourceId);
+      if (documents.length < PERMISSION_READBACK_PAGE_SIZE) break;
+      afterId = nextAfterId;
+    }
+    docIds.sort();
+
+    if (docIds.length === 0) {
+      // Empty corpus: emit the fail-closed boundary container WITHOUT
+      // resolving its audience (Jira precedent — not a resolution failure).
+      yield {
+        kind: "container",
+        containerKey,
+        permissions: { isPublic: false, users: [], groups: [] },
+        audienceResolutionFailed: false,
+        cursor: containerKey,
+      };
+      return;
+    }
+
+    const root = await this.resolveDriveRootAudience(client, driveId);
+    yield {
+      kind: "container",
+      containerKey,
+      permissions: root.permissions,
+      audienceResolutionFailed: root.resolutionFailed,
+      cursor: containerKey,
+    };
+
+    const emittedNested = new Set<string>();
+    for (const sourceId of docIds) {
+      const governingItemId = this.findGoverningScopeRoot(items, sourceId);
+      if (!governingItemId) {
+        yield {
+          kind: "document",
+          sourceId,
+          containerKey,
+          cursor: containerKey,
+        };
+        continue;
+      }
+      const nestedKey = `${containerKey}/item:${governingItemId}`;
+      if (!emittedNested.has(nestedKey)) {
+        const audience = await this.resolveItemAudience(
+          client,
+          driveId,
+          governingItemId,
+        );
+        yield {
+          kind: "container",
+          containerKey: nestedKey,
+          permissions: audience.permissions,
+          audienceResolutionFailed: audience.resolutionFailed,
+          cursor: containerKey,
+        };
+        emittedNested.add(nestedKey);
+      }
+      yield {
+        kind: "document",
+        sourceId,
+        containerKey: nestedKey,
+        cursor: containerKey,
+      };
+    }
+  }
+
+  private async *syncSiteContainerSnapshot(
+    client: Client,
+    containerKey: string,
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const siteId = containerKey.slice("site:".length);
+    const docIds: string[] = [];
+    let afterId: string | null = null;
+    for (;;) {
+      const { documents, nextAfterId } = await params.readIngestedDocuments({
+        metadataFilter: { siteId },
+        afterId,
+        limit: PERMISSION_READBACK_PAGE_SIZE,
+      });
+      for (const doc of documents) docIds.push(doc.sourceId);
+      if (documents.length < PERMISSION_READBACK_PAGE_SIZE) break;
+      afterId = nextAfterId;
+    }
+    docIds.sort();
+
+    const audience =
+      docIds.length > 0
+        ? await this.resolveSitePagesAudience(client, containerKey)
+        : // Empty corpus: boundary container only (Jira precedent).
+          { permissions: emptyAudience(), resolutionFailed: false };
+    yield {
+      kind: "container",
+      containerKey,
+      permissions: audience.permissions,
+      audienceResolutionFailed: audience.resolutionFailed,
+      cursor: containerKey,
+    };
+    for (const sourceId of docIds) {
+      yield {
+        kind: "document",
+        sourceId,
+        containerKey,
+        cursor: containerKey,
+      };
+    }
+  }
+
+  /**
+   * The nearest ancestor (or self) whose permissions no longer inherit —
+   * the item whose audience governs this document. `null` means the drive
+   * root's audience governs. The delta walk covers the whole drive, so a
+   * chain that leaves the buffer exited at the root.
+   */
+  private findGoverningScopeRoot(
+    items: Map<string, DeltaItemEntry>,
+    sourceId: string,
+  ): string | null {
+    let currentId: string | null = sourceId;
+    while (currentId) {
+      const entry = items.get(currentId);
+      if (!entry || entry.parentId === null) return null;
+      if (entry.scopeRoot) return currentId;
+      currentId = entry.parentId;
+    }
+    return null;
+  }
+
+  /**
+   * One drive's delta feed. Enumeration mode (`forProbe: false`) buffers
+   * every item's id/parent/scope-root flag and asks for `hierarchicalsharing`
+   * so scope roots carry a `shared` facet. Probe mode walks a stored delta
+   * link and reports whether anything drifted — sharing-only drift when the
+   * elevated `deltashowsharingchanges` preference is honored, any drift when
+   * the tenant denies it (403 ⇒ cache the denial, retry coarse).
+   */
+  private async walkDriveDelta(
+    client: Client,
+    containerKey: string,
+    opts: { token?: string; forProbe: boolean },
+  ): Promise<{
+    items: Map<string, DeltaItemEntry> | null;
+    deltaLink: string;
+    sawChange: boolean;
+  }> {
+    const driveId = containerKey.slice("drive:".length);
+    const startUrl =
+      opts.token ?? `${GRAPH_API_BASE}/drives/${driveId}/root/delta`;
+
+    let sharingPreference = opts.forProbe && this.deltaSharingTier !== false;
+    let url: string | undefined = startUrl;
+    const items = opts.forProbe ? null : new Map<string, DeltaItemEntry>();
+    let sawChange = false;
+
+    for (;;) {
+      if (!url) break;
+      await this.rateLimit();
+      let result: GraphDeltaPage;
+      try {
+        result = (await client
+          .api(url)
+          .header(
+            "Prefer",
+            opts.forProbe
+              ? sharingPreference
+                ? DELTA_SHARING_PREFER
+                : DELTA_PLAIN_PREFER
+              : DELTA_ENUM_PREFER,
+          )
+          .get()) as GraphDeltaPage;
+      } catch (error) {
+        if (opts.forProbe && sharingPreference && isGraphForbidden(error)) {
+          // Progressive degradation: the app lacks Sites.FullControl.All —
+          // the sharing-aware preference is rejected, so probe coarsely (any
+          // drift dirties the container) for the rest of this pass.
+          sharingPreference = false;
+          this.deltaSharingTier = false;
+          this.log.warn(
+            "SharePoint delta sharing-change preference rejected (Sites.FullControl.All missing); probing coarsely",
+          );
+          url = startUrl;
+          sawChange = false;
+          continue;
+        }
+        throw error;
+      }
+
+      for (const item of result.value ?? []) {
+        if (opts.forProbe) {
+          if (sharingPreference) {
+            const marker = item["@microsoft.graph.sharedChanged"];
+            if (marker === "True" || marker === "true" || marker === true) {
+              sawChange = true;
+            }
+          } else {
+            sawChange = true;
+          }
+          continue;
+        }
+        if (item.deleted) continue;
+        const parentId = item.parentReference?.id ?? null;
+        items?.set(item.id, {
+          parentId,
+          // hierarchicalsharing marks permission-hierarchy roots with a
+          // `shared` facet (empty when the root establishes an unshared
+          // scope) — presence is the unique-permissions signal.
+          scopeRoot: parentId !== null && item.shared !== undefined,
+        });
+      }
+
+      const deltaLink = result["@odata.deltaLink"];
+      if (deltaLink) {
+        return { items, deltaLink, sawChange };
+      }
+      url = result["@odata.nextLink"] ?? undefined;
+    }
+    // A delta walk always ends in a deltaLink; reaching here means the feed
+    // ended without one — treat as a rejected token upstream of the caller.
+    throw new Error("SharePoint delta walk ended without a delta link");
+  }
+
+  private async getLatestDeltaToken(
+    client: Client,
+    containerKey: string,
+  ): Promise<string> {
+    const driveId = containerKey.slice("drive:".length);
+    await this.rateLimit();
+    const result = (await client
+      .api(`${GRAPH_API_BASE}/drives/${driveId}/root/delta?token=latest`)
+      .get()) as GraphDeltaPage;
+    return result["@odata.deltaLink"] ?? "";
+  }
+
+  private async captureDeltaTokens(
+    client: Client,
+    containers: SpContainer[],
+  ): Promise<Record<string, string>> {
+    const tokens: Record<string, string> = {};
+    for (const container of containers) {
+      if (container.kind !== "drive") continue;
+      tokens[container.key] = await this.getLatestDeltaToken(
+        client,
+        container.key,
+      );
+    }
+    return tokens;
+  }
+
+  /** A drive root's effective audience; failure fail-closes the corpus. */
+  private async resolveDriveRootAudience(
+    client: Client,
+    driveId: string,
+  ): Promise<{ permissions: DocumentPermissions; resolutionFailed: boolean }> {
+    try {
+      const permissions = await this.listItemPermissions(
+        client,
+        `/drives/${driveId}/root/permissions`,
+      );
+      return {
+        permissions: await this.permissionsToAudience(permissions),
+        resolutionFailed: false,
+      };
+    } catch (error) {
+      this.log.error(
+        { driveId, error: extractErrorMessage(error) },
+        "Could not read the drive root's permissions; every document in it is fail-closed for this pass",
+      );
+      return { permissions: emptyAudience(), resolutionFailed: true };
+    }
+  }
+
+  /**
+   * One item's effective audience (the permission list folds inherited
+   * entries in — no inheritance math here). A read failure fail-closes THIS
+   * item's subtree only — never fall back to the parent audience on error
+   * (a transient 429/5xx must not become an over-grant).
+   */
+  private async resolveItemAudience(
+    client: Client,
+    driveId: string,
+    itemId: string,
+  ): Promise<{ permissions: DocumentPermissions; resolutionFailed: boolean }> {
+    try {
+      const permissions = await this.listItemPermissions(
+        client,
+        `/drives/${driveId}/items/${itemId}/permissions`,
+      );
+      return {
+        permissions: await this.permissionsToAudience(permissions),
+        resolutionFailed: false,
+      };
+    } catch (error) {
+      this.log.warn(
+        { driveId, itemId, error: extractErrorMessage(error) },
+        "Could not read the item's permissions; its documents are fail-closed for this pass",
+      );
+      return { permissions: emptyAudience(), resolutionFailed: true };
+    }
+  }
+
+  /**
+   * Site pages have no v1.0 permission API, so the pages container takes the
+   * site's DEFAULT drive root audience — site-level groups govern both
+   * (documented approximation).
+   */
+  private async resolveSitePagesAudience(
+    client: Client,
+    containerKey: string,
+  ): Promise<{ permissions: DocumentPermissions; resolutionFailed: boolean }> {
+    const siteId = containerKey.slice("site:".length);
+    try {
+      await this.rateLimit();
+      const drive = (await client
+        .api(`${GRAPH_API_BASE}/sites/${siteId}/drive?$select=id`)
+        .get()) as { id?: string };
+      if (!drive.id) throw new Error("site has no default drive");
+      return await this.resolveDriveRootAudience(client, drive.id);
+    } catch (error) {
+      this.log.error(
+        { siteId, error: extractErrorMessage(error) },
+        "Could not read the site's default drive permissions; every page is fail-closed for this pass",
+      );
+      return { permissions: emptyAudience(), resolutionFailed: true };
+    }
+  }
+
+  /** Paginate a Graph permission collection. */
+  private async listItemPermissions(
+    client: Client,
+    path: string,
+  ): Promise<SpPermission[]> {
+    const out: SpPermission[] = [];
+    let url: string | undefined = `${GRAPH_API_BASE}${path}`;
+    while (url) {
+      await this.rateLimit();
+      const result = (await client
+        .api(url)
+        .get()) as GraphListResponse<SpPermission>;
+      out.push(...(result.value ?? []));
+      url = result["@odata.nextLink"] ?? undefined;
+    }
+    return out;
+  }
+
+  /**
+   * Map Graph permission principals to a document audience. Group grants
+   * emit group REFERENCES (`entra:<guid>` / `sitegroup:<title>`) — resolved
+   * to users at query time through the roster `syncGroups` maintains — and
+   * direct users resolve inline to emails (with the admin member-override
+   * fallback for accounts whose upstream email is hidden). Anonymous links
+   * are genuinely public (isPublic — the Jira "anyone" precedent);
+   * organization links expand to the tenant's active users, NOT org-wide
+   * (a revocable set — the Jira applicationRole precedent). Application
+   * grants carry no user access and are ignored.
+   */
+  private async permissionsToAudience(
+    permissions: SpPermission[],
+  ): Promise<DocumentPermissions> {
+    const users = new Set<string>();
+    const groups = new Set<string>();
+    let isPublic = false;
+    for (const permission of permissions) {
+      const scope = permission.link?.scope;
+      if (scope === "anonymous") {
+        isPublic = true;
+      } else if (scope === "organization") {
+        const tenantUsers = await this.expandTenantUsers();
+        if (tenantUsers) {
+          for (const email of tenantUsers) users.add(email);
+        }
+      }
+      const identitySets = [
+        permission.grantedToV2,
+        ...(permission.grantedToIdentitiesV2 ?? []),
+      ];
+      for (const identitySet of identitySets) {
+        await this.applyIdentitySet(identitySet, users, groups);
+      }
+    }
+    return { isPublic, users: [...users], groups: [...groups] };
+  }
+
+  private async applyIdentitySet(
+    identitySet: SpIdentitySet | undefined,
+    users: Set<string>,
+    groups: Set<string>,
+  ): Promise<void> {
+    if (!identitySet) return;
+    if (identitySet.user?.id) {
+      const email = await this.resolveGraphUserEmail(identitySet.user.id);
+      const mapped = email ?? this.mappedEmailResolver?.(identitySet.user.id);
+      if (mapped) users.add(mapped.toLowerCase());
+      else this.droppedPrincipals += 1;
+    }
+    if (identitySet.siteUser?.loginName) {
+      await this.applyLoginName(identitySet.siteUser.loginName, users, groups);
+    }
+    if (identitySet.siteGroup?.displayName) {
+      groups.add(spGroupRef(identitySet.siteGroup.displayName));
+    }
+    if (identitySet.group?.id) {
+      groups.add(entraGroupRef(identitySet.group.id));
+    }
+  }
+
+  /**
+   * A SharePoint claims login name → whoever it denotes: a user email
+   * (`i:0#.f|membership|user@domain`), an Entra group
+   * (`…|federateddirectoryclaimprovider|<guid>`), or the whole-tenant claim
+   * (`spo-grid-all-users` / `rolemanager|…|true`).
+   */
+  private async applyLoginName(
+    loginName: string,
+    users: Set<string>,
+    groups: Set<string>,
+  ): Promise<void> {
+    const lowered = loginName.toLowerCase();
+    if (
+      lowered.includes("spo-grid-all-users") ||
+      lowered.includes("|rolemanager|") ||
+      lowered === "c:0(.s|true"
+    ) {
+      const tenantUsers = await this.expandTenantUsers();
+      if (tenantUsers) {
+        for (const email of tenantUsers) users.add(email);
+      }
+      return;
+    }
+    if (lowered.includes("|federateddirectoryclaimprovider|")) {
+      const groupId = loginName.split("|").pop();
+      if (groupId) groups.add(entraGroupRef(groupId));
+      else this.droppedPrincipals += 1;
+      return;
+    }
+    if (lowered.startsWith("i:0#.f|membership|")) {
+      const email = loginName.split("|").pop()?.toLowerCase();
+      if (email?.includes("@")) {
+        users.add(email);
+        return;
+      }
+    }
+    const mapped = this.mappedEmailResolver?.(loginName);
+    if (mapped) {
+      users.add(mapped.toLowerCase());
+      return;
+    }
+    this.droppedPrincipals += 1;
+  }
+
+  /** Graph user id → email. Tier: User.Read.All (probed once per pass). */
+  private async resolveGraphUserEmail(userId: string): Promise<string | null> {
+    const cached = this.userEmailCache.get(userId);
+    if (cached !== undefined) return cached;
+    let email: string | null = null;
+    if (await this.hasGraphUsersTier()) {
+      try {
+        const client = this.getGraphClient(
+          this.requirePermCredentials(),
+          this.requirePermConfig(),
+        );
+        await this.rateLimit();
+        const user = (await client
+          .api(
+            `${GRAPH_API_BASE}/users/${userId}?$select=mail,userPrincipalName`,
+          )
+          .get()) as { mail?: string | null; userPrincipalName?: string };
+        email = (user.mail ?? user.userPrincipalName)?.toLowerCase() ?? null;
+      } catch (error) {
+        this.log.debug(
+          { error: extractErrorMessage(error) },
+          "Could not resolve Graph user email",
+        );
+      }
+    }
+    this.userEmailCache.set(userId, email);
+    return email;
+  }
+
+  /**
+   * Entra/M365 group → transitive member roster. Tier: GroupMember.Read.All.
+   * Nested groups arrive pre-flattened (transitiveMembers); non-user
+   * directory objects are skipped. A member whose email is hidden is still
+   * rostered (email: null — admin-visible, override-assignable).
+   */
+  private async expandEntraGroup(
+    groupId: string,
+  ): Promise<GroupMemberYield[] | null> {
+    const cached = this.entraGroupCache.get(groupId);
+    if (cached !== undefined) return cached;
+    if (this.graphGroupsTier === false) return null;
+    let members: GroupMemberYield[] | null = null;
+    try {
+      const client = this.getGraphClient(
+        this.requirePermCredentials(),
+        this.requirePermConfig(),
+      );
+      const byAccount = new Map<string, GroupMemberYield>();
+      let url: string | undefined =
+        `${GRAPH_API_BASE}/groups/${groupId}/transitiveMembers?$select=id,displayName,mail,userPrincipalName,accountEnabled&$top=999`;
+      while (url) {
+        await this.rateLimit();
+        const result = (await client.api(url).get()) as GraphListResponse<{
+          "@odata.type"?: string;
+          id?: string;
+          displayName?: string | null;
+          mail?: string | null;
+          userPrincipalName?: string;
+          accountEnabled?: boolean;
+        }>;
+        for (const member of result.value ?? []) {
+          if (!member.id) continue;
+          const odataType = member["@odata.type"];
+          // transitiveMembers mixes users with nested groups/devices; only
+          // user objects carry access. Entries without a type hint are kept
+          // when they look like users (have a UPN).
+          if (odataType && !odataType.endsWith("user")) continue;
+          if (!odataType && !member.userPrincipalName && !member.mail) {
+            continue;
+          }
+          const email =
+            member.accountEnabled === false
+              ? null
+              : ((member.mail ?? member.userPrincipalName)?.toLowerCase() ??
+                null);
+          byAccount.set(member.id, {
+            accountId: member.id,
+            displayName: member.displayName ?? null,
+            email,
+          });
+        }
+        url = result["@odata.nextLink"] ?? undefined;
+      }
+      members = [...byAccount.values()];
+      this.graphGroupsTier = true;
+    } catch (error) {
+      if (isGraphForbidden(error)) {
+        this.graphGroupsTier = false;
+        this.log.warn(
+          "Entra group expansion denied (GroupMember.Read.All missing); group memberships degrade fail-closed for this pass",
+        );
+      } else {
+        this.log.warn(
+          { error: extractErrorMessage(error) },
+          "Could not expand Entra group; its memberships are dropped fail-closed",
+        );
+      }
+      this.droppedPrincipals += 1;
+    }
+    this.entraGroupCache.set(groupId, members);
+    return members;
+  }
+
+  /**
+   * SharePoint site group → member roster via the site's REST API (Graph
+   * cannot expand site groups). Tier: SharePoint Sites.FullControl.All —
+   * the SAME app registration, a second token audience. Direct users roster
+   * by email/claims; a nested Entra-group claim is flattened through the
+   * Graph roster expansion (Salesforce nesting precedent); a whole-tenant
+   * claim cannot be rostered and is kept as an email-less member so the
+   * admin can see it rather than it vanishing.
+   */
+  private async expandSpGroup(
+    title: string,
+  ): Promise<GroupMemberYield[] | null> {
+    const cached = this.spGroupCache.get(title);
+    if (cached !== undefined) return cached;
+    if (this.spRestTier === false) return null;
+    let members: GroupMemberYield[] | null = null;
+    const token = await this.getSpAccessToken();
+    const siteUrl = this.permConfig?.siteUrl;
+    if (token && siteUrl) {
+      try {
+        const path = `_api/web/sitegroups/getbyname('${encodeURIComponent(title).replace(/'/g, "''")}')/users?$select=Email,LoginName,Title&$top=5000`;
+        const response = await this.fetchWithRetry(
+          `${siteUrl.replace(/\/+$/, "")}/${path}`,
+          {
+            headers: {
+              authorization: `Bearer ${token}`,
+              accept: "application/json;odata=nometadata",
+            },
+          },
+        );
+        if (response.status === 401 || response.status === 403) {
+          throw new SpRestForbiddenError();
+        }
+        if (!response.ok) {
+          throw new Error(`SharePoint REST ${response.status}`);
+        }
+        const body = (await response.json()) as {
+          value?: Array<{ Email?: string; LoginName?: string; Title?: string }>;
+        };
+        const byAccount = new Map<string, GroupMemberYield>();
+        for (const member of body.value ?? []) {
+          const loginName = member.LoginName ?? "";
+          const lowered = loginName.toLowerCase();
+          if (lowered.includes("|federateddirectoryclaimprovider|")) {
+            const nestedId = loginName.split("|").pop();
+            const nested = nestedId
+              ? await this.expandEntraGroup(nestedId)
+              : null;
+            for (const m of nested ?? []) byAccount.set(m.accountId, m);
+            continue;
+          }
+          const accountId = loginName || member.Email?.toLowerCase();
+          if (!accountId) continue;
+          const claimEmail = lowered.startsWith("i:0#.f|membership|")
+            ? loginName.split("|").pop()?.toLowerCase()
+            : undefined;
+          const email =
+            member.Email?.toLowerCase() ??
+            (claimEmail?.includes("@") ? claimEmail : null);
+          byAccount.set(accountId, {
+            accountId,
+            displayName: member.Title ?? null,
+            email,
+            accountType: "siteUser",
+          });
+        }
+        members = [...byAccount.values()];
+        this.spRestTier = true;
+      } catch (error) {
+        if (error instanceof SpRestForbiddenError) {
+          this.spRestTier = false;
+          this.log.warn(
+            "SharePoint REST denied (SharePoint Sites.FullControl.All missing); site-group memberships degrade fail-closed for this pass",
+          );
+        } else {
+          this.log.warn(
+            { error: extractErrorMessage(error) },
+            "Could not expand SharePoint site group; its memberships are dropped fail-closed",
+          );
+        }
+        this.droppedPrincipals += 1;
+      }
+    }
+    this.spGroupCache.set(title, members);
+    return members;
+  }
+
+  /** All active tenant users (org-wide links). Tier: User.Read.All. */
+  private async expandTenantUsers(): Promise<string[] | null> {
+    if (this.tenantUsersCache !== undefined) return this.tenantUsersCache;
+    let members: string[] | null = null;
+    if (await this.hasGraphUsersTier()) {
+      try {
+        const client = this.getGraphClient(
+          this.requirePermCredentials(),
+          this.requirePermConfig(),
+        );
+        const emails = new Set<string>();
+        let url: string | undefined =
+          `${GRAPH_API_BASE}/users?$select=mail,userPrincipalName,accountEnabled&$top=999`;
+        while (url) {
+          await this.rateLimit();
+          const result = (await client.api(url).get()) as GraphListResponse<{
+            mail?: string | null;
+            userPrincipalName?: string;
+            accountEnabled?: boolean;
+          }>;
+          for (const user of result.value ?? []) {
+            if (user.accountEnabled === false) continue;
+            const email = (user.mail ?? user.userPrincipalName)?.toLowerCase();
+            if (email) emails.add(email);
+          }
+          url = result["@odata.nextLink"] ?? undefined;
+        }
+        members = [...emails];
+      } catch (error) {
+        this.log.warn(
+          { error: extractErrorMessage(error) },
+          "Could not enumerate tenant users; organization-wide links degrade fail-closed for this pass",
+        );
+      }
+    }
+    if (!members) this.droppedPrincipals += 1;
+    this.tenantUsersCache = members;
+    return members;
+  }
+
+  /** User.Read.All probe, cached per pass. */
+  private async hasGraphUsersTier(): Promise<boolean> {
+    if (this.graphUsersTier === null) {
+      try {
+        const client = this.getGraphClient(
+          this.requirePermCredentials(),
+          this.requirePermConfig(),
+        );
+        await this.rateLimit();
+        await client.api(`${GRAPH_API_BASE}/users?$select=id&$top=1`).get();
+        this.graphUsersTier = true;
+      } catch (error) {
+        this.graphUsersTier = false;
+        this.log.debug(
+          { error: extractErrorMessage(error) },
+          "Graph users tier unavailable (User.Read.All missing); Graph-id principals drop fail-closed",
+        );
+      }
+    }
+    return this.graphUsersTier;
+  }
+
+  /** SharePoint-resource access token for the SAME app registration. */
+  private async getSpAccessToken(): Promise<string | null> {
+    if (this.spAccessToken) return this.spAccessToken;
+    const credentials = this.permCredentials;
+    const config = this.permConfig;
+    if (!credentials?.email || !config) return null;
+    try {
+      const hostname = new URL(config.siteUrl).hostname;
+      const credential = new ClientSecretCredential(
+        config.tenantId,
+        credentials.email,
+        credentials.apiToken,
+      );
+      const token = await credential.getToken(`https://${hostname}/.default`);
+      this.spAccessToken = token?.token ?? null;
+    } catch (error) {
+      this.log.debug(
+        { error: extractErrorMessage(error) },
+        "Could not acquire a SharePoint-resource token",
+      );
+      this.spAccessToken = null;
+    }
+    return this.spAccessToken;
+  }
+
+  private requirePermCredentials(): ConnectorCredentials {
+    if (!this.permCredentials) throw new Error("permission pass not armed");
+    return this.permCredentials;
+  }
+
+  private requirePermConfig(): SharePointConfig {
+    if (!this.permConfig) throw new Error("permission pass not armed");
+    return this.permConfig;
+  }
+
+  /** Surface principals dropped this pass (fail-closed under-grant). */
+  private reportDroppedPrincipals(): void {
+    if (this.droppedPrincipals <= 0) return;
+    const count = this.droppedPrincipals;
+    this.droppedPrincipals = 0;
+    this.log.debug(
+      { count, connectorType: this.type },
+      "Dropped SharePoint principals that could not be resolved (fail-closed)",
+    );
+    metrics.rag.reportPermissionSyncDroppedPrincipals({
+      connectorType: this.type,
+      reason: "no_email",
+      count,
+    });
+  }
 }
 
 // ===== Module-level helpers =====
@@ -991,6 +2214,78 @@ type GraphListResponse<T> = {
   value: T[];
   "@odata.nextLink"?: string;
 };
+
+// ===== Permission-sync types =====
+
+const PERMISSION_READBACK_PAGE_SIZE = 1000;
+/** Scanning-guidance preference: mark permission-hierarchy roots. */
+const DELTA_ENUM_PREFER = "deltashowremovedasdeleted, hierarchicalsharing";
+/** Elevated probe preference: annotate items whose SHARING changed. */
+const DELTA_SHARING_PREFER =
+  "deltashowremovedasdeleted, deltatraversepermissiongaps, deltashowsharingchanges";
+const DELTA_PLAIN_PREFER = "deltashowremovedasdeleted";
+
+/** A top-level permission container: a document library, or the site's pages. */
+type SpContainer = { key: string; kind: "drive" | "site" };
+
+/** One buffered delta-walk item (ids + the unique-permissions marker only). */
+type DeltaItemEntry = { parentId: string | null; scopeRoot: boolean };
+
+type GraphDeltaPage = {
+  value?: Array<{
+    id: string;
+    parentReference?: { id?: string };
+    deleted?: object;
+    shared?: object;
+    "@microsoft.graph.sharedChanged"?: string | boolean;
+  }>;
+  "@odata.nextLink"?: string;
+  "@odata.deltaLink"?: string;
+};
+
+/** Narrowed Graph permission resource (the facets we read). */
+type SpPermission = {
+  link?: { scope?: string };
+  grantedToV2?: SpIdentitySet;
+  grantedToIdentitiesV2?: SpIdentitySet[];
+};
+
+type SpIdentitySet = {
+  user?: { id?: string; displayName?: string };
+  siteUser?: { loginName?: string; displayName?: string };
+  siteGroup?: { displayName?: string };
+  group?: { id?: string };
+  application?: { id?: string };
+};
+
+/**
+ * Roster group ids — byte-matched between the audience path's `groups` refs
+ * and `syncGroups` yields (the `group:sharepoint_<id>` token contract).
+ */
+function entraGroupRef(groupId: string): string {
+  return `entra:${groupId}`;
+}
+function spGroupRef(title: string): string {
+  return `sitegroup:${title}`;
+}
+/** Synthetic roster group for direct (non-group) grantees. */
+const DIRECT_GRANTS_GROUP_ID = "direct-grants";
+
+class SpRestForbiddenError extends Error {
+  constructor() {
+    super("SharePoint REST forbidden");
+  }
+}
+
+function emptyAudience(): DocumentPermissions {
+  return { isPublic: false, users: [], groups: [] };
+}
+
+/** 401/403 from the Graph SDK (statusCode on the thrown object). */
+function isGraphForbidden(error: unknown): boolean {
+  const status = (error as { statusCode?: number })?.statusCode;
+  return status === 401 || status === 403;
+}
 
 // Narrowed from @microsoft/microsoft-graph-types using Pick + Required + NonNullable.
 // Our $select queries guarantee these fields are present and non-null.

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
@@ -322,15 +322,17 @@ export function getConnectorTypeLabel(type: ConnectorType): string {
 // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
 /**
  * Connector types whose backend implementation supports auto-sync-permissions
- * (`supportsPermissionSync`). Stage 1: GitHub, Confluence, Jira, Google Drive. Keep in sync
- * with the connectors that set `supportsPermissionSync = true`; the backend
- * re-validates on create/update (400 otherwise), so this only gates the UI.
+ * (`supportsPermissionSync`). Keep in sync with the connectors that set
+ * `supportsPermissionSync = true`; the backend re-validates on create/update
+ * (400 otherwise), so this only gates the UI.
  */
 const AUTO_SYNC_CONNECTOR_TYPES: ReadonlySet<ConnectorType> = new Set([
   "github",
   "confluence",
   "jira",
   "gdrive",
+  "sharepoint",
+  "salesforce",
 ]);
 
 export function connectorSupportsAutoSync(type: ConnectorType): boolean {


### PR DESCRIPTION
Adds knowledge-base permission auto-sync (`auto-sync-permissions` visibility) support for the **SharePoint** and **Salesforce** connectors, joining the existing Jira/Confluence/GitHub implementations. Google Drive was decomposed out of the original task and is not part of this PR.

Origin: PM task T-907 ([thread](https://slack.com/archives/C0B2AGC0AFQ/p1786021571648129?thread_ts=1784311583.399659&cid=C0B2AGC0AFQ)).

Everything is connector-local — the permission-sync pass, scheduler, routes, and frontend already key off `supportsPermissionSync`, so no core changes were needed.

## SharePoint

- Containers `drive:<driveId>` per document library, `site:<siteId>` for site pages (pages take the default drive's root audience — Graph v1.0 exposes no page-level permissions; documented approximation).
- Unique-permission detection rides the delta feed's `hierarchicalsharing` preference (the mechanism from Microsoft's scanning guidance), so it costs no per-item requests; a document joins its nearest uniquely-permissioned ancestor's nested `item:` container.
- Group grants emit group tokens (`entra:<guid>` / `sitegroup:<title>`), and a `syncGroups` roster snapshots each granted group's members (Entra via `transitiveMembers`, site groups via the site's REST API with a SharePoint-audience token from the same app registration) — so the Users/Groups tabs populate, unresolvable accounts surface as Unassigned, and admin member overrides work (group resolution at query time; direct grants via `resolveMappedEmail`). Direct grantees roster under a synthetic `direct-grants` group; tenant-wide links still expand inline to the tenant's active users. The roster walks library-root surfaces — a group granted only on a nested item shows in the Groups tab but resolves no members until granted at library level (bounded: neither site groups nor granted Entra groups are globally enumerable).
- Progressive elevation, probed lazily and always degrading fail-closed: `User.Read.All` (user emails + tenant links) → `GroupMember.Read.All` (Entra groups) → `Sites.FullControl.All` (site-group expansion + sharing-aware delta probes via `deltashowsharingchanges`). A 403 falls back to coarse probing; a 410 delta-token resync promotes to a full reconcile.

## Salesforce

- Containers `sobject:<ObjectName>` per synced object; the org-wide-default sharing model (Metadata API, same session — no extra credential tier) decides the shape: public objects resolve to one `isPublic` container; private objects resolve per-record nested containers from owner + `<Obj>Share` rows (chunked by ParentId, RowCause-filtered, guest causes excluded). Contacts inherit their parent Account's resolved audience.
- Groups sync via Group/GroupMember with recursive nesting (role-hierarchy groups arrive pre-expanded by Salesforce); group ids byte-match share-row grantee ids. Direct grant-holders (record owners and per-user share grantees, one distinct-value SOQL per surface) roster under a synthetic `direct-grants` group, and member overrides materialize owner/user-share access via `resolveMappedEmail` — so unresolvable accounts are Users-tab-visible and assignable. Inactive users stay rostered but never resolve.
- The probe watches record edits, share writes, and share **deletions** (`getDeleted`) per object — an object whose share table cannot report deletions stays always-dirty rather than risking a missed revocation.
- `UserRecordAccess` was rejected: O(users × records / 200) per pass and it ignores restriction rules. Documented under-grant-only gaps: restriction rules, territories, high-volume portal shares.

Both connectors follow the Jira/Confluence invariants: per-container/per-group failure isolation with `audienceResolutionFailed` (an upstream read error fail-closes that scope only and is never reported as "nobody has access"), empty-corpus boundary containers, monotonic resume cursors, and dropped-principal metrics.

## Test plan

- 96 connector tests (54 SharePoint + 42 Salesforce) covering audiences, exception containers, byte-match contracts, every degradation tier, and probe transitions; 52 pass-machinery tests re-run green.
- Live-verified on a dev stack: registry discovery, the create-gate admitting both types with `auto-sync-permissions`, probe fallback and tier degradation observed in task-queue logs, plus a seeded fixture set for manual QA.
- Docs updated (`platform-knowledge.md`): support table + per-provider permission tier matrices.

