### PR TITLE
fix(proxy): stop refusing client-declared tools on non-Anthropic providers

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -242,25 +242,20 @@ describe("AnthropicRequestAdapter", () => {
       { type: "text_editor_20250124", name: "str_replace_editor" },
     ] as unknown as Anthropic.Types.MessagesRequest["tools"];
 
-    // The availability set is built from the declared names, so built-ins are
-    // counted even though getTools() drops them. The two must not converge:
-    // getTools() feeds persistence and other callers that want schemas.
-    test("getDeclaredToolNames counts built-ins that getTools drops", () => {
+    // getTools() feeds persistence and other callers that want schemas, so it
+    // drops the schema-less built-ins. That loss is why availability is read
+    // from the request body instead — see utils/declared-tool-names.
+    test("getTools drops built-ins that carry no schema", () => {
       const adapter = anthropicAdapterFactory.createRequestAdapter(
         createMockRequest(messages, { tools }),
       );
 
-      expect(adapter.getDeclaredToolNames?.()).toEqual([
-        "github__list_issues",
-        "bash",
-        "str_replace_editor",
-      ]);
       expect(adapter.getTools().map((t) => t.name)).toEqual([
         "github__list_issues",
       ]);
     });
 
-    test("a request declaring only built-ins still names them", () => {
+    test("a request declaring only built-ins has no schema-carrying tools", () => {
       const adapter = anthropicAdapterFactory.createRequestAdapter(
         createMockRequest(messages, {
           tools: [
@@ -269,8 +264,10 @@ describe("AnthropicRequestAdapter", () => {
         }),
       );
 
-      expect(adapter.getDeclaredToolNames?.()).toEqual(["bash"]);
       expect(adapter.getTools()).toEqual([]);
+      // The caller did declare a tool, so the request still counts as having
+      // one even though nothing schema-carrying survives getTools().
+      expect(adapter.hasTools()).toBe(true);
     });
 
     test("is empty when no tools are declared", () => {
@@ -278,25 +275,8 @@ describe("AnthropicRequestAdapter", () => {
         createMockRequest(messages),
       );
 
-      expect(adapter.getDeclaredToolNames?.()).toEqual([]);
+      expect(adapter.getTools()).toEqual([]);
       expect(adapter.hasTools()).toBe(false);
-    });
-
-    // These names become availability-set members, so an entry with no usable
-    // name must not land in the set — nothing a model can call would match it,
-    // and it would make an otherwise-empty set look populated.
-    test("skips entries carrying no usable name", () => {
-      const adapter = anthropicAdapterFactory.createRequestAdapter(
-        createMockRequest(messages, {
-          tools: [
-            { type: "bash_20250124" },
-            { name: "" },
-            { name: "kept", input_schema: { type: "object", properties: {} } },
-          ] as unknown as Anthropic.Types.MessagesRequest["tools"],
-        }),
-      );
-
-      expect(adapter.getDeclaredToolNames?.()).toEqual(["kept"]);
     });
   });
 

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -175,14 +175,6 @@ class AnthropicRequestAdapter
     return result;
   }
 
-  getDeclaredToolNames(): string[] {
-    return (this.request.tools ?? [])
-      .map((tool) => (tool as { name?: unknown }).name)
-      .filter(
-        (name): name is string => typeof name === "string" && name !== "",
-      );
-  }
-
   hasTools(): boolean {
     return (this.request.tools?.length ?? 0) > 0;
   }

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -1157,11 +1157,9 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       expect(response.body).not.toContain('"finish_reason":"tool_calls"');
     });
 
-    // Only the Anthropic adapter names its declared tools; every other one
-    // falls back to getTools(). The fallback is what keeps the availability
-    // check running for those providers, and a regression that yielded an empty
-    // set here would disable filtering rather than fail loudly.
-    test("a provider that cannot name its declared tools falls back to getTools", async () => {
+    // The availability set is read from the request body for every provider,
+    // so the ordinary function-tool shape has to keep working unchanged.
+    test("names the function tools a caller declared", async () => {
       openAiStubOptions.includeToolCalls = true;
       mockEvaluatePolicies.mockResolvedValue(null);
 
@@ -1193,6 +1191,83 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       const enabledToolNames = mockEvaluatePolicies.mock
         .calls[0][4] as Set<string>;
       expect([...enabledToolNames]).toEqual(["get_weather"]);
+    });
+
+    // The regression this guards: a caller declares a tool it executes itself
+    // in a shape getTools() drops (here a freeform `custom` tool — the same
+    // loss that hides Anthropic built-ins and every non-function tool on the
+    // Responses surface). Sourcing availability from that view refused the call
+    // and told the model to stop trying, costing it a capability mid-turn.
+    test("a client-declared tool getTools drops is not refused", async () => {
+      openAiStubOptions.includeToolCalls = true;
+      const { evaluatePolicies } = await vi.importActual<
+        typeof import("@/guardrails/tool-invocation")
+      >("@/guardrails/tool-invocation");
+      mockEvaluatePolicies.mockImplementation((...args) =>
+        evaluatePolicies(...(args as Parameters<typeof evaluatePolicies>)),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+          // The only shape the caller has to declare this in — no `function`
+          // wrapper, so the adapter's tool view cannot see it.
+          tools: [{ type: "custom", custom: { name: "get_weather" } }],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const enabledToolNames = mockEvaluatePolicies.mock
+        .calls[0][4] as Set<string>;
+      expect([...enabledToolNames]).toEqual(["get_weather"]);
+      expect(response.body).not.toContain("are not enabled for this");
+      // The call reaches the caller, so it can actually run the tool.
+      expect(response.body).toContain("get_weather");
+      expect(response.body).toContain('"finish_reason":"tool_calls"');
+    });
+
+    // The other half of the contract: widening what counts as declared must not
+    // hollow out the check. A tool the caller never declared is still refused,
+    // which is what per-conversation tool selection relies on.
+    test("a tool the caller never declared is still refused", async () => {
+      openAiStubOptions.includeToolCalls = true;
+      const { evaluatePolicies } = await vi.importActual<
+        typeof import("@/guardrails/tool-invocation")
+      >("@/guardrails/tool-invocation");
+      mockEvaluatePolicies.mockImplementation((...args) =>
+        evaluatePolicies(...(args as Parameters<typeof evaluatePolicies>)),
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+          // The stub calls `get_weather`, which this request never declares.
+          tools: [{ type: "custom", custom: { name: "something_else" } }],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const enabledToolNames = mockEvaluatePolicies.mock
+        .calls[0][4] as Set<string>;
+      expect([...enabledToolNames]).toEqual(["something_else"]);
+      expect(response.body).toContain("are not enabled for this");
+      expect(response.body).not.toContain('"finish_reason":"tool_calls"');
     });
 
     // The refusal sibling above only pins that a refused call is absent, which

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -1176,10 +1176,11 @@ export async function handleLLMProxy<
     const finalRequest = requestAdapter.toProviderRequest();
 
     // Which called tool names count as available to evaluatePolicies, in the
-    // canonical form tool-call names are compared in. Declared names rather
-    // than `getTools()`, which keeps only schema-carrying custom tools: a
-    // provider built-in the caller declared and executes itself (Anthropic's
-    // bash/text_editor/computer) is absent from that list, so every call to
+    // canonical form tool-call names are compared in. Read from the request
+    // body rather than `getTools()`, which keeps only schema-carrying function
+    // tools: a tool the caller declared and executes itself (Anthropic's
+    // bash/text_editor/computer, OpenAI chat `custom` tools, every non-function
+    // tool on the Responses surface) is absent from that list, so every call to
     // one would be refused.
     //
     // Those names resolve to no `toolsTable` row, so no policy speaks for them
@@ -1188,11 +1189,8 @@ export async function handleLLMProxy<
     // them, and leaves the client — which is the one executing them — as the
     // boundary that governs them.
     const enabledToolNames = new Set(
-      (
-        requestAdapter.getDeclaredToolNames?.() ??
-        requestAdapter.getTools().map((t) => t.name)
-      )
-        .filter(Boolean)
+      utils
+        .collectDeclaredToolNames(requestAdapter.getOriginalRequest())
         .map(canonicalizeToolName),
     );
 

--- a/platform/backend/src/routes/proxy/utils/declared-tool-names.test.ts
+++ b/platform/backend/src/routes/proxy/utils/declared-tool-names.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "vitest";
+import { collectDeclaredToolNames } from "./declared-tool-names";
+
+describe("collectDeclaredToolNames", () => {
+  describe("Anthropic messages", () => {
+    // Built-ins carry a `type` and no input schema, so getTools() drops them.
+    // The caller runs them itself, so the availability set has to count them.
+    test("counts custom tools and schema-less built-ins alike", () => {
+      expect(
+        collectDeclaredToolNames({
+          tools: [
+            {
+              name: "github__list_issues",
+              description: "list issues",
+              input_schema: { type: "object", properties: {} },
+            },
+            { type: "bash_20250124", name: "bash" },
+            { type: "text_editor_20250124", name: "str_replace_editor" },
+          ],
+        }),
+      ).toEqual(["github__list_issues", "bash", "str_replace_editor"]);
+    });
+
+    test("a request declaring only built-ins still names them", () => {
+      expect(
+        collectDeclaredToolNames({
+          tools: [{ type: "bash_20250124", name: "bash" }],
+        }),
+      ).toEqual(["bash"]);
+    });
+  });
+
+  describe("OpenAI chat completions", () => {
+    test("names function tools", () => {
+      expect(
+        collectDeclaredToolNames({
+          tools: [
+            {
+              type: "function",
+              function: { name: "get_weather", parameters: {} },
+            },
+          ],
+        }),
+      ).toEqual(["get_weather"]);
+    });
+
+    // Freeform custom tools name themselves under `custom`, not `function`, so
+    // the adapter's function-only view drops them entirely.
+    test("names freeform custom tools alongside function tools", () => {
+      expect(
+        collectDeclaredToolNames({
+          tools: [
+            { type: "function", function: { name: "get_weather" } },
+            { type: "custom", custom: { name: "run_sql" } },
+          ],
+        }),
+      ).toEqual(["get_weather", "run_sql"]);
+    });
+  });
+
+  describe("OpenAI Responses", () => {
+    // Responses tools name themselves at the top level, and everything that is
+    // not `type: "function"` is dropped by the adapter's view.
+    test("names function tools and provider built-ins", () => {
+      expect(
+        collectDeclaredToolNames({
+          tools: [
+            { type: "function", name: "Grep", parameters: {} },
+            { type: "web_search" },
+            { type: "computer_use_preview", name: "computer" },
+          ],
+        }),
+      ).toEqual(["Grep", "computer"]);
+    });
+  });
+
+  describe("other provider shapes", () => {
+    test("Gemini groups declarations under one tool entry", () => {
+      expect(
+        collectDeclaredToolNames({
+          tools: [
+            {
+              functionDeclarations: [
+                { name: "get_weather" },
+                { name: "get_time" },
+              ],
+            },
+          ],
+        }),
+      ).toEqual(["get_weather", "get_time"]);
+    });
+
+    test("Gemini accepts a lone tool object instead of an array", () => {
+      expect(
+        collectDeclaredToolNames({
+          tools: { functionDeclarations: [{ name: "get_weather" }] },
+        }),
+      ).toEqual(["get_weather"]);
+    });
+
+    test("Bedrock Converse nests its tools under toolConfig", () => {
+      expect(
+        collectDeclaredToolNames({
+          toolConfig: {
+            tools: [{ toolSpec: { name: "get_weather", inputSchema: {} } }],
+          },
+        }),
+      ).toEqual(["get_weather"]);
+    });
+  });
+
+  describe("entries with no usable name", () => {
+    // An unusable entry must not land in the set: nothing a model can call
+    // would match it, and on a request that declares nothing else it would turn
+    // an empty set into a populated one — switching the check on and refusing
+    // every call the caller actually declared.
+    test("skips entries that name nothing", () => {
+      expect(
+        collectDeclaredToolNames({
+          tools: [
+            { type: "bash_20250124" },
+            { name: "" },
+            { type: "function", function: {} },
+            null,
+            "not-a-tool",
+            { name: "kept", input_schema: { type: "object" } },
+          ],
+        }),
+      ).toEqual(["kept"]);
+    });
+
+    test("is empty when no tools are declared", () => {
+      expect(collectDeclaredToolNames({ model: "gpt-4o" })).toEqual([]);
+    });
+
+    test("is empty for a body that is not an object", () => {
+      expect(collectDeclaredToolNames(undefined)).toEqual([]);
+      expect(collectDeclaredToolNames("nonsense")).toEqual([]);
+    });
+  });
+});

--- a/platform/backend/src/routes/proxy/utils/declared-tool-names.ts
+++ b/platform/backend/src/routes/proxy/utils/declared-tool-names.ts
@@ -1,0 +1,106 @@
+/**
+ * Every tool name a caller declared, read from the request body itself rather
+ * than from an adapter's parsed view of it.
+ *
+ * The proxy decides which of the model's tool calls count as available from
+ * the names the caller declared. Sourcing that from
+ * `LLMRequestAdapter.getTools()` is lossy by design: that method exists to feed
+ * persistence, so every adapter keeps only the schema-carrying function tools
+ * it can describe and drops the rest — Anthropic's `bash`/`text_editor`
+ * built-ins, OpenAI chat `custom` tools, every non-function tool on the
+ * Responses surface. The caller executes those itself, so dropping them refuses
+ * calls it explicitly asked for, and the refusal tells the model to stop
+ * trying.
+ *
+ * Reading the body keeps that correct for every provider at once, including
+ * ones added later: there is no per-adapter method to forget to implement, so a
+ * new adapter cannot silently reintroduce the refusal. Only the container and
+ * item shapes differ between providers, and they are enumerated below.
+ *
+ * This is deliberately permissive about *which* names it counts. A name here
+ * only ever makes a tool reachable, and everything it admits is something the
+ * caller put in its own request — the tools the guardrail exists to refuse are
+ * the ones absent from that request, and they stay absent.
+ */
+export function collectDeclaredToolNames(request: unknown): string[] {
+  const names: string[] = [];
+  for (const container of toolContainers(request)) {
+    for (const tool of container) {
+      collectToolNames(tool, names);
+    }
+  }
+  return names;
+}
+
+// === Internal helpers ===
+
+/**
+ * The arrays a request keeps its tool declarations in: `tools` for nearly
+ * everyone, plus Bedrock Converse's `toolConfig.tools`.
+ */
+function toolContainers(request: unknown): unknown[][] {
+  if (!isRecord(request)) {
+    return [];
+  }
+
+  const containers: unknown[][] = [];
+  const add = (value: unknown) => {
+    if (Array.isArray(value)) {
+      containers.push(value);
+    } else if (isRecord(value)) {
+      // Gemini accepts a lone tool object anywhere it accepts an array.
+      containers.push([value]);
+    }
+  };
+
+  add(request.tools);
+  if (isRecord(request.toolConfig)) {
+    add(request.toolConfig.tools);
+  }
+  return containers;
+}
+
+function collectToolNames(tool: unknown, names: string[]): void {
+  if (!isRecord(tool)) {
+    return;
+  }
+
+  // Anthropic (custom tools and built-ins alike), OpenAI Responses.
+  addName(tool.name, names);
+  // OpenAI chat completions and every OpenAI-compatible provider.
+  addNestedName(tool.function, names);
+  // OpenAI chat completions freeform custom tools.
+  addNestedName(tool.custom, names);
+  // Bedrock Converse.
+  addNestedName(tool.toolSpec, names);
+
+  // Gemini groups its declarations under a single tool entry.
+  if (Array.isArray(tool.functionDeclarations)) {
+    for (const declaration of tool.functionDeclarations) {
+      if (isRecord(declaration)) {
+        addName(declaration.name, names);
+      }
+    }
+  }
+}
+
+function addNestedName(value: unknown, names: string[]): void {
+  if (isRecord(value)) {
+    addName(value.name, names);
+  }
+}
+
+/**
+ * An entry with no usable name must not land in the set: nothing a model can
+ * call would match it, and it would make an otherwise-empty set look populated
+ * — which turns the check on and refuses everything else the caller declared.
+ */
+function addName(name: unknown, names: string[]): void {
+  if (typeof name === "string" && name !== "") {
+    names.push(name);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/platform/backend/src/routes/proxy/utils/index.ts
+++ b/platform/backend/src/routes/proxy/utils/index.ts
@@ -4,6 +4,7 @@ export * as tracing from "@/observability/tracing";
 export * as tokenizers from "@/tokenizers";
 export { resolveInteractionBillingMode } from "./billing-mode";
 export * as costOptimization from "./cost-optimization";
+export { collectDeclaredToolNames } from "./declared-tool-names";
 export * as gatewayToolNames from "./gateway-tool-names";
 export * as headers from "./headers";
 export { checkModelTeamAccess } from "./model-team-access";

--- a/platform/backend/src/types/llm-provider.ts
+++ b/platform/backend/src/types/llm-provider.ts
@@ -107,17 +107,15 @@ export interface LLMRequestAdapter<TRequest, TMessages = unknown> {
   /** Get tool results from messages (for trusted data evaluation) */
   getToolResults(): CommonToolResult[];
 
-  /** Get tool definitions (for persistence, hasTools check) */
-  getTools(): CommonMcpToolDefinition[];
-
   /**
-   * Every tool name the caller declared, including provider built-ins that
-   * `getTools()` omits because they carry no input schema (Anthropic's
-   * `bash`/`text_editor`/`computer`). The caller executes those itself, so an
-   * availability check has to count them or every call to one is refused.
-   * Adapters that don't implement it fall back to `getTools()`.
+   * Get tool definitions (for persistence, hasTools check).
+   *
+   * Lossy on purpose: it keeps only the schema-carrying function tools this
+   * provider can describe. Do not use it to decide which tool calls the caller
+   * made available — that comes from `collectDeclaredToolNames`, which reads
+   * the request body and so counts built-ins and other schema-less tools too.
    */
-  getDeclaredToolNames?(): string[];
+  getTools(): CommonMcpToolDefinition[];
 
   /** Check if request has tools */
   hasTools(): boolean;


### PR DESCRIPTION
## Symptom

A client routed through a non-Anthropic provider called one of its **own** built-in tools and, instead of running it, got back a synthetic result:

> The tools "…" are not enabled for this conversation and were not run. Do not call them again here.

The client declares that tool in its request and executes it itself — the proxy has no business refusing it. Worse, the message tells the model to stop trying, so it loses a capability mid-conversation and starts working around it. It did not reproduce on a direct Anthropic passthrough.

## Root cause

`handleLLMProxy` builds `enabledToolNames` — the set deciding which of the model's tool calls count as available — like this:

```ts
requestAdapter.getDeclaredToolNames?.() ?? requestAdapter.getTools().map((t) => t.name)
```

`getDeclaredToolNames` was **optional on the interface and implemented by exactly one adapter** (`adapters/anthropic.ts`). Every other provider fell through to `getTools()`.

`getTools()` exists to feed persistence, so each adapter keeps only the schema-carrying function tools it can describe and drops everything else:

| Shape | Dropped by `getTools()` |
| --- | --- |
| OpenAI chat completions | `type: "custom"` freeform tools (name lives at `custom.name`, not `function.name`) |
| OpenAI Responses (`openai-responses`, `azure-responses`, and everything composing them) | every non-`function` tool — `web_search`, `computer_use_preview`, `local_shell`, `custom` |
| Anthropic | schema-less built-ins (`bash`, `text_editor`) — the case `getDeclaredToolNames` was added for |

So the fix applied for Anthropic never reached any other provider, and the comment above the code already warned this was the lossy path.

### The same defect also silently disabled the check

`evaluatePolicies` (`guardrails/tool-invocation.ts:226`) wraps the filter in `if (enabledToolNames && enabledToolNames.size > 0)`, so an empty set means "skip filtering" rather than "nothing is available". That makes the extraction bug cut two ways depending on what the caller declared:

| What the caller declared | Extracted set | Result on `main` |
| --- | --- | --- |
| only function tools | complete | correct |
| function tools **and** dropped-shape tools | partial | dropped-shape tools **spuriously refused** |
| only dropped-shape tools | **empty** | filter silently no-ops — **nothing is refused, including tools that genuinely are disabled** |

The third row is the more serious one: for those requests the per-conversation tool-disabling filter was not enforced at all. It is directly observable on `main` — run this PR's `a tool the caller never declared is still refused` against unmodified `main` and the set comes back `[]`, so the model's call to a tool the request never mentions goes through.

Scope, precisely: this is the *enabled-tools filter*, not all enforcement. With an empty set `filteredToolCalls` keeps every call and evaluation continues, so tool-invocation policies and trusted-data policies still ran normally. And it only ever affected requests where *every* declaration was of a shape `getTools()` drops.

Both rows are closed by the same change, and each has a test: `a client-declared tool getTools drops is not refused` pins the spurious refusal, `a tool the caller never declared is still refused` pins the silent no-op. Both fail on `main`.

## The fix

One change, at the single point where the set is built. `enabledToolNames` now comes from `collectDeclaredToolNames(requestAdapter.getOriginalRequest())` — the tool names read from the request body itself, enumerating the container/item shapes (`tools[]`, Bedrock's `toolConfig.tools[]`; `name`, `function.name`, `custom.name`, `toolSpec.name`, Gemini's `functionDeclarations[]`).

Reading the body makes the correct behavior automatic for all ~87 adapters and any added later. The optional `getDeclaredToolNames` and its lone implementation are **removed**, so there is no per-adapter method left to forget — a provider added next year cannot silently reintroduce this.

**The guardrail is not weakened.** A name only counts if the caller put it in its own request; tools that were never declared stay absent from the set and are still refused, which is what per-conversation tool selection relies on. `archestra__*` tools and `run_tool` dispatch targets are untouched. Anthropic behavior is byte-identical — the generic extractor subsumes the adapter's old implementation, and the handler tests that pin it were not modified.

Notes on things I checked and ruled out:
- **Delegating adapters** (`groq`, `azure`, `mistral`, `openrouter`, `xai`, `bedrock-invoke`) delegate `getTools()` to an inner adapter, so they inherited the same loss; they are fixed by the same single change.
- **Concrete adapters on the affected paths.** Each OpenAI-compatible chat provider builds `OpenAIRequestAdapter` (`adapters/openai.ts:299`) via `createOpenAiCompatibleAdapterFactory`; each Responses-surface provider builds `OpenAiResponsesRequestAdapter` (`adapters/openai-responses.ts:195`). Neither implemented `getDeclaredToolNames`, so both were affected, and both are fixed here.
- **Translator adapter classes were never the gap.** `makeAnthropicOpenaiAdapterFactory` (`adapters/anthropic-openai.ts`) serves the OpenAI-shaped-client → Anthropic-model direction and overrides only the response and stream adapters — it spreads `anthropicAdapterFactory`, so it constructs the ordinary `AnthropicRequestAdapter`, which did implement the method on `main`.
- **`canonicalizeToolName`** is applied symmetrically to declared names and to emitted call names, so it does not contribute.
- **Translator adapters** (`openaiToAnthropic`, `openaiToGemini`, `openaiToConverse`, `openaiToCohere`) each filter to `type === "function"` when building the upstream body. That is self-consistent: a tool dropped there never reaches the model, so the model cannot call it. No false refusal, and no change needed.

## What the tests pin

`utils/declared-tool-names.test.ts` (new, 11 cases) covers each provider's shape, including the four Anthropic cases migrated from `adapters/anthropic.test.ts`, and that unusable entries never enter the set — an entry naming nothing would turn an otherwise-empty set into a populated one and switch the check on.

In `llm-proxy-handler.test.ts`, two end-to-end tests run the **real** `evaluatePolicies` through the OpenAI route:
- `a client-declared tool getTools drops is not refused` — declares the tool in a shape `getTools()` drops, model calls it, asserts no refusal and that the tool call reaches the client with `finish_reason: "tool_calls"`. **This fails on `main`.**
- `a tool the caller never declared is still refused` — the companion, asserting the guardrail is not hollowed out.

## Verification

`pnpm type-check` — 8/8 successful. `pnpm lint` — 8/8 successful (2 pre-existing frontend warnings, untouched files). `cd backend && pnpm knip` (dev + production) — clean.

Vitest across every touched directory (`src/routes/proxy src/guardrails src/types`):

```
this branch:    Test Files  2 failed | 94 passed (96)
                     Tests  3 failed | 1552 passed | 64 skipped (1619)

origin/main:    Test Files  2 failed | 93 passed (95)
                     Tests  3 failed | 1540 passed | 64 skipped (1607)
```

The same 3 tests fail on both, verified by running them on a detached `origin/main` worktree. They assert plaintext in persisted `interactions` columns that this local environment stores encrypted (`{"__encrypted":"v1:…"}`) — environmental, unrelated to this change:
- `llm-proxy-handler.test.ts` — `streaming failure before any usage persists an error interaction`
- `llm-proxy-handler.test.ts` — `streaming failure after SSE headers and content persists an error interaction`
- `llm-proxy-tool-invocation.test.ts` — `blocks the read_file call on untrusted data and persists the interaction`

The +12 passing tests are exactly this PR's net new coverage (+11 new util tests, +2 handler tests, −1 adapter test folded into the util suite).

## Out of scope

- **Responses `type: "mcp"` tools.** These declare a remote *server*, not tool names, so the tools it exposes cannot be enumerated from the request body. A request declaring both function tools and an `mcp` tool can still refuse a call to one of that server's tools. Pre-existing and unchanged here; fixing it needs a different mechanism than reading the request.
- **Docs.** Audited `docs/pages`. Nothing is made wrong: no page documents `LLMRequestAdapter` or `getDeclaredToolNames`, and the one hit for "declared tool persistence" in `platform-adding-llm-providers.md` refers to the `getTools()` persistence path, which this PR does not change.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
