### PR TITLE
fix(llm): list [1m] context-variant siblings so Claude Code keeps 1M-context models

### DIFF
--- a/platform/backend/src/routes/proxy/routes/anthropic.ts
+++ b/platform/backend/src/routes/proxy/routes/anthropic.ts
@@ -13,6 +13,7 @@ import { handleLLMProxy } from "../llm-proxy-handler";
 import {
   AnthropicModelsHeadersSchema,
   AnthropicModelsListResponseSchema,
+  appendClaudeContextVariants,
   extractAnthropicToken,
   resolveProxyModelsApiKey,
   toAnthropicModelsList,
@@ -150,7 +151,9 @@ const anthropicProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
     });
     logger.debug({ agentId }, "[UnifiedProxy] Listing Anthropic models");
     return toAnthropicModelsList(
-      await fetchAnthropicModels(apiKey, baseUrl, extraHeaders),
+      await appendClaudeContextVariants(
+        await fetchAnthropicModels(apiKey, baseUrl, extraHeaders),
+      ),
     );
   }
 

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
@@ -6,7 +6,7 @@ import {
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
 import { vi } from "vitest";
-import { VirtualApiKeyModel } from "@/models";
+import { ModelModel, VirtualApiKeyModel } from "@/models";
 import type { ModelInfo } from "@/routes/chat/model-fetchers/types";
 import { describe, expect, test } from "@/test";
 import { ApiError } from "@/types";
@@ -251,6 +251,115 @@ describe("provider-specific proxy GET /models (virtual-key-aware)", () => {
       undefined,
       null,
     );
+  });
+
+  // Claude Code's gateway model discovery keeps only the ids this endpoint
+  // returns, so without the synthesized `[1m]` siblings a client configured
+  // with a long-context variant silently drops to the base id on first
+  // connect.
+  test("anthropic: appends a [1m] sibling for Claude models the catalog records a 1M window for", async () => {
+    await ModelModel.upsert({
+      externalId: "anthropic/claude-opus-5",
+      provider: "anthropic",
+      modelId: "claude-opus-5",
+      inputModalities: null,
+      outputModalities: null,
+      contextLength: 1_000_000,
+      lastSyncedAt: new Date(),
+    });
+    await ModelModel.upsert({
+      externalId: "anthropic/claude-haiku-4-5",
+      provider: "anthropic",
+      modelId: "claude-haiku-4-5",
+      inputModalities: null,
+      outputModalities: null,
+      contextLength: 200_000,
+      lastSyncedAt: new Date(),
+    });
+    vi.mocked(fetchAnthropicModels).mockResolvedValue([
+      {
+        id: "claude-opus-5",
+        displayName: "Claude Opus 5",
+        provider: "anthropic",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "claude-haiku-4-5",
+        displayName: "Claude Haiku 4.5",
+        provider: "anthropic",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        // No catalog row at all: no window is known, so no sibling.
+        id: "claude-uncatalogued",
+        displayName: "Claude Uncatalogued",
+        provider: "anthropic",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    const app = await buildApp(anthropicProxyRoutes);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/anthropic/${randomUUID()}/v1/models`,
+      headers: { "x-api-key": "sk-ant-raw" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      data: Array<{ id: string; display_name: string }>;
+    };
+    // The sibling sits directly after its base id; sub-1M and uncatalogued
+    // models get none.
+    expect(body.data.map((model) => model.id)).toEqual([
+      "claude-opus-5",
+      "claude-opus-5[1m]",
+      "claude-haiku-4-5",
+      "claude-uncatalogued",
+    ]);
+    expect(
+      body.data.find((model) => model.id === "claude-opus-5[1m]")?.display_name,
+    ).toBe("Claude Opus 5 (1M context)");
+  });
+
+  test("anthropic: does not duplicate a variant id the upstream already lists", async () => {
+    await ModelModel.upsert({
+      externalId: "anthropic/claude-opus-5",
+      provider: "anthropic",
+      modelId: "claude-opus-5",
+      inputModalities: null,
+      outputModalities: null,
+      contextLength: 1_000_000,
+      lastSyncedAt: new Date(),
+    });
+    vi.mocked(fetchAnthropicModels).mockResolvedValue([
+      {
+        id: "claude-opus-5",
+        displayName: "Claude Opus 5",
+        provider: "anthropic",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        provider: "anthropic",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    const app = await buildApp(anthropicProxyRoutes);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/anthropic/${randomUUID()}/v1/models`,
+      headers: { "x-api-key": "sk-ant-raw" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { data: Array<{ id: string }> };
+    expect(body.data.map((model) => model.id)).toEqual([
+      "claude-opus-5",
+      "claude-opus-5[1m]",
+    ]);
   });
 
   test("openai: resolves a Bearer virtual key and returns the native OpenAI models shape", async ({

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
@@ -1,10 +1,11 @@
 import {
   hasArchestraTokenPrefix,
   type SupportedProvider,
+  stripClaudeContextVariantSuffix,
 } from "@archestra/shared";
 import type { FastifyRequest } from "fastify";
 import { z } from "zod";
-import { LlmProviderApiKeyModel } from "@/models";
+import { LlmProviderApiKeyModel, ModelModel } from "@/models";
 import type { ModelInfo } from "@/routes/chat/model-fetchers/types";
 import { assertSubscriptionCredentialForProvider } from "@/services/subscription-credential-guard";
 import { ApiError } from "@/types";
@@ -116,6 +117,9 @@ function headerValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
+/** The window size the `[1m]` context-variant marker names. */
+const ONE_MILLION_TOKEN_CONTEXT = 1_000_000;
+
 export function extractBearerToken(
   authorization: string | string[] | undefined,
 ): string | undefined {
@@ -135,6 +139,61 @@ export function extractAnthropicToken(headers: {
     headerValue(headers["x-api-key"]) ??
     extractBearerToken(headers.authorization)
   );
+}
+
+/**
+ * Interleave a `[1m]` long-context sibling after each Claude model whose
+ * catalog row records a 1M-token window.
+ *
+ * Anthropic's own `/v1/models` never lists the bracketed variant ids — the
+ * marker is a client convention — but Claude Code populates its model picker
+ * from this endpoint when gateway model discovery is enabled, keeping only the
+ * ids the gateway returns. Passing the upstream list through unchanged
+ * therefore made a Claude Code configured with e.g. `claude-opus-5[1m]`
+ * switch to the base id — and the 200K window it assumes behind a gateway —
+ * the first time it connected. A model the catalog records no 1M window for
+ * gets no sibling, so nothing is advertised that the model may not serve.
+ */
+export async function appendClaudeContextVariants(
+  models: ModelInfo[],
+): Promise<ModelInfo[]> {
+  const variantCandidates = models.filter(
+    (model) =>
+      /claude/i.test(model.id) &&
+      stripClaudeContextVariantSuffix(model.id) === model.id,
+  );
+  if (variantCandidates.length === 0) {
+    return models;
+  }
+
+  const catalogRows = await ModelModel.findByProviderModelIds(
+    variantCandidates.map((model) => ({
+      provider: "anthropic" as const,
+      modelId: model.id,
+    })),
+  );
+  const listedIds = new Set(models.map((model) => model.id));
+
+  const withVariants: ModelInfo[] = [];
+  for (const model of models) {
+    withVariants.push(model);
+    const variantId = `${model.id}[1m]`;
+    const contextLength = catalogRows.get(
+      `anthropic:${model.id}`,
+    )?.contextLength;
+    if (
+      contextLength != null &&
+      contextLength >= ONE_MILLION_TOKEN_CONTEXT &&
+      !listedIds.has(variantId)
+    ) {
+      withVariants.push({
+        ...model,
+        id: variantId,
+        displayName: `${model.displayName} (1M context)`,
+      });
+    }
+  }
+  return withVariants;
 }
 
 export function toAnthropicModelsList(models: ModelInfo[]) {


### PR DESCRIPTION
## Problem

When Claude Code is first connected to the Archestra LLM proxy, it silently switches the selected model from a 1M-context variant (e.g. `claude-opus-5[1m]`) to the base, smaller-context-window id.

Root cause: Claude Code's gateway model discovery populates its model picker from the gateway's `GET /v1/models` and keeps only the ids the gateway returns. Behind a gateway it can't verify 1M-context support, so it assumes a 200K window unless the picker offers the bracketed `[1m]` variant id (per the Claude Code gateway-protocol / model-config docs). Archestra passed Anthropic's native model list through unchanged — which never contains `[1m]` ids, since the bracketed marker is a client-side convention — so on first connect the 1M entry disappears from the picker and Claude Code drops to the base model.

## Fix

The Anthropic-native models listing (`GET /v1/anthropic[/:agentId]/v1/models`) now interleaves a `<id>[1m]` sibling (display name `"<name> (1M context)"`) after each Claude model whose catalog row records a context window of at least 1M tokens (`models.context_length`, kept current by the models.dev sync).

- Models without a catalog row, or with a sub-1M window, get no sibling — nothing is advertised that the model may not serve.
- An upstream list that already carries a variant id is not duplicated.
- The `/v1/messages` inference path already forwarded `[1m]` ids to Anthropic unchanged (pinned by an existing test) and is untouched, as is the `[1m]`-stripping for cost bookkeeping.

## Testing

- Two new integration tests in `proxy-model-listing.test.ts`: sibling synthesis gated on catalog context length (1M yes, 200K no, uncatalogued no) with ordering + display name, and no duplication when the upstream already lists a variant id.
- Existing `proxy-model-listing.test.ts` and `anthropic.test.ts` suites pass; backend `type-check` and `lint` clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>