### PR TITLE
fix(ui): show one less installation avatar so MCP card circles don't overflow

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -519,7 +519,10 @@ export function McpServerCard({
     </Button>
   );
 
-  const MAX_AVATARS = 4;
+  // 3 keeps the compact info row on one line at grid card width; a 4th
+  // connection folds into the +N count instead of pushing the circle stack
+  // past the card edge.
+  const MAX_AVATARS = 3;
   const connectionAvatars: Array<{
     type: "team" | "user";
     label: string;
@@ -590,7 +593,7 @@ export function McpServerCard({
   const hasCompactInfoContent = showScopeBadge || hasCompactInfoAfterScopeBadge;
 
   const compactInfoRow = hasCompactInfoContent ? (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-muted-foreground">
+    <div className="flex items-center gap-3 text-sm text-muted-foreground">
       {showScopeBadge && (
         <>
           <ResourceVisibilityBadge

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -590,7 +590,7 @@ export function McpServerCard({
   const hasCompactInfoContent = showScopeBadge || hasCompactInfoAfterScopeBadge;
 
   const compactInfoRow = hasCompactInfoContent ? (
-    <div className="flex items-center gap-3 text-sm text-muted-foreground">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-muted-foreground">
       {showScopeBadge && (
         <>
           <ResourceVisibilityBadge


### PR DESCRIPTION
## Summary

On MCP registry cards, the compact info row (scope badge, tool/agent counts, user-installation avatar circles) could overrun the card's padding when enough installations stacked up — the `+N` and `+` circles clipped against the card edge at grid card width.

Fix: show at most **3** connection avatars (down from 4); anything beyond folds into the existing `+N` count circle. The row stays on a single line and the circle stack stays inside the card. (An earlier revision made the row `flex-wrap`; reverted in favor of this — wrapping read worse.)

## Test plan

- `pnpm lint` (biome) and `pnpm type-check` pass in `frontend/`
- Verified visually with a markup replica at grid card width: before (4 avatars + count) clips at the card edge; after (3 avatars + count) fits on one line
- Styling/threshold-only change; no behavior change, so no new tests