### PR TITLE
fix(mcp): start OAuth directly when the install target is already fixed

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect } from "react";
 import { toast } from "sonner";
@@ -27,6 +27,15 @@ vi.mock("@/lib/mcp/enterprise-managed-install-auth", () => ({
 vi.mock("@/lib/websocket/websocket", () => ({ default: { send: vi.fn() } }));
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Feature flags the hook reads. byosEnabled keeps the OAuth confirmation
+// dialog alive (it carries the credential-storage warning), so tests flip it.
+const features = vi.hoisted(
+  () => ({ byosEnabled: false }) as Record<string, boolean>,
+);
+vi.mock("@/lib/config/config.query", () => ({
+  useFeature: (key: string) => features[key] ?? false,
 }));
 
 // The install dialogs are stubbed to a single testid so the test asserts the
@@ -295,5 +304,121 @@ describe("useCatalogInstall — local install completion", () => {
     expect(toast.success).toHaveBeenCalledWith(
       "Successfully installed Playwright Browser",
     );
+  });
+});
+
+// A local OAuth server whose env vars are prompted at install time: the
+// local-install dialog collects them (plus the install target), after which
+// OAuth starts.
+const localOAuthItem = {
+  id: "cat-local-oauth-1",
+  name: "local-oauth-server",
+  serverType: "local",
+  oauthConfig: { name: "local-oauth-server" },
+  localConfig: {
+    command: "serve",
+    environment: [{ key: "API_HOST", promptOnInstallation: true }],
+  },
+  userConfig: {},
+} as unknown as CatalogItem;
+
+function AddPersonalConnectionHarness({ item }: { item: CatalogItem }) {
+  const install = useCatalogInstall();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fire once on mount, like the "Connect my account" click
+  useEffect(() => {
+    install.addPersonalConnection(item);
+  }, []);
+  return <>{install.dialogs}</>;
+}
+
+// "Connect my account" (and the other fixed-target entry points) pre-select
+// the install scope, so the OAuth confirmation dialog would render an empty
+// body with nothing to choose — the flow must start immediately instead.
+describe("useCatalogInstall — fixed-target OAuth skips the confirmation dialog", () => {
+  const originalLocation = window.location;
+  const AUTHORIZATION_URL = "https://provider.example/oauth/authorize";
+  let initiateOAuth: ReturnType<typeof vi.fn>;
+
+  function renderAddPersonal(item: CatalogItem) {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={client}>
+        <AddPersonalConnectionHarness item={item} />
+      </QueryClientProvider>,
+    );
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    nav.search = new URLSearchParams();
+    features.byosEnabled = false;
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/mcp/registry" },
+      writable: true,
+    });
+    vi.mocked(useInternalMcpCatalog).mockReturnValue({
+      data: [oauthItem, localOAuthItem],
+    } as unknown as ReturnType<typeof useInternalMcpCatalog>);
+    vi.mocked(useMcpServers).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useMcpServers>);
+    vi.mocked(useInstallMcpServer).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useInstallMcpServer>);
+    initiateOAuth = vi.fn().mockResolvedValue({
+      authorizationUrl: AUTHORIZATION_URL,
+      state: "oauth-state-1",
+    });
+    vi.mocked(useInitiateOAuth).mockReturnValue({
+      mutateAsync: initiateOAuth,
+    } as unknown as ReturnType<typeof useInitiateOAuth>);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("starts OAuth immediately for a remote server (no empty dialog)", async () => {
+    renderAddPersonal(oauthItem);
+
+    await waitFor(() => {
+      expect(initiateOAuth).toHaveBeenCalledWith({ catalogId: CATALOG_ID });
+      expect(window.location.href).toBe(AUTHORIZATION_URL);
+    });
+    expect(screen.queryByTestId("install-dialog")).not.toBeInTheDocument();
+  });
+
+  it("starts OAuth right after the local-install dialog collected env vars", async () => {
+    const user = userEvent.setup();
+    renderAddPersonal(localOAuthItem);
+
+    // The env-var dialog still shows (it has real content to collect)…
+    await user.click(await screen.findByTestId("install-dialog-confirm"));
+
+    // …but the follow-up OAuth confirmation is skipped.
+    await waitFor(() => {
+      expect(initiateOAuth).toHaveBeenCalledWith({
+        catalogId: localOAuthItem.id,
+      });
+      expect(window.location.href).toBe(AUTHORIZATION_URL);
+    });
+    expect(screen.queryByTestId("install-dialog")).not.toBeInTheDocument();
+  });
+
+  it("keeps the dialog when BYOS is enabled (storage warning has content)", async () => {
+    features.byosEnabled = true;
+
+    renderAddPersonal(oauthItem);
+
+    expect(await screen.findByTestId("install-dialog")).toBeInTheDocument();
+    expect(initiateOAuth).not.toHaveBeenCalled();
+    expect(window.location.href).toBe("http://localhost/mcp/registry");
   });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.test.tsx
@@ -126,7 +126,7 @@ const CATALOG_ID = "cat-oauth-1";
 
 // A remote server with an OAuth config and no user config — installRemote takes
 // the OAuth-dialog branch, so the deep link opens a dialog we can observe.
-const oauthItem = {
+const remoteConnectItem = {
   id: CATALOG_ID,
   name: "deeplink-server",
   serverType: "remote",
@@ -178,7 +178,7 @@ describe("useCatalogInstall — deep-link install", () => {
     sessionStorage.clear();
     nav.search = new URLSearchParams();
     vi.mocked(useInternalMcpCatalog).mockReturnValue({
-      data: [oauthItem],
+      data: [remoteConnectItem],
     } as unknown as ReturnType<typeof useInternalMcpCatalog>);
     vi.mocked(useMcpServers).mockReturnValue({
       data: [],
@@ -310,7 +310,7 @@ describe("useCatalogInstall — local install completion", () => {
 // A local OAuth server whose env vars are prompted at install time: the
 // local-install dialog collects them (plus the install target), after which
 // OAuth starts.
-const localOAuthItem = {
+const localItemWithPromptedEnv = {
   id: "cat-local-oauth-1",
   name: "local-oauth-server",
   serverType: "local",
@@ -359,7 +359,7 @@ describe("useCatalogInstall — fixed-target OAuth skips the confirmation dialog
       writable: true,
     });
     vi.mocked(useInternalMcpCatalog).mockReturnValue({
-      data: [oauthItem, localOAuthItem],
+      data: [remoteConnectItem, localItemWithPromptedEnv],
     } as unknown as ReturnType<typeof useInternalMcpCatalog>);
     vi.mocked(useMcpServers).mockReturnValue({
       data: [],
@@ -386,7 +386,7 @@ describe("useCatalogInstall — fixed-target OAuth skips the confirmation dialog
   });
 
   it("starts OAuth immediately for a remote server (no empty dialog)", async () => {
-    renderAddPersonal(oauthItem);
+    renderAddPersonal(remoteConnectItem);
 
     await waitFor(() => {
       expect(initiateOAuth).toHaveBeenCalledWith({ catalogId: CATALOG_ID });
@@ -397,7 +397,7 @@ describe("useCatalogInstall — fixed-target OAuth skips the confirmation dialog
 
   it("starts OAuth right after the local-install dialog collected env vars", async () => {
     const user = userEvent.setup();
-    renderAddPersonal(localOAuthItem);
+    renderAddPersonal(localItemWithPromptedEnv);
 
     // The env-var dialog still shows (it has real content to collect)…
     await user.click(await screen.findByTestId("install-dialog-confirm"));
@@ -405,7 +405,7 @@ describe("useCatalogInstall — fixed-target OAuth skips the confirmation dialog
     // …but the follow-up OAuth confirmation is skipped.
     await waitFor(() => {
       expect(initiateOAuth).toHaveBeenCalledWith({
-        catalogId: localOAuthItem.id,
+        catalogId: localItemWithPromptedEnv.id,
       });
       expect(window.location.href).toBe(AUTHORIZATION_URL);
     });
@@ -415,7 +415,7 @@ describe("useCatalogInstall — fixed-target OAuth skips the confirmation dialog
   it("keeps the dialog when BYOS is enabled (storage warning has content)", async () => {
     features.byosEnabled = true;
 
-    renderAddPersonal(oauthItem);
+    renderAddPersonal(remoteConnectItem);
 
     expect(await screen.findByTestId("install-dialog")).toBeInTheDocument();
     expect(initiateOAuth).not.toHaveBeenCalled();

--- a/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.tsx
@@ -36,6 +36,7 @@ import {
   setOAuthTeamId,
   setOAuthUserConfigValues,
 } from "@/lib/auth/oauth-session";
+import { useFeature } from "@/lib/config/config.query";
 import { useDialogs } from "@/lib/hooks/use-dialog";
 import {
   clearPendingEnterpriseManagedInstall,
@@ -123,6 +124,7 @@ export function useCatalogInstall(opts?: {
   const installMutation = useInstallMcpServer();
   const initiateOAuthMutation = useInitiateOAuth();
   const queryClient = useQueryClient();
+  const byosEnabled = useFeature("byosEnabled");
 
   const { isDialogOpened, openDialog, closeDialog } = useDialogs<
     "remote-install" | "local-install" | "oauth" | "no-auth"
@@ -338,6 +340,11 @@ export function useCatalogInstall(opts?: {
 
     // Check if this server requires OAuth authentication if there is no user config
     if (!hasUserConfig && catalogItem.oauthConfig) {
+      const directTarget = resolveDirectOAuthTarget(scope, teamId);
+      if (directTarget) {
+        await startOAuthFlow(catalogItem, directTarget);
+        return;
+      }
       setSelectedCatalogItem(catalogItem);
       openDialog("oauth");
       return;
@@ -404,6 +411,11 @@ export function useCatalogInstall(opts?: {
         // No env vars needed - go straight to OAuth flow
         // Store server type so OAuth callback knows this is a local server
         setOAuthServerType("local");
+        const directTarget = resolveDirectOAuthTarget(scope, teamId);
+        if (directTarget) {
+          await startOAuthFlow(catalogItem, directTarget);
+          return;
+        }
         setSelectedCatalogItem(catalogItem);
         openDialog("oauth");
       }
@@ -776,9 +788,19 @@ export function useCatalogInstall(opts?: {
         });
       }
       closeDialog("local-install");
-      // Now initiate OAuth flow
-      setSelectedCatalogItem(localServerCatalogItem);
+      // The local-install dialog already collected the install target, so the
+      // OAuth confirmation has nothing further to ask — start the flow
+      // directly (unless BYOS keeps the dialog for its storage warning).
+      const directTarget = resolveDirectOAuthTarget(
+        installResult.scope,
+        installResult.scope === "team" ? installResult.teamId : undefined,
+      );
       setLocalServerCatalogItem(null);
+      if (directTarget) {
+        await startOAuthFlow(localServerCatalogItem, directTarget);
+        return;
+      }
+      setSelectedCatalogItem(localServerCatalogItem);
       openDialog("oauth");
       return;
     }
@@ -843,25 +865,30 @@ export function useCatalogInstall(opts?: {
     onInstalled?.();
   };
 
-  const handleOAuthConfirm = async (result: OAuthInstallResult) => {
-    if (!selectedCatalogItem) return;
-
+  // Initiate the OAuth flow for a catalog item and redirect to the provider.
+  // Shared by the OAuth dialog's confirm and the direct (no-dialog) path used
+  // when the install target is already fixed.
+  const startOAuthFlow = async (
+    catalogItem: CatalogItem,
+    target: { scope: McpServerInstallScope; teamId?: string | null },
+  ) => {
+    setInstallingItemId(catalogItem.id);
     try {
       // Call backend to initiate OAuth flow
       const { authorizationUrl, state } =
         await initiateOAuthMutation.mutateAsync({
-          catalogId: selectedCatalogItem.id,
+          catalogId: catalogItem.id,
         });
 
       // Store state in session storage for the callback
       setOAuthState(state);
-      setOAuthCatalogId(selectedCatalogItem.id);
-      setOAuthTeamId(result.scope === "team" ? (result.teamId ?? null) : null);
-      setOAuthScope(result.scope);
+      setOAuthCatalogId(catalogItem.id);
+      setOAuthTeamId(target.scope === "team" ? (target.teamId ?? null) : null);
+      setOAuthScope(target.scope);
 
       // Store if this is a first installation (for auto-opening assignments dialog)
       const isFirstInstallation = !installedServers?.some(
-        (s) => s.catalogId === selectedCatalogItem.id,
+        (s) => s.catalogId === catalogItem.id,
       );
       setOAuthIsFirstInstallation(isFirstInstallation);
 
@@ -871,7 +898,7 @@ export function useCatalogInstall(opts?: {
       // The user has committed to authorizing; the deep-link intent is now
       // being fulfilled through the OAuth flow (which has its own return
       // handling), so drop the pending-install intent to avoid the registry
-      // re-opening this dialog when the OAuth callback returns.
+      // re-opening the install dialog when the OAuth callback returns.
       clearPendingInstall();
 
       // Redirect to OAuth provider
@@ -882,7 +909,30 @@ export function useCatalogInstall(opts?: {
           ? error.message
           : "Failed to initiate OAuth flow",
       );
+    } finally {
+      setInstallingItemId(null);
     }
+  };
+
+  // With a fully-determined install target (personal, org, or team with the
+  // team already chosen), the OAuth confirmation dialog has no choices left to
+  // offer and renders an empty body — so the flow should start immediately
+  // instead of showing it. Returns null when the dialog is still needed:
+  // either the scope is not fixed yet, or BYOS is enabled (the dialog then
+  // carries the OAuth-credentials-stored-in-database warning).
+  const resolveDirectOAuthTarget = (
+    scope: McpServerInstallScope | undefined,
+    teamId: string | null | undefined,
+  ): { scope: McpServerInstallScope; teamId?: string | null } | null => {
+    if (byosEnabled) return null;
+    if (!scope) return null;
+    if (scope === "team") return teamId ? { scope, teamId } : null;
+    return { scope };
+  };
+
+  const handleOAuthConfirm = async (result: OAuthInstallResult) => {
+    if (!selectedCatalogItem) return;
+    await startOAuthFlow(selectedCatalogItem, result);
   };
 
   const cancelInstallation = (serverId: string) => {

--- a/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.tsx
@@ -340,7 +340,7 @@ export function useCatalogInstall(opts?: {
 
     // Check if this server requires OAuth authentication if there is no user config
     if (!hasUserConfig && catalogItem.oauthConfig) {
-      const directTarget = resolveDirectOAuthTarget(scope, teamId);
+      const directTarget = resolveFixedInstallTarget(scope, teamId);
       if (directTarget) {
         await startOAuthFlow(catalogItem, directTarget);
         return;
@@ -411,7 +411,7 @@ export function useCatalogInstall(opts?: {
         // No env vars needed - go straight to OAuth flow
         // Store server type so OAuth callback knows this is a local server
         setOAuthServerType("local");
-        const directTarget = resolveDirectOAuthTarget(scope, teamId);
+        const directTarget = resolveFixedInstallTarget(scope, teamId);
         if (directTarget) {
           await startOAuthFlow(catalogItem, directTarget);
           return;
@@ -791,7 +791,7 @@ export function useCatalogInstall(opts?: {
       // The local-install dialog already collected the install target, so the
       // OAuth confirmation has nothing further to ask — start the flow
       // directly (unless BYOS keeps the dialog for its storage warning).
-      const directTarget = resolveDirectOAuthTarget(
+      const directTarget = resolveFixedInstallTarget(
         installResult.scope,
         installResult.scope === "team" ? installResult.teamId : undefined,
       );
@@ -920,7 +920,7 @@ export function useCatalogInstall(opts?: {
   // instead of showing it. Returns null when the dialog is still needed:
   // either the scope is not fixed yet, or BYOS is enabled (the dialog then
   // carries the OAuth-credentials-stored-in-database warning).
-  const resolveDirectOAuthTarget = (
+  const resolveFixedInstallTarget = (
     scope: McpServerInstallScope | undefined,
     teamId: string | null | undefined,
   ): { scope: McpServerInstallScope; teamId?: string | null } | null => {


### PR DESCRIPTION
## Problem

Clicking **Connect my account** on an OAuth MCP server's detail page (Credentials tab) opened an "OAuth Authorization" dialog with an **empty body** — the scope selector renders nothing when the install target is already fixed (`personalOnly` / `orgOnly` / `preselectedTeamId`), so the dialog's only purpose was a redundant "Continue to Authorization…" click.

The same empty dialog appeared for **Add service account** (team/org already chosen) and after the local-install dialog had already collected env vars + target.

## Fix

In `useCatalogInstall`, when the install target is fully determined (personal, org, or team with the team already chosen), skip the confirmation dialog and initiate the OAuth flow immediately (`startOAuthFlow`, extracted from the dialog's confirm handler — same sessionStorage bookkeeping and redirect).

The dialog is **kept** when:
- the scope still needs choosing (top-of-page **Connect** button, `?install=` deep link without a scope) — it has a real "Install for" selector, and
- BYOS is enabled — the dialog carries the "OAuth credentials will be stored in the database" warning.

`installingItemId` is set while the initiate request is in flight, so the triggering button shows its pending state instead of appearing dead.

## Testing

- 3 new tests in `use-catalog-install.test.tsx` (direct start for remote, direct start after local env-var collection, BYOS keeps the dialog); existing deep-link tests pin the dialog still opening when scope isn't fixed.
- Manually verified against the local dev env in Chrome with a Sentry remote MCP catalog item (`https://mcp.sentry.dev/mcp`, OAuth 2.1 auto-discovery):
  - **Connect my account** → immediate redirect to `https://mcp.sentry.dev/oauth/authorize?...` — no empty dialog.
  - Header **Connect** (scope not fixed) → dialog still opens, now with the scope selector content.