### PR TITLE
feat(connection): swap the CLI connect banner to the braille Archestra mark

### DIFF
--- a/platform/backend/src/services/archestra-mark.test.ts
+++ b/platform/backend/src/services/archestra-mark.test.ts
@@ -41,10 +41,10 @@ function setupCtx(
   };
 }
 
-// One distinctive interior line and the top border of the canonical mark — if
-// these appear verbatim, the surface is drawing the exact shared logo.
-const MARK_GLYPH_ROW = ARCHESTRA_MARK.unicode[2]; // "   │        ▟██▙      │"
-const MARK_TOP_BORDER = ARCHESTRA_MARK.unicode[0]; // "   ╭──────────────────╮"
+// Two distinctive rows of the canonical braille mark — if these appear
+// verbatim, the surface is drawing the exact shared logo.
+const MARK_GLYPH_ROW = ARCHESTRA_MARK.unicode[2]; // "⠀⠀⣸⣿⣿⣿⣿⣿⠇…"
+const MARK_TOP_BORDER = ARCHESTRA_MARK.unicode[0]; // "⠀⠀⠀⢀⣤⣶⣶⣦⡀…"
 
 describe("archestraMarkWithText", () => {
   test("overlays the product name and tagline on their rows, leaving the art intact", () => {
@@ -56,14 +56,14 @@ describe("archestraMarkWithText", () => {
     );
   });
 
-  test("ASCII variant preserves the same 9-line layout for the legacy console", () => {
+  test("ASCII variant keeps its 9-line box layout for the legacy console", () => {
     const ascii = archestraMarkWithText({
       appName: "Archestra",
       variant: "ascii",
     });
     expect(ascii).toHaveLength(9);
     expect(ascii[3]).toContain("Archestra");
-    expect(ascii.join("\n")).not.toContain("▟"); // no block glyphs in the fallback
+    expect(ascii.join("\n")).not.toContain("⣿"); // no braille glyphs in the fallback
   });
 });
 

--- a/platform/backend/src/services/archestra-mark.ts
+++ b/platform/backend/src/services/archestra-mark.ts
@@ -3,30 +3,30 @@
  * the setup-script banner AND the startup-guard pre-loader ("startup screen") —
  * on macOS/Linux and Windows, so all of them render the identical logo.
  *
- * `unicode` is the block-glyph art used everywhere a UTF-8-capable terminal is
+ * `unicode` is the braille art used everywhere a UTF-8-capable terminal is
  * guaranteed: bash (`curl | bash`), the startup guards (the bash guard, and the
  * PowerShell guard which is written to disk as UTF-8-with-BOM so PowerShell
  * decodes it correctly), and the Windows connect banner when the host is
  * capable (Windows Terminal / PowerShell 7). `ascii` is the portable fallback
  * for the legacy Windows console, where the connect banner is streamed inline
- * via `irm | iex` with no BOM and block glyphs would mojibake on the OEM
+ * via `irm | iex` with no BOM and braille glyphs would mojibake on the OEM
  * codepage.
  *
- * Both variants are 9 lines with the same layout: the product name is overlaid
- * to the right of {@link ARCHESTRA_MARK_NAME_ROW} and the tagline to the right
- * of {@link ARCHESTRA_MARK_TAGLINE_ROW}.
+ * Within each variant every row has the same width — the unicode rows are
+ * padded to 14 columns with U+2800 braille blanks (visually empty, immune to
+ * trailing-whitespace trimming) — because the product name is overlaid to the
+ * right of {@link ARCHESTRA_MARK_NAME_ROW} and the tagline to the right of
+ * {@link ARCHESTRA_MARK_TAGLINE_ROW}, and both must start at the same column.
  */
 export const ARCHESTRA_MARK = {
   unicode: [
-    "   ╭──────────────────╮",
-    "   │                  │",
-    "   │        ▟██▙      │",
-    "   │        ████      │",
-    "   │       ████       │",
-    "   │       ████ ▟▙    │",
-    "   │      ▜██▛  ▜▛    │",
-    "   │                  │",
-    "   ╰──────────────────╯",
+    "⠀⠀⠀⢀⣤⣶⣶⣦⡀⠀⠀⠀⠀⠀",
+    "⠀⠀⠀⣾⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀",
+    "⠀⠀⣸⣿⣿⣿⣿⣿⠇⠀⠀⠀⠀⠀",
+    "⠀⢠⣿⣿⣿⣿⣿⡟⠀⠀⠀⠀⠀⠀",
+    "⢀⣿⣿⣿⣿⣿⡟⠀⢀⣴⣶⣶⣦⡀",
+    "⢸⣿⣿⣿⣿⣿⠁⠀⢿⣿⣿⣿⣿⡇",
+    "⠀⠛⠿⠿⠟⠃⠀⠀⠈⠻⠿⠿⠛⠁",
   ],
   ascii: [
     "   .------------------.",

--- a/platform/backend/src/services/connection-setup-script.test.ts
+++ b/platform/backend/src/services/connection-setup-script.test.ts
@@ -1244,8 +1244,8 @@ describe("banner", () => {
     await expectValidBash(branded);
     expect(branded).toContain("cat <<'ARCHESTRA_BANNER'");
     expect(branded).toContain("Secure access to your AI tools");
-    // the Archestra block-mark is printed under the default brand
-    expect(branded).toContain("▟██▙");
+    // the Archestra braille mark is printed under the default brand
+    expect(branded).toContain("⣾⣿⣿⣿⣿⣷");
     expect(branded).toContain("Client:     Claude Code");
     expect(branded).toContain("Configures:");
     expect(branded).toContain("one-time setup");
@@ -1257,7 +1257,7 @@ describe("banner", () => {
       appName: "Archestra Staging",
     });
     await expectValidBash(variant);
-    expect(variant).toContain("▟██▙");
+    expect(variant).toContain("⣾⣿⣿⣿⣿⣷");
     expect(variant).toContain("Archestra Staging");
 
     const whiteLabel = renderSetupScript({
@@ -1266,8 +1266,8 @@ describe("banner", () => {
     });
     await expectValidBash(whiteLabel);
     expect(whiteLabel).toContain("Acme AI");
-    // the Archestra block-mark is not printed under a custom brand
-    expect(whiteLabel).not.toContain("▟██▙");
+    // the Archestra braille mark is not printed under a custom brand
+    expect(whiteLabel).not.toContain("⣾⣿⣿⣿⣿⣷");
   });
 });
 

--- a/platform/backend/src/services/connection-setup-script.windows.ts
+++ b/platform/backend/src/services/connection-setup-script.windows.ts
@@ -112,8 +112,8 @@ const SCRIPT_HELPERS = `$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 $ArchUseColor = [string]::IsNullOrEmpty($env:NO_COLOR)
 # Header-mark capability. Windows Terminal and PowerShell 7 render the Unicode
-# block mark (the exact macOS/Linux/guard logo); the legacy console (Windows
-# PowerShell 5.1 in conhost) mojibakes block glyphs on its OEM codepage, so it
+# braille mark (the exact macOS/Linux/guard logo); the legacy console (Windows
+# PowerShell 5.1 in conhost) mojibakes braille glyphs on its OEM codepage, so it
 # falls back to the ASCII mark. Switching this session to UTF-8 is best-effort
 # and harmless if it fails — it only affects how the banner below is drawn.
 $ArchUtf8 = $false
@@ -155,7 +155,7 @@ Say ${psq(`${ctx.appName} setup: ${label}`)}${requireBinary}`;
  * details block, emitted through single-quoted here-strings so nothing in them
  * is ever expanded by PowerShell. The mark is the exact canonical logo (shared
  * with the macOS/Linux banner and every startup guard) when the host can render
- * UTF-8 block glyphs, and the portable ASCII rendition of the same composition
+ * UTF-8 braille glyphs, and the portable ASCII rendition of the same composition
  * otherwise — chosen at runtime by $ArchUtf8 (set in SCRIPT_HELPERS) so a legacy
  * `irm | iex` console never mojibakes.
  */

--- a/platform/backend/src/services/startup-guard.test.ts
+++ b/platform/backend/src/services/startup-guard.test.ts
@@ -419,7 +419,7 @@ describe("renderStartupGuardScript", () => {
 
   test("renders the Archestra mark for the default brand and its own variants, plain title when genuinely white-labeled", () => {
     const branded = renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT);
-    expect(branded).toContain("▟██▙");
+    expect(branded).toContain("⣾⣿⣿⣿⣿⣷");
     expect(branded).toContain("Secure access to your AI tools");
 
     // an org named "Archestra Staging" is still Archestra's own brand — the
@@ -428,14 +428,14 @@ describe("renderStartupGuardScript", () => {
       { ...CTX, appName: "Archestra Staging" },
       CLAUDE_CODE_GUARD_CLIENT,
     );
-    expect(variant).toContain("▟██▙");
+    expect(variant).toContain("⣾⣿⣿⣿⣿⣷");
     expect(variant).toContain("'Archestra Staging'");
 
     const whiteLabel = renderStartupGuardScript(
       { ...CTX, appName: "Acme AI" },
       CLAUDE_CODE_GUARD_CLIENT,
     );
-    expect(whiteLabel).not.toContain("▟██▙");
+    expect(whiteLabel).not.toContain("⣾⣿⣿⣿⣿⣷");
     expect(whiteLabel).toContain("'Acme AI'");
   });
 

--- a/platform/backend/src/services/startup-guard.ts
+++ b/platform/backend/src/services/startup-guard.ts
@@ -1057,10 +1057,10 @@ function guardHeader(ctx: StartupGuardContext): string {
   if (!isDefaultBrandedAppName(ctx.appName)) {
     return `printf '%s%s%s\\n\\n' "$C_TITLE" "$APP_NAME" "$C_RESET"`;
   }
-  // The exact canonical mark, colored per line: the box art in C_LOGO with the
-  // product name (C_TITLE) and tagline (C_DIM) overlaid on their rows. The box
-  // lines carry no `%`, so they are safe inside the printf format string; the
-  // app name is always passed as an argument, never interpolated into it.
+  // The exact canonical mark, colored per line: the braille art in C_LOGO with
+  // the product name (C_TITLE) and tagline (C_DIM) overlaid on their rows. The
+  // art lines carry no `%`, so they are safe inside the printf format string;
+  // the app name is always passed as an argument, never interpolated into it.
   const lines = ARCHESTRA_MARK.unicode;
   return lines
     .map((line, i) => {

--- a/platform/backend/src/services/startup-guard.windows.test.ts
+++ b/platform/backend/src/services/startup-guard.windows.test.ts
@@ -200,7 +200,7 @@ describe("renderStartupGuardPowerShell (Claude Code)", () => {
 
   test("renders the Archestra mark for the default brand and its own variants, plain title when genuinely white-labeled", () => {
     const branded = renderStartupGuardPowerShell(CTX, CLAUDE_CODE_GUARD_CLIENT);
-    expect(branded).toContain("▟██▙");
+    expect(branded).toContain("⣾⣿⣿⣿⣿⣷");
     expect(branded).toContain("Secure access to your AI tools");
 
     // an org named "Archestra Staging" is still Archestra's own brand — the
@@ -212,7 +212,7 @@ describe("renderStartupGuardPowerShell (Claude Code)", () => {
       },
       CLAUDE_CODE_GUARD_CLIENT,
     );
-    expect(variant).toContain("▟██▙");
+    expect(variant).toContain("⣾⣿⣿⣿⣿⣷");
     expect(variant).toContain("'Archestra Staging'");
 
     const whiteLabel = renderStartupGuardPowerShell(
@@ -222,7 +222,7 @@ describe("renderStartupGuardPowerShell (Claude Code)", () => {
       },
       CLAUDE_CODE_GUARD_CLIENT,
     );
-    expect(whiteLabel).not.toContain("▟██▙");
+    expect(whiteLabel).not.toContain("⣾⣿⣿⣿⣿⣷");
     expect(whiteLabel).toContain("'Acme AI'");
   });
 

--- a/platform/backend/src/services/startup-guard.windows.ts
+++ b/platform/backend/src/services/startup-guard.windows.ts
@@ -886,9 +886,9 @@ function guardHeader(ctx: StartupGuardContext): string {
 Write-Host ''`;
   }
   // The exact canonical mark (identical art to the bash guard and the connect
-  // banner): box lines in White, product name (Cyan) and tagline (DarkGray)
+  // banner): braille lines in White, product name (Cyan) and tagline (DarkGray)
   // overlaid on their rows. The .ps1 is written UTF-8-with-BOM, so PowerShell
-  // decodes these block glyphs correctly.
+  // decodes the braille glyphs correctly.
   const lines = ARCHESTRA_MARK.unicode;
   const out = lines.map((line, i) => {
     if (i === ARCHESTRA_MARK_NAME_ROW) {


### PR DESCRIPTION
## Summary

Replaces the block-glyph box logo in the CLI connection surfaces with the smoother braille-art Archestra mark:

```
⠀⠀⠀⢀⣤⣶⣶⣦⡀
⠀⠀⠀⣾⣿⣿⣿⣿⣷
⠀⠀⣸⣿⣿⣿⣿⣿⠇
⠀⢠⣿⣿⣿⣿⣿⡟                    Archestra
⢀⣿⣿⣿⣿⣿⡟⠀⢀⣴⣶⣶⣦⡀     Secure access to your AI tools
⢸⣿⣿⣿⣿⣿⠁⠀⢿⣿⣿⣿⣿⡇
⠀⠛⠿⠿⠟⠃⠀⠀⠈⠻⠿⠿⠛⠁
```

The mark is defined once in `archestra-mark.ts` and shared by every /connection surface, so all of them pick it up: the `curl | bash` setup-script banner, the Windows connect banner (capable hosts), and the bash + PowerShell startup guards.

- Rows are padded to a uniform 14 columns with U+2800 braille blanks so the product-name/tagline overlays keep starting at the same column on every surface (and survive trailing-whitespace trimming).
- Name/tagline rows stay at rows 3/4 — no consumer changes needed; guards still render per line with color.
- The 9-line ASCII box is unchanged as the legacy Windows console fallback (`irm | iex` on conhost would mojibake braille on the OEM codepage).
- Tests that pinned the old `▟██▙` glyph as the branded-vs-white-label sentinel now pin a braille row (`⣾⣿⣿⣿⣿⣷`).

## Test plan

- `pnpm vitest run` on `archestra-mark`, `startup-guard`, `startup-guard.windows`, `connection-setup-script` test files: 133/133 pass, including the PTY suites that execute the generated bash under a real pseudo-terminal.
- `biome check` clean on all touched files.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>