### PR TITLE
fix(llm-proxy): report the serving provider in /models owned_by

### DIFF
--- a/platform/backend/src/routes/proxy/routes/github-copilot.ts
+++ b/platform/backend/src/routes/proxy/routes/github-copilot.ts
@@ -194,6 +194,7 @@ const githubCopilotProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
     logger.debug({ agentId }, "[UnifiedProxy] Listing GitHub Copilot models");
     return toOpenAiModelsList(
       await fetchGithubCopilotModels(apiKey, baseUrl, extraHeaders),
+      "github-copilot",
     );
   }
 

--- a/platform/backend/src/routes/proxy/routes/microsoft-365-copilot.ts
+++ b/platform/backend/src/routes/proxy/routes/microsoft-365-copilot.ts
@@ -139,6 +139,7 @@ const microsoft365CopilotProxyRoutes: FastifyPluginAsyncZod = async (
     );
     return toOpenAiModelsList(
       await fetchMicrosoft365CopilotModels(apiKey, baseUrl, extraHeaders),
+      "microsoft-365-copilot",
     );
   }
 

--- a/platform/backend/src/routes/proxy/routes/openai.ts
+++ b/platform/backend/src/routes/proxy/routes/openai.ts
@@ -232,6 +232,7 @@ const openAiProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
     logger.debug({ agentId }, "[UnifiedProxy] Listing OpenAI models");
     return toOpenAiModelsList(
       await fetchOpenAiModels(apiKey, baseUrl, extraHeaders),
+      "openai",
     );
   }
 

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
@@ -17,6 +17,15 @@ vi.mock("@/routes/chat/model-fetchers/anthropic", async (importOriginal) => ({
   >()),
   fetchAnthropicModels: vi.fn(),
 }));
+vi.mock(
+  "@/routes/chat/model-fetchers/github-copilot",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/routes/chat/model-fetchers/github-copilot")
+    >()),
+    fetchGithubCopilotModels: vi.fn(),
+  }),
+);
 vi.mock("@/routes/chat/model-fetchers/openai", async (importOriginal) => ({
   ...(await importOriginal<
     typeof import("@/routes/chat/model-fetchers/openai")
@@ -25,12 +34,17 @@ vi.mock("@/routes/chat/model-fetchers/openai", async (importOriginal) => ({
 }));
 
 import { fetchAnthropicModels } from "@/routes/chat/model-fetchers/anthropic";
+import { fetchGithubCopilotModels } from "@/routes/chat/model-fetchers/github-copilot";
 import { fetchOpenAiModels } from "@/routes/chat/model-fetchers/openai";
 import anthropicProxyRoutes from "./anthropic";
+import githubCopilotProxyRoutes from "./github-copilot";
 import openAiProxyRoutes from "./openai";
 
 async function buildApp(
-  plugin: typeof anthropicProxyRoutes | typeof openAiProxyRoutes,
+  plugin:
+    | typeof anthropicProxyRoutes
+    | typeof openAiProxyRoutes
+    | typeof githubCopilotProxyRoutes,
 ) {
   const app = Fastify().withTypeProvider<ZodTypeProvider>();
   app.setValidatorCompiler(validatorCompiler);
@@ -407,6 +421,65 @@ describe("provider-specific proxy GET /models (virtual-key-aware)", () => {
       undefined,
       null,
     );
+  });
+
+  test("github-copilot: reports the serving provider in owned_by, not openai", async ({
+    makeOrganization,
+    makeSecret,
+    makeLlmProviderApiKey,
+    makeUser,
+  }) => {
+    // The list helper used to hardcode owned_by: "openai" — right on the
+    // OpenAI route by coincidence, wrong here, and contradicting the model
+    // router, which reports owned_by: "github-copilot" for the same models.
+    vi.mocked(fetchGithubCopilotModels).mockResolvedValue([
+      {
+        id: "gpt-4o",
+        displayName: "GPT-4o",
+        provider: "github-copilot",
+        createdAt: "2025-01-01T00:00:00.000Z",
+      },
+      {
+        id: "gpt-5.3-codex",
+        displayName: "gpt-5.3-codex",
+        provider: "github-copilot",
+      },
+    ]);
+    const app = await buildApp(githubCopilotProxyRoutes);
+
+    // A Copilot credential is per-user, and llm-proxy-auth re-checks at
+    // request time that both the virtual key and the mapped provider key are
+    // the same user's personal keys — so the fixture must model real
+    // ownership, not just a mapping.
+    const org = await makeOrganization();
+    const owner = await makeUser();
+    const secret = await makeSecret({ secret: { apiKey: "gho_real_token" } });
+    const providerKey = await makeLlmProviderApiKey(org.id, secret.id, {
+      provider: "github-copilot",
+      scope: "personal",
+      userId: owner.id,
+    });
+    const { value } = await VirtualApiKeyModel.create({
+      name: "vk-copilot",
+      scope: "personal",
+      authorId: owner.id,
+      providerApiKeys: [
+        { provider: "github-copilot", providerApiKeyId: providerKey.id },
+      ],
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/github-copilot/${randomUUID()}/models`,
+      headers: { authorization: `Bearer ${value}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { data: Array<{ owned_by: string }> };
+    expect(body.data).toHaveLength(2);
+    for (const model of body.data) {
+      expect(model.owned_by).toBe("github-copilot");
+    }
   });
 
   test("openai: default-agent route lists models", async ({

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
@@ -208,7 +208,16 @@ export function toAnthropicModelsList(models: ModelInfo[]) {
   };
 }
 
-export function toOpenAiModelsList(models: ModelInfo[]) {
+/**
+ * `ownedBy` is the provider actually serving the models. It used to be
+ * hardcoded to "openai" — right on the OpenAI route by coincidence, wrong on
+ * the GitHub Copilot and Microsoft 365 Copilot routes, and contradicting the
+ * model router, which reports `owned_by: <provider>` for the same models.
+ */
+export function toOpenAiModelsList(
+  models: ModelInfo[],
+  ownedBy: SupportedProvider,
+) {
   return {
     object: "list" as const,
     data: models.map((model) => ({
@@ -217,7 +226,7 @@ export function toOpenAiModelsList(models: ModelInfo[]) {
       created: model.createdAt
         ? Math.floor(new Date(model.createdAt).getTime() / 1000)
         : 0,
-      owned_by: "openai",
+      owned_by: ownedBy,
     })),
   };
 }


### PR DESCRIPTION
## Why

`GET /models` on the direct provider proxy routes and on the model router disagreed about who owns a model. The router reports `owned_by: <serving provider>`; the direct routes hardcoded `owned_by: "openai"` for every provider sharing the OpenAI list shape. So the same GitHub Copilot model showed `owned_by: "github-copilot"` through the router and `owned_by: "openai"` through `/v1/github-copilot/models`.

It's cosmetic — nothing routes on the field, and the model ids are unaffected — but any client that groups models by owner renders it wrong, and the two surfaces contradicting each other is indefensible on its own.

## What changed

`toOpenAiModelsList` (the shared helper) now takes the serving provider from its caller instead of hardcoding `"openai"`. Three routes call it:

| Route | before | after |
|---|---|---|
| `/v1/openai/models` | `openai` | `openai` (unchanged) |
| `/v1/github-copilot/models` | `openai` | `github-copilot` |
| `/v1/microsoft-365-copilot/models` | `openai` | `microsoft-365-copilot` |

No consumer inside the repo reads `owned_by` from these responses (checked backend, frontend, shared, e2e), so the only observable change is the corrected value.

## Testing

- New route-level test: a Copilot virtual key listing through `/v1/github-copilot/{id}/models` gets `owned_by: "github-copilot"` on every model. Verified non-vacuous — restoring the hardcode makes exactly this test fail.
- The fixture models real per-user ownership (personal provider key + personal virtual key, same owner), since `llm-proxy-auth` re-checks that at request time; a bare mapping gets a 403 before the route logic runs.
- Existing suites: `proxy-model-listing` 12/12, plus `openai` / `github-copilot` / `model-router` route tests, 116/116. Type-check and lint clean.
- **Live, against a real Copilot subscription**: booted this branch's backend on a spare port against the dev database and listed models through a real virtual key — 15 models fetched from Copilot's actual catalog (token exchange included), all `owned_by: "github-copilot"`; the model router on the same branch lists the same 15 with the same owner. The unpatched backend running side by side returned `owned_by: "openai"` for the identical request, reproducing the report.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>