### PR TITLE
feat(chat): polish the incognito composer

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -29,6 +29,7 @@ import { ModelSelector } from "@/components/chat/model-selector";
 import { NoToolsModelBadge } from "@/components/chat/no-tools-model-notice";
 import { ThinkingEffortSelector } from "@/components/chat/thinking-effort-selector";
 import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
 import {
   Popover,
   PopoverContent,
@@ -39,10 +40,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { SHORTCUT_NEW_INCOGNITO_CHAT } from "@/consts";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import type { ModelSource } from "@/lib/chat/use-chat-preferences";
 import { useModelSelectorDisplay } from "@/lib/chat/use-model-selector-display.hook";
 import { useFeature } from "@/lib/config/config.query";
+import { usePlatform } from "@/lib/hooks/use-platform";
 import { providerToLogoProvider } from "@/lib/provider-logos";
 import { cn } from "@/lib/utils";
 
@@ -247,6 +250,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   // the same gate InitialAgentSelector uses via its callback prop) and only
   // when the instance has incognito chats enabled.
   const incognitoEnabled = useFeature("chatIncognitoEnabled") ?? false;
+  const { altKey } = usePlatform();
   const showIncognitoToggle =
     incognitoEnabled && !conversationId && !!onIncognitoChange;
 
@@ -588,7 +592,10 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="top" sideOffset={4}>
-            Incognito chat
+            <span className="flex items-center gap-1.5">
+              Incognito chat <Kbd>{altKey}</Kbd>
+              <Kbd>{SHORTCUT_NEW_INCOGNITO_CHAT.label}</Kbd>
+            </span>
           </TooltipContent>
         </Tooltip>
       )}

--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -10,7 +10,7 @@ import {
   type ThinkingEffortSetting,
 } from "@archestra/shared";
 import { MoreVerticalIcon, PaperclipIcon, XIcon } from "lucide-react";
-import { memo, useCallback } from "react";
+import { memo, useCallback, useEffect } from "react";
 import { ModelSelectorLogo } from "@/components/ai-elements/model-selector";
 import {
   PromptInputButton,
@@ -40,7 +40,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { SHORTCUT_NEW_INCOGNITO_CHAT } from "@/consts";
+import {
+  INCOGNITO_DRAFT_SHORTCUT_EVENT,
+  SHORTCUT_NEW_INCOGNITO_CHAT,
+} from "@/consts";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import type { ModelSource } from "@/lib/chat/use-chat-preferences";
 import { useModelSelectorDisplay } from "@/lib/chat/use-model-selector-display.hook";
@@ -253,6 +256,34 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   const { altKey } = usePlatform();
   const showIncognitoToggle =
     incognitoEnabled && !conversationId && !!onIncognitoChange;
+
+  const toggleIncognito = useCallback(() => {
+    // Files staged before the toggle would ride the first message of a chat
+    // that rejects attachments — drop them now (the attach button greys out
+    // while the toggle is on).
+    if (!incognito) {
+      attachments.clear();
+    }
+    onIncognitoChange?.(!incognito);
+  }, [incognito, onIncognitoChange, attachments]);
+
+  // While the toggle is on screen, Alt+I toggles the draft in place: the
+  // global shortcut dispatches this cancelable event before navigating and
+  // claiming it (preventDefault) suppresses the navigation — see
+  // useConversationSearch.
+  useEffect(() => {
+    if (!showIncognitoToggle) return;
+    const handleShortcut = (event: Event) => {
+      event.preventDefault();
+      toggleIncognito();
+    };
+    window.addEventListener(INCOGNITO_DRAFT_SHORTCUT_EVENT, handleShortcut);
+    return () =>
+      window.removeEventListener(
+        INCOGNITO_DRAFT_SHORTCUT_EVENT,
+        handleShortcut,
+      );
+  }, [showIncognitoToggle, toggleIncognito]);
 
   // RBAC: check if user can see agent picker and provider settings in chat
   const { data: canSeeAgentPicker } = useHasPermissions({
@@ -578,15 +609,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
                 incognito &&
                   "bg-accent text-accent-foreground hover:bg-accent/80",
               )}
-              onClick={() => {
-                // Files staged before the toggle would ride the first message
-                // of a chat that rejects attachments — drop them now (the
-                // attach button greys out while the toggle is on).
-                if (!incognito) {
-                  attachments.clear();
-                }
-                onIncognitoChange?.(!incognito);
-              }}
+              onClick={toggleIncognito}
             >
               <IncognitoIcon className="size-4" />
             </Button>

--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -43,7 +43,6 @@ import { useHasPermissions } from "@/lib/auth/auth.query";
 import type { ModelSource } from "@/lib/chat/use-chat-preferences";
 import { useModelSelectorDisplay } from "@/lib/chat/use-model-selector-display.hook";
 import { useFeature } from "@/lib/config/config.query";
-import { useAppName } from "@/lib/hooks/use-app-name";
 import { providerToLogoProvider } from "@/lib/provider-logos";
 import { cn } from "@/lib/utils";
 
@@ -63,10 +62,10 @@ export interface ChatPromptInputToolsProps {
   /** Whether file uploads are allowed (controlled by organization setting) */
   allowFileUploads?: boolean;
   /**
-   * Hide the attachment button entirely (incognito conversations: the backend
-   * rejects attachments, so no affordance — not even a disabled one — shows).
+   * Grey out the attachment button (incognito conversations: attachment bytes
+   * are stored unencrypted server-side, so the backend rejects them).
    */
-  attachmentsHidden?: boolean;
+  attachmentsDisabledByIncognito?: boolean;
   /**
    * Whether the next chat will be created incognito. New-chat composer only —
    * the toggle renders only while there is no conversation yet.
@@ -167,7 +166,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   onApiKeyChange,
   onProviderChange,
   allowFileUploads = false,
-  attachmentsHidden = false,
+  attachmentsDisabledByIncognito = false,
   incognito = false,
   onIncognitoChange,
   sandboxAvailable = false,
@@ -248,7 +247,6 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   // the same gate InitialAgentSelector uses via its callback prop) and only
   // when the instance has incognito chats enabled.
   const incognitoEnabled = useFeature("chatIncognitoEnabled") ?? false;
-  const appName = useAppName();
   const showIncognitoToggle =
     incognitoEnabled && !conversationId && !!onIncognitoChange;
 
@@ -484,10 +482,30 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
         <NotRecommendedForAgentsNoticeBadge />
       )}
 
-      {/* File attachment button - always visible, except on incognito
-          conversations where the affordance is hidden entirely (the backend
-          rejects attachments there). */}
-      {attachmentsHidden ? null : showFileUploadButton ? (
+      {/* File attachment button - always visible. Incognito greys it out
+          (the backend rejects attachments there because their bytes are
+          stored unencrypted); the org-level toggle greys it out with a
+          settings pointer. */}
+      {attachmentsDisabledByIncognito ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className="inline-flex cursor-not-allowed"
+              data-testid={E2eTestId.ChatDisabledFileUploadButton}
+            >
+              <PromptInputButton disabled>
+                <PaperclipIcon className="size-4" />
+              </PromptInputButton>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            <span>
+              Attachments are stored unencrypted, so incognito chats can't use
+              them
+            </span>
+          </TooltipContent>
+        </Tooltip>
+      ) : showFileUploadButton ? (
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -559,7 +577,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
               onClick={() => {
                 // Files staged before the toggle would ride the first message
                 // of a chat that rejects attachments — drop them now (the
-                // attach button hides while the toggle is on).
+                // attach button greys out while the toggle is on).
                 if (!incognito) {
                   attachments.clear();
                 }
@@ -569,9 +587,8 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
               <IncognitoIcon className="size-4" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="top" sideOffset={4} className="max-w-64">
-            Incognito chat: encrypted with a key that stays in this browser.{" "}
-            {appName} cannot read it. Not usable from other devices.
+          <TooltipContent side="top" sideOffset={4}>
+            Incognito chat
           </TooltipContent>
         </Tooltip>
       )}

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -15,6 +15,7 @@ const {
   mockProfileState,
   mockUploadPolicy,
   mockToolbarState,
+  mockConversationState,
 } = vi.hoisted(() => ({
   mockUseChatPlaceholder: vi.fn(),
   mockUseSkillsPaginated: vi.fn(),
@@ -23,12 +24,18 @@ const {
   mockControllerState: { value: "", files: [] as { url: string }[] },
   mockFeatureState: {
     chatSecretScanEnabled: false,
+    chatIncognitoEnabled: false,
     chatAttachmentStorageBytesLimit: undefined as number | undefined,
     apiBodyLimitBytes: undefined as number | undefined,
     sandboxArtifactBytesLimit: undefined as number | undefined,
   },
   mockProfileState: {
     agent: null as { sandboxAvailable: boolean } | null,
+  },
+  // What useConversation resolves to — lets tests exercise an existing
+  // incognito conversation (vs the new-chat toggle).
+  mockConversationState: {
+    conversation: null as { incognito?: boolean } | null,
   },
   // The upload policy the composer hands to the file picker: the byte cap it
   // enforces and the per-file check it runs. Captured so tests can exercise
@@ -232,6 +239,7 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
   }),
   usePromptInputAttachments: () => ({
     openFileDialog: vi.fn(),
+    clear: vi.fn(),
   }),
 }));
 
@@ -294,7 +302,7 @@ vi.mock("@/lib/chat/chat.query", () => ({
     isLoading: false,
     error: null,
   }),
-  useConversation: () => ({ data: null }),
+  useConversation: () => ({ data: mockConversationState.conversation }),
   useToggleHooksDebug: () => ({ mutate: vi.fn() }),
 }));
 
@@ -350,6 +358,9 @@ describe("ArchestraPromptInput", () => {
       if (flag === "chatSecretScanEnabled") {
         return mockFeatureState.chatSecretScanEnabled;
       }
+      if (flag === "chatIncognitoEnabled") {
+        return mockFeatureState.chatIncognitoEnabled;
+      }
       if (flag === "chatAttachmentStorageBytesLimit") {
         return mockFeatureState.chatAttachmentStorageBytesLimit;
       }
@@ -377,8 +388,10 @@ describe("ArchestraPromptInput", () => {
     mockControllerState.value = "";
     mockControllerState.files = [];
     mockFeatureState.chatSecretScanEnabled = false;
+    mockFeatureState.chatIncognitoEnabled = false;
     mockProfileState.agent = null;
     mockToolbarState.isNarrow = false;
+    mockConversationState.conversation = null;
     localStorage.clear();
   });
 
@@ -825,6 +838,107 @@ describe("ArchestraPromptInput", () => {
 
       expect(onCompactConversation).toHaveBeenCalledTimes(1);
       expect(mockTextInputClear).toHaveBeenCalled();
+    });
+  });
+
+  describe("incognito composer", () => {
+    it("greys out (not hides) the attach button and shows the explainer drawer while the new-chat toggle is on", () => {
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          allowFileUploads={true}
+          incognito
+          onIncognitoChange={vi.fn()}
+        />,
+      );
+
+      // The drawer carries the copy that used to live in the toggle tooltip.
+      const notice = screen.getByTestId(E2eTestId.ChatIncognitoNotice);
+      expect(notice).toHaveTextContent(
+        /Incognito chat — encrypted with a key that stays in this browser/,
+      );
+
+      // Attach affordance stays visible but disabled, with the reason on hover.
+      const disabledUpload = screen.getByTestId(
+        E2eTestId.ChatDisabledFileUploadButton,
+      );
+      expect(disabledUpload.querySelector("button")).toBeDisabled();
+      expect(
+        screen.queryByTestId(E2eTestId.ChatFileUploadButton),
+      ).not.toBeInTheDocument();
+      expect(
+        screen
+          .getAllByTestId("tooltip-content")
+          .some((tooltip) =>
+            tooltip.textContent?.includes(
+              "Attachments are stored unencrypted, so incognito chats can't use them",
+            ),
+          ),
+      ).toBe(true);
+    });
+
+    it("renders no drawer and a normal attach button when incognito is off", () => {
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          allowFileUploads={true}
+          incognito={false}
+          onIncognitoChange={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.queryByTestId(E2eTestId.ChatIncognitoNotice),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId(E2eTestId.ChatFileUploadButton),
+      ).toBeInTheDocument();
+    });
+
+    it("keeps the drawer and greyed-out attach button on an existing incognito conversation", () => {
+      mockConversationState.conversation = { incognito: true };
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          conversationId="conversation-1"
+          allowFileUploads={true}
+        />,
+      );
+
+      expect(
+        screen.getByTestId(E2eTestId.ChatIncognitoNotice),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(E2eTestId.ChatDisabledFileUploadButton),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(E2eTestId.ChatFileUploadButton),
+      ).not.toBeInTheDocument();
+    });
+
+    it("toggles incognito from the composer button, whose tooltip is just the name", () => {
+      mockFeatureState.chatIncognitoEnabled = true;
+      const onIncognitoChange = vi.fn();
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          allowFileUploads={true}
+          incognito={false}
+          onIncognitoChange={onIncognitoChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Incognito chat" }));
+      expect(onIncognitoChange).toHaveBeenCalledWith(true);
+
+      // The long explanation moved to the drawer; the hover stays succinct.
+      expect(
+        screen
+          .getAllByTestId("tooltip-content")
+          .some((tooltip) => tooltip.textContent?.trim() === "Incognito chat"),
+      ).toBe(true);
     });
   });
 

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -933,11 +933,14 @@ describe("ArchestraPromptInput", () => {
       fireEvent.click(screen.getByRole("button", { name: "Incognito chat" }));
       expect(onIncognitoChange).toHaveBeenCalledWith(true);
 
-      // The long explanation moved to the drawer; the hover stays succinct.
+      // The long explanation moved to the drawer; the hover stays succinct —
+      // just the name plus the global shortcut.
       expect(
         screen
           .getAllByTestId("tooltip-content")
-          .some((tooltip) => tooltip.textContent?.trim() === "Incognito chat"),
+          .some((tooltip) =>
+            tooltip.textContent?.trim().startsWith("Incognito chat"),
+          ),
       ).toBe(true);
     });
   });

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -1,7 +1,8 @@
 import { type ChatSkillMetadata, E2eTestId } from "@archestra/shared";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { INCOGNITO_DRAFT_SHORTCUT_EVENT } from "@/consts";
 import { chatMessageQueue } from "@/lib/chat/chat-message-queue";
 import { NEW_CHAT_DRAFT_STORAGE_KEY } from "@/lib/chat/chat-utils";
 
@@ -942,6 +943,72 @@ describe("ArchestraPromptInput", () => {
             tooltip.textContent?.trim().startsWith("Incognito chat"),
           ),
       ).toBe(true);
+    });
+
+    it("claims the Alt+I handshake event and toggles the draft off and back on", () => {
+      mockFeatureState.chatIncognitoEnabled = true;
+      const onIncognitoChange = vi.fn();
+
+      const { rerender } = render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          allowFileUploads={true}
+          incognito
+          onIncognitoChange={onIncognitoChange}
+        />,
+      );
+
+      // Armed draft + shortcut: claimed (no navigation) and toggled off.
+      const disarm = new Event(INCOGNITO_DRAFT_SHORTCUT_EVENT, {
+        cancelable: true,
+      });
+      let unclaimed: boolean | undefined;
+      act(() => {
+        unclaimed = window.dispatchEvent(disarm);
+      });
+      expect(unclaimed).toBe(false);
+      expect(onIncognitoChange).toHaveBeenLastCalledWith(false);
+
+      // Shortcut again on the disarmed composer: toggled back on.
+      rerender(
+        <ArchestraPromptInput
+          {...defaultProps}
+          allowFileUploads={true}
+          incognito={false}
+          onIncognitoChange={onIncognitoChange}
+        />,
+      );
+      act(() => {
+        window.dispatchEvent(
+          new Event(INCOGNITO_DRAFT_SHORTCUT_EVENT, { cancelable: true }),
+        );
+      });
+      expect(onIncognitoChange).toHaveBeenLastCalledWith(true);
+    });
+
+    it("leaves the handshake event unclaimed while chatting in a conversation", () => {
+      mockFeatureState.chatIncognitoEnabled = true;
+      const onIncognitoChange = vi.fn();
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          conversationId="conversation-1"
+          allowFileUploads={true}
+          onIncognitoChange={onIncognitoChange}
+        />,
+      );
+
+      let unclaimed: boolean | undefined;
+      act(() => {
+        unclaimed = window.dispatchEvent(
+          new Event(INCOGNITO_DRAFT_SHORTCUT_EVENT, { cancelable: true }),
+        );
+      });
+
+      // Unclaimed → the global handler proceeds to navigate to a fresh draft.
+      expect(unclaimed).toBe(true);
+      expect(onIncognitoChange).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -931,7 +931,12 @@ const PromptInputContent = ({
         onError={handleFileError}
         className={cn(
           incognitoActive &&
-            "[&_[data-slot=input-group]]:border-dashed [&_[data-slot=input-group]]:border-muted-foreground/60",
+            // The dashed border replaces the composer's ring outright (both
+            // at once read as two competing outlines). !important because the
+            // ring and focus border are has-[]-variant classes on the
+            // InputGroup that otherwise win on specificity; focus feedback
+            // comes from brightening the dashes instead.
+            "[&_[data-slot=input-group]]:border-dashed [&_[data-slot=input-group]]:border-muted-foreground/60 [&_[data-slot=input-group]]:!ring-0 [&:has([data-slot=input-group-control]:focus-visible)_[data-slot=input-group]]:!border-muted-foreground",
         )}
       >
         {/* File attachments display - shown inline above textarea */}

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -35,6 +35,7 @@ import {
   PromptInputTextarea,
   usePromptInputController,
 } from "@/components/ai-elements/prompt-input";
+import { IncognitoIcon } from "@/components/chat/incognito-icon";
 import { PlaywrightInstallInline } from "@/components/chat/playwright-install-dialog";
 import { SensitiveDataConfirmDialog } from "@/components/chat/sensitive-data-confirm-dialog";
 import { Button } from "@/components/ui/button";
@@ -58,6 +59,7 @@ import {
 } from "@/lib/chat/chat-utils";
 import { isActionAvailableForConversation } from "@/lib/chat/incognito";
 import { useFeature } from "@/lib/config/config.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { useToolbarCollapse } from "@/lib/hooks/use-toolbar-collapse";
 import { useOrganization } from "@/lib/organization.query";
 import { scanText } from "@/lib/sensitive-data";
@@ -298,6 +300,7 @@ const PromptInputContent = ({
   const incognitoActive =
     !isActionAvailableForConversation(conversation, "attachments") ||
     (incognito && !conversationId);
+  const appName = useAppName();
 
   // Any file type can be attached regardless of model modalities or sandbox:
   // a file the model can't read is still stored and surfaced in the
@@ -903,6 +906,22 @@ const PromptInputContent = ({
           </PromptInputCommand>
         </div>
       )}
+      {/* Incognito "drawer": a slim strip tucked against the composer's top
+          edge, carrying the explanation that used to live in the toggle's
+          tooltip. Paired with the dashed composer border below so an
+          incognito chat is unmistakable while composing. */}
+      {incognitoActive && (
+        <div
+          data-testid={E2eTestId.ChatIncognitoNotice}
+          className="mx-3 -mb-px flex items-center gap-2 rounded-t-lg border border-b-0 border-dashed border-muted-foreground/40 bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground animate-in fade-in slide-in-from-bottom-2"
+        >
+          <IncognitoIcon className="size-3.5" />
+          <span>
+            Incognito chat — encrypted with a key that stays in this browser.{" "}
+            {appName} cannot read it, and it isn't available on other devices.
+          </span>
+        </div>
+      )}
       <PromptInput
         globalDrop
         multiple
@@ -910,6 +929,10 @@ const PromptInputContent = ({
         accept={showFileUploadButton ? undefined : "application/x-empty"}
         maxFileSize={storageByteLimit}
         onError={handleFileError}
+        className={cn(
+          incognitoActive &&
+            "[&_[data-slot=input-group]]:border-dashed [&_[data-slot=input-group]]:border-muted-foreground/40",
+        )}
       >
         {/* File attachments display - shown inline above textarea */}
         <PromptInputAttachments className="px-3 pt-2 pb-0">
@@ -955,7 +978,7 @@ const PromptInputContent = ({
             onApiKeyChange={onApiKeyChange}
             onProviderChange={onProviderChange}
             allowFileUploads={allowFileUploads}
-            attachmentsHidden={incognitoActive}
+            attachmentsDisabledByIncognito={incognitoActive}
             incognito={incognito}
             onIncognitoChange={onIncognitoChange}
             sandboxAvailable={sandboxAvailable}

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -913,7 +913,7 @@ const PromptInputContent = ({
       {incognitoActive && (
         <div
           data-testid={E2eTestId.ChatIncognitoNotice}
-          className="mx-3 -mb-px flex items-center gap-2 rounded-t-lg border border-b-0 border-dashed border-muted-foreground/40 bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground animate-in fade-in slide-in-from-bottom-2"
+          className="mx-3 -mb-px flex items-center gap-2 rounded-t-lg border border-b-0 border-dashed border-muted-foreground/60 bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground animate-in fade-in slide-in-from-bottom-2"
         >
           <IncognitoIcon className="size-3.5" />
           <span>
@@ -931,7 +931,7 @@ const PromptInputContent = ({
         onError={handleFileError}
         className={cn(
           incognitoActive &&
-            "[&_[data-slot=input-group]]:border-dashed [&_[data-slot=input-group]]:border-muted-foreground/40",
+            "[&_[data-slot=input-group]]:border-dashed [&_[data-slot=input-group]]:border-muted-foreground/60",
         )}
       >
         {/* File attachments display - shown inline above textarea */}

--- a/platform/frontend/src/consts.tsx
+++ b/platform/frontend/src/consts.tsx
@@ -28,6 +28,14 @@ export const SHORTCUT_NEW_INCOGNITO_CHAT = {
  */
 export const NEW_INCOGNITO_CHAT_HREF = "/chat?incognito=1";
 
+/**
+ * Cancelable window event the Alt+I handler dispatches before navigating to
+ * {@link NEW_INCOGNITO_CHAT_HREF}: the new-chat composer, while mounted,
+ * claims it (preventDefault) and toggles its incognito draft in place, so the
+ * shortcut arms AND disarms instead of re-pushing an identical URL.
+ */
+export const INCOGNITO_DRAFT_SHORTCUT_EVENT = "incognito-draft-shortcut";
+
 // Alt-qualified (matching SHORTCUT_NEW_CHAT) so the palette has no bare
 // character-key shortcuts (WCAG 2.1.4) and the keys still work while a search
 // query is being typed. `code` dodges macOS Option dead-key characters.

--- a/platform/frontend/src/lib/chat/conversation-search.hook.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-search.hook.test.ts
@@ -3,6 +3,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { useRouter } from "next/navigation";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { INCOGNITO_DRAFT_SHORTCUT_EVENT } from "@/consts";
 import { useConversationSearch } from "@/lib/chat/conversation-search.hook";
 import { useFeature } from "@/lib/config/config.query";
 
@@ -210,6 +211,25 @@ describe("useConversationSearch", () => {
     });
 
     expect(mockRouterPush).toHaveBeenCalledWith("/chat?incognito=1");
+  });
+
+  it("does not navigate on Alt+I when the new-chat composer claims the shortcut", () => {
+    mockPlatform("MacIntel");
+    renderHook(() => useConversationSearch());
+
+    // Stand in for the mounted new-chat composer: claim the cancelable
+    // handshake event so the shortcut toggles in place instead of navigating.
+    const claim = (event: Event) => event.preventDefault();
+    window.addEventListener(INCOGNITO_DRAFT_SHORTCUT_EVENT, claim);
+    try {
+      act(() => {
+        dispatchKeydown({ key: "Dead", code: "KeyI", altKey: true });
+      });
+    } finally {
+      window.removeEventListener(INCOGNITO_DRAFT_SHORTCUT_EVENT, claim);
+    }
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
   it("ignores Alt+I when incognito chats are disabled", () => {

--- a/platform/frontend/src/lib/chat/conversation-search.hook.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-search.hook.test.ts
@@ -213,6 +213,38 @@ describe("useConversationSearch", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/chat?incognito=1");
   });
 
+  it("blurs the focused editable while handling Alt+I, then restores focus", async () => {
+    // macOS Option+I is a dead key whose composition Chromium starts even on
+    // a preventDefault'ed keydown — the handler blurs the editable so the
+    // "ˆ" has no target, and the composer must be refocused afterwards.
+    mockPlatform("MacIntel");
+    renderHook(() => useConversationSearch());
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    textarea.focus();
+
+    let activeDuringDispatch: Element | null = null;
+    const observe = () => {
+      activeDuringDispatch = document.activeElement;
+    };
+    window.addEventListener(INCOGNITO_DRAFT_SHORTCUT_EVENT, observe);
+    try {
+      act(() => {
+        dispatchKeydown({ key: "Dead", code: "KeyI", altKey: true });
+      });
+    } finally {
+      window.removeEventListener(INCOGNITO_DRAFT_SHORTCUT_EVENT, observe);
+    }
+
+    expect(activeDuringDispatch).not.toBe(textarea);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(document.activeElement).toBe(textarea);
+    textarea.remove();
+  });
+
   it("does not navigate on Alt+I when the new-chat composer claims the shortcut", () => {
     mockPlatform("MacIntel");
     renderHook(() => useConversationSearch());

--- a/platform/frontend/src/lib/chat/conversation-search.hook.ts
+++ b/platform/frontend/src/lib/chat/conversation-search.hook.ts
@@ -51,6 +51,7 @@ export function useConversationSearch() {
       if (event.altKey && event.code === SHORTCUT_NEW_CHAT.code) {
         event.preventDefault();
         event.stopPropagation();
+        suppressDeadKeyComposition();
         setIsOpen(false);
         router.push("/chat");
       }
@@ -64,6 +65,7 @@ export function useConversationSearch() {
       ) {
         event.preventDefault();
         event.stopPropagation();
+        suppressDeadKeyComposition();
         setIsOpen(false);
         // Handshake with the new-chat composer: when it's on screen it
         // claims the shortcut (preventDefault on this cancelable event) and
@@ -92,4 +94,22 @@ export function useConversationSearch() {
     setIsOpen,
     recentChatsView,
   };
+}
+
+/**
+ * On macOS, Option+N / Option+I are dead keys and Chromium starts their
+ * composition even when the keydown is preventDefault'ed — so a "˜" or "ˆ"
+ * would still land in whichever editable has focus (e.g. the chat textarea).
+ * Blur it for the duration of the event so the composition has no target,
+ * then restore focus.
+ */
+function suppressDeadKeyComposition() {
+  const active = document.activeElement;
+  if (active instanceof HTMLElement) {
+    active.blur();
+    setTimeout(() => {
+      // No-op if navigation replaced the view and detached the element.
+      active.focus();
+    }, 0);
+  }
 }

--- a/platform/frontend/src/lib/chat/conversation-search.hook.ts
+++ b/platform/frontend/src/lib/chat/conversation-search.hook.ts
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import {
+  INCOGNITO_DRAFT_SHORTCUT_EVENT,
   NEW_INCOGNITO_CHAT_HREF,
   SHORTCUT_NEW_CHAT,
   SHORTCUT_NEW_INCOGNITO_CHAT,
@@ -64,7 +65,16 @@ export function useConversationSearch() {
         event.preventDefault();
         event.stopPropagation();
         setIsOpen(false);
-        router.push(NEW_INCOGNITO_CHAT_HREF);
+        // Handshake with the new-chat composer: when it's on screen it
+        // claims the shortcut (preventDefault on this cancelable event) and
+        // toggles its draft in place; dispatchEvent returns false in that
+        // case. Anywhere else, navigate to a fresh incognito draft.
+        const unclaimed = window.dispatchEvent(
+          new Event(INCOGNITO_DRAFT_SHORTCUT_EVENT, { cancelable: true }),
+        );
+        if (unclaimed) {
+          router.push(NEW_INCOGNITO_CHAT_HREF);
+        }
       }
     };
 

--- a/platform/shared/e2e-test-ids.ts
+++ b/platform/shared/e2e-test-ids.ts
@@ -119,6 +119,7 @@ export const E2eTestId = {
   // Chat Prompt Input
   ChatFileUploadButton: "chat-file-upload-button",
   ChatDisabledFileUploadButton: "chat-disabled-file-upload-button",
+  ChatIncognitoNotice: "chat-incognito-notice",
   ChatContextUsageTrigger: "chat-context-usage-trigger",
   ChatContextUsagePanel: "chat-context-usage-panel",
   ChatContextUsageTooltip: "chat-context-usage-tooltip",


### PR DESCRIPTION
## What

UX polish for incognito chats, centered on the new-chat composer:

- **Attach button greys out instead of disappearing.** On incognito chats the paperclip stays visible but disabled, with a succinct hover explanation of the real reason: attachment bytes are stored unencrypted server-side, so the backend rejects them there.
- **Toggle tooltip trimmed to "Incognito chat"** plus the global shortcut rendered as keycaps (⌥ I), mirroring how other shortcut hints render.
- **Active incognito gets a distinct composer treatment:** a subtle dashed border around the prompt input plus a slim "drawer" tucked against its top edge carrying the explanation that used to live in the toggle tooltip — "Incognito chat — encrypted with a key that stays in this browser. {appName} cannot read it, and it isn't available on other devices." The composer's usual ring/glow is suppressed while incognito so the dashes stand alone; focus feedback comes from brightening the dashes. The same treatment persists while chatting in an existing incognito conversation.
- **Alt+I toggles the armed draft.** Pressing the shortcut on the new-chat composer now disarms/re-arms the incognito draft in place instead of re-pushing `/chat?incognito=1`. Implemented as a cancelable-event handshake: the global handler dispatches `incognito-draft-shortcut` first and only navigates when nobody claims it, so the palette entry, sidebar link, and deep-link all behave exactly as before. Arming via shortcut clears staged files, same as clicking the toggle.
- **macOS dead-key fix:** Option+N / Option+I are dead keys whose composition Chromium starts even on a `preventDefault`'ed keydown, so a stray `˜`/`ˆ` landed in the focused textarea. The handler now blurs the focused editable for the duration of the shortcut and restores focus after.