### PR TITLE
fix(knowledge): citations for run_tool-dispatched queries + bounded search-lane timeouts

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1618,6 +1618,10 @@ These environment variables configure the [Knowledge Base](/docs/platform-knowle
   - Default: `true`
   - Set to `false` to use vector similarity search only.
 
+- **`ARCHESTRA_KNOWLEDGE_BASE_SEARCH_STATEMENT_TIMEOUT_MILLIS`** - Per-statement timeout for the knowledge search lanes (vector and keyword), in milliseconds.
+  - Default: `8000`
+  - Tighter than the pool-wide `ARCHESTRA_DATABASE_STATEMENT_TIMEOUT_MILLIS`. A search lane that exceeds it is dropped and the remaining lanes' results are merged. The query fails only when every lane times out. Timed-out lanes are counted in the `rag_search_lane_timeout_total` metric. Set to `0` to inherit the pool-wide timeout.
+
 - **`ARCHESTRA_KNOWLEDGE_BASE_QUOTE_VERIFICATION_ENABLED`** - Verifiable citations. In the built-in chat, the model is asked to back each claim with a short verbatim quote tagged with its source chunk's ref; this checks each quote against the chunk its ref names and logs plus meters (`rag_quote_verification_total`) every miss — a quote found in no returned chunk is a likely fabrication, a quote whose ref names no returned chunk but whose text exists in another one is a mis-citation.
   - Default: `true`
   - Log-only: it never blocks or alters an answer, and only covers the internal chat (external MCP clients answer where Archestra cannot see the text). Set to `false` to disable the feature: the model is no longer asked to quote, and no check runs.

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -584,6 +584,11 @@ ARCHESTRA_CHATOPS_TELEGRAM_BOT_TOKEN=
 # ARCHESTRA_KNOWLEDGE_BASE_STALLED_EMBEDDING_AGE_SECONDS=900
 # Enable or disable hybrid search (vector + full-text with RRF).
 # ARCHESTRA_KNOWLEDGE_BASE_HYBRID_SEARCH_ENABLED=true
+# Per-statement timeout (ms) for the knowledge search lanes (vector + keyword),
+# tighter than the pool-wide statement timeout. A lane that exceeds it is dropped
+# and the remaining lanes' results are merged; only when every lane times out does
+# the query fail (with an actionable message). 0 inherits the pool-wide timeout.
+# ARCHESTRA_KNOWLEDGE_BASE_SEARCH_STATEMENT_TIMEOUT_MILLIS=8000
 # Verifiable citations: in the internal chat, check the verbatim quotes the model
 # tags with a chunk ref against the returned chunks, logging + metering any quote
 # that matches no chunk. Log-only (never blocks or alters the answer). Set to

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2830,6 +2830,22 @@ const config = {
       process.env.ARCHESTRA_KNOWLEDGE_BASE_TASK_WORKER_SHUTDOWN_TIMEOUT_SECONDS,
       30,
     ),
+    /**
+     * Per-statement timeout for the chunk search lanes (vector + keyword),
+     * tighter than the pool-wide statement_timeout. Retrieval fans out into
+     * several parallel search statements per tool call, so a corpus where one
+     * lane degenerates (e.g. a keyword query matching most of a large corpus)
+     * would otherwise burn the full pool timeout once per lane and fail the
+     * whole call. A lane that exceeds this budget is dropped and the remaining
+     * lanes' results are merged instead. 0 disables the override (lanes
+     * inherit the pool-wide statement_timeout).
+     */
+    searchStatementTimeoutMillis: parseClampedInt(
+      process.env.ARCHESTRA_KNOWLEDGE_BASE_SEARCH_STATEMENT_TIMEOUT_MILLIS,
+      8_000,
+      0,
+      120_000,
+    ),
     // Liveness lease for connector sync runs. The owning worker renews the
     // lease every `heartbeatInterval`; a run whose lease is not renewed within
     // `leaseTtl` is treated as orphaned and reclaimed. TTL must be several times

--- a/platform/backend/src/knowledge-base/errors.ts
+++ b/platform/backend/src/knowledge-base/errors.ts
@@ -138,6 +138,24 @@ export class RerankerConfigUnresolvableError extends KnowledgeBaseError {
 }
 
 /**
+ * Every search lane of a knowledge query hit the database statement timeout, so
+ * there is nothing to merge and no results to return. Thrown only in that
+ * all-lanes case: a partial timeout degrades silently to the surviving lanes'
+ * results instead.
+ */
+export class KnowledgeBaseSearchTimeoutError extends KnowledgeBaseError {
+  readonly userMessage =
+    "Knowledge search timed out before any results were retrieved — the corpus is too large for the " +
+    "current search time budget. Retry with a more specific query; if this persists, an administrator " +
+    "should investigate search performance or raise ARCHESTRA_KNOWLEDGE_BASE_SEARCH_STATEMENT_TIMEOUT_MILLIS.";
+
+  constructor(public readonly timeoutMillis: number) {
+    super(`All knowledge search lanes timed out after ${timeoutMillis}ms`);
+    this.name = "KnowledgeBaseSearchTimeoutError";
+  }
+}
+
+/**
  * The single safe mapper: a `KnowledgeBaseError` yields its actionable
  * `userMessage`; anything else yields `undefined` so the caller falls back to its
  * generic message (never leaking internal detail). Used by both the query handler

--- a/platform/backend/src/knowledge-base/query.test.ts
+++ b/platform/backend/src/knowledge-base/query.test.ts
@@ -85,6 +85,7 @@ import { KbChunkModel, KbDocumentModel } from "@/models";
 import type { VectorSearchResult } from "@/models/kb-chunk";
 import { describe, expect, test } from "@/test";
 
+import { KnowledgeBaseSearchTimeoutError } from "./errors";
 import { findEmbeddingDimensionMismatch, queryService } from "./query";
 
 function makeFakeEmbedding(seed: number): number[] {
@@ -749,6 +750,132 @@ describe("QueryService", () => {
 
     const [interaction] = await waitForKbInteractions(1);
     expect(interaction.connectorId).toBeNull();
+  });
+
+  // A statement-timeout cancellation is a process-boundary condition the PGlite
+  // test database cannot produce, so these tests simulate it at the model
+  // seam with the same error shape node-postgres raises (SQLSTATE 57014
+  // wrapped by the ORM).
+  function makeStatementTimeoutError(): Error {
+    return Object.assign(new Error("Failed query: SELECT ..."), {
+      cause: Object.assign(
+        new Error("canceling statement due to statement timeout"),
+        { code: "57014" },
+      ),
+    });
+  }
+
+  test("drops a lane cut by the statement timeout and serves the surviving lane", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    setupEmbeddingConfig();
+    setupSingleQueryExpansion();
+
+    const doc = await KbDocumentModel.create({
+      connectorId: connector.id,
+      organizationId: org.id,
+      title: "Timeout Survivor",
+      content: "Some content",
+      contentHash: "hash-lane-timeout-1",
+      sourceUrl: null,
+      embeddingStatus: "completed",
+    });
+    await KbChunkModel.insertMany([
+      {
+        documentId: doc.id,
+        content: "Resilient chunk about TypeScript",
+        chunkIndex: 0,
+        acl: ["org:*"],
+      },
+    ]);
+
+    const vectorSpy = vi
+      .spyOn(KbChunkModel, "vectorSearch")
+      .mockRejectedValue(makeStatementTimeoutError());
+    try {
+      embeddingQueue.push(makeFakeEmbedding(1));
+      const results = await queryService.query({
+        connectorIds: [connector.id],
+        organizationId: org.id,
+        queryText: "TypeScript",
+        userAcl: ["org:*"],
+      });
+
+      // The keyword lane's hit still comes back even though the vector lane
+      // burned its statement timeout.
+      expect(results.map((r) => r.content)).toEqual([
+        "Resilient chunk about TypeScript",
+      ]);
+    } finally {
+      vectorSpy.mockRestore();
+    }
+  });
+
+  test("fails with an actionable error when every search lane times out", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    setupEmbeddingConfig();
+    setupSingleQueryExpansion();
+
+    const vectorSpy = vi
+      .spyOn(KbChunkModel, "vectorSearch")
+      .mockRejectedValue(makeStatementTimeoutError());
+    const fullTextSpy = vi
+      .spyOn(KbChunkModel, "fullTextSearch")
+      .mockRejectedValue(makeStatementTimeoutError());
+    try {
+      embeddingQueue.push(makeFakeEmbedding(1));
+      await expect(
+        queryService.query({
+          connectorIds: [connector.id],
+          organizationId: org.id,
+          queryText: "TypeScript",
+          userAcl: ["org:*"],
+        }),
+      ).rejects.toThrow(KnowledgeBaseSearchTimeoutError);
+    } finally {
+      vectorSpy.mockRestore();
+      fullTextSpy.mockRestore();
+    }
+  });
+
+  test("non-timeout search failures still propagate", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    setupEmbeddingConfig();
+    setupSingleQueryExpansion();
+
+    const vectorSpy = vi
+      .spyOn(KbChunkModel, "vectorSearch")
+      .mockRejectedValue(new Error("relation does not exist"));
+    try {
+      embeddingQueue.push(makeFakeEmbedding(1));
+      await expect(
+        queryService.query({
+          connectorIds: [connector.id],
+          organizationId: org.id,
+          queryText: "TypeScript",
+          userAcl: ["org:*"],
+        }),
+      ).rejects.toThrow("relation does not exist");
+    } finally {
+      vectorSpy.mockRestore();
+    }
   });
 });
 

--- a/platform/backend/src/knowledge-base/query.ts
+++ b/platform/backend/src/knowledge-base/query.ts
@@ -1,5 +1,6 @@
 import { addNomicTaskPrefix, type TextSearchLanguage } from "@archestra/shared";
 import config from "@/config";
+import { isDbStatementTimeoutError } from "@/database/retry";
 import logger from "@/logging";
 import { KbChunkModel } from "@/models";
 import type { VectorSearchResult } from "@/models/kb-chunk";
@@ -9,6 +10,7 @@ import { expandChunkContext } from "./context-expansion";
 import { callEmbedding, getEmbeddingDiscriminator } from "./embedding-clients";
 import {
   EmbeddingDimensionMismatchError,
+  KnowledgeBaseSearchTimeoutError,
   normalizeEmbeddingError,
 } from "./errors";
 import {
@@ -115,10 +117,30 @@ class QueryService {
       ),
     );
 
+    // Search-lane degradation: a lane cut by the statement timeout was dropped
+    // (logged + metered in searchSingleQuery) and the rest merged. Only when
+    // EVERY lane of every expanded query timed out is there genuinely nothing
+    // to serve — surface that as an actionable error rather than an empty
+    // result a caller would read as "no matching documents".
+    const lanesAttempted = perQueryResults.reduce(
+      (n, r) => n + r.lanesAttempted,
+      0,
+    );
+    const lanesTimedOut = perQueryResults.reduce(
+      (n, r) => n + r.lanesTimedOut,
+      0,
+    );
+    if (lanesAttempted > 0 && lanesTimedOut === lanesAttempted) {
+      throw new KnowledgeBaseSearchTimeoutError(
+        config.kb.searchStatementTimeoutMillis ||
+          config.database.statementTimeoutMillis,
+      );
+    }
+
     const weights = expandedQueries.map((eq) => eq.weight);
 
     const merged = reciprocalRankFusion<VectorSearchResult>({
-      rankings: perQueryResults,
+      rankings: perQueryResults.map((r) => r.rows),
       idExtractor: (row) => row.id,
       weights,
       k: 50,
@@ -225,7 +247,7 @@ class QueryService {
     type: "semantic" | "keyword";
     hybridEnabled: boolean;
     searchLanguages: TextSearchLanguage[];
-  }): Promise<VectorSearchResult[]> {
+  }): Promise<SingleQuerySearchResult> {
     const {
       queryText,
       embeddingConfig,
@@ -295,46 +317,56 @@ class QueryService {
         { queryLength: queryText.length },
         "[QueryService] Embedding API returned no embedding for query",
       );
-      return [];
+      return { rows: [], lanesAttempted: 0, lanesTimedOut: 0 };
     }
     const queryEmbedding = embeddingResponse.data[0].embedding;
 
-    const fullTextPromise = hybridEnabled
-      ? KbChunkModel.fullTextSearch({
+    // Each lane is cut individually by the search statement timeout (`null` =
+    // timed out): dropping one lane degrades the merge instead of failing the
+    // whole query, and the caller escalates only when every lane is gone.
+    const [vectorRows, fullTextRows] = await Promise.all([
+      runSearchLane("vector", () =>
+        KbChunkModel.vectorSearch({
           connectorIds,
-          queryText,
-          languages: searchLanguages,
+          queryEmbedding,
+          dimensions: embeddingConfig.dimensions,
           limit,
           userAcl,
           bypassAcl,
           environmentId,
-        })
-      : Promise.resolve([] as VectorSearchResult[]);
-
-    const [vectorRows, fullTextRows] = await Promise.all([
-      KbChunkModel.vectorSearch({
-        connectorIds,
-        queryEmbedding,
-        dimensions: embeddingConfig.dimensions,
-        limit,
-        userAcl,
-        bypassAcl,
-        environmentId,
-      }),
-      fullTextPromise,
+        }),
+      ),
+      hybridEnabled
+        ? runSearchLane("keyword", () =>
+            KbChunkModel.fullTextSearch({
+              connectorIds,
+              queryText,
+              languages: searchLanguages,
+              limit,
+              userAcl,
+              bypassAcl,
+              environmentId,
+            }),
+          )
+        : Promise.resolve<VectorSearchResult[] | null>([]),
     ]);
+
+    const lanesAttempted = hybridEnabled ? 2 : 1;
+    const lanesTimedOut =
+      (vectorRows === null ? 1 : 0) +
+      (hybridEnabled && fullTextRows === null ? 1 : 0);
 
     logger.info(
       {
         type,
-        vectorCount: vectorRows.length,
-        fullTextCount: fullTextRows.length,
+        vectorCount: vectorRows?.length ?? "timed_out",
+        fullTextCount: fullTextRows?.length ?? "timed_out",
       },
       "[QueryService] Expanded query search results",
     );
 
     if (!hybridEnabled) {
-      return vectorRows;
+      return { rows: vectorRows ?? [], lanesAttempted, lanesTimedOut };
     }
 
     // Inner RRF: for keyword queries, favor BM25 (full-text)
@@ -342,13 +374,13 @@ class QueryService {
       type === "keyword" ? [1.0, KEYWORD_QUERY_HYBRID_ALPHA_WEIGHT] : undefined;
 
     const fused = reciprocalRankFusion<VectorSearchResult>({
-      rankings: [vectorRows, fullTextRows],
+      rankings: [vectorRows ?? [], fullTextRows ?? []],
       idExtractor: (row) => row.id,
       k: 60,
       weights: innerWeights,
     });
 
-    return fused.slice(0, limit);
+    return { rows: fused.slice(0, limit), lanesAttempted, lanesTimedOut };
   }
 
   private mapResults(rows: VectorSearchResult[]): ChunkResult[] {
@@ -370,6 +402,36 @@ class QueryService {
 }
 
 export const queryService = new QueryService();
+
+interface SingleQuerySearchResult {
+  rows: VectorSearchResult[];
+  /** Search statements actually issued: vector always, keyword when hybrid. */
+  lanesAttempted: number;
+  /** Of those, how many the database statement timeout cut. */
+  lanesTimedOut: number;
+}
+
+/**
+ * Run one search lane, absorbing a statement-timeout cancellation into `null`
+ * (logged + metered) so the caller can merge the surviving lanes. Every other
+ * failure still throws — only the timeout is a planned degradation.
+ */
+async function runSearchLane(
+  lane: "vector" | "keyword",
+  run: () => Promise<VectorSearchResult[]>,
+): Promise<VectorSearchResult[] | null> {
+  try {
+    return await run();
+  } catch (error) {
+    if (!isDbStatementTimeoutError(error)) throw error;
+    metrics.rag.reportSearchLaneTimeout(lane);
+    logger.warn(
+      { lane },
+      "[QueryService] Search lane hit the statement timeout; dropping it and merging the remaining lanes",
+    );
+    return null;
+  }
+}
 
 /**
  * Decide whether an empty search result reflects a dimension mismatch rather than

--- a/platform/backend/src/models/kb-chunk.ts
+++ b/platform/backend/src/models/kb-chunk.ts
@@ -3,7 +3,8 @@ import {
   getEmbeddingColumnName,
   type TextSearchLanguage,
 } from "@archestra/shared";
-import { count, eq, sql } from "drizzle-orm";
+import { count, eq, type SQL, sql } from "drizzle-orm";
+import config from "@/config";
 import db, { schema } from "@/database";
 import type { AclEntry, InsertKbChunk, KbChunk } from "@/types";
 
@@ -128,7 +129,7 @@ class KbChunkModel {
 
     const col = sql.raw(getEmbeddingColumnName(dimensions));
     const vectorCast = sql.raw(`::vector(${dimensions})`);
-    const rows = await db.execute(sql`
+    const rows = await executeWithSearchTimeout(sql`
       SELECT
         c.id, c.content, c.chunk_index AS "chunkIndex", c.document_id AS "documentId",
         d.source_id AS "sourceId", d.title, d.source_url AS "sourceUrl", d.metadata,
@@ -306,7 +307,7 @@ class KbChunkModel {
       sql`, `,
     );
 
-    const rows = await db.execute(sql`
+    const rows = await executeWithSearchTimeout(sql`
       SELECT
         c.id, c.content, c.chunk_index AS "chunkIndex", c.document_id AS "documentId",
         d.source_id AS "sourceId", d.title, d.source_url AS "sourceUrl", d.metadata,
@@ -457,3 +458,23 @@ class KbChunkModel {
 }
 
 export default KbChunkModel;
+
+// === Internal helpers ===
+
+/**
+ * Run a search statement under the KB-specific statement timeout
+ * ({@link config.kb.searchStatementTimeoutMillis}), leaving the pool-wide
+ * statement_timeout in force for everything else. SET LOCAL semantics via
+ * set_config(..., true) scope the override to the wrapping transaction, and
+ * set_config takes the value as a bound parameter (plain SET cannot).
+ */
+async function executeWithSearchTimeout(query: SQL) {
+  const timeoutMillis = config.kb.searchStatementTimeoutMillis;
+  if (timeoutMillis <= 0) return db.execute(query);
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT set_config('statement_timeout', ${String(timeoutMillis)}, true)`,
+    );
+    return tx.execute(query);
+  });
+}

--- a/platform/backend/src/observability/metrics/rag.ts
+++ b/platform/backend/src/observability/metrics/rag.ts
@@ -30,6 +30,7 @@ let ragQueryDuration: client.Histogram<string>;
 let ragQueriesTotal: client.Counter<string>;
 let ragQueryResultsCount: client.Histogram<string>;
 let ragQuoteVerificationTotal: client.Counter<string>;
+let ragSearchLaneTimeoutTotal: client.Counter<string>;
 
 // ===== Permission-sync metrics (auto-sync-permissions connectors) =====
 let ragPermissionSyncsTotal: client.Counter<string>;
@@ -124,6 +125,12 @@ export function initializeRagMetrics(): void {
     name: "rag_quote_verification_total",
     help: "Chat-answer quotes checked against their cited knowledge chunk (issue #7161). result=matched|wrong_ref|failed|unverifiable|unparseable; `failed` = the quote appears where it should not (fabrication), `wrong_ref` = the cited ref names no returned chunk but the quote exists in another one (mis-citation), `unverifiable` = unresolvable ref and the quote is too short to search for broadly, `unparseable` (once per turn) = chunks were returned but the answer carried no parseable quote, i.e. thin citation coverage",
     labelNames: ["result"],
+  });
+
+  ragSearchLaneTimeoutTotal = new client.Counter({
+    name: "rag_search_lane_timeout_total",
+    help: "Search lanes of a knowledge query cut by the database statement timeout (ARCHESTRA_KNOWLEDGE_BASE_SEARCH_STATEMENT_TIMEOUT_MILLIS). A timed-out lane is dropped and the remaining lanes' results are merged; a query where every lane times out fails with an actionable error",
+    labelNames: ["lane"],
   });
 
   ragPermissionSyncsTotal = new client.Counter({
@@ -421,6 +428,15 @@ export function reportQuoteVerification(params: {
       ragQuoteVerificationTotal.inc({ result }, count);
     }
   }
+}
+
+/**
+ * Reports a search lane (one vector or keyword statement of a knowledge query)
+ * cut by the database statement timeout.
+ */
+export function reportSearchLaneTimeout(lane: "vector" | "keyword"): void {
+  if (!ragSearchLaneTimeoutTotal) return;
+  ragSearchLaneTimeoutTotal.inc({ lane });
 }
 
 /**

--- a/platform/frontend/src/components/chat/knowledge-graph-citations.test.ts
+++ b/platform/frontend/src/components/chat/knowledge-graph-citations.test.ts
@@ -17,6 +17,36 @@ describe("hasKnowledgeBaseToolCall", () => {
     expect(hasKnowledgeBaseToolCall(parts)).toBe(true);
   });
 
+  it("returns true when the KB query is dispatched through run_tool (Auto tool mode)", () => {
+    const parts = [
+      {
+        type: "tool-archestra__run_tool",
+        state: "output-available",
+        input: {
+          tool_name: "archestra__query_knowledge_sources",
+          tool_args: { query: "rate limit" },
+        },
+      },
+    ];
+    expect(hasKnowledgeBaseToolCall(parts)).toBe(true);
+  });
+
+  it("returns false when run_tool dispatched a different tool", () => {
+    const parts = [
+      {
+        type: "tool-archestra__run_tool",
+        state: "output-available",
+        input: { tool_name: "archestra__list_projects", tool_args: {} },
+      },
+    ];
+    expect(hasKnowledgeBaseToolCall(parts)).toBe(false);
+  });
+
+  it("returns false for a run_tool part with no input", () => {
+    const parts = [{ type: "tool-archestra__run_tool" }];
+    expect(hasKnowledgeBaseToolCall(parts)).toBe(false);
+  });
+
   it("returns false when no knowledge base tool call exists", () => {
     const parts = [
       { type: "text" },
@@ -133,6 +163,53 @@ describe("extractCitations", () => {
     const citations = extractCitations([makeKbPart(output)]);
     expect(citations).toHaveLength(1);
     expect(citations[0].documentId).toBe("doc-dup");
+  });
+
+  it("extracts citations from a run_tool-wrapped KB query (Auto tool mode)", () => {
+    // Shape observed from a persisted Auto-mode conversation: the part is
+    // named after the dispatcher, the real tool is in input.tool_name, and
+    // the output carries the KB payload as a JSON string under `content`.
+    const part = {
+      type: "tool-archestra__run_tool",
+      state: "output-available" as const,
+      input: {
+        tool_name: "archestra__query_knowledge_sources",
+        tool_args: { query: "rate limit" },
+      },
+      output: {
+        content: JSON.stringify({
+          results: [
+            {
+              citation: {
+                title: "Zephyr Billing API Reference",
+                sourceUrl: "http://example.com/zephyr",
+                connectorType: "web_crawler",
+                documentId: "doc-run-tool",
+              },
+            },
+          ],
+        }),
+      },
+    };
+    const citations = extractCitations([part]);
+    expect(citations).toHaveLength(1);
+    expect(citations[0]).toEqual({
+      title: "Zephyr Billing API Reference",
+      sourceUrl: "http://example.com/zephyr",
+      connectorType: "web_crawler",
+      documentId: "doc-run-tool",
+      sourceId: null,
+    });
+  });
+
+  it("does not extract citations from a run_tool part that dispatched another tool", () => {
+    const part = {
+      type: "tool-archestra__run_tool",
+      state: "output-available" as const,
+      input: { tool_name: "archestra__list_projects", tool_args: {} },
+      output: { content: JSON.stringify({ results: [] }) },
+    };
+    expect(extractCitations([part])).toEqual([]);
   });
 
   it("returns empty array when no KB parts exist", () => {

--- a/platform/frontend/src/components/chat/knowledge-graph-citations.tsx
+++ b/platform/frontend/src/components/chat/knowledge-graph-citations.tsx
@@ -3,6 +3,7 @@
 import {
   type ChatMessagePart,
   TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
+  TOOL_RUN_TOOL_SHORT_NAME,
 } from "@archestra/shared";
 import { ChevronDown, ChevronUp, ExternalLink, FileText } from "lucide-react";
 import { useState } from "react";
@@ -14,12 +15,31 @@ import { Button } from "@/components/ui/button";
 import { getToolNameFromPart } from "@/lib/chat/chat-tools-display.utils";
 
 export function hasKnowledgeBaseToolCall(parts: ChatMessagePart[]): boolean {
-  return parts.some(
-    (part) =>
-      getToolNameFromPart(part)?.endsWith(
-        TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
-      ) ?? false,
-  );
+  return parts.some(isKnowledgeBaseQueryPart);
+}
+
+/**
+ * True when the part is a `query_knowledge_sources` call — either invoked
+ * directly, or dispatched through the Auto-tool-mode `run_tool` wrapper. In
+ * Auto mode the part is named after the dispatcher and the real tool only
+ * appears in the call input's `tool_name`, so matching on the part name alone
+ * would miss every KB query made by an Auto-mode agent.
+ */
+function isKnowledgeBaseQueryPart(part: ChatMessagePart): boolean {
+  const partToolName = getToolNameFromPart(part);
+  if (!partToolName) return false;
+  if (partToolName.endsWith(TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME)) {
+    return true;
+  }
+  if (partToolName.endsWith(TOOL_RUN_TOOL_SHORT_NAME)) {
+    const dispatched = (part.input as { tool_name?: unknown } | undefined)
+      ?.tool_name;
+    return (
+      typeof dispatched === "string" &&
+      dispatched.endsWith(TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME)
+    );
+  }
+  return false;
 }
 
 export interface ExtractedCitation {
@@ -37,12 +57,9 @@ export function extractCitations(
   const citations: ExtractedCitation[] = [];
 
   for (const part of parts) {
-    const isKbTool =
-      getToolNameFromPart(part)?.endsWith(
-        TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
-      ) ?? false;
-
-    if (!isKbTool || part.state !== "output-available") continue;
+    if (!isKnowledgeBaseQueryPart(part) || part.state !== "output-available") {
+      continue;
+    }
 
     let results: Array<{
       citation?: {


### PR DESCRIPTION
## Summary

Two knowledge fixes found while testing this week's KB PRs end to end.

### 1. Citations panel never rendered for Auto-tool-mode agents

In Auto tool mode the model reaches `query_knowledge_sources` through the `run_tool` dispatcher, so the message part is `tool-…run_tool` and the real tool name only appears in the call input's `tool_name`. `hasKnowledgeBaseToolCall`/`extractCitations` matched on the part name alone, so Auto-mode agents — the default chat setup — never showed a Sources panel, even though the backend half of quote verification (#7199) already unwraps `run_tool` dispatches. Both now resolve the dispatched tool name before matching. Verified live in the chat UI; tests pin the persisted `run_tool` part shape (`input.tool_name` + `output.content` JSON).

### 2. Knowledge search dies wholesale when a lane exceeds the pool statement timeout

On staging, `query_knowledge_sources` fails every time with "An internal error occurred while querying knowledge base". Root cause (confirmed in Cloud SQL logs): every search statement is canceled by the pool-wide 30s `statement_timeout`. A knowledge query fans out into several parallel statements (query expansion × vector+keyword lanes), so one degenerate lane shape burns 30s × N and the whole tool call fails opaquely. The keyword lane is the structural suspect: it ORs every query word and `ts_rank`-sorts the full match set, a cost that grows with the corpus (the staging corpus is well past the 300k-chunk scale the FTS comment in `kb-chunk.ts` was measured at).

This PR makes retrieval degrade instead of die:

- Search lanes run under their own tighter statement timeout — `ARCHESTRA_KNOWLEDGE_BASE_SEARCH_STATEMENT_TIMEOUT_MILLIS`, default 8s, applied per-statement via `SET LOCAL` (`set_config(..., true)`) inside a transaction, so nothing else inherits it. `0` falls back to the pool-wide timeout.
- A lane cut by the timeout is dropped, logged, and metered (`rag_search_lane_timeout_total{lane="vector"|"keyword"}`); the surviving lanes' results are merged — RRF and the reranker already handle partial rankings.
- Only when **every** lane of every expanded query times out does the query fail, now with an actionable `KnowledgeBaseSearchTimeoutError` ("Knowledge search timed out … retry with a more specific query / raise the env var") instead of the generic internal error.

Not addressed here (follow-ups): making the keyword lane's cost independent of corpus size (e.g. bounding the ranked match set), folding the model-written plain-text Sources block into the citation chips, and the `ON DELETE SET NULL` severing of `organization.embedding_chat_api_key_id` when a credential row is recreated.

## Testing

- `frontend`: citation tests extended with `run_tool`-wrapped shapes (26 pass); type-check + lint clean.
- `backend`: new lane-degradation tests (drop one lane / all lanes → typed error / non-timeout errors propagate); query, context-expansion, knowledge-base routes, knowledge-management, config suites all pass (561 tests); `pnpm knip` clean.
- Live: local KB query through the MCP gateway returns correct results via the new wrapper against real Postgres.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>