### PR TITLE
fix(mcp-registry): keep server card metadata inside the card

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -984,7 +984,7 @@ export function InternalMCPCatalog({
                 onCancelInstallation={install.cancelInstallation}
               />
             ) : (
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              <div className={CARD_GRID_CLASS}>
                 {personalItems.map((item) => {
                   const serverInfo = getInstalledServerInfo(item);
                   return (
@@ -1042,7 +1042,7 @@ export function InternalMCPCatalog({
                 onCancelInstallation={install.cancelInstallation}
               />
             ) : (
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              <div className={CARD_GRID_CLASS}>
                 {sharedItems.map((item) => {
                   const serverInfo = getInstalledServerInfo(item);
                   return (
@@ -1234,3 +1234,18 @@ function McpCatalogLabelKeyRow({
     />
   );
 }
+
+/**
+ * Columns are sized from what a card needs, not from viewport breakpoints. The
+ * breakpoints measured the window rather than the space left after the nav, so
+ * `lg:grid-cols-3` kept promising three columns while handing each card ~190px
+ * — far less than its metadata row (scope badge, tool and agent counts,
+ * deployment state, connection avatars) can lay out on one line. Sizing from
+ * the content drops a column at those widths instead of squeezing.
+ *
+ * 19rem: measured against the widest real cards, every one of them fits by
+ * 296px and the worst overflows by 1px at 288px, so this floor clears it with
+ * a little room for the author name to occupy rather than truncate.
+ */
+const CARD_GRID_CLASS =
+  "grid gap-4 grid-cols-[repeat(auto-fill,minmax(19rem,1fr))]";

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -620,7 +620,7 @@ export function McpServerCard({
             authorName={item.authorName}
             currentUserId={currentUserId}
             showSelfAsMe={false}
-            className="max-w-full"
+            compact
           />
         </div>
       )}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -519,9 +519,10 @@ export function McpServerCard({
     </Button>
   );
 
-  // 3 keeps the compact info row on one line at grid card width; a 4th
-  // connection folds into the +N count instead of pushing the circle stack
-  // past the card edge.
+  // A 4th connection folds into the +N count rather than lengthening the
+  // stack: the stack is the widest fixed item in the compact info row, and
+  // every extra circle comes straight out of the width the scope badge's name
+  // has left to truncate into.
   const MAX_AVATARS = 3;
   const connectionAvatars: Array<{
     type: "team" | "user";
@@ -572,30 +573,46 @@ export function McpServerCard({
   // Who can reach this catalog item. Personal items of the viewer's own say
   // nothing new — the grid already groups them under a "Personal" heading, so
   // the badge is asked not to label them "Me" (`showSelfAsMe={false}`) and
-  // renders null for that case; the gate mirrors it to keep the row (and its
-  // separator) from reserving space for an empty badge.
+  // renders null for that case; the gate mirrors it to keep the row from
+  // reserving space for an empty badge.
   const showScopeBadge =
     item.scope !== "personal" ||
     Boolean(item.authorId && item.authorId !== currentUserId);
 
-  // Whether anything follows the badge in the row. Shared by the row's "is there
-  // anything at all to show" gate and the badge's trailing divider so the two
-  // can't drift and leave a divider hanging at the end of the row.
+  /** Who is connected and whether a connection needs attention. */
+  const hasTrailingCluster =
+    !isBuiltinVariant &&
+    (connectionAvatars.length > 0 ||
+      hasOrgConnection ||
+      Boolean(oauthReauthIndicator));
+
+  /** Whether anything follows the badge in the row. */
   const hasCompactInfoAfterScopeBadge =
     toolsCount > 0 ||
     totalAgentCount > 0 ||
     (variant === "local" && deploymentServerIds.length > 0) ||
-    (!isBuiltinVariant &&
-      (connectionAvatars.length > 0 ||
-        hasOrgConnection ||
-        Boolean(oauthReauthIndicator)));
+    hasTrailingCluster;
 
   const hasCompactInfoContent = showScopeBadge || hasCompactInfoAfterScopeBadge;
 
+  /*
+    One line, and it has to stay one line at the grid's card width — which
+    leaves it roughly 250-300px to seat a scope badge, two counts, a deployment
+    state and a stack of connection avatars. Two rules keep it there.
+
+    Fixed items are `shrink-0` and the badge is the single elastic cell, so
+    pressure lands on the one thing that can absorb it — a long author or team
+    name truncates (its `title` keeps it readable) instead of every item
+    refusing to shrink and the row spilling over the card edge.
+
+    Nothing separates the items but the gap. The 1px rules that used to sit
+    between them cost ~21px each once their two gaps are counted — around a
+    fifth of the row — which is most of what a name has to truncate into.
+  */
   const compactInfoRow = hasCompactInfoContent ? (
-    <div className="flex items-center gap-3 text-sm text-muted-foreground">
+    <div className="flex min-w-0 items-center gap-3 text-sm text-muted-foreground">
       {showScopeBadge && (
-        <>
+        <div className="flex min-w-0 items-center">
           <ResourceVisibilityBadge
             scope={item.scope}
             teams={item.teams}
@@ -603,22 +620,17 @@ export function McpServerCard({
             authorName={item.authorName}
             currentUserId={currentUserId}
             showSelfAsMe={false}
+            className="max-w-full"
           />
-          {hasCompactInfoAfterScopeBadge && (
-            <div className="h-4 w-px bg-border" />
-          )}
-        </>
+        </div>
       )}
       {toolsCount > 0 && (
-        <>
-          <div className="flex items-center gap-1">
-            <Wrench className="h-3.5 w-3.5" />
-            <span data-testid={`${E2eTestId.McpServerToolsCount}`}>
-              {toolsCount}
-            </span>
-          </div>
-          <div className="h-4 w-px bg-border" />
-        </>
+        <div className="flex shrink-0 items-center gap-1">
+          <Wrench className="h-3.5 w-3.5" />
+          <span data-testid={`${E2eTestId.McpServerToolsCount}`}>
+            {toolsCount}
+          </span>
+        </div>
       )}
       {totalAgentCount > 0 && (
         <>
@@ -628,7 +640,7 @@ export function McpServerCard({
           */}
           <HoverCard openDelay={150}>
             <HoverCardTrigger asChild>
-              <div className="flex items-center gap-1 cursor-help">
+              <div className="flex shrink-0 items-center gap-1 cursor-help">
                 <Bot className="h-3.5 w-3.5" />
                 <span data-testid={`${E2eTestId.McpServerAgentsCount}`}>
                   {totalAgentCount}
@@ -664,35 +676,36 @@ export function McpServerCard({
               </Link>
             </HoverCardContent>
           </HoverCard>
-          <div className="h-4 w-px bg-border" />
         </>
       )}
-      {variant === "local" && deploymentServerIds.length > 0 && (
-        <>
-          {deploymentSummary ? (
-            <button
-              type="button"
-              onClick={() => goToItemPage("logs")}
-              aria-label={`${deploymentSummary.running} of ${deploymentSummary.total} deployments running for ${item.name}, view logs`}
-              className="flex items-center gap-1.5 cursor-pointer hover:text-foreground transition-colors"
-            >
-              <DeploymentStatusDot state={deploymentSummary.overallState} />
-              <span aria-hidden>
-                {deploymentSummary.running}/{deploymentSummary.total}
-              </span>
-            </button>
-          ) : (
-            <span className="relative flex h-2 w-2 shrink-0">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-muted-foreground/50 opacity-75" />
-              <span className="relative inline-flex rounded-full h-2 w-2 bg-muted-foreground/50" />
+      {variant === "local" &&
+        deploymentServerIds.length > 0 &&
+        (deploymentSummary ? (
+          <button
+            type="button"
+            onClick={() => goToItemPage("logs")}
+            aria-label={`${deploymentSummary.running} of ${deploymentSummary.total} deployments running for ${item.name}, view logs`}
+            className="flex shrink-0 items-center gap-1.5 cursor-pointer hover:text-foreground transition-colors"
+          >
+            <DeploymentStatusDot state={deploymentSummary.overallState} />
+            <span aria-hidden>
+              {deploymentSummary.running}/{deploymentSummary.total}
             </span>
-          )}
-          <div className="h-4 w-px bg-border" />
-        </>
-      )}
-      {!isBuiltinVariant &&
-        (connectionAvatars.length > 0 || hasOrgConnection) && (
-          <div className="flex items-center gap-2">
+          </button>
+        ) : (
+          <span className="relative flex h-2 w-2 shrink-0">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-muted-foreground/50 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-muted-foreground/50" />
+          </span>
+        ))}
+      {/*
+        Trailing cluster, pushed to the card's right edge by `ml-auto` so the
+        avatar stacks line up down a column of cards instead of each starting
+        wherever its neighbour's name happened to end.
+      */}
+      {hasTrailingCluster && (
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          {(connectionAvatars.length > 0 || hasOrgConnection) && (
             <AvatarGroup>
               {hasOrgConnection && (
                 <TooltipProvider>
@@ -775,9 +788,10 @@ export function McpServerCard({
                 </Tooltip>
               </TooltipProvider>
             </AvatarGroup>
-          </div>
-        )}
-      {!isBuiltinVariant && oauthReauthIndicator}
+          )}
+          {oauthReauthIndicator}
+        </div>
+      )}
     </div>
   ) : null;
 
@@ -966,7 +980,10 @@ export function McpServerCard({
 
   return (
     <Card
-      className="flex flex-col relative pt-4 gap-4 h-full"
+      // `overflow-hidden` is a backstop, not the fix: the rows inside are laid
+      // out to fit. It means that if some future combination still doesn't,
+      // the card clips it instead of painting it over its neighbour.
+      className="flex flex-col relative pt-4 gap-4 h-full overflow-hidden"
       data-testid={`${E2eTestId.McpServerCard}-${item.name}`}
     >
       <CardHeader className="gap-0">

--- a/platform/frontend/src/app/mcp/registry/_parts/oauth-reauth-indicator.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/oauth-reauth-indicator.tsx
@@ -1,12 +1,26 @@
 import { AlertTriangle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+
+const LABEL = "Needs re-authentication";
 
 /**
  * Compact needs-reauthentication marker for an OAuth connection on a server
- * card: an alert icon and a short label, nothing more. When `onActivate` is
- * supplied (the caller may re-authenticate the connection), the whole marker is
- * one click target that opens the credential surface, where the detailed reason
- * lives; without it the marker is shown but inert.
+ * card: an alert icon, nothing more. When `onActivate` is supplied (the caller
+ * may re-authenticate the connection), the marker is one click target that
+ * opens the credential surface, where the detailed reason lives; without it the
+ * marker is shown but inert.
+ *
+ * The label is carried by a tooltip and an sr-only span rather than set inline.
+ * The marker shares one card row with the scope badge, the tool and agent
+ * counts, the deployment state and the connection avatars, and at the grid's
+ * card width there is no room for a five-word string — rendered inline it
+ * pushed the row past the card edge on exactly the cards that had something to
+ * report.
  */
 export function OAuthReauthIndicator({
   onActivate,
@@ -18,37 +32,40 @@ export function OAuthReauthIndicator({
   // amber-800 in light mode: amber-600 measures ~3.1:1 on the card background,
   // below the 4.5:1 minimum for small text (WCAG 1.4.3).
   const containerClassName = cn(
-    "inline-flex items-center gap-1 text-xs text-amber-800 dark:text-amber-400",
+    "inline-flex shrink-0 items-center text-amber-800 dark:text-amber-400",
     className,
   );
 
   const body = (
     <>
       <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-      <span>Needs re-authentication</span>
+      <span className="sr-only">{LABEL}</span>
     </>
   );
 
-  if (!onActivate) {
-    return (
-      <span className={containerClassName} data-testid="oauth-reauth-state">
-        {body}
-      </span>
-    );
-  }
-
-  return (
+  const marker = onActivate ? (
     <button
       type="button"
       onClick={onActivate}
       className={cn(
         containerClassName,
-        "cursor-pointer rounded-sm underline-offset-2 hover:text-amber-900 dark:hover:text-amber-300 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500",
+        "cursor-pointer rounded-sm hover:text-amber-900 dark:hover:text-amber-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500",
       )}
       data-testid="oauth-reauth-state"
-      aria-label="Needs re-authentication, open credentials"
+      aria-label={`${LABEL}, open credentials`}
     >
       {body}
     </button>
+  ) : (
+    <span className={containerClassName} data-testid="oauth-reauth-state">
+      {body}
+    </span>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{marker}</TooltipTrigger>
+      <TooltipContent>{LABEL}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/platform/frontend/src/components/resource-visibility-badge.test.tsx
+++ b/platform/frontend/src/components/resource-visibility-badge.test.tsx
@@ -150,3 +150,63 @@ describe("ResourceVisibilityBadge per-user shares", () => {
     expect(container).toBeEmptyDOMElement();
   });
 });
+
+describe("ResourceVisibilityBadge compact team scope", () => {
+  const TEAMS = [
+    { id: "t1", name: "Engineering" },
+    { id: "t2", name: "Consultants" },
+  ];
+
+  it("names the scope instead of listing every team", () => {
+    render(
+      <ResourceVisibilityBadge
+        scope="team"
+        teams={TEAMS}
+        authorId="user-other"
+        authorName="Someone"
+        currentUserId={ME}
+        showSelfAsMe
+        compact
+      />,
+    );
+
+    // One pill carrying the count, not one pill per team — a card's metadata
+    // row has a single line to spend and the roster is not what it answers.
+    expect(screen.getByText("2 teams")).toBeInTheDocument();
+    expect(screen.queryByText("Engineering")).not.toBeInTheDocument();
+    expect(screen.queryByText("Consultants")).not.toBeInTheDocument();
+  });
+
+  it("keeps the team names reachable on the collapsed pill", () => {
+    render(
+      <ResourceVisibilityBadge
+        scope="team"
+        teams={TEAMS}
+        authorId="user-other"
+        authorName="Someone"
+        currentUserId={ME}
+        showSelfAsMe
+        compact
+      />,
+    );
+
+    expect(screen.getByTitle("Engineering, Consultants")).toBeInTheDocument();
+  });
+
+  it("still lists the teams when not compact", () => {
+    render(
+      <ResourceVisibilityBadge
+        scope="team"
+        teams={TEAMS}
+        authorId="user-other"
+        authorName="Someone"
+        currentUserId={ME}
+        showSelfAsMe
+      />,
+    );
+
+    // The "Accessible to" column is asking exactly who, so it still enumerates.
+    expect(screen.getByText("Engineering")).toBeInTheDocument();
+    expect(screen.getByText("Consultants")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/resource-visibility-badge.tsx
+++ b/platform/frontend/src/components/resource-visibility-badge.tsx
@@ -20,7 +20,7 @@ export function ResourceVisibilityBadge({
   authorName,
   currentUserId,
   showSelfAsMe,
-  className,
+  compact = false,
 }: {
   scope: ResourceVisibilityScope | undefined;
   teams: TeamInfo[] | undefined;
@@ -50,12 +50,13 @@ export function ResourceVisibilityBadge({
    */
   showSelfAsMe: boolean;
   /**
-   * Merged onto the rendered badge. Lets a caller whose layout is tighter than
-   * the default 180px cap hand the badge its own budget — `max-w-full` inside a
-   * `min-w-0` flex cell makes the name the part that truncates, instead of the
-   * badge holding its width and pushing its row's siblings out of view.
+   * Name the scope rather than enumerate it: one "Team" / "N teams" pill in
+   * place of a pill per team. For surfaces where the badge is one item among
+   * many competing for a single line — a card's metadata row — and the point is
+   * which kind of resource this is, not the roster. The names stay reachable in
+   * the tooltip. Columns headed "Accessible to" want the roster; leave it off.
    */
-  className?: string;
+  compact?: boolean;
 }) {
   // An unknown scope says nothing rather than guessing. Falling through to the
   // team branch would label a resource "Team" on no evidence, which is worse
@@ -71,8 +72,8 @@ export function ResourceVisibilityBadge({
         title="Organization"
         className={cn(
           scopeStyles.org,
+          BADGE_WIDTH,
           "inline-flex items-center gap-1 overflow-hidden text-xs",
-          className,
         )}
       >
         <OrgIcon className="h-3 w-3 shrink-0" />
@@ -104,8 +105,8 @@ export function ResourceVisibilityBadge({
           title={displayName ?? undefined}
           className={cn(
             scopeStyles.personal,
-            "inline-flex max-w-[180px] items-center gap-1 overflow-hidden text-xs",
-            className,
+            BADGE_WIDTH,
+            "inline-flex items-center gap-1 overflow-hidden text-xs",
           )}
         >
           <PersonalIcon className="h-3 w-3 shrink-0" />
@@ -127,8 +128,8 @@ export function ResourceVisibilityBadge({
               aria-label={label}
               className={cn(
                 scopeStyles.personal,
-                "inline-flex max-w-[180px] cursor-help items-center gap-1 overflow-hidden text-xs",
-                className,
+                BADGE_WIDTH,
+                "inline-flex cursor-help items-center gap-1 overflow-hidden text-xs",
               )}
             >
               <UserRoundCheck className="h-3 w-3 shrink-0" />
@@ -144,20 +145,36 @@ export function ResourceVisibilityBadge({
     );
   }
 
-  if (!teams || teams.length === 0) {
-    return (
+  if (!teams || teams.length === 0 || compact) {
+    // Named, not enumerated. With no teams to name there is nothing else to
+    // say; under `compact` the caller has asked for the scope only, and the
+    // roster moves to the tooltip.
+    const names = (teams ?? []).map((team) => team.name);
+    const label = names.length > 1 ? `${names.length} teams` : "Team";
+    const badge = (
       <Badge
         variant="outline"
-        title="Team"
+        title={names.length > 0 ? names.join(", ") : "Team"}
         className={cn(
           scopeStyles.team,
+          BADGE_WIDTH,
           "inline-flex items-center gap-1 overflow-hidden text-xs",
-          className,
         )}
       >
         <TeamIcon className="h-3 w-3 shrink-0" />
-        <span className="truncate">Team</span>
+        <span className="truncate">{label}</span>
       </Badge>
+    );
+    if (names.length === 0) {
+      return badge;
+    }
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{badge}</TooltipTrigger>
+          <TooltipContent>{names.join(", ")}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     );
   }
 
@@ -169,10 +186,17 @@ export function ResourceVisibilityBadge({
         icon: TeamIcon,
       }))}
       style={scopeStyles.team}
-      className={className}
     />
   );
 }
+
+/**
+ * Never wider than whatever contains it, and never more than 180px even when
+ * there is room. The container half matters: this badge sits in fixed-layout
+ * table cells narrower than 180px, where a bare `max-w-[180px]` let it render
+ * over the next column instead of truncating inside its own.
+ */
+const BADGE_WIDTH = "max-w-[min(100%,180px)]";
 
 const OrgIcon = SCOPE_META.org.icon;
 const PersonalIcon = SCOPE_META.personal.icon;
@@ -185,15 +209,7 @@ type Pill = { key: string; name: string; icon: typeof TeamIcon };
 const MAX_PILLS_TO_SHOW = 3;
 
 /** A row of name pills, overflowing into a "+N more" tooltip. */
-function PillRow({
-  pills,
-  style,
-  className,
-}: {
-  pills: Pill[];
-  style: string;
-  className?: string;
-}) {
+function PillRow({ pills, style }: { pills: Pill[]; style: string }) {
   const visible = pills.slice(0, MAX_PILLS_TO_SHOW);
   const remaining = pills.slice(MAX_PILLS_TO_SHOW);
 
@@ -207,8 +223,8 @@ function PillRow({
           title={name}
           className={cn(
             style,
-            "inline-flex max-w-[180px] items-center gap-1 overflow-hidden text-xs",
-            className,
+            BADGE_WIDTH,
+            "inline-flex items-center gap-1 overflow-hidden text-xs",
           )}
         >
           <Icon className="h-3 w-3 shrink-0" />

--- a/platform/frontend/src/components/resource-visibility-badge.tsx
+++ b/platform/frontend/src/components/resource-visibility-badge.tsx
@@ -20,6 +20,7 @@ export function ResourceVisibilityBadge({
   authorName,
   currentUserId,
   showSelfAsMe,
+  className,
 }: {
   scope: ResourceVisibilityScope | undefined;
   teams: TeamInfo[] | undefined;
@@ -48,6 +49,13 @@ export function ResourceVisibilityBadge({
    * where a "Me" pill on every row is noise.
    */
   showSelfAsMe: boolean;
+  /**
+   * Merged onto the rendered badge. Lets a caller whose layout is tighter than
+   * the default 180px cap hand the badge its own budget — `max-w-full` inside a
+   * `min-w-0` flex cell makes the name the part that truncates, instead of the
+   * badge holding its width and pushing its row's siblings out of view.
+   */
+  className?: string;
 }) {
   // An unknown scope says nothing rather than guessing. Falling through to the
   // team branch would label a resource "Team" on no evidence, which is worse
@@ -58,9 +66,17 @@ export function ResourceVisibilityBadge({
 
   if (scope === "org") {
     return (
-      <Badge variant="outline" className={cn(scopeStyles.org, "gap-1 text-xs")}>
-        <OrgIcon className="h-3 w-3" />
-        Organization
+      <Badge
+        variant="outline"
+        title="Organization"
+        className={cn(
+          scopeStyles.org,
+          "inline-flex items-center gap-1 overflow-hidden text-xs",
+          className,
+        )}
+      >
+        <OrgIcon className="h-3 w-3 shrink-0" />
+        <span className="truncate">Organization</span>
       </Badge>
     );
   }
@@ -84,9 +100,12 @@ export function ResourceVisibilityBadge({
       return (
         <Badge
           variant="outline"
+          // `title` so a name the layout had to truncate is still readable.
+          title={displayName ?? undefined}
           className={cn(
             scopeStyles.personal,
             "inline-flex max-w-[180px] items-center gap-1 overflow-hidden text-xs",
+            className,
           )}
         >
           <PersonalIcon className="h-3 w-3 shrink-0" />
@@ -109,6 +128,7 @@ export function ResourceVisibilityBadge({
               className={cn(
                 scopeStyles.personal,
                 "inline-flex max-w-[180px] cursor-help items-center gap-1 overflow-hidden text-xs",
+                className,
               )}
             >
               <UserRoundCheck className="h-3 w-3 shrink-0" />
@@ -128,10 +148,15 @@ export function ResourceVisibilityBadge({
     return (
       <Badge
         variant="outline"
-        className={cn(scopeStyles.team, "gap-1 text-xs")}
+        title="Team"
+        className={cn(
+          scopeStyles.team,
+          "inline-flex items-center gap-1 overflow-hidden text-xs",
+          className,
+        )}
       >
-        <TeamIcon className="h-3 w-3" />
-        Team
+        <TeamIcon className="h-3 w-3 shrink-0" />
+        <span className="truncate">Team</span>
       </Badge>
     );
   }
@@ -144,6 +169,7 @@ export function ResourceVisibilityBadge({
         icon: TeamIcon,
       }))}
       style={scopeStyles.team}
+      className={className}
     />
   );
 }
@@ -159,7 +185,15 @@ type Pill = { key: string; name: string; icon: typeof TeamIcon };
 const MAX_PILLS_TO_SHOW = 3;
 
 /** A row of name pills, overflowing into a "+N more" tooltip. */
-function PillRow({ pills, style }: { pills: Pill[]; style: string }) {
+function PillRow({
+  pills,
+  style,
+  className,
+}: {
+  pills: Pill[];
+  style: string;
+  className?: string;
+}) {
   const visible = pills.slice(0, MAX_PILLS_TO_SHOW);
   const remaining = pills.slice(MAX_PILLS_TO_SHOW);
 
@@ -169,9 +203,12 @@ function PillRow({ pills, style }: { pills: Pill[]; style: string }) {
         <Badge
           key={key}
           variant="outline"
+          // `title` so a name the layout had to truncate is still readable.
+          title={name}
           className={cn(
             style,
             "inline-flex max-w-[180px] items-center gap-1 overflow-hidden text-xs",
+            className,
           )}
         >
           <Icon className="h-3 w-3 shrink-0" />

--- a/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
+++ b/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
@@ -1,0 +1,233 @@
+import { makeCatalogItem } from "@/mocks/data/catalog";
+import { makeInstalledServer } from "@/mocks/data/servers";
+import { expect, test } from "./fixtures";
+
+/**
+ * The registry card packs a scope badge, two counts, a deployment state and a
+ * stack of connection avatars onto one line, and the table packs a scope badge
+ * into a 140px column. Both used to lay their contents out past their own edge,
+ * where it painted over the neighbouring card or the next column.
+ *
+ * These assert the invariant rather than the styling: nothing inside a card may
+ * lay out past the card, and no badge past its cell. A class-name assertion
+ * would have passed throughout the bug — the classes were reasonable, the
+ * arithmetic was not.
+ *
+ * The shapes below are drawn from the widest real catalog entries: an org card
+ * with seven distinct connections, a card owned by someone with a long name, a
+ * card scoped to two teams, and a connection needing re-authentication. Names
+ * are invented; only the shapes are borrowed.
+ */
+
+const LONG_NAME = "Bartholomew Featherstonehaugh";
+
+const CATALOG = [
+  makeCatalogItem({
+    id: "cat-org-crowded",
+    name: "org-crowded",
+    description: "Org-scoped server reached through many separate connections.",
+    scope: "org",
+    serverType: "local",
+    toolCount: 136,
+  }),
+  makeCatalogItem({
+    id: "cat-long-author",
+    name: "long-author",
+    description: "Personal server whose owner has a long display name.",
+    scope: "personal",
+    authorId: "user-other",
+    authorName: LONG_NAME,
+    serverType: "local",
+    toolCount: 51,
+  }),
+  makeCatalogItem({
+    id: "cat-two-teams",
+    name: "two-teams",
+    description: "Server shared with two teams.",
+    scope: "team",
+    teams: [
+      { id: "team-eng", name: "Engineering", level: "use" },
+      { id: "team-con", name: "Consultants", level: "use" },
+    ],
+    toolCount: 14,
+  }),
+  makeCatalogItem({
+    id: "cat-reauth",
+    name: "needs-reauth",
+    description: "Remote server whose OAuth connection has gone stale.",
+    scope: "org",
+    serverType: "remote",
+    oauthConfig: {
+      name: "example",
+      server_url: "https://example.test",
+      client_id: "example-client",
+      redirect_uris: ["https://example.test/callback"],
+      scopes: [],
+      default_scopes: [],
+      supports_resource_metadata: false,
+    },
+    toolCount: 22,
+  }),
+];
+
+// Seven distinct connections on the crowded card: one org-wide plus six
+// owners, which is what drives the avatar stack to its widest.
+const CROWDED_SERVERS = [
+  makeInstalledServer({
+    id: "srv-org",
+    name: "org-crowded-org",
+    catalogId: "cat-org-crowded",
+    scope: "org",
+    ownerId: "user-admin",
+  }),
+  ...Array.from({ length: 6 }, (_, i) =>
+    makeInstalledServer({
+      id: `srv-crowded-${i}`,
+      name: `org-crowded-${i}`,
+      catalogId: "cat-org-crowded",
+      scope: "personal",
+      ownerId: `user-${i}`,
+      ownerEmail: `person${i}@example.test`,
+    }),
+  ),
+];
+
+const SERVERS = [
+  ...CROWDED_SERVERS,
+  makeInstalledServer({
+    id: "srv-long-author",
+    name: "long-author",
+    catalogId: "cat-long-author",
+    ownerId: "user-other",
+    ownerEmail: "someone@example.test",
+  }),
+  makeInstalledServer({
+    id: "srv-two-teams",
+    name: "two-teams",
+    catalogId: "cat-two-teams",
+    scope: "team",
+    teamId: "team-eng",
+    teamDetails: {
+      teamId: "team-eng",
+      name: "Engineering",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  }),
+  makeInstalledServer({
+    id: "srv-reauth",
+    name: "needs-reauth",
+    catalogId: "cat-reauth",
+    serverType: "remote",
+    ownerId: "test-user-admin",
+    ownerEmail: "admin@example.test",
+    oauthRefreshError: "refresh_failed",
+  }),
+];
+
+async function seed(mswControl: {
+  use: (o: { method: "get"; url: string; body: unknown }) => Promise<void>;
+}) {
+  await mswControl.use({
+    method: "get",
+    url: "/api/internal_mcp_catalog",
+    body: CATALOG,
+  });
+  await mswControl.use({
+    method: "get",
+    url: "/api/mcp_server",
+    body: SERVERS,
+  });
+}
+
+test.describe("MCP Registry layout", () => {
+  // The narrowest the grid will ever make a card, which is where the row has
+  // the least room and the old layout broke worst.
+  test.use({ viewport: { width: 1024, height: 900 } });
+
+  test("no card lays its contents out past its own edge", async ({
+    mcpRegistryPage,
+    mswControl,
+    page,
+  }) => {
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.serverCards.first()).toBeVisible();
+
+    const spills = await page.evaluate(() => {
+      const out: Array<{ card: string; by: number; text: string }> = [];
+      for (const card of document.querySelectorAll<HTMLElement>(
+        '[data-testid^="mcp-server-card-"]',
+      )) {
+        const edge = card.getBoundingClientRect().right;
+        for (const node of card.querySelectorAll<HTMLElement>("*")) {
+          // Zero-size nodes carry no visible content to spill.
+          const r = node.getBoundingClientRect();
+          if (r.width === 0 && r.height === 0) continue;
+          const by = Math.round(r.right - edge);
+          if (by > 0) {
+            out.push({
+              card: card.getAttribute("data-testid") ?? "?",
+              by,
+              text: (node.textContent ?? "").replace(/\s+/g, " ").slice(0, 40),
+            });
+          }
+        }
+      }
+      return out;
+    });
+
+    expect(spills).toEqual([]);
+  });
+
+  test("a card names the team scope instead of listing every team", async ({
+    mcpRegistryPage,
+    mswControl,
+  }) => {
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+
+    const card = mcpRegistryPage.cardForCatalogItem("two-teams");
+    await expect(card).toBeVisible();
+
+    // The roster belongs on the detail page; the card has one line to spend.
+    await expect(card.getByText("2 teams")).toBeVisible();
+    await expect(card.getByText("Engineering", { exact: true })).toHaveCount(0);
+    await expect(card.getByText("Consultants", { exact: true })).toHaveCount(0);
+  });
+
+  test("no scope badge lays out past its table cell", async ({
+    mcpRegistryPage,
+    mswControl,
+    page,
+  }) => {
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.serverCards.first()).toBeVisible();
+
+    await page.getByRole("button", { name: "View as table" }).click();
+    await expect(page.locator("table").first()).toBeVisible();
+
+    const spills = await page.evaluate(() => {
+      const out: Array<{ by: number; text: string; cell: number }> = [];
+      for (const cell of document.querySelectorAll<HTMLElement>("td")) {
+        const edge = cell.getBoundingClientRect();
+        for (const badge of cell.querySelectorAll<HTMLElement>(
+          '[data-slot="badge"]',
+        )) {
+          const r = badge.getBoundingClientRect();
+          const by = Math.round(r.right - edge.right);
+          if (by > 0) {
+            out.push({
+              by,
+              cell: Math.round(edge.width),
+              text: (badge.textContent ?? "").trim().slice(0, 40),
+            });
+          }
+        }
+      }
+      return out;
+    });
+
+    expect(spills).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

MCP Registry card and table contents laid out past their own edges, painting over the neighbouring card / the next column.

Measured against the real staging catalog: **33 of 51 cards overflowed, the worst by 229px**, and **4 table cells spilled 45px** into the Status column. After: **0 and 0**.

## Why it overflowed

**Cards.** Three things fought over a row only ~250–300px wide:

1. **Nothing could shrink.** Every item held its natural width. Fixed items are now `shrink-0` and the scope badge is the single elastic cell, so a long author name truncates (with a `title`) instead of the row spilling.
2. **The 1px rules were expensive.** Each divider cost ~21px once its two gaps are counted — around a fifth of the row, and most of what a name has to truncate into. The gap separates the items on its own.
3. **The grid promised columns it couldn't pay for.** `lg:grid-cols-3` measures the *window*, not the space left after the nav, so cards were handed ~190px at widths where it still applied. Columns are now sized from the card's own minimum (`auto-fill` / `minmax(19rem,1fr)`) and a column drops instead of squeezing. 19rem is measured: every real card fits by 296px, the worst overflows by 1px at 288px.

**Team pills.** A team-scoped card rendered one pill per team, which wrapped to a second line and made the card taller than its neighbours. A card's metadata row answers *which kind* of resource this is, not who exactly is on it, so it now names the scope — `Team` / `N teams` — and keeps the roster in the tooltip. The "Accessible to" column, which is asking exactly who, still enumerates.

**Table.** The badge capped its width at 180px but never at its *container*, so in the 140px "Accessible to" cell it rendered 169px wide and painted 45px over Status. The cap is now `min(100%, 180px)`, fixing all seven call sites at once — every one of them a table cell.

The re-authentication marker keeps its icon and moves its five-word label to a tooltip + `sr-only` span; inline it overflowed exactly the cards that had something to report. `overflow-hidden` on the card is a backstop, not the fix.

## Verification

**1. Against the live staging catalog.** Applied the layout rules to the real `frontend.archestra.dev` DOM and measured every card and cell:

| | before | after |
|---|---|---|
| cards whose row overflows | 33 / 51 (worst 229px) | 0 / 50 |
| table cells whose badge spills | 4 / 58 (worst 45px) | 0 / 58 |

**2. Against this branch's real code.** New integration specs drive the actual components through MSW with the widest shapes found in that catalog — an org card with 7 connections and 136 tools, an owner with a long name, a card scoped to 2 teams, a stale OAuth connection — and assert the invariant geometrically: nothing inside a card may lay out past the card, no badge past its cell.

Both fail on the pre-fix code (table badge spills 56px) and pass on this branch, so they are not vacuous.

`pnpm type-check` clean, biome clean (3 warnings, all pre-existing in `chat/page.tsx`), 1779 unit tests and 33 integration tests pass.

## Tests

The new specs assert the invariant, not the styling — a class-name assertion would have passed throughout this bug, since the classes were reasonable and the arithmetic was not. Fixture names are invented; only the shapes are borrowed from the real catalog.