### PR TITLE
fix(llm-proxy): scope the virtual-key failure limiter to the presented credential

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -718,10 +718,14 @@ The following environment variables can be used to configure Archestra Platform.
   - Must be an integer between `1` and `65535`; invalid values disable the listener with a warning
   - Helm: set `archestra.publicEndpointsPort` to inject this variable and expose the port on the Service
 
-- **`ARCHESTRA_TRUST_PROXY`** - Set this when Archestra runs behind a TLS-terminating reverse proxy (e.g. AWS ALB, nginx, Cloudflare) so that generated OAuth metadata and auth URLs use the external `https://` scheme rather than the internal `http://` scheme seen by the backend.
+- **`ARCHESTRA_TRUST_PROXY`** - Controls whether Archestra trusts the `X-Forwarded-*` headers a proxy sets. Set it when Archestra runs behind a TLS-terminating reverse proxy or load balancer (e.g. AWS ALB, nginx, Cloudflare).
   - Default: `false` (no proxy trust)
   - Values: `true`, `false`, or a comma-separated list of trusted proxy IPs/CIDRs (e.g. `10.0.0.0/8,172.16.0.0/12`)
-  - Example: `ARCHESTRA_TRUST_PROXY=true`
+  - Example: `ARCHESTRA_TRUST_PROXY=35.191.0.0/16,130.211.0.0/22`
+  - Generated OAuth metadata and auth URLs use the external `https://` scheme instead of the internal `http://` scheme the backend sees.
+  - Each request resolves to the calling client's IP rather than the proxy's. Per-IP rate limits and audit `sourceIp` values follow that IP. Behind a load balancer they stay per-client instead of collapsing onto one shared address.
+  - Prefer the IP/CIDR list over `true`. With `true`, Archestra trusts a client-supplied `X-Forwarded-For` header, so a caller can choose the IP it is rate-limited and audited under. List your proxy's own ranges instead.
+  - Any non-`false` value also makes Archestra accept an `X-Forwarded-Host` header as its public origin without checking it against `ARCHESTRA_API_BASE_URL`. Set it only when your proxy overwrites that header on the way in.
 
 - **`ARCHESTRA_API_BODY_LIMIT`** - Maximum request body size for LLM proxy and chat routes.
   - Default: `70MB` (73400320 bytes)

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -232,6 +232,19 @@ ARCHESTRA_INTERNAL_API_BASE_URL="http://127.0.0.1:9000"
 # them either way.
 # ARCHESTRA_PUBLIC_ENDPOINTS_PORT=
 
+# Optional. Trust the X-Forwarded-* headers set by a proxy in front of Archestra.
+# Set it behind a TLS-terminating reverse proxy or load balancer: OAuth metadata
+# and auth URLs then use the external https:// scheme, and each request resolves
+# to the calling client's IP instead of the proxy's — so per-IP rate limits and
+# audit sourceIp stay per-client rather than collapsing onto one shared address.
+# Values: true, false, or a comma-separated list of trusted proxy IPs/CIDRs.
+# Prefer the list: "true" trusts a client-supplied X-Forwarded-For, letting a
+# caller pick the IP it is rate-limited and audited under. Any non-false value
+# also accepts X-Forwarded-Host as the public origin without validating it
+# against ARCHESTRA_API_BASE_URL, so set it only when your proxy overwrites that
+# header on the way in.
+# ARCHESTRA_TRUST_PROXY=false
+
 # Optional for local dev
 # Frontend URL - The URL where users access the frontend
 ARCHESTRA_FRONTEND_URL=http://localhost:3000

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.test.ts
@@ -825,48 +825,107 @@ function createTestLimiter() {
   };
 }
 
+const KEY_A = "arch_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const KEY_B = "arch_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
 describe("VirtualKeyRateLimiter", () => {
   test("allows requests under the failure threshold", async () => {
     const { limiter } = createTestLimiter();
     for (let i = 0; i < 9; i++) {
-      await limiter.recordFailure("1.2.3.4");
+      await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
     }
-    await expect(limiter.check("1.2.3.4")).resolves.toBeUndefined();
+    await expect(
+      limiter.check({ ip: "1.2.3.4", credential: KEY_A }),
+    ).resolves.toBeUndefined();
   });
 
   test("blocks requests at the failure threshold", async () => {
     const { limiter } = createTestLimiter();
     for (let i = 0; i < 10; i++) {
-      await limiter.recordFailure("1.2.3.4");
+      await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
     }
-    await expect(limiter.check("1.2.3.4")).rejects.toThrow(
-      "Too many failed virtual API key attempts",
-    );
+    await expect(
+      limiter.check({ ip: "1.2.3.4", credential: KEY_A }),
+    ).rejects.toThrow("Too many failed virtual API key attempts");
   });
 
   test("does not block unrelated IPs", async () => {
     const { limiter } = createTestLimiter();
     for (let i = 0; i < 10; i++) {
-      await limiter.recordFailure("1.2.3.4");
+      await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
     }
-    await expect(limiter.check("5.6.7.8")).resolves.toBeUndefined();
+    await expect(
+      limiter.check({ ip: "5.6.7.8", credential: KEY_A }),
+    ).resolves.toBeUndefined();
+  });
+
+  // The collateral-lockout fix: clients sharing an origin (a load balancer, or
+  // loopback for frontend-rewritten requests) must not lock each other out.
+  test("does not block a different credential from the same IP", async () => {
+    const { limiter } = createTestLimiter();
+    for (let i = 0; i < 20; i++) {
+      await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
+    }
+    await expect(
+      limiter.check({ ip: "1.2.3.4", credential: KEY_A }),
+    ).rejects.toThrow("Too many failed virtual API key attempts");
+    await expect(
+      limiter.check({ ip: "1.2.3.4", credential: KEY_B }),
+    ).resolves.toBeUndefined();
+  });
+
+  // ...but per-credential scoping must not hand an enumerator a fresh bucket
+  // per guess, so the IP-wide backstop still closes.
+  test("blocks an IP that cycles through many distinct credentials", async () => {
+    const { limiter } = createTestLimiter();
+    for (let i = 0; i < 100; i++) {
+      await limiter.recordFailure({
+        ip: "1.2.3.4",
+        credential: `arch_guess_${i}`,
+      });
+    }
+    await expect(
+      limiter.check({ ip: "1.2.3.4", credential: "arch_guess_fresh" }),
+    ).rejects.toThrow("Too many failed virtual API key attempts");
+  });
+
+  test("never writes the credential into the cache key", async () => {
+    const { limiter, store } = createTestLimiter();
+    await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
+    const keys = [...store.keys()];
+    expect(keys.length).toBeGreaterThan(0);
+    for (const key of keys) {
+      expect(key).not.toContain(KEY_A);
+    }
+  });
+
+  test("counts requests that present no credential in a shared bucket", async () => {
+    const { limiter } = createTestLimiter();
+    for (let i = 0; i < 10; i++) {
+      await limiter.recordFailure({ ip: "1.2.3.4" });
+    }
+    await expect(limiter.check({ ip: "1.2.3.4" })).rejects.toThrow(
+      "Too many failed virtual API key attempts",
+    );
   });
 
   test("increments failure count correctly", async () => {
     const { limiter, mockCache } = createTestLimiter();
-    await limiter.recordFailure("1.2.3.4");
-    await limiter.recordFailure("1.2.3.4");
-    await limiter.recordFailure("1.2.3.4");
+    await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
+    await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
+    await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
 
-    // Verify cache.set was called with incrementing counts
-    const setCalls = mockCache.set.mock.calls;
-    const counts = setCalls.map((call) => (call[1] as { count: number }).count);
+    // Each failure touches two buckets; the per-credential one is keyed by
+    // fingerprint, the IP-wide one by the "-ip-" infix.
+    const counts = mockCache.set.mock.calls
+      .filter((call) => !String(call[0]).includes("-ip-"))
+      .map((call) => (call[1] as { count: number }).count);
     expect(counts).toEqual([1, 2, 3]);
   });
 
   test("passes TTL to cache set", async () => {
     const { limiter, mockCache } = createTestLimiter();
-    await limiter.recordFailure("1.2.3.4");
+    await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
 
     // Verify TTL (60_000 ms) is passed
     expect(mockCache.set).toHaveBeenCalledWith(
@@ -879,23 +938,27 @@ describe("VirtualKeyRateLimiter", () => {
   test("allows requests when cache returns undefined (entry expired)", async () => {
     const { limiter, store } = createTestLimiter();
     for (let i = 0; i < 10; i++) {
-      await limiter.recordFailure("1.2.3.4");
+      await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
     }
     // Simulate TTL expiration by clearing the store
     store.clear();
-    await expect(limiter.check("1.2.3.4")).resolves.toBeUndefined();
+    await expect(
+      limiter.check({ ip: "1.2.3.4", credential: KEY_A }),
+    ).resolves.toBeUndefined();
   });
 
   test("resets counter when cache entry expires and new failure recorded", async () => {
     const { limiter, store } = createTestLimiter();
     for (let i = 0; i < 10; i++) {
-      await limiter.recordFailure("1.2.3.4");
+      await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
     }
     // Simulate TTL expiration
     store.clear();
     // New failure starts fresh
-    await limiter.recordFailure("1.2.3.4");
-    await expect(limiter.check("1.2.3.4")).resolves.toBeUndefined();
+    await limiter.recordFailure({ ip: "1.2.3.4", credential: KEY_A });
+    await expect(
+      limiter.check({ ip: "1.2.3.4", credential: KEY_A }),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.ts
@@ -5,7 +5,7 @@
  * request/response orchestration. Each function is independently testable.
  */
 
-import { createHash } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 import {
   credentialRequiresPerUserScope,
   hasArchestraTokenPrefix,
@@ -18,6 +18,7 @@ import type { FastifyRequest } from "fastify";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { userHasPermission } from "@/auth";
 import { type AllowedCacheKey, CacheKey, cacheManager } from "@/cache-manager";
+import config from "@/config";
 import logger from "@/logging";
 import {
   AgentModel,
@@ -920,6 +921,23 @@ function isJwtLike(token: string): boolean {
 }
 
 /**
+ * Domain-separated key for {@link fingerprintCredential}.
+ *
+ * Derived from the session-signing secret, so an existing deployment needs no
+ * new configuration, and domain-separated so a rate-limit fingerprint can never
+ * be mistaken for another HMAC that secret protects. The key must be identical
+ * on every pod — limiter state is shared through PostgreSQL, so a per-process
+ * key would give one credential a different bucket on each pod and multiply its
+ * effective threshold by the replica count. A deployment with no auth secret
+ * configured falls back to a per-process key and accepts that fragmentation.
+ */
+const CREDENTIAL_FINGERPRINT_KEY = config.auth.secret
+  ? createHmac("sha256", config.auth.secret)
+      .update("virtual-key-rate-limit-fingerprint")
+      .digest()
+  : randomBytes(32);
+
+/**
  * Reduce a presented credential to a stable, non-reversible bucket id for the
  * rate limiter's cache key.
  *
@@ -927,12 +945,20 @@ function isJwtLike(token: string): boolean {
  * their own bucket (the whole point of scoping by credential), short enough
  * that the key stays readable in the cache table. A collision merely puts two
  * credentials in one bucket — the same situation as before this scoping
- * existed — so preimage resistance, not collision resistance, is what matters,
- * and that is what keeps the token itself out of PostgreSQL.
+ * existed — so collision resistance is not what this needs to buy.
+ *
+ * Keyed rather than a bare digest because these keys are persisted: an observer
+ * of the cache table can neither read a token out of a bucket id nor confirm a
+ * guessed one, which matters most for whatever low-entropy bearer tokens a
+ * deployment's upstream may accept.
  *
  * Requests that present no credential at all share the "none" bucket.
  */
 function fingerprintCredential(credential: string | undefined): string {
   if (!credential) return "none";
-  return createHash("sha256").update(credential).digest("hex").slice(0, 8);
+  // codeql[js/insufficient-password-hash] Buckets a bearer token for rate limiting, not password verification: the digest is never stored as a credential nor compared against one.
+  return createHmac("sha256", CREDENTIAL_FINGERPRINT_KEY)
+    .update(credential)
+    .digest("hex")
+    .slice(0, 8);
 }

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.ts
@@ -956,9 +956,7 @@ const CREDENTIAL_FINGERPRINT_KEY = config.auth.secret
  */
 function fingerprintCredential(credential: string | undefined): string {
   if (!credential) return "none";
+  const hmac = createHmac("sha256", CREDENTIAL_FINGERPRINT_KEY);
   // codeql[js/insufficient-password-hash] Buckets a bearer token for rate limiting, not password verification: the digest is never stored as a credential nor compared against one.
-  return createHmac("sha256", CREDENTIAL_FINGERPRINT_KEY)
-    .update(credential)
-    .digest("hex")
-    .slice(0, 8);
+  return hmac.update(credential).digest("hex").slice(0, 8);
 }

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.ts
@@ -5,6 +5,7 @@
  * request/response orchestration. Each function is independently testable.
  */
 
+import { createHash } from "node:crypto";
 import {
   credentialRequiresPerUserScope,
   hasArchestraTokenPrefix,
@@ -552,7 +553,11 @@ export async function authenticatePassthroughProxyRequest(params: {
     throw unauthenticated;
   }
 
-  await virtualKeyRateLimiter.check(request.ip);
+  const presentedCredential = passthroughToken ?? bearerToken ?? undefined;
+  await virtualKeyRateLimiter.check({
+    ip: request.ip,
+    credential: presentedCredential,
+  });
   try {
     if (passthroughToken) {
       await validatePassthroughVirtualKey({
@@ -588,7 +593,10 @@ export async function authenticatePassthroughProxyRequest(params: {
     throw unauthenticated;
   } catch (error) {
     if (error instanceof ApiError && error.statusCode === 401) {
-      await virtualKeyRateLimiter.recordFailure(request.ip);
+      await virtualKeyRateLimiter.recordFailure({
+        ip: request.ip,
+        credential: presentedCredential,
+      });
     }
     throw error;
   }
@@ -598,7 +606,18 @@ export async function authenticatePassthroughProxyRequest(params: {
 // Virtual Key Rate Limiter
 // =========================================================================
 
+/**
+ * Failures allowed per (IP, credential) pair before that pair is rejected.
+ * Sized for a client retrying one credential, not for a shared origin.
+ */
 const RATE_LIMIT_MAX_FAILURES = 10;
+/**
+ * Failures allowed from one IP across ALL credentials before the whole IP is
+ * rejected. This is the anti-enumeration backstop, so it must stay well above
+ * the per-credential threshold: a single misconfigured client should exhaust
+ * its own bucket long before it can exhaust its origin's.
+ */
+const RATE_LIMIT_MAX_FAILURES_PER_IP = 100;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 
 interface RateLimitEntry {
@@ -607,8 +626,23 @@ interface RateLimitEntry {
 
 /**
  * Distributed rate limiter for failed virtual API key validation attempts.
- * Prevents brute-force enumeration of valid tokens by tracking failures per
- * client IP and rejecting further attempts after exceeding the threshold.
+ *
+ * Counts failures in two buckets, both of which can reject a request:
+ *
+ *  - **(IP, credential)** at {@link RATE_LIMIT_MAX_FAILURES} — the bucket that
+ *    does the day-to-day work. Scoping to the presented credential means one
+ *    client hammering a revoked token cannot lock out a different client that
+ *    holds a valid one, which is the failure mode a shared origin produces:
+ *    behind a reverse proxy or LB (or, for requests the frontend rewrites to
+ *    the API, behind loopback) many unrelated callers share a single `ip`.
+ *  - **IP-wide** at {@link RATE_LIMIT_MAX_FAILURES_PER_IP} — retains the
+ *    brute-force ceiling the per-credential bucket alone would give up, since
+ *    an enumerator gets a fresh credential bucket for every token it guesses.
+ *
+ * The credential is reduced to a short salted-by-nothing SHA-256 fingerprint
+ * rather than used verbatim: cache keys are persisted to PostgreSQL by the
+ * shared CacheManager, and a bearer token (or any prefix long enough to
+ * identify one) must not be written there in the clear.
  *
  * Uses the PostgreSQL-backed CacheManager (Keyv) so rate limit state is
  * shared across all application pods. Entries expire automatically via TTL.
@@ -634,11 +668,17 @@ export class VirtualKeyRateLimiter {
     this.cacheManager = cacheManager;
   }
 
-  async check(ip: string): Promise<void> {
-    const entry = await this.cacheManager.get<RateLimitEntry>(this.key(ip));
-    if (!entry) return;
+  async check(params: { ip: string; credential?: string }): Promise<void> {
+    const { ip, credential } = params;
+    const [credentialEntry, ipEntry] = await Promise.all([
+      this.cacheManager.get<RateLimitEntry>(this.credentialKey(ip, credential)),
+      this.cacheManager.get<RateLimitEntry>(this.ipKey(ip)),
+    ]);
 
-    if (entry.count >= RATE_LIMIT_MAX_FAILURES) {
+    if (
+      (credentialEntry?.count ?? 0) >= RATE_LIMIT_MAX_FAILURES ||
+      (ipEntry?.count ?? 0) >= RATE_LIMIT_MAX_FAILURES_PER_IP
+    ) {
       throw new ApiError(
         429,
         "Too many failed virtual API key attempts. Please try again later.",
@@ -646,18 +686,32 @@ export class VirtualKeyRateLimiter {
     }
   }
 
-  async recordFailure(ip: string): Promise<void> {
-    const entry = await this.cacheManager.get<RateLimitEntry>(this.key(ip));
-    const newCount = (entry?.count ?? 0) + 1;
+  async recordFailure(params: {
+    ip: string;
+    credential?: string;
+  }): Promise<void> {
+    const { ip, credential } = params;
+    await Promise.all([
+      this.increment(this.credentialKey(ip, credential)),
+      this.increment(this.ipKey(ip)),
+    ]);
+  }
+
+  private async increment(key: AllowedCacheKey): Promise<void> {
+    const entry = await this.cacheManager.get<RateLimitEntry>(key);
     await this.cacheManager.set<RateLimitEntry>(
-      this.key(ip),
-      { count: newCount },
+      key,
+      { count: (entry?.count ?? 0) + 1 },
       RATE_LIMIT_WINDOW_MS,
     );
   }
 
-  private key(ip: string): AllowedCacheKey {
-    return `${CacheKey.VirtualKeyRateLimit}-${ip}`;
+  private credentialKey(ip: string, credential?: string): AllowedCacheKey {
+    return `${CacheKey.VirtualKeyRateLimit}-${ip}-${fingerprintCredential(credential)}`;
+  }
+
+  private ipKey(ip: string): AllowedCacheKey {
+    return `${CacheKey.VirtualKeyRateLimit}-ip-${ip}`;
   }
 }
 
@@ -863,4 +917,22 @@ function isJwtLike(token: string): boolean {
   const parts = token.split(".");
   if (parts.length !== 3) return false;
   return parts.every((part) => /^[A-Za-z0-9_-]+$/.test(part));
+}
+
+/**
+ * Reduce a presented credential to a stable, non-reversible bucket id for the
+ * rate limiter's cache key.
+ *
+ * Truncated to 32 bits: enough that unrelated callers on a shared origin get
+ * their own bucket (the whole point of scoping by credential), short enough
+ * that the key stays readable in the cache table. A collision merely puts two
+ * credentials in one bucket — the same situation as before this scoping
+ * existed — so preimage resistance, not collision resistance, is what matters,
+ * and that is what keeps the token itself out of PostgreSQL.
+ *
+ * Requests that present no credential at all share the "none" bucket.
+ */
+function fingerprintCredential(credential: string | undefined): string {
+  if (!credential) return "none";
+  return createHash("sha256").update(credential).digest("hex").slice(0, 8);
 }

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -379,7 +379,10 @@ export async function handleLLMProxy<
   // credential — the provider auth still comes from the Authorization header.
   // Skipped for internal loopback auth overrides (in-app chat).
   if (passthroughVirtualKeyToken && !authOverride) {
-    await virtualKeyRateLimiter.check(request.ip);
+    await virtualKeyRateLimiter.check({
+      ip: request.ip,
+      credential: passthroughVirtualKeyToken,
+    });
     try {
       const passthroughResult = await validatePassthroughVirtualKey({
         tokenValue: passthroughVirtualKeyToken,
@@ -392,7 +395,10 @@ export async function handleLLMProxy<
       resolvedUser = await UserModel.getById(userId);
     } catch (error) {
       if (error instanceof ApiError && error.statusCode === 401) {
-        await virtualKeyRateLimiter.recordFailure(request.ip);
+        await virtualKeyRateLimiter.recordFailure({
+          ip: request.ip,
+          credential: passthroughVirtualKeyToken,
+        });
       }
       throw error;
     }
@@ -508,7 +514,10 @@ export async function handleLLMProxy<
     rawApiKey &&
     hasArchestraTokenPrefix(rawApiKey)
   ) {
-    await virtualKeyRateLimiter.check(request.ip);
+    await virtualKeyRateLimiter.check({
+      ip: request.ip,
+      credential: rawApiKey,
+    });
     try {
       const virtualResult = await validateVirtualApiKey(
         rawApiKey,
@@ -542,7 +551,10 @@ export async function handleLLMProxy<
         );
       } else {
         if (error instanceof ApiError && error.statusCode === 401) {
-          await virtualKeyRateLimiter.recordFailure(request.ip);
+          await virtualKeyRateLimiter.recordFailure({
+            ip: request.ip,
+            credential: rawApiKey,
+          });
         }
         throw error;
       }

--- a/platform/backend/src/routes/proxy/routes/bedrock-openai.ts
+++ b/platform/backend/src/routes/proxy/routes/bedrock-openai.ts
@@ -195,13 +195,19 @@ const bedrockOpenaiProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
     } else if (bearerToken) {
       if (hasArchestraTokenPrefix(bearerToken)) {
         logger.info("[BedrockOpenai] auth: virtual-key");
-        await virtualKeyRateLimiter.check(request.ip);
+        await virtualKeyRateLimiter.check({
+          ip: request.ip,
+          credential: bearerToken,
+        });
         try {
           const resolved = await validateVirtualApiKey(bearerToken, "bedrock");
           apiKey = resolved.apiKey;
           baseUrl = resolved.baseUrl;
         } catch (err) {
-          await virtualKeyRateLimiter.recordFailure(request.ip);
+          await virtualKeyRateLimiter.recordFailure({
+            ip: request.ip,
+            credential: bearerToken,
+          });
           throw err;
         }
       } else {

--- a/platform/backend/src/routes/proxy/routes/model-router.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.ts
@@ -898,7 +898,10 @@ async function getModelRouterAuth(
     return getModelRouterOAuthClientAuth(bearerToken);
   }
 
-  await virtualKeyRateLimiter.check(request.ip);
+  await virtualKeyRateLimiter.check({
+    ip: request.ip,
+    credential: bearerToken,
+  });
   try {
     const resolved = await validateVirtualApiKeyToken(bearerToken);
     const mappings = await VirtualApiKeyModel.getProviderApiKeysForRouting(
@@ -923,7 +926,10 @@ async function getModelRouterAuth(
   } catch (error) {
     if (error instanceof ApiError && error.statusCode === 401) {
       try {
-        await virtualKeyRateLimiter.recordFailure(request.ip);
+        await virtualKeyRateLimiter.recordFailure({
+          ip: request.ip,
+          credential: bearerToken,
+        });
       } catch (rateLimitError) {
         logger.warn(
           {

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
@@ -80,7 +80,7 @@ export async function resolveProxyModelsApiKey(params: {
     return { apiKey: token, baseUrl: undefined, extraHeaders: null };
   }
 
-  await virtualKeyRateLimiter.check(request.ip);
+  await virtualKeyRateLimiter.check({ ip: request.ip, credential: token });
   try {
     const resolved = await validateVirtualApiKey(token, provider);
     if (!resolved.apiKey) {
@@ -107,7 +107,9 @@ export async function resolveProxyModelsApiKey(params: {
   } catch (error) {
     if (error instanceof ApiError && error.statusCode === 401) {
       // Best-effort: a failure to record must never mask the underlying 401.
-      await virtualKeyRateLimiter.recordFailure(request.ip).catch(() => {});
+      await virtualKeyRateLimiter
+        .recordFailure({ ip: request.ip, credential: token })
+        .catch(() => {});
     }
     throw error;
   }


### PR DESCRIPTION
Fixes the second half of #7229 (the rate-limiter item). The auth-bypass half of that issue is **not** touched here and stays open.

## Problem

`VirtualKeyRateLimiter` counted failed virtual-key validations per client IP alone, and rejected *before* validation - so once a bucket was full, valid keys got 429 too. Behind a reverse proxy or load balancer, and for requests the frontend rewrites to the API over loopback, many unrelated callers share one `request.ip`. Ten failures from one misconfigured client (an expired token in a retry loop, a scanner, a bad agent config) returned `429 Too many failed virtual API key attempts` to *everyone* on that address.

## Change

Two buckets, either of which can reject:

- **(IP, credential)** at 10 failures/60s - does the day-to-day work. One client hammering a revoked token can no longer lock out a client holding a valid one.
- **IP-wide** at 100 failures/60s - retains the brute-force ceiling that per-credential scoping alone would give up, since an enumerator would otherwise get a fresh bucket for every token it guesses.

`check()` / `recordFailure()` now take `{ ip, credential }`; all six call sites (passthrough auth, both handler paths, model router, model listing, Bedrock) pass the credential already in scope.

### Why a fingerprint and not a literal key prefix

The issue suggested keying on a key *prefix*. Cache keys are persisted to PostgreSQL by the shared `CacheManager`, so a prefix long enough to identify a token would write bearer-token material to the database in the clear. The credential is instead reduced to a truncated SHA-256 fingerprint. Preimage resistance is the property that matters; a collision merely puts two credentials in one bucket, which is where they both were before this change. A test asserts the credential never appears in a cache key.

## `ARCHESTRA_TRUST_PROXY`

**Docs only - the staging value is deliberately unchanged.** The env var's entry described only the forwarded `https://` scheme, and never mentioned that the setting decides whether per-IP limits and audit `sourceIp` see the real client or the proxy. It was also missing from `.env.example` entirely. Both fixed, including the caveat that `true` trusts a client-supplied `X-Forwarded-For` (so the IP/CIDR list form is preferable).

I did **not** flip `ARCHESTRA_TRUST_PROXY` on staging, because auditing the blast radius turned up two prerequisites that make it unsafe today:

1. `routes/request-origin.ts:56` returns a client-supplied `X-Forwarded-Host` as the public origin, with **no allowlist check**, whenever `trustProxy` is truthy. It reads the raw header rather than `request.hostname`, so Fastify's CIDR gating never applies - meaning even a narrow trusted-CIDR list opens this for *every* request, not just ones arriving through the proxy. That origin feeds OAuth protected-resource metadata, `WWW-Authenticate`, oauth-server base URLs, and skill-share links. The existing comment there anticipates this: it says the scoped validation exists to avoid "the (too-broad) ARCHESTRA_TRUST_PROXY".
2. Six security seams gate on `isLoopbackAddress(request.ip)` - the SSRF base-URL override, the internal chat-api-key header, the keyless-provider allowance, and the passthrough auth bypass. Two sibling seams were already hardened to read `request.socket.remoteAddress` instead, with comments naming exactly this attack ("trustProxy can rewrite request.ip from forwarded headers"). The remaining six should move to the socket peer before any trusted proxies are configured.

Neither is a blocker for this PR - the per-credential scoping is what removes the collateral lockouts, and it works regardless of how `request.ip` resolves. Both prerequisites are written up on #7229.

## Testing

`llm-proxy-auth.test.ts` - 56 passed, including new coverage for: a second credential from the same IP staying unblocked while the first is locked out; the IP-wide backstop still closing on an IP that cycles 100 distinct credentials; and the credential never landing in a cache key.

Backend `type-check` and `knip` (dev + production) are clean. Full `src/routes/proxy/` run: 1344 passed, 3 failed - those 3 fail identically on unmodified `main` in the same environment (they assert plaintext interaction bodies while encryption-at-rest is configured locally), so they're environmental and unrelated.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>