### PR TITLE
fix(security): stop forwarded headers from deciding loopback trust

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -127,7 +127,13 @@ archestra:
     #     first-time Slack/Teams sender still lands in the org.
     ARCHESTRA_AUTH_DISABLE_INVITATIONS: "true"
     ARCHESTRA_FRONTEND_URL: "https://frontend.archestra.dev"
-    ARCHESTRA_TRUST_PROXY: "false"
+    # Trust only the Google Front End ranges that terminate the ingress, so
+    # request.ip is the real caller instead of the load balancer. Per-IP rate
+    # limits and audit sourceIp then stop collapsing onto one shared address.
+    # These two CIDRs are the documented GCLB/health-check ranges, and are the
+    # socket peers this deployment actually sees. NOT "true": that would trust a
+    # client-supplied X-Forwarded-For and let any caller choose its own IP.
+    ARCHESTRA_TRUST_PROXY: "35.191.0.0/16,130.211.0.0/22"
     ARCHESTRA_SENTRY_ENVIRONMENT: "archestra.dev"
     ARCHESTRA_AGENTS_INCOMING_EMAIL_PROVIDER: "outlook"
     ARCHESTRA_AGENTS_INCOMING_EMAIL_OUTLOOK_MAILBOX_ADDRESS: "agents@archestraai.onmicrosoft.com"

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -725,7 +725,7 @@ The following environment variables can be used to configure Archestra Platform.
   - Generated OAuth metadata and auth URLs use the external `https://` scheme instead of the internal `http://` scheme the backend sees.
   - Each request resolves to the calling client's IP rather than the proxy's. Per-IP rate limits and audit `sourceIp` values follow that IP. Behind a load balancer they stay per-client instead of collapsing onto one shared address.
   - Prefer the IP/CIDR list over `true`. With `true`, Archestra trusts a client-supplied `X-Forwarded-For` header, so a caller can choose the IP it is rate-limited and audited under. List your proxy's own ranges instead.
-  - Any non-`false` value also makes Archestra accept an `X-Forwarded-Host` header as its public origin without checking it against `ARCHESTRA_API_BASE_URL`. Set it only when your proxy overwrites that header on the way in.
+  - This setting does not affect the OAuth public origin. A forwarded host is always checked against `ARCHESTRA_API_BASE_URL` and `ARCHESTRA_FRONTEND_URL`, so name your public host in one of them.
 
 - **`ARCHESTRA_API_BODY_LIMIT`** - Maximum request body size for LLM proxy and chat routes.
   - Default: `70MB` (73400320 bytes)

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -239,10 +239,9 @@ ARCHESTRA_INTERNAL_API_BASE_URL="http://127.0.0.1:9000"
 # audit sourceIp stay per-client rather than collapsing onto one shared address.
 # Values: true, false, or a comma-separated list of trusted proxy IPs/CIDRs.
 # Prefer the list: "true" trusts a client-supplied X-Forwarded-For, letting a
-# caller pick the IP it is rate-limited and audited under. Any non-false value
-# also accepts X-Forwarded-Host as the public origin without validating it
-# against ARCHESTRA_API_BASE_URL, so set it only when your proxy overwrites that
-# header on the way in.
+# caller pick the IP it is rate-limited and audited under. This setting does not
+# affect the OAuth public origin — a forwarded host is always checked against
+# ARCHESTRA_API_BASE_URL and ARCHESTRA_FRONTEND_URL.
 # ARCHESTRA_TRUST_PROXY=false
 
 # Optional for local dev

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.test.ts
@@ -685,7 +685,7 @@ describe("assertAuthenticatedForKeylessProvider", () => {
     apiKey: undefined,
     wasVirtualKeyResolved: false,
     wasJwksAuthenticated: false,
-    requestIp: "1.2.3.4",
+    isLoopbackCaller: false,
   };
 
   test("allows request when apiKey is present", () => {
@@ -715,29 +715,13 @@ describe("assertAuthenticatedForKeylessProvider", () => {
     ).not.toThrow();
   });
 
-  test("allows localhost IPv4 without any auth", () => {
+  // Which addresses count as loopback is isLoopbackRequest's contract, covered
+  // in utils/network.test.ts. This function only consumes the verdict.
+  test("allows a loopback caller without any auth", () => {
     expect(() =>
       assertAuthenticatedForKeylessProvider({
         ...keylessArgs,
-        requestIp: "127.0.0.1",
-      }),
-    ).not.toThrow();
-  });
-
-  test("allows localhost IPv6 without any auth", () => {
-    expect(() =>
-      assertAuthenticatedForKeylessProvider({
-        ...keylessArgs,
-        requestIp: "::1",
-      }),
-    ).not.toThrow();
-  });
-
-  test("allows localhost IPv4-mapped IPv6 without any auth", () => {
-    expect(() =>
-      assertAuthenticatedForKeylessProvider({
-        ...keylessArgs,
-        requestIp: "::ffff:127.0.0.1",
+        isLoopbackCaller: true,
       }),
     ).not.toThrow();
   });
@@ -746,15 +730,6 @@ describe("assertAuthenticatedForKeylessProvider", () => {
     expect(() => assertAuthenticatedForKeylessProvider(keylessArgs)).toThrow(
       "Authentication required",
     );
-  });
-
-  test("rejects external request with empty apiKey", () => {
-    expect(() =>
-      assertAuthenticatedForKeylessProvider({
-        ...keylessArgs,
-        requestIp: "10.0.0.5",
-      }),
-    ).toThrow("Authentication required");
   });
 
   // When the backend authenticates upstream with its own credentials (Gemini on
@@ -796,7 +771,7 @@ describe("assertAuthenticatedForKeylessProvider", () => {
       assertAuthenticatedForKeylessProvider({
         ...keylessArgs,
         apiKey: "Bearer anything",
-        requestIp: "127.0.0.1",
+        isLoopbackCaller: true,
         providerSuppliesServerCredential: true,
       }),
     ).not.toThrow();

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.ts
@@ -40,7 +40,7 @@ import {
   type ResourceVisibilityScope,
 } from "@/types";
 import { resolveProviderApiKey } from "@/utils/llm-api-key-resolution";
-import { isLoopbackAddress } from "@/utils/network";
+import { isLoopbackRequest } from "@/utils/network";
 import { getPassthroughVirtualKeyToken } from "./utils/headers/virtual-key";
 
 // =========================================================================
@@ -473,7 +473,12 @@ export function assertAuthenticatedForKeylessProvider(params: {
   apiKey: string | undefined;
   wasVirtualKeyResolved: boolean;
   wasJwksAuthenticated: boolean;
-  requestIp: string;
+  /**
+   * Whether the request arrived over the loopback socket. Resolve it with
+   * `isLoopbackRequest`, never from `request.ip`, which `trustProxy` rewrites
+   * from forwarded headers.
+   */
+  isLoopbackCaller: boolean;
   /**
    * True when the backend authenticates upstream with its OWN credentials and
    * discards whatever the caller sent (Gemini in Vertex AI mode). A
@@ -488,14 +493,14 @@ export function assertAuthenticatedForKeylessProvider(params: {
     apiKey,
     wasVirtualKeyResolved,
     wasJwksAuthenticated,
-    requestIp,
+    isLoopbackCaller,
     providerSuppliesServerCredential = false,
   } = params;
 
   if (wasVirtualKeyResolved || wasJwksAuthenticated) return;
   if (apiKey && !providerSuppliesServerCredential) return;
 
-  if (!isLoopbackAddress(requestIp)) {
+  if (!isLoopbackCaller) {
     throw new ApiError(
       401,
       providerSuppliesServerCredential
@@ -533,7 +538,12 @@ export async function authenticatePassthroughProxyRequest(params: {
 
   // Internal loopback callers (in-app chat → proxy) are trusted, matching the
   // keyless-provider allowance in the instrumented handler.
-  if (isLoopbackAddress(request.ip)) return;
+  //
+  // NOTE: this remains a broad allowance — traffic the frontend rewrites to the
+  // API genuinely arrives over loopback, so it still lands here (#7229). Reading
+  // the socket peer only removes the ability to *forge* that state through
+  // forwarded headers; it does not narrow which callers qualify.
+  if (isLoopbackRequest(request)) return;
 
   const unauthenticated = new ApiError(
     401,

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -89,7 +89,7 @@ import {
   UNSAFE_CONTEXT_BOUNDARY_REASON,
   type UnsafeContextBoundary,
 } from "@/types";
-import { isLoopbackAddress } from "@/utils/network";
+import { isLoopbackRequest } from "@/utils/network";
 import { isUuid } from "@/utils/uuid";
 import {
   assertAuthenticatedForKeylessProvider,
@@ -477,7 +477,7 @@ export async function handleLLMProxy<
   const providerBaseUrlHeaderValue =
     headersForExtraction[PROVIDER_BASE_URL_HEADER.toLowerCase()];
   const isInternalChatForward =
-    isLoopbackAddress(request.ip) &&
+    isLoopbackRequest(request) &&
     typeof chatApiKeyIdHeader === "string" &&
     chatApiKeyIdHeader.length > 0 &&
     typeof providerBaseUrlHeaderValue === "string" &&
@@ -571,7 +571,7 @@ export async function handleLLMProxy<
       headersForExtraction[CHAT_API_KEY_ID_HEADER.toLowerCase()];
     const headerPresent =
       typeof headerValue === "string" && headerValue.length > 0;
-    if (isLoopbackAddress(request.ip)) {
+    if (isLoopbackRequest(request)) {
       if (headerPresent) {
         perKeyChatApiKeyId = headerValue;
         perKeyChatApiKeyIdFromLoopbackHeader = true;
@@ -582,7 +582,7 @@ export async function handleLLMProxy<
       }
     } else if (headerPresent) {
       logger.warn(
-        { ip: request.ip },
+        { ip: request.socket.remoteAddress },
         `[${providerName}Proxy] ignoring provider-api-key-id header from non-loopback request`,
       );
     }
@@ -640,7 +640,7 @@ export async function handleLLMProxy<
     apiKey,
     wasVirtualKeyResolved: wasVirtualKeyResolved || wasOAuthAuthenticated,
     wasJwksAuthenticated,
-    requestIp: request.ip,
+    isLoopbackCaller: isLoopbackRequest(request),
     providerSuppliesServerCredential:
       providerSuppliesServerCredential(providerName),
   });
@@ -682,7 +682,7 @@ export async function handleLLMProxy<
   if (!authMethod) {
     authMethod = passthroughVirtualKeyId
       ? "passthrough_virtual_key"
-      : isLoopbackAddress(request.ip)
+      : isLoopbackRequest(request)
         ? "internal"
         : "provider_key";
   }
@@ -1100,7 +1100,7 @@ export async function handleLLMProxy<
     // External clients must NOT be able to set this header — it would be an SSRF vector
     // (attacker could redirect the proxy to arbitrary URLs like cloud metadata endpoints).
     const providerBaseUrlHeader =
-      isLoopbackAddress(request.ip) &&
+      isLoopbackRequest(request) &&
       typeof headersForExtraction["x-archestra-provider-base-url"] === "string"
         ? headersForExtraction["x-archestra-provider-base-url"]
         : undefined;
@@ -2435,7 +2435,7 @@ async function resolveDelegationBillingEnvironment(
     return undefined;
   }
 
-  if (!isLoopbackAddress(request.socket.remoteAddress)) {
+  if (!isLoopbackRequest(request)) {
     logger.warn(
       { agentId: agent.id },
       "Ignoring delegation billing environment header from a non-loopback peer",

--- a/platform/backend/src/routes/request-origin.test.ts
+++ b/platform/backend/src/routes/request-origin.test.ts
@@ -1,0 +1,101 @@
+import type { FastifyRequest } from "fastify";
+import { describe, expect, test, vi } from "vitest";
+
+// trustProxy is deliberately ON for every case here: the allowlist must hold
+// regardless of it. This module reads the raw X-Forwarded-Host header rather
+// than request.hostname, so Fastify's trusted-proxy gating never filters the
+// value — honoring trustProxy would accept a forwarded host from any client.
+vi.mock("@/config", async () => {
+  const actual = await vi.importActual<typeof import("@/config")>("@/config");
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      api: { ...actual.default.api, trustProxy: true },
+    },
+    getMCPGatewayOauthAllowedPublicHosts: () =>
+      new Set(["allowed.example.com"]),
+  };
+});
+
+import { getPublicRequestOrigin } from "./request-origin";
+
+function makeRequest(params: {
+  host?: string;
+  forwardedHost?: string;
+  forwardedProto?: string;
+  encrypted?: boolean;
+}): FastifyRequest {
+  const headers: Record<string, string> = {};
+  if (params.host) headers.host = params.host;
+  if (params.forwardedHost) headers["x-forwarded-host"] = params.forwardedHost;
+  if (params.forwardedProto)
+    headers["x-forwarded-proto"] = params.forwardedProto;
+  return {
+    headers,
+    socket: { encrypted: params.encrypted ?? false },
+  } as unknown as FastifyRequest;
+}
+
+describe("getPublicRequestOrigin", () => {
+  test("uses the direct origin when nothing is forwarded", () => {
+    expect(getPublicRequestOrigin(makeRequest({ host: "internal:9000" }))).toBe(
+      "http://internal:9000",
+    );
+  });
+
+  test("honors a forwarded host that is in the allowlist", () => {
+    const origin = getPublicRequestOrigin(
+      makeRequest({
+        host: "internal:9000",
+        forwardedHost: "allowed.example.com",
+        forwardedProto: "https",
+      }),
+    );
+    expect(origin).toBe("https://allowed.example.com");
+  });
+
+  // The regression this file exists for: before, any truthy trustProxy returned
+  // the forwarded host unchecked, letting a caller choose the OAuth issuer
+  // origin the platform advertises.
+  test("rejects a forwarded host outside the allowlist even when trustProxy is on", () => {
+    const origin = getPublicRequestOrigin(
+      makeRequest({
+        host: "internal:9000",
+        forwardedHost: "attacker.example.com",
+        forwardedProto: "https",
+      }),
+    );
+    expect(origin).toBe("http://internal:9000");
+  });
+
+  test("ignores a malformed forwarded host", () => {
+    const origin = getPublicRequestOrigin(
+      makeRequest({
+        host: "internal:9000",
+        forwardedHost: "not a host",
+        forwardedProto: "https",
+      }),
+    );
+    expect(origin).toBe("http://internal:9000");
+  });
+
+  test("takes the first hop of a comma-joined forwarded host", () => {
+    const origin = getPublicRequestOrigin(
+      makeRequest({
+        host: "internal:9000",
+        forwardedHost: "allowed.example.com, attacker.example.com",
+        forwardedProto: "https",
+      }),
+    );
+    expect(origin).toBe("https://allowed.example.com");
+  });
+
+  test("derives https from an encrypted socket with no forwarded headers", () => {
+    expect(
+      getPublicRequestOrigin(
+        makeRequest({ host: "internal:9000", encrypted: true }),
+      ),
+    ).toBe("https://internal:9000");
+  });
+});

--- a/platform/backend/src/routes/request-origin.ts
+++ b/platform/backend/src/routes/request-origin.ts
@@ -1,13 +1,13 @@
 import type { FastifyRequest } from "fastify";
 
-import config, { getMCPGatewayOauthAllowedPublicHosts } from "@/config";
+import { getMCPGatewayOauthAllowedPublicHosts } from "@/config";
 import logger from "@/logging";
 
 /**
  * Return the public origin for a request — used to build the OAuth
  * protected-resource metadata URL. Scoping origin derivation to OAuth lets MCP
  * gateway OAuth work out of the box without the (too-broad) ARCHESTRA_TRUST_PROXY,
- * while still validating the forwarded host to prevent X-Forwarded-Host spoofing.
+ * while always validating the forwarded host to prevent X-Forwarded-Host spoofing.
  * The origin-derivation logic is adapted from Fastify.
  *
  * MUST BE USED ONLY FOR MCP OAUTH (the MCP gateway and the shareable-App connector).
@@ -50,12 +50,13 @@ function computePublicRequestOrigin(request: FastifyRequest): string {
     candidateHost = directHost;
   }
 
-  // If trustProxy is set, the candidate is returned as-is.
-  // It's needed not to break any existing setups which already ARCHESTRA_TRUST_PROXY=true.
-  // Once we are happy with how scoped validation works, we can remove this alongside with the trustProxy.
-  if (config.api.trustProxy) {
-    return `${protocol}://${candidateHost}`;
-  }
+  // The allowlist applies regardless of ARCHESTRA_TRUST_PROXY. This function
+  // reads the raw X-Forwarded-Host header rather than request.hostname, so
+  // Fastify's trusted-proxy gating never filters it: honoring trustProxy here
+  // would accept a forwarded host from ANY client, including one whose socket
+  // peer is not a trusted proxy at all. A deployment that terminates TLS at a
+  // proxy names its public host in ARCHESTRA_API_BASE_URL (or
+  // ARCHESTRA_FRONTEND_URL), which is what the allowlist is built from.
 
   // Check if the candidate host is in the allowed list
   const allowed = getMCPGatewayOauthAllowedPublicHosts();

--- a/platform/backend/src/utils/network.test.ts
+++ b/platform/backend/src/utils/network.test.ts
@@ -4,9 +4,43 @@ import {
   isIpLiteralHost,
   isLoopbackAddress,
   isLoopbackRedirectUri,
+  isLoopbackRequest,
   isPrivateOrLoopbackHostname,
   loopbackRedirectUriMatchesIgnoringPort,
 } from "./network";
+
+describe("isLoopbackRequest", () => {
+  test("returns true for a loopback socket peer", () => {
+    expect(isLoopbackRequest({ socket: { remoteAddress: "127.0.0.1" } })).toBe(
+      true,
+    );
+    expect(isLoopbackRequest({ socket: { remoteAddress: "::1" } })).toBe(true);
+    expect(
+      isLoopbackRequest({ socket: { remoteAddress: "::ffff:127.0.0.1" } }),
+    ).toBe(true);
+  });
+
+  test("returns false for a remote socket peer", () => {
+    expect(isLoopbackRequest({ socket: { remoteAddress: "10.0.0.5" } })).toBe(
+      false,
+    );
+  });
+
+  test("returns false when the peer is unknown", () => {
+    expect(isLoopbackRequest({ socket: {} })).toBe(false);
+    expect(isLoopbackRequest({})).toBe(false);
+  });
+
+  // The reason this helper exists: `request.ip` is derived from forwarded
+  // headers under trustProxy, so it must never decide a loopback trust seam.
+  test("ignores a request.ip that claims to be loopback", () => {
+    const spoofed = {
+      ip: "127.0.0.1",
+      socket: { remoteAddress: "203.0.113.7" },
+    };
+    expect(isLoopbackRequest(spoofed)).toBe(false);
+  });
+});
 
 describe("isLoopbackAddress", () => {
   // IPv4 loopback range (127.0.0.0/8)

--- a/platform/backend/src/utils/network.ts
+++ b/platform/backend/src/utils/network.ts
@@ -25,6 +25,25 @@ export function isLoopbackAddress(ip: string | null | undefined): boolean {
 }
 
 /**
+ * Whether a request actually arrived over the loopback socket.
+ *
+ * Reads the raw socket peer, NOT `request.ip`. Under `trustProxy` Fastify
+ * rewrites `request.ip` from forwarded headers, so a remote caller could
+ * otherwise present itself as loopback and take the seams reserved for the
+ * in-process callers that dial the API over 127.0.0.1 — the provider base-URL
+ * override, the internal chat-api-key header, and the keyless-provider
+ * allowance. Every such trust decision must go through this, never `request.ip`.
+ *
+ * Structurally typed rather than taking a FastifyRequest so this module stays
+ * free of a Fastify import; the raw `IncomingMessage` shape works too.
+ */
+export function isLoopbackRequest(request: {
+  socket?: { remoteAddress?: string | undefined } | undefined;
+}): boolean {
+  return isLoopbackAddress(request.socket?.remoteAddress);
+}
+
+/**
  * Check if a redirect URI targets a loopback address.
  * Per RFC 8252 Section 7.3, authorization servers must allow any port
  * for loopback redirect URIs in native app OAuth flows.


### PR DESCRIPTION
Follow-up to #7232 (now merged), fixing the two prerequisites I flagged on #7229 as blocking `ARCHESTRA_TRUST_PROXY`. With both fixed, the last hunk sets it on staging.

## 1. `request-origin` no longer short-circuits on `trustProxy`

```ts
// If trustProxy is set, the candidate is returned as-is.
if (config.api.trustProxy) return `${protocol}://${candidateHost}`;
```

This returned a client-supplied `X-Forwarded-Host` as the public origin with no allowlist check. Crucially it reads the **raw header**, not `request.hostname`, so Fastify's trusted-CIDR gating never filtered it — even a narrow CIDR list would have opened this for *every* request, including callers whose socket peer is not a proxy at all. That origin feeds OAuth protected-resource metadata, `WWW-Authenticate`, oauth-server base URLs, and skill-share links, so a caller could pick the issuer the platform advertises.

The allowlist now applies unconditionally. A deployment behind a proxy names its public host in `ARCHESTRA_API_BASE_URL` / `ARCHESTRA_FRONTEND_URL`, which is what the allowlist is already built from — staging's covers both hosts. The file's own comment anticipated this removal ("Once we are happy with how scoped validation works, we can remove this alongside with the trustProxy").

## 2. Loopback trust seams read the socket peer, not `request.ip`

`trustProxy` rewrites `request.ip` from forwarded headers, so these six could be forged into looking internal:

| seam | what it grants |
|---|---|
| `llm-proxy-handler.ts` | `x-archestra-provider-base-url` override — an SSRF sink |
| `llm-proxy-handler.ts` | `CHAT_API_KEY_ID_HEADER`, reads stored provider-key config |
| `llm-proxy-handler.ts` | downstream virtual-key forwarding |
| `llm-proxy-handler.ts` | `authMethod = "internal"` attribution |
| `llm-proxy-auth.ts` | keyless-provider auth allowance |
| `llm-proxy-auth.ts` | passthrough proxy auth |

All now go through a new `isLoopbackRequest(request)` in `utils/network`, which reads `request.socket.remoteAddress`. Two sibling seams already did this by hand and named the attack in their comments — they now share the helper, so there is one place to get this right.

`assertAuthenticatedForKeylessProvider` takes the resolved boolean instead of an IP string, so no caller can hand it the wrong address. The address-shape cases (IPv4 / `::1` / IPv4-mapped) moved to `utils/network.test.ts`, where that contract lives.

**This does not narrow the passthrough allowance itself.** Traffic the frontend rewrites to the API genuinely arrives over loopback and still lands there — that is bug 1 of #7229 and stays open. This only removes the ability to *forge* that state through headers.

## 3. Staging trusts the ingress ranges

`ARCHESTRA_TRUST_PROXY: "35.191.0.0/16,130.211.0.0/22"` — the Google Front End ranges that terminate the ingress, and the socket peers this deployment actually sees. Not `"true"`, which would trust a client-supplied `X-Forwarded-For` and let any caller choose the IP it is rate-limited and audited under.

Effect: per-IP rate limits (the virtual-key limiter, chatops and email webhooks, connection-setup) and audit `sourceIp` see the real caller instead of one shared address. Combined with #7232's per-credential scoping, that removes both halves of the collateral-lockout problem.

The docs bullet and `.env.example` note added in #7232 said any non-`false` value bypasses forwarded-host validation; that is no longer true, so both are corrected here.

## Testing

New `request-origin.test.ts` (6 tests). I verified the key one is a real regression test by temporarily restoring the old short-circuit — "rejects a forwarded host outside the allowlist even when trustProxy is on" fails against the old behavior and passes against the new. `trustProxy` is mocked ON for every case in that file, since the allowlist must hold regardless of it.

New `isLoopbackRequest` coverage in `utils/network.test.ts`, including a request whose `ip` claims `127.0.0.1` while its socket peer is remote — the exact forgery the helper exists to stop.

`type-check` and `knip` (dev + production) clean. 102 passed across the affected files after rebasing onto current `main`. Full `src/routes/proxy/` run: 1341 passed, 3 failed — the same 3 that fail without these changes in this environment (they assert plaintext interaction bodies while encryption-at-rest is configured locally). One `mcp-gateway` scaffold_app test also fails identically with these changes stashed; both baselines verified, not regressions.