### PR TITLE
perf(knowledge): AND-first keyword search with an OR recall fallback

### DIFF
--- a/platform/backend/src/models/kb-chunk.test.ts
+++ b/platform/backend/src/models/kb-chunk.test.ts
@@ -375,6 +375,79 @@ describe("KbChunkModel", () => {
       expect(results[0].score).toBeGreaterThan(0);
     });
 
+    test("a multi-term query requires every term (AND semantics)", async ({
+      makeOrganization,
+      makeKnowledgeBase,
+      makeKnowledgeBaseConnector,
+    }) => {
+      const org = await makeOrganization();
+      const kb = await makeKnowledgeBase(org.id);
+      const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+      const doc = await KbDocumentModel.create(
+        createDocumentData(connector.id, org.id),
+      );
+      await KbChunkModel.insertMany([
+        {
+          documentId: doc.id,
+          content: "apple banana cherry",
+          chunkIndex: 0,
+          acl: ["org:*"],
+        },
+        {
+          documentId: doc.id,
+          content: "apple date",
+          chunkIndex: 1,
+          acl: ["org:*"],
+        },
+      ]);
+
+      // Only the chunk containing BOTH terms matches — the always-OR rewrite
+      // would have returned both, and its match set is what made the keyword
+      // lane's cost scale with the corpus.
+      const results = await KbChunkModel.fullTextSearch({
+        connectorIds: [connector.id],
+        queryText: "apple banana",
+        userAcl: ["org:*"],
+      });
+      expect(results.map((r) => r.chunkIndex)).toEqual([0]);
+    });
+
+    test("falls back to OR matching when no chunk holds every term", async ({
+      makeOrganization,
+      makeKnowledgeBase,
+      makeKnowledgeBaseConnector,
+    }) => {
+      const org = await makeOrganization();
+      const kb = await makeKnowledgeBase(org.id);
+      const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+      const doc = await KbDocumentModel.create(
+        createDocumentData(connector.id, org.id),
+      );
+      await KbChunkModel.insertMany([
+        {
+          documentId: doc.id,
+          content: "apple banana cherry",
+          chunkIndex: 0,
+          acl: ["org:*"],
+        },
+        {
+          documentId: doc.id,
+          content: "banana date",
+          chunkIndex: 1,
+          acl: ["org:*"],
+        },
+      ]);
+
+      // "zzzabsent" appears nowhere, so the AND pass matches nothing; the OR
+      // fallback recovers the chunks that hold any of the real terms.
+      const results = await KbChunkModel.fullTextSearch({
+        connectorIds: [connector.id],
+        queryText: "banana zzzabsent",
+        userAcl: ["org:*"],
+      });
+      expect(results.map((r) => r.chunkIndex).sort()).toEqual([0, 1]);
+    });
+
     test("returns empty array when connectorIds is empty", async () => {
       const results = await KbChunkModel.fullTextSearch({
         connectorIds: [],

--- a/platform/backend/src/models/kb-chunk.ts
+++ b/platform/backend/src/models/kb-chunk.ts
@@ -233,102 +233,34 @@ class KbChunkModel {
     environmentId?: string | null;
     limit?: number;
   }): Promise<VectorSearchResult[]> {
-    const {
-      connectorIds,
-      queryText,
-      languages,
-      userAcl,
-      bypassAcl = false,
-      environmentId,
-      limit = 10,
-    } = params;
+    const { connectorIds, queryText, userAcl, bypassAcl = false } = params;
     if (connectorIds.length === 0) return [];
     if (!bypassAcl && userAcl.length === 0) return [];
-    const ids = sql.join(
-      connectorIds.map((id) => sql`${id}`),
-      sql`, `,
-    );
-    const aclEntries = bypassAcl
-      ? null
-      : sql.join(
-          userAcl.map((entry) => sql`${entry}`),
-          sql`, `,
-        );
 
-    const envFilter =
-      environmentId !== undefined
-        ? sql`AND kbc.environment_id IS NOT DISTINCT FROM ${environmentId}`
-        : sql``;
+    const terms = queryText.split(/\s+/).filter(Boolean);
+    if (terms.length === 0) return [];
 
-    const orQuery = queryText.split(/\s+/).filter(Boolean).join(" OR ");
+    // AND-first, OR-fallback. The query text goes to websearch_to_tsquery
+    // as written, whose natural semantics AND the plain terms — a selective
+    // match set the GIN index serves with a bitmap scan. The previous
+    // always-OR rewrite matched ~40% of a 113k-chunk corpus (measured via
+    // EXPLAIN on that corpus): at that selectivity the planner rightly
+    // abandons the GIN for a parallel seq scan and ts_rank detoasts every
+    // match — ~7.6s per statement, growing with the corpus, which is what
+    // drove the keyword lane into the statement timeout. The OR form
+    // survives only as a recall fallback when the AND query matches nothing
+    // (no chunk holds every term), where RRF and the reranker downstream
+    // absorb its loose precision.
+    const andRows = await KbChunkModel.runFullTextStatement({
+      ...params,
+      tsQueryText: queryText,
+    });
+    if (andRows.length > 0 || terms.length <= 1) return andRows;
 
-    // The query is parsed once per text-search configuration present, and the
-    // per-language predicates are OR-ed together.
-    //
-    // The obvious formulation — `websearch_to_tsquery(c.fts_language, ...)`,
-    // matching each chunk under its own stored configuration — is a per-row
-    // expression, so PostgreSQL cannot constant-fold it into an index lookup
-    // key and the GIN index on search_vector becomes unusable. Measured on a
-    // 300k-chunk corpus that turned a bitmap index scan into a full sequential
-    // scan: ~18 buffers to ~14,000, growing with the corpus rather than with
-    // the number of matches, on the keyword leg of every hybrid query.
-    //
-    // Each branch here uses a literal configuration, so each is index-driven
-    // and PostgreSQL combines them with a BitmapOr. A single-language corpus —
-    // the common case — collapses to exactly one indexed predicate.
-    //
-    // A chunk is therefore matched under every configuration present, not only
-    // its own. In a mixed-language corpus that trades a little precision for
-    // recall, which RRF and the reranker downstream are well placed to absorb;
-    // the alternative failure (a chunk matched under no configuration at all,
-    // and so invisible to keyword search) is far worse.
-    const searchLanguages =
-      languages && languages.length > 0
-        ? languages
-        : [DEFAULT_TEXT_SEARCH_LANGUAGE];
-
-    // Bound parameters, not interpolated literals: a bound `regconfig` is still
-    // constant at execution time, so it stays index-eligible, and nothing from
-    // the column reaches the SQL text.
-    const matchPredicate = sql.join(
-      searchLanguages.map(
-        (language) =>
-          sql`c.search_vector @@ websearch_to_tsquery(${language}::regconfig, ${orQuery})`,
-      ),
-      sql` OR `,
-    );
-    // Rank under the best-matching configuration, so a chunk is not penalized
-    // for the languages it is not written in.
-    const scoreExpression = sql.join(
-      searchLanguages.map(
-        (language) =>
-          sql`ts_rank(c.search_vector, websearch_to_tsquery(${language}::regconfig, ${orQuery}))`,
-      ),
-      sql`, `,
-    );
-
-    const rows = await executeWithSearchTimeout(sql`
-      SELECT
-        c.id, c.content, c.chunk_index AS "chunkIndex", c.document_id AS "documentId",
-        d.source_id AS "sourceId", d.title, d.source_url AS "sourceUrl", d.metadata,
-        kbc.connector_type AS "connectorType",
-        GREATEST(${scoreExpression}) AS score
-      FROM kb_chunks c
-      JOIN kb_documents d ON d.id = c.document_id
-      LEFT JOIN knowledge_base_connectors kbc ON kbc.id = d.connector_id
-      WHERE d.connector_id IN (${ids})
-        -- Mirrors the same guard in vectorSearch: retrieval is a security
-        -- surface, so never serve chunks from a soft-deleted connector even if
-        -- a stale connectorId reaches this far.
-        AND kbc.deleted_at IS NULL
-        AND (${matchPredicate})
-        ${envFilter}
-        ${bypassAcl ? sql`` : sql`AND c.acl ?| ARRAY[${aclEntries}]`}
-      ORDER BY score DESC
-      LIMIT ${limit}
-    `);
-
-    return rows.rows as unknown as VectorSearchResult[];
+    return KbChunkModel.runFullTextStatement({
+      ...params,
+      tsQueryText: terms.join(" OR "),
+    });
   }
 
   /**
@@ -454,6 +386,110 @@ class KbChunkModel {
         WHERE c.id = v.id
       `),
     );
+  }
+
+  private static async runFullTextStatement(params: {
+    connectorIds: string[];
+    /** The text handed to websearch_to_tsquery, verbatim. */
+    tsQueryText: string;
+    languages?: TextSearchLanguage[];
+    userAcl: AclEntry[];
+    bypassAcl?: boolean;
+    environmentId?: string | null;
+    limit?: number;
+  }): Promise<VectorSearchResult[]> {
+    const {
+      connectorIds,
+      tsQueryText,
+      languages,
+      userAcl,
+      bypassAcl = false,
+      environmentId,
+      limit = 10,
+    } = params;
+    const ids = sql.join(
+      connectorIds.map((id) => sql`${id}`),
+      sql`, `,
+    );
+    const aclEntries = bypassAcl
+      ? null
+      : sql.join(
+          userAcl.map((entry) => sql`${entry}`),
+          sql`, `,
+        );
+
+    const envFilter =
+      environmentId !== undefined
+        ? sql`AND kbc.environment_id IS NOT DISTINCT FROM ${environmentId}`
+        : sql``;
+
+    // The query is parsed once per text-search configuration present, and the
+    // per-language predicates are OR-ed together.
+    //
+    // The obvious formulation — `websearch_to_tsquery(c.fts_language, ...)`,
+    // matching each chunk under its own stored configuration — is a per-row
+    // expression, so PostgreSQL cannot constant-fold it into an index lookup
+    // key and the GIN index on search_vector becomes unusable. Measured on a
+    // 300k-chunk corpus that turned a bitmap index scan into a full sequential
+    // scan: ~18 buffers to ~14,000, growing with the corpus rather than with
+    // the number of matches, on the keyword leg of every hybrid query.
+    //
+    // Each branch here uses a literal configuration, so each is index-driven
+    // and PostgreSQL combines them with a BitmapOr. A single-language corpus —
+    // the common case — collapses to exactly one indexed predicate.
+    //
+    // A chunk is therefore matched under every configuration present, not only
+    // its own. In a mixed-language corpus that trades a little precision for
+    // recall, which RRF and the reranker downstream are well placed to absorb;
+    // the alternative failure (a chunk matched under no configuration at all,
+    // and so invisible to keyword search) is far worse.
+    const searchLanguages =
+      languages && languages.length > 0
+        ? languages
+        : [DEFAULT_TEXT_SEARCH_LANGUAGE];
+
+    // Bound parameters, not interpolated literals: a bound `regconfig` is still
+    // constant at execution time, so it stays index-eligible, and nothing from
+    // the column reaches the SQL text.
+    const matchPredicate = sql.join(
+      searchLanguages.map(
+        (language) =>
+          sql`c.search_vector @@ websearch_to_tsquery(${language}::regconfig, ${tsQueryText})`,
+      ),
+      sql` OR `,
+    );
+    // Rank under the best-matching configuration, so a chunk is not penalized
+    // for the languages it is not written in.
+    const scoreExpression = sql.join(
+      searchLanguages.map(
+        (language) =>
+          sql`ts_rank(c.search_vector, websearch_to_tsquery(${language}::regconfig, ${tsQueryText}))`,
+      ),
+      sql`, `,
+    );
+
+    const rows = await executeWithSearchTimeout(sql`
+      SELECT
+        c.id, c.content, c.chunk_index AS "chunkIndex", c.document_id AS "documentId",
+        d.source_id AS "sourceId", d.title, d.source_url AS "sourceUrl", d.metadata,
+        kbc.connector_type AS "connectorType",
+        GREATEST(${scoreExpression}) AS score
+      FROM kb_chunks c
+      JOIN kb_documents d ON d.id = c.document_id
+      LEFT JOIN knowledge_base_connectors kbc ON kbc.id = d.connector_id
+      WHERE d.connector_id IN (${ids})
+        -- Mirrors the same guard in vectorSearch: retrieval is a security
+        -- surface, so never serve chunks from a soft-deleted connector even if
+        -- a stale connectorId reaches this far.
+        AND kbc.deleted_at IS NULL
+        AND (${matchPredicate})
+        ${envFilter}
+        ${bypassAcl ? sql`` : sql`AND c.acl ?| ARRAY[${aclEntries}]`}
+      ORDER BY score DESC
+      LIMIT ${limit}
+    `);
+
+    return rows.rows as unknown as VectorSearchResult[];
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #7230 — the permanent fix for the keyword-lane cost that its per-lane timeout defends against.

`fullTextSearch` rewrote every query into an OR of its words (`rate limit billing api` → `'rate' | 'limit' | 'bill' | 'api'`). On a 113k-chunk corpus, `EXPLAIN (ANALYZE, BUFFERS)` shows that tsquery matching **~40% of the corpus (45,595 rows)**: the planner rightly abandons the GIN index for a **parallel seq scan**, detoasts every matching `search_vector` for `ts_rank` (~4.4GB of buffer traffic), and takes **7.6s per statement** — a cost that grows with the corpus. Query expansion fans out ~8–10 such statements per tool call onto a 2-vCPU instance, which is how every knowledge search on a large deployment hit the 30s statement timeout while the vector lane answered via HNSW in 735ms.

The change:

- **AND-first**: the query text goes to `websearch_to_tsquery` as written — its natural semantics AND the plain terms, producing a selective match set the GIN index serves with a bitmap scan, at a cost independent of corpus size. (Quoted phrases and websearch operators now also work as the function intends, instead of being destroyed by the split-and-OR rewrite.)
- **OR fallback**: only when the AND query matches nothing (no chunk holds every term) does the old OR form run — the recall case the rewrite existed for, where RRF and the reranker absorb the loose precision. The per-lane statement timeout from #7230 still bounds the fallback on a degenerate corpus.
- Single-term queries and the per-language predicate construction (bound `regconfig` parameters, BitmapOr across configurations) are unchanged.

## Testing

- New model tests pin both behaviors against real FTS in PGlite: a multi-term query returns only chunks holding every term, and a query with an absent term falls back to OR and recovers partial matches.
- kb-chunk, query, knowledge-base routes, connector-sync, and context-expansion suites pass (195 tests); knip + type-check + lint clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>