### PR TITLE
fix(mcp-registry): stop the usage hover card from swallowing card action clicks

### DIFF
--- a/platform/frontend/src/app/globals.css
+++ b/platform/frontend/src/app/globals.css
@@ -604,3 +604,13 @@ div:has(> [data-testid="emoji-picker-list-header"]) {
     animation-delay: 0s !important;
   }
 }
+
+/* Informational hover cards (`<HoverCardContent pointerEventsNone />`) must not
+   absorb clicks meant for the UI they float over. Radix wraps positioned
+   content in a `[data-radix-popper-content-wrapper]` div that stays
+   pointer-interactive, so opting the content out is not enough on its own —
+   the wrapper has to leave the hit-test path too, and only an ancestor
+   selector can reach it. */
+[data-radix-popper-content-wrapper]:has(> [data-pointer-events-none]) {
+  pointer-events: none;
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -635,19 +635,31 @@ export function McpServerCard({
       {totalAgentCount > 0 && (
         <>
           {/*
-            A hover card rather than a tooltip: the footer links through to the
-            full list, and tooltip content is not reachable by the pointer.
+            The popover is informational only, and it MUST NOT capture pointer
+            events: it opens directly on top of the card's action row (Chat /
+            Reinstall / Uninstall), so an interactive popover sits between the
+            cursor and those buttons and swallows the click — the user presses
+            Reinstall and nothing happens. `pointerEventsNone` puts the popper
+            wrapper out of the hit-test path so clicks fall through to the
+            button underneath. That leaves nothing clickable inside the card,
+            so the trigger itself carries the link to the full usage list.
           */}
           <HoverCard openDelay={150}>
             <HoverCardTrigger asChild>
-              <div className="flex shrink-0 items-center gap-1 cursor-help">
+              <Link
+                href={`/mcp/registry/${item.id}?tab=usage`}
+                aria-label={`${totalAgentCount} ${
+                  totalAgentCount === 1 ? "agent" : "agents"
+                } can use ${item.name}, view usage`}
+                className="flex shrink-0 items-center gap-1 hover:text-foreground transition-colors"
+              >
                 <Bot className="h-3.5 w-3.5" />
                 <span data-testid={`${E2eTestId.McpServerAgentsCount}`}>
                   {totalAgentCount}
                 </span>
-              </div>
+              </Link>
             </HoverCardTrigger>
-            <HoverCardContent className="w-72 p-3 text-sm">
+            <HoverCardContent pointerEventsNone className="w-72 p-3 text-sm">
               {assignedAgents.length > 0 && (
                 <AgentUsageSection
                   title={`Used by ${assignedAgents.length} ${
@@ -667,13 +679,10 @@ export function McpServerCard({
                   agents={autoModeOnlyAgents}
                 />
               )}
-              <Link
-                href={`/mcp/registry/${item.id}?tab=usage`}
-                className="mt-2.5 flex items-center gap-1 border-t pt-2 text-xs text-muted-foreground hover:text-foreground"
-              >
+              <p className="mt-2.5 flex items-center gap-1 border-t pt-2 text-xs text-muted-foreground">
                 <span>View all usage</span>
                 <ArrowUpRight className="h-3 w-3" />
-              </Link>
+              </p>
             </HoverCardContent>
           </HoverCard>
         </>

--- a/platform/frontend/src/components/ui/hover-card.tsx
+++ b/platform/frontend/src/components/ui/hover-card.tsx
@@ -23,15 +23,32 @@ function HoverCardContent({
   className,
   align = "center",
   sideOffset = 4,
+  pointerEventsNone = false,
   ...props
-}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+}: React.ComponentProps<typeof HoverCardPrimitive.Content> & {
+  /**
+   * Take the popover out of the hit-test path, so a click passes through to
+   * whatever it is covering. Use it for purely informational content that
+   * opens over interactive UI: a hover card floating above a row of buttons
+   * otherwise absorbs the click and the button underneath looks dead.
+   *
+   * Radix positions the content inside a `[data-radix-popper-content-wrapper]`
+   * div sized to the content, and that wrapper stays pointer-interactive — so
+   * `pointer-events: none` on the content alone is not enough, the wrapper
+   * still swallows the click. A child cannot style its ancestor, hence the
+   * marker attribute plus the `:has()` rule in globals.css.
+   */
+  pointerEventsNone?: boolean;
+}) {
   return (
     <HoverCardPrimitive.Portal data-slot="hover-card-portal">
       <HoverCardPrimitive.Content
         data-slot="hover-card-content"
+        data-pointer-events-none={pointerEventsNone || undefined}
         align={align}
         sideOffset={sideOffset}
         className={cn(
+          pointerEventsNone && "pointer-events-none",
           "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
           className,
         )}

--- a/platform/frontend/tests-integration/mcp-card-actions.spec.ts
+++ b/platform/frontend/tests-integration/mcp-card-actions.spec.ts
@@ -1,0 +1,118 @@
+import { makeCatalogItem } from "../src/mocks/data/catalog";
+import { makeInstalledServer } from "../src/mocks/data/servers";
+import { expect, test } from "./fixtures";
+
+/**
+ * The registry card's agent-usage hover card opens directly on top of the
+ * card's action row. While it was pointer-interactive it absorbed the click:
+ * moving the cursor down towards Reinstall crossed the agent count, the card
+ * opened, and the button underneath did nothing.
+ */
+/** First-render budget, wide enough for the route's cold compile on CI. */
+const COLD_COMPILE = 60_000;
+
+test.describe("MCP registry card actions under the usage hover card", () => {
+  const catalog = makeCatalogItem({
+    id: "test-remote-usage-hover",
+    name: "test-remote-usage-hover",
+    serverType: "remote",
+    serverUrl: "https://example.test/mcp",
+    scope: "org",
+    userConfig: null,
+    toolCount: 19,
+  });
+  const flaggedInstall = makeInstalledServer({
+    id: "test-server-usage-hover",
+    name: "test-remote-usage-hover",
+    catalogId: catalog.id,
+    serverType: "remote",
+    scope: "personal",
+    reinstallRequired: true,
+    reinstallReason: "restart",
+    users: ["test-user-admin"],
+    assignedAgents: [
+      { id: "agent-1", name: "Agent One" },
+      { id: "agent-2", name: "Agent Two" },
+      // biome-ignore lint/suspicious/noExplicitAny: only id/name are rendered
+    ] as any,
+  });
+
+  test.beforeEach(async ({ mswControl }) => {
+    await mswControl.use({
+      method: "get",
+      url: "/api/internal_mcp_catalog",
+      body: [catalog],
+    });
+    await mswControl.use({
+      method: "get",
+      url: "/api/mcp_server",
+      body: [flaggedInstall],
+    });
+    await mswControl.use({
+      method: "post",
+      url: "/api/mcp_server/:id/reinstall",
+      body: { ...flaggedInstall, reinstallRequired: false },
+    });
+  });
+
+  test("the open hover card does not swallow the Reinstall click", async ({
+    page,
+    mcpRegistryPage,
+  }) => {
+    await mcpRegistryPage.goto();
+    // Whichever spec touches /mcp/registry first pays for the route's cold
+    // compile under `next dev`, which on a loaded CI runner overruns the 30s
+    // default. Only the first render needs the wider budget.
+    await expect(mcpRegistryPage.heading).toBeVisible({
+      timeout: COLD_COMPILE,
+    });
+    await expect(mcpRegistryPage.cardForCatalogItem(catalog.name)).toBeVisible({
+      timeout: COLD_COMPILE,
+    });
+
+    const agentCount = page.getByTestId("mcp-server-agents-count");
+    const reinstall = page.getByRole("button", { name: "Reinstall" });
+    await expect(agentCount).toBeVisible();
+    await expect(reinstall).toBeVisible();
+
+    const box = await reinstall.boundingBox();
+    if (!box) throw new Error("Reinstall button has no bounding box");
+
+    // Walk the cursor the way a user does — down across the agent count, then
+    // on to Reinstall — instead of `reinstall.click()`. Playwright's click
+    // retries until the target is hittable, which waits out the hover card and
+    // would pass with or without the fix; raw mouse events do not.
+    await agentCount.hover();
+    // The hover card must actually be open, or the click below proves nothing.
+    const hoverCard = page.locator("[data-slot=hover-card-content]");
+    await expect(hoverCard).toBeVisible();
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2, {
+      steps: 4,
+    });
+    await page.mouse.down();
+    await page.mouse.up();
+
+    // Before the fix the press landed on the popover and nothing opened.
+    await expect(
+      page.getByRole("dialog").filter({ hasText: "Reinstall Required" }),
+    ).toBeVisible();
+  });
+
+  test("the agent count links through to the usage tab", async ({
+    page,
+    mcpRegistryPage,
+  }) => {
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.cardForCatalogItem(catalog.name)).toBeVisible({
+      timeout: COLD_COMPILE,
+    });
+
+    // The hover card lost its footer link when it became non-interactive, so
+    // the count itself has to carry the route to the full usage list.
+    await expect(page.getByTestId("mcp-server-agents-count")).toBeVisible();
+    await expect(
+      page.locator(`a[href="/mcp/registry/${catalog.id}?tab=usage"]`),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## The bug

On the MCP registry, clicking **Reinstall** on a card did nothing. Same for **Chat** and **Uninstall** — Reinstall is just the one you notice, because a card only shows it when something is already wrong.

## Root cause

The card's agent-usage hover card (the `🤖 N` count) opens on the **bottom** side of a trigger that sits directly above the card's action row. While open it covers the buttons, and Radix keeps the popper wrapper pointer-interactive, so the click lands on the popover instead of the button.

The trap is that you open it *on the way to* the button: the cursor travels down from the meta row, crosses the agent count, the card opens after its 150 ms delay, and the click is eaten. Move the mouse away to look and the card closes, so the card looks perfectly normal — which is why the screenshot in the report shows nothing wrong.

Worth noting for anyone reading the old comment on this block ("a hover card rather than a tooltip… tooltip content is not reachable by the pointer"): the difference that actually bites here is the **default side**. Radix `Tooltip.Content` defaults to `side="top"`, so the sibling avatar tooltips in the same row open *above* it and never touch the buttons. `HoverCard.Content` defaults to `side="bottom"`, straight onto them.

## The fix

Take the popover out of the hit-test path. `pointer-events: none` on the content alone is not enough: Radix positions it inside a `[data-radix-popper-content-wrapper]` div that stays interactive, and a child cannot style its ancestor. So `HoverCardContent` grows a `pointerEventsNone` prop that stamps a marker attribute, paired with one `:has()` rule in `globals.css` that neutralises the wrapper.

That leaves nothing clickable inside the popover, so the "View all usage" link moves onto the trigger — the agent count itself now routes to the usage tab and carries an accessible name. The footer stays as a hint.
