### PR TITLE
fix(mcp-gateway): stop advertising tools whose install was uninstalled

### DIFF
--- a/platform/backend/src/models/tool.test.ts
+++ b/platform/backend/src/models/tool.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, test } from "@/test";
 import AgentConnectorAssignmentModel from "./agent-connector-assignment";
 import AgentKnowledgeBaseModel from "./agent-knowledge-base";
 import AgentToolModel from "./agent-tool";
+import McpServerModel from "./mcp-server";
 import OrganizationModel from "./organization";
 import TeamModel from "./team";
 import ToolModel, { parseArchestraBuiltInName } from "./tool";
@@ -1002,6 +1003,108 @@ describe("ToolModel", () => {
         expect.objectContaining({ id: tool.id, name: "scoped_tool" }),
       );
       expect(result2).toBeNull();
+    });
+  });
+
+  describe("getMcpToolsByAgent - uninstalled MCP servers", () => {
+    test("hides a statically-pinned tool once its only install is uninstalled", async ({
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeTool,
+    }) => {
+      const agent = await makeAgent();
+      const catalogItem = await makeInternalMcpCatalog();
+      const mcpServer = await makeMcpServer({ catalogId: catalogItem.id });
+      const tool = await makeTool({
+        name: "uninstalled_tool",
+        parameters: {},
+        catalogId: catalogItem.id,
+      });
+      await AgentToolModel.create(agent.id, tool.id, {
+        mcpServerId: mcpServer.id,
+      });
+
+      const before = (await ToolModel.getMcpToolsByAgent(agent.id)).map(
+        (t) => t.name,
+      );
+      expect(before).toContain("uninstalled_tool");
+
+      // Uninstall: soft-deletes the install but deliberately retains the tool
+      // row and the agent_tools assignment so a reconnect restores them.
+      await McpServerModel.delete(mcpServer.id);
+
+      const after = (await ToolModel.getMcpToolsByAgent(agent.id)).map(
+        (t) => t.name,
+      );
+      expect(after).not.toContain("uninstalled_tool");
+    });
+
+    test("keeps the tool listed when a sibling install of the same catalog survives", async ({
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeTool,
+    }) => {
+      const agent = await makeAgent();
+      const catalogItem = await makeInternalMcpCatalog();
+      const mine = await makeMcpServer({ catalogId: catalogItem.id });
+      await makeMcpServer({ catalogId: catalogItem.id });
+      const tool = await makeTool({
+        name: "shared_tool",
+        parameters: {},
+        catalogId: catalogItem.id,
+      });
+      await AgentToolModel.create(agent.id, tool.id, {
+        mcpServerId: mine.id,
+      });
+
+      // Only one caller's install goes away; the call path would still route
+      // through the surviving sibling, so the tool must stay listed.
+      await McpServerModel.delete(mine.id);
+
+      const after = (await ToolModel.getMcpToolsByAgent(agent.id)).map(
+        (t) => t.name,
+      );
+      expect(after).toContain("shared_tool");
+    });
+
+    test("keeps a dynamic-credential tool listed with no installs at all", async ({
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeTool,
+    }) => {
+      const agent = await makeAgent();
+      const catalogItem = await makeInternalMcpCatalog();
+      const tool = await makeTool({
+        name: "connect_at_call_time_tool",
+        parameters: {},
+        catalogId: catalogItem.id,
+      });
+      // Dynamic assignments resolve credentials per caller at call time and are
+      // meant to be advertised before anyone has connected, so the caller gets
+      // an actionable "connect" prompt rather than a missing tool.
+      await AgentToolModel.create(agent.id, tool.id, {
+        credentialResolutionMode: "dynamic",
+      });
+
+      const listed = (await ToolModel.getMcpToolsByAgent(agent.id)).map(
+        (t) => t.name,
+      );
+      expect(listed).toContain("connect_at_call_time_tool");
+    });
+
+    test("keeps built-in Archestra tools listed even though they have no install", async ({
+      makeAgent,
+      seedAndAssignArchestraTools,
+    }) => {
+      const agent = await makeAgent();
+      await seedAndAssignArchestraTools(agent.id);
+
+      const listed = (await ToolModel.getMcpToolsByAgent(agent.id)).map(
+        (t) => t.name,
+      );
+      expect(listed).toContain("archestra__whoami");
     });
   });
 

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -187,6 +187,67 @@ function notDisabledAppLaunchTool(): SQL {
   );
 }
 
+/**
+ * Excludes tools whose assignment is pinned to an MCP install that has been
+ * uninstalled, and for which no surviving install of the same catalog can
+ * stand in.
+ *
+ * Uninstalling a server is a soft delete that deliberately retains the `tools`
+ * rows and the `agent_tools` assignments so a reconnect restores them
+ * (`McpServerModel.delete`). Because the row survives, the assignment's
+ * `mcp_server_id` FK (`on delete set null`) never fires and the pin is left
+ * dangling at a dead install. Without this predicate those tools stay
+ * advertised on the gateway forever: the caller sees a tool it can never
+ * invoke, and because the subscription fingerprint hashes this same name set,
+ * no `notifications/tools/list_changed` fires either.
+ *
+ * Mirrors what the execution path can actually service
+ * (`McpClient.determineTargetMcpServer`): a static assignment resolves through
+ * its pinned install, else through any surviving install of the same catalog,
+ * else it errors.
+ *
+ * Deliberately scoped to *pinned* assignments. An unpinned assignment
+ * (`mcp_server_id IS NULL`) covers built-in tools, delegation tools, and
+ * dynamic / enterprise-managed assignments that resolve a connection per caller
+ * at call time — all of which are meant to be advertised before anyone has
+ * connected, so the caller gets an actionable "connect" prompt rather than a
+ * missing tool.
+ *
+ * Correlates on `agent_tools` and `tools`, so every caller must have both in
+ * its FROM.
+ *
+ * @param agentTools pass an aliased agent_tools table when the query aliases it.
+ */
+function toolInstallNotUninstalled(agentTools = schema.agentToolsTable): SQL {
+  const pinnedInstall = alias(schema.mcpServersTable, "pinned_install");
+  const siblingInstall = alias(schema.mcpServersTable, "sibling_install");
+  return or(
+    isNull(agentTools.mcpServerId),
+    exists(
+      db
+        .select({ one: sql`1` })
+        .from(pinnedInstall)
+        .where(
+          and(
+            eq(pinnedInstall.id, agentTools.mcpServerId),
+            notDeleted(pinnedInstall),
+          ),
+        ),
+    ),
+    exists(
+      db
+        .select({ one: sql`1` })
+        .from(siblingInstall)
+        .where(
+          and(
+            eq(siblingInstall.catalogId, schema.toolsTable.catalogId),
+            notDeleted(siblingInstall),
+          ),
+        ),
+    ),
+  ) as SQL;
+}
+
 class ToolModel {
   /**
    * Slugify a tool name to get a unique name for the MCP server's tool.
@@ -885,6 +946,9 @@ class ToolModel {
                 ),
                 toolInEnvironmentPredicate(agentEnvironmentId),
                 notDisabledAppLaunchTool(),
+                // Hide tools pinned to an uninstalled install (retained
+                // assignment); see toolInstallNotUninstalled.
+                toolInstallNotUninstalled(),
                 // Hide tools whose catalog was soft-deleted (retained binding).
                 notDeleted(schema.toolsTable),
               ),

--- a/platform/backend/src/routes/mcp-gateway/subscriptions.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/subscriptions.test.ts
@@ -10,6 +10,7 @@
 
 import { EventEmitter } from "node:events";
 import type { FastifyReply, FastifyRequest } from "fastify";
+import McpServerModel from "@/models/mcp-server";
 import { describe, expect, test } from "@/test";
 import {
   acknowledgedFilter,
@@ -245,5 +246,35 @@ describe("toolsListFingerprint", () => {
     // Stable when nothing changed — an unstable fingerprint would spam
     // list_changed on every poll.
     expect(await toolsListFingerprint(agent.id)).toBe(after);
+  });
+
+  test("changes when the tool's pinned install is uninstalled", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+    makeAgentTool,
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({ organizationId: org.id });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "uninstall-fp-catalog",
+    });
+    const mcpServer = await makeMcpServer({ catalogId: catalog.id });
+    const tool = await makeTool({
+      catalogId: catalog.id,
+      name: "uninstall-fp-catalog__alpha",
+    });
+    await makeAgentTool(agent.id, tool.id, { mcpServerId: mcpServer.id });
+
+    const before = await toolsListFingerprint(agent.id);
+
+    await McpServerModel.delete(mcpServer.id);
+
+    // The fingerprint hashes the same name set the gateway advertises, so
+    // dropping the tool is what lets subscribers get a list_changed at all.
+    expect(await toolsListFingerprint(agent.id)).not.toBe(before);
   });
 });


### PR DESCRIPTION
## Problem

Reported internally: an MCP server was installed and used from Claude, then its credentials and the server itself were deleted. A brand-new Claude session still saw the tools.

Two things were going on. Claude does cache remote tool lists per install (a new conversation is not a reliable refresh), but that is not the whole story — **the gateway was genuinely still advertising the tools**, so even a client that re-fetched perfectly would still have seen them.

## Root cause

Uninstalling an MCP server is a soft delete that *deliberately* retains the `tools` rows and the `agent_tools` assignments so a reconnect restores them (`McpServerModel.delete`). Its own comment states that a tool's availability "is derived from whether the catalog still has an active install" — but that derivation was never implemented.

`ToolModel.getMcpToolsByAgent`, which feeds the gateway's `tools/list`, filtered only on `notDeleted(schema.toolsTable)` — the **tool row's own** `deleted_at`, which is stamped when a *catalog entry* is deleted, not when an install is removed. Install health was consulted exactly once, in `hasHealthyMcpServerInstall`, and only in `ORDER BY` — it sorts broken installs last, never excludes them.

Because the `mcp_servers` row survives the soft delete, the assignment's `mcp_server_id` FK (`on delete set null`) never fires, so the pin is left dangling at a dead install.

Two knock-on effects:

- **No `list_changed` fired.** The SEP-2575 subscription fingerprint hashes tool *names* from this same query. An uninstall didn't change the name set, so subscribers were never notified.
- **The call-time error was the wrong one.** With the pin dangling, calls missed the intended typed "not connected — reconnect" message (only reachable when `mcp_server_id IS NULL`) and surfaced a raw `MCP server not found when getting secrets for MCP server <uuid>`.

## Fix

Filter the list on whether the assignment still has a usable install, mirroring exactly what the execution path can service (`McpClient.determineTargetMcpServer`): the pinned install, else any surviving install of the same catalog, else it errors.

Deliberately scoped to **pinned** assignments. An unpinned assignment (`mcp_server_id IS NULL`) covers built-in tools, delegation tools, and dynamic / enterprise-managed assignments that resolve a connection per caller at call time — all of which are *meant* to be advertised before anyone has connected, so the caller gets an actionable "connect" prompt rather than a missing tool. An earlier, broader version of this predicate keyed on "catalog has any active install" and broke 14 tests for exactly that reason.

Fixing the list also makes `list_changed` fire on uninstall for the first time, for free.

## Scope

Applied only to `getMcpToolsByAgent` (the gateway `tools/list` path). The execution resolver `getMcpToolsAssignedToAgent` is intentionally left alone so anything that slips through still gets the call path's richer, typed errors rather than a bare unknown-tool.

## Testing

Each new test was confirmed to **fail before** the fix and **pass after**:

- `hides a statically-pinned tool once its only install is uninstalled` — the reported repro.
- `changes when the tool's pinned install is uninstalled` — proves `list_changed` now fires.

Regression guards added for behavior that must *not* change (all passing before and after): a surviving sibling install keeps the tool listed; a dynamic-credential tool stays listed with no installs at all; built-in Archestra tools stay listed despite having no install.

- Targeted selection (models/tool, tool-archestra-assignment, environment-isolation, all of routes/mcp-gateway, app mcp-backing, agent-tool-exclusions): **485/485 passing across 21 files**.
- Full backend suite: 15262 passed, 26 pre-existing failures. Those 26 were verified identical with the fix reverted — unrelated to this change (conversation/mcp-tool-call search, interaction-delta-manager, onboarding, proxy, task-queue).
- `pnpm type-check` 8/8, `pnpm lint` clean, `pnpm knip` (dev + `--production`) clean.

## Note for anyone hitting this

Claude caches remote tool lists per install. After this ships, an already-connected client still needs a one-time **Settings → Connectors → ⋮ → Refresh tools list** (per install) — starting a new conversation does not clear it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>