### PR TITLE
fix(guardrails): steer dispatch-mode agents to run_tool instead of dead-ending

### DIFF
--- a/platform/backend/src/archestra-mcp-server/tool-recovery-messages.ts
+++ b/platform/backend/src/archestra-mcp-server/tool-recovery-messages.ts
@@ -94,6 +94,42 @@ export function disabledToolsNotRunMessage(toolNames: string[]): string {
 }
 
 /**
+ * Recovery message for the LLM-proxy guardrail path when the blocked names were
+ * not in the request's tool list because the agent advertises only the
+ * search_tools/run_tool dispatch pair (`search_and_run_only` exposure, which
+ * Auto tool mode implies).
+ *
+ * `disabledToolsNotRunMessage` is the wrong steer there on both counts: the
+ * tools are not "disabled" (they are reachable, just not directly callable),
+ * and "do not call them again" strands the model — it never learns the calling
+ * convention, so a subsequent search_tools round returns the very names it was
+ * just told not to use, and the turn dead-ends. The names the model chose are
+ * usually already correct, so this hands them straight back as a run_tool
+ * retry and leaves search_tools as the fallback for when one does not resolve.
+ *
+ * The dispatch tool names are passed in as they appear in the request's tool
+ * list, so a custom-branded prefix is preserved.
+ */
+export function toolsRequireRunToolMessage(params: {
+  toolNames: string[];
+  searchToolsName: string;
+  runToolName: string;
+}): string {
+  const { toolNames, searchToolsName, runToolName } = params;
+  const quoted = toolNames.map((name) => `"${name}"`).join(", ");
+  const plural = toolNames.length > 1;
+  return (
+    `The ${plural ? "tools" : "tool"} ${quoted} cannot be called directly in ` +
+    `this chat and ${plural ? "were" : "was"} not run. Only the tools in your ` +
+    `tool list are directly callable; every other tool is invoked through ` +
+    `${runToolName}. Retry by calling ${runToolName} with tool_name set to ` +
+    `${plural ? "each exact name above" : "that exact name"} and the arguments ` +
+    `you intended in tool_args. If a name turns out not to resolve, call ` +
+    `${searchToolsName} to find the right one. Do not guess tool names.`
+  );
+}
+
+/**
  * Soft warning prepended to a successful run_tool result when a short name was
  * recovered to its exact `server__tool` form. The call ran; this steers the
  * model to pass the exact name next time so the implicit short-name fallback is

--- a/platform/backend/src/guardrails/tool-invocation.test.ts
+++ b/platform/backend/src/guardrails/tool-invocation.test.ts
@@ -1,8 +1,10 @@
 import {
   getArchestraToolFullName,
   TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON,
+  TOOL_INVOCATION_NOT_DIRECTLY_CALLABLE_REASON,
   TOOL_LIST_AGENTS_SHORT_NAME,
   TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
+  TOOL_RUN_TOOL_SHORT_NAME,
   TOOL_SEARCH_TOOLS_SHORT_NAME,
   TOOL_WHOAMI_SHORT_NAME,
 } from "@archestra/shared";
@@ -110,6 +112,123 @@ describe("evaluatePolicies", () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  test("steers to run_tool instead of 'not enabled' when the tool list advertises the dispatch pair", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    // A `search_and_run_only` / Auto-mode request: the list carries only the
+    // dispatch pair, so third-party tools are reachable but never directly
+    // callable. The model calling one by name must be taught the convention,
+    // not told to stop.
+    const searchToolsName = archestraMcpBranding.getToolName(
+      TOOL_SEARCH_TOOLS_SHORT_NAME,
+    );
+    const runToolName = archestraMcpBranding.getToolName(
+      TOOL_RUN_TOOL_SHORT_NAME,
+    );
+    const enabledTools = new Set([searchToolsName, runToolName]);
+
+    const result = await evaluatePolicies(
+      [{ toolCallName: "pm__whoami", toolCallArgs: "{}" }],
+      agent.id,
+      { teamIds: [] },
+      true,
+      enabledTools,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.reason).toBe(TOOL_INVOCATION_NOT_DIRECTLY_CALLABLE_REASON);
+    expect(result?.blockedToolName).toBe("pm__whoami");
+    // The name is handed back so the retry is a single step, not a re-search.
+    expect(result?.contentMessage).toContain("pm__whoami");
+    expect(result?.contentMessage).toContain(runToolName);
+    expect(result?.contentMessage).toContain(searchToolsName);
+    // The two halves of the old dead end must be gone: the wrong diagnosis and
+    // the instruction that leaves the model with nowhere to go.
+    expect(result?.contentMessage).not.toContain("not enabled");
+    expect(result?.contentMessage).not.toContain("Do not call them again");
+  });
+
+  test("keeps the 'not enabled for this conversation' steer when the list has no dispatch pair", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    // `full` exposure hides the meta tools, so a tool missing from the list
+    // really was disabled for the conversation — run_tool is not the answer.
+    const enabledTools = new Set(["github__list_repos"]);
+
+    const result = await evaluatePolicies(
+      [{ toolCallName: "github__delete_repo", toolCallArgs: "{}" }],
+      agent.id,
+      { teamIds: [] },
+      true,
+      enabledTools,
+    );
+
+    expect(result?.reason).toBe(
+      TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON,
+    );
+    expect(result?.contentMessage).toContain("not enabled");
+  });
+
+  test("half a dispatch pair is not a dispatch surface", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    // search_tools alone cannot run anything, so steering at run_tool would
+    // name a tool the model cannot call.
+    const enabledTools = new Set([
+      archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME),
+    ]);
+
+    const result = await evaluatePolicies(
+      [{ toolCallName: "pm__whoami", toolCallArgs: "{}" }],
+      agent.id,
+      { teamIds: [] },
+      true,
+      enabledTools,
+    );
+
+    expect(result?.reason).toBe(
+      TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON,
+    );
+  });
+
+  test("the run_tool steer echoes white-labeled dispatch tool names", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    archestraMcpBranding.syncFromOrganization({
+      appName: "Acme Copilot",
+      iconLogo: null,
+    });
+    const brandingIdentity = {
+      appName: "Acme Copilot",
+      fullWhiteLabeling: true,
+    };
+    const brandedSearchTools = getArchestraToolFullName(
+      TOOL_SEARCH_TOOLS_SHORT_NAME,
+      brandingIdentity,
+    );
+    const brandedRunTool = getArchestraToolFullName(
+      TOOL_RUN_TOOL_SHORT_NAME,
+      brandingIdentity,
+    );
+
+    const result = await evaluatePolicies(
+      [{ toolCallName: "pm__whoami", toolCallArgs: "{}" }],
+      agent.id,
+      { teamIds: [] },
+      true,
+      new Set([brandedSearchTools, brandedRunTool]),
+    );
+
+    // Naming the canonical `archestra__*` form would point the model at a tool
+    // it cannot see, defeating the recovery loop.
+    expect(result?.contentMessage).toContain(brandedRunTool);
+    expect(result?.contentMessage).not.toContain("archestra__run_tool");
   });
 
   test("a run_tool dispatch target is blocked by its sensitive-context policy even when only the wrapper was enabled", async ({

--- a/platform/backend/src/guardrails/tool-invocation.test.ts
+++ b/platform/backend/src/guardrails/tool-invocation.test.ts
@@ -131,7 +131,7 @@ describe("evaluatePolicies", () => {
     const enabledTools = new Set([searchToolsName, runToolName]);
 
     const result = await evaluatePolicies(
-      [{ toolCallName: "pm__whoami", toolCallArgs: "{}" }],
+      [{ toolCallName: "github__list_issues", toolCallArgs: "{}" }],
       agent.id,
       { teamIds: [] },
       true,
@@ -140,9 +140,9 @@ describe("evaluatePolicies", () => {
 
     expect(result).not.toBeNull();
     expect(result?.reason).toBe(TOOL_INVOCATION_NOT_DIRECTLY_CALLABLE_REASON);
-    expect(result?.blockedToolName).toBe("pm__whoami");
+    expect(result?.blockedToolName).toBe("github__list_issues");
     // The name is handed back so the retry is a single step, not a re-search.
-    expect(result?.contentMessage).toContain("pm__whoami");
+    expect(result?.contentMessage).toContain("github__list_issues");
     expect(result?.contentMessage).toContain(runToolName);
     expect(result?.contentMessage).toContain(searchToolsName);
     // The two halves of the old dead end must be gone: the wrong diagnosis and
@@ -184,7 +184,7 @@ describe("evaluatePolicies", () => {
     ]);
 
     const result = await evaluatePolicies(
-      [{ toolCallName: "pm__whoami", toolCallArgs: "{}" }],
+      [{ toolCallName: "github__list_issues", toolCallArgs: "{}" }],
       agent.id,
       { teamIds: [] },
       true,
@@ -218,7 +218,7 @@ describe("evaluatePolicies", () => {
     );
 
     const result = await evaluatePolicies(
-      [{ toolCallName: "pm__whoami", toolCallArgs: "{}" }],
+      [{ toolCallName: "github__list_issues", toolCallArgs: "{}" }],
       agent.id,
       { teamIds: [] },
       true,

--- a/platform/backend/src/guardrails/tool-invocation.ts
+++ b/platform/backend/src/guardrails/tool-invocation.ts
@@ -7,10 +7,16 @@ import {
   type SensitiveContextOrigin,
   TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
   TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON,
+  TOOL_INVOCATION_NOT_DIRECTLY_CALLABLE_REASON,
+  TOOL_RUN_TOOL_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
   type ToolInvocationEnforcementSurface,
 } from "@archestra/shared";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
-import { disabledToolsNotRunMessage } from "@/archestra-mcp-server/tool-recovery-messages";
+import {
+  disabledToolsNotRunMessage,
+  toolsRequireRunToolMessage,
+} from "@/archestra-mcp-server/tool-recovery-messages";
 import logger from "@/logging";
 import { AgentTeamModel, ToolInvocationPolicyModel, ToolModel } from "@/models";
 import type { PolicyEvaluationContext } from "@/models/tool-invocation-policy";
@@ -236,10 +242,26 @@ export const evaluatePolicies = async (
     }
   }
 
-  // If any tools were disabled, return distinct message about them
+  // If any tools were disabled, return distinct message about them.
+  //
+  // Two different situations reach here, and they need different steers. When
+  // the request's tool list carries the search_tools/run_tool dispatch pair the
+  // agent is in `search_and_run_only` exposure (which Auto tool mode implies),
+  // where third-party tools are deliberately absent from the list rather than
+  // disabled — so the model is told how to reach them through run_tool instead
+  // of being told to stop. Mirrors the same discrimination the chat surface
+  // makes for nonexistent-tool errors (`routes/chat/errors.ts`).
   if (disabledToolNames.length > 0) {
-    const message = disabledToolsNotRunMessage(disabledToolNames);
-    const reason = TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON;
+    const dispatchPair = findDispatchToolNames(enabledToolNames);
+    const message = dispatchPair
+      ? toolsRequireRunToolMessage({
+          toolNames: disabledToolNames,
+          ...dispatchPair,
+        })
+      : disabledToolsNotRunMessage(disabledToolNames);
+    const reason = dispatchPair
+      ? TOOL_INVOCATION_NOT_DIRECTLY_CALLABLE_REASON
+      : TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON;
     return {
       refusalMessage: message,
       contentMessage: message,
@@ -317,6 +339,35 @@ export const evaluatePolicies = async (
 const MCP_GATEWAY_ENFORCEMENT: PolicyEnforcementContext = {
   surface: "mcp-gateway",
 };
+
+/**
+ * The search_tools/run_tool pair as it appears in the request's tool list, or
+ * null when the list does not advertise both.
+ *
+ * Presence of the pair is what identifies a dispatch-mode surface: the gateway
+ * advertises these two only under `search_and_run_only` exposure and hides them
+ * under `full` (see `filterExposedTools` in `routes/mcp-gateway/utils.ts`), so
+ * a list containing them is one where third-party tools are reachable but not
+ * directly callable. Located by short name so a custom-branded prefix (e.g.
+ * `acme__run_tool`) is recognized and echoed back exactly as the model sees it.
+ */
+function findDispatchToolNames(
+  declaredToolNames: Set<string>,
+): { searchToolsName: string; runToolName: string } | null {
+  let searchToolsName: string | undefined;
+  let runToolName: string | undefined;
+  for (const name of declaredToolNames) {
+    const shortName = archestraMcpBranding.getToolShortName(name);
+    if (shortName === TOOL_SEARCH_TOOLS_SHORT_NAME) {
+      searchToolsName = name;
+    } else if (shortName === TOOL_RUN_TOOL_SHORT_NAME) {
+      runToolName = name;
+    }
+  }
+  return searchToolsName && runToolName
+    ? { searchToolsName, runToolName }
+    : null;
+}
 
 function buildToolInvocationPolicyBlockResult(params: {
   toolName: string;

--- a/platform/shared/tool-invocation-policy-reasons.ts
+++ b/platform/shared/tool-invocation-policy-reasons.ts
@@ -25,6 +25,18 @@ export const TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON =
 export const TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON =
   "Tool is not enabled for this conversation";
 
+/**
+ * Distinct from {@link TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON}: the
+ * tool is not disabled at all, it is simply absent from the request's tool list
+ * because the agent advertises only the search_tools/run_tool dispatch pair
+ * (`search_and_run_only` exposure, which Auto tool mode implies). The call is
+ * still blocked — a direct call to an unlisted name is never executed — but the
+ * tool remains reachable by retrying through run_tool, so blocked-call metrics
+ * and logs must not file this under "disabled for conversation".
+ */
+export const TOOL_INVOCATION_NOT_DIRECTLY_CALLABLE_REASON =
+  "Tool is not directly callable in this chat; it must be invoked through run_tool";
+
 export const TOOL_INVOCATION_UNTRUSTED_CONTEXT_REASON =
   '"Block in sensitive context" tool call policy violated: this session contains sensitive data (likely introduced by an earlier tool result)';
 


### PR DESCRIPTION
## The bug

An agent in `search_and_run_only` exposure — which **Auto tool mode implies and enforces** (`AgentModel` keeps the `accessAllTools ⇒ search_and_run_only` invariant) — advertises only the `search_tools` / `run_tool` pair. Every third-party tool is reachable *through* `run_tool` but is deliberately absent from the request's tool list; `filterExposedTools` (`routes/mcp-gateway/utils.ts`) hides the meta tools under `full` exposure and hides everything *but* them under `search_and_run_only`.

The LLM-proxy guardrail computes `enabledToolNames` from the tools declared in the request body (`llm-proxy-handler.ts`). So when the model calls a third-party tool **directly** by name, the name isn't in that set and `evaluatePolicies` refuses it with:

> The tools "…" are not enabled for this conversation and were not run. Do not call them again here. Use a tool that is available to you, or call `…__search_tools` to discover the tools you can use.

That message is wrong on both halves:

1. **The diagnosis is false.** The tool is not disabled. It is fully reachable — just not *directly* callable. The block is also filed under `TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON` in blocked-call metrics and logs, which is the same false claim in the telemetry.
2. **It's a dead end.** "Do not call them again here" plus a pointer to `search_tools` — and *no mention of `run_tool`* — leaves the model nowhere to go. It searches, gets back the very names it was just told not to use, and still has not been told the calling convention. The turn stalls.

This is not specific to any one skill or agent. Any dispatch-mode agent hits it whenever the model learns a tool name from somewhere other than its tool list: a skill body, an earlier tool result, or its own prior turn. It is reliably reproducible as the *first* tool call of a fresh conversation, before the model has been nudged into the `run_tool` habit by a successful dispatch.

Worth noting how convincing the wrong message is: it has already produced folklore that the conversation's tool set needs "warming" with a discovery call first. There is no warming — the declared tool list is built once per turn from agent config plus the conversation's persisted selection and is never widened mid-conversation by `search_tools`, `run_tool`, `load_skill`, or an open app. Leading with a `run_tool` call appears to help only because it puts the model into the right calling convention for the rest of the turn.

## The fix

Split the branch on whether the request's tool list carries the dispatch pair:

- **Pair present** (dispatch mode) → a steer that hands the blocked names straight back as a `run_tool` retry, with `search_tools` as the fallback for a name that doesn't resolve. Filed under a new `TOOL_INVOCATION_NOT_DIRECTLY_CALLABLE_REASON`.
- **No pair** (`full` exposure) → unchanged. A tool missing from that list really was disabled for the conversation, and `run_tool` is not the answer.

Recovery is one step rather than a re-search, because the name the model chose is usually already correct — it just used the wrong convention. And the retry genuinely works: `run_tool` appends the dynamically-resolved tool to the enabled set it passes to the policy gate (`run-tool.ts`), so the steer doesn't hand the model a second dead end.

The chat surface already made exactly this discrimination for nonexistent-tool errors (`unavailableToolMessage` in `routes/chat/errors.ts`, which picks `unavailableToolDispatchModeMessage` when the pair is present). The proxy guardrail simply never did. It now matches, and locates the pair by short name so a white-labeled prefix (`acme__run_tool`) is echoed exactly as the model sees it — naming the canonical `archestra__*` form would point the model at a tool it cannot see.

## Tests

Four cases in `guardrails/tool-invocation.test.ts`:

- dispatch pair present → `run_tool` steer, new reason, blocked name echoed, and neither "not enabled" nor "Do not call them again" survives
- no pair → the existing conversation-disabled steer is preserved
- half a pair (`search_tools` alone, which cannot run anything) → not treated as a dispatch surface
- white-labeled prefix is echoed and the canonical name is not

The two behavior-change tests fail without the fix; the two regression guards pass either way, which is their job.

## Checks

`type-check` (backend + shared), `biome`, `knip` (dev + production) all clean. `guardrails/` + `archestra-mcp-server/` + `routes/chat/errors` suites: 299 passed.

The wider `routes/proxy` + `routes/mcp-gateway` + `archestra-mcp-server` run reports 6 failed files / 137 failed tests, but that is an untouched `main` baseline, not a regression here: the same run on clean `origin/main` produces the same 6 files and the same 137 failures, and a `diff` of the failing test names between the two is empty. The bulk (124) is `archestra-mcp-server/apps.test.ts`.

## Follow-up, not in this PR

Skill frontmatter `allowed-tools` renders into the activation block as *"This skill expects these tools; enable any that are not already active."* (`skills/skill-activation.ts`). It is inert text with no code path behind it, and in dispatch mode it asks for something the model cannot do while implying the named tools are directly callable — which invites exactly the blocked call this PR now recovers from. Worth rewording separately; the guardrail fix makes recovery work regardless.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>