### PR TITLE
fix(oauth): fall back to root protected resource metadata during discovery

### DIFF
--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -587,6 +587,66 @@ describe("OAuth helper functions", () => {
       globalThis.fetch = originalFetch;
     });
 
+    test("falls back to root protected resource metadata when the path-aware document is missing", async () => {
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (
+          url ===
+          "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+        ) {
+          return { ok: false, status: 404 };
+        }
+        if (
+          url === "https://mcp.example.com/.well-known/oauth-protected-resource"
+        ) {
+          return {
+            ok: true,
+            json: async () => ({
+              resource: "https://mcp.example.com",
+              authorization_servers: ["https://auth.example.com"],
+            }),
+          };
+        }
+        if (
+          url ===
+          "https://auth.example.com/.well-known/oauth-authorization-server"
+        ) {
+          return {
+            ok: true,
+            json: async () => ({
+              authorization_endpoint:
+                "https://auth.example.com/oauth2/authorize",
+              token_endpoint: "https://auth.example.com/oauth2/token",
+            }),
+          };
+        }
+        return { ok: false, status: 404 };
+      }) as Mock;
+
+      globalThis.fetch = fetchMock;
+
+      const endpoints = await discoverOAuthEndpoints({
+        server_url: "https://mcp.example.com/mcp",
+        supports_resource_metadata: true,
+      });
+
+      expect(endpoints.authorizationEndpoint).toBe(
+        "https://auth.example.com/oauth2/authorize",
+      );
+      expect(endpoints.tokenEndpoint).toBe(
+        "https://auth.example.com/oauth2/token",
+      );
+      // The path-aware document is tried first; the root document is the fallback
+      // that hands discovery over to the advertised authorization server.
+      expect(fetchMock.mock.calls.map((call) => String(call[0]))).toEqual([
+        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+        "https://mcp.example.com/.well-known/oauth-protected-resource",
+        "https://auth.example.com/.well-known/oauth-authorization-server",
+      ]);
+
+      globalThis.fetch = originalFetch;
+    });
+
     test("falls back to explicit endpoints when discovery fails", async () => {
       globalThis.fetch = vi.fn().mockRejectedValue(new Error("404")) as Mock;
 

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -60,34 +60,44 @@ async function discoverOAuthResourceMetadata(
   serverUrl: string,
   overrides?: OAuthDiscoveryOverrides,
 ) {
-  try {
-    // MCP SDK uses "path-aware discovery": /.well-known/{type}{pathname}
-    // For https://huggingface.co/mcp -> https://huggingface.co/.well-known/oauth-protected-resource/mcp
-    const url = new URL(serverUrl);
-    const pathname = url.pathname.endsWith("/")
-      ? url.pathname.slice(0, -1)
-      : url.pathname;
-    const wellKnownUrl =
-      overrides?.resourceMetadataUrl ||
-      `${url.origin}/.well-known/oauth-protected-resource${pathname}`;
+  // MCP SDK uses "path-aware discovery": /.well-known/{type}{pathname}
+  // For https://huggingface.co/mcp -> https://huggingface.co/.well-known/oauth-protected-resource/mcp
+  // Like the SDK, fall back to the root well-known document for servers that
+  // publish their metadata only at /.well-known/oauth-protected-resource.
+  const url = new URL(serverUrl);
+  const pathname = url.pathname.endsWith("/")
+    ? url.pathname.slice(0, -1)
+    : url.pathname;
+  const rootWellKnownUrl = `${url.origin}/.well-known/oauth-protected-resource`;
+  const wellKnownUrls = overrides?.resourceMetadataUrl
+    ? [overrides.resourceMetadataUrl]
+    : [...new Set([`${rootWellKnownUrl}${pathname}`, rootWellKnownUrl])];
 
-    const response = await fetch(wellKnownUrl, {
-      headers: {
-        "MCP-Protocol-Version": "2025-06-18",
-        Accept: "application/json",
-      },
-    });
+  let lastError: unknown;
+  for (const wellKnownUrl of wellKnownUrls) {
+    try {
+      const response = await fetch(wellKnownUrl, {
+        headers: {
+          "MCP-Protocol-Version": "2025-06-18",
+          Accept: "application/json",
+        },
+      });
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch resource metadata: ${response.status}`);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch resource metadata: ${response.status}`,
+        );
+      }
+
+      return await response.json();
+    } catch (error) {
+      lastError = error;
     }
-
-    return await response.json();
-  } catch (error) {
-    throw new Error(
-      `Resource metadata discovery failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
   }
+
+  throw new Error(
+    `Resource metadata discovery failed: ${lastError instanceof Error ? lastError.message : "Unknown error"}`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

Adding some remote MCP servers fails OAuth endpoint discovery with:

> Failed to discover OAuth endpoints: Authorization server metadata discovery failed: No valid metadata found at any discovery endpoint.

even though the server publishes valid OAuth metadata and works with other MCP clients.

RFC 9728 protected resource metadata discovery only tried the path-aware well-known URL (`/.well-known/oauth-protected-resource{pathname}`). Some servers publish their protected resource metadata only at the root document (`/.well-known/oauth-protected-resource`) — their 401 `WWW-Authenticate` header advertises exactly that URL. For such servers the path-aware lookup 404s, resource metadata discovery is skipped, and authorization server discovery then runs against the MCP server URL itself (which serves no authorization server metadata), failing the whole flow. The MCP SDK handles this by falling back to the root document, which is why the same servers work in other clients.

## Fix

`discoverOAuthResourceMetadata` now tries the path-aware URL first and falls back to the root well-known document, mirroring the MCP SDK. An explicit `resource_metadata_url` override still short-circuits to exactly that URL, and the error message shape on total failure is unchanged.

## Testing

- New test pinning the fallback chain: path-aware 404 → root document → authorization server metadata from the advertised authorization server.
- `pnpm vitest run src/routes/oauth.test.ts` — 51/51 pass; backend `pnpm type-check` and biome clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>