### PR TITLE
feat(connect): add a Space skip key to the CLI startup guard

### DIFF
--- a/docs/pages/platform-connection.md
+++ b/docs/pages/platform-connection.md
@@ -3,7 +3,7 @@ title: Connect Your Agents
 category: Archestra Platform
 order: 8
 description: How the one-command setup script connects your AI tools, and how to audit or undo it
-lastUpdated: 2026-08-04
+lastUpdated: 2026-08-13
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -67,7 +67,7 @@ For Claude Code, Codex, and Copilot CLI, the script installs a startup guard —
 
 A remote the platform reports down gets a "Failed to connect to …" line. After the last check, one prompt covers every down remote — "Disconnect MCP gateway (name) from Codex now? (Y/n)", naming your client, or "Disconnect all 3 unreachable resources…" when several are down. Enter or `y` disconnects them all — the exact reverse of the connect steps; `n` keeps them. The guard reads the client's config back to confirm each removal landed. A removal it cannot confirm gets a ✗ line with the command to run by hand, and the guard stays installed to try again. Later launches skip a remote the guard disconnected. Once no connected remote is left, the guard removes itself — the script and the profile hook — so a stale wrapper can never break a launch. When the platform itself is unreachable, the guard retries its request for up to 15 seconds with a status line, showing the same disconnect prompt below it, then treats every remote as down. Every path ends with the CLI starting; the guard never blocks a launch. Non-interactive runs, `codex exec` or `claude -p` for example, only get a warning on stderr.
 
-Under the checks the guard always shows a reconfigure entry: "To reconfigure your Archestra connection press [C]". When everything is healthy it waits about a second and a half for that key, then starts the CLI. Press `C` and the rows turn into a numbered menu — one per remote — so you can disconnect any of them, reachable or not, by pressing its number. The row lands on a check, later launches skip it, and removing the last connected remote uninstalls the guard. Press `Esc` to leave the menu and start the CLI.
+Under the checks the guard always shows its two keys: "To skip press [Space] · to reconfigure your Archestra connection press [C]". Press `Space` at any point to skip the rest of the checks and start the CLI at once — nothing is disconnected or remembered. When everything is healthy the guard waits about a second and a half for a key, then starts the CLI. Press `C` and the rows turn into a numbered menu — one per remote — so you can disconnect any of them, reachable or not, by pressing its number. The row lands on a check, later launches skip it, and removing the last connected remote uninstalls the guard. Press `Esc` to leave the menu and start the CLI.
 
 The guard lives under `~/.archestra/`, hooked in by a marked wrapper block in your shell profile — on Windows, in each PowerShell edition's `profile.ps1`. Each client has its own file and its own disable variable:
 

--- a/platform/backend/src/services/startup-guard.test.ts
+++ b/platform/backend/src/services/startup-guard.test.ts
@@ -344,8 +344,9 @@ describe("renderStartupGuardScript", () => {
 
   test("always offers a reconfigure entry under the rows; the down prompt routes [C] into the same menu", () => {
     const script = renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT);
-    // the persistent [C] entry, present on every launch
-    expect(script).toContain("To reconfigure your");
+    // the persistent entry, present on every launch, offers both keys
+    expect(script).toContain("To skip press [Space]");
+    expect(script).toContain("to reconfigure your");
     expect(script).toContain("press [C]");
     expect(script).toContain("offer_reconfigure_tail");
     expect(script).toContain("reconfigure_menu");
@@ -363,6 +364,25 @@ describe("renderStartupGuardScript", () => {
     // the menu numbers every remote and disconnects the chosen one in place
     expect(script).toContain("Press 1-");
     expect(script).toContain("menu_disconnect_row");
+  });
+
+  test("keeps a skip entry live the whole run: Space in the hint, the retry wait, and between animation frames", () => {
+    const script = renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT);
+    // the persistent hint names the key
+    expect(script).toContain("To skip press [Space]");
+    // the retry ladder answers it directly
+    expect(script).toContain("' ') SKIP_NOW=1; break ;;");
+    // animation frames poll the tty on bash >= 4, so the key lands
+    // mid-probe; 3.2 keeps plain sleep frames (no fractional read -t) and
+    // honors the buffered key at the closing beat instead. IFS= keeps the
+    // read space from collapsing to '' — Enter — on every read that must
+    // hear it.
+    expect(script).toContain('IFS= read -rs -n 1 -t "$FRAME_SLEEP" key');
+    expect(script).toContain('sleep "$FRAME_SLEEP"');
+    // skipping goes straight to finish_guard: no disconnect, no skip file
+    expect(script).toContain(
+      'if [ "$SKIP_NOW" = "1" ]; then\n  finish_guard\nfi',
+    );
   });
 
   test("encodes the retry contract on the single request: 15s budget, notice at 3s, hang-tight at 10s, own-line (Y/n) offer", () => {
@@ -708,6 +728,51 @@ describe("renderStartupGuardScript", () => {
     expect(existsSync(guardHome.guardFile)).toBe(true);
   });
 
+  test("interactive, all healthy, Space skips straight to launch touching nothing", async () => {
+    const { output, guardHome } = await runGuardInteractive({
+      script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 0,
+      curlBody: '{"mcp":"ok","llm":"ok"}',
+      keys: " ",
+    });
+    expect(output).toContain("To skip press [Space]");
+    // nothing is disconnected, nothing remembered, the guard stays installed
+    expect(await readClaudeLog(guardHome)).toBe("");
+    expect(output).not.toContain("Disconnected");
+    expect(existsSync(guardHome.skipFile)).toBe(false);
+    expect(existsSync(guardHome.guardFile)).toBe(true);
+  });
+
+  test("interactive, platform unreachable, Space during the wait: launches at once, disconnecting and remembering nothing", async () => {
+    const { output, guardHome } = await runGuardInteractive({
+      script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 7,
+      keys: " ",
+    });
+    expect(await readClaudeLog(guardHome)).toBe("");
+    expect(output).not.toContain("Disconnected");
+    expect(output).not.toContain("Failed to connect");
+    // no "Skipped — still configured" summary either: Space exits silently
+    expect(output).not.toContain("Skipped");
+    expect(existsSync(guardHome.skipFile)).toBe(false);
+    expect(existsSync(guardHome.guardFile)).toBe(true);
+  });
+
+  test("interactive, a remote down, Space never disconnects — the skip key cannot read as the (Y/n) Enter-default", async () => {
+    // Space must skip whether it lands mid-probe (bash >= 4 frame polling)
+    // or, buffered, at the down prompt (bash 3.2): default IFS would strip
+    // the read space to '' — Enter — and Enter at that prompt DISCONNECTS.
+    const { guardHome } = await runGuardInteractive({
+      script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 0,
+      curlBody: '{"mcp":"down","llm":"ok"}',
+      keys: " ",
+    });
+    expect(await readClaudeLog(guardHome)).toBe("");
+    expect(existsSync(guardHome.skipFile)).toBe(false);
+    expect(existsSync(guardHome.guardFile)).toBe(true);
+  });
+
   test("interactive, all healthy, [C] opens the menu; a number disconnects that (healthy) remote in place", async () => {
     // everything is reachable, but the user still opens the reconfigure menu
     // and removes the LLM proxy — row 1 — then leaves with Enter. NOTE: the
@@ -721,7 +786,7 @@ describe("renderStartupGuardScript", () => {
       keys: "c1\r",
     });
     expect(output).toContain(
-      "To reconfigure your Archestra connection press [C]",
+      "To skip press [Space] · to reconfigure your Archestra connection press [C]",
     );
     // the numbered menu opened (the number glyph carries its own color, so
     // assert the footer that names the range instead of the split "[1] …")

--- a/platform/backend/src/services/startup-guard.ts
+++ b/platform/backend/src/services/startup-guard.ts
@@ -45,6 +45,14 @@ import type { SetupScriptContext } from "./connection-setup-script";
  *   after the whole turn, ONE "Disconnect … from Claude? (Y/n)" prompt covers
  *   every down remote. Everything draws on the alternate screen, so the
  *   terminal is clean again after claude exits;
+ * - keeps a skip entry live the whole run: Space — polled between animation
+ *   frames (bash ≥ 4) and during the retry wait — ends the pre-loader
+ *   immediately and lets the client start, disconnecting and remembering
+ *   nothing. Reads that must hear it carry an IFS= prefix (default IFS
+ *   strips a read space into '', colliding with Enter — and Enter at the
+ *   down prompt means disconnect). Bash 3.2 cannot poll between frames (no
+ *   fractional read -t); there the pressed key stays buffered and lands at
+ *   the closing beat;
  * - disconnecting runs the exact reverse of the connect steps and records the
  *   remote in a skip file so later launches don't re-check it. Once nothing
  *   connected is left to check, the guard uninstalls itself entirely (script,
@@ -432,6 +440,10 @@ fi
 # macOS system bash 3.2 falls back to 1s ticks.
 TICK=1
 if [ "\${BASH_VERSINFO[0]:-3}" -ge 4 ]; then TICK=0.25; fi
+# Animation frames double as key polls (for Space/[C]) only with that same
+# fractional read -t; 3.2 keeps plain sleep frames (see frame_tick).
+FRAME_KEYS=0
+if [ "\${BASH_VERSINFO[0]:-3}" -ge 4 ]; then FRAME_KEYS=1; fi
 # The [C] window on the all-healthy pass. Fractional read -t needs bash 4;
 # 3.2 rounds it up to a whole second.
 RECONFIG_WAIT=2
@@ -464,6 +476,36 @@ spin_tick() {
     return 0
   fi
   printf '%s.%s' "$C_DIM" "$C_RESET"
+}
+
+# Frame pacing that can hear the skip key: on bash ≥ 4 each animation frame
+# is a fractional read on the tty, so Space (and [C]) land the moment they
+# are pressed. The IFS= prefix is load-bearing: default IFS strips a read
+# space into '', indistinguishable from Enter. System bash 3.2 has no
+# sub-second read -t and keeps plain sleep — there a pressed key stays
+# buffered (echo is off) and is honored at the closing beat instead.
+#
+# Any OTHER key pressed mid-probe belongs to a prompt that has not appeared
+# yet (a typed-ahead y for the down prompt, the 1 after a [C]); consuming it
+# here would make that prompt hang. So the first such key ends the polling —
+# it is kept in PENDING_KEY for the next prompt to read first, and every key
+# after it stays buffered in the tty, exactly as before frames read keys.
+SKIP_NOW=0
+PENDING_KEY=''
+PENDING_KEY_SET=0
+frame_tick() { # one animation frame; harvests Space/[C] pressed mid-probe
+  if [ "$FRAME_KEYS" = "1" ]; then
+    key=''
+    IFS= read -rs -n 1 -t "$FRAME_SLEEP" key </dev/tty 2>/dev/null || return 0
+    case "$key" in
+      ' ') SKIP_NOW=1 ;;
+      c|C) OPEN_MENU=1; FRAME_KEYS=0 ;;
+      *) PENDING_KEY="$key"; PENDING_KEY_SET=1; FRAME_KEYS=0 ;;
+    esac
+  else
+    sleep "$FRAME_SLEEP"
+  fi
+  return 0
 }
 
 # Status glyphs stay in the narrow ranges (○ ✓ ✗) so every row's icon and
@@ -698,7 +740,7 @@ reconfigure_menu() {
 # healthy pass's closing beat — so [C] is always offered, never just at the
 # end. Drawn one line below the block via save/restore, so the rows above
 # keep animating without touching it.
-RECONFIG_HINT_TEXT="  To reconfigure your $APP_NAME connection press [C]"
+RECONFIG_HINT_TEXT="  To skip press [Space] · to reconfigure your $APP_NAME connection press [C]"
 draw_reconfigure_hint() { printf '\\033[s\\n\\r\\033[2K%s%s%s\\033[u' "$C_DIM" "$RECONFIG_HINT_TEXT" "$C_RESET"; }
 clear_reconfigure_hint() { printf '\\033[s\\n\\r\\033[2K\\033[u'; }
 
@@ -707,8 +749,13 @@ clear_reconfigure_hint() { printf '\\033[s\\n\\r\\033[2K\\033[u'; }
 # while the probes ran was buffered (echo is off, so it left no smudge) and is
 # read here.
 offer_reconfigure_tail() {
-  key=''
-  read -rs -n 1 -t "$RECONFIG_WAIT" key </dev/tty 2>/dev/null || key=''
+  if [ "$PENDING_KEY_SET" = "1" ]; then
+    # a key typed ahead during the probes counts as the pressed key
+    key="$PENDING_KEY"; PENDING_KEY_SET=0
+  else
+    key=''
+    IFS= read -rs -n 1 -t "$RECONFIG_WAIT" key </dev/tty 2>/dev/null || key=''
+  fi
   clear_reconfigure_hint
   case "$key" in
     c|C) reconfigure_menu ;;
@@ -729,8 +776,15 @@ prompt_down_all() {
     down_prompt="Disconnect all $DOWN_COUNT unreachable resources from ${client.promptName} now? (Y/n)"
   fi
   printf '\\033[s\\n\\r\\033[2K%s\\n\\r\\033[2K%s  or press [C] to reconfigure your %s connection%s\\033[u' "$down_prompt" "$C_DIM" "$APP_NAME" "$C_RESET"
-  key=''
-  read -rs -n 1 key </dev/tty 2>/dev/null || key='n'
+  if [ "$PENDING_KEY_SET" = "1" ]; then
+    # a key typed ahead during the probes answers this prompt
+    key="$PENDING_KEY"; PENDING_KEY_SET=0
+  else
+    key=''
+    # IFS= keeps a pressed Space as ' ': without it Space reads as '' —
+    # Enter — and the advertised skip key would accept the disconnect
+    IFS= read -rs -n 1 key </dev/tty 2>/dev/null || key='n'
+  fi
   printf '\\033[s\\n\\r\\033[2K\\n\\r\\033[2K\\033[u'
   case "$key" in
     c|C)
@@ -795,11 +849,12 @@ wait_for_health() {
   while :; do
     key=''
     got_key=0
-    read -rs -n 1 -t "$TICK" key </dev/tty 2>/dev/null && got_key=1
+    IFS= read -rs -n 1 -t "$TICK" key </dev/tty 2>/dev/null && got_key=1
     if [ "$got_key" = "1" ]; then
       case "$key" in
         y|Y) DISC_ALL=1; break ;;
         n|N) SKIP_ALL=1; break ;;
+        ' ') SKIP_NOW=1; break ;;
         c|C) OPEN_MENU=1; break ;;
         '') [ "$WAIT_PROMPT_SHOWN" = "1" ] && { DISC_ALL=1; break; } ;;
       esac
@@ -873,6 +928,11 @@ if [ -n "$HEALTH_URL" ]; then
   spin_start "\${GUARD_LABELS[$FIRST_ACTIVE]}"
   wait_for_health || true
 fi
+# Space means "get out of the way": end the pre-loader at once, disconnect and
+# remember nothing — the alternate screen closes over the half-drawn rows.
+if [ "$SKIP_NOW" = "1" ]; then
+  finish_guard
+fi
 if [ "$OPEN_MENU" = "1" ]; then
   printf '\\033[%dB\\r' "$ACTIVE_TOTAL"
   clear_reconfigure_hint
@@ -903,7 +963,8 @@ while [ "$i" -lt "\${#GUARD_URLS[@]}" ]; do
   spin_start "\${GUARD_LABELS[$i]}"
   pad=0
   while [ "$pad" -lt "$MIN_CHECK_FRAMES" ]; do
-    sleep "$FRAME_SLEEP"
+    frame_tick
+    [ "$SKIP_NOW" = "1" ] && break 2
     spin_tick
     pad=$((pad + 1))
   done
@@ -916,9 +977,17 @@ while [ "$i" -lt "\${#GUARD_URLS[@]}" ]; do
   fi
   i=$((i+1))
 done
+if [ "$SKIP_NOW" = "1" ]; then
+  finish_guard
+fi
 if [ "$DOWN_COUNT" -gt 0 ]; then
   clear_reconfigure_hint
   prompt_down_all
+elif [ "$OPEN_MENU" = "1" ]; then
+  # a [C] harvested by frame_tick mid-probe — the same menu the closing
+  # beat's buffered read used to catch before frames read the tty
+  clear_reconfigure_hint
+  reconfigure_menu
 else
   offer_reconfigure_tail
 fi

--- a/platform/backend/src/services/startup-guard.windows.test.ts
+++ b/platform/backend/src/services/startup-guard.windows.test.ts
@@ -112,7 +112,7 @@ describe("renderStartupGuardPowerShell (Claude Code)", () => {
     expect(script).toContain("function Show-ArchReconfigureOffer");
     expect(script).toContain("function Show-ArchReconfigureHint");
     expect(script).toContain(
-      "To reconfigure your ' + $AppName + ' connection press [C]",
+      "To skip press [Space] · to reconfigure your ' + $AppName + ' connection press [C]",
     );
     expect(script).toContain("AddMilliseconds(1500)");
     expect(script).toContain("Show-ArchReconfigureOffer");
@@ -155,6 +155,20 @@ describe("renderStartupGuardPowerShell (Claude Code)", () => {
     // the self-removal is silent — no trailing explainer after the
     // Disconnected rows
     expect(script).not.toContain("Nothing connected is left to check");
+  });
+
+  test("keeps a skip entry live the whole run: Space in the hint, the retry wait, and between animation frames", () => {
+    const script = renderStartupGuardPowerShell(CTX, CLAUDE_CODE_GUARD_CLIENT);
+    // the persistent hint names the key
+    expect(script).toContain("To skip press [Space]");
+    // both the retry ladder and the probe frames answer it directly
+    // (Read-ArchKey polls [Console]::KeyAvailable, naturally non-blocking)
+    expect(script).toContain(
+      "if ($key -eq ' ') { $Script:SkipNow = $true; break }",
+    );
+    // skipping bypasses every prompt and launches at once, touching nothing
+    expect(script).toContain("if ($Script:SkipNow) { Exit-ArchGuard }");
+    expect(script).toContain("if ($Script:SkipNow) { break }");
   });
 
   test("encodes the retry contract on the single request: 15s budget, notice at 3s, hang-tight at 10s, own-line (Y/n) offer", () => {

--- a/platform/backend/src/services/startup-guard.windows.ts
+++ b/platform/backend/src/services/startup-guard.windows.ts
@@ -27,6 +27,10 @@ import type { StartupGuardClient, StartupGuardContext } from "./startup-guard";
  *   disconnect (Y/n) offer on its own line below the row, `y`/`n` live
  *   throughout; after the whole turn, ONE "Disconnect … from <promptName> now?
  *   (Y/n)" prompt covers every down remote;
+ * - keeps a skip entry live the whole run: Space — polled between animation
+ *   frames and during the retry wait ([Console]::KeyAvailable is naturally
+ *   non-blocking here) — ends the pre-loader immediately and lets the client
+ *   start, disconnecting and remembering nothing;
  * - disconnect = the exact reverse of connect (mcp remove, the client's own
  *   proxy-config strip with a one-time backup, marketplace remove — all from
  *   the client descriptor), recorded in a skip file so later launches don't
@@ -511,7 +515,7 @@ function Invoke-ArchReconfigureMenu {
 # (cursor at the block's base) and stays on screen the whole run; legacy
 # consoles draw it in the closing tail instead. One line below the block.
 function Show-ArchReconfigureHint {
-  $text = '  To reconfigure your ' + $AppName + ' connection press [C]'
+  $text = '  To skip press [Space] · to reconfigure your ' + $AppName + ' connection press [C]'
   if ($UseVt) {
     Write-Host -NoNewline ("$Esc" + '7' + "$Esc[1B\`r$Esc[2K")
     Write-Arch $text DarkGray -NoNewline
@@ -539,11 +543,16 @@ function Clear-ArchReconfigureHint {
 function Show-ArchReconfigureOffer {
   if (-not $UseVt) { Show-ArchReconfigureHint }
   $key = ''
-  $deadline = [DateTime]::UtcNow.AddMilliseconds(1500)
-  while ([DateTime]::UtcNow -lt $deadline) {
-    $key = Read-ArchKey
-    if ($key) { break }
-    Start-Sleep -Milliseconds 40
+  if ($null -ne $Script:PendingKey) {
+    # a key typed ahead during the probes counts as the pressed key
+    $key = $Script:PendingKey; $Script:PendingKey = $null
+  } else {
+    $deadline = [DateTime]::UtcNow.AddMilliseconds(1500)
+    while ([DateTime]::UtcNow -lt $deadline) {
+      $key = Read-ArchKey
+      if ($key) { break }
+      Start-Sleep -Milliseconds 40
+    }
   }
   Clear-ArchReconfigureHint
   if ($key -eq 'c' -or $key -eq 'C') { Invoke-ArchReconfigureMenu }
@@ -574,11 +583,18 @@ function Show-ArchDownSummaryPrompt($downRemotes) {
     try { [Console]::SetCursorPosition(0, $baseTop) } catch { }
   }
   $choice = 'n'
-  try {
-    $k = [Console]::ReadKey($true)
-    if ($k.Key -eq 'Enter' -or $k.KeyChar -eq 'y' -or $k.KeyChar -eq 'Y') { $choice = 'y' }
-    elseif ($k.KeyChar -eq 'c' -or $k.KeyChar -eq 'C') { $choice = 'c' }
-  } catch { }
+  if ($null -ne $Script:PendingKey) {
+    # a key typed ahead during the probes answers this prompt
+    $pk = $Script:PendingKey; $Script:PendingKey = $null
+    if ($pk -eq "\`r" -or $pk -eq 'y' -or $pk -eq 'Y') { $choice = 'y' }
+    elseif ($pk -eq 'c' -or $pk -eq 'C') { $choice = 'c' }
+  } else {
+    try {
+      $k = [Console]::ReadKey($true)
+      if ($k.Key -eq 'Enter' -or $k.KeyChar -eq 'y' -or $k.KeyChar -eq 'Y') { $choice = 'y' }
+      elseif ($k.KeyChar -eq 'c' -or $k.KeyChar -eq 'C') { $choice = 'c' }
+    } catch { }
+  }
   if ($UseVt) {
     Write-Host -NoNewline ("$Esc" + '7' + "$Esc[1B\`r$Esc[2K$Esc[1B\`r$Esc[2K$Esc" + '8')
   } else {
@@ -651,7 +667,14 @@ function Clear-ArchWaitPrompt {
 # only once the prompt is actually on screen.
 $Script:SkipAll = $false
 $Script:DiscAll = $false
+$Script:SkipNow = $false
 $Script:OpenMenu = $false
+# A key the probe frames had to consume that belongs to a LATER prompt (a
+# typed-ahead y for the down prompt, the 1 after a [C]). The next prompt
+# answers it before reading the console again; polling stops the moment it
+# is set, so every later key stays buffered for that prompt.
+$Script:PendingKey = $null
+$Script:FramePolling = $true
 $Script:LastWaitNote = ''
 function Wait-ArchHealth {
   if (Invoke-ArchHealthFetch) { $Script:HealthState = 'ok'; return }
@@ -664,6 +687,7 @@ function Wait-ArchHealth {
     $key = Read-ArchKey
     if ($key -eq 'y' -or $key -eq 'Y') { $Script:DiscAll = $true; break }
     if ($key -eq 'n' -or $key -eq 'N') { $Script:SkipAll = $true; break }
+    if ($key -eq ' ') { $Script:SkipNow = $true; break }
     if ($key -eq 'c' -or $key -eq 'C') { $Script:OpenMenu = $true; break }
     if ($key -eq "\`r" -and $Script:WaitPromptShown) { $Script:DiscAll = $true; break }
     $now = [DateTime]::UtcNow
@@ -725,6 +749,9 @@ if ($HealthUrl) {
   Show-ArchSpinStart $ActiveRemotes[0].Label ''
   Wait-ArchHealth
 }
+# Space means "get out of the way": end the pre-loader at once, disconnect and
+# remember nothing — the alternate screen closes over the half-drawn rows.
+if ($Script:SkipNow) { Exit-ArchGuard }
 if ($Script:OpenMenu) {
   if ($UseVt) { Write-Host -NoNewline ("$Esc[" + $ActiveRemotes.Count + 'B' + "\`r") }
   Clear-ArchReconfigureHint
@@ -750,14 +777,32 @@ foreach ($r in $ActiveRemotes) {
   Show-ArchSpinStart $r.Label ''
   for ($pad = 0; $pad -lt $MinCheckFrames; $pad++) {
     Start-Sleep -Milliseconds $FrameSleepMs
+    if ($Script:FramePolling) {
+      # harvest Space/[C] between frames, so skip lands mid-animation and a
+      # [C] pressed here still opens the menu after the turn. Any other key
+      # belongs to a prompt that has not appeared yet — consuming it here
+      # would make that prompt hang — so it ends the polling and is kept
+      # in PendingKey for the next prompt to answer first.
+      $key = Read-ArchKey
+      if ($key -eq ' ') { $Script:SkipNow = $true; break }
+      if ($key -eq 'c' -or $key -eq 'C') { $Script:OpenMenu = $true; $Script:FramePolling = $false }
+      elseif ($key) { $Script:PendingKey = $key; $Script:FramePolling = $false }
+    }
     Show-ArchSpinTick
   }
+  if ($Script:SkipNow) { break }
   if (Test-ArchResourceDown $r) { Show-ArchDown $r; $DownRemotes += $r }
   else { Show-ArchOk $r.Label }
 }
+if ($Script:SkipNow) { Exit-ArchGuard }
 if ($DownRemotes.Count -gt 0) {
   if ($UseVt) { Clear-ArchReconfigureHint }
   Show-ArchDownSummaryPrompt $DownRemotes
+} elseif ($Script:OpenMenu) {
+  # a [C] harvested between frames — the same menu the closing beat's
+  # buffered read used to catch before the frames consumed the keys
+  Clear-ArchReconfigureHint
+  Invoke-ArchReconfigureMenu
 } else {
   Show-ArchReconfigureOffer
 }


### PR DESCRIPTION
The startup guard shown before a connected CLI launches (Claude Code, Codex, Copilot CLI) had no way out of the checks — the only hotkey was `[C]` (reconfigure), so every launch sat through the probe animation.

The hint now reads `To skip press [Space] · to reconfigure your <app> connection press [C]`, and Space is live the whole run: during the probe animation, the 15s outage retry ladder, and the closing beat. It ends the pre-loader at once and lets the client start — nothing is disconnected, nothing is written to the skip file.

Both engines now poll keys between animation frames (bash >= 4 via fractional `read -t`, keeping plain-sleep frames plus buffered-key handling for macOS bash 3.2; PowerShell via `[Console]::KeyAvailable`). Two things that needed care:

- **Typed-ahead keys must survive.** A key that is neither Space nor `[C]` belongs to a prompt that has not appeared yet — a typed-ahead `y` for the down prompt, the `1` after a `[C]`. Consuming it in a frame would hang that prompt, so the first such key ends the polling and is pushed back for the next prompt to answer first; later keys stay buffered in the tty as before.
- **`IFS=` on every key read that must hear Space.** Default IFS strips a read space into `''` — indistinguishable from Enter — and Enter at the "Disconnect … ? (Y/n)" prompt accepts the *disconnect* default. Without this, the advertised skip key would have disconnected remotes on bash 3.2, where the keypress reaches that prompt buffered.

Tests: 4 added (2 behavioral pty runs for the healthy and platform-unreachable paths, 1 pinning that Space with a down remote disconnects nothing, plus the rendered-script contracts for both engines); existing hint assertions updated. Docs updated on the connection page.

Task: T-1071

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>