### PR TITLE
fix(knowledge): tidy connector status timestamps and configure-dialog title spacing

### DIFF
--- a/platform/frontend/src/app/knowledge/connectors/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/page.client.tsx
@@ -216,7 +216,7 @@ function ConnectorsList() {
               <>
                 <ConnectorStatusBadge status={row.original.lastSyncStatus} />
                 <span
-                  className="text-xs text-muted-foreground"
+                  className="text-xs text-muted-foreground whitespace-nowrap"
                   title={formatDate({ date: row.original.lastSyncAt })}
                 >
                   {formatDistanceToNow(new Date(row.original.lastSyncAt), {

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
@@ -346,11 +346,13 @@ export function CreateConnectorDialog({
                   >
                     <ArrowLeft className="h-4 w-4" />
                   </Button>
-                  Configure{" "}
-                  {selectedType ? (
-                    <span>{getConnectorTypeLabel(selectedType)}</span>
-                  ) : null}{" "}
-                  Connector
+                  <span>
+                    Configure{" "}
+                    {selectedType
+                      ? `${getConnectorTypeLabel(selectedType)} `
+                      : ""}
+                    Connector
+                  </span>
                 </DialogTitle>
                 <DialogDescription>
                   Enter the connection details for your{" "}

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -507,7 +507,7 @@ function ExpandedConnectors({
             <>
               <ConnectorStatusBadge status={row.original.lastSyncStatus} />
               <span
-                className="text-xs text-muted-foreground"
+                className="text-xs text-muted-foreground whitespace-nowrap"
                 title={formatDate({ date: row.original.lastSyncAt })}
               >
                 {formatDistanceToNow(new Date(row.original.lastSyncAt), {


### PR DESCRIPTION
## What

Two small UI polish fixes on the knowledge connectors surfaces:

1. **Status column timestamps wrapped sloppily.** In both the Connectors and Knowledge Bases tables, the last-sync relative timestamp ("about 1 hour ago") sits next to the status badge; with wider badges ("No documents", "Completed with errors") it wrapped into two or three ragged lines. The timestamp span is now `whitespace-nowrap`, so each status cell renders on a single line (the badge itself already carries `whitespace-nowrap shrink-0`, and the column is auto-sized).

2. **"Configure X Connector" dialog title had oversized gaps between words.** The `DialogTitle` is a `flex items-center gap-2` container (for the back button), and the title was written as raw text + a `<span>` + raw text — three separate flex items, so the `gap-2` inserted large gaps between "Configure", the connector label, and "Connector". The title text is now a single `<span>` (one flex item), restoring normal word spacing.

## Testing

- `create-connector-dialog.test.tsx` (34 tests) passes; frontend type-check clean; biome clean on the touched files.
- Verified both fixes locally in the running dev app (connectors table single-line status cell, "Configure Jira Connector" title spacing).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>