### PR TITLE
fix(oauth): serve a slash-free issuer so authorization responses pass RFC 9207

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -89,11 +89,15 @@ const {
  */
 export const JWT_PLUGIN_OPTIONS = {
   jwt: {
-    // Pydantic's AnyHttpUrl (used by MCP/Open WebUI OAuthMetadata model)
-    // normalizes URLs by appending a trailing slash when the path is empty.
-    // The JWT iss claim must match the normalized issuer from the well-known
-    // metadata to pass authlib's claim validation.
-    issuer: `${frontendBaseUrl}/`,
+    // The issuer identifier for tokens we sign. Deliberately slash-free: the
+    // oauth-provider plugin derives the RFC 9207 `iss` authorization-response
+    // parameter from this value with any trailing slash stripped, and strict
+    // clients (Claude Code, MCP TS SDK) abort authorization unless that
+    // parameter byte-matches the issuer in
+    // /.well-known/oauth-authorization-server (served by oauth-server.ts) —
+    // so all three must stay the exact same slash-free string
+    // (frontendBaseUrl is normalized in config).
+    issuer: frontendBaseUrl,
   },
   jwks: {
     keyPairConfig: { alg: "RS256", modulusLength: 2048 },

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -44,6 +44,7 @@ import config, {
   parseFileStorageFilesystemRoot,
   parseFileStorageProvider,
   parseFileStorageS3Config,
+  parseFrontendBaseUrl,
   parseHackathonGalleryRepo,
   parseHackathonRecorderEnabled,
   parseHackathonRecorderMaxFinalCutMs,
@@ -393,6 +394,31 @@ describe("getRumOtlpAuthHeaders", () => {
     expect(getRumOtlpAuthHeaders()).toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(
       "OTEL authentication misconfigured: both ARCHESTRA_RUM_EXPORTER_OTLP_AUTH_USERNAME and ARCHESTRA_RUM_EXPORTER_OTLP_AUTH_PASSWORD must be provided for basic auth",
+    );
+  });
+});
+
+describe("parseFrontendBaseUrl", () => {
+  test("defaults to localhost when unset or blank", () => {
+    expect(parseFrontendBaseUrl(undefined)).toBe("http://localhost:3000");
+    expect(parseFrontendBaseUrl("   ")).toBe("http://localhost:3000");
+  });
+
+  test("returns a clean URL unchanged", () => {
+    expect(parseFrontendBaseUrl("https://app.example.com")).toBe(
+      "https://app.example.com",
+    );
+  });
+
+  test("strips trailing slashes so the OAuth issuer identifier stays slash-free", () => {
+    // A slashed value would disagree with the RFC 9207 `iss` parameter
+    // (better-auth strips the slash) and break URL-building call sites that
+    // append their own paths.
+    expect(parseFrontendBaseUrl("https://app.example.com/")).toBe(
+      "https://app.example.com",
+    );
+    expect(parseFrontendBaseUrl(" https://app.example.com// ")).toBe(
+      "https://app.example.com",
     );
   });
 });

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -83,8 +83,26 @@ if (devAutoAuthenticateEmail) {
   );
 }
 
-const frontendBaseUrl =
-  process.env.ARCHESTRA_FRONTEND_URL?.trim() || "http://localhost:3000";
+/**
+ * Parse `ARCHESTRA_FRONTEND_URL` into the canonical frontend base URL.
+ *
+ * Trailing slashes are stripped: every consumer appends its own path
+ * (`${frontendBaseUrl}/settings`), and the OAuth issuer identifier is this
+ * exact string — RFC 8414 requires the metadata issuer to be byte-identical
+ * to the URL clients resolved the well-known document from, and better-auth
+ * derives the RFC 9207 `iss` authorization-response parameter from it with
+ * any trailing slash stripped. A slashed value here would re-introduce the
+ * issuer mismatch that makes strict clients abort authorization.
+ * @public — exported for testability
+ */
+export function parseFrontendBaseUrl(rawValue: string | undefined): string {
+  const trimmed = rawValue?.trim();
+  return (trimmed || "http://localhost:3000").replace(/\/+$/, "");
+}
+
+const frontendBaseUrl = parseFrontendBaseUrl(
+  process.env.ARCHESTRA_FRONTEND_URL,
+);
 const DEFAULT_POSTHOG_KEY = "phc_FFZO7LacnsvX2exKFWehLDAVaXLBfoBaJypdOuYoTk7";
 const DEFAULT_POSTHOG_HOST = "https://eu.i.posthog.com";
 

--- a/platform/backend/src/routes/oauth-server.test.ts
+++ b/platform/backend/src/routes/oauth-server.test.ts
@@ -108,10 +108,11 @@ describe("OAuth Server - Well-Known Endpoints", () => {
       // is independent of a local .env that points the frontend origin at a
       // tunnel domain.
       const browserBaseUrl = config.frontendBaseUrl;
-      const expectedIssuer = browserBaseUrl.endsWith("/")
-        ? browserBaseUrl
-        : `${browserBaseUrl}/`;
-      expect(body.issuer).toBe(expectedIssuer);
+      expect(body.issuer).toBe(browserBaseUrl);
+      // RFC 9207 regression: better-auth strips any trailing slash from the
+      // `iss` authorization-response parameter, so a slashed metadata issuer
+      // makes strict clients abort with an issuer mismatch.
+      expect(body.issuer).not.toMatch(/\/$/);
       expect(body.authorization_endpoint).toBe(
         `${browserBaseUrl}/api/auth/oauth2/authorize`,
       );
@@ -174,10 +175,8 @@ describe("OAuth Server - Well-Known Endpoints", () => {
       // the test is independent of a local .env that points the frontend origin
       // at a tunnel domain.
       const browserBaseUrl = config.frontendBaseUrl;
-      const expectedIssuer = browserBaseUrl.endsWith("/")
-        ? browserBaseUrl
-        : `${browserBaseUrl}/`;
-      expect(body.issuer).toBe(expectedIssuer);
+      expect(body.issuer).toBe(browserBaseUrl);
+      expect(body.issuer).not.toMatch(/\/$/);
       expect(body.authorization_endpoint).toBe(
         `${browserBaseUrl}/api/auth/oauth2/authorize`,
       );

--- a/platform/backend/src/routes/oauth-server.ts
+++ b/platform/backend/src/routes/oauth-server.ts
@@ -112,13 +112,16 @@ const oauthServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
       // request Host so Docker containers can reach them directly.
       const browserBaseUrl = config.frontendBaseUrl;
 
-      // The issuer MUST match the JWT "iss" claim exactly. Pydantic's AnyHttpUrl
-      // (used by MCP clients like Open WebUI) normalizes URLs by appending a
-      // trailing slash when the path is empty. We include the trailing slash so
-      // the JWT iss claim, the well-known issuer, and the normalized URL all match.
-      const issuer = browserBaseUrl.endsWith("/")
-        ? browserBaseUrl
-        : `${browserBaseUrl}/`;
+      // The issuer identifier MUST byte-match both the JWT "iss" claim and the
+      // RFC 9207 `iss` authorization-response parameter, which better-auth
+      // derives from the JWT plugin issuer with any trailing slash stripped —
+      // strict clients (Claude Code, MCP TS SDK) abort authorization on any
+      // mismatch. RFC 8414 §3.3 likewise requires this value to be identical
+      // to the (slash-free) URL clients built the well-known URL from, and
+      // /.well-known/oauth-protected-resource advertises the same slash-free
+      // origin in authorization_servers. frontendBaseUrl is normalized
+      // slash-free in config, so it is used verbatim.
+      const issuer = browserBaseUrl;
 
       reply.type("application/json");
       return {

--- a/platform/backend/src/services/identity-providers/enterprise-managed/authorization.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/authorization.test.ts
@@ -204,6 +204,16 @@ describe("exchangeIdentityAssertionForAccessToken", () => {
     expect(storedToken?.referenceId).toBe(
       `${MCP_RESOURCE_REFERENCE_PREFIX}${agent.id}`,
     );
+
+    // The issuer identifier clients copy into the assertion audience is
+    // slash-free (it must byte-match the advertised metadata issuer and the
+    // RFC 9207 `iss` parameter), but assertions minted against the previously
+    // advertised slashed issuer must stay valid during the transition.
+    const issuer = buildOAuthIssuer();
+    expect(issuer).not.toMatch(/\/$/);
+    expect(mockValidateJwt).toHaveBeenCalledWith(
+      expect.objectContaining({ audience: [issuer, `${issuer}/`] }),
+    );
   });
 
   test("uses the organization MCP OAuth token lifetime for issued access tokens", async ({

--- a/platform/backend/src/services/identity-providers/enterprise-managed/authorization.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/authorization.ts
@@ -124,11 +124,16 @@ export async function exchangeIdentityAssertionForAccessToken(params: {
     return invalidGrant("Unable to determine the identity provider JWKS URL.");
   }
 
+  // The assertion's audience is our issuer identifier, which clients copy
+  // from the advertised AS metadata. That metadata historically carried a
+  // trailing slash, so accept the slashed form too — IdP integrations and
+  // cached metadata configured against the old value keep working.
+  const expectedIssuer = buildOAuthIssuer();
   const validationResult = await jwksValidator.validateJwt({
     token: params.assertion,
     issuerUrl: identityProvider.issuer,
     jwksUrl,
-    audience: buildOAuthIssuer(),
+    audience: [expectedIssuer, `${expectedIssuer}/`],
   });
   if (!validationResult) {
     return invalidGrant("Assertion JWT validation failed.");
@@ -182,9 +187,10 @@ export async function exchangeIdentityAssertionForAccessToken(params: {
 }
 
 export function buildOAuthIssuer(): string {
-  return config.frontendBaseUrl.endsWith("/")
-    ? config.frontendBaseUrl
-    : `${config.frontendBaseUrl}/`;
+  // The canonical issuer identifier: frontendBaseUrl is normalized slash-free
+  // in config, and must stay byte-identical to the metadata issuer, the JWT
+  // "iss" claim, and the RFC 9207 `iss` authorization-response parameter.
+  return config.frontendBaseUrl;
 }
 
 function extractProfileIdFromMcpResource(resource: string): string | null {

--- a/platform/backend/src/services/jwks-validator.ts
+++ b/platform/backend/src/services/jwks-validator.ts
@@ -40,7 +40,8 @@ class JwksValidator {
     token: string;
     issuerUrl: string;
     jwksUrl: string;
-    audience: string | null;
+    /** Accepted `aud` value(s); an array accepts any listed value (jose semantics). */
+    audience: string | string[] | null;
     /**
      * Claim holding the caller's email, taken from the IdP's attribute mapping.
      * IdPs that namespace custom claims (`https://example.com/email`) never


### PR DESCRIPTION
## Problem

When Archestra acts as the OAuth authorization server for MCP, strict clients (e.g. Claude Code) abort every authorization with **"Issuer mismatch in authorization response (RFC 9207)"**:

- `/.well-known/oauth-authorization-server` advertises `issuer` **with** a trailing slash (`https://host/`)
- the `iss` parameter on the authorization redirect carries **no** trailing slash (`https://host`)

Existing tokens keep working, so deployments look healthy until a token expires and re-authorization fails.

## Cause

The trailing slash is appended in two places — the AS metadata route (`oauth-server.ts`) and the better-auth JWT plugin issuer (`better-auth.ts`) — as an old workaround for clients that normalized path-less URLs with a trailing slash. Since `@better-auth/oauth-provider` 1.6.0, better-auth appends an RFC 9207 `iss` parameter to authorization responses, derived from that same JWT issuer but with any trailing slash **stripped** (`validateIssuerUrl`). The two values can never agree, so clients that enforce the exact-match check abort. The slashed metadata issuer also disagrees with RFC 8414 §3.3 (it must be byte-identical to the slash-free URL clients built the well-known URL from) and with `/.well-known/oauth-protected-resource`, whose `resource`/`authorization_servers` are already slash-free. There is no operator workaround: the value derives from `ARCHESTRA_FRONTEND_URL`, and configuring that env var with a trailing slash breaks URL building instead (`https://host//api/auth/...`).

## Fix

Normalize `frontendBaseUrl` slash-free at the source (`parseFrontendBaseUrl` in `config.ts` — every call site already appends its own paths, so this also fixes the double-slash footgun above), and drop both slash-append sites. Metadata `issuer`, the RFC 9207 `iss` parameter, and the JWT `iss` claim are now the same byte-identical slash-free string, which is also better-auth's own canonical form (`validateIssuerUrl`).

Compatibility:

- Archestra-issued access tokens are validated by hash lookup, not by `iss` claim, so existing tokens are unaffected.
- ID-JAG assertion validation (`buildOAuthIssuer` as expected audience) accepts both the slash-free and the previously advertised slashed audience, so integrations and cached metadata configured against the old value keep working through the transition.

## Testing

- Regression assertions that the advertised issuer is slash-free (both Host variants) in `oauth-server.test.ts`, `parseFrontendBaseUrl` unit tests, and a pin on the dual-audience acceptance in `authorization.test.ts`.
- `config.test.ts` + `oauth-server.test.ts` + `authorization.test.ts` + the issuer-adjacent suites (auth routes, oauth, oauth-cors, jwks guard, mcp-client, gdrive oauth): all green except 3 `mcp-client.test.ts` failures that reproduce identically on an unmodified checkout (pre-existing baseline).
- Backend `pnpm type-check`, biome, and `pnpm knip` (dev + production) clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>