### PR TITLE
feat(knowledge-base): permission auto-sync for the OneDrive connector

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -191,6 +191,7 @@ Auto-sync permissions works with the connectors marked *Supported* below. The ot
 | Jira         | Supported                     |
 | M-Files      | Supported with the VAF Add On |
 | Google Drive | Supported                     |
+| OneDrive     | Supported                     |
 | Salesforce   | Supported                     |
 | SharePoint   | Supported                     |
 | Asana        | Not supported                 |
@@ -198,7 +199,6 @@ Auto-sync permissions works with the connectors marked *Supported* below. The ot
 | GitLab       | Not supported                 |
 | Linear       | Not supported                 |
 | Notion       | Not supported                 |
-| OneDrive     | Not supported                 |
 | Outline      | Not supported                 |
 | Perforce     | Not supported                 |
 | ServiceNow   | Not supported                 |
@@ -209,6 +209,7 @@ Auto-sync permissions works with the connectors marked *Supported* below. The ot
 - **Jira and Confluence Cloud** only return another user's email through the product REST API when that user's Atlassian profile has email visibility set to **"Anyone"**. Add an Atlassian **organization admin API key** to the connector credentials to read managed accounts' emails.
 - **GitHub** only exposes an email the user has made **public on their profile**; no token scope reveals a private email.
 - **SharePoint** returns SharePoint user logins directly. Expanding a Microsoft 365 group or a SharePoint site group to its members needs the extra app permissions listed under [SharePoint](#sharepoint).
+- **OneDrive** resolves user grants and drive owners to emails through the `User.Read.All` app permission. Without it, those accounts stay unresolvable. See [OneDrive](#onedrive).
 - **Salesforce** reads user emails and group membership through the same login the connector already uses. No extra credential is needed.
 
 **Permission-read access.** The credential must also be able to read the source's permission settings — Jira permission schemes, Confluence space permissions, GitHub repository collaborators. A credential that cannot read them hides that project or space from everyone, because Archestra never assumes an audience it could not verify. Each sync run reports how many it could not read, so a project nobody can find is easy to tell apart from a project nobody is granted.
@@ -426,6 +427,20 @@ To configure the connector:
 - `User IDs` should be user principal names (UPNs, e.g. `user@company.com`) or Azure AD object IDs for the users whose drives you want to sync
 
 Incremental sync uses the `lastModifiedDateTime` field to fetch only items modified since the last run.
+
+**Auto-sync permissions.** Each configured user's drive is one permission scope, and an item (file or folder) that breaks permission inheritance becomes its own scope — a document inherits its nearest such ancestor. The drive's owner is always part of its audience. Anonymous sharing links map to everyone in your Archestra organization; "people in your organization" links expand to the tenant's active users.
+
+Grants to Microsoft 365 / Entra groups carry the group's identity, and each permission sync also snapshots those groups' member rosters — so the connector's **Users** and **Groups** tabs show every member with their assignment status, and an account whose email is hidden upstream can be assigned manually from the Users tab. Direct grantees appear there too, under the synthetic `direct-grants` group. SharePoint site groups granted on a personal drive are listed in the Groups tab but resolve no members; assign their users manually if you need them.
+
+`Files.Read.All` covers drive and item grants. Three more application permissions unlock more, progressively:
+
+| Extra permission | Unlocks |
+| ---------------- | ------- |
+| `User.Read.All` | User and owner grants expand to emails, and organization-wide links expand to the tenant's active users. |
+| `GroupMember.Read.All` | Microsoft 365 / Entra group member rosters (the Users and Groups tabs, and group-based document access). |
+| `Sites.FullControl.All` | Permission sync switches to cheaper sharing-aware delta runs. |
+
+Each tier is detected at runtime: without it, that kind of grant or roster drops (fail-closed) and the rest of the sync proceeds.
 
 #### Known Limitations
 

--- a/platform/backend/src/knowledge-base/connectors/onedrive/onedrive-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/onedrive/onedrive-connector.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import type { ConnectorSyncBatch } from "@/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConnectorSyncBatch, PermissionSnapshotYield } from "@/types";
 import { OneDriveConnector } from "./onedrive-connector";
 
 const credentials = { email: "test-client-id", apiToken: "test-client-secret" };
@@ -841,6 +841,754 @@ describe("OneDriveConnector", () => {
       });
 
       expect(count).toBe(1);
+    });
+  });
+
+  describe("permission sync", () => {
+    type ContainerYield = Extract<
+      PermissionSnapshotYield,
+      { kind: "container" }
+    >;
+    type DocumentYield = Extract<PermissionSnapshotYield, { kind: "document" }>;
+
+    const permConfig = {
+      tenantId: "test-tenant-id",
+      userIds: ["user-1"],
+    };
+
+    /** Route table: url substring → response body, or a thrown Graph error. */
+    let routes: Array<{
+      match: string;
+      body?: unknown;
+      error?: { statusCode: number };
+      /** Only match when the Prefer header contains this. */
+      prefer?: string;
+    }>;
+    let requestedUrls: string[];
+
+    function routeFor(url: string, prefer: string | null) {
+      const route = routes.find(
+        (r) =>
+          url.includes(r.match) &&
+          (r.prefer === undefined || (prefer ?? "").includes(r.prefer)),
+      );
+      if (route?.error) {
+        const err = new Error("Graph error") as Error & { statusCode: number };
+        err.statusCode = route.error.statusCode;
+        throw err;
+      }
+      if (!route) throw new Error(`No route for ${url}`);
+      return route.body;
+    }
+
+    function installClient(connector: OneDriveConnector) {
+      const mockApi = vi.fn((url: string) => {
+        let prefer: string | null = null;
+        const chain = {
+          get: () => {
+            requestedUrls.push(url);
+            return Promise.resolve(routeFor(url, prefer));
+          },
+          header: (name: string, value: string) => {
+            if (name === "Prefer") prefer = value;
+            return chain;
+          },
+          responseType: () => chain,
+          select: () => chain,
+        };
+        return chain;
+      });
+      vi.spyOn(
+        connector as unknown as { getGraphClient: () => unknown },
+        "getGraphClient",
+      ).mockReturnValue({ api: mockApi } as never);
+    }
+
+    function readBack(docs: Array<{ sourceId: string; userId?: string }>) {
+      return vi.fn(
+        async (args: {
+          metadataFilter?: Record<string, string>;
+          afterId?: string | null;
+          limit: number;
+        }) => ({
+          documents: docs
+            .filter(
+              (d) =>
+                !args.metadataFilter?.userId ||
+                d.userId === args.metadataFilter.userId,
+            )
+            .map((d) => ({
+              sourceId: d.sourceId,
+              metadata: d.userId ? { userId: d.userId } : null,
+            })),
+          nextAfterId: null,
+        }),
+      );
+    }
+
+    function syncParams(overrides?: {
+      config?: Record<string, unknown>;
+      docs?: Array<{ sourceId: string; userId?: string }>;
+      cursor?: string | null;
+      scope?: { containerKeys: string[] };
+      resolveMappedEmail?: (accountId: string) => string | null;
+    }) {
+      return {
+        config: overrides?.config ?? permConfig,
+        credentials,
+        cursor: overrides?.cursor ?? null,
+        scope: overrides?.scope,
+        resolveMappedEmail: overrides?.resolveMappedEmail,
+        readIngestedDocuments: readBack(
+          overrides?.docs ?? [{ sourceId: "I1", userId: "user-1" }],
+        ),
+      };
+    }
+
+    function collectSnapshot(gen: AsyncGenerator<PermissionSnapshotYield>) {
+      const containers = new Map<string, ContainerYield>();
+      const documents: DocumentYield[] = [];
+      return (async () => {
+        for await (const item of gen) {
+          if (item.kind === "container")
+            containers.set(item.containerKey, item);
+          else documents.push(item);
+        }
+        return { containers, documents };
+      })();
+    }
+
+    /** The user's drive resolution route (id + owner). */
+    function stubDrive() {
+      routes.push({
+        match: "/users/user-1/drive?$select=id,owner",
+        body: {
+          id: "D1",
+          owner: { user: { id: "owner-1", displayName: "Owner One" } },
+        },
+      });
+    }
+
+    /** The default delta walk over D1. */
+    function stubDeltaWalk(items: unknown[]) {
+      routes.push({
+        match: "/drives/D1/root/delta",
+        body: { value: items, "@odata.deltaLink": "delta-link-1" },
+      });
+    }
+
+    /** User.Read.All tier probe + owner email resolution. */
+    function stubUsersTier() {
+      routes.push(
+        { match: "/users?$select=id&$top=1", body: { value: [] } },
+        {
+          match: "/users/owner-1?$select=mail,userPrincipalName",
+          body: { mail: "owner@example.com" },
+        },
+      );
+    }
+
+    beforeEach(() => {
+      routes = [];
+      requestedUrls = [];
+    });
+
+    it("supportsPermissionSync is true", () => {
+      expect(new OneDriveConnector().supportsPermissionSync).toBe(true);
+    });
+
+    it("scopeKeyForDocument maps metadata.userId to the container key", () => {
+      const connector = new OneDriveConnector();
+      expect(connector.scopeKeyForDocument({ userId: "user-1" })).toBe(
+        "user:user-1",
+      );
+      expect(connector.scopeKeyForDocument({})).toBeNull();
+      expect(connector.scopeKeyForDocument({ userId: "" })).toBeNull();
+    });
+
+    it("root audience: direct grant + entra group token + drive owner; plain items assign to the top container", async () => {
+      const connector = new OneDriveConnector();
+      installClient(connector);
+      stubDrive();
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" } },
+      ]);
+      stubUsersTier();
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [
+              { grantedToV2: { user: { id: "u-alice" } } },
+              { grantedToV2: { group: { id: "G1" } } },
+            ],
+          },
+        },
+        {
+          match: "/users/u-alice?$select=mail,userPrincipalName",
+          body: { mail: "Alice@Example.com" },
+        },
+      );
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      const top = containers.get("user:user-1");
+      expect(top).toBeDefined();
+      expect(top?.audienceResolutionFailed).toBe(false);
+      expect(top?.permissions.isPublic).toBe(false);
+      // can-read: alice + the owner; cannot-read: anyone else is absent.
+      expect([...(top?.permissions.users ?? [])].sort()).toEqual([
+        "alice@example.com",
+        "owner@example.com",
+      ]);
+      expect(top?.permissions.groups).toEqual(["entra:G1"]);
+      expect(documents).toEqual([
+        {
+          kind: "document",
+          sourceId: "I1",
+          containerKey: "user:user-1",
+          cursor: "user:user-1",
+        },
+      ]);
+    });
+
+    it("a permission-hierarchy root becomes a nested item container with its own audience", async () => {
+      const connector = new OneDriveConnector();
+      installClient(connector);
+      stubDrive();
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I1", parentReference: { id: "root" } },
+        // shared facet present ⇒ unique permissions (hierarchicalsharing)
+        { id: "I2", parentReference: { id: "root" }, shared: {} },
+      ]);
+      stubUsersTier();
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: { value: [{ grantedToV2: { user: { id: "u-alice" } } }] },
+        },
+        {
+          match: "/drives/D1/items/I2/permissions",
+          body: { value: [{ grantedToV2: { user: { id: "u-bob" } } }] },
+        },
+        {
+          match: "/users/u-alice?$select=mail,userPrincipalName",
+          body: { mail: "alice@example.com" },
+        },
+        {
+          match: "/users/u-bob?$select=mail,userPrincipalName",
+          body: { mail: "bob@example.com" },
+        },
+      );
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(
+          syncParams({
+            docs: [
+              { sourceId: "I1", userId: "user-1" },
+              { sourceId: "I2", userId: "user-1" },
+            ],
+          }),
+        ),
+      );
+
+      const nested = containers.get("user:user-1/item:I2");
+      expect(nested?.permissions.users).toContain("bob@example.com");
+      // the owner belongs to every audience in the drive
+      expect(nested?.permissions.users).toContain("owner@example.com");
+      // alice governs the root, not the nested subtree
+      expect(nested?.permissions.users).not.toContain("alice@example.com");
+      expect(documents.find((d) => d.sourceId === "I2")?.containerKey).toBe(
+        "user:user-1/item:I2",
+      );
+      expect(documents.find((d) => d.sourceId === "I1")?.containerKey).toBe(
+        "user:user-1",
+      );
+    });
+
+    it("an unreadable root permission list fail-closes the container — owner included", async () => {
+      const connector = new OneDriveConnector();
+      installClient(connector);
+      stubDrive();
+      stubDeltaWalk([{ id: "root", parentReference: {} }]);
+      stubUsersTier();
+      routes.push({
+        match: "/drives/D1/root/permissions",
+        error: { statusCode: 500 },
+      });
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      const top = containers.get("user:user-1");
+      expect(top?.audienceResolutionFailed).toBe(true);
+      expect(top?.permissions).toEqual({
+        isPublic: false,
+        users: [],
+        groups: [],
+      });
+    });
+
+    it("an unreadable nested item fail-closes that subtree only", async () => {
+      const connector = new OneDriveConnector();
+      installClient(connector);
+      stubDrive();
+      stubDeltaWalk([
+        { id: "root", parentReference: {} },
+        { id: "I2", parentReference: { id: "root" }, shared: {} },
+      ]);
+      stubUsersTier();
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: { value: [{ grantedToV2: { user: { id: "u-alice" } } }] },
+        },
+        {
+          match: "/users/u-alice?$select=mail,userPrincipalName",
+          body: { mail: "alice@example.com" },
+        },
+        {
+          match: "/drives/D1/items/I2/permissions",
+          error: { statusCode: 429 },
+        },
+      );
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(
+          syncParams({ docs: [{ sourceId: "I2", userId: "user-1" }] }),
+        ),
+      );
+
+      const nested = containers.get("user:user-1/item:I2");
+      expect(nested?.audienceResolutionFailed).toBe(true);
+      expect(nested?.permissions.users).toEqual([]);
+      const top = containers.get("user:user-1");
+      expect(top?.audienceResolutionFailed).toBe(false);
+    });
+
+    it("a failed drive resolution fail-closes the whole corpus under the top container", async () => {
+      const connector = new OneDriveConnector();
+      installClient(connector);
+      routes.push({
+        match: "/users/user-1/drive?$select=id,owner",
+        error: { statusCode: 404 },
+      });
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      const top = containers.get("user:user-1");
+      expect(top?.audienceResolutionFailed).toBe(true);
+      expect(top?.permissions.users).toEqual([]);
+      expect(documents.map((d) => d.sourceId)).toEqual(["I1"]);
+    });
+
+    it("an empty corpus emits the boundary container without resolving its audience", async () => {
+      const connector = new OneDriveConnector();
+      installClient(connector);
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams({ docs: [] })),
+      );
+
+      const top = containers.get("user:user-1");
+      expect(top?.audienceResolutionFailed).toBe(false);
+      expect(top?.permissions).toEqual({
+        isPublic: false,
+        users: [],
+        groups: [],
+      });
+      expect(documents).toEqual([]);
+      expect(requestedUrls.some((u) => u.includes("/permissions"))).toBe(false);
+    });
+
+    it("anonymous links are public; organization links expand to active tenant users", async () => {
+      const connector = new OneDriveConnector();
+      installClient(connector);
+      stubDrive();
+      stubDeltaWalk([{ id: "root", parentReference: {} }]);
+      stubUsersTier();
+      routes.push(
+        {
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [
+              { link: { scope: "anonymous" } },
+              { link: { scope: "organization" } },
+            ],
+          },
+        },
+        {
+          match: "/users?$select=mail,userPrincipalName,accountEnabled",
+          body: {
+            value: [
+              { mail: "active@example.com", accountEnabled: true },
+              { mail: "gone@example.com", accountEnabled: false },
+            ],
+          },
+        },
+      );
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(syncParams()),
+      );
+
+      const top = containers.get("user:user-1");
+      expect(top?.permissions.isPublic).toBe(true);
+      expect(top?.permissions.users).toContain("active@example.com");
+      expect(top?.permissions.users).not.toContain("gone@example.com");
+    });
+
+    it("User.Read.All denied: unresolvable principals drop fail-closed, group tokens survive, member overrides still apply", async () => {
+      const connector = new OneDriveConnector();
+      installClient(connector);
+      stubDrive();
+      stubDeltaWalk([{ id: "root", parentReference: {} }]);
+      routes.push(
+        { match: "/users?$select=id&$top=1", error: { statusCode: 403 } },
+        {
+          match: "/drives/D1/root/permissions",
+          body: {
+            value: [
+              { grantedToV2: { user: { id: "u-alice" } } },
+              { grantedToV2: { user: { id: "u-mapped" } } },
+              { grantedToV2: { group: { id: "G1" } } },
+            ],
+          },
+        },
+      );
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(
+          syncParams({
+            resolveMappedEmail: (accountId) =>
+              accountId === "u-mapped" ? "mapped@example.com" : null,
+          }),
+        ),
+      );
+
+      const top = containers.get("user:user-1");
+      expect(top?.audienceResolutionFailed).toBe(false);
+      // alice and the owner are unresolvable without User.Read.All; the
+      // admin override rescues u-mapped.
+      expect(top?.permissions.users).toEqual(["mapped@example.com"]);
+      expect(top?.permissions.groups).toEqual(["entra:G1"]);
+    });
+
+    it("resume cursor skips containers strictly before it; scope filters containers", async () => {
+      const connector = new OneDriveConnector();
+      installClient(connector);
+      const config = { ...permConfig, userIds: ["user-1", "user-2"] };
+      const docs = [
+        { sourceId: "I1", userId: "user-1" },
+        { sourceId: "I2", userId: "user-2" },
+      ];
+      routes.push({
+        match: "/users/user-2/drive?$select=id,owner",
+        body: { id: "D2", owner: { user: { id: "owner-1" } } },
+      });
+      stubUsersTier();
+      routes.push(
+        {
+          match: "/drives/D2/root/delta",
+          body: {
+            value: [{ id: "root2", parentReference: {} }],
+            "@odata.deltaLink": "dl-2",
+          },
+        },
+        { match: "/drives/D2/root/permissions", body: { value: [] } },
+      );
+
+      const cursored = await collectSnapshot(
+        connector.syncPermissionSnapshot(
+          syncParams({ config, docs, cursor: "user:user-2" }),
+        ),
+      );
+      expect([...cursored.containers.keys()]).toEqual(["user:user-2"]);
+
+      const scoped = await collectSnapshot(
+        connector.syncPermissionSnapshot(
+          syncParams({
+            config,
+            docs,
+            scope: { containerKeys: ["user:user-2"] },
+          }),
+        ),
+      );
+      expect([...scoped.containers.keys()]).toEqual(["user:user-2"]);
+    });
+
+    describe("syncGroups", () => {
+      it("rosters entra groups, site groups (empty), and direct grantees incl. the owner", async () => {
+        const connector = new OneDriveConnector();
+        installClient(connector);
+        stubDrive();
+        stubUsersTier();
+        routes.push(
+          {
+            match: "/drives/D1/root/permissions",
+            body: {
+              value: [
+                { grantedToV2: { group: { id: "G1" } } },
+                {
+                  grantedToV2: {
+                    siteGroup: { displayName: "Personal Site Members" },
+                  },
+                },
+                {
+                  grantedToV2: {
+                    user: { id: "u-alice", displayName: "Alice" },
+                  },
+                },
+              ],
+            },
+          },
+          {
+            match: "/groups/G1/transitiveMembers",
+            body: {
+              value: [
+                {
+                  "@odata.type": "#microsoft.graph.user",
+                  id: "m1",
+                  displayName: "Member One",
+                  mail: "member1@example.com",
+                  accountEnabled: true,
+                },
+                {
+                  "@odata.type": "#microsoft.graph.user",
+                  id: "m2",
+                  displayName: "Hidden Member",
+                  accountEnabled: false,
+                },
+                { "@odata.type": "#microsoft.graph.group", id: "nested-g" },
+              ],
+            },
+          },
+          {
+            match: "/users/u-alice?$select=mail,userPrincipalName",
+            body: { mail: "alice@example.com" },
+          },
+        );
+
+        const groups: Array<{
+          groupId: string;
+          members: Array<{ accountId: string; email?: string | null }>;
+        }> = [];
+        for await (const g of connector.syncGroups(syncParams())) {
+          groups.push(g);
+        }
+
+        const entra = groups.find((g) => g.groupId === "entra:G1");
+        expect(entra?.members.map((m) => m.accountId).sort()).toEqual([
+          "m1",
+          "m2",
+        ]);
+        expect(
+          entra?.members.find((m) => m.accountId === "m2")?.email,
+        ).toBeNull();
+
+        const site = groups.find(
+          (g) => g.groupId === "sitegroup:Personal Site Members",
+        );
+        expect(site?.members).toEqual([]);
+
+        const direct = groups.find((g) => g.groupId === "direct-grants");
+        expect(direct?.members.map((m) => m.accountId).sort()).toEqual([
+          "owner-1",
+          "u-alice",
+        ]);
+      });
+
+      it("GroupMember.Read.All denied: the group rosters empty (fail-closed)", async () => {
+        const connector = new OneDriveConnector();
+        installClient(connector);
+        stubDrive();
+        stubUsersTier();
+        routes.push(
+          {
+            match: "/drives/D1/root/permissions",
+            body: { value: [{ grantedToV2: { group: { id: "G1" } } }] },
+          },
+          {
+            match: "/groups/G1/transitiveMembers",
+            error: { statusCode: 403 },
+          },
+        );
+
+        const groups: Array<{ groupId: string; members: unknown[] }> = [];
+        for await (const g of connector.syncGroups(syncParams())) {
+          groups.push(g);
+        }
+        expect(groups.find((g) => g.groupId === "entra:G1")?.members).toEqual(
+          [],
+        );
+      });
+
+      it("an unreadable permission surface is skipped, not fail-closed here", async () => {
+        const connector = new OneDriveConnector();
+        installClient(connector);
+        stubDrive();
+        stubUsersTier();
+        routes.push({
+          match: "/drives/D1/root/permissions",
+          error: { statusCode: 500 },
+        });
+
+        const groups: Array<{ groupId: string }> = [];
+        for await (const g of connector.syncGroups(syncParams())) {
+          groups.push(g);
+        }
+        // only the owner's direct-grants roster survives
+        expect(groups.map((g) => g.groupId)).toEqual(["direct-grants"]);
+      });
+    });
+
+    describe("probePermissionChanges", () => {
+      it("no stored state: fullRequired with fresh delta tokens", async () => {
+        const connector = new OneDriveConnector();
+        installClient(connector);
+        stubDrive();
+        routes.push({
+          match: "/drives/D1/root/delta?token=latest",
+          body: { "@odata.deltaLink": "dl-fresh" },
+        });
+
+        const result = await connector.probePermissionChanges({
+          config: permConfig,
+          credentials,
+          state: null,
+        });
+
+        expect(result.fullRequired).toBe(true);
+        expect(result.nextState).toEqual({
+          deltaTokens: { "user:user-1": "dl-fresh" },
+        });
+      });
+
+      it("sharing-annotated drift dirties the container; unannotated drift does not (elevated tier)", async () => {
+        const connector = new OneDriveConnector();
+        installClient(connector);
+        stubDrive();
+        routes.push({
+          match: "stored-token",
+          prefer: "deltashowsharingchanges",
+          body: {
+            value: [
+              { id: "I1", parentReference: { id: "root" } },
+              {
+                id: "I2",
+                parentReference: { id: "root" },
+                "@microsoft.graph.sharedChanged": "True",
+              },
+            ],
+            "@odata.deltaLink": "dl-next",
+          },
+        });
+
+        const result = await connector.probePermissionChanges({
+          config: permConfig,
+          credentials,
+          state: { deltaTokens: { "user:user-1": "stored-token" } },
+        });
+
+        expect(result.fullRequired).toBe(false);
+        expect(result.dirtyContainerKeys).toEqual(["user:user-1"]);
+        expect(result.nextState).toEqual({
+          deltaTokens: { "user:user-1": "dl-next" },
+        });
+      });
+
+      it("sharing preference denied (403): degrades to coarse probing where any drift dirties", async () => {
+        const connector = new OneDriveConnector();
+        installClient(connector);
+        stubDrive();
+        routes.push(
+          {
+            match: "stored-token",
+            prefer: "deltashowsharingchanges",
+            error: { statusCode: 403 },
+          },
+          {
+            match: "stored-token",
+            body: {
+              value: [{ id: "I1", parentReference: { id: "root" } }],
+              "@odata.deltaLink": "dl-next",
+            },
+          },
+        );
+
+        const result = await connector.probePermissionChanges({
+          config: permConfig,
+          credentials,
+          state: { deltaTokens: { "user:user-1": "stored-token" } },
+        });
+
+        expect(result.fullRequired).toBe(false);
+        expect(result.dirtyContainerKeys).toEqual(["user:user-1"]);
+      });
+
+      it("a rejected delta token (410) promotes to a full reconcile", async () => {
+        const connector = new OneDriveConnector();
+        installClient(connector);
+        stubDrive();
+        routes.push(
+          { match: "stored-token", error: { statusCode: 410 } },
+          {
+            match: "/drives/D1/root/delta?token=latest",
+            body: { "@odata.deltaLink": "dl-fresh" },
+          },
+        );
+
+        const result = await connector.probePermissionChanges({
+          config: permConfig,
+          credentials,
+          state: { deltaTokens: { "user:user-1": "stored-token" } },
+        });
+
+        expect(result.fullRequired).toBe(true);
+        expect(result.nextState).toEqual({
+          deltaTokens: { "user:user-1": "dl-fresh" },
+        });
+      });
+    });
+
+    describe("refreshContainerAudiences", () => {
+      it("re-resolves top-level audiences and skips nested item containers", async () => {
+        const connector = new OneDriveConnector();
+        installClient(connector);
+        stubDrive();
+        stubUsersTier();
+        routes.push({
+          match: "/drives/D1/root/permissions",
+          body: { value: [{ grantedToV2: { user: { id: "u-alice" } } }] },
+        });
+        routes.push({
+          match: "/users/u-alice?$select=mail,userPrincipalName",
+          body: { mail: "alice@example.com" },
+        });
+
+        const yields: Array<{
+          containerKey: string;
+          permissions: { users?: string[] };
+        }> = [];
+        for await (const y of connector.refreshContainerAudiences({
+          config: permConfig,
+          credentials,
+          containerKeys: ["user:user-1", "user:user-1/item:I2"],
+        })) {
+          yields.push(y);
+        }
+
+        expect(yields.map((y) => y.containerKey)).toEqual(["user:user-1"]);
+        expect(yields[0].permissions.users).toContain("alice@example.com");
+        expect(yields[0].permissions.users).toContain("owner@example.com");
+      });
     });
   });
 });

--- a/platform/backend/src/knowledge-base/connectors/onedrive/onedrive-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/onedrive/onedrive-connector.ts
@@ -3,12 +3,21 @@ import { ClientSecretCredential } from "@azure/identity";
 import { Client, ResponseType } from "@microsoft/microsoft-graph-client";
 import { TokenCredentialAuthenticationProvider } from "@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials/index.js";
 import type { DriveItem as GraphDriveItem } from "@microsoft/microsoft-graph-types";
+import * as metrics from "@/observability/metrics";
 import type {
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorSyncBatch,
+  DocumentPermissions,
+  GroupMembershipYield,
+  GroupMemberYield,
   OneDriveCheckpoint,
   OneDriveConfig,
+  PermissionProbeResult,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
+  PermissionSyncState,
+  ResolveMappedEmail,
 } from "@/types";
 import { OneDriveConfigSchema } from "@/types";
 import {
@@ -74,6 +83,24 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 
 export class OneDriveConnector extends BaseConnector {
   type = "onedrive" as const;
+  supportsPermissionSync = true;
+
+  // ----- Per-pass permission-sync state (armed by initPermissionPass) -----
+  private permCredentials: ConnectorCredentials | null = null;
+  private permConfig: OneDriveConfig | null = null;
+  /** Graph user id → email (null = unresolvable this pass). */
+  private userEmailCache = new Map<string, string | null>();
+  /** Entra group id → transitive member roster (null = expansion failed). */
+  private entraGroupCache = new Map<string, GroupMemberYield[] | null>();
+  /** Configured user id → resolved drive (null = resolution failed). */
+  private driveInfoCache = new Map<string, OdDriveInfo | null>();
+  /** Tenant active-user emails (null = enumeration failed/denied). */
+  private tenantUsersCache: string[] | null | undefined;
+  private graphUsersTier: boolean | null = null;
+  private graphGroupsTier: boolean | null = null;
+  private deltaSharingTier: boolean | null = null;
+  private droppedPrincipals = 0;
+  private mappedEmailResolver: ResolveMappedEmail | null = null;
 
   async validateConfig(
     config: Record<string, unknown>,
@@ -229,6 +256,288 @@ export class OneDriveConnector extends BaseConnector {
         hasMoreUsers: !isLastUser,
       });
     }
+  }
+
+  // ===== Permission sync =====
+
+  /**
+   * Container model: `user:<userId>` per configured user — the key is the
+   * CONFIGURED id (UPN or object id), byte-matching the `metadata.userId`
+   * every ingested document already carries, so existing corpora need no
+   * re-ingestion and `scopeKeyForDocument` stays a pure metadata read. The
+   * user's drive id is resolved once per pass for the Graph calls. Items
+   * that BREAK permission inheritance (permission-hierarchy roots surfaced
+   * by the delta feed's `hierarchicalsharing` preference — the SharePoint
+   * mechanism verbatim; OneDrive for Business drives are Graph drives)
+   * become nested `user:<id>/item:<itemId>` containers; a document's
+   * container is its nearest uniquely-permissioned ancestor.
+   *
+   * A personal drive's root permission list does NOT include its owner, so
+   * the resolved drive OWNER is added to every audience in that drive (root
+   * and nested) — definitionally correct for single-owner drives, never an
+   * over-grant. When the root permission read fails the container still
+   * fail-closes to the empty audience (no owner shortcut): an audience we
+   * could not verify is not partially granted.
+   *
+   * Group grants emit GROUP TOKENS (`entra:<guid>`, byte-matched into
+   * `group:onedrive_…` ACL tokens) resolved at query time through the
+   * roster `syncGroups` maintains. SharePoint site-group grants (rare on
+   * personal drives — OneDrive is SharePoint underneath) emit
+   * `sitegroup:<title>` tokens but are NOT expanded: personal sites expose
+   * no practical roster API surface here, so those groups stay visible in
+   * the Groups tab with an empty roster — bounded fail-closed, admin member
+   * overrides still apply. Direct grantees resolve inline to emails (with
+   * the `resolveMappedEmail` override fallback) and roster under the
+   * synthetic `direct-grants` group. Tiers are progressive, probed lazily,
+   * cached per pass, always degrading fail-closed:
+   *  - base (Files.Read.All / Sites.Read.All): drive + permission lists,
+   *    group-token emission (identity only — no membership)
+   *  - + User.Read.All: Graph user-id → email, tenant-wide link expansion
+   *  - + GroupMember.Read.All: Entra/M365 roster expansion (syncGroups)
+   *  - + Sites.FullControl.All: sharing-aware delta probing
+   */
+  async *syncPermissionSnapshot(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const config = parseOneDriveConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid OneDrive configuration for permission sync");
+    }
+    this.initPermissionPass(params.credentials, config);
+    this.mappedEmailResolver = params.resolveMappedEmail ?? null;
+    const client = this.getGraphClient(params.credentials, config);
+
+    const containers = topContainers(config);
+    const scope = params.scope ? new Set(params.scope.containerKeys) : null;
+
+    for (const container of containers) {
+      if (scope && !scope.has(container.key)) continue;
+      // Resume: containers strictly before the cursor are done; the cursor
+      // container is re-processed (idempotent — same audiences).
+      if (params.cursor && container.key < params.cursor) continue;
+      yield* this.syncUserContainerSnapshot(client, container, params);
+    }
+
+    this.reportDroppedPrincipals();
+  }
+
+  /**
+   * Group roster sync (Users/Groups tabs + member overrides). Walks each
+   * configured user's drive-root permission surface, collects every granted
+   * Entra group and direct grantee, and expands Entra groups to members.
+   * Yielded groupIds byte-match the refs the audience path emits
+   * (`entra:<guid>` / `sitegroup:<title>`). Site groups yield an empty
+   * roster (not expandable here — see the container-model note). Direct
+   * grantees — including each drive's OWNER — roster under the synthetic
+   * `direct-grants` group so unmatched accounts are visible and
+   * override-assignable. A surface whose permission read fails is skipped
+   * here: the audience phase owns fail-closing its containers.
+   */
+  async *syncGroups(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<GroupMembershipYield> {
+    const config = parseOneDriveConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid OneDrive configuration for group sync");
+    }
+    this.initPermissionPass(params.credentials, config);
+    const client = this.getGraphClient(params.credentials, config);
+
+    const entraIds = new Set<string>();
+    const siteGroupTitles = new Set<string>();
+    const direct = new Map<string, GroupMemberYield>();
+
+    for (const container of topContainers(config)) {
+      const info = await this.resolveUserDrive(client, container.userId);
+      if (!info) continue; // audience phase owns fail-closing this container
+      if (info.ownerId) {
+        const email = await this.resolveGraphUserEmail(info.ownerId);
+        direct.set(info.ownerId, {
+          accountId: info.ownerId,
+          displayName: info.ownerDisplayName ?? null,
+          email: email ?? info.ownerEmail ?? null,
+          accountType: "user",
+        });
+      }
+      let permissions: OdPermission[];
+      try {
+        permissions = await this.listItemPermissions(
+          client,
+          `/drives/${info.driveId}/root/permissions`,
+        );
+      } catch (error) {
+        this.log.warn(
+          { userId: container.userId, error: extractErrorMessage(error) },
+          "Could not read a drive root's permissions for the group roster; its groups keep their previous roster this pass",
+        );
+        continue;
+      }
+      for (const permission of permissions) {
+        const identitySets = [
+          permission.grantedToV2,
+          ...(permission.grantedToIdentitiesV2 ?? []),
+        ];
+        for (const identitySet of identitySets) {
+          await this.collectRosterIdentity(
+            identitySet,
+            entraIds,
+            siteGroupTitles,
+            direct,
+          );
+        }
+      }
+    }
+
+    for (const groupId of [...entraIds].sort()) {
+      const members = await this.expandEntraGroup(groupId);
+      yield { groupId: entraGroupRef(groupId), members: members ?? [] };
+    }
+    for (const title of [...siteGroupTitles].sort()) {
+      // Not expandable on personal sites — empty roster, fail-closed.
+      yield { groupId: siteGroupRef(title), members: [] };
+    }
+    if (direct.size > 0) {
+      yield {
+        groupId: DIRECT_GRANTS_GROUP_ID,
+        members: [...direct.values()].sort((a, b) =>
+          a.accountId.localeCompare(b.accountId),
+        ),
+      };
+    }
+
+    this.reportDroppedPrincipals();
+  }
+
+  /**
+   * Delta-pass probe over each configured user's drive delta feed. With the
+   * elevated `deltashowsharingchanges` preference (Sites.FullControl.All),
+   * items whose SHARING changed carry an annotation and only those dirty
+   * the container; without the elevation any item drift dirties it (the
+   * safe coarse fallback). 410 Gone / rejected token ⇒ fullRequired.
+   */
+  async probePermissionChanges(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+    state: PermissionSyncState | null;
+  }): Promise<PermissionProbeResult> {
+    const config = parseOneDriveConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid OneDrive configuration for permission probe");
+    }
+    this.initPermissionPass(params.credentials, config);
+    const client = this.getGraphClient(params.credentials, config);
+    const containers = topContainers(config);
+
+    const stored =
+      params.state?.deltaTokens && typeof params.state.deltaTokens === "object"
+        ? (params.state.deltaTokens as Record<string, unknown>)
+        : null;
+    if (!stored) {
+      return {
+        dirtyContainerKeys: [],
+        fullRequired: true,
+        nextState: {
+          deltaTokens: await this.captureDeltaTokens(client, containers),
+        },
+      };
+    }
+
+    const dirty: string[] = [];
+    const nextTokens: Record<string, string> = {};
+    for (const container of containers) {
+      const token = stored[container.key];
+      if (typeof token !== "string" || !token) {
+        nextTokens[container.key] = await this.getLatestDeltaToken(
+          client,
+          container,
+        );
+        dirty.push(container.key);
+        continue;
+      }
+      try {
+        const outcome = await this.walkDriveDelta(client, container, {
+          token,
+          forProbe: true,
+        });
+        nextTokens[container.key] = outcome.deltaLink;
+        if (outcome.sawChange) dirty.push(container.key);
+      } catch (error) {
+        // Rejected/expired delta token (410 resync etc.) — the drift window
+        // is lost, so only a full reconcile restores correctness.
+        this.log.warn(
+          { containerKey: container.key, error: extractErrorMessage(error) },
+          "OneDrive delta token rejected; promoting to a full reconcile",
+        );
+        return {
+          dirtyContainerKeys: [],
+          fullRequired: true,
+          nextState: {
+            deltaTokens: await this.captureDeltaTokens(client, containers),
+          },
+        };
+      }
+    }
+
+    return {
+      dirtyContainerKeys: dirty.sort(),
+      fullRequired: false,
+      nextState: { deltaTokens: nextTokens },
+    };
+  }
+
+  /**
+   * Audience verification, run on every delta pass: re-resolve each stored
+   * top-level container's audience without enumerating items. Nested
+   * `.../item:<id>` containers are deliberately NOT yielded — their
+   * audiences follow assignment drift, which the enumerating passes own.
+   */
+  async *refreshContainerAudiences(params: {
+    config: Record<string, unknown>;
+    credentials: ConnectorCredentials;
+    containerKeys: string[];
+    resolveMappedEmail?: ResolveMappedEmail;
+  }): AsyncGenerator<{
+    containerKey: string;
+    permissions: DocumentPermissions;
+    audienceResolutionFailed?: boolean;
+  }> {
+    const config = parseOneDriveConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid OneDrive configuration for audience refresh");
+    }
+    this.initPermissionPass(params.credentials, config);
+    this.mappedEmailResolver = params.resolveMappedEmail ?? null;
+    const client = this.getGraphClient(params.credentials, config);
+
+    for (const containerKey of params.containerKeys) {
+      const userMatch = containerKey.match(/^user:([^/]+)$/);
+      if (!userMatch) continue; // nested item containers: assignment-tier
+      const audience = await this.resolveDriveRootAudience(
+        client,
+        userMatch[1],
+      );
+      yield {
+        containerKey,
+        permissions: audience.permissions,
+        audienceResolutionFailed: audience.resolutionFailed,
+      };
+    }
+
+    this.reportDroppedPrincipals();
+  }
+
+  /**
+   * Local-adoption scoping for delta passes: content-sync stamps
+   * `metadata.userId` on every drive item. Scoping only — the container
+   * enumeration resolves the authoritative assignment, so this can never
+   * over-grant.
+   */
+  scopeKeyForDocument(metadata: Record<string, unknown>): string | null {
+    const userId = metadata.userId;
+    if (typeof userId === "string" && userId.length > 0) {
+      return `user:${userId}`;
+    }
+    return null;
   }
 
   // ===== Private methods =====
@@ -636,6 +945,753 @@ export class OneDriveConnector extends BaseConnector {
 
     return count;
   }
+
+  // ===== Permission-sync internals =====
+
+  /** Arm (or re-arm) the per-pass state every permission hook shares. */
+  private initPermissionPass(
+    credentials: ConnectorCredentials,
+    config: OneDriveConfig,
+  ): void {
+    this.permCredentials = credentials;
+    this.permConfig = config;
+    this.userEmailCache = new Map();
+    this.entraGroupCache = new Map();
+    this.driveInfoCache = new Map();
+    this.tenantUsersCache = undefined;
+    this.graphUsersTier = null;
+    this.graphGroupsTier = null;
+    this.deltaSharingTier = null;
+    this.droppedPrincipals = 0;
+    this.mappedEmailResolver = null;
+  }
+
+  private async *syncUserContainerSnapshot(
+    client: Client,
+    container: OdContainer,
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const containerKey = container.key;
+
+    const docIds: string[] = [];
+    let afterId: string | null = null;
+    for (;;) {
+      const { documents, nextAfterId } = await params.readIngestedDocuments({
+        metadataFilter: { userId: container.userId },
+        afterId,
+        limit: PERMISSION_READBACK_PAGE_SIZE,
+      });
+      for (const doc of documents) docIds.push(doc.sourceId);
+      if (documents.length < PERMISSION_READBACK_PAGE_SIZE) break;
+      afterId = nextAfterId;
+    }
+    docIds.sort();
+
+    if (docIds.length === 0) {
+      // Empty corpus: emit the fail-closed boundary container WITHOUT
+      // resolving its audience (Jira precedent — not a resolution failure).
+      yield {
+        kind: "container",
+        containerKey,
+        permissions: emptyAudience(),
+        audienceResolutionFailed: false,
+        cursor: containerKey,
+      };
+      return;
+    }
+
+    const info = await this.resolveUserDrive(client, container.userId);
+    if (!info) {
+      // The drive itself could not be resolved: no enumeration is possible,
+      // so the whole corpus fail-closes under the top-level container.
+      yield {
+        kind: "container",
+        containerKey,
+        permissions: emptyAudience(),
+        audienceResolutionFailed: true,
+        cursor: containerKey,
+      };
+      for (const sourceId of docIds) {
+        yield {
+          kind: "document",
+          sourceId,
+          containerKey,
+          cursor: containerKey,
+        };
+      }
+      return;
+    }
+
+    // The corpus enumeration: one delta walk with hierarchicalsharing, which
+    // marks permission-hierarchy roots (items whose permissions no longer
+    // inherit) so unique-permission detection costs no per-item requests.
+    const walk = await this.walkDriveDelta(client, container, {
+      forProbe: false,
+    });
+    const items = walk.items ?? new Map();
+
+    const root = await this.resolveDriveRootAudience(client, container.userId);
+    yield {
+      kind: "container",
+      containerKey,
+      permissions: root.permissions,
+      audienceResolutionFailed: root.resolutionFailed,
+      cursor: containerKey,
+    };
+
+    const emittedNested = new Set<string>();
+    for (const sourceId of docIds) {
+      const governingItemId = findGoverningScopeRoot(items, sourceId);
+      if (!governingItemId) {
+        yield {
+          kind: "document",
+          sourceId,
+          containerKey,
+          cursor: containerKey,
+        };
+        continue;
+      }
+      const nestedKey = `${containerKey}/item:${governingItemId}`;
+      if (!emittedNested.has(nestedKey)) {
+        const audience = await this.resolveItemAudience(
+          client,
+          info,
+          governingItemId,
+        );
+        yield {
+          kind: "container",
+          containerKey: nestedKey,
+          permissions: audience.permissions,
+          audienceResolutionFailed: audience.resolutionFailed,
+          cursor: containerKey,
+        };
+        emittedNested.add(nestedKey);
+      }
+      yield {
+        kind: "document",
+        sourceId,
+        containerKey: nestedKey,
+        cursor: containerKey,
+      };
+    }
+  }
+
+  /**
+   * Resolve a configured user's drive (id + owner), cached per pass.
+   * `null` means the drive could not be resolved — callers fail-close.
+   */
+  private async resolveUserDrive(
+    client: Client,
+    userId: string,
+  ): Promise<OdDriveInfo | null> {
+    const cached = this.driveInfoCache.get(userId);
+    if (cached !== undefined) return cached;
+    let info: OdDriveInfo | null = null;
+    try {
+      await this.rateLimit();
+      const drive = (await client
+        .api(`${GRAPH_API_BASE}/users/${userId}/drive?$select=id,owner`)
+        .get()) as {
+        id?: string;
+        owner?: {
+          user?: { id?: string; displayName?: string; email?: string };
+        };
+      };
+      if (drive.id) {
+        info = {
+          driveId: drive.id,
+          ownerId: drive.owner?.user?.id ?? null,
+          ownerDisplayName: drive.owner?.user?.displayName ?? null,
+          ownerEmail: drive.owner?.user?.email?.toLowerCase() ?? null,
+        };
+      }
+    } catch (error) {
+      this.log.error(
+        { userId, error: extractErrorMessage(error) },
+        "Could not resolve the user's drive; every document in it is fail-closed for this pass",
+      );
+    }
+    this.driveInfoCache.set(userId, info);
+    return info;
+  }
+
+  /**
+   * One drive's delta feed. Enumeration mode (`forProbe: false`) buffers
+   * every item's id/parent/scope-root flag and asks for
+   * `hierarchicalsharing` so scope roots carry a `shared` facet. Probe mode
+   * walks a stored delta link and reports whether anything drifted —
+   * sharing-only drift when the elevated `deltashowsharingchanges`
+   * preference is honored, any drift when the tenant denies it (403 ⇒
+   * cache the denial, retry coarse).
+   */
+  private async walkDriveDelta(
+    client: Client,
+    container: OdContainer,
+    opts: { token?: string; forProbe: boolean },
+  ): Promise<{
+    items: Map<string, DeltaItemEntry> | null;
+    deltaLink: string;
+    sawChange: boolean;
+  }> {
+    const info = await this.resolveUserDrive(client, container.userId);
+    if (!info) {
+      throw new Error(
+        `OneDrive drive resolution failed for user ${container.userId}`,
+      );
+    }
+    const startUrl =
+      opts.token ?? `${GRAPH_API_BASE}/drives/${info.driveId}/root/delta`;
+
+    let sharingPreference = opts.forProbe && this.deltaSharingTier !== false;
+    let url: string | undefined = startUrl;
+    const items = opts.forProbe ? null : new Map<string, DeltaItemEntry>();
+    let sawChange = false;
+
+    for (;;) {
+      if (!url) break;
+      await this.rateLimit();
+      let result: GraphDeltaPage;
+      try {
+        result = (await client
+          .api(url)
+          .header(
+            "Prefer",
+            opts.forProbe
+              ? sharingPreference
+                ? DELTA_SHARING_PREFER
+                : DELTA_PLAIN_PREFER
+              : DELTA_ENUM_PREFER,
+          )
+          .get()) as GraphDeltaPage;
+      } catch (error) {
+        if (opts.forProbe && sharingPreference && isGraphForbidden(error)) {
+          // Progressive degradation: the app lacks Sites.FullControl.All —
+          // the sharing-aware preference is rejected, so probe coarsely
+          // (any drift dirties the container) for the rest of this pass.
+          sharingPreference = false;
+          this.deltaSharingTier = false;
+          this.log.warn(
+            "OneDrive delta sharing-change preference rejected (Sites.FullControl.All missing); probing coarsely",
+          );
+          url = startUrl;
+          sawChange = false;
+          continue;
+        }
+        throw error;
+      }
+
+      for (const item of result.value ?? []) {
+        if (opts.forProbe) {
+          if (sharingPreference) {
+            const marker = item["@microsoft.graph.sharedChanged"];
+            if (marker === "True" || marker === "true" || marker === true) {
+              sawChange = true;
+            }
+          } else {
+            sawChange = true;
+          }
+          continue;
+        }
+        if (item.deleted) continue;
+        const parentId = item.parentReference?.id ?? null;
+        items?.set(item.id, {
+          parentId,
+          // hierarchicalsharing marks permission-hierarchy roots with a
+          // `shared` facet (empty when the root establishes an unshared
+          // scope) — presence is the unique-permissions signal.
+          scopeRoot: parentId !== null && item.shared !== undefined,
+        });
+      }
+
+      const deltaLink = result["@odata.deltaLink"];
+      if (deltaLink) {
+        return { items, deltaLink, sawChange };
+      }
+      url = result["@odata.nextLink"] ?? undefined;
+    }
+    // A delta walk always ends in a deltaLink; reaching here means the feed
+    // ended without one — treat as a rejected token upstream of the caller.
+    throw new Error("OneDrive delta walk ended without a delta link");
+  }
+
+  private async getLatestDeltaToken(
+    client: Client,
+    container: OdContainer,
+  ): Promise<string> {
+    const info = await this.resolveUserDrive(client, container.userId);
+    if (!info) {
+      throw new Error(
+        `OneDrive drive resolution failed for user ${container.userId}`,
+      );
+    }
+    await this.rateLimit();
+    const result = (await client
+      .api(`${GRAPH_API_BASE}/drives/${info.driveId}/root/delta?token=latest`)
+      .get()) as GraphDeltaPage;
+    return result["@odata.deltaLink"] ?? "";
+  }
+
+  private async captureDeltaTokens(
+    client: Client,
+    containers: OdContainer[],
+  ): Promise<Record<string, string>> {
+    const tokens: Record<string, string> = {};
+    for (const container of containers) {
+      tokens[container.key] = await this.getLatestDeltaToken(client, container);
+    }
+    return tokens;
+  }
+
+  /**
+   * A drive root's effective audience: the root permission list PLUS the
+   * drive owner (personal drives do not list their owner). Failure
+   * fail-closes the corpus — including the owner (an unverified audience
+   * is not partially granted).
+   */
+  private async resolveDriveRootAudience(
+    client: Client,
+    userId: string,
+  ): Promise<{ permissions: DocumentPermissions; resolutionFailed: boolean }> {
+    const info = await this.resolveUserDrive(client, userId);
+    if (!info) {
+      return { permissions: emptyAudience(), resolutionFailed: true };
+    }
+    try {
+      const permissions = await this.listItemPermissions(
+        client,
+        `/drives/${info.driveId}/root/permissions`,
+      );
+      return {
+        permissions: await this.permissionsToAudience(permissions, info),
+        resolutionFailed: false,
+      };
+    } catch (error) {
+      this.log.error(
+        { userId, error: extractErrorMessage(error) },
+        "Could not read the drive root's permissions; every document in it is fail-closed for this pass",
+      );
+      return { permissions: emptyAudience(), resolutionFailed: true };
+    }
+  }
+
+  /**
+   * One item's effective audience (the permission list folds inherited
+   * entries in — no inheritance math here), plus the drive owner. A read
+   * failure fail-closes THIS item's subtree only — never fall back to the
+   * parent audience on error (a transient 429/5xx must not become an
+   * over-grant).
+   */
+  private async resolveItemAudience(
+    client: Client,
+    info: OdDriveInfo,
+    itemId: string,
+  ): Promise<{ permissions: DocumentPermissions; resolutionFailed: boolean }> {
+    try {
+      const permissions = await this.listItemPermissions(
+        client,
+        `/drives/${info.driveId}/items/${itemId}/permissions`,
+      );
+      return {
+        permissions: await this.permissionsToAudience(permissions, info),
+        resolutionFailed: false,
+      };
+    } catch (error) {
+      this.log.warn(
+        { driveId: info.driveId, itemId, error: extractErrorMessage(error) },
+        "Could not read the item's permissions; its documents are fail-closed for this pass",
+      );
+      return { permissions: emptyAudience(), resolutionFailed: true };
+    }
+  }
+
+  /** Paginate a Graph permission collection. */
+  private async listItemPermissions(
+    client: Client,
+    path: string,
+  ): Promise<OdPermission[]> {
+    const out: OdPermission[] = [];
+    let url: string | undefined = `${GRAPH_API_BASE}${path}`;
+    while (url) {
+      await this.rateLimit();
+      const result = (await client
+        .api(url)
+        .get()) as GraphListResponse<OdPermission>;
+      out.push(...(result.value ?? []));
+      url = result["@odata.nextLink"] ?? undefined;
+    }
+    return out;
+  }
+
+  /**
+   * Map Graph permission principals to a document audience, always
+   * including the drive owner. Group grants emit group REFERENCES
+   * (`entra:<guid>` / `sitegroup:<title>`) — resolved to users at query
+   * time through the roster `syncGroups` maintains — and direct users
+   * resolve inline to emails (with the admin member-override fallback for
+   * accounts whose upstream email is hidden). Anonymous links are genuinely
+   * public (isPublic — the Jira "anyone" precedent); organization links
+   * expand to the tenant's active users, NOT org-wide (a revocable set —
+   * the Jira applicationRole precedent). Application grants carry no user
+   * access and are ignored.
+   */
+  private async permissionsToAudience(
+    permissions: OdPermission[],
+    info: OdDriveInfo,
+  ): Promise<DocumentPermissions> {
+    const users = new Set<string>();
+    const groups = new Set<string>();
+    let isPublic = false;
+    for (const permission of permissions) {
+      const scope = permission.link?.scope;
+      if (scope === "anonymous") {
+        isPublic = true;
+      } else if (scope === "organization") {
+        const tenantUsers = await this.expandTenantUsers();
+        if (tenantUsers) {
+          for (const email of tenantUsers) users.add(email);
+        }
+      }
+      const identitySets = [
+        permission.grantedToV2,
+        ...(permission.grantedToIdentitiesV2 ?? []),
+      ];
+      for (const identitySet of identitySets) {
+        await this.applyIdentitySet(identitySet, users, groups);
+      }
+    }
+    await this.applyDriveOwner(info, users);
+    return { isPublic, users: [...users], groups: [...groups] };
+  }
+
+  /** The owner belongs to every audience in a single-owner drive. */
+  private async applyDriveOwner(
+    info: OdDriveInfo,
+    users: Set<string>,
+  ): Promise<void> {
+    if (info.ownerId) {
+      const email =
+        (await this.resolveGraphUserEmail(info.ownerId)) ??
+        info.ownerEmail ??
+        this.mappedEmailResolver?.(info.ownerId);
+      if (email) {
+        users.add(email.toLowerCase());
+        return;
+      }
+      this.droppedPrincipals += 1;
+      return;
+    }
+    if (info.ownerEmail) users.add(info.ownerEmail);
+  }
+
+  private async applyIdentitySet(
+    identitySet: OdIdentitySet | undefined,
+    users: Set<string>,
+    groups: Set<string>,
+  ): Promise<void> {
+    if (!identitySet) return;
+    if (identitySet.user?.id) {
+      const email = await this.resolveGraphUserEmail(identitySet.user.id);
+      const mapped = email ?? this.mappedEmailResolver?.(identitySet.user.id);
+      if (mapped) users.add(mapped.toLowerCase());
+      else this.droppedPrincipals += 1;
+    }
+    if (identitySet.siteUser?.loginName) {
+      await this.applyLoginName(identitySet.siteUser.loginName, users, groups);
+    }
+    if (identitySet.siteGroup?.displayName) {
+      groups.add(siteGroupRef(identitySet.siteGroup.displayName));
+    }
+    if (identitySet.group?.id) {
+      groups.add(entraGroupRef(identitySet.group.id));
+    }
+  }
+
+  /**
+   * A SharePoint claims login name → whoever it denotes: a user email
+   * (`i:0#.f|membership|user@domain`), an Entra group
+   * (`…|federateddirectoryclaimprovider|<guid>`), or the whole-tenant claim
+   * (`spo-grid-all-users` / `rolemanager|…|true`). OneDrive for Business is
+   * SharePoint underneath, so these facets appear on its permissions too.
+   */
+  private async applyLoginName(
+    loginName: string,
+    users: Set<string>,
+    groups: Set<string>,
+  ): Promise<void> {
+    const lowered = loginName.toLowerCase();
+    if (
+      lowered.includes("spo-grid-all-users") ||
+      lowered.includes("|rolemanager|") ||
+      lowered === "c:0(.s|true"
+    ) {
+      const tenantUsers = await this.expandTenantUsers();
+      if (tenantUsers) {
+        for (const email of tenantUsers) users.add(email);
+      }
+      return;
+    }
+    if (lowered.includes("|federateddirectoryclaimprovider|")) {
+      const groupId = loginName.split("|").pop();
+      if (groupId) groups.add(entraGroupRef(groupId));
+      else this.droppedPrincipals += 1;
+      return;
+    }
+    if (lowered.startsWith("i:0#.f|membership|")) {
+      const email = loginName.split("|").pop()?.toLowerCase();
+      if (email?.includes("@")) {
+        users.add(email);
+        return;
+      }
+    }
+    const mapped = this.mappedEmailResolver?.(loginName);
+    if (mapped) {
+      users.add(mapped.toLowerCase());
+      return;
+    }
+    this.droppedPrincipals += 1;
+  }
+
+  /** Roster-side principal collection (audience-side is applyIdentitySet). */
+  private async collectRosterIdentity(
+    identitySet: OdIdentitySet | undefined,
+    entraIds: Set<string>,
+    siteGroupTitles: Set<string>,
+    direct: Map<string, GroupMemberYield>,
+  ): Promise<void> {
+    if (!identitySet) return;
+    if (identitySet.group?.id) entraIds.add(identitySet.group.id);
+    if (identitySet.siteGroup?.displayName) {
+      siteGroupTitles.add(identitySet.siteGroup.displayName);
+    }
+    if (identitySet.user?.id) {
+      // Roster the UPSTREAM identity: email stays null when hidden — that
+      // is exactly the row an admin assigns manually.
+      const email = await this.resolveGraphUserEmail(identitySet.user.id);
+      direct.set(identitySet.user.id, {
+        accountId: identitySet.user.id,
+        displayName: identitySet.user.displayName ?? null,
+        email,
+        accountType: "user",
+      });
+      return;
+    }
+    const loginName = identitySet.siteUser?.loginName;
+    if (!loginName) return;
+    const lowered = loginName.toLowerCase();
+    if (lowered.includes("|federateddirectoryclaimprovider|")) {
+      const groupId = loginName.split("|").pop();
+      if (groupId) entraIds.add(groupId);
+      return;
+    }
+    if (
+      lowered.includes("spo-grid-all-users") ||
+      lowered.includes("|rolemanager|") ||
+      lowered === "c:0(.s|true"
+    ) {
+      return; // whole-tenant claims are not rosterable
+    }
+    const claimEmail = lowered.startsWith("i:0#.f|membership|")
+      ? loginName.split("|").pop()?.toLowerCase()
+      : undefined;
+    direct.set(loginName, {
+      accountId: loginName,
+      displayName: identitySet.siteUser?.displayName ?? null,
+      email: claimEmail?.includes("@") ? claimEmail : null,
+      accountType: "siteUser",
+    });
+  }
+
+  /** Graph user id → email. Tier: User.Read.All (probed once per pass). */
+  private async resolveGraphUserEmail(userId: string): Promise<string | null> {
+    const cached = this.userEmailCache.get(userId);
+    if (cached !== undefined) return cached;
+    let email: string | null = null;
+    if (await this.hasGraphUsersTier()) {
+      try {
+        const client = this.getGraphClient(
+          this.requirePermCredentials(),
+          this.requirePermConfig(),
+        );
+        await this.rateLimit();
+        const user = (await client
+          .api(
+            `${GRAPH_API_BASE}/users/${userId}?$select=mail,userPrincipalName`,
+          )
+          .get()) as { mail?: string | null; userPrincipalName?: string };
+        email = (user.mail ?? user.userPrincipalName)?.toLowerCase() ?? null;
+      } catch (error) {
+        this.log.debug(
+          { error: extractErrorMessage(error) },
+          "Could not resolve Graph user email",
+        );
+      }
+    }
+    this.userEmailCache.set(userId, email);
+    return email;
+  }
+
+  /**
+   * Entra/M365 group → transitive member roster. Tier:
+   * GroupMember.Read.All. Nested groups arrive pre-flattened
+   * (transitiveMembers); non-user directory objects are skipped. A member
+   * whose email is hidden is still rostered (email: null — admin-visible,
+   * override-assignable).
+   */
+  private async expandEntraGroup(
+    groupId: string,
+  ): Promise<GroupMemberYield[] | null> {
+    const cached = this.entraGroupCache.get(groupId);
+    if (cached !== undefined) return cached;
+    if (this.graphGroupsTier === false) return null;
+    let members: GroupMemberYield[] | null = null;
+    try {
+      const client = this.getGraphClient(
+        this.requirePermCredentials(),
+        this.requirePermConfig(),
+      );
+      const byAccount = new Map<string, GroupMemberYield>();
+      let url: string | undefined =
+        `${GRAPH_API_BASE}/groups/${groupId}/transitiveMembers?$select=id,displayName,mail,userPrincipalName,accountEnabled&$top=999`;
+      while (url) {
+        await this.rateLimit();
+        const result = (await client.api(url).get()) as GraphListResponse<{
+          "@odata.type"?: string;
+          id?: string;
+          displayName?: string | null;
+          mail?: string | null;
+          userPrincipalName?: string;
+          accountEnabled?: boolean;
+        }>;
+        for (const member of result.value ?? []) {
+          if (!member.id) continue;
+          const odataType = member["@odata.type"];
+          // transitiveMembers mixes users with nested groups/devices; only
+          // user objects carry access. Entries without a type hint are kept
+          // when they look like users (have a UPN).
+          if (odataType && !odataType.endsWith("user")) continue;
+          if (!odataType && !member.userPrincipalName && !member.mail) {
+            continue;
+          }
+          const email =
+            member.accountEnabled === false
+              ? null
+              : ((member.mail ?? member.userPrincipalName)?.toLowerCase() ??
+                null);
+          byAccount.set(member.id, {
+            accountId: member.id,
+            displayName: member.displayName ?? null,
+            email,
+          });
+        }
+        url = result["@odata.nextLink"] ?? undefined;
+      }
+      members = [...byAccount.values()];
+      this.graphGroupsTier = true;
+    } catch (error) {
+      if (isGraphForbidden(error)) {
+        this.graphGroupsTier = false;
+        this.log.warn(
+          "Entra group expansion denied (GroupMember.Read.All missing); group memberships degrade fail-closed for this pass",
+        );
+      } else {
+        this.log.warn(
+          { error: extractErrorMessage(error) },
+          "Could not expand Entra group; its memberships are dropped fail-closed",
+        );
+      }
+      this.droppedPrincipals += 1;
+    }
+    this.entraGroupCache.set(groupId, members);
+    return members;
+  }
+
+  /** All active tenant users (org-wide links). Tier: User.Read.All. */
+  private async expandTenantUsers(): Promise<string[] | null> {
+    if (this.tenantUsersCache !== undefined) return this.tenantUsersCache;
+    let members: string[] | null = null;
+    if (await this.hasGraphUsersTier()) {
+      try {
+        const client = this.getGraphClient(
+          this.requirePermCredentials(),
+          this.requirePermConfig(),
+        );
+        const emails = new Set<string>();
+        let url: string | undefined =
+          `${GRAPH_API_BASE}/users?$select=mail,userPrincipalName,accountEnabled&$top=999`;
+        while (url) {
+          await this.rateLimit();
+          const result = (await client.api(url).get()) as GraphListResponse<{
+            mail?: string | null;
+            userPrincipalName?: string;
+            accountEnabled?: boolean;
+          }>;
+          for (const user of result.value ?? []) {
+            if (user.accountEnabled === false) continue;
+            const email = (user.mail ?? user.userPrincipalName)?.toLowerCase();
+            if (email) emails.add(email);
+          }
+          url = result["@odata.nextLink"] ?? undefined;
+        }
+        members = [...emails];
+      } catch (error) {
+        this.log.warn(
+          { error: extractErrorMessage(error) },
+          "Could not enumerate tenant users; organization-wide links degrade fail-closed for this pass",
+        );
+      }
+    }
+    if (!members) this.droppedPrincipals += 1;
+    this.tenantUsersCache = members;
+    return members;
+  }
+
+  /** User.Read.All probe, cached per pass. */
+  private async hasGraphUsersTier(): Promise<boolean> {
+    if (this.graphUsersTier === null) {
+      try {
+        const client = this.getGraphClient(
+          this.requirePermCredentials(),
+          this.requirePermConfig(),
+        );
+        await this.rateLimit();
+        await client.api(`${GRAPH_API_BASE}/users?$select=id&$top=1`).get();
+        this.graphUsersTier = true;
+      } catch (error) {
+        this.graphUsersTier = false;
+        this.log.debug(
+          { error: extractErrorMessage(error) },
+          "Graph users tier unavailable (User.Read.All missing); Graph-id principals drop fail-closed",
+        );
+      }
+    }
+    return this.graphUsersTier;
+  }
+
+  private requirePermCredentials(): ConnectorCredentials {
+    if (!this.permCredentials) throw new Error("permission pass not armed");
+    return this.permCredentials;
+  }
+
+  private requirePermConfig(): OneDriveConfig {
+    if (!this.permConfig) throw new Error("permission pass not armed");
+    return this.permConfig;
+  }
+
+  /** Surface principals dropped this pass (fail-closed under-grant). */
+  private reportDroppedPrincipals(): void {
+    if (this.droppedPrincipals <= 0) return;
+    const count = this.droppedPrincipals;
+    this.droppedPrincipals = 0;
+    this.log.debug(
+      { count, connectorType: this.type },
+      "Dropped OneDrive principals that could not be resolved (fail-closed)",
+    );
+    metrics.rag.reportPermissionSyncDroppedPrincipals({
+      connectorType: this.type,
+      reason: "no_email",
+      count,
+    });
+  }
 }
 
 // ===== Module-level helpers =====
@@ -644,6 +1700,110 @@ type GraphListResponse<T> = {
   value: T[];
   "@odata.nextLink"?: string;
 };
+
+// ===== Permission-sync types & helpers =====
+
+const PERMISSION_READBACK_PAGE_SIZE = 1000;
+/** Scanning-guidance preference: mark permission-hierarchy roots. */
+const DELTA_ENUM_PREFER = "deltashowremovedasdeleted, hierarchicalsharing";
+/** Elevated probe preference: annotate items whose SHARING changed. */
+const DELTA_SHARING_PREFER =
+  "deltashowremovedasdeleted, deltatraversepermissiongaps, deltashowsharingchanges";
+const DELTA_PLAIN_PREFER = "deltashowremovedasdeleted";
+
+/** A top-level permission container: one configured user's drive. */
+type OdContainer = { key: string; userId: string };
+
+/** A configured user's resolved drive (id + owner), cached per pass. */
+type OdDriveInfo = {
+  driveId: string;
+  ownerId: string | null;
+  ownerDisplayName: string | null;
+  ownerEmail: string | null;
+};
+
+/** One buffered delta-walk item (ids + the unique-permissions marker only). */
+type DeltaItemEntry = { parentId: string | null; scopeRoot: boolean };
+
+type GraphDeltaPage = {
+  value?: Array<{
+    id: string;
+    parentReference?: { id?: string };
+    deleted?: object;
+    shared?: object;
+    "@microsoft.graph.sharedChanged"?: string | boolean;
+  }>;
+  "@odata.nextLink"?: string;
+  "@odata.deltaLink"?: string;
+};
+
+/** Narrowed Graph permission resource (the facets we read). */
+type OdPermission = {
+  link?: { scope?: string };
+  grantedToV2?: OdIdentitySet;
+  grantedToIdentitiesV2?: OdIdentitySet[];
+};
+
+type OdIdentitySet = {
+  user?: { id?: string; displayName?: string };
+  siteUser?: { loginName?: string; displayName?: string };
+  siteGroup?: { displayName?: string };
+  group?: { id?: string };
+  application?: { id?: string };
+};
+
+/**
+ * The connector's top-level containers, sorted for a monotonic cursor. The
+ * key embeds the CONFIGURED user id so it byte-matches `metadata.userId`.
+ */
+function topContainers(config: OneDriveConfig): OdContainer[] {
+  return config.userIds
+    .map((userId) => ({ key: `user:${userId}`, userId }))
+    .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+}
+
+/**
+ * The nearest ancestor (or self) whose permissions no longer inherit — the
+ * item whose audience governs this document. `null` means the drive root's
+ * audience governs. The delta walk covers the whole drive, so a chain that
+ * leaves the buffer exited at the root.
+ */
+function findGoverningScopeRoot(
+  items: Map<string, DeltaItemEntry>,
+  sourceId: string,
+): string | null {
+  let currentId: string | null = sourceId;
+  while (currentId) {
+    const entry = items.get(currentId);
+    if (!entry || entry.parentId === null) return null;
+    if (entry.scopeRoot) return currentId;
+    currentId = entry.parentId;
+  }
+  return null;
+}
+
+/**
+ * Roster group ids — byte-matched between the audience path's `groups` refs
+ * and `syncGroups` yields (the `group:onedrive_<id>` token contract).
+ */
+function entraGroupRef(groupId: string): string {
+  return `entra:${groupId}`;
+}
+function siteGroupRef(title: string): string {
+  return `sitegroup:${title}`;
+}
+/** Synthetic roster group for direct (non-group) grantees. */
+const DIRECT_GRANTS_GROUP_ID = "direct-grants";
+
+function emptyAudience(): DocumentPermissions {
+  return { isPublic: false, users: [], groups: [] };
+}
+
+/** 401/403 from the Graph SDK (statusCode on the thrown object). */
+function isGraphForbidden(error: unknown): boolean {
+  const status = (error as { statusCode?: number })?.statusCode;
+  return status === 401 || status === 403;
+}
 
 type RequiredNonNull<T, K extends keyof T> = {
   [P in K]-?: NonNullable<T[P]>;

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
@@ -347,6 +347,7 @@ const AUTO_SYNC_CONNECTOR_TYPES: ReadonlySet<ConnectorType> = new Set([
   "gdrive",
   "sharepoint",
   "salesforce",
+  "onedrive",
 ]);
 
 export function connectorSupportsAutoSync(type: ConnectorType): boolean {


### PR DESCRIPTION
Adds knowledge-base permission auto-sync (`auto-sync-permissions` visibility) support for the **OneDrive** connector, following the SharePoint implementation ([#7209](https://github.com/archestra-ai/archestra/pull/7209), T-907). One connector of the remaining nine tracked in T-908 ([issue #7154](https://github.com/archestra-ai/archestra/issues/7154)) — the others are unaffected and unaddressed here.

Everything is connector-local — the permission-sync pass, scheduler, routes, and frontend already key off `supportsPermissionSync`, so no core changes were needed.

## OneDrive

- Containers `user:<userId>` per configured user, byte-matching the `metadata.userId` every ingested document already carries (no re-ingestion needed, pure `scopeKeyForDocument`). An item that breaks permission inheritance becomes its own nested `user:<id>/item:<itemId>` scope, via the delta feed's `hierarchicalsharing` preference (no per-item requests).
- The drive **owner** joins every audience in the drive — personal drives do not list their owner in permission lists, so the connector adds them explicitly. A failed permission read still fail-closes to the empty audience, owner included: an audience that couldn't be verified is never partially granted.
- Group grants emit `entra:<guid>` tokens; `syncGroups` rosters them via `transitiveMembers`. Direct grantees (including the owner) roster under the synthetic `direct-grants` group. SharePoint site groups on personal drives emit tokens but roster empty (documented approximation — no practical roster API surface for personal sites).
- Progressive tiers, probed lazily, always degrading fail-closed: `Files.Read.All` base → `User.Read.All` (emails, tenant-wide links) → `GroupMember.Read.All` (Entra rosters) → `Sites.FullControl.All` (sharing-aware delta probes). A rejected/expired delta token (410) promotes to a full reconcile.

## Test plan

- 17 new connector tests (51 total in the file): can-read / cannot-read audiences, unreadable container / item / drive fail-close, empty-corpus boundary, anonymous/organization link scopes, tier denials (403 degrades fail-closed), roster contracts, probe transitions (fresh / sharing-annotated / coarse-degraded / 410), cursor resume + scope filtering.
- 152 tests green across the OneDrive connector, SharePoint connector, pass-machinery (`permission-sync.test.ts`, `.integration.test.ts`, `.mixed-visibility.test.ts`), and the permission-sync task-queue handler — no regression.
- Live-verified on a dev stack: the `auto-sync-permissions` create gate admits `onedrive` and still rejects unsupported connector types with the standard 400; a real Entra tenant round-trip confirmed client-credentials auth and Graph calls succeed end-to-end (content sync reached the user's drive; further live verification with seeded fixtures in progress separately).
- Docs updated (`platform-knowledge.md`): OneDrive moved to the Supported table, an email-visibility bullet, and a permission-tier matrix section matching SharePoint's.

Origin: PM task T-908 (OneDrive slice).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>