### PR TITLE
feat(knowledge): auto-sync permissions for the Notion connector (Limited)

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -182,27 +182,27 @@ Auto-sync connectors are gated by the dedicated `knowledgeSourceAutoSync` permis
 
 Auto-sync permissions mirrors the data source system's access control into Archestra. When a user queries the knowledge base, they get back only the content they are allowed to see in the source system. A user with the `knowledgeSource:admin` role bypasses the ACL and sees everything.
 
-Auto-sync permissions works with the connectors marked *Supported* below. The others do not support it yet.
+Auto-sync permissions works with the connectors marked *Supported* below. *Limited* means the source's access control is mirrored with a coarser audience model — the row says which. The others do not support it yet.
 
-| Connector    | Auto-sync permissions         |
-| ------------ | ----------------------------- |
-| Confluence   | Supported                     |
-| GitHub       | Supported                     |
-| Jira         | Supported                     |
-| M-Files      | Supported with the VAF Add On |
-| Google Drive | Supported                     |
-| OneDrive     | Supported                     |
-| Salesforce   | Supported                     |
-| SharePoint   | Supported                     |
-| Asana        | Not supported                 |
-| Dropbox      | Not supported                 |
-| GitLab       | Not supported                 |
-| Linear       | Not supported                 |
-| Notion       | Not supported                 |
-| Outline      | Not supported                 |
-| Perforce     | Not supported                 |
-| ServiceNow   | Not supported                 |
-| Web Crawler  | Not supported                 |
+| Connector    | Auto-sync permissions                                                                                     |
+| ------------ | --------------------------------------------------------------------------------------------------------- |
+| Confluence   | Supported                                                                                                 |
+| GitHub       | Supported                                                                                                 |
+| Jira         | Supported                                                                                                 |
+| M-Files      | Supported with the VAF Add On                                                                             |
+| Google Drive | Supported                                                                                                 |
+| Notion       | Limited: every synced page is visible to all workspace members ([details](#notion-auto-sync-permissions)) |
+| OneDrive     | Supported                                                                                                 |
+| Salesforce   | Supported                                                                                                 |
+| SharePoint   | Supported                                                                                                 |
+| Asana        | Not supported                                                                                             |
+| Dropbox      | Not supported                                                                                             |
+| GitLab       | Not supported                                                                                             |
+| Linear       | Not supported                                                                                             |
+| Outline      | Not supported                                                                                             |
+| Perforce     | Not supported                                                                                             |
+| ServiceNow   | Not supported                                                                                             |
+| Web Crawler  | Not supported                                                                                             |
 
 **Upstream email visibility.** Each source hides emails behind its own rule, and a credential that can't see them produces a snapshot full of unresolvable (fail-closed) members:
 
@@ -211,6 +211,7 @@ Auto-sync permissions works with the connectors marked *Supported* below. The ot
 - **SharePoint** returns SharePoint user logins directly. Expanding a Microsoft 365 group or a SharePoint site group to its members needs the extra app permissions listed under [SharePoint](#sharepoint).
 - **OneDrive** resolves user grants and drive owners to emails through the `User.Read.All` app permission. Without it, those accounts stay unresolvable. See [OneDrive](#onedrive).
 - **Salesforce** reads user emails and group membership through the same login the connector already uses. No extra credential is needed.
+- **Notion** returns member emails only when the integration has the **"read user information including email addresses"** capability. Guests are never listed.
 
 **Permission-read access.** The credential must also be able to read the source's permission settings — Jira permission schemes, Confluence space permissions, GitHub repository collaborators. A credential that cannot read them hides that project or space from everyone, because Archestra never assumes an audience it could not verify. Each sync run reports how many it could not read, so a project nobody can find is easy to tell apart from a project nobody is granted.
 
@@ -356,12 +357,29 @@ Sync pages and databases from a Notion workspace.
 
 **Indexed:** pages from a Notion workspace.
 
-**Authentication:** a [Notion integration token](https://www.notion.so/my-integrations) (starts with `secret_`). Create an internal integration in your workspace and share the relevant pages or databases with it.
+**Authentication:** an internal integration secret from the [Notion Developer portal](https://app.notion.com/developers/connections). New secrets start with `ntn_`; older `secret_` tokens keep working. Create an internal integration in your workspace and share the relevant pages or databases with it.
 
 | Field        | Description                                                                                        |
 | ------------ | -------------------------------------------------------------------------------------------------- |
 | Database IDs | Comma-separated Notion database IDs to sync (optional -- leave blank to sync all accessible pages) |
 | Page IDs     | Comma-separated specific Notion page IDs to sync (optional -- takes precedence over Database IDs)  |
+
+#### Notion Auto-Sync Permissions
+
+Support is *Limited*. Notion's API does not say who can see a page — there is no sharing endpoint, and teamspaces are not exposed. Archestra cannot mirror per-page access, so every synced page shares one workspace-wide audience:
+
+- A synced page is visible to every workspace member whose Notion email matches an Archestra user's email.
+- Each permission sync refreshes the member roster from Notion's users API. The connector page shows a **Workspaces** tab in place of Groups, with one row per connector: the workspace, named as it is in Notion.
+- Guests are never in Notion's member listing, so a guest never gains access through Archestra.
+- Member emails need the integration capability **"read user information including email addresses"** (integration settings, **Capabilities** tab). A member without a readable email stays unresolvable (fail-closed) until you assign them from the Users tab.
+
+A page that is private or teamspace-restricted in Notion, but shared with the integration, becomes readable by every workspace member through Archestra. Set up the integration's access with that in mind:
+
+- Share only workspace-appropriate content with the integration — a company wiki teamspace, for example.
+- Do not share private pages or restricted teamspaces with the integration.
+- For content that must reach a narrower audience, use a separate connector with **Team-scoped** visibility.
+
+This is still stricter than an org-wide connector: access stops at the workspace member roster instead of your whole Archestra organization, and it updates as members join and leave.
 
 ### SharePoint
 

--- a/platform/backend/src/knowledge-base/connectors/notion/notion-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/notion/notion-connector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ConnectorSyncBatch } from "@/types";
+import type { ConnectorSyncBatch, ReadIngestedDocuments } from "@/types";
 import { NotionConnector } from "./notion-connector";
 
 // Helper to build a mock Notion page object
@@ -1017,6 +1017,288 @@ describe("NotionConnector", () => {
 
       await expect(generator.next()).rejects.toThrow(
         "Invalid Notion configuration",
+      );
+    });
+  });
+
+  describe("permission sync", () => {
+    async function collect<T>(gen: AsyncGenerator<T>): Promise<T[]> {
+      const items: T[] = [];
+      for await (const item of gen) {
+        items.push(item);
+      }
+      return items;
+    }
+
+    function makeUser(
+      id: string,
+      opts?: { name?: string | null; email?: string | null; bot?: boolean },
+    ) {
+      return {
+        object: "user",
+        id,
+        name: opts?.name ?? null,
+        avatar_url: null,
+        ...(opts?.bot
+          ? { type: "bot", bot: {} }
+          : {
+              type: "person",
+              person: opts?.email != null ? { email: opts.email } : {},
+            }),
+      };
+    }
+
+    function makeUsersResponse(
+      users: ReturnType<typeof makeUser>[],
+      opts?: { hasMore?: boolean; nextCursor?: string },
+    ) {
+      return {
+        ok: true,
+        json: async () => ({
+          object: "list",
+          type: "user",
+          results: users,
+          has_more: opts?.hasMore ?? false,
+          next_cursor: opts?.nextCursor ?? null,
+        }),
+      } as unknown as Response;
+    }
+
+    function makeParams(
+      overrides?: Partial<{
+        cursor: string | null;
+        scope: { containerKeys: string[] };
+        readIngestedDocuments: ReadIngestedDocuments;
+      }>,
+    ) {
+      return {
+        config: {},
+        credentials,
+        cursor: overrides?.cursor ?? null,
+        readIngestedDocuments:
+          overrides?.readIngestedDocuments ??
+          vi.fn().mockResolvedValue({ documents: [], nextAfterId: null }),
+        ...(overrides?.scope ? { scope: overrides.scope } : {}),
+      };
+    }
+
+    // The bot user behind the token; carries the workspace identity that
+    // scopes the members group id.
+    function makeBotMeResponse(opts?: {
+      workspaceId?: string | null;
+      workspaceName?: string | null;
+    }) {
+      return {
+        ok: true,
+        json: async () => ({
+          object: "user",
+          id: "bot-self-id",
+          name: "Test Integration",
+          type: "bot",
+          bot: {
+            ...(opts?.workspaceId === null
+              ? {}
+              : { workspace_id: opts?.workspaceId ?? "ws-abc123" }),
+            workspace_name: opts?.workspaceName ?? "Acme Inc",
+          },
+        }),
+      } as unknown as Response;
+    }
+
+    function spyFetch(connector: NotionConnector) {
+      return vi.spyOn(
+        connector as unknown as {
+          fetchWithRetry: (...args: unknown[]) => unknown;
+        },
+        "fetchWithRetry",
+      );
+    }
+
+    it("supportsPermissionSync is true", () => {
+      expect(new NotionConnector().supportsPermissionSync).toBe(true);
+    });
+
+    it("syncPermissionSnapshot yields the workspace container then every ingested doc's assignment", async () => {
+      const connector = new NotionConnector();
+      spyFetch(connector).mockResolvedValueOnce(makeBotMeResponse());
+      const readIngestedDocuments = vi.fn().mockResolvedValue({
+        documents: [
+          { sourceId: "page-1", metadata: {} },
+          { sourceId: "page-2", metadata: {} },
+        ],
+        nextAfterId: null,
+      });
+
+      const yields = await collect(
+        connector.syncPermissionSnapshot(makeParams({ readIngestedDocuments })),
+      );
+
+      expect(yields[0]).toEqual({
+        kind: "container",
+        containerKey: "workspace",
+        // Group id carries the workspace id: two Notion connectors bound to
+        // different workspaces must never share a group token.
+        permissions: { groups: ["workspace-members-ws-abc123"] },
+        cursor: "workspace",
+      });
+      expect(yields.slice(1)).toEqual([
+        {
+          kind: "document",
+          sourceId: "page-1",
+          containerKey: "workspace",
+          cursor: "workspace",
+        },
+        {
+          kind: "document",
+          sourceId: "page-2",
+          containerKey: "workspace",
+          cursor: "workspace",
+        },
+      ]);
+      // The whole corpus belongs to the one container — no metadata filter.
+      expect(readIngestedDocuments).toHaveBeenCalledWith(
+        expect.not.objectContaining({ metadataFilter: expect.anything() }),
+      );
+    });
+
+    it("syncPermissionSnapshot paginates the ingested-document read-back", async () => {
+      const connector = new NotionConnector();
+      spyFetch(connector).mockResolvedValueOnce(makeBotMeResponse());
+      const fullPage = Array.from({ length: 200 }, (_, i) => ({
+        sourceId: `page-${i}`,
+        metadata: {},
+      }));
+      const readIngestedDocuments = vi
+        .fn()
+        .mockResolvedValueOnce({ documents: fullPage, nextAfterId: "row-200" })
+        .mockResolvedValueOnce({
+          documents: [{ sourceId: "page-last", metadata: {} }],
+          nextAfterId: null,
+        });
+
+      const yields = await collect(
+        connector.syncPermissionSnapshot(makeParams({ readIngestedDocuments })),
+      );
+
+      expect(yields).toHaveLength(1 + 200 + 1);
+      expect(readIngestedDocuments).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ afterId: null }),
+      );
+      expect(readIngestedDocuments).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ afterId: "row-200" }),
+      );
+    });
+
+    it("syncPermissionSnapshot respects a delta scope that excludes the workspace container", async () => {
+      const connector = new NotionConnector();
+      const fetchMock = spyFetch(connector);
+      const readIngestedDocuments = vi.fn<ReadIngestedDocuments>();
+
+      const yields = await collect(
+        connector.syncPermissionSnapshot(
+          makeParams({
+            readIngestedDocuments,
+            scope: { containerKeys: ["something-else"] },
+          }),
+        ),
+      );
+
+      expect(yields).toEqual([]);
+      expect(readIngestedDocuments).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("syncGroups yields one workspace-scoped members group rostered from the paginated user listing", async () => {
+      const connector = new NotionConnector();
+      const fetchMock = spyFetch(connector);
+      fetchMock.mockResolvedValueOnce(makeBotMeResponse());
+      fetchMock.mockResolvedValueOnce(
+        makeUsersResponse(
+          [makeUser("user-1", { name: "Ada", email: "ada@example.com" })],
+          { hasMore: true, nextCursor: "cursor-2" },
+        ),
+      );
+      fetchMock.mockResolvedValueOnce(
+        makeUsersResponse([
+          makeUser("user-2", { name: "No Email Person" }),
+          makeUser("bot-1", { name: "Integration Bot", bot: true }),
+        ]),
+      );
+
+      const yields = await collect(connector.syncGroups(makeParams()));
+
+      expect(yields).toHaveLength(1);
+      expect(yields[0].groupId).toBe("workspace-members-ws-abc123");
+      // The group is named after the workspace so several Notion connectors
+      // stay tellable apart: the details page renders this row as a
+      // Workspace, so the display name is the plain workspace name.
+      expect(yields[0].name).toBe("Acme Inc");
+      expect(yields[0].members).toEqual([
+        {
+          accountId: "user-1",
+          displayName: "Ada",
+          email: "ada@example.com",
+          accountType: "person",
+        },
+        {
+          accountId: "user-2",
+          displayName: "No Email Person",
+          email: null,
+          accountType: "person",
+        },
+        {
+          accountId: "bot-1",
+          displayName: "Integration Bot",
+          email: null,
+          accountType: "bot",
+        },
+      ]);
+
+      const paginatedCallUrl = (
+        fetchMock.mock.calls[2] as unknown[]
+      )[0] as string;
+      expect(paginatedCallUrl).toContain("start_cursor=cursor-2");
+    });
+
+    it("syncGroups throws on an upstream failure instead of yielding a partial roster", async () => {
+      const connector = new NotionConnector();
+      const fetchMock = spyFetch(connector);
+      fetchMock.mockResolvedValueOnce(makeBotMeResponse());
+      fetchMock.mockResolvedValueOnce(
+        makeUsersResponse([makeUser("user-1", { email: "ada@example.com" })], {
+          hasMore: true,
+          nextCursor: "cursor-2",
+        }),
+      );
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => "upstream down",
+      } as unknown as Response);
+
+      const gen = connector.syncGroups(makeParams());
+      await expect(collect(gen)).rejects.toThrow(
+        "Notion user listing failed with HTTP 503",
+      );
+    });
+
+    it("syncGroups fails when the bot user carries no workspace id instead of falling back to a collidable group id", async () => {
+      const connector = new NotionConnector();
+      spyFetch(connector).mockResolvedValueOnce(
+        makeBotMeResponse({ workspaceId: null }),
+      );
+
+      const gen = connector.syncGroups(makeParams());
+      await expect(collect(gen)).rejects.toThrow("no workspace id");
+    });
+
+    it("scopeKeyForDocument places every document in the workspace container", () => {
+      const connector = new NotionConnector();
+      expect(connector.scopeKeyForDocument({})).toBe("workspace");
+      expect(connector.scopeKeyForDocument({ notionPageId: "page-1" })).toBe(
+        "workspace",
       );
     });
   });

--- a/platform/backend/src/knowledge-base/connectors/notion/notion-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/notion/notion-connector.ts
@@ -1,3 +1,4 @@
+import { NOTION_WORKSPACE_MEMBERS_GROUP_ID_PREFIX } from "@archestra/shared";
 import type {
   BlockObjectResponse,
   ListBlockChildrenResponse,
@@ -9,12 +10,17 @@ import type {
   RichTextItemResponse,
 } from "@notionhq/client/build/src/api-endpoints/common";
 import type { SearchResponse } from "@notionhq/client/build/src/api-endpoints/search";
+import type { ListUsersResponse } from "@notionhq/client/build/src/api-endpoints/users";
 import type {
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorSyncBatch,
+  GroupMembershipYield,
+  GroupMemberYield,
   NotionCheckpoint,
   NotionConfig,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
 } from "@/types";
 import { NotionConfigSchema } from "@/types";
 import {
@@ -27,6 +33,13 @@ const NOTION_API_BASE = "https://api.notion.com/v1";
 const NOTION_API_VERSION = "2022-06-28";
 const DEFAULT_BATCH_SIZE = 50;
 const MAX_BLOCK_DEPTH = 3;
+// The single top-level permission container: Notion's public API cannot say
+// who can see an individual page, so the whole synced corpus shares one
+// workspace-wide audience (see syncPermissionSnapshot). The key needs no
+// workspace qualifier — container tokens embed the connector id.
+const NOTION_WORKSPACE_CONTAINER_KEY = "workspace";
+const NOTION_READBACK_PAGE_SIZE = 200;
+const NOTION_USERS_PAGE_SIZE = 100;
 // Subtract 5 min from syncFrom to guard against clock skew between Notion
 // servers and our system, so we never skip a page that was edited right
 // around the checkpoint boundary.
@@ -48,6 +61,7 @@ type NotionDatabaseQueryResponse = {
 
 export class NotionConnector extends BaseConnector {
   type = "notion" as const;
+  supportsPermissionSync = true;
 
   async validateConfig(
     config: Record<string, unknown>,
@@ -137,6 +151,131 @@ export class NotionConnector extends BaseConnector {
       syncFrom,
       batchSize,
     );
+  }
+
+  // ===== Permission sync hooks =====
+
+  /**
+   * Workspace-scoped snapshot — deliberately coarse ("Limited" support in the
+   * docs). Notion's public API cannot report who can see an individual page
+   * (no sharing/permissions endpoint, no teamspace API), so per-page
+   * audiences are unknowable here. The whole synced corpus is one `workspace`
+   * container whose audience is the synthetic workspace-members group
+   * rostered by `syncGroups`: every ingested page becomes visible to every
+   * workspace member matched by email. That over-grants pages that are
+   * private or teamspace-restricted upstream — the connector docs tell admins
+   * to share only workspace-appropriate content with the integration. Guests
+   * never appear in Notion's user listing, so they never gain access.
+   * Already-ingested documents are assigned via read-back (like GitHub);
+   * upstream calls are O(members), never O(documents).
+   */
+  async *syncPermissionSnapshot(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    if (
+      params.scope &&
+      !params.scope.containerKeys.includes(NOTION_WORKSPACE_CONTAINER_KEY)
+    ) {
+      return;
+    }
+
+    const workspace = await this.fetchWorkspaceIdentity(params.credentials);
+
+    // A single container makes the resume cursor trivial: re-enumerating it
+    // after an interruption is idempotent (same audience, same assignments).
+    yield {
+      kind: "container",
+      containerKey: NOTION_WORKSPACE_CONTAINER_KEY,
+      permissions: { groups: [workspaceMembersGroupId(workspace.id)] },
+      cursor: NOTION_WORKSPACE_CONTAINER_KEY,
+    };
+
+    let afterId: string | null = null;
+    for (;;) {
+      const { documents, nextAfterId } = await params.readIngestedDocuments({
+        afterId,
+        limit: NOTION_READBACK_PAGE_SIZE,
+      });
+      for (const doc of documents) {
+        yield {
+          kind: "document",
+          sourceId: doc.sourceId,
+          containerKey: NOTION_WORKSPACE_CONTAINER_KEY,
+          cursor: NOTION_WORKSPACE_CONTAINER_KEY,
+        };
+      }
+      if (documents.length < NOTION_READBACK_PAGE_SIZE) break;
+      afterId = nextAfterId;
+    }
+  }
+
+  /**
+   * One synthetic group: the workspace member roster from `GET /v1/users`.
+   * Emails appear only when the integration has the "read user information
+   * including email addresses" capability — members without one are yielded
+   * with `email: null` (fail-closed, admin-assignable), and bots carry
+   * accountType "bot" so admin stats separate them from unresolvable humans.
+   * A mid-pagination failure throws instead of yielding the partial roster:
+   * a group yield is an authoritative complete membership, and a truncated
+   * one would revoke every member in the unfetched tail.
+   */
+  async *syncGroups(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<GroupMembershipYield> {
+    const workspace = await this.fetchWorkspaceIdentity(params.credentials);
+    const members: GroupMemberYield[] = [];
+    let cursor: string | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      await this.rateLimit();
+
+      const url = cursor
+        ? `${NOTION_API_BASE}/users?page_size=${NOTION_USERS_PAGE_SIZE}&start_cursor=${encodeURIComponent(cursor)}`
+        : `${NOTION_API_BASE}/users?page_size=${NOTION_USERS_PAGE_SIZE}`;
+      const response = await this.fetchWithRetry(url, {
+        headers: buildHeaders(params.credentials),
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(
+          `Notion user listing failed with HTTP ${response.status}: ${body.slice(0, 200)}`,
+        );
+      }
+
+      const result = (await response.json()) as ListUsersResponse;
+      for (const user of result.results) {
+        members.push({
+          accountId: user.id,
+          displayName: user.name ?? null,
+          email: user.type === "person" ? (user.person.email ?? null) : null,
+          accountType: user.type,
+        });
+      }
+
+      cursor = result.next_cursor ?? undefined;
+      hasMore = result.has_more === true && !!cursor;
+    }
+
+    const groupId = workspaceMembersGroupId(workspace.id);
+    yield {
+      groupId,
+      // The connector details page renders this roster row as a WORKSPACE
+      // (its tabs say Workspaces, not Groups), so the display name is the
+      // plain workspace name; a null name falls back to the group id in the
+      // UI.
+      name: workspace.name,
+      members,
+      cursor: groupId,
+    };
+  }
+
+  /**
+   * Every Notion document is covered by the single workspace container's
+   * enumeration, whatever its metadata says.
+   */
+  scopeKeyForDocument(_metadata: Record<string, unknown>): string | null {
+    return NOTION_WORKSPACE_CONTAINER_KEY;
   }
 
   // ===== Private methods =====
@@ -539,9 +678,58 @@ export class NotionConnector extends BaseConnector {
 
     return parts.join("\n");
   }
+
+  /**
+   * The workspace this integration token is bound to, read from the token's
+   * own bot user. `workspace_id` scopes the members group id (see the
+   * group-id prefix comment); a response without one fails the pass rather
+   * than falling back to an id that could collide across workspaces.
+   */
+  private async fetchWorkspaceIdentity(
+    credentials: ConnectorCredentials,
+  ): Promise<{ id: string; name: string | null }> {
+    await this.rateLimit();
+    const response = await this.fetchWithRetry(`${NOTION_API_BASE}/users/me`, {
+      headers: buildHeaders(credentials),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(
+        `Notion bot lookup failed with HTTP ${response.status}: ${body.slice(0, 200)}`,
+      );
+    }
+
+    const me = (await response.json()) as {
+      bot?: { workspace_id?: string; workspace_name?: string | null };
+    };
+    const workspaceId = me.bot?.workspace_id;
+    if (!workspaceId) {
+      throw new Error(
+        "Notion bot lookup returned no workspace id; cannot scope the workspace-members group",
+      );
+    }
+    return { id: workspaceId, name: me.bot?.workspace_name ?? null };
+  }
 }
 
 // ===== Module-level helpers =====
+
+/**
+ * The synthetic group id rostered by syncGroups, which must byte-match the id
+ * the container audience references (the platform builds `group:notion_<id>`
+ * tokens from both sides). The workspace id is REQUIRED for safety, not
+ * decoration: query-time container-audience overlap matches raw token strings
+ * across all of a user's connectors, so a constant id would let a member
+ * rostered by one Notion workspace's connector match the workspace container
+ * of a DIFFERENT workspace's connector (cross-workspace over-grant). An
+ * integration token is bound to exactly one workspace, so the id is stable for
+ * a connector's lifetime unless the token is swapped to another workspace — in
+ * which case a new group id (and fail-close of the old audience) is exactly
+ * right.
+ */
+function workspaceMembersGroupId(workspaceId: string): string {
+  return `${NOTION_WORKSPACE_MEMBERS_GROUP_ID_PREFIX}${workspaceId}`;
+}
 
 function isFullPageObject(item: {
   object: string;

--- a/platform/backend/src/routes/knowledge-base.test.ts
+++ b/platform/backend/src/routes/knowledge-base.test.ts
@@ -1082,24 +1082,25 @@ describe("knowledge base routes", () => {
     });
 
     test("rejects auto-sync-permissions for a connector type that does not support it", async () => {
-      // notion is not a permission-sync connector (Stage 1: jira/confluence/github;
-      // Stage 2: gdrive/salesforce/sharepoint) — so this must 400.
+      // dropbox is not a permission-sync connector (Stage 1: jira/confluence/
+      // github; Stage 2: gdrive/salesforce/sharepoint/mfiles/onedrive/notion)
+      // — so this must 400.
       const response = await app.inject({
         method: "POST",
         url: "/api/connectors",
         payload: {
-          name: "Auto-sync Notion",
-          connectorType: "notion",
+          name: "Auto-sync Dropbox",
+          connectorType: "dropbox",
           visibility: "auto-sync-permissions",
           teamIds: [],
-          config: { type: "notion" },
+          config: { type: "dropbox" },
           credentials: { apiToken: "token" },
         },
       });
 
       expect(response.statusCode).toBe(400);
       expect(response.json().error.message).toContain(
-        "Auto-sync permissions is not supported for notion connectors",
+        "Auto-sync permissions is not supported for dropbox connectors",
       );
     });
 
@@ -2797,13 +2798,13 @@ describe("knowledge base routes", () => {
       makeKnowledgeBaseConnector,
     }) => {
       const kb = await makeKnowledgeBase(organizationId);
-      // notion is not a permission-sync connector, but a stored row can still
-      // carry the auto-sync visibility; the trigger must reject it.
+      // dropbox is not a permission-sync connector, but a stored row can
+      // still carry the auto-sync visibility; the trigger must reject it.
       const connector = await makeKnowledgeBaseConnector(
         kb.id,
         organizationId,
         {
-          connectorType: "notion",
+          connectorType: "dropbox",
           visibility: "auto-sync-permissions",
         },
       );

--- a/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
@@ -30,6 +30,12 @@ import { ConnectorUnassignedUsersAlert } from "@/app/knowledge/connectors/_parts
 import { ConnectorUserGroupsTable } from "@/app/knowledge/connectors/_parts/connector-user-groups-table";
 import { contentRunPhase } from "@/app/knowledge/connectors/_parts/content-run-phase";
 import { GoogleDriveConnectionCard } from "@/app/knowledge/connectors/_parts/gdrive-connection-card";
+import {
+  capitalizeNoun,
+  GROUP_ROSTER_NOUN,
+  type RosterNoun,
+  WORKSPACE_ROSTER_NOUN,
+} from "@/app/knowledge/connectors/_parts/roster-noun";
 import { ConnectorStatusDot } from "@/app/knowledge/knowledge-bases/_parts/connector-enabled-dot";
 import { ConnectorTypeIcon } from "@/app/knowledge/knowledge-bases/_parts/connector-icons";
 import { ConnectorStatusBadge } from "@/app/knowledge/knowledge-bases/_parts/connector-status-badge";
@@ -174,6 +180,10 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
   // live behind the in-tab filter rather than a separate tab.
   const isAutoSync =
     connector?.visibility === "auto-sync-permissions" && autoSyncBeta;
+  // Notion's one roster row per connector IS the workspace, so its page says
+  // "Workspace(s)" wherever the group snapshot would say "Group(s)".
+  const rosterNoun =
+    connector?.connectorType === "notion" ? WORKSPACE_ROSTER_NOUN : undefined;
   const tabs = [
     { label: "Sync Runs", href: `/knowledge/connectors/${connectorId}` },
     {
@@ -187,7 +197,7 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
             href: `/knowledge/connectors/${connectorId}?tab=users`,
           },
           {
-            label: "Groups",
+            label: rosterNoun ? capitalizeNoun(rosterNoun.plural) : "Groups",
             href: `/knowledge/connectors/${connectorId}?tab=groups`,
           },
         ]
@@ -367,7 +377,9 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
         // compact Status/Type columns.
         size: 520,
         minSize: 220,
-        cell: ({ row }) => <RunResultsSummary run={row.original} />,
+        cell: ({ row }) => (
+          <RunResultsSummary run={row.original} noun={rosterNoun} />
+        ),
       },
       {
         id: "logs",
@@ -395,7 +407,7 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
         },
       },
     ],
-    [isAutoSync, openRunDetails],
+    [isAutoSync, openRunDetails, rosterNoun],
   );
 
   if (isPending) {
@@ -658,11 +670,15 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
           <ConnectorDocumentsTable
             connectorId={connectorId}
             showGroupFilter={isAutoSync}
+            noun={rosterNoun}
           />
         ) : currentTab === "users" && isAutoSync ? (
-          <ConnectorMembersTable connectorId={connectorId} />
+          <ConnectorMembersTable connectorId={connectorId} noun={rosterNoun} />
         ) : currentTab === "groups" && isAutoSync ? (
-          <ConnectorUserGroupsTable connectorId={connectorId} />
+          <ConnectorUserGroupsTable
+            connectorId={connectorId}
+            noun={rosterNoun}
+          />
         ) : (
           <div>
             <TableFilters>
@@ -788,7 +804,13 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
  * is what visually identifies it; there is no mode label. Full numbers live
  * in the run details dialog.
  */
-function RunResultsSummary({ run }: { run: ConnectorRunItem }) {
+function RunResultsSummary({
+  run,
+  noun = GROUP_ROSTER_NOUN,
+}: {
+  run: ConnectorRunItem;
+  noun?: RosterNoun;
+}) {
   if (run.status === "queued") {
     return (
       <div className="text-sm text-muted-foreground">Waiting for a worker…</div>
@@ -815,8 +837,8 @@ function RunResultsSummary({ run }: { run: ConnectorRunItem }) {
         ? [
             countedItem(
               stats.membershipsUpserted,
-              "group member updated",
-              "group members updated",
+              `${noun.singular} member updated`,
+              `${noun.singular} members updated`,
             ),
           ]
         : []),
@@ -824,8 +846,8 @@ function RunResultsSummary({ run }: { run: ConnectorRunItem }) {
         ? [
             countedItem(
               membersRemoved,
-              "group member removed",
-              "group members removed",
+              `${noun.singular} member removed`,
+              `${noun.singular} members removed`,
             ),
           ]
         : []),
@@ -835,8 +857,12 @@ function RunResultsSummary({ run }: { run: ConnectorRunItem }) {
       warn: stats.failClosed > 0,
     };
     const groupsItem: RunStatItem = stats.groupSyncFailed
-      ? { label: "group sync failed", warn: true }
-      : countedItem(stats.groupsSynced, "group checked", "groups checked");
+      ? { label: `${noun.singular} sync failed`, warn: true }
+      : countedItem(
+          stats.groupsSynced,
+          `${noun.singular} checked`,
+          `${noun.plural} checked`,
+        );
     // A pass that could not READ a project's permissions hid everything in it.
     // It must never settle as "no changes" — from the outside that is
     // indistinguishable from a pass that found nothing to do.

--- a/platform/frontend/src/app/knowledge/connectors/_parts/acl-badges.test.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/acl-badges.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useTeams } from "@/lib/teams/team.query";
 import { AclBadges } from "./acl-badges";
+import { WORKSPACE_ROSTER_NOUN } from "./roster-noun";
 
 vi.mock("@/lib/teams/team.query");
 
@@ -61,6 +62,26 @@ describe("AclBadges", () => {
     expect(screen.getByText("b@example.com")).toBeInTheDocument();
     expect(screen.getByText("Group: jira_engineers")).toBeInTheDocument();
     expect(screen.getByText("Group: jira_admins")).toBeInTheDocument();
+  });
+
+  it("names group grants after the roster row, in the connector's own noun", () => {
+    render(
+      <AclBadges
+        acl={[
+          "group:notion_workspace-members-ws-1",
+          "group:notion_workspace-members-ws-unsynced",
+        ]}
+        groupNamesByToken={
+          new Map([["group:notion_workspace-members-ws-1", "Acme Inc"]])
+        }
+        noun={WORKSPACE_ROSTER_NOUN}
+      />,
+    );
+    expect(screen.getByText("Workspace: Acme Inc")).toBeInTheDocument();
+    // A grant with no roster row yet still shows its group id — never nothing.
+    expect(
+      screen.getByText("Workspace: notion_workspace-members-ws-unsynced"),
+    ).toBeInTheDocument();
   });
 
   it("collapses very large ACLs into +N more with every entry in the tooltip", () => {

--- a/platform/frontend/src/app/knowledge/connectors/_parts/acl-badges.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/acl-badges.tsx
@@ -11,15 +11,30 @@ import {
 } from "@/components/ui/tooltip";
 import { useTeams } from "@/lib/teams/team.query";
 import { CollapsedBadgeList } from "./collapsed-badge-list";
+import {
+  capitalizeNoun,
+  GROUP_ROSTER_NOUN,
+  type RosterNoun,
+} from "./roster-noun";
 
 /**
  * Human-readable rendering of a document's ACL. Every entry kind the backend
  * writes is covered: `org:*`, `team:<id>` (resolved to the team name),
- * `user_email:<email>`, `group:<connectorType>_<groupId>`, and the empty ACL
+ * `user_email:<email>`, `group:<connectorType>_<groupId>` (resolved to the
+ * roster's display name when the caller knows it), and the empty ACL
  * (fail-closed — nobody can retrieve the document until a permission sync tags
  * it). Raw tokens stay available on hover for correlation with the Groups tab.
  */
-export function AclBadges({ acl }: { acl: string[] }) {
+export function AclBadges({
+  acl,
+  groupNamesByToken,
+  noun = GROUP_ROSTER_NOUN,
+}: {
+  acl: string[];
+  /** Full ACL token (`group:<connectorType>_<groupId>`) to its display name. */
+  groupNamesByToken?: Map<string, string>;
+  noun?: RosterNoun;
+}) {
   const { data: teams } = useTeams();
 
   if (acl.length === 0) {
@@ -45,7 +60,7 @@ export function AclBadges({ acl }: { acl: string[] }) {
     <CollapsedBadgeList
       items={acl.map((entry) => ({
         id: entry,
-        label: formatAclEntry(entry, teams),
+        label: formatAclEntry({ entry, teams, groupNamesByToken, noun }),
         // The raw token, for correlation with the Groups tab.
         title: entry,
       }))}
@@ -53,10 +68,17 @@ export function AclBadges({ acl }: { acl: string[] }) {
   );
 }
 
-function formatAclEntry(
-  entry: string,
-  teams: { id: string; name: string }[] | undefined,
-): string {
+function formatAclEntry({
+  entry,
+  teams,
+  groupNamesByToken,
+  noun,
+}: {
+  entry: string;
+  teams: { id: string; name: string }[] | undefined;
+  groupNamesByToken: Map<string, string> | undefined;
+  noun: RosterNoun;
+}): string {
   if (entry === "org:*") {
     return "Everyone in org";
   }
@@ -69,7 +91,10 @@ function formatAclEntry(
     return entry.slice("user_email:".length);
   }
   if (entry.startsWith("group:")) {
-    return `Group: ${entry.slice("group:".length)}`;
+    // The roster's display name where it is known; the connector-qualified
+    // group id otherwise. Either way the raw token stays on hover.
+    const label = groupNamesByToken?.get(entry) ?? entry.slice("group:".length);
+    return `${capitalizeNoun(noun.singular)}: ${label}`;
   }
   return entry;
 }

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
@@ -33,6 +33,7 @@ import {
   useDeleteConnectorDocument,
 } from "@/lib/knowledge/kb-document.query";
 import { formatDate } from "@/lib/utils";
+import { GROUP_ROSTER_NOUN, type RosterNoun } from "./roster-noun";
 
 type PaginationMeta =
   archestraApiTypes.GetConnectorDocumentsResponses["200"]["pagination"];
@@ -43,10 +44,12 @@ const MAX_PREVIEW_CHARS = 20_000;
 export function ConnectorDocumentsTable({
   connectorId,
   showGroupFilter = false,
+  noun = GROUP_ROSTER_NOUN,
 }: {
   connectorId: string;
   /** Auto-sync connectors only: filter documents by upstream group. */
   showGroupFilter?: boolean;
+  noun?: RosterNoun;
 }) {
   const {
     searchParams,
@@ -64,8 +67,30 @@ export function ConnectorDocumentsTable({
     connectorId,
     enabled: showGroupFilter,
   });
-  const groupIds = useMemo(
-    () => [...new Set((userGroups?.groups ?? []).map((g) => g.groupId))].sort(),
+  // Rows are named upstream (a Notion workspace, a Jira group); the group id
+  // is only the authorization identity. Filter options and Access badges both
+  // show the name, so this tab reads the same as the roster tab.
+  const groupOptions = useMemo(
+    () =>
+      [
+        ...new Map(
+          (userGroups?.groups ?? []).map((group) => [
+            group.groupId,
+            group.name ?? group.groupId,
+          ]),
+        ),
+      ]
+        .map(([groupId, label]) => ({ groupId, label }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [userGroups?.groups],
+  );
+  const groupNamesByToken = useMemo(
+    () =>
+      new Map(
+        (userGroups?.groups ?? []).flatMap((group) =>
+          group.name ? [[group.token, group.name] as const] : [],
+        ),
+      ),
     [userGroups?.groups],
   );
 
@@ -169,7 +194,13 @@ export function ConnectorDocumentsTable({
         header: "Access",
         size: 340,
         minSize: 240,
-        cell: ({ row }) => <AclBadges acl={row.original.acl} />,
+        cell: ({ row }) => (
+          <AclBadges
+            acl={row.original.acl}
+            groupNamesByToken={groupNamesByToken}
+            noun={noun}
+          />
+        ),
       },
       {
         id: "updatedAt",
@@ -211,7 +242,7 @@ export function ConnectorDocumentsTable({
         },
       },
     ],
-    [openPreviewDialog],
+    [openPreviewDialog, groupNamesByToken, noun],
   );
 
   return (
@@ -240,15 +271,15 @@ export function ConnectorDocumentsTable({
           >
             <SelectTrigger
               className="h-9 w-full text-sm sm:w-[200px]"
-              aria-label="Filter by group"
+              aria-label={`Filter by ${noun.singular}`}
             >
-              <SelectValue placeholder="All groups" />
+              <SelectValue placeholder={`All ${noun.plural}`} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">All groups</SelectItem>
-              {groupIds.map((groupId) => (
+              <SelectItem value="all">{`All ${noun.plural}`}</SelectItem>
+              {groupOptions.map(({ groupId, label }) => (
                 <SelectItem key={groupId} value={groupId}>
-                  {groupId}
+                  {label}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-members-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-members-table.tsx
@@ -43,6 +43,11 @@ import {
 import { useOrganizationMembers } from "@/lib/organization.query";
 import { CollapsedBadgeList } from "./collapsed-badge-list";
 import { MembershipTruncationNotice } from "./connector-membership-truncation-notice";
+import {
+  capitalizeNoun,
+  GROUP_ROSTER_NOUN,
+  type RosterNoun,
+} from "./roster-noun";
 
 /** One distinct upstream human account, with every group it appears in. */
 interface ConnectorMember extends ConnectorUserGroupMember {
@@ -64,8 +69,10 @@ type MemberFilter = "all" | "automatic" | "manual" | "unassigned";
  */
 export function ConnectorMembersTable({
   connectorId,
+  noun = GROUP_ROSTER_NOUN,
 }: {
   connectorId: string;
+  noun?: RosterNoun;
 }) {
   const appName = useAppName();
   const { data: userGroups, isPending } = useConnectorUserGroups({
@@ -259,7 +266,7 @@ export function ConnectorMembersTable({
       },
       {
         id: "groups",
-        header: "Groups",
+        header: capitalizeNoun(noun.plural),
         // Wider than the even share the unsized columns get: two group
         // badges plus the "+N more" badge fit on two lines.
         size: 280,
@@ -300,7 +307,7 @@ export function ConnectorMembersTable({
         },
       },
     ],
-    [appName, orgEmailById, openAssignDialog, groupLabel],
+    [appName, orgEmailById, openAssignDialog, groupLabel, noun],
   );
 
   return (
@@ -310,7 +317,7 @@ export function ConnectorMembersTable({
           <SearchInput
             value={search}
             syncQueryParams={false}
-            placeholder="Search by ID, email, name, or group"
+            placeholder={`Search by ID, email, name, or ${noun.singular}`}
             onSearchChange={setSearch}
           />
           <Select
@@ -333,12 +340,12 @@ export function ConnectorMembersTable({
           <Select value={groupFilter} onValueChange={setGroupFilter}>
             <SelectTrigger
               className="h-9 w-full text-sm sm:w-[200px]"
-              aria-label="Filter by group"
+              aria-label={`Filter by ${noun.singular}`}
             >
-              <SelectValue placeholder="All groups" />
+              <SelectValue placeholder={`All ${noun.plural}`} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">All groups</SelectItem>
+              <SelectItem value="all">{`All ${noun.plural}`}</SelectItem>
               {groupIds.map((groupId) => (
                 <SelectItem key={groupId} value={groupId}>
                   {groupLabel(groupId)}

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.test.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.test.tsx
@@ -4,6 +4,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectorUserGroupsTable } from "./connector-user-groups-table";
+import { WORKSPACE_ROSTER_NOUN } from "./roster-noun";
 
 const mockUseConnectorUserGroups = vi.fn();
 
@@ -242,5 +243,74 @@ describe("ConnectorUserGroupsTable", () => {
     render(<ConnectorUserGroupsTable connectorId="connector-1" />);
 
     expect(screen.getByText(/No user groups synced yet/)).toBeInTheDocument();
+  });
+
+  // Notion's group id is synthetic (`workspace-members-<workspaceId>`), so the
+  // row shows the workspace id Notion itself reports — not the internal id.
+  it("identifies a workspace row by the workspace id, not the synthetic group id", () => {
+    mockUseConnectorUserGroups.mockReturnValue({
+      data: {
+        groups: [
+          {
+            groupId: "workspace-members-11111111-2222-3333-4444-555555555555",
+            name: "Acme Inc",
+            token:
+              "group:notion_workspace-members-11111111-2222-3333-4444-555555555555",
+            documentCount: 2,
+            lastSyncedAt: "2026-07-08T15:00:00.000Z",
+            members: [],
+          },
+        ],
+      },
+      isPending: false,
+      isError: false,
+    });
+
+    render(
+      <ConnectorUserGroupsTable
+        connectorId="connector-1"
+        noun={WORKSPACE_ROSTER_NOUN}
+      />,
+    );
+
+    expect(screen.getByText("Acme Inc")).toBeInTheDocument();
+    expect(
+      screen.getByText("ID 11111111-2222-3333-4444-555555555555"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/workspace-members-/)).not.toBeInTheDocument();
+  });
+
+  // Notion's roster rows are workspaces, and the whole page family follows
+  // the noun — column header, filters, and empty states included.
+  it("renders workspace copy when given the workspace roster noun", () => {
+    mockGroups();
+
+    render(
+      <ConnectorUserGroupsTable
+        connectorId="connector-1"
+        noun={WORKSPACE_ROSTER_NOUN}
+      />,
+    );
+
+    expect(
+      screen.getByRole("columnheader", { name: "Workspace" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Group" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("All workspaces")).toBeInTheDocument();
+
+    mockUseConnectorUserGroups.mockReturnValue({
+      data: { groups: [] },
+      isPending: false,
+      isError: false,
+    });
+    render(
+      <ConnectorUserGroupsTable
+        connectorId="connector-1"
+        noun={WORKSPACE_ROSTER_NOUN}
+      />,
+    );
+    expect(screen.getByText(/No workspaces synced yet/)).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.tsx
@@ -30,6 +30,11 @@ import { useConnectorUserGroups } from "@/lib/knowledge/connector.query";
 import { formatDate } from "@/lib/utils";
 import { CollapsedBadgeList } from "./collapsed-badge-list";
 import { MembershipTruncationNotice } from "./connector-membership-truncation-notice";
+import {
+  capitalizeNoun,
+  GROUP_ROSTER_NOUN,
+  type RosterNoun,
+} from "./roster-noun";
 
 type GroupFilter = "all" | "fully-assigned" | "not-fully-assigned";
 
@@ -43,8 +48,10 @@ type GroupFilter = "all" | "fully-assigned" | "not-fully-assigned";
  */
 export function ConnectorUserGroupsTable({
   connectorId,
+  noun = GROUP_ROSTER_NOUN,
 }: {
   connectorId: string;
+  noun?: RosterNoun;
 }) {
   const {
     data: userGroups,
@@ -104,33 +111,38 @@ export function ConnectorUserGroupsTable({
       {
         id: "group",
         accessorKey: "groupId",
-        header: "Group",
+        header: noun.columnHeader,
         // Group ids run long (e.g. `confluence-user-access-admins-…`); a
         // fixed wide column keeps them readable instead of truncating at
         // the even share.
         size: 320,
-        cell: ({ row }) => (
-          <div className="min-w-0">
-            <div
-              className="truncate text-sm font-medium"
-              title={row.original.name ?? row.original.groupId}
-            >
-              {row.original.name ?? row.original.groupId}
+        cell: ({ row }) => {
+          // A synthetic group id (Notion's `workspace-members-<workspaceId>`)
+          // is an Archestra construct: show the id the source itself shows, so
+          // this line matches what an admin sees upstream.
+          const sourceId =
+            noun.sourceId?.(row.original.groupId) ?? row.original.groupId;
+          return (
+            <div className="min-w-0">
+              <div
+                className="truncate text-sm font-medium"
+                title={row.original.name ?? row.original.groupId}
+              >
+                {row.original.name ?? row.original.groupId}
+              </div>
+              <div
+                className="truncate text-xs text-muted-foreground"
+                title={
+                  row.original.name
+                    ? `${noun.idLabel}: ${sourceId}`
+                    : row.original.token
+                }
+              >
+                {row.original.name ? `ID ${sourceId}` : row.original.token}
+              </div>
             </div>
-            <div
-              className="truncate text-xs text-muted-foreground"
-              title={
-                row.original.name
-                  ? `Stable source ID: ${row.original.groupId}`
-                  : row.original.token
-              }
-            >
-              {row.original.name
-                ? `ID ${row.original.groupId}`
-                : row.original.token}
-            </div>
-          </div>
-        ),
+          );
+        },
       },
       {
         id: "documentCount",
@@ -147,7 +159,9 @@ export function ConnectorUserGroupsTable({
         id: "assigned",
         header: "Assigned",
         size: 110,
-        cell: ({ row }) => <GroupMembersSummary group={row.original} />,
+        cell: ({ row }) => (
+          <GroupMembersSummary group={row.original} noun={noun} />
+        ),
       },
       {
         id: "members",
@@ -179,7 +193,7 @@ export function ConnectorUserGroupsTable({
           ),
       },
     ],
-    [],
+    [noun],
   );
 
   return (
@@ -189,7 +203,7 @@ export function ConnectorUserGroupsTable({
           <SearchInput
             value={search}
             syncQueryParams={false}
-            placeholder="Search by group or member name"
+            placeholder={`Search by ${noun.singular} or member name`}
             onSearchChange={setSearch}
           />
           <Select
@@ -198,12 +212,12 @@ export function ConnectorUserGroupsTable({
           >
             <SelectTrigger
               className="h-9 w-full text-sm sm:w-[200px]"
-              aria-label="Filter groups"
+              aria-label={`Filter ${noun.plural}`}
             >
-              <SelectValue placeholder="All groups" />
+              <SelectValue placeholder={`All ${noun.plural}`} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">All groups</SelectItem>
+              <SelectItem value="all">{`All ${noun.plural}`}</SelectItem>
               <SelectItem value="fully-assigned">Fully assigned</SelectItem>
               <SelectItem value="not-fully-assigned">
                 Not fully assigned
@@ -241,10 +255,10 @@ export function ConnectorUserGroupsTable({
         isLoading={isPending}
         emptyMessage={
           isError
-            ? "Failed to load user groups. Please try again."
+            ? `Failed to load ${noun.emptyNoun}. Please try again.`
             : groups.length > 0
-              ? "No groups match your search or filter."
-              : "No user groups synced yet. Groups appear after the first permission sync."
+              ? `No ${noun.plural} match your search or filter.`
+              : `No ${noun.emptyNoun} synced yet. ${capitalizeNoun(noun.plural)} appear after the first permission sync.`
         }
       />
     </div>
@@ -320,7 +334,13 @@ function compareGroupsBySeverity(
  * documents while resolving to nobody is the one state that makes documents
  * unreachable, so it gets an explicit verdict instead of a count.
  */
-function GroupMembersSummary({ group }: { group: ConnectorUserGroup }) {
+function GroupMembersSummary({
+  group,
+  noun,
+}: {
+  group: ConnectorUserGroup;
+  noun: RosterNoun;
+}) {
   const humans = group.members.filter((m) => !isServiceAccount(m));
   const assigned = humans.filter((m) => m.user).length;
 
@@ -334,7 +354,7 @@ function GroupMembersSummary({ group }: { group: ConnectorUserGroup }) {
         </TooltipTrigger>
         <TooltipContent className="max-w-xs">
           Nobody resolves to a user, so documents granting access only through
-          this group are inaccessible.
+          this {noun.singular} are inaccessible.
         </TooltipContent>
       </Tooltip>
     ) : (

--- a/platform/frontend/src/app/knowledge/connectors/_parts/roster-noun.ts
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/roster-noun.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+import { notionWorkspaceIdFromGroupId } from "@archestra/shared";
+
+/**
+ * What a roster row IS for this connector type. Group snapshots are groups
+ * everywhere except Notion, whose one roster row per connector is the
+ * workspace itself — its details page says "Workspace(s)" wherever this page
+ * family would say "Group(s)".
+ */
+export type RosterNoun = {
+  singular: string;
+  plural: string;
+  /** Roster column header ("Group" / "Workspace"). */
+  columnHeader: string;
+  /** Noun used by the load-failure/empty states ("user groups" / "workspaces"). */
+  emptyNoun: string;
+  /** Label for the row's secondary identifier line. */
+  idLabel: string;
+  /**
+   * The id the source itself shows for the row, when the group id is synthetic.
+   * Notion's is `workspace-members-<workspaceId>`, so the row shows the bare
+   * workspace id. Defaults to the group id.
+   */
+  sourceId?: (groupId: string) => string | null;
+};
+
+export const GROUP_ROSTER_NOUN: RosterNoun = {
+  singular: "group",
+  plural: "groups",
+  columnHeader: "Group",
+  emptyNoun: "user groups",
+  idLabel: "Stable source ID",
+};
+
+export const WORKSPACE_ROSTER_NOUN: RosterNoun = {
+  singular: "workspace",
+  plural: "workspaces",
+  columnHeader: "Workspace",
+  emptyNoun: "workspaces",
+  idLabel: "Workspace ID",
+  sourceId: notionWorkspaceIdFromGroupId,
+};
+
+export function capitalizeNoun(noun: string): string {
+  return noun.charAt(0).toUpperCase() + noun.slice(1);
+}

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
@@ -348,6 +348,7 @@ const AUTO_SYNC_CONNECTOR_TYPES: ReadonlySet<ConnectorType> = new Set([
   "sharepoint",
   "salesforce",
   "onedrive",
+  "notion",
 ]);
 
 export function connectorSupportsAutoSync(type: ConnectorType): boolean {
@@ -414,6 +415,37 @@ export function getPermissionSyncCredentialNote(
 
 const ATLASSIAN_ADMIN_API_KEY_DOC_ANCHOR =
   "atlassian-organization-admin-api-key";
+
+/**
+ * Rendered under the visibility selector on the Notion create/edit forms when
+ * Auto-sync permissions is selected. Notion's public API cannot report who
+ * can see an individual page, so support is deliberately coarse ("Limited"
+ * in the docs): the admin must know the audience model and scope what the
+ * integration can see.
+ */
+export function NotionAutoSyncPermissionsNote() {
+  return (
+    <p className="text-sm text-muted-foreground">
+      Notion&apos;s API cannot report who can see each page, so auto-sync makes
+      every synced page visible to all workspace members matched by email, and
+      never to guests. Share only workspace-appropriate teamspaces and pages
+      with the integration, and grant it the &quot;read user information
+      including email addresses&quot; capability.{" "}
+      <ExternalDocsLink
+        href={getFrontendDocsUrl(
+          DocsPage.PlatformKnowledge,
+          NOTION_AUTO_SYNC_DOC_ANCHOR,
+        )}
+        className="underline"
+        showIcon={false}
+      >
+        Learn more
+      </ExternalDocsLink>
+    </p>
+  );
+}
+
+const NOTION_AUTO_SYNC_DOC_ANCHOR = "notion-auto-sync-permissions";
 // SPDX-SnippetEnd
 
 export function getConnectorUrlConfig(
@@ -542,7 +574,7 @@ export function getConnectorCredentialConfig(params: {
   const createApiTokenPlaceholders: Record<ConnectorType, string | undefined> =
     {
       servicenow: "Your ServiceNow password",
-      notion: "secret_...",
+      notion: "ntn_...",
       sharepoint: "Your Azure AD client secret",
       gdrive: gdriveUsesOAuth
         ? undefined
@@ -699,8 +731,16 @@ function getApiTokenHelpText(params: {
   if (params.type === "notion") {
     return (
       <p className="text-[0.8rem] text-muted-foreground">
-        Your Notion integration token (starts with <code>secret_</code>). Create
-        one at notion.so/my-integrations.
+        Your Notion internal integration secret (starts with <code>ntn_</code>,
+        older <code>secret_</code> tokens keep working). Create one in the{" "}
+        <ExternalDocsLink
+          href="https://app.notion.com/developers/connections"
+          className="underline"
+          showIcon={false}
+        >
+          Notion Developer portal
+        </ExternalDocsLink>
+        .
       </p>
     );
   }

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
@@ -61,6 +61,7 @@ import {
   getConnectorUrlConfig,
   getDefaultConnectorConfig,
   getPermissionSyncCredentialNote,
+  NotionAutoSyncPermissionsNote,
 } from "./connector-dialog-config";
 import { ConnectorTypeIcon } from "./connector-icons";
 import { PermissionSyncIntervalPicker } from "./permission-sync-interval-picker";
@@ -437,6 +438,11 @@ export function CreateConnectorDialog({
                   supportsAutoSync={connectorSupportsAutoSync(connectorType)}
                   autoSyncPermissionAction="create"
                 />
+
+                {visibility === "auto-sync-permissions" &&
+                  connectorType === "notion" && (
+                    <NotionAutoSyncPermissionsNote />
+                  )}
 
                 <div className="border-t" />
 

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.test.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.test.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EditConnectorDialog } from "./edit-connector-dialog";
@@ -330,5 +336,84 @@ describe("EditConnectorDialog - permission sync interval (auto-sync)", () => {
 
     const [call] = mockMutateAsync.mock.calls;
     expect(call[0].body.permissionSyncIntervalSeconds).toBe(3600);
+  });
+});
+
+describe("EditConnectorDialog - Notion auto-sync limitation note", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useTeams).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useTeams>);
+  });
+
+  function makeNotionConnector(
+    visibility: ConnectorFixture["visibility"],
+  ): ConnectorFixture {
+    return {
+      id: "conn-notion-1",
+      name: "Company Notion",
+      description: "",
+      visibility,
+      teamIds: [],
+      connectorType: "notion",
+      environmentId: null,
+      config: { type: "notion" },
+      schedule: "0 */6 * * *",
+      ftsLanguage: "english",
+      permissionSyncIntervalSeconds: 1800,
+      enabled: true,
+    } as ConnectorFixture;
+  }
+
+  it("shows the workspace-audience note with a Learn more link for auto-sync Notion", () => {
+    renderDialog(makeNotionConnector("auto-sync-permissions"));
+
+    const note = screen.getByText(
+      /every synced page visible to all workspace members/,
+    );
+    expect(note).toBeInTheDocument();
+    // The recommendation sentence and the docs link ride in the same note.
+    expect(note).toHaveTextContent(/Share only workspace-appropriate/);
+    // The generic connector-docs link is also a "Learn more"; the note's own
+    // link is the one pointing at the auto-sync section anchor.
+    expect(
+      within(note).getByRole("link", { name: /Learn more/ }),
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("#notion-auto-sync-permissions"),
+    );
+  });
+
+  it("hides the note for a Notion connector without auto-sync visibility", () => {
+    renderDialog(makeNotionConnector("org-wide"));
+    expect(
+      screen.queryByText(/every synced page visible to all workspace members/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show the Notion note on other auto-sync connector types", () => {
+    renderDialog({
+      id: "conn-gh-2",
+      name: "Engineering GitHub",
+      description: "",
+      visibility: "auto-sync-permissions",
+      teamIds: [],
+      connectorType: "github",
+      environmentId: null,
+      config: {
+        type: "github",
+        githubUrl: "https://api.github.com",
+        owner: "test-org",
+        authMethod: "pat",
+      },
+      schedule: "0 */6 * * *",
+      ftsLanguage: "english",
+      permissionSyncIntervalSeconds: 1800,
+      enabled: true,
+    } as ConnectorFixture);
+    expect(
+      screen.queryByText(/every synced page visible to all workspace members/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
@@ -42,6 +42,7 @@ import {
   getConnectorDocsUrl,
   getConnectorTypeLabel,
   getConnectorUrlConfig,
+  NotionAutoSyncPermissionsNote,
 } from "./connector-dialog-config";
 import { ConnectorTypeIcon } from "./connector-icons";
 import { PermissionSyncIntervalPicker } from "./permission-sync-interval-picker";
@@ -335,6 +336,9 @@ export function EditConnectorDialog({
             supportsAutoSync={connectorSupportsAutoSync(connectorType)}
             autoSyncPermissionAction="update"
           />
+
+          {visibility === "auto-sync-permissions" &&
+            connectorType === "notion" && <NotionAutoSyncPermissionsNote />}
 
           <div className="border-t" />
 

--- a/platform/shared/knowledge-base.test.ts
+++ b/platform/shared/knowledge-base.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { addNomicTaskPrefix } from "./knowledge-base";
+import {
+  addNomicTaskPrefix,
+  notionWorkspaceIdFromGroupId,
+} from "./knowledge-base";
+
+describe("notionWorkspaceIdFromGroupId", () => {
+  it("returns the workspace id carried by a synthetic members-group id", () => {
+    expect(notionWorkspaceIdFromGroupId("workspace-members-ws-abc123")).toBe(
+      "ws-abc123",
+    );
+  });
+
+  it("returns null for an id that carries no workspace id", () => {
+    // Another connector's real group id, and the bare prefix.
+    expect(notionWorkspaceIdFromGroupId("engineers")).toBeNull();
+    expect(notionWorkspaceIdFromGroupId("workspace-members-")).toBeNull();
+  });
+});
 
 describe("addNomicTaskPrefix", () => {
   it("adds search_document prefix for nomic models", () => {

--- a/platform/shared/knowledge-base.ts
+++ b/platform/shared/knowledge-base.ts
@@ -186,6 +186,25 @@ export const CONNECTOR_TYPE_LABELS = {
 
 export type ConnectorType = keyof typeof CONNECTOR_TYPE_LABELS;
 
+/**
+ * Notion has no groups: its permission sync rosters the whole workspace as one
+ * synthetic group whose id embeds the Notion workspace id, so two Notion
+ * connectors never share a grant. The connector builds the id; the UI strips
+ * the prefix back off to show the workspace's own id.
+ */
+export const NOTION_WORKSPACE_MEMBERS_GROUP_ID_PREFIX = "workspace-members-";
+
+/**
+ * The Notion workspace id carried by a synthetic members-group id, or null for
+ * an id that does not carry one.
+ */
+export function notionWorkspaceIdFromGroupId(groupId: string): string | null {
+  if (!groupId.startsWith(NOTION_WORKSPACE_MEMBERS_GROUP_ID_PREFIX)) {
+    return null;
+  }
+  return groupId.slice(NOTION_WORKSPACE_MEMBERS_GROUP_ID_PREFIX.length) || null;
+}
+
 const CONNECTOR_PLACEHOLDER_DEPARTMENTS = [
   "Engineering",
   "Finance",


### PR DESCRIPTION
## Summary

- Adds auto-sync permissions support for the Notion connector, scoped as *Limited*: Notion's public API has no per-page sharing endpoint, so every synced page shares one workspace-wide audience (a synthetic members group rostered from `GET /v1/users`, workspace-scoped so multiple Notion connectors never collide on the same grant).
- Adds the create/edit form note explaining the limitation and setup recommendations, and documents it in the auto-sync permissions support matrix.
- Presents a Notion connector's roster as **Workspaces** instead of Groups throughout the connector details page, and makes every surface (roster row, Access badges, filters) lead with the workspace's display name instead of the internal synthetic group id.

Part of #7154 (permission auto-sync for the remaining KB connectors) — this PR covers Notion only; the issue stays open for the other connectors.

## Test plan

- [x] Backend: 38 Notion connector unit tests (permission snapshot, group roster, workspace-scoped group id, pagination, failure isolation)
- [x] Frontend: 134 tests across the connector page, dialogs, and roster/ACL components, including new tests pinning the Workspaces copy and the workspace-id display
- [x] `tsc --noEmit` clean (frontend + backend), `biome check` clean, `knip` clean (frontend + backend + shared)
- [x] Live-verified end-to-end on a dev stack against a mock Notion tenant: documents ACLed to the workspace container, roster paginated and resolved (email/no-email/bot classification), group-step failure isolated with previous-snapshot retention

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>