### PR TITLE
fix(deps): bump nanoid v3 override to 3.3.18 for CVE-2026-67213

### DIFF
--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -79,7 +79,7 @@ overrides:
   fastify: '>=5.8.5'
   find-my-way: 9.7.0
   postcss: '>=8.5.18'
-  nanoid@<4: 3.3.17
+  nanoid@<4: 3.3.18
   uuid@^11: '>=11.1.1'
   ip-address: '>=10.3.1'
   brace-expansion: 5.0.9
@@ -8928,8 +8928,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -19898,7 +19898,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -20328,7 +20328,7 @@ snapshots:
 
   postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -125,12 +125,13 @@ overrides:
   # floor, so the floor has to clear the higher of the two fixes.
   postcss: '>=8.5.18'
   # CVE-2026-67213 (GHSA-2v37-7h3g-55p8, HIGH, custom generators loop forever
-  # when size is 0) fixed in 3.3.17 on the v3 line. Transitive via postcss and
-  # points-on-path; scoped to <4 so the frontend's direct nanoid ^5.1.6 (already
-  # past the v5 fix) keeps its own resolution. Pinned exact (not a `>=` floor)
-  # because nanoid is temporarily excluded from minimumReleaseAge below, so a
-  # floor could otherwise pull an unvetted release.
-  nanoid@<4: 3.3.17
+  # when size is 0): the 3.3.17 fix was incomplete, advisory now requires
+  # 3.3.18 on the v3 line. Transitive via postcss and points-on-path; scoped
+  # to <4 so the frontend's direct nanoid ^5.1.6 (already past the 5.1.6 v5
+  # fix) keeps its own resolution. Pinned exact (not a `>=` floor) because
+  # nanoid is temporarily excluded from minimumReleaseAge below, so a floor
+  # could otherwise pull an unvetted release.
+  nanoid@<4: 3.3.18
   uuid@^11: '>=11.1.1'
   # CVE-2026-69192 (HIGH) affects <=10.3.0, fixed in 10.3.1 — the previous
   # >=10.1.1 floor resolved 10.2.0, inside the vulnerable range.
@@ -217,9 +218,9 @@ minimumReleaseAgeExclude:
   # 2026-07-31 and clears the 7-day window on 2026-08-07. Remove on/after that
   # date — the lockfile stays pinned at 3.1.5 regardless.
   - fast-uri
-  # TEMPORARY: nanoid 3.3.17 (fix CVE-2026-67213, HIGH) was published
-  # 2026-08-03 and clears the 7-day window on 2026-08-10. Remove on/after that
-  # date — the lockfile stays pinned at 3.3.17 regardless.
+  # TEMPORARY: nanoid 3.3.18 (complete fix for CVE-2026-67213, HIGH) was
+  # published 2026-08-07 and clears the 7-day window on 2026-08-14. Remove
+  # on/after that date — the lockfile stays pinned at 3.3.18 regardless.
   - nanoid
 
 # OpenTelemetry instrumentation requires these packages hoisted to root.


### PR DESCRIPTION
## Summary

The [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) advisory for CVE-2026-67213 (HIGH — custom generators loop forever when `size` is 0) was updated on 2026-08-13: the 3.3.17 fix on the v3 line was incomplete, and the patched version is now **3.3.18**. This made the Docker Image Scanning workflow start failing on `main` ([failing run](https://github.com/archestra-ai/archestra/actions/runs/31718374247/job/94508807453)).

- Bump the existing `nanoid@<4` override from 3.3.17 → 3.3.18 (still exact-pinned, still scoped to `<4` so the frontend's direct `nanoid ^5.1.6` — already past the 5.1.6 v5 fix — keeps its own resolution)
- Refresh the temporary `minimumReleaseAge` exclusion comment: 3.3.18 was published 2026-08-07 and clears the 7-day window on 2026-08-14, after which the exclusion can be removed

## Test plan

- `pnpm install` resolves `nanoid@3.3.18` in the lockfile (verified locally)
- Docker Image Scanning workflow on this PR should pass

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>