### PR TITLE
fix(knowledge): stop connector status cells painting over the neighboring column

### DIFF
--- a/platform/frontend/src/app/knowledge/connectors/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/page.client.tsx
@@ -6,7 +6,6 @@ import {
   type ConnectorType,
 } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
-import { formatDistanceToNow } from "date-fns";
 import { ArchiveRestore, Database, Pencil, Trash2 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useState } from "react";
@@ -15,7 +14,7 @@ import { KnowledgePageLayout } from "@/app/knowledge/_parts/knowledge-page-layou
 import { ConnectorAccessBadge } from "@/app/knowledge/connectors/_parts/connector-access-badge";
 import { GoogleDriveOAuthResultToast } from "@/app/knowledge/connectors/_parts/gdrive-connection-card";
 import { ConnectorTypeIcon } from "@/app/knowledge/knowledge-bases/_parts/connector-icons";
-import { ConnectorStatusBadge } from "@/app/knowledge/knowledge-bases/_parts/connector-status-badge";
+import { ConnectorStatusCell } from "@/app/knowledge/knowledge-bases/_parts/connector-status-badge";
 import { CreateConnectorDialog } from "@/app/knowledge/knowledge-bases/_parts/create-connector-dialog";
 import { EditConnectorDialog } from "@/app/knowledge/knowledge-bases/_parts/edit-connector-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
@@ -46,7 +45,6 @@ import {
   useRestoreConnector,
 } from "@/lib/knowledge/connector.query";
 import { useIsGlobalAdmin } from "@/lib/organization.query";
-import { formatDate } from "@/lib/utils";
 import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { formatCronSchedule } from "@/lib/utils/format-cron";
 
@@ -209,29 +207,12 @@ function ConnectorsList() {
     {
       id: "status",
       header: "Status",
-      cell: ({ row }) => {
-        return (
-          <div className="flex items-center gap-2">
-            {row.original.lastSyncAt ? (
-              <>
-                <ConnectorStatusBadge status={row.original.lastSyncStatus} />
-                <span
-                  className="text-xs text-muted-foreground whitespace-nowrap"
-                  title={formatDate({ date: row.original.lastSyncAt })}
-                >
-                  {formatDistanceToNow(new Date(row.original.lastSyncAt), {
-                    addSuffix: true,
-                  })}
-                </span>
-              </>
-            ) : (
-              <span className="text-xs text-muted-foreground">
-                Never synced
-              </span>
-            )}
-          </div>
-        );
-      },
+      cell: ({ row }) => (
+        <ConnectorStatusCell
+          lastSyncAt={row.original.lastSyncAt}
+          lastSyncStatus={row.original.lastSyncStatus}
+        />
+      ),
     },
     {
       id: "accessibleTo",

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-status-badge.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-status-badge.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import type { archestraApiTypes } from "@archestra/shared";
+import { formatDistanceToNow } from "date-fns";
 import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 
 type ConnectorSyncStatus = NonNullable<
   archestraApiTypes.GetConnectorsResponses["200"]["data"][number]["lastSyncStatus"]
@@ -59,6 +60,39 @@ const STATUS_CONFIG: Record<ConnectorSyncStatus, StatusConfig> = {
     animated: false,
   },
 };
+
+/**
+ * Status badge plus the last-sync relative timestamp, as used in the
+ * connectors and knowledge-bases table Status columns. The badge and the
+ * timestamp each stay on one line, but wrap as whole units relative to each
+ * other: side by side when the column is wide enough, timestamp under the
+ * badge when it is not. The tables render with a fixed layout that does not
+ * clip overflow, so anything wider than the column would paint over the
+ * neighboring column instead of wrapping.
+ */
+export function ConnectorStatusCell({
+  lastSyncAt,
+  lastSyncStatus,
+}: {
+  lastSyncAt: string | null;
+  lastSyncStatus: ConnectorSyncStatus | null;
+}) {
+  if (!lastSyncAt) {
+    return <span className="text-xs text-muted-foreground">Never synced</span>;
+  }
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+      <ConnectorStatusBadge status={lastSyncStatus} />
+      <span
+        className="whitespace-nowrap text-xs text-muted-foreground"
+        title={formatDate({ date: lastSyncAt })}
+      >
+        {formatDistanceToNow(new Date(lastSyncAt), { addSuffix: true })}
+      </span>
+    </div>
+  );
+}
 
 export function ConnectorStatusBadge({
   status,

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -2,7 +2,6 @@
 
 import type { archestraApiTypes } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
-import { formatDistanceToNow } from "date-fns";
 import {
   ArchiveRestore,
   ArrowLeft,
@@ -22,7 +21,7 @@ import { toast } from "sonner";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { KnowledgePageLayout } from "@/app/knowledge/_parts/knowledge-page-layout";
 import { ConnectorAccessBadge } from "@/app/knowledge/connectors/_parts/connector-access-badge";
-import { ConnectorStatusBadge } from "@/app/knowledge/knowledge-bases/_parts/connector-status-badge";
+import { ConnectorStatusCell } from "@/app/knowledge/knowledge-bases/_parts/connector-status-badge";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import {
   PERMANENT_DELETE_LABEL,
@@ -55,7 +54,7 @@ import {
   useRestoreKnowledgeBase,
 } from "@/lib/knowledge/knowledge-base.query";
 import { useIsGlobalAdmin } from "@/lib/organization.query";
-import { cn, formatDate } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { formatCronSchedule } from "@/lib/utils/format-cron";
 import { ConnectorTypeIcon } from "./_parts/connector-icons";
@@ -502,23 +501,10 @@ function ExpandedConnectors({
       id: "status",
       header: "Status",
       cell: ({ row }) => (
-        <div className="flex items-center gap-2">
-          {row.original.lastSyncAt ? (
-            <>
-              <ConnectorStatusBadge status={row.original.lastSyncStatus} />
-              <span
-                className="text-xs text-muted-foreground whitespace-nowrap"
-                title={formatDate({ date: row.original.lastSyncAt })}
-              >
-                {formatDistanceToNow(new Date(row.original.lastSyncAt), {
-                  addSuffix: true,
-                })}
-              </span>
-            </>
-          ) : (
-            <span className="text-xs text-muted-foreground">Never synced</span>
-          )}
-        </div>
+        <ConnectorStatusCell
+          lastSyncAt={row.original.lastSyncAt}
+          lastSyncStatus={row.original.lastSyncStatus}
+        />
       ),
     },
     {


### PR DESCRIPTION
## Problem

At narrower window widths, the Status column on **Knowledge → Connectors** (and the same cell on Knowledge Bases) painted its relative timestamp over the "Accessible to" column:

The tables render through the shared `DataTable`, which uses a fixed table layout that distributes column widths and does not clip cell overflow. #7249 put `whitespace-nowrap` on the timestamp to stop it wrapping mid-phrase into two/three lines — which traded tall rows for the badge + timestamp overflowing the column and overlapping the neighboring cells at certain widths.

## Fix

The badge + timestamp pair is extracted into a shared `ConnectorStatusCell` (used by both the connectors and knowledge-bases tables) laid out with `flex-wrap`:

- badge and timestamp each stay on a single line (`whitespace-nowrap` kept on the timestamp),
- they sit side by side when the column is wide enough,
- and the timestamp wraps **as a whole unit** under the badge when it isn't — so nothing ever paints over the next column, and the mid-phrase wrapping #7249 fixed doesn't come back.

## Testing

- `pnpm type-check`, biome, and the knowledge frontend suites (134 tests) pass.
- Verified live against a local table with the same volume/variety of data as the report (11 rows: success / failed / no documents / completed with errors, org-wide + source-permissions visibility, mixed schedules) at narrow, mid, and wide widths.
- No new test added deliberately: the change is CSS wrapping behavior, and a test would only assert Tailwind class names (implementation-detail markup, per our testing guidance).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>