### PR TITLE
fix(knowledge-base): audit member-override mappings in connector snapshots

### DIFF
--- a/platform/backend/src/middleware/audit-decisions.ts
+++ b/platform/backend/src/middleware/audit-decisions.ts
@@ -580,7 +580,7 @@ export const AUDIT_DECISIONS = {
   kbMemberOverridesTable: {
     audited: false,
     reason:
-      "admin member mapping mutated only via /api/connectors/:id/member-overrides, audited at the route level as connector.updated",
+      "admin member mapping mutated only via /api/connectors/:id/member-overrides, audited at the route level as connector.updated; the connector audit snapshot carries the mapping list so upsert/delete diffs",
   },
   llmProviderApiKeyModelsTable: {
     audited: false,

--- a/platform/backend/src/models/knowledge-base-connector.ts
+++ b/platform/backend/src/models/knowledge-base-connector.ts
@@ -932,6 +932,34 @@ class KnowledgeBaseConnectorModel {
       .map((r) => `${r.name} (${r.id})`)
       .sort((a, b) => a.localeCompare(b));
 
+    // SPDX-SnippetBegin
+    // SPDX-SnippetCopyrightText: 2026 Archestra Inc.
+    // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+    // Admin member-override mappings (kb_member_overrides is audited:false).
+    // Without them here, the member-override routes' connector.updated rows
+    // would record identical before/after snapshots — the mapping itself,
+    // who an upstream account resolves to, would never reach the audit log.
+    const overrideRows = await db
+      .select({
+        externalAccountId: schema.kbMemberOverridesTable.externalAccountId,
+        userId: schema.kbMemberOverridesTable.userId,
+        email: schema.usersTable.email,
+      })
+      .from(schema.kbMemberOverridesTable)
+      .leftJoin(
+        schema.usersTable,
+        eq(schema.usersTable.id, schema.kbMemberOverridesTable.userId),
+      )
+      .where(eq(schema.kbMemberOverridesTable.connectorId, id));
+
+    const memberOverrides = overrideRows
+      .map(
+        (o) =>
+          `${o.externalAccountId} -> ${o.email ?? "unknown"} (${o.userId})`,
+      )
+      .sort((a, b) => a.localeCompare(b));
+    // SPDX-SnippetEnd
+
     const configKeys =
       row.config && typeof row.config === "object" && !Array.isArray(row.config)
         ? Object.keys(row.config as Record<string, unknown>).sort()
@@ -953,6 +981,7 @@ class KnowledgeBaseConnectorModel {
         ? String(row.lastSyncError).slice(0, 500)
         : null,
       knowledgeBases,
+      memberOverrides,
       configKeys,
       permissionSyncIntervalSeconds: row.permissionSyncIntervalSeconds ?? null,
       environmentId: row.environmentId ?? null,

--- a/platform/backend/src/routes/knowledge-base.test.ts
+++ b/platform/backend/src/routes/knowledge-base.test.ts
@@ -11,6 +11,7 @@ import {
   buildContainerToken,
   buildGroupToken,
 } from "@/knowledge-base/acl-tokens";
+import { registerAuditLogHook } from "@/middleware/audit-log-hook";
 import {
   ConnectorRunModel,
   GithubAppConfigModel,
@@ -23,6 +24,7 @@ import {
   KnowledgeBaseModel,
   TaskModel,
 } from "@/models";
+import AuditLogModel from "@/models/audit-log";
 import { secretManager } from "@/secrets-manager";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
@@ -51,6 +53,8 @@ describe("knowledge base routes", () => {
         }
       ).organizationId = organizationId;
     });
+
+    registerAuditLogHook(app);
 
     const { default: knowledgeBaseRoutes } = await import("./knowledge-base");
     await app.register(knowledgeBaseRoutes);
@@ -3492,6 +3496,89 @@ describe("knowledge base routes", () => {
       });
       expect(deleteResponse.statusCode).toBe(200);
       expect(await refreshTasks()).toHaveLength(2);
+    });
+
+    test("mapping writes a connector.updated audit row whose snapshot diffs the override", async ({
+      makeKnowledgeBase,
+      makeKnowledgeBaseConnector,
+      makeUser,
+      makeMember,
+    }) => {
+      const connector = await makeConnectorWithHiddenMember({
+        makeKnowledgeBase,
+        makeKnowledgeBaseConnector,
+      });
+      const alice = await makeUser({ email: "alice@example.com" });
+      await makeMember(alice.id, organizationId);
+
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/connectors/${connector.id}/member-overrides`,
+        payload: { externalAccountId: "acc-hidden", userId: alice.id },
+      });
+      expect(response.statusCode).toBe(200);
+      // The audit row is written fire-and-forget after the response.
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { data } = await AuditLogModel.findPaginated({
+        organizationId,
+        resourceType: "connector",
+        limit: 20,
+        offset: 0,
+      });
+      const row = data.find(
+        (r) => r.resourceId === connector.id && r.httpMethod === "PUT",
+      );
+      expect(row?.action).toBe("connector.updated");
+      expect(row?.outcome).toBe("success");
+      expect(row?.before?.memberOverrides).toEqual([]);
+      expect(row?.after?.memberOverrides).toEqual([
+        `acc-hidden -> alice@example.com (${alice.id})`,
+      ]);
+    });
+
+    test("unmapping writes connector.updated (not connector.deleted) with the override removed", async ({
+      makeKnowledgeBase,
+      makeKnowledgeBaseConnector,
+      makeUser,
+      makeMember,
+    }) => {
+      const connector = await makeConnectorWithHiddenMember({
+        makeKnowledgeBase,
+        makeKnowledgeBaseConnector,
+      });
+      const alice = await makeUser({ email: "alice@example.com" });
+      await makeMember(alice.id, organizationId);
+      await app.inject({
+        method: "PUT",
+        url: `/api/connectors/${connector.id}/member-overrides`,
+        payload: { externalAccountId: "acc-hidden", userId: alice.id },
+      });
+
+      const deleteResponse = await app.inject({
+        method: "DELETE",
+        url: `/api/connectors/${connector.id}/member-overrides/acc-hidden`,
+      });
+      expect(deleteResponse.statusCode).toBe(200);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { data } = await AuditLogModel.findPaginated({
+        organizationId,
+        resourceType: "connector",
+        limit: 20,
+        offset: 0,
+      });
+      const row = data.find(
+        (r) => r.resourceId === connector.id && r.httpMethod === "DELETE",
+      );
+      // The mapping DELETE must read as a connector update (the connector
+      // survives), with the removed mapping visible in the diff.
+      expect(row?.action).toBe("connector.updated");
+      expect(row?.outcome).toBe("success");
+      expect(row?.before?.memberOverrides).toEqual([
+        `acc-hidden -> alice@example.com (${alice.id})`,
+      ]);
+      expect(row?.after?.memberOverrides).toEqual([]);
     });
   });
 


### PR DESCRIPTION
Manually mapping an upstream member account to an Archestra user (PUT/DELETE `/api/connectors/:id/member-overrides`, the auto-sync-permissions admin escape hatch) already wrote a `connector.updated` audit row — but the snapshot fetcher read only the connector row, which the mapping upsert/delete never touches. The recorded `before`/`after` were identical, so the audit log could not answer who granted an upstream account's identity to which org user, or when a mapping was revoked.

The connector audit snapshot (`KnowledgeBaseConnectorModel.findByIdForAudit`) now includes the connector's `kb_member_overrides` mappings as a sorted `"<externalAccountId> -> <email> (<userId>)"` list, mirroring how the team snapshot carries members/external-groups. Both member-override mutations now produce a real diff (`[] -> ["5b10ac…"]` on map, the reverse on unmap), on this route and any other `connector.updated` record.

Tests: two route-level assertions on the persisted audit rows (map + unmap), with the audit hook now registered in the knowledge-base route suite. Live-verified on a dev stack: created a Jira auto-sync connector, mapped/unmapped a member, and confirmed the diffs through `/api/audit-logs`.

Task: T-908 (stays open — remaining connectors).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>