### PR TITLE
feat(knowledge-base): permission auto-sync for the Asana connector

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -185,7 +185,8 @@ Auto-sync permissions mirrors the data source system's access control into Arche
 Auto-sync permissions works with the connectors marked *Supported* below. *Limited* means the source's access control is mirrored with a coarser audience model — the row says which. The others do not support it yet.
 
 | Connector    | Auto-sync permissions                                                                                     |
-| ------------ | --------------------------------------------------------------------------------------------------------- |
+| ------------ | ----------------------------------------------------------------------------------------------------------- |
+| Asana        | Supported                                                                                                 |
 | Confluence   | Supported                                                                                                 |
 | GitHub       | Supported                                                                                                 |
 | GitLab       | Supported                                                                                                 |
@@ -196,7 +197,6 @@ Auto-sync permissions works with the connectors marked *Supported* below. *Limit
 | OneDrive     | Supported                                                                                                 |
 | Salesforce   | Supported                                                                                                 |
 | SharePoint   | Supported                                                                                                 |
-| Asana        | Not supported                                                                                             |
 | Dropbox      | Not supported                                                                                             |
 | Linear       | Not supported                                                                                             |
 | Outline      | Not supported                                                                                             |
@@ -213,6 +213,7 @@ Auto-sync permissions works with the connectors marked *Supported* below. *Limit
 - **OneDrive** resolves user grants and drive owners to emails through the `User.Read.All` app permission. Without it, those accounts stay unresolvable. See [OneDrive](#onedrive).
 - **Salesforce** reads user emails and group membership through the same login the connector already uses. No extra credential is needed.
 - **Notion** returns member emails only when the integration has the **"read user information including email addresses"** capability. Guests are never listed.
+- **Asana** returns workspace members' emails through the same personal access token the connector already uses. No extra credential is needed, but the token's user must be able to see the synced projects and their members.
 
 **Permission-read access.** The credential must also be able to read the source's permission settings — Jira permission schemes, Confluence space permissions, GitHub repository collaborators, GitLab project members. A credential that cannot read them hides that project or space from everyone, because Archestra never assumes an audience it could not verify. Each sync run reports how many it could not read, so a project nobody can find is easy to tell apart from a project nobody is granted.
 
@@ -336,6 +337,12 @@ Sync tasks and discussions from Asana projects.
 | Workspace GID | Your Asana workspace GID (found in the URL when viewing your workspace)                       |
 | Project GIDs  | Comma-separated project GIDs to sync (optional -- leave blank to sync all workspace projects) |
 | Tags to Skip  | Comma-separated tag names to exclude (optional)                                               |
+
+**Auto-sync permissions.** Each project is one permission scope. A project shared with the whole workspace grants every workspace member — guests excluded. Any other project grants its explicit members: users directly, teams through their team rosters. A task in several projects is readable through any of them; its scope is the union of those audiences. Task collaborators are granted individually on their tasks.
+
+Each permission sync also snapshots workspace members and team rosters — the connector's **Users** and **Groups** tabs show every member with their assignment status, and an account whose email is hidden upstream can be assigned manually from the Users tab. Limited-access team members get only the projects they are explicitly added to. Guests get only explicit project and task grants.
+
+Permission reads run as the token's user. A project or roster the token cannot read stays fail-closed — use a token from a user who can see every synced project. A task removed from every synced project is hidden until a sync sees it again.
 
 ### ServiceNow
 

--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -340,7 +340,7 @@ Sync tasks and discussions from Asana projects.
 
 **Auto-sync permissions.** Each project is one permission scope. A project shared with the whole workspace grants every workspace member — guests excluded. Any other project grants its explicit members: users directly, teams through their team rosters. A task in several projects is readable through any of them; its scope is the union of those audiences. Task collaborators are granted individually on their tasks.
 
-Each permission sync also snapshots workspace members and team rosters — the connector's **Users** and **Groups** tabs show every member with their assignment status, and an account whose email is hidden upstream can be assigned manually from the Users tab. Limited-access team members get only the projects they are explicitly added to. Guests get only explicit project and task grants.
+Each permission sync also snapshots workspace members and team rosters — the connector's **Users** and **Groups** tabs show every member with their assignment status, and an account whose email is hidden upstream can be assigned manually from the Users tab. Users added to a project directly — guests included — appear there too, under the synthetic **Direct project members** group. Limited-access team members get only the projects they are explicitly added to. Guests get only explicit project and task grants.
 
 Permission reads run as the token's user. A project or roster the token cannot read stays fail-closed — use a token from a user who can see every synced project. A task removed from every synced project is hidden until a sync sees it again.
 

--- a/platform/backend/src/knowledge-base/connectors/asana/asana-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/asana/asana-connector.test.ts
@@ -15,7 +15,7 @@ const mockGetProject = vi.fn();
 const mockGetProjectsForWorkspace = vi.fn();
 const mockGetTasksForProject = vi.fn();
 const mockGetStoriesForTask = vi.fn();
-const mockGetProjectMembershipsForProject = vi.fn();
+const mockGetMemberships = vi.fn();
 const mockGetTeamsForWorkspace = vi.fn();
 const mockGetTeamMembershipsForTeam = vi.fn();
 const mockGetWorkspaceMembershipsForWorkspace = vi.fn();
@@ -39,8 +39,8 @@ vi.mock("asana", () => ({
   StoriesApi: class MockStoriesApi {
     getStoriesForTask = mockGetStoriesForTask;
   },
-  ProjectMembershipsApi: class MockProjectMembershipsApi {
-    getProjectMembershipsForProject = mockGetProjectMembershipsForProject;
+  MembershipsApi: class MockMembershipsApi {
+    getMemberships = mockGetMemberships;
   },
   TeamsApi: class MockTeamsApi {
     getTeamsForWorkspace = mockGetTeamsForWorkspace;
@@ -1459,8 +1459,8 @@ describe("AsanaConnector", () => {
         const entry = projects[gid];
         return Promise.resolve(page(entry?.tasks ?? []));
       });
-      mockGetProjectMembershipsForProject.mockImplementation((gid: string) => {
-        const entry = projects[gid];
+      mockGetMemberships.mockImplementation((opts: { parent?: string }) => {
+        const entry = projects[opts.parent ?? ""];
         if (entry?.membershipsError) {
           return Promise.reject(entry.membershipsError);
         }
@@ -1589,7 +1589,7 @@ describe("AsanaConnector", () => {
         },
       });
       // Membership pagination: the team lands on page two.
-      mockGetProjectMembershipsForProject
+      mockGetMemberships
         .mockResolvedValueOnce(
           page([userMembership("u-alice"), userMembership("u-hidden")], "off2"),
         )
@@ -1759,6 +1759,51 @@ describe("AsanaConnector", () => {
       ]);
     });
 
+    test("audience reads use the generic memberships API keyed by parent, without opt_fields", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [permTask("t1", { projects: ["111111"] })],
+          memberships: [userMembership("u-alice")],
+        },
+      });
+
+      await collectSnapshot(snapshotParams());
+
+      // The legacy project_memberships endpoint ignores member.* opt_fields
+      // and returns rows without a member object; the generic API carries
+      // member (user or team) in its default payload. Pin both properties.
+      expect(mockGetMemberships).toHaveBeenCalledWith(
+        expect.objectContaining({ parent: "111111" }),
+      );
+      expect(mockGetMemberships.mock.calls[0][0]).not.toHaveProperty(
+        "opt_fields",
+      );
+    });
+
+    test("membership rows without a member object fail-close the container with the failure flag", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [permTask("t1", { projects: ["111111"] })],
+          memberships: [{ gid: "row-1" }, { gid: "row-2" }],
+        },
+      });
+
+      const yields = await collectSnapshot(snapshotParams());
+      const [container] = containerYields(yields);
+
+      // Unreadable rows are an observed lookup failure, not "nobody has
+      // access" — the exact silent-empty failure the legacy endpoint caused.
+      expect(container.audienceResolutionFailed).toBe(true);
+      expect(container.permissions).toEqual({
+        isPublic: false,
+        users: [],
+        groups: [],
+      });
+      expect(documentYields(yields)).toHaveLength(1);
+    });
+
     test("an empty project emits a boundary container without resolving its audience", async () => {
       stubProjects({
         "111111": {
@@ -1779,7 +1824,7 @@ describe("AsanaConnector", () => {
           cursor: "project:111111",
         },
       ]);
-      expect(mockGetProjectMembershipsForProject).not.toHaveBeenCalled();
+      expect(mockGetMemberships).not.toHaveBeenCalled();
     });
 
     test("task followers become per-document exception users", async () => {

--- a/platform/backend/src/knowledge-base/connectors/asana/asana-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/asana/asana-connector.test.ts
@@ -1,14 +1,25 @@
 import { vi } from "vitest";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
-import type { ConnectorSyncBatch } from "@/types";
+import type {
+  ConnectorSyncBatch,
+  GroupMembershipYield,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
+} from "@/types";
 import { AsanaConnector, extractAsanaHtml } from "./asana-connector";
 
 // Mock asana SDK
 const mockGetUser = vi.fn();
+const mockGetUsers = vi.fn();
 const mockGetProject = vi.fn();
 const mockGetProjectsForWorkspace = vi.fn();
 const mockGetTasksForProject = vi.fn();
 const mockGetStoriesForTask = vi.fn();
+const mockGetProjectMembershipsForProject = vi.fn();
+const mockGetTeamsForWorkspace = vi.fn();
+const mockGetTeamMembershipsForTeam = vi.fn();
+const mockGetWorkspaceMembershipsForWorkspace = vi.fn();
+const mockGetWorkspace = vi.fn();
 
 vi.mock("asana", () => ({
   ApiClient: class MockApiClient {
@@ -16,6 +27,7 @@ vi.mock("asana", () => ({
   },
   UsersApi: class MockUsersApi {
     getUser = mockGetUser;
+    getUsers = mockGetUsers;
   },
   ProjectsApi: class MockProjectsApi {
     getProject = mockGetProject;
@@ -26,6 +38,22 @@ vi.mock("asana", () => ({
   },
   StoriesApi: class MockStoriesApi {
     getStoriesForTask = mockGetStoriesForTask;
+  },
+  ProjectMembershipsApi: class MockProjectMembershipsApi {
+    getProjectMembershipsForProject = mockGetProjectMembershipsForProject;
+  },
+  TeamsApi: class MockTeamsApi {
+    getTeamsForWorkspace = mockGetTeamsForWorkspace;
+  },
+  TeamMembershipsApi: class MockTeamMembershipsApi {
+    getTeamMembershipsForTeam = mockGetTeamMembershipsForTeam;
+  },
+  WorkspaceMembershipsApi: class MockWorkspaceMembershipsApi {
+    getWorkspaceMembershipsForWorkspace =
+      mockGetWorkspaceMembershipsForWorkspace;
+  },
+  WorkspacesApi: class MockWorkspacesApi {
+    getWorkspace = mockGetWorkspace;
   },
 }));
 
@@ -1358,6 +1386,585 @@ describe("AsanaConnector", () => {
 
       expect(batches[0].documents[0].content).toContain(
         "plain-only comment body",
+      );
+    });
+  });
+
+  describe("permission sync", () => {
+    const WS = "1234567890";
+
+    /** Collection-shaped response page (see extractCollectionData/NextOffset). */
+    function page<T>(data: T[], nextOffset?: string) {
+      return {
+        data,
+        ...(nextOffset ? { next_page: { offset: nextOffset } } : {}),
+      };
+    }
+
+    function permProject(
+      gid: string,
+      opts?: {
+        privacy?: string;
+        teamGid?: string;
+        name?: string;
+        workspaceGid?: string;
+      },
+    ) {
+      return {
+        gid,
+        name: opts?.name ?? `Project ${gid}`,
+        privacy_setting: opts?.privacy ?? "private",
+        team: opts?.teamGid ? { gid: opts.teamGid } : null,
+        workspace: { gid: opts?.workspaceGid ?? WS },
+      };
+    }
+
+    function permTask(
+      gid: string,
+      opts?: { projects?: string[]; followers?: string[] },
+    ) {
+      return {
+        gid,
+        projects: (opts?.projects ?? []).map((p) => ({ gid: p })),
+        followers: (opts?.followers ?? []).map((f) => ({ gid: f })),
+      };
+    }
+
+    function userMembership(gid: string) {
+      return { member: { gid, resource_type: "user" } };
+    }
+
+    function teamMembership(gid: string) {
+      return { member: { gid, resource_type: "team" } };
+    }
+
+    /** Route getProject/getTasksForProject/memberships by project gid. */
+    function stubProjects(
+      projects: Record<
+        string,
+        {
+          project: ReturnType<typeof permProject>;
+          tasks?: ReturnType<typeof permTask>[];
+          memberships?: unknown[];
+          membershipsError?: unknown;
+        }
+      >,
+    ) {
+      mockGetProject.mockImplementation((gid: string) => {
+        const entry = projects[gid];
+        if (!entry) return Promise.reject(new Error(`no project ${gid}`));
+        return Promise.resolve({ data: entry.project });
+      });
+      mockGetTasksForProject.mockImplementation((gid: string) => {
+        const entry = projects[gid];
+        return Promise.resolve(page(entry?.tasks ?? []));
+      });
+      mockGetProjectMembershipsForProject.mockImplementation((gid: string) => {
+        const entry = projects[gid];
+        if (entry?.membershipsError) {
+          return Promise.reject(entry.membershipsError);
+        }
+        return Promise.resolve(page(entry?.memberships ?? []));
+      });
+    }
+
+    function stubWorkspaceUsers(
+      users: Array<{ gid: string; email?: string | null; name?: string }>,
+    ) {
+      mockGetUsers.mockResolvedValue(
+        page(
+          users.map((u) => ({
+            gid: u.gid,
+            email: u.email ?? null,
+            name: u.name ?? `User ${u.gid}`,
+          })),
+        ),
+      );
+    }
+
+    function snapshotParams(
+      overrides?: Partial<PermissionSyncParams>,
+    ): PermissionSyncParams {
+      return {
+        config: validConfig,
+        credentials,
+        cursor: null,
+        readIngestedDocuments: async () => ({
+          documents: [],
+          nextAfterId: null,
+        }),
+        ...overrides,
+      };
+    }
+
+    async function collectSnapshot(params: PermissionSyncParams) {
+      const yields: PermissionSnapshotYield[] = [];
+      for await (const item of connector.syncPermissionSnapshot(params)) {
+        yields.push(item);
+      }
+      return yields;
+    }
+
+    async function collectGroups(params: PermissionSyncParams) {
+      const yields: GroupMembershipYield[] = [];
+      for await (const item of connector.syncGroups(params)) {
+        yields.push(item);
+      }
+      return yields;
+    }
+
+    function containerYields(yields: PermissionSnapshotYield[]) {
+      return yields.filter(
+        (y): y is Extract<PermissionSnapshotYield, { kind: "container" }> =>
+          y.kind === "container",
+      );
+    }
+
+    function documentYields(yields: PermissionSnapshotYield[]) {
+      return yields.filter(
+        (y): y is Extract<PermissionSnapshotYield, { kind: "document" }> =>
+          y.kind === "document",
+      );
+    }
+
+    beforeEach(() => {
+      vi.spyOn(
+        connector as unknown as RateLimitedConnector,
+        "rateLimit",
+      ).mockResolvedValue(undefined);
+      stubWorkspaceUsers([
+        { gid: "u-alice", email: "alice@example.com", name: "Alice" },
+        { gid: "u-bob", email: "bob@example.com", name: "Bob" },
+        { gid: "u-hidden", email: null, name: "Hidden" },
+      ]);
+      mockGetWorkspace.mockResolvedValue({ data: { name: "Acme" } });
+      mockGetTeamsForWorkspace.mockResolvedValue(page([]));
+      mockGetWorkspaceMembershipsForWorkspace.mockResolvedValue(page([]));
+    });
+
+    test("supportsPermissionSync is enabled", () => {
+      expect(connector.supportsPermissionSync).toBe(true);
+    });
+
+    test("public_to_workspace project grants the workspace-members group plus explicit members", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111", { privacy: "public_to_workspace" }),
+          tasks: [permTask("t1", { projects: ["111111"] })],
+          memberships: [userMembership("u-alice")],
+        },
+      });
+
+      const yields = await collectSnapshot(snapshotParams());
+      const containers = containerYields(yields);
+      const documents = documentYields(yields);
+
+      expect(containers).toHaveLength(1);
+      expect(containers[0]).toMatchObject({
+        containerKey: "project:111111",
+        cursor: "project:111111",
+        permissions: {
+          isPublic: false,
+          users: ["alice@example.com"],
+          groups: [`workspace-members:${WS}`],
+        },
+      });
+      expect(containers[0].audienceResolutionFailed ?? false).toBe(false);
+      expect(documents).toEqual([
+        {
+          kind: "document",
+          sourceId: "task-t1",
+          containerKey: "project:111111",
+          cursor: "project:111111",
+        },
+      ]);
+    });
+
+    test("private project grants direct users and member teams; hidden-email member is dropped fail-closed", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [permTask("t1", { projects: ["111111"] })],
+          memberships: [],
+        },
+      });
+      // Membership pagination: the team lands on page two.
+      mockGetProjectMembershipsForProject
+        .mockResolvedValueOnce(
+          page([userMembership("u-alice"), userMembership("u-hidden")], "off2"),
+        )
+        .mockResolvedValueOnce(page([teamMembership("team-eng")]));
+
+      const yields = await collectSnapshot(snapshotParams());
+      const [container] = containerYields(yields);
+
+      expect(container.permissions).toEqual({
+        isPublic: false,
+        users: ["alice@example.com"],
+        groups: ["team:team-eng"],
+      });
+      expect(container.audienceResolutionFailed ?? false).toBe(false);
+    });
+
+    test("hidden-email direct member resolves through the admin mapping", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [permTask("t1", { projects: ["111111"] })],
+          memberships: [userMembership("u-hidden")],
+        },
+      });
+
+      const yields = await collectSnapshot(
+        snapshotParams({
+          resolveMappedEmail: (accountId) =>
+            accountId === "u-hidden" ? "mapped@example.com" : null,
+        }),
+      );
+
+      expect(containerYields(yields)[0].permissions.users).toEqual([
+        "mapped@example.com",
+      ]);
+    });
+
+    test("deprecated private_to_team grants the project's own team", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111", {
+            privacy: "private_to_team",
+            teamGid: "team-legacy",
+          }),
+          tasks: [permTask("t1", { projects: ["111111"] })],
+          memberships: [],
+        },
+      });
+
+      const yields = await collectSnapshot(snapshotParams());
+      expect(containerYields(yields)[0].permissions.groups).toEqual([
+        "team:team-legacy",
+      ]);
+    });
+
+    test("multi-homed task gets a nested union container and is assigned exactly once", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [
+            permTask("t1", { projects: ["111111", "222222"] }),
+            permTask("t2", { projects: ["111111"] }),
+          ],
+          memberships: [userMembership("u-alice")],
+        },
+        "222222": {
+          project: permProject("222222"),
+          tasks: [
+            permTask("t1", { projects: ["111111", "222222"] }),
+            permTask("t3", { projects: ["222222"] }),
+          ],
+          memberships: [userMembership("u-bob")],
+        },
+      });
+
+      const yields = await collectSnapshot(
+        snapshotParams({
+          config: { workspaceGid: WS, projectGids: ["111111", "222222"] },
+        }),
+      );
+
+      const containers = containerYields(yields);
+      expect(containers.map((c) => c.containerKey)).toEqual([
+        "project:111111",
+        "project:111111/multi:222222",
+        "project:222222",
+      ]);
+      const union = containers[1];
+      expect(union.permissions.users).toEqual([
+        "alice@example.com",
+        "bob@example.com",
+      ]);
+      expect(union.cursor).toBe("project:111111");
+
+      const documents = documentYields(yields);
+      expect(documents).toEqual([
+        expect.objectContaining({
+          sourceId: "task-t1",
+          containerKey: "project:111111/multi:222222",
+        }),
+        expect.objectContaining({
+          sourceId: "task-t2",
+          containerKey: "project:111111",
+        }),
+        expect.objectContaining({
+          sourceId: "task-t3",
+          containerKey: "project:222222",
+        }),
+      ]);
+    });
+
+    test("multi-home into an out-of-scope project contributes audience without a top-level container", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [permTask("t1", { projects: ["111111", "999999"] })],
+          memberships: [userMembership("u-alice")],
+        },
+        "999999": {
+          project: permProject("999999"),
+          memberships: [userMembership("u-bob")],
+        },
+      });
+
+      const yields = await collectSnapshot(snapshotParams());
+      const containers = containerYields(yields);
+
+      expect(containers.map((c) => c.containerKey)).toEqual([
+        "project:111111",
+        "project:111111/multi:999999",
+      ]);
+      expect(containers[1].permissions.users).toEqual([
+        "alice@example.com",
+        "bob@example.com",
+      ]);
+      // The out-of-scope project is an audience source only — its tasks were
+      // never enumerated.
+      expect(mockGetTasksForProject).not.toHaveBeenCalledWith(
+        "999999",
+        expect.anything(),
+      );
+    });
+
+    test("an unreadable project audience fail-closes the container but keeps its documents assigned", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [permTask("t1", { projects: ["111111"] })],
+          membershipsError: Object.assign(new Error("boom"), { status: 500 }),
+        },
+      });
+
+      const yields = await collectSnapshot(snapshotParams());
+      const [container] = containerYields(yields);
+
+      expect(container.audienceResolutionFailed).toBe(true);
+      expect(container.permissions).toEqual({
+        isPublic: false,
+        users: [],
+        groups: [],
+      });
+      expect(documentYields(yields)).toEqual([
+        expect.objectContaining({
+          sourceId: "task-t1",
+          containerKey: "project:111111",
+        }),
+      ]);
+    });
+
+    test("an empty project emits a boundary container without resolving its audience", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [],
+          memberships: [userMembership("u-alice")],
+        },
+      });
+
+      const yields = await collectSnapshot(snapshotParams());
+
+      expect(yields).toEqual([
+        {
+          kind: "container",
+          containerKey: "project:111111",
+          permissions: { isPublic: false, users: [], groups: [] },
+          audienceResolutionFailed: false,
+          cursor: "project:111111",
+        },
+      ]);
+      expect(mockGetProjectMembershipsForProject).not.toHaveBeenCalled();
+    });
+
+    test("task followers become per-document exception users", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [
+            permTask("t1", {
+              projects: ["111111"],
+              followers: ["u-bob", "u-hidden"],
+            }),
+          ],
+          memberships: [userMembership("u-alice")],
+        },
+      });
+
+      const yields = await collectSnapshot(snapshotParams());
+      expect(documentYields(yields)[0].exceptionUsers).toEqual([
+        "bob@example.com",
+      ]);
+    });
+
+    test("resume cursor skips completed top-level containers", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [permTask("t1", { projects: ["111111"] })],
+          memberships: [],
+        },
+        "222222": {
+          project: permProject("222222"),
+          tasks: [permTask("t2", { projects: ["222222"] })],
+          memberships: [],
+        },
+      });
+
+      const yields = await collectSnapshot(
+        snapshotParams({
+          config: { workspaceGid: WS, projectGids: ["111111", "222222"] },
+          cursor: "project:222222",
+        }),
+      );
+
+      expect(containerYields(yields).map((c) => c.containerKey)).toEqual([
+        "project:222222",
+      ]);
+      expect(mockGetTasksForProject).not.toHaveBeenCalledWith(
+        "111111",
+        expect.anything(),
+      );
+    });
+
+    test("a failed workspace-user walk degrades direct grants but keeps group audiences", async () => {
+      mockGetUsers.mockRejectedValue(new Error("users down"));
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          tasks: [permTask("t1", { projects: ["111111"] })],
+          memberships: [teamMembership("team-eng"), userMembership("u-alice")],
+        },
+      });
+
+      const yields = await collectSnapshot(snapshotParams());
+      const [container] = containerYields(yields);
+
+      expect(container.permissions.groups).toEqual(["team:team-eng"]);
+      expect(container.permissions.users).toEqual([]);
+      expect(container.audienceResolutionFailed ?? false).toBe(false);
+      // One walk attempt per pass, not one per principal.
+      expect(mockGetUsers).toHaveBeenCalledTimes(1);
+    });
+
+    test("syncGroups yields the workspace-members roster without guests or deactivated users", async () => {
+      stubWorkspaceUsers([
+        { gid: "u-alice", email: "alice@example.com", name: "Alice" },
+        { gid: "u-bob", email: "bob@example.com", name: "Bob" },
+        { gid: "u-guest", email: "guest@example.com", name: "Guest" },
+        { gid: "u-gone", email: "gone@example.com", name: "Gone" },
+      ]);
+      mockGetWorkspaceMembershipsForWorkspace.mockResolvedValue(
+        page([
+          { user: { gid: "u-alice", name: "Alice" } },
+          { user: { gid: "u-bob", name: "Bob" }, is_guest: false },
+          { user: { gid: "u-guest", name: "Guest" }, is_guest: true },
+          { user: { gid: "u-gone", name: "Gone" }, is_active: false },
+        ]),
+      );
+
+      const yields = await collectGroups(snapshotParams());
+
+      expect(yields[0]).toEqual({
+        groupId: `workspace-members:${WS}`,
+        name: "Acme workspace members",
+        members: [
+          {
+            accountId: "u-alice",
+            displayName: "Alice",
+            email: "alice@example.com",
+            accountType: "user",
+          },
+          {
+            accountId: "u-bob",
+            displayName: "Bob",
+            email: "bob@example.com",
+            accountType: "user",
+          },
+        ],
+      });
+    });
+
+    test("syncGroups team rosters exclude limited-access members and byte-match audience group ids", async () => {
+      mockGetTeamsForWorkspace.mockResolvedValue(
+        page([{ gid: "team-eng", name: "Engineering" }]),
+      );
+      mockGetTeamMembershipsForTeam.mockResolvedValue(
+        page([
+          { user: { gid: "u-alice", name: "Alice" } },
+          { user: { gid: "u-bob", name: "Bob" }, is_limited_access: true },
+        ]),
+      );
+
+      const yields = await collectGroups(snapshotParams());
+      const teamYield = yields.find((y) => y.groupId === "team:team-eng");
+
+      expect(teamYield).toEqual({
+        groupId: "team:team-eng",
+        name: "Engineering",
+        members: [
+          {
+            accountId: "u-alice",
+            displayName: "Alice",
+            email: "alice@example.com",
+            accountType: "user",
+          },
+        ],
+      });
+    });
+
+    test("a 403 team roster yields an observed fail-closed empty group and later teams still sync", async () => {
+      mockGetTeamsForWorkspace.mockResolvedValue(
+        page([
+          { gid: "team-locked", name: "Locked" },
+          { gid: "team-open", name: "Open" },
+        ]),
+      );
+      mockGetTeamMembershipsForTeam.mockImplementation((teamGid: string) => {
+        if (teamGid === "team-locked") {
+          return Promise.reject(
+            Object.assign(new Error("Forbidden"), { status: 403 }),
+          );
+        }
+        return Promise.resolve(page([{ user: { gid: "u-bob", name: "Bob" } }]));
+      });
+
+      const yields = await collectGroups(snapshotParams());
+
+      expect(yields.find((y) => y.groupId === "team:team-locked")).toEqual({
+        groupId: "team:team-locked",
+        name: "Locked",
+        members: [],
+        membershipResolutionFailed: true,
+      });
+      expect(
+        yields.find((y) => y.groupId === "team:team-open")?.members,
+      ).toHaveLength(1);
+    });
+
+    test("a transient team roster failure aborts the group phase instead of truncating", async () => {
+      mockGetTeamsForWorkspace.mockResolvedValue(
+        page([{ gid: "team-eng", name: "Engineering" }]),
+      );
+      mockGetTeamMembershipsForTeam.mockRejectedValue(
+        Object.assign(new Error("upstream 502"), { status: 502 }),
+      );
+
+      await expect(collectGroups(snapshotParams())).rejects.toThrow(
+        "upstream 502",
+      );
+    });
+
+    test("a failed workspace-user walk aborts syncGroups so resolved emails are never overwritten with nulls", async () => {
+      mockGetUsers.mockRejectedValue(new Error("users down"));
+
+      await expect(collectGroups(snapshotParams())).rejects.toThrow(
+        "users down",
       );
     });
   });

--- a/platform/backend/src/knowledge-base/connectors/asana/asana-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/asana/asana-connector.test.ts
@@ -1540,6 +1540,13 @@ describe("AsanaConnector", () => {
       mockGetWorkspace.mockResolvedValue({ data: { name: "Acme" } });
       mockGetTeamsForWorkspace.mockResolvedValue(page([]));
       mockGetWorkspaceMembershipsForWorkspace.mockResolvedValue(page([]));
+      // syncGroups walks the scoped projects for the direct-grants roster;
+      // default to a resolvable project with no members (tests override via
+      // stubProjects).
+      mockGetProject.mockImplementation((gid: string) =>
+        Promise.resolve({ data: permProject(gid) }),
+      );
+      mockGetMemberships.mockResolvedValue(page([]));
     });
 
     test("supportsPermissionSync is enabled", () => {
@@ -1990,6 +1997,57 @@ describe("AsanaConnector", () => {
       expect(
         yields.find((y) => y.groupId === "team:team-open")?.members,
       ).toHaveLength(1);
+    });
+
+    test("syncGroups rosters direct project members — guests included — under the synthetic direct-grants group", async () => {
+      stubWorkspaceUsers([
+        { gid: "u-alice", email: "alice@example.com", name: "Alice" },
+        { gid: "u-guest", email: "guest@example.com", name: "Guest" },
+      ]);
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          memberships: [
+            userMembership("u-alice"),
+            userMembership("u-guest"),
+            teamMembership("team-eng"),
+          ],
+        },
+      });
+
+      const yields = await collectGroups(snapshotParams());
+      const direct = yields.find((y) => y.groupId === "direct-grants");
+
+      expect(direct).toEqual({
+        groupId: "direct-grants",
+        name: "Direct project members",
+        members: [
+          expect.objectContaining({
+            accountId: "u-alice",
+            email: "alice@example.com",
+          }),
+          expect.objectContaining({
+            accountId: "u-guest",
+            email: "guest@example.com",
+          }),
+        ],
+      });
+    });
+
+    test("an unreadable project is skipped by the direct-grants roster without aborting the group phase", async () => {
+      stubProjects({
+        "111111": {
+          project: permProject("111111"),
+          membershipsError: Object.assign(new Error("boom"), { status: 500 }),
+        },
+      });
+
+      const yields = await collectGroups(snapshotParams());
+
+      expect(yields.find((y) => y.groupId === "direct-grants")).toBeUndefined();
+      expect(
+        yields.find((y) => y.groupId === `workspace-members:${WS}`),
+      ).toBeDefined();
     });
 
     test("a transient team roster failure aborts the group phase instead of truncating", async () => {

--- a/platform/backend/src/knowledge-base/connectors/asana/asana-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/asana/asana-connector.ts
@@ -1,6 +1,6 @@
 import {
   ApiClient,
-  ProjectMembershipsApi,
+  MembershipsApi,
   ProjectsApi,
   StoriesApi,
   TasksApi,
@@ -69,7 +69,6 @@ const STORY_OPT_FIELDS = "gid,type,text,html_text,created_by.name,created_at";
 const PERMISSION_TASK_OPT_FIELDS = "gid,projects.gid,followers.gid";
 const PERMISSION_PROJECT_OPT_FIELDS =
   "gid,name,privacy_setting,team.gid,workspace.gid";
-const PROJECT_MEMBERSHIP_OPT_FIELDS = "member.gid,member.resource_type";
 const WORKSPACE_USER_OPT_FIELDS = "email,name";
 const WORKSPACE_MEMBERSHIP_OPT_FIELDS = "user.gid,user.name,is_guest,is_active";
 const TEAM_MEMBERSHIP_OPT_FIELDS = "user.gid,user.name,is_limited_access";
@@ -905,16 +904,25 @@ export class AsanaConnector extends BaseConnector {
       if (project.privacy_setting === "private_to_team" && project.team?.gid) {
         groups.add(teamGroupId(String(project.team.gid)));
       }
+      // The generic memberships API, NOT the legacy project_memberships
+      // endpoint: only this one returns TEAM members alongside users, and its
+      // default compact payload carries `member` — the legacy endpoint's
+      // opt_fields grammar silently ignores `member.gid`/`member.resource_type`
+      // and serves rows without a member object (proven against real Asana).
       const memberships = await this.paginateAll<AsanaProjectMembershipRecord>(
         (opts) =>
-          apis.projectMemberships.getProjectMembershipsForProject(projectGid, {
+          apis.memberships.getMemberships({
             ...opts,
-            opt_fields: PROJECT_MEMBERSHIP_OPT_FIELDS,
+            parent: projectGid,
           }),
       );
+      let skippedRows = 0;
       for (const membership of memberships) {
         const member = membership.member;
-        if (!member?.gid) continue;
+        if (!member?.gid) {
+          skippedRows += 1;
+          continue;
+        }
         if (member.resource_type === "team") {
           groups.add(teamGroupId(String(member.gid)));
           continue;
@@ -930,7 +938,20 @@ export class AsanaConnector extends BaseConnector {
           this.permDroppedPrincipals += 1;
         }
       }
-      audience = { users, groups };
+      if (skippedRows > 0) {
+        this.log.warn(
+          { projectGid, skippedRows },
+          "Asana membership rows without a member object were skipped",
+        );
+      }
+      // Membership rows existed but none were readable → an observed lookup
+      // failure, not an upstream "nobody has access": fail-close WITH the
+      // flag so admins can tell the two apart (this exact shape drift is how
+      // the legacy endpoint failed silently).
+      audience =
+        skippedRows > 0 && users.size === 0 && groups.size === 0
+          ? null
+          : { users, groups };
     } catch (error) {
       this.log.warn(
         { projectGid, error: extractErrorMessage(error) },
@@ -1373,7 +1394,7 @@ function taskToDocument(
 
 interface AsanaPermissionApis {
   projects: ProjectsApi;
-  projectMemberships: ProjectMembershipsApi;
+  memberships: MembershipsApi;
   tasks: TasksApi;
   teams: TeamsApi;
   teamMemberships: TeamMembershipsApi;
@@ -1388,7 +1409,7 @@ function createPermissionApis(
   const client = createAsanaClient(credentials);
   return {
     projects: new ProjectsApi(client),
-    projectMemberships: new ProjectMembershipsApi(client),
+    memberships: new MembershipsApi(client),
     tasks: new TasksApi(client),
     teams: new TeamsApi(client),
     teamMemberships: new TeamMembershipsApi(client),

--- a/platform/backend/src/knowledge-base/connectors/asana/asana-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/asana/asana-connector.ts
@@ -1,11 +1,29 @@
-import { ApiClient, ProjectsApi, StoriesApi, TasksApi, UsersApi } from "asana";
+import {
+  ApiClient,
+  ProjectMembershipsApi,
+  ProjectsApi,
+  StoriesApi,
+  TasksApi,
+  TeamMembershipsApi,
+  TeamsApi,
+  UsersApi,
+  WorkspaceMembershipsApi,
+  WorkspacesApi,
+} from "asana";
 import * as cheerio from "cheerio";
+import * as metrics from "@/observability/metrics";
 import type {
   AsanaCheckpoint,
   AsanaConfig,
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorSyncBatch,
+  DocumentPermissions,
+  GroupMembershipYield,
+  GroupMemberYield,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
+  ResolveMappedEmail,
 } from "@/types";
 import { AsanaConfigSchema } from "@/types";
 import {
@@ -47,8 +65,30 @@ const TASK_OPT_FIELDS = [
 const PROJECT_OPT_FIELDS_WITH_WORKSPACE = "gid,name,workspace.gid";
 const STORY_OPT_FIELDS = "gid,type,text,html_text,created_by.name,created_at";
 
+// ----- Permission-sync opt_fields (ids and flags only, never content) -----
+const PERMISSION_TASK_OPT_FIELDS = "gid,projects.gid,followers.gid";
+const PERMISSION_PROJECT_OPT_FIELDS =
+  "gid,name,privacy_setting,team.gid,workspace.gid";
+const PROJECT_MEMBERSHIP_OPT_FIELDS = "member.gid,member.resource_type";
+const WORKSPACE_USER_OPT_FIELDS = "email,name";
+const WORKSPACE_MEMBERSHIP_OPT_FIELDS = "user.gid,user.name,is_guest,is_active";
+const TEAM_MEMBERSHIP_OPT_FIELDS = "user.gid,user.name,is_limited_access";
+
 export class AsanaConnector extends BaseConnector {
   type = "asana" as const;
+  supportsPermissionSync = true;
+
+  // ----- Per-pass permission-sync state (armed by initPermissionPass) -----
+  /** Project gid → resolved audience (null = lookup failed, fail-closed). */
+  private permAudienceByProjectGid = new Map<
+    string,
+    AsanaProjectAudience | null
+  >();
+  /** Workspace user gid → email/name, one walk per pass. */
+  private permWorkspaceUsers: Map<string, AsanaWorkspaceUserInfo> | null = null;
+  private permWorkspaceUsersFailed = false;
+  private permDroppedPrincipals = 0;
+  private permResolveMappedEmail: ResolveMappedEmail | null = null;
 
   async validateConfig(
     config: Record<string, unknown>,
@@ -155,6 +195,186 @@ export class AsanaConnector extends BaseConnector {
         seenTaskGids,
         isLastProject,
       });
+    }
+  }
+
+  // ===== Permission sync =====
+  //
+  // Projection of Asana's sharing model onto the container-ACL system:
+  //
+  // - CONTAINER = an Asana project (`project:<gid>`), the audience-sharing
+  //   unit. `public_to_workspace` projects grant the synthetic
+  //   workspace-members group; every project additionally grants its explicit
+  //   memberships — users by email, teams as `team:<gid>` groups. All Asana
+  //   access levels (admin/editor/commenter/viewer) can read, so there is no
+  //   level filtering. The deprecated `private_to_team` privacy value still
+  //   grants the project's own team.
+  // - MULTI-HOMED tasks (several home projects) are readable by anyone who
+  //   can see ANY home project. They are assigned once, under their
+  //   lowest-keyed scoped project, to a nested union container
+  //   `project:<gid>/multi:<others>` whose audience unions every home
+  //   project's audience (out-of-scope home projects contribute audience but
+  //   never become top-level containers).
+  // - Task COLLABORATORS (followers) can read a task regardless of project
+  //   membership → per-document `exceptionUsers`.
+  // - Asana gids are globally unique, so `team:<gid>` and
+  //   `workspace-members:<workspaceGid>` ids cannot collide across two Asana
+  //   connectors of different workspaces (group tokens are namespaced by
+  //   connector TYPE only).
+  // - Tasks the walk no longer sees (deleted, or removed from every synced
+  //   project and therefore private to collaborators) are fail-closed by the
+  //   pass's sweeps.
+  // - No change probe: every pass is a full reconcile (GitHub precedent). The
+  //   walk re-enumerates task ids/flags per project, never task content.
+
+  /**
+   * Snapshot generator (see the model comment above). Ordering contract:
+   * top-level container keys ascend in plain string order, a container yield
+   * precedes its documents, and `cursor` is always the current top-level key.
+   */
+  async *syncPermissionSnapshot(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const config = parseAsanaConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid Asana configuration for permission sync");
+    }
+    this.initPermissionPass(params);
+    const apis = createPermissionApis(params.credentials);
+
+    const projects = await this.getPermissionProjects(apis, config);
+    const scope = params.scope ? new Set(params.scope.containerKeys) : null;
+    // Multi-homed dedup across the whole pass: each task is assigned exactly
+    // once, under its lowest-keyed scoped project — the same walk order and
+    // dedup rule as the content sync.
+    const seenTaskGids = new Set<string>();
+
+    for (const project of projects) {
+      const containerKey = projectContainerKey(project.gid);
+      if (scope && !scope.has(containerKey)) continue;
+      if (params.cursor && containerKey < params.cursor) continue;
+      yield* this.syncProjectPermissionSnapshot({
+        apis,
+        config,
+        project,
+        seenTaskGids,
+      });
+    }
+    this.reportDroppedPermissionPrincipals();
+  }
+
+  /**
+   * Group rosters: the synthetic workspace-members group (audience of
+   * `public_to_workspace` projects — guests and deactivated users excluded,
+   * view-only members included) and every team visible to the credential.
+   * Limited-access team members are excluded: Asana grants them only the
+   * projects they are explicitly added to, which the project-membership path
+   * already covers. Organization guests who are real team members remain
+   * included. A team attached to a project but invisible to the credential is
+   * never yielded, so its grant stays fail-closed.
+   *
+   * Failure semantics: a failed roster walk THROWS — the pass isolates the
+   * group phase and the previous membership snapshot stays in force (a
+   * truncated roster would silently revoke its tail; a null-email roster
+   * would overwrite resolved emails fail-closed). Only a 403/404 on a single
+   * team's roster yields that team as an observed fail-closed empty group.
+   */
+  async *syncGroups(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<GroupMembershipYield> {
+    const config = parseAsanaConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid Asana configuration for group sync");
+    }
+    this.initPermissionPass(params);
+    const apis = createPermissionApis(params.credentials);
+
+    const users = await this.getWorkspaceUsers(apis, config, {
+      required: true,
+    });
+
+    const workspaceName = await this.fetchWorkspaceName(apis, config);
+    const memberships = await this.paginateAll<AsanaWorkspaceMembershipRecord>(
+      (opts) =>
+        apis.workspaceMemberships.getWorkspaceMembershipsForWorkspace(
+          config.workspaceGid,
+          { ...opts, opt_fields: WORKSPACE_MEMBERSHIP_OPT_FIELDS },
+        ),
+    );
+    const workspaceMembers: GroupMemberYield[] = [];
+    for (const membership of memberships) {
+      const userGid = membership.user?.gid ? String(membership.user.gid) : null;
+      if (!userGid) continue;
+      // Guests only ever see what they are explicitly added to — they are
+      // granted through project memberships, never the workspace audience.
+      if (membership.is_guest === true) continue;
+      if (membership.is_active === false) continue;
+      workspaceMembers.push({
+        accountId: userGid,
+        displayName: membership.user?.name ?? users.get(userGid)?.name ?? null,
+        email: users.get(userGid)?.email ?? null,
+        accountType: "user",
+      });
+    }
+    yield {
+      groupId: workspaceMembersGroupId(config.workspaceGid),
+      name: `${workspaceName} workspace members`,
+      members: workspaceMembers,
+    };
+
+    const teams = await this.paginateAll<AsanaTeamRecord>((opts) =>
+      apis.teams.getTeamsForWorkspace(config.workspaceGid, {
+        ...opts,
+        opt_fields: "name",
+      }),
+    );
+    for (const team of [...teams].sort((a, b) =>
+      compareStrings(a.gid, b.gid),
+    )) {
+      let roster: AsanaTeamMembershipRecord[];
+      try {
+        roster = await this.paginateAll<AsanaTeamMembershipRecord>((opts) =>
+          apis.teamMemberships.getTeamMembershipsForTeam(team.gid, {
+            ...opts,
+            opt_fields: TEAM_MEMBERSHIP_OPT_FIELDS,
+          }),
+        );
+      } catch (error) {
+        if (isPermissionDeniedError(error)) {
+          this.log.warn(
+            { teamGid: team.gid, error: extractErrorMessage(error) },
+            "Asana team roster unreadable; recording an observed fail-closed empty roster",
+          );
+          yield {
+            groupId: teamGroupId(team.gid),
+            name: team.name ?? null,
+            members: [],
+            membershipResolutionFailed: true,
+          };
+          continue;
+        }
+        throw error;
+      }
+      const members: GroupMemberYield[] = [];
+      for (const membership of roster) {
+        const userGid = membership.user?.gid
+          ? String(membership.user.gid)
+          : null;
+        if (!userGid) continue;
+        if (membership.is_limited_access === true) continue;
+        members.push({
+          accountId: userGid,
+          displayName:
+            membership.user?.name ?? users.get(userGid)?.name ?? null,
+          email: users.get(userGid)?.email ?? null,
+          accountType: "user",
+        });
+      }
+      yield {
+        groupId: teamGroupId(team.gid),
+        name: team.name ?? null,
+        members,
+      };
     }
   }
 
@@ -469,6 +689,419 @@ export class AsanaConnector extends BaseConnector {
       }
     }
   }
+
+  // ----- Permission-sync helpers -----
+
+  private initPermissionPass(params: PermissionSyncParams): void {
+    this.permAudienceByProjectGid = new Map();
+    this.permWorkspaceUsers = null;
+    this.permWorkspaceUsersFailed = false;
+    this.permDroppedPrincipals = 0;
+    this.permResolveMappedEmail = params.resolveMappedEmail ?? null;
+  }
+
+  /**
+   * Projects whose tasks the content sync ingests, with permission fields,
+   * sorted by container key so the resume cursor is monotonic. Mirrors
+   * `getProjects`: configured gids are validated against the workspace, else
+   * every project the credential can see in the workspace.
+   */
+  private async getPermissionProjects(
+    apis: AsanaPermissionApis,
+    config: AsanaConfig,
+  ): Promise<AsanaPermissionProject[]> {
+    const projects: AsanaPermissionProject[] = [];
+    if (config.projectGids && config.projectGids.length > 0) {
+      for (const gid of config.projectGids) {
+        const project = await this.fetchPermissionProject(apis, gid);
+        const projectWorkspaceGid = project.workspace?.gid
+          ? String(project.workspace.gid)
+          : undefined;
+        if (
+          projectWorkspaceGid &&
+          projectWorkspaceGid !== config.workspaceGid
+        ) {
+          throw new Error(
+            `Asana project ${gid} belongs to workspace ${projectWorkspaceGid}, ` +
+              `which does not match the configured workspace ${config.workspaceGid}. ` +
+              `Either remove the project from projectGids or change workspaceGid.`,
+          );
+        }
+        projects.push(project);
+      }
+    } else {
+      const listed = await this.paginateAll<AsanaPermissionProject>((opts) =>
+        apis.projects.getProjectsForWorkspace(config.workspaceGid, {
+          ...opts,
+          opt_fields: PERMISSION_PROJECT_OPT_FIELDS,
+        }),
+      );
+      projects.push(...listed);
+    }
+    return projects.sort((a, b) =>
+      compareStrings(projectContainerKey(a.gid), projectContainerKey(b.gid)),
+    );
+  }
+
+  private async fetchPermissionProject(
+    apis: AsanaPermissionApis,
+    projectGid: string,
+  ): Promise<AsanaPermissionProject> {
+    await this.rateLimit();
+    const result = await this.callWithRetry(() =>
+      apis.projects.getProject(projectGid, {
+        opt_fields: PERMISSION_PROJECT_OPT_FIELDS,
+      }),
+    );
+    const data = unwrapSingle<AsanaPermissionProject>(result);
+    if (!data?.gid) {
+      throw new Error(
+        `Asana getProject(${projectGid}) returned no usable data`,
+      );
+    }
+    return data;
+  }
+
+  private async *syncProjectPermissionSnapshot(params: {
+    apis: AsanaPermissionApis;
+    config: AsanaConfig;
+    project: AsanaPermissionProject;
+    seenTaskGids: Set<string>;
+  }): AsyncGenerator<PermissionSnapshotYield> {
+    const { apis, config, project, seenTaskGids } = params;
+    const containerKey = projectContainerKey(project.gid);
+
+    // Buffer this project's NEW task rows first: the container yield must
+    // carry the audience and precede its documents, and a project whose tasks
+    // were all claimed by earlier projects still needs its boundary container
+    // for the pass's fail-close set-diff. Ids and flags only, never content.
+    const tasks: AsanaPermissionTaskRecord[] = [];
+    let offset: string | undefined;
+    let hasMore = true;
+    while (hasMore) {
+      await this.rateLimit();
+      const result = await this.callWithRetry(() =>
+        apis.tasks.getTasksForProject(project.gid, {
+          limit: BATCH_SIZE,
+          ...(offset ? { offset } : {}),
+          opt_fields: PERMISSION_TASK_OPT_FIELDS,
+        }),
+      );
+      for (const task of extractCollectionData<AsanaPermissionTask>(result)) {
+        if (!task.gid || seenTaskGids.has(task.gid)) continue;
+        seenTaskGids.add(task.gid);
+        tasks.push({
+          gid: task.gid,
+          projectGids: (task.projects ?? [])
+            .map((p) => (p?.gid ? String(p.gid) : null))
+            .filter((gid): gid is string => gid !== null),
+          followerGids: (task.followers ?? [])
+            .map((f) => (f?.gid ? String(f.gid) : null))
+            .filter((gid): gid is string => gid !== null),
+        });
+      }
+      const nextOffset = extractNextOffset(result);
+      hasMore = nextOffset !== null;
+      offset = nextOffset ?? undefined;
+    }
+
+    if (tasks.length === 0) {
+      // An empty-corpus project emits a fail-closed boundary container
+      // WITHOUT resolving its audience — nothing references it, the pass only
+      // needs the enumeration boundary to fail-close leftover documents.
+      yield {
+        kind: "container",
+        containerKey,
+        permissions: emptyPermissions(),
+        audienceResolutionFailed: false,
+        cursor: containerKey,
+      };
+      return;
+    }
+
+    const audience = await this.resolveProjectAudience(
+      apis,
+      config,
+      project.gid,
+      project,
+    );
+    yield {
+      kind: "container",
+      containerKey,
+      permissions: audience
+        ? audienceToPermissions(audience)
+        : emptyPermissions(),
+      audienceResolutionFailed: audience === null,
+      cursor: containerKey,
+    };
+
+    const emittedUnionKeys = new Set<string>();
+    for (const task of tasks) {
+      const exceptionUsers = await this.resolveExceptionEmails(
+        apis,
+        config,
+        task.followerGids,
+      );
+      const otherProjectGids = [...new Set(task.projectGids)]
+        .filter((gid) => gid !== project.gid)
+        .sort(compareStrings);
+      let taskContainerKey = containerKey;
+      if (otherProjectGids.length > 0) {
+        // Multi-homed: readable through ANY home project, so the task's
+        // container is the union of every home project's audience.
+        taskContainerKey = `${containerKey}/multi:${otherProjectGids.join("+")}`;
+        if (!emittedUnionKeys.has(taskContainerKey)) {
+          emittedUnionKeys.add(taskContainerKey);
+          const union = await this.resolveUnionAudience(apis, config, [
+            project.gid,
+            ...otherProjectGids,
+          ]);
+          yield {
+            kind: "container",
+            containerKey: taskContainerKey,
+            permissions: union.permissions,
+            audienceResolutionFailed: union.resolutionFailed,
+            cursor: containerKey,
+          };
+        }
+      }
+      yield {
+        kind: "document",
+        sourceId: `task-${task.gid}`,
+        containerKey: taskContainerKey,
+        ...(exceptionUsers.length > 0 ? { exceptionUsers } : {}),
+        cursor: containerKey,
+      };
+    }
+  }
+
+  /**
+   * A project's read audience — every Asana access level can read, so no
+   * level filtering. Cached per pass; null = the lookup failed and the
+   * caller fail-closes. Membership enumeration runs for public projects too:
+   * guests are granted only through explicit memberships, never the
+   * workspace audience.
+   */
+  private async resolveProjectAudience(
+    apis: AsanaPermissionApis,
+    config: AsanaConfig,
+    projectGid: string,
+    known?: AsanaPermissionProject,
+  ): Promise<AsanaProjectAudience | null> {
+    const cached = this.permAudienceByProjectGid.get(projectGid);
+    if (cached !== undefined) return cached;
+
+    let audience: AsanaProjectAudience | null = null;
+    try {
+      const project =
+        known ?? (await this.fetchPermissionProject(apis, projectGid));
+      const users = new Set<string>();
+      const groups = new Set<string>();
+      if (project.privacy_setting === "public_to_workspace") {
+        groups.add(workspaceMembersGroupId(config.workspaceGid));
+      }
+      // Deprecated privacy value predating team project-memberships: the
+      // project is shared with its own team without a membership row.
+      if (project.privacy_setting === "private_to_team" && project.team?.gid) {
+        groups.add(teamGroupId(String(project.team.gid)));
+      }
+      const memberships = await this.paginateAll<AsanaProjectMembershipRecord>(
+        (opts) =>
+          apis.projectMemberships.getProjectMembershipsForProject(projectGid, {
+            ...opts,
+            opt_fields: PROJECT_MEMBERSHIP_OPT_FIELDS,
+          }),
+      );
+      for (const membership of memberships) {
+        const member = membership.member;
+        if (!member?.gid) continue;
+        if (member.resource_type === "team") {
+          groups.add(teamGroupId(String(member.gid)));
+          continue;
+        }
+        const email = await this.resolvePrincipalEmail(
+          apis,
+          config,
+          String(member.gid),
+        );
+        if (email) {
+          users.add(email);
+        } else {
+          this.permDroppedPrincipals += 1;
+        }
+      }
+      audience = { users, groups };
+    } catch (error) {
+      this.log.warn(
+        { projectGid, error: extractErrorMessage(error) },
+        "Could not resolve an Asana project audience; its documents fail-close this pass",
+      );
+      audience = null;
+    }
+    this.permAudienceByProjectGid.set(projectGid, audience);
+    return audience;
+  }
+
+  /**
+   * Union audience of a multi-homed task's home projects.
+   * `resolutionFailed` only when EVERY lookup failed (the audience is empty
+   * because of failures); a partial failure under-grants — the fail-closed
+   * direction — and each failed project is logged by
+   * `resolveProjectAudience`.
+   */
+  private async resolveUnionAudience(
+    apis: AsanaPermissionApis,
+    config: AsanaConfig,
+    projectGids: string[],
+  ): Promise<{ permissions: DocumentPermissions; resolutionFailed: boolean }> {
+    const users = new Set<string>();
+    const groups = new Set<string>();
+    let anyResolved = false;
+    let anyFailed = false;
+    for (const gid of projectGids) {
+      const audience = await this.resolveProjectAudience(apis, config, gid);
+      if (!audience) {
+        anyFailed = true;
+        continue;
+      }
+      anyResolved = true;
+      for (const user of audience.users) users.add(user);
+      for (const group of audience.groups) groups.add(group);
+    }
+    return {
+      permissions: {
+        isPublic: false,
+        users: [...users].sort(),
+        groups: [...groups].sort(),
+      },
+      resolutionFailed: anyFailed && !anyResolved,
+    };
+  }
+
+  /** Follower emails for per-document exception grants (sorted, deduped). */
+  private async resolveExceptionEmails(
+    apis: AsanaPermissionApis,
+    config: AsanaConfig,
+    userGids: string[],
+  ): Promise<string[]> {
+    const emails = new Set<string>();
+    for (const gid of new Set(userGids)) {
+      const email = await this.resolvePrincipalEmail(apis, config, gid);
+      if (email) {
+        emails.add(email);
+      } else {
+        this.permDroppedPrincipals += 1;
+      }
+    }
+    return [...emails].sort();
+  }
+
+  /**
+   * Upstream email first (the workspace user walk exposes emails to any
+   * workspace member), the admin's manual member mapping as fallback —
+   * matches the Jira/OneDrive exception-grant precedence.
+   */
+  private async resolvePrincipalEmail(
+    apis: AsanaPermissionApis,
+    config: AsanaConfig,
+    userGid: string,
+  ): Promise<string | null> {
+    const users = await this.getWorkspaceUsers(apis, config, {
+      required: false,
+    });
+    const upstream = users.get(userGid)?.email ?? null;
+    return upstream ?? this.permResolveMappedEmail?.(userGid) ?? null;
+  }
+
+  /**
+   * One workspace user walk per pass resolves every member/follower email
+   * (guests included — they matter for team rosters and direct grants). When
+   * `required`, a failed walk throws (group rosters must never replace
+   * resolved emails with nulls); otherwise the failure is remembered and
+   * direct grants fall back to the admin mapping or fail-closed while
+   * group-based audiences stay usable.
+   */
+  private async getWorkspaceUsers(
+    apis: AsanaPermissionApis,
+    config: AsanaConfig,
+    { required }: { required: boolean },
+  ): Promise<Map<string, AsanaWorkspaceUserInfo>> {
+    if (this.permWorkspaceUsers) return this.permWorkspaceUsers;
+    if (this.permWorkspaceUsersFailed && !required) {
+      return new Map();
+    }
+    try {
+      const users = await this.paginateAll<AsanaWorkspaceUser>((opts) =>
+        apis.users.getUsers({
+          ...opts,
+          workspace: config.workspaceGid,
+          opt_fields: WORKSPACE_USER_OPT_FIELDS,
+        }),
+      );
+      const map = new Map<string, AsanaWorkspaceUserInfo>();
+      for (const user of users) {
+        if (!user.gid) continue;
+        map.set(String(user.gid), {
+          email: user.email ?? null,
+          name: user.name ?? null,
+        });
+      }
+      this.permWorkspaceUsers = map;
+      return map;
+    } catch (error) {
+      this.permWorkspaceUsersFailed = true;
+      this.log.warn(
+        {
+          workspaceGid: config.workspaceGid,
+          error: extractErrorMessage(error),
+        },
+        "Could not enumerate Asana workspace users; direct grants resolve via the admin mapping only this pass",
+      );
+      if (required) throw error;
+      return new Map();
+    }
+  }
+
+  private async fetchWorkspaceName(
+    apis: AsanaPermissionApis,
+    config: AsanaConfig,
+  ): Promise<string> {
+    try {
+      await this.rateLimit();
+      const result = await this.callWithRetry(() =>
+        apis.workspaces.getWorkspace(config.workspaceGid, {
+          opt_fields: "name",
+        }),
+      );
+      const data = unwrapSingle<{ name?: string | null }>(result);
+      if (data?.name) return String(data.name);
+    } catch (error) {
+      this.log.warn(
+        {
+          workspaceGid: config.workspaceGid,
+          error: extractErrorMessage(error),
+        },
+        "Could not read the Asana workspace name; using the gid",
+      );
+    }
+    return `Workspace ${config.workspaceGid}`;
+  }
+
+  /** Surface principals dropped this pass (fail-closed under-grant). */
+  private reportDroppedPermissionPrincipals(): void {
+    if (this.permDroppedPrincipals <= 0) return;
+    const count = this.permDroppedPrincipals;
+    this.permDroppedPrincipals = 0;
+    this.log.debug(
+      { count, connectorType: this.type },
+      "Dropped Asana principals that could not be resolved (fail-closed)",
+    );
+    metrics.rag.reportPermissionSyncDroppedPrincipals({
+      connectorType: this.type,
+      reason: "no_email",
+      count,
+    });
+  }
 }
 
 // ===== Module-level helpers =====
@@ -734,4 +1367,134 @@ function taskToDocument(
     },
     updatedAt: task.modified_at ? new Date(task.modified_at) : undefined,
   };
+}
+
+// ===== Permission-sync module helpers =====
+
+interface AsanaPermissionApis {
+  projects: ProjectsApi;
+  projectMemberships: ProjectMembershipsApi;
+  tasks: TasksApi;
+  teams: TeamsApi;
+  teamMemberships: TeamMembershipsApi;
+  workspaceMemberships: WorkspaceMembershipsApi;
+  workspaces: WorkspacesApi;
+  users: UsersApi;
+}
+
+function createPermissionApis(
+  credentials: ConnectorCredentials,
+): AsanaPermissionApis {
+  const client = createAsanaClient(credentials);
+  return {
+    projects: new ProjectsApi(client),
+    projectMemberships: new ProjectMembershipsApi(client),
+    tasks: new TasksApi(client),
+    teams: new TeamsApi(client),
+    teamMemberships: new TeamMembershipsApi(client),
+    workspaceMemberships: new WorkspaceMembershipsApi(client),
+    workspaces: new WorkspacesApi(client),
+    users: new UsersApi(client),
+  };
+}
+
+interface AsanaProjectAudience {
+  users: Set<string>;
+  groups: Set<string>;
+}
+
+interface AsanaWorkspaceUserInfo {
+  email: string | null;
+  name: string | null;
+}
+
+// Partial Asana API response shapes for the permission pass (same convention
+// as the content-sync shapes above: only fields we actually read).
+
+interface AsanaPermissionProject {
+  gid: string;
+  name?: string | null;
+  privacy_setting?: string | null;
+  team?: { gid?: string | null } | null;
+  workspace?: { gid?: string | null } | null;
+}
+
+interface AsanaPermissionTask {
+  gid?: string;
+  projects?: Array<{ gid?: string | null } | null> | null;
+  followers?: Array<{ gid?: string | null } | null> | null;
+}
+
+interface AsanaPermissionTaskRecord {
+  gid: string;
+  projectGids: string[];
+  followerGids: string[];
+}
+
+interface AsanaProjectMembershipRecord {
+  member?: { gid?: string | null; resource_type?: string | null } | null;
+}
+
+interface AsanaWorkspaceMembershipRecord {
+  user?: { gid?: string | null; name?: string | null } | null;
+  is_guest?: boolean;
+  is_active?: boolean;
+}
+
+interface AsanaTeamRecord {
+  gid: string;
+  name?: string | null;
+}
+
+interface AsanaTeamMembershipRecord {
+  user?: { gid?: string | null; name?: string | null } | null;
+  is_limited_access?: boolean;
+}
+
+interface AsanaWorkspaceUser {
+  gid?: string;
+  email?: string | null;
+  name?: string | null;
+}
+
+function projectContainerKey(projectGid: string): string {
+  return `project:${projectGid}`;
+}
+
+/** Asana gids are globally unique → distinct across connectors of one type. */
+function teamGroupId(teamGid: string): string {
+  return `team:${teamGid}`;
+}
+
+function workspaceMembersGroupId(workspaceGid: string): string {
+  return `workspace-members:${workspaceGid}`;
+}
+
+function emptyPermissions(): DocumentPermissions {
+  return { isPublic: false, users: [], groups: [] };
+}
+
+function audienceToPermissions(
+  audience: AsanaProjectAudience,
+): DocumentPermissions {
+  return {
+    isPublic: false,
+    users: [...audience.users].sort(),
+    groups: [...audience.groups].sort(),
+  };
+}
+
+/** Byte-order comparator matching the pass's plain `<` cursor comparisons. */
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/** 403/404 from Asana: the credential cannot read the resource. */
+function isPermissionDeniedError(err: unknown): boolean {
+  if (!isRecord(err)) return false;
+  const e = err as SuperagentErrorLike;
+  const status = e.status ?? e.response?.status;
+  return status === 403 || status === 404;
 }

--- a/platform/backend/src/knowledge-base/connectors/asana/asana-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/asana/asana-connector.ts
@@ -72,6 +72,15 @@ const PERMISSION_PROJECT_OPT_FIELDS =
 const WORKSPACE_USER_OPT_FIELDS = "email,name";
 const WORKSPACE_MEMBERSHIP_OPT_FIELDS = "user.gid,user.name,is_guest,is_active";
 const TEAM_MEMBERSHIP_OPT_FIELDS = "user.gid,user.name,is_limited_access";
+/**
+ * Synthetic roster-only group for users directly added to a synced project —
+ * most importantly workspace GUESTS, who are excluded from the
+ * workspace-members audience and often belong to no team, yet hold real
+ * grants. Rostering them makes them visible in the Users tab and manually
+ * assignable (OneDrive precedent). The id is never emitted into a container
+ * or document ACL, so the constant cannot collide across connectors.
+ */
+const DIRECT_GRANTS_GROUP_ID = "direct-grants";
 
 export class AsanaConnector extends BaseConnector {
   type = "asana" as const;
@@ -373,6 +382,48 @@ export class AsanaConnector extends BaseConnector {
         groupId: teamGroupId(team.gid),
         name: team.name ?? null,
         members,
+      };
+    }
+
+    // Direct project members (see DIRECT_GRANTS_GROUP_ID). A failed project
+    // enumeration throws — the pass keeps the previous group snapshot — while
+    // a single unreadable project is skipped: the audience phase owns
+    // fail-closing its containers.
+    const directMembers = new Map<string, GroupMemberYield>();
+    for (const project of await this.getPermissionProjects(apis, config)) {
+      let memberships: AsanaProjectMembershipRecord[];
+      try {
+        memberships = await this.paginateAll<AsanaProjectMembershipRecord>(
+          (opts) =>
+            apis.memberships.getMemberships({ ...opts, parent: project.gid }),
+        );
+      } catch (error) {
+        this.log.warn(
+          { projectGid: project.gid, error: extractErrorMessage(error) },
+          "Could not read a project's memberships for the direct-grants roster; skipping it this pass",
+        );
+        continue;
+      }
+      for (const membership of memberships) {
+        const member = membership.member;
+        if (!member?.gid || member.resource_type === "team") continue;
+        const gid = String(member.gid);
+        if (directMembers.has(gid)) continue;
+        directMembers.set(gid, {
+          accountId: gid,
+          displayName: member.name ?? users.get(gid)?.name ?? null,
+          email: users.get(gid)?.email ?? null,
+          accountType: "user",
+        });
+      }
+    }
+    if (directMembers.size > 0) {
+      yield {
+        groupId: DIRECT_GRANTS_GROUP_ID,
+        name: "Direct project members",
+        members: [...directMembers.values()].sort((a, b) =>
+          compareStrings(a.accountId, b.accountId),
+        ),
       };
     }
   }
@@ -1453,7 +1504,11 @@ interface AsanaPermissionTaskRecord {
 }
 
 interface AsanaProjectMembershipRecord {
-  member?: { gid?: string | null; resource_type?: string | null } | null;
+  member?: {
+    gid?: string | null;
+    resource_type?: string | null;
+    name?: string | null;
+  } | null;
 }
 
 interface AsanaWorkspaceMembershipRecord {

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
@@ -350,6 +350,7 @@ const AUTO_SYNC_CONNECTOR_TYPES: ReadonlySet<ConnectorType> = new Set([
   "salesforce",
   "onedrive",
   "notion",
+  "asana",
 ]);
 
 export function connectorSupportsAutoSync(type: ConnectorType): boolean {
@@ -411,6 +412,8 @@ export function getPermissionSyncCredentialNote(
       return "Auto-sync permissions matches members by their public GitHub profile email. No token scope reveals a private email, so members without a public profile email are recorded but stay unresolvable.";
     case "gitlab":
       return "Auto-sync permissions matches project members by their public GitLab profile email. A non-admin token cannot read a private email, so members without a public profile email are recorded but stay unresolvable.";
+    case "asana":
+      return "Auto-sync permissions reads projects, memberships, teams, and member emails as this Personal Access Token's user. Use a token from a user who can see every synced project — typically a workspace admin or a dedicated service user — because audiences the token cannot read stay fail-closed.";
     default:
       return null;
   }


### PR DESCRIPTION
Permission auto-sync for the Asana connector (part of #7154, [T-908]).

**Model:** container = project (`project:<gid>`); `public_to_workspace` projects grant a synthetic `workspace-members:<workspaceGid>` group (guests and inactive members excluded); every project also grants its explicit memberships — a member can be a user (by email) or a team (`team:<gid>`). Deprecated `private_to_team` projects grant their team. Multi-homed tasks get a nested union container (`project:<lowest>/multi:<others>`) whose audience unions every home project, including out-of-scope ones. Task followers get per-document exception grants. Direct project members — guests above all, since they're excluded from the workspace audience and rarely sit on a team — roster under a synthetic `direct-grants` group ("Direct project members") so they stay visible and assignable from the Users tab even though the group grants nothing itself.

**Real-workspace fix:** the legacy `GET /projects/{gid}/project_memberships` endpoint silently ignores unsupported `opt_fields` and returns member-less rows, which read as empty audiences on every project. Switched to the generic `GET /memberships?parent=<gid>` (the only endpoint that also returns team members) and added a guard so an unparseable membership row fails the container closed instead of silently empty — verified against a real Asana workspace, where container ACLs now match the native Share dialog exactly.

Live-verified end-to-end on a dev stack: mock-API QA (every audience path) plus a real Asana workspace (team membership resolution, guest direct-grant sync, second-pass idempotence).

Tests: connector unit tests covering every permission path (container containers, unions, exceptions, group rosters, direct grants, fail-closed guards) — 69 passing.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>