### PR TITLE
feat(knowledge-base): permission auto-sync for the Linear connector

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -192,13 +192,13 @@ Auto-sync permissions works with the connectors marked *Supported* below. *Limit
 | GitHub       | Supported                                                                                                 |
 | GitLab       | Supported                                                                                                 |
 | Jira         | Supported                                                                                                 |
+| Linear       | Supported                                                                                                 |
 | M-Files      | Supported with the VAF Add On                                                                             |
 | Google Drive | Supported                                                                                                 |
 | Notion       | Limited: every synced page is visible to all workspace members ([details](#notion-auto-sync-permissions)) |
 | OneDrive     | Supported                                                                                                 |
 | Salesforce   | Supported                                                                                                 |
 | SharePoint   | Supported                                                                                                 |
-| Linear       | Not supported                                                                                             |
 | Outline      | Not supported                                                                                             |
 | Perforce     | Not supported                                                                                             |
 | ServiceNow   | Not supported                                                                                             |
@@ -211,6 +211,7 @@ Auto-sync permissions works with the connectors marked *Supported* below. *Limit
 - **GitLab** only exposes an email the user has made **public on their profile**. An instance admin token also reads private emails; a regular token does not.
 - **SharePoint** returns SharePoint user logins directly. Expanding a Microsoft 365 group or a SharePoint site group to its members needs the extra app permissions listed under [SharePoint](#sharepoint).
 - **OneDrive** resolves user grants and drive owners to emails through the `User.Read.All` app permission. Without it, those accounts stay unresolvable. See [OneDrive](#onedrive).
+- **Linear** returns member emails to any workspace API key. No extra credential is needed.
 - **Salesforce** reads user emails and group membership through the same login the connector already uses. No extra credential is needed.
 - **Dropbox** returns member emails directly in shared-folder member lists. Group member rosters expand when the access token is a Business **team access token** (`groups.read` + `members.read` team scopes); with a member token, granted groups appear in the Groups tab with no members — assign them manually. See [Dropbox](#dropbox).
 - **Notion** returns member emails only when the integration has the **"read user information including email addresses"** capability. Guests are never listed.
@@ -571,6 +572,10 @@ Sync issues, projects, and cycles from a Linear workspace.
 | Include Projects | Sync projects and recent project updates as documents (default: off)       |
 | Include Cycles   | Sync cycles as documents (default: off)                                    |
 | Batch Size       | Items fetched per request (optional, defaults to connector implementation) |
+
+**Auto-sync permissions.** Linear's access unit is the team. Issues and cycles get their team's audience: a public team admits every workspace member, a private team only its listed members. Guests get access only through teams they were invited to. A project's audience is the members of its teams plus the users listed on the project. Each sync also snapshots every team's roster, so the connector's **Users** and **Groups** tabs show each member with their assignment status. Suspended accounts belong to no audience.
+
+The API key sees what its owner can see. A private team the owner does not belong to syncs no content and grants no access. Use a key from an owner whose access matches what you want indexed.
 
 ### Outline
 

--- a/platform/backend/src/knowledge-base/connectors/linear/linear-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/linear/linear-connector.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import type { ConnectorSyncBatch } from "@/types";
+import type {
+  ConnectorSyncBatch,
+  GroupMembershipYield,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
+} from "@/types";
 import { LinearConnector } from "./linear-connector";
 
 const credentials = { apiToken: "lin_api_test" };
@@ -786,5 +791,392 @@ describe("LinearConnector", () => {
         expect(captureUpdatedAfter(0)).toBe(lockedAfter);
       });
     });
+  });
+});
+
+// ===== Permission sync =====
+
+describe("permission sync", () => {
+  type ContainerYield = Extract<PermissionSnapshotYield, { kind: "container" }>;
+  type DocumentYield = Extract<PermissionSnapshotYield, { kind: "document" }>;
+
+  const ORG = { id: "org-uuid-1", name: "Acme" };
+  const ENG = {
+    id: "team-uuid-eng",
+    key: "ENG",
+    name: "Engineering",
+    private: false,
+  };
+  const SEC = {
+    id: "team-uuid-sec",
+    key: "SEC",
+    name: "Security",
+    private: true,
+  };
+
+  const alice = {
+    id: "u-alice",
+    name: "Alice",
+    email: "Alice@example.com",
+    active: true,
+    guest: false,
+    app: false,
+  };
+  const bob = {
+    id: "u-bob",
+    name: "Bob",
+    email: "bob@example.com",
+    active: true,
+    guest: true,
+    app: false,
+  };
+  const carol = {
+    id: "u-carol",
+    name: "Carol",
+    email: "carol@example.com",
+    active: false,
+    guest: false,
+    app: false,
+  };
+  const botUser = {
+    id: "u-bot",
+    name: "Sync Bot",
+    email: null,
+    active: true,
+    guest: false,
+    app: true,
+  };
+
+  const permDocs = [
+    { sourceId: "i1", metadata: { kind: "issue", teamKey: "ENG" } },
+    { sourceId: "i2", metadata: { kind: "issue", teamKey: "ENG" } },
+    { sourceId: "i3", metadata: { kind: "issue", teamKey: "SEC" } },
+    {
+      sourceId: "linear-cycle-c1",
+      metadata: { kind: "cycle", teamKey: "ENG" },
+    },
+    {
+      sourceId: "linear-project-p1",
+      metadata: { kind: "project", projectId: "p1" },
+    },
+    // Ingested before the projectId stamp: id comes from the sourceId.
+    { sourceId: "linear-project-p2", metadata: { kind: "project" } },
+  ];
+
+  function makePermReadBack(
+    docs: Array<{ sourceId: string; metadata: Record<string, unknown> }>,
+  ) {
+    return vi.fn(
+      async (args: {
+        metadataFilter?: Record<string, string>;
+        afterId?: string | null;
+        limit: number;
+      }) => {
+        let rows = docs.filter(
+          (doc) =>
+            !args.metadataFilter ||
+            Object.entries(args.metadataFilter).every(
+              ([key, value]) => doc.metadata[key] === value,
+            ),
+        );
+        rows = rows
+          .filter((doc) => !args.afterId || doc.sourceId > args.afterId)
+          .sort((a, b) => (a.sourceId < b.sourceId ? -1 : 1));
+        const page = rows.slice(0, args.limit);
+        return {
+          documents: page,
+          nextAfterId: page.length ? page[page.length - 1].sourceId : null,
+        };
+      },
+    );
+  }
+
+  /**
+   * Route the raw GraphQL mock by operation name. Overridable per test via
+   * the overrides map (operation substring -> implementation).
+   */
+  function stubPermissionApi(
+    overrides: Partial<
+      Record<string, (variables: Record<string, unknown>) => unknown>
+    > = {},
+  ) {
+    mockRawRequest.mockImplementation(
+      (query: unknown, variables: Record<string, unknown>) => {
+        const q = String(query);
+        for (const [needle, impl] of Object.entries(overrides)) {
+          if (q.includes(needle)) return Promise.resolve(impl?.(variables));
+        }
+        if (q.includes("LinearPermissionOrganization")) {
+          return Promise.resolve({ data: { organization: ORG } });
+        }
+        if (q.includes("LinearPermissionTeamMembers")) {
+          const nodes =
+            variables.teamId === ENG.id ? [alice, bob, carol] : [alice];
+          return Promise.resolve({
+            data: {
+              team: {
+                members: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes,
+                },
+              },
+            },
+          });
+        }
+        if (q.includes("LinearPermissionTeams")) {
+          return Promise.resolve({
+            data: {
+              teams: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [ENG, SEC],
+              },
+            },
+          });
+        }
+        if (q.includes("LinearPermissionUsers")) {
+          return Promise.resolve({
+            data: {
+              users: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [alice, bob, carol, botUser],
+              },
+            },
+          });
+        }
+        if (q.includes("LinearPermissionProjectAudiences")) {
+          const filter = variables.filter as { id?: { in?: string[] } };
+          const known = (filter.id?.in ?? []).includes("p1")
+            ? [
+                {
+                  id: "p1",
+                  teams: {
+                    pageInfo: { hasNextPage: false },
+                    nodes: [{ id: SEC.id }],
+                  },
+                  members: {
+                    pageInfo: { hasNextPage: false },
+                    nodes: [
+                      {
+                        id: "u-eve",
+                        email: "Eve@example.com",
+                        active: true,
+                        app: false,
+                      },
+                      { id: "u-bot", email: null, active: true, app: true },
+                    ],
+                  },
+                },
+              ]
+            : [];
+          return Promise.resolve({
+            data: {
+              projects: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: known,
+              },
+            },
+          });
+        }
+        throw new Error(`Unexpected permission query: ${q.slice(0, 120)}`);
+      },
+    );
+  }
+
+  function syncParams(
+    overrides: Partial<PermissionSyncParams> = {},
+  ): PermissionSyncParams {
+    return {
+      config: { linearApiUrl: "https://api.linear.app" },
+      credentials,
+      cursor: null,
+      readIngestedDocuments: makePermReadBack(permDocs),
+      ...overrides,
+    };
+  }
+
+  async function collectSnapshot(gen: AsyncGenerator<PermissionSnapshotYield>) {
+    const containers = new Map<string, ContainerYield>();
+    const documents: DocumentYield[] = [];
+    const order: string[] = [];
+    for await (const y of gen) {
+      expect(y.cursor).toBe(y.containerKey);
+      if (y.kind === "container") {
+        containers.set(y.containerKey, y);
+        order.push(y.containerKey);
+      } else {
+        documents.push(y);
+      }
+    }
+    return { containers, documents, order };
+  }
+
+  beforeEach(() => {
+    mockRawRequest.mockReset();
+  });
+
+  test("supportsPermissionSync is true", () => {
+    expect(new LinearConnector().supportsPermissionSync).toBe(true);
+  });
+
+  test("full snapshot: team and project containers, sorted, fail-closed for a vanished project", async () => {
+    stubPermissionApi();
+    const connector = new LinearConnector();
+    const { containers, documents, order } = await collectSnapshot(
+      connector.syncPermissionSnapshot(syncParams()),
+    );
+
+    expect(order).toEqual(["project:p1", "project:p2", "team:ENG", "team:SEC"]);
+
+    // Public team: its own group plus the workspace-members group.
+    expect(containers.get("team:ENG")?.permissions.groups?.sort()).toEqual([
+      `team-${ENG.id}`,
+      `workspace-members-${ORG.id}`,
+    ]);
+    // Private team: its roster only.
+    expect(containers.get("team:SEC")?.permissions.groups).toEqual([
+      `team-${SEC.id}`,
+    ]);
+
+    // Project on a private team: no workspace group; explicit project
+    // members appear as direct (lowercased) user emails; app users dropped.
+    const p1 = containers.get("project:p1");
+    expect(p1?.permissions.groups).toEqual([`team-${SEC.id}`]);
+    expect(p1?.permissions.users).toEqual(["eve@example.com"]);
+    expect(p1?.audienceResolutionFailed).toBeUndefined();
+
+    // Vanished project: empty audience, flagged, docs still assigned.
+    const p2 = containers.get("project:p2");
+    expect(p2?.permissions).toEqual({ users: [], groups: [] });
+    expect(p2?.audienceResolutionFailed).toBe(true);
+
+    const byContainer = new Map<string, string[]>();
+    for (const doc of documents) {
+      const list = byContainer.get(doc.containerKey) ?? [];
+      list.push(doc.sourceId);
+      byContainer.set(doc.containerKey, list);
+    }
+    expect(byContainer.get("team:ENG")?.sort()).toEqual([
+      "i1",
+      "i2",
+      "linear-cycle-c1",
+    ]);
+    expect(byContainer.get("team:SEC")).toEqual(["i3"]);
+    expect(byContainer.get("project:p1")).toEqual(["linear-project-p1"]);
+    expect(byContainer.get("project:p2")).toEqual(["linear-project-p2"]);
+  });
+
+  test("resume cursor skips containers strictly below it", async () => {
+    stubPermissionApi();
+    const connector = new LinearConnector();
+    const { order } = await collectSnapshot(
+      connector.syncPermissionSnapshot(syncParams({ cursor: "team:ENG" })),
+    );
+    expect(order).toEqual(["team:ENG", "team:SEC"]);
+  });
+
+  test("delta scope enumerates only the requested containers", async () => {
+    stubPermissionApi();
+    const connector = new LinearConnector();
+    const { order, documents } = await collectSnapshot(
+      connector.syncPermissionSnapshot(
+        syncParams({ scope: { containerKeys: ["team:SEC"] } }),
+      ),
+    );
+    expect(order).toEqual(["team:SEC"]);
+    expect(documents.map((d) => d.sourceId)).toEqual(["i3"]);
+  });
+
+  test("syncGroups: one group per team plus workspace members, sorted, rosters filtered", async () => {
+    stubPermissionApi();
+    const connector = new LinearConnector();
+    const groups: GroupMembershipYield[] = [];
+    for await (const g of connector.syncGroups(syncParams())) groups.push(g);
+
+    expect(groups.map((g) => g.groupId)).toEqual([
+      `team-${ENG.id}`,
+      `team-${SEC.id}`,
+      `workspace-members-${ORG.id}`,
+    ]);
+
+    const eng = groups[0];
+    expect(eng.name).toBe("Engineering");
+    // Suspended carol is dropped; guest bob stays with accountType "guest".
+    expect(eng.members).toEqual([
+      {
+        accountId: "u-alice",
+        displayName: "Alice",
+        email: "alice@example.com",
+        accountType: "member",
+      },
+      {
+        accountId: "u-bob",
+        displayName: "Bob",
+        email: "bob@example.com",
+        accountType: "guest",
+      },
+    ]);
+
+    const workspace = groups[2];
+    expect(workspace.name).toBe("Acme workspace members");
+    // Guests never enter the workspace group; apps are rostered as "app".
+    expect(workspace.members).toEqual([
+      {
+        accountId: "u-alice",
+        displayName: "Alice",
+        email: "alice@example.com",
+        accountType: "member",
+      },
+      {
+        accountId: "u-bot",
+        displayName: "Sync Bot",
+        email: null,
+        accountType: "app",
+      },
+    ]);
+  });
+
+  test("syncGroups throws on a mid-pagination roster failure instead of truncating", async () => {
+    let membersCall = 0;
+    stubPermissionApi({
+      LinearPermissionTeamMembers: () => {
+        membersCall += 1;
+        if (membersCall === 1) {
+          return {
+            data: {
+              team: {
+                members: {
+                  pageInfo: { hasNextPage: true, endCursor: "page-2" },
+                  nodes: [alice],
+                },
+              },
+            },
+          };
+        }
+        throw new Error("boom");
+      },
+    });
+    const connector = new LinearConnector();
+    const gen = connector.syncGroups(syncParams());
+    await expect(async () => {
+      for await (const _ of gen) {
+        // drain
+      }
+    }).rejects.toThrow("boom");
+  });
+
+  test("scopeKeyForDocument maps kinds to their governing container", () => {
+    const connector = new LinearConnector();
+    expect(
+      connector.scopeKeyForDocument({ kind: "issue", teamKey: "ENG" }),
+    ).toBe("team:ENG");
+    expect(
+      connector.scopeKeyForDocument({ kind: "cycle", teamKey: "SEC" }),
+    ).toBe("team:SEC");
+    expect(
+      connector.scopeKeyForDocument({ kind: "project", projectId: "p1" }),
+    ).toBe("project:p1");
+    expect(connector.scopeKeyForDocument({ kind: "project" })).toBeNull();
+    expect(connector.scopeKeyForDocument({ kind: "issue" })).toBeNull();
+    expect(connector.scopeKeyForDocument({ kind: "mystery" })).toBeNull();
   });
 });

--- a/platform/backend/src/knowledge-base/connectors/linear/linear-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/linear/linear-connector.ts
@@ -4,8 +4,13 @@ import type {
   ConnectorDocument,
   ConnectorItemFailure,
   ConnectorSyncBatch,
+  GroupMembershipYield,
+  GroupMemberYield,
   LinearCheckpoint,
   LinearConfig,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
+  ReadIngestedDocuments,
 } from "@/types";
 import { LinearConfigSchema } from "@/types";
 import {
@@ -160,6 +165,112 @@ const CYCLES_QUERY = `
   }
 `;
 
+// ===== Permission-sync queries =====
+
+const PERMISSION_READBACK_PAGE_SIZE = 1000;
+const PERMISSION_TEAMS_PAGE_SIZE = 50;
+const PERMISSION_MEMBERS_PAGE_SIZE = 100;
+const PERMISSION_PROJECTS_CHUNK_SIZE = 50;
+
+const PERMISSION_ORGANIZATION_QUERY = `
+  query LinearPermissionOrganization {
+    organization {
+      id
+      name
+    }
+  }
+`;
+
+const PERMISSION_TEAMS_QUERY = `
+  query LinearPermissionTeams($first: Int!, $after: String) {
+    teams(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        key
+        name
+        private
+      }
+    }
+  }
+`;
+
+const PERMISSION_TEAM_MEMBERS_QUERY = `
+  query LinearPermissionTeamMembers($teamId: String!, $first: Int!, $after: String) {
+    team(id: $teamId) {
+      members(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          name
+          email
+          active
+          guest
+          app
+        }
+      }
+    }
+  }
+`;
+
+const PERMISSION_WORKSPACE_USERS_QUERY = `
+  query LinearPermissionUsers($first: Int!, $after: String) {
+    users(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        name
+        email
+        active
+        guest
+        app
+      }
+    }
+  }
+`;
+
+const PERMISSION_PROJECT_AUDIENCES_QUERY = `
+  query LinearPermissionProjectAudiences($first: Int!, $filter: ProjectFilter) {
+    projects(first: $first, filter: $filter) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        teams(first: 50) {
+          pageInfo {
+            hasNextPage
+          }
+          nodes {
+            id
+          }
+        }
+        members(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
+          nodes {
+            id
+            email
+            active
+            app
+          }
+        }
+      }
+    }
+  }
+`;
+
 type LinearSyncPhase = "issues" | "projects" | "cycles";
 type LinearPageInfo = { hasNextPage: boolean; endCursor: string | null };
 type LinearLabelNode = { name?: string };
@@ -221,9 +332,49 @@ type LinearProjectsQueryData = {
 type LinearCyclesQueryData = {
   cycles?: { pageInfo?: LinearPageInfo; nodes?: LinearCycleNode[] };
 };
+type LinearPermissionTeamNode = {
+  id: string;
+  key?: string;
+  name?: string;
+  private?: boolean;
+};
+type LinearPermissionUserNode = {
+  id: string;
+  name?: string;
+  email?: string | null;
+  active?: boolean;
+  guest?: boolean;
+  app?: boolean;
+};
+type LinearOrganizationQueryData = {
+  organization?: { id?: string; name?: string } | null;
+};
+type LinearTeamsQueryData = {
+  teams?: { pageInfo?: LinearPageInfo; nodes?: LinearPermissionTeamNode[] };
+};
+type LinearTeamMembersQueryData = {
+  team?: {
+    members?: { pageInfo?: LinearPageInfo; nodes?: LinearPermissionUserNode[] };
+  } | null;
+};
+type LinearUsersQueryData = {
+  users?: { pageInfo?: LinearPageInfo; nodes?: LinearPermissionUserNode[] };
+};
+type LinearProjectAudienceNode = {
+  id: string;
+  teams?: { pageInfo?: LinearPageInfo; nodes?: Array<{ id?: string }> };
+  members?: { pageInfo?: LinearPageInfo; nodes?: LinearPermissionUserNode[] };
+};
+type LinearProjectAudiencesQueryData = {
+  projects?: {
+    pageInfo?: LinearPageInfo;
+    nodes?: LinearProjectAudienceNode[];
+  };
+};
 
 export class LinearConnector extends BaseConnector {
   type = "linear" as const;
+  supportsPermissionSync = true;
 
   async validateConfig(
     config: Record<string, unknown>,
@@ -376,6 +527,173 @@ export class LinearConnector extends BaseConnector {
         },
       });
     }
+  }
+
+  /**
+   * Linear's GraphQL API reports real access boundaries, so this projection
+   * is faithful rather than declared: the TEAM is Linear's ACL unit. Issues
+   * and cycles belong to exactly one team; a PUBLIC team is readable by every
+   * non-guest workspace member, while a PRIVATE team is readable only by its
+   * explicit members (guests included). A project is readable by the members
+   * of any of its teams plus the users explicitly listed on the project.
+   *
+   * Containers: `team:<teamKey>` per team visible to the API key (issues and
+   * cycles are assigned via read-back on the `teamKey` metadata both kinds
+   * already carry) and `project:<projectId>` per ingested project document
+   * (discovered from read-back; audiences batch-resolved in one query).
+   * Audiences reference the groups rostered by `syncGroups`: one group per
+   * team plus the synthetic workspace-members group for public teams. A doc
+   * whose team or project no longer resolves fails closed (empty audience,
+   * or the pass's unassigned sweep).
+   *
+   * The API key sees exactly what its owning user can see, so a private team
+   * outside that user's membership neither syncs content nor leaks audience.
+   * Sharing changes bump no queryable watermark, so there is no cheap probe:
+   * every scheduled pass is a full pass.
+   */
+  async *syncPermissionSnapshot(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const parsed = parseLinearConfig(params.config);
+    if (!parsed) {
+      throw new Error("Invalid Linear configuration");
+    }
+    const client = createLinearClient(
+      params.credentials.apiToken,
+      parsed.linearApiUrl,
+    );
+
+    const organization = await this.fetchOrganization(client);
+    const teams = await this.fetchAllTeams(client);
+    const teamsById = new Map(teams.map((team) => [team.id, team]));
+
+    const projectDocs = await collectProjectDocs(params.readIngestedDocuments);
+    const projectAudiences = await this.fetchProjectAudiences(client, [
+      ...projectDocs.keys(),
+    ]);
+
+    const teamsByContainerKey = new Map<string, LinearPermissionTeamNode>();
+    for (const team of teams) {
+      if (team.key) teamsByContainerKey.set(teamContainerKey(team.key), team);
+    }
+    const projectIdsByContainerKey = new Map<string, string>();
+    for (const projectId of projectDocs.keys()) {
+      projectIdsByContainerKey.set(projectContainerKey(projectId), projectId);
+    }
+
+    const containerKeys = [
+      ...teamsByContainerKey.keys(),
+      ...projectIdsByContainerKey.keys(),
+    ].sort();
+
+    for (const containerKey of containerKeys) {
+      if (params.scope && !params.scope.containerKeys.includes(containerKey)) {
+        continue;
+      }
+      if (params.cursor && containerKey < params.cursor) continue;
+
+      const projectId = projectIdsByContainerKey.get(containerKey);
+      if (projectId) {
+        yield* this.emitProjectContainer({
+          containerKey,
+          audience: projectAudiences.get(projectId),
+          docIds: projectDocs.get(projectId) ?? [],
+          teamsById,
+          organizationId: organization.id,
+        });
+        continue;
+      }
+
+      const team = teamsByContainerKey.get(containerKey);
+      if (team) {
+        yield* this.emitTeamContainer({
+          containerKey,
+          team,
+          organizationId: organization.id,
+          readIngestedDocuments: params.readIngestedDocuments,
+        });
+      }
+    }
+  }
+
+  /**
+   * One group per Linear team plus the synthetic workspace-members group
+   * (every active non-guest user — the baseline audience of public teams).
+   * Group ids embed globally-unique Linear UUIDs, so two Linear connectors
+   * can never collide on a group token. Suspended users are omitted (they
+   * cannot sign in to Linear), guests appear only in the rosters of teams
+   * they were invited to, and integration users carry accountType "app" so
+   * admin stats separate them from unresolvable humans. A mid-pagination
+   * failure throws instead of yielding a partial roster: a group yield is an
+   * authoritative complete membership, and a truncated one would revoke
+   * every member in the unfetched tail.
+   */
+  async *syncGroups(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<GroupMembershipYield> {
+    const parsed = parseLinearConfig(params.config);
+    if (!parsed) {
+      throw new Error("Invalid Linear configuration");
+    }
+    const client = createLinearClient(
+      params.credentials.apiToken,
+      parsed.linearApiUrl,
+    );
+
+    const organization = await this.fetchOrganization(client);
+    const teams = await this.fetchAllTeams(client);
+
+    // Order the groups before fetching any roster: the yield cursor is the
+    // group id, so emission order must be stable, and resolving each roster
+    // only when its turn comes holds one roster in memory rather than every
+    // team's at once.
+    const groups: Array<{
+      groupId: string;
+      name: string | null;
+      fetchMembers: () => Promise<GroupMemberYield[]>;
+    }> = teams.map((team) => ({
+      groupId: teamGroupId(team.id),
+      name: team.name ?? team.key ?? null,
+      fetchMembers: () => this.fetchTeamMembers(client, team.id),
+    }));
+    groups.push({
+      groupId: workspaceMembersGroupId(organization.id),
+      name: organization.name
+        ? `${organization.name} workspace members`
+        : "Workspace members",
+      fetchMembers: () => this.fetchWorkspaceMembers(client),
+    });
+    groups.sort((a, b) => (a.groupId < b.groupId ? -1 : 1));
+
+    for (const group of groups) {
+      yield {
+        groupId: group.groupId,
+        name: group.name,
+        members: await group.fetchMembers(),
+        cursor: group.groupId,
+      };
+    }
+  }
+
+  /**
+   * Issues and cycles are governed by their team's container; project docs
+   * by their own project container. Docs whose metadata cannot place them
+   * (no teamKey, or a project doc ingested before projectId stamping) wait
+   * for the next full pass, which assigns project docs from their sourceId.
+   */
+  scopeKeyForDocument(metadata: Record<string, unknown>): string | null {
+    const kind = metadata.kind;
+    if (kind === "project") {
+      return typeof metadata.projectId === "string" && metadata.projectId
+        ? projectContainerKey(metadata.projectId)
+        : null;
+    }
+    if (kind === "issue" || kind === "cycle") {
+      return typeof metadata.teamKey === "string" && metadata.teamKey
+        ? teamContainerKey(metadata.teamKey)
+        : null;
+    }
+    return null;
   }
 
   private async *syncIssuesPhase(params: {
@@ -775,6 +1093,249 @@ export class LinearConnector extends BaseConnector {
       };
     }
   }
+
+  // ===== Permission-sync helpers =====
+
+  private async *emitTeamContainer(params: {
+    containerKey: string;
+    team: LinearPermissionTeamNode;
+    organizationId: string;
+    readIngestedDocuments: ReadIngestedDocuments;
+  }): AsyncGenerator<PermissionSnapshotYield> {
+    const { containerKey, team, organizationId, readIngestedDocuments } =
+      params;
+
+    // A private team is exactly its roster; a public team additionally
+    // admits every non-guest workspace member.
+    const groups = team.private
+      ? [teamGroupId(team.id)]
+      : [teamGroupId(team.id), workspaceMembersGroupId(organizationId)];
+    yield {
+      kind: "container",
+      containerKey,
+      permissions: { groups },
+      cursor: containerKey,
+    };
+
+    let afterId: string | null = null;
+    for (;;) {
+      const { documents, nextAfterId } = await readIngestedDocuments({
+        metadataFilter: { teamKey: team.key ?? "" },
+        afterId,
+        limit: PERMISSION_READBACK_PAGE_SIZE,
+      });
+      for (const doc of documents) {
+        yield {
+          kind: "document",
+          sourceId: doc.sourceId,
+          containerKey,
+          cursor: containerKey,
+        };
+      }
+      if (documents.length < PERMISSION_READBACK_PAGE_SIZE) break;
+      afterId = nextAfterId;
+    }
+  }
+
+  private async *emitProjectContainer(params: {
+    containerKey: string;
+    audience: LinearProjectAudienceNode | undefined;
+    docIds: string[];
+    teamsById: Map<string, LinearPermissionTeamNode>;
+    organizationId: string;
+  }): AsyncGenerator<PermissionSnapshotYield> {
+    const { containerKey, audience, docIds, teamsById, organizationId } =
+      params;
+
+    if (!audience) {
+      // The project vanished upstream or the key lost access to it: emit the
+      // container with an empty audience so every assigned doc fails closed.
+      yield {
+        kind: "container",
+        containerKey,
+        permissions: { users: [], groups: [] },
+        audienceResolutionFailed: true,
+        cursor: containerKey,
+      };
+    } else {
+      const groups = new Set<string>();
+      for (const team of audience.teams?.nodes ?? []) {
+        if (!team.id) continue;
+        groups.add(teamGroupId(team.id));
+        if (teamsById.get(team.id)?.private === false) {
+          groups.add(workspaceMembersGroupId(organizationId));
+        }
+      }
+      const users = new Set<string>();
+      for (const member of audience.members?.nodes ?? []) {
+        if (member.active === false || member.app === true) continue;
+        if (member.email) users.add(member.email.toLowerCase());
+      }
+      if (
+        audience.teams?.pageInfo?.hasNextPage ||
+        audience.members?.pageInfo?.hasNextPage
+      ) {
+        // Truncation under-grants (fail-closed direction); flag it loudly.
+        this.log.warn(
+          { containerKey },
+          "Linear project audience truncated beyond the first page of teams/members; unfetched principals will not be granted access.",
+        );
+      }
+      yield {
+        kind: "container",
+        containerKey,
+        permissions: {
+          users: [...users].sort(),
+          groups: [...groups].sort(),
+        },
+        cursor: containerKey,
+      };
+    }
+
+    for (const sourceId of docIds) {
+      yield {
+        kind: "document",
+        sourceId,
+        containerKey,
+        cursor: containerKey,
+      };
+    }
+  }
+
+  private async fetchOrganization(
+    client: LinearClient,
+  ): Promise<{ id: string; name?: string }> {
+    await this.rateLimit();
+    const payload = await linearRawRequest<LinearOrganizationQueryData>(
+      client,
+      PERMISSION_ORGANIZATION_QUERY,
+    );
+    const id = payload.organization?.id;
+    if (!id) {
+      throw new Error(
+        "Linear GraphQL: organization id missing; cannot derive collision-safe group ids",
+      );
+    }
+    return { id, name: payload.organization?.name };
+  }
+
+  private async fetchAllTeams(
+    client: LinearClient,
+  ): Promise<LinearPermissionTeamNode[]> {
+    const teams: LinearPermissionTeamNode[] = [];
+    let after: string | null = null;
+    let hasMore = true;
+    while (hasMore) {
+      await this.rateLimit();
+      const payload: LinearTeamsQueryData =
+        await linearRawRequest<LinearTeamsQueryData>(
+          client,
+          PERMISSION_TEAMS_QUERY,
+          { first: PERMISSION_TEAMS_PAGE_SIZE, after },
+        );
+      const conn = payload.teams;
+      if (!conn) {
+        throw new Error("Linear GraphQL: missing teams connection");
+      }
+      teams.push(...(conn.nodes ?? []));
+      hasMore = !!conn.pageInfo?.hasNextPage;
+      after = conn.pageInfo?.endCursor ?? null;
+      if (hasMore && !after) break;
+    }
+    return teams;
+  }
+
+  private async fetchTeamMembers(
+    client: LinearClient,
+    teamId: string,
+  ): Promise<GroupMemberYield[]> {
+    const members: GroupMemberYield[] = [];
+    let after: string | null = null;
+    let hasMore = true;
+    while (hasMore) {
+      await this.rateLimit();
+      const payload: LinearTeamMembersQueryData =
+        await linearRawRequest<LinearTeamMembersQueryData>(
+          client,
+          PERMISSION_TEAM_MEMBERS_QUERY,
+          { teamId, first: PERMISSION_MEMBERS_PAGE_SIZE, after },
+        );
+      const conn = payload.team?.members;
+      if (!conn) {
+        throw new Error(
+          `Linear GraphQL: missing members connection for team ${teamId}`,
+        );
+      }
+      members.push(...toGroupMembers(conn.nodes ?? []));
+      hasMore = !!conn.pageInfo?.hasNextPage;
+      after = conn.pageInfo?.endCursor ?? null;
+      if (hasMore && !after) break;
+    }
+    return members;
+  }
+
+  private async fetchWorkspaceMembers(
+    client: LinearClient,
+  ): Promise<GroupMemberYield[]> {
+    const members: GroupMemberYield[] = [];
+    let after: string | null = null;
+    let hasMore = true;
+    while (hasMore) {
+      await this.rateLimit();
+      const payload: LinearUsersQueryData =
+        await linearRawRequest<LinearUsersQueryData>(
+          client,
+          PERMISSION_WORKSPACE_USERS_QUERY,
+          { first: PERMISSION_MEMBERS_PAGE_SIZE, after },
+        );
+      const conn = payload.users;
+      if (!conn) {
+        throw new Error("Linear GraphQL: missing users connection");
+      }
+      // Guests are excluded here by design: the workspace group is the
+      // audience of PUBLIC teams, which guests cannot browse. Guests gain
+      // access only through the rosters of teams they were invited to.
+      members.push(
+        ...toGroupMembers(
+          (conn.nodes ?? []).filter((user) => user.guest !== true),
+        ),
+      );
+      hasMore = !!conn.pageInfo?.hasNextPage;
+      after = conn.pageInfo?.endCursor ?? null;
+      if (hasMore && !after) break;
+    }
+    return members;
+  }
+
+  private async fetchProjectAudiences(
+    client: LinearClient,
+    projectIds: string[],
+  ): Promise<Map<string, LinearProjectAudienceNode>> {
+    const audiences = new Map<string, LinearProjectAudienceNode>();
+    for (
+      let start = 0;
+      start < projectIds.length;
+      start += PERMISSION_PROJECTS_CHUNK_SIZE
+    ) {
+      const chunk = projectIds.slice(
+        start,
+        start + PERMISSION_PROJECTS_CHUNK_SIZE,
+      );
+      await this.rateLimit();
+      const payload = await linearRawRequest<LinearProjectAudiencesQueryData>(
+        client,
+        PERMISSION_PROJECT_AUDIENCES_QUERY,
+        {
+          first: PERMISSION_PROJECTS_CHUNK_SIZE,
+          filter: { id: { in: chunk } },
+        },
+      );
+      for (const node of payload.projects?.nodes ?? []) {
+        audiences.set(node.id, node);
+      }
+    }
+    return audiences;
+  }
 }
 
 // ===== SDK helpers =====
@@ -1169,9 +1730,92 @@ function projectNodeToDocument(project: LinearProjectNode): ConnectorDocument {
     metadata: {
       kind: "project",
       state: project.state,
+      projectId: project.id,
     },
+    // Permission-sync bookkeeping only (scopeKeyForDocument): must not
+    // re-chunk the corpus that predates the stamp.
+    operationalMetadataKeys: ["projectId"],
     updatedAt: project.updatedAt ? new Date(project.updatedAt) : undefined,
   };
+}
+
+// ===== Permission-sync mapping =====
+
+function teamContainerKey(teamKey: string): string {
+  return `team:${teamKey}`;
+}
+
+function projectContainerKey(projectId: string): string {
+  return `project:${projectId}`;
+}
+
+/**
+ * Group ids embed Linear's globally-unique UUIDs (team id / organization id)
+ * so the `group:linear_<id>` ACL tokens of two Linear connectors can never
+ * collide, even across separate Linear workspaces.
+ */
+function teamGroupId(teamId: string): string {
+  return `team-${teamId}`;
+}
+
+function workspaceMembersGroupId(organizationId: string): string {
+  return `workspace-members-${organizationId}`;
+}
+
+function toGroupMembers(nodes: LinearPermissionUserNode[]): GroupMemberYield[] {
+  const members: GroupMemberYield[] = [];
+  for (const user of nodes) {
+    // Suspended users cannot sign in to Linear; they belong in no audience.
+    if (user.active === false) continue;
+    members.push({
+      accountId: user.id,
+      displayName: user.name ?? null,
+      email: user.email ? user.email.toLowerCase() : null,
+      accountType:
+        user.app === true ? "app" : user.guest === true ? "guest" : "member",
+    });
+  }
+  return members;
+}
+
+/**
+ * Ingested project docs grouped by project id, discovered from read-back.
+ * The id comes from the stamped `projectId` metadata when present, else from
+ * the `linear-project-<id>` sourceId (docs ingested before the stamp).
+ * Unparseable docs stay unassigned and fail closed via the pass's sweep.
+ */
+async function collectProjectDocs(
+  readIngestedDocuments: ReadIngestedDocuments,
+): Promise<Map<string, string[]>> {
+  const byProject = new Map<string, string[]>();
+  let afterId: string | null = null;
+  for (;;) {
+    const { documents, nextAfterId } = await readIngestedDocuments({
+      metadataFilter: { kind: "project" },
+      afterId,
+      limit: PERMISSION_READBACK_PAGE_SIZE,
+    });
+    for (const doc of documents) {
+      const stamped = doc.metadata?.projectId;
+      const projectId =
+        typeof stamped === "string" && stamped
+          ? stamped
+          : sourceIdToProjectId(doc.sourceId);
+      if (!projectId) continue;
+      const docIds = byProject.get(projectId);
+      if (docIds) docIds.push(doc.sourceId);
+      else byProject.set(projectId, [doc.sourceId]);
+    }
+    if (documents.length < PERMISSION_READBACK_PAGE_SIZE) break;
+    afterId = nextAfterId;
+  }
+  for (const docIds of byProject.values()) docIds.sort();
+  return byProject;
+}
+
+function sourceIdToProjectId(sourceId: string): string | null {
+  const prefix = "linear-project-";
+  return sourceId.startsWith(prefix) ? sourceId.slice(prefix.length) : null;
 }
 
 function cycleNodeToDocument(cycle: LinearCycleNode): ConnectorDocument {

--- a/platform/backend/src/routes/knowledge-base.test.ts
+++ b/platform/backend/src/routes/knowledge-base.test.ts
@@ -1086,23 +1086,25 @@ describe("knowledge base routes", () => {
     });
 
     test("rejects auto-sync-permissions for a connector type that does not support it", async () => {
-      // linear is not a permission-sync connector — so this must 400.
+      // A crawled site has no upstream ACL to mirror, so web_crawler is the
+      // stable stand-in here: connectors gaining permission sync one by one
+      // never turn this case green by accident.
       const response = await app.inject({
         method: "POST",
         url: "/api/connectors",
         payload: {
-          name: "Auto-sync Linear",
-          connectorType: "linear",
+          name: "Auto-sync Web Crawler",
+          connectorType: "web_crawler",
           visibility: "auto-sync-permissions",
           teamIds: [],
-          config: { type: "linear" },
+          config: { type: "web_crawler", startUrl: "https://example.com" },
           credentials: { apiToken: "token" },
         },
       });
 
       expect(response.statusCode).toBe(400);
       expect(response.json().error.message).toContain(
-        "Auto-sync permissions is not supported for linear connectors",
+        "Auto-sync permissions is not supported for web_crawler connectors",
       );
     });
 
@@ -2800,13 +2802,13 @@ describe("knowledge base routes", () => {
       makeKnowledgeBaseConnector,
     }) => {
       const kb = await makeKnowledgeBase(organizationId);
-      // linear is not a permission-sync connector, but a stored row can
+      // web_crawler is not a permission-sync connector, but a stored row can
       // still carry the auto-sync visibility; the trigger must reject it.
       const connector = await makeKnowledgeBaseConnector(
         kb.id,
         organizationId,
         {
-          connectorType: "linear",
+          connectorType: "web_crawler",
           visibility: "auto-sync-permissions",
         },
       );

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
@@ -352,6 +352,7 @@ const AUTO_SYNC_CONNECTOR_TYPES: ReadonlySet<ConnectorType> = new Set([
   "notion",
   "asana",
   "dropbox",
+  "linear",
 ]);
 
 export function connectorSupportsAutoSync(type: ConnectorType): boolean {


### PR DESCRIPTION
Mirrors Linear's own access control into Archestra, so a user querying a Knowledge Base only gets the Linear issues, cycles, and projects they can see upstream.

Linear's ACL unit is the **team**, and its GraphQL API reports the boundary directly — so this is a faithful projection rather than a declared audience:

- **Containers.** One `team:<teamKey>` per team the API key can see (issues and cycles are assigned by read-back on the `teamKey` metadata both kinds already carry), plus one `project:<projectId>` per ingested project document.
- **Audiences.** A public team admits its own team group plus the synthetic workspace-members group; a private team admits only its roster. A project admits its teams' groups plus the users listed directly on it.
- **Groups.** One per team plus a workspace-members group, rostered from `users`/`team.members`. Group ids embed Linear's UUIDs, so two Linear connectors can never collide on a group token. Suspended users join no roster, guests appear only in teams they were invited to, and integration users are rostered as `app`.
- **Fail-closed.** A project that vanishes upstream, or a document whose team no longer resolves, ends with an empty audience rather than a stale one.

Project documents now carry a `projectId` stamp so they can be placed by `scopeKeyForDocument`; it is registered as operational metadata, so adding it does not re-chunk an existing corpus. Documents ingested before the stamp are still placed, from their `linear-project-<id>` source id.

Sharing changes bump no timestamp Linear will report, so there is no honest probe and every scheduled pass is a full pass.

Part of #7154 (T-908) — the issue stays open; ServiceNow, Outline, and Perforce remain.

## Test plan

- 26 connector unit tests, 7 of them new: snapshot ordering and container audiences, resume-cursor skipping, delta scoping, group rosters and their filtering, throw-rather-than-truncate on a mid-pagination roster failure, and scope-key mapping.
- 34 permission-sync machinery tests re-run green.
- Live pass on a dev stack against a mock Linear GraphQL API: 3 containers with the expected audiences, 4 documents ACLed, rosters filtered as designed, and a deleted project observed failing closed and then recovering.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>