### PR TITLE
fix(docker): bump x/net and the MCP base Go toolchain for CVE-2026-46600

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -34,7 +34,8 @@ RUN git clone --depth 1 --branch "${KIND_VERSION}" https://github.com/kubernetes
     cd /kind && \
     go mod edit -go=1.25.11 && \
     # golang.org/x/net <0.55.0: CVE-2026-39821 (CRITICAL); fixed in >= 0.55.0
-    go get golang.org/x/net@v0.55.0 && \
+    # golang.org/x/net <0.56.0: CVE-2026-46600 (HIGH); fixed in >= 0.56.0
+    go get golang.org/x/net@v0.56.0 && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /kind-binary .
 RUN git clone --depth 1 --branch "${DOCKER_CLI_VERSION}" https://github.com/docker/cli.git /docker-cli && \
     test "$(git -C /docker-cli rev-parse HEAD)" = "${DOCKER_CLI_COMMIT}" && \
@@ -49,13 +50,14 @@ RUN git clone --depth 1 --branch "${DOCKER_CLI_VERSION}" https://github.com/dock
     # CVE-2026-34986: go-jose uncaught exception fixed in >= 4.1.4
     go get github.com/go-jose/go-jose/v4@v4.1.4 && \
     # x/sys/x/term must be pinned for `go mod vendor` to find windows/registry and plan9 sub-pkgs.
-    # Versions must satisfy x/net@v0.55.0 requirements: x/sys >= v0.45.0, x/term >= v0.43.0.
-    go get golang.org/x/sys@v0.45.0 && \
-    go get golang.org/x/term@v0.43.0 && \
+    # Versions must satisfy x/net@v0.56.0 requirements: x/sys >= v0.46.0, x/term >= v0.44.0.
+    go get golang.org/x/sys@v0.46.0 && \
+    go get golang.org/x/term@v0.44.0 && \
     # golang.org/x/net <0.55.0: CVE-2026-39821 (CRITICAL); fixed in >= 0.55.0.
+    # golang.org/x/net <0.56.0: CVE-2026-46600 (HIGH); fixed in >= 0.56.0.
     # Must be the LAST `go get` before `go mod vendor` — earlier `go get`s for grpc/otel/x/sys
     # transitively pull older x/net and would otherwise override our explicit requirement.
-    go get golang.org/x/net@v0.55.0 && \
+    go get golang.org/x/net@v0.56.0 && \
     go mod vendor && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=vendor \
     -ldflags "-X github.com/docker/cli/cli/version.Version=${DOCKER_CLI_VERSION#v}" \
@@ -77,6 +79,7 @@ RUN git clone --depth 1 --branch "${DAGGER_VERSION}" https://github.com/dagger/d
     # cve-2026-44973: go-billy path traversal fixed in >= 5.9.0
     go get github.com/go-git/go-billy/v5@v5.9.0 && \
     # cve-2026-39821: x/net CRITICAL fixed in >= 0.55.0.
+    # cve-2026-46600: x/net HIGH fixed in >= 0.56.0.
     # Pinned to 0.56.0 (not 0.55.0) because go-git 5.19.2 requires >= 0.56.0 — asking for
     # anything lower here makes `go get` downgrade go-git back below 5.19.2 to satisfy it,
     # silently reintroducing cve-2026-71556. Do not lower without also lowering go-git.
@@ -106,7 +109,8 @@ RUN git clone --depth 1 --branch "${KUBECTL_VERSION}" https://github.com/kuberne
     # cve-2026-29181: OTel resource exhaustion fixed in >= 1.41.0.
     go get go.opentelemetry.io/otel@v1.41.0 go.opentelemetry.io/otel/metric@v1.41.0 go.opentelemetry.io/otel/trace@v1.41.0 go.opentelemetry.io/otel/sdk@v1.41.0 && \
     # cve-2026-39821: x/net CRITICAL fixed in >= 0.55.0.
-    go get golang.org/x/net@v0.55.0 && \
+    # cve-2026-46600: x/net HIGH fixed in >= 0.56.0.
+    go get golang.org/x/net@v0.56.0 && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=readonly \
     -ldflags "-X k8s.io/component-base/version.gitVersion=${KUBECTL_VERSION} -X k8s.io/component-base/version.gitCommit=${KUBECTL_COMMIT} -X k8s.io/component-base/version.gitTreeState=clean" \
     -o /kubectl-binary ./cmd/kubectl

--- a/platform/mcp_server_docker_image/Dockerfile
+++ b/platform/mcp_server_docker_image/Dockerfile
@@ -4,7 +4,7 @@ ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.9.26@sha256:9a23023be68b2ed09750ae636228e903
 # Go toolchain is sourced from the official golang:alpine image because Alpine's
 # community repo lags upstream Go patch releases. Stays binary-compatible since
 # both images share the Alpine base.
-ARG GOLANG_IMAGE=golang:1.25.13-alpine@sha256:844b27705f54e73773e0f9bc3c780633b9d7f4b4831bf35cdad02a81a4c80bd0
+ARG GOLANG_IMAGE=golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df
 
 FROM ${GOLANG_IMAGE} AS go-bin
 
@@ -123,10 +123,13 @@ RUN apk add --no-cache \
    # CVE-2026-6276, CVE-2026-5773: curl/libcurl vulnerabilities (HIGH) fixed in 8.20.0-r0.
    # The base image ships 8.19.0-r0; the explicit `apk add curl` above installs it, so
    # curl/libcurl must be listed here to be upgraded to the fixed version.
-   # Go runtime is copied from the golang:1.25.13-alpine image below to pick up the
+   # Go runtime is copied from the golang:1.26.6-alpine image below to pick up the
    # Go stdlib HIGH CVEs fixed in 1.25.10 (CVE-2026-42499/39836/39820/33814/33811),
-   # 1.25.11 (CVE-2026-42504), and the CRITICAL fixed in 1.25.13 (CVE-2026-39821)
-   # that Alpine's apk index has not yet shipped.
+   # 1.25.11 (CVE-2026-42504), the CRITICAL fixed in 1.25.13 (CVE-2026-39821), and the
+   # HIGH fixed in 1.26.6 (CVE-2026-46600) that Alpine's apk index has not yet shipped.
+   # No 1.25.x release carries the CVE-2026-46600 fix (the line ends at 1.25.13
+   # upstream), so this moves to the same 1.26.6 toolchain the platform image's
+   # go-builder stage already uses.
    apk upgrade --no-cache nodejs bind openssl zlib expat curl libcurl
 
 # Go toolchain sourced from upstream Alpine-based image (Alpine apk currently ships go-1.25.9-r0)


### PR DESCRIPTION
## What

Docker Scout is failing **both** image scans on `CVE-2026-46600` (HIGH, `only-fixed`), which blocks the merge queue for every PR:

| Image | Flagged package | Fixed in |
| --- | --- | --- |
| Platform | `golang.org/x/net` 0.55.0 | 0.56.0 |
| MCP server base | Go `stdlib` 1.25.13 | 1.26.6 |

## Changes

**Platform image** — the `kind`, `docker-cli`, and `kubectl` builder stages each pinned `x/net@v0.55.0`; all three move to `v0.56.0`. The Dagger stage was already on `0.56.0` (its go-git 5.19.2 floor), so it only gains a comment.

`x/net@v0.56.0` raises its own floors to `x/sys >= v0.46.0` and `x/term >= v0.44.0`, so the docker-cli stage's explicit `x/sys`/`x/term` pins move with it — those exist so `go mod vendor` can find the `windows/registry` and `plan9` sub-packages, and leaving them lower would leave the comment lying about why they're there. `x/net` stays the last `go get` before `go mod vendor`, per the existing ordering note.

**MCP server base image** — the copied Go runtime moves from `golang:1.25.13-alpine` to `golang:1.26.6-alpine`. Upstream has no `1.25.14+` release, so the 1.25 line never gets this fix; 1.26.6 is the same toolchain the platform image's `go-builder` stage already pins.

## Verification

- Confirmed `golang:1.26.6-alpine` layered into the pinned `python:3.12-alpine` base still runs: `go version` reports `go1.26.6`, and a compiled test binary embeds `go1.26.6` in its module metadata — that embedded version is exactly what Scout reads.
- Confirmed against the module proxy that `x/net@v0.56.0` declares `x/sys v0.46.0` / `x/term v0.44.0` / `x/crypto v0.53.0`, and that no `golang:1.25.14-alpine` or later exists on the 1.25 line.
- `run-docker-scan` label applied so the real Scout scan runs on this PR instead of only in the merge queue.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>