### PR TITLE
feat(knowledge-base): permission auto-sync for the Outline connector

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -196,10 +196,10 @@ Auto-sync permissions works with the connectors marked *Supported* below. *Limit
 | Google Drive | Supported                                                                                                 |
 | Notion       | Limited: every synced page is visible to all workspace members ([details](#notion-auto-sync-permissions)) |
 | OneDrive     | Supported                                                                                                 |
+| Outline      | Supported                                                                                                 |
 | Salesforce   | Supported                                                                                                 |
 | SharePoint   | Supported                                                                                                 |
 | Linear       | Not supported                                                                                             |
-| Outline      | Not supported                                                                                             |
 | Perforce     | Not supported                                                                                             |
 | ServiceNow   | Not supported                                                                                             |
 | Web Crawler  | Not supported                                                                                             |
@@ -215,6 +215,7 @@ Auto-sync permissions works with the connectors marked *Supported* below. *Limit
 - **Dropbox** returns member emails directly in shared-folder member lists. Group member rosters expand when the access token is a Business **team access token** (`groups.read` + `members.read` team scopes); with a member token, granted groups appear in the Groups tab with no members — assign them manually. See [Dropbox](#dropbox).
 - **Notion** returns member emails only when the integration has the **"read user information including email addresses"** capability. Guests are never listed.
 - **Asana** returns workspace members' emails through the same personal access token the connector already uses. No extra credential is needed, but the token's user must be able to see the synced projects and their members.
+- **Outline** returns member emails only when listing workspace users, never inside collection or group membership listings. The connector reads every member's email from that user list, so an API key that cannot list workspace users leaves all members unresolvable. See [Outline](#outline).
 
 **Permission-read access.** The credential must also be able to read the source's permission settings — Jira permission schemes, Confluence space permissions, GitHub repository collaborators, GitLab project members. A credential that cannot read them hides that project or space from everyone, because Archestra never assumes an audience it could not verify. Each sync run reports how many it could not read, so a project nobody can find is easy to tell apart from a project nobody is granted.
 
@@ -585,6 +586,14 @@ Sync published documents from an [Outline](https://www.getoutline.com/) workspac
 | Instance URL   | The base URL of your Outline workspace (e.g. `https://app.getoutline.com` or your self-hosted URL).    |
 | API Key        | Your Outline API key (starts with `ol_api_`).                                                          |
 | Collection IDs | Optional comma-separated list of collection IDs to sync. Leave blank to sync all accessible documents. |
+
+**Auto-sync permissions.** Each collection is one permission scope. A collection's audience is its individual members, its granted groups, and — when the collection has workspace-wide default access — every active workspace member except guests. Guests only see collections they are explicitly added to, directly or through a group.
+
+Each permission sync also snapshots group member rosters, so the connector's **Users** and **Groups** tabs show every member with their assignment status. Members granted a collection individually appear there too, under the synthetic `direct-grants` group. Workspace-wide default access appears as a group named after your workspace, holding every active non-guest member.
+
+Published share links are the only public surface. A published document share maps that document — and its child documents, when the share includes them — to everyone in your Archestra organization. A published collection share does the same for the whole collection.
+
+A collection whose permissions cannot be read hides its documents from everyone until a later sync reads them. Documents an Outline user can only reach through a direct per-document share (not a public link) are not carried over; they stay limited to the collection's audience.
 
 ### Salesforce
 

--- a/platform/backend/src/knowledge-base/connectors/outline/outline-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/outline/outline-connector.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ConnectorSyncBatch } from "@/types";
+import type {
+  ConnectorSyncBatch,
+  GroupMembershipYield,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
+} from "@/types";
 import { OutlineConnector } from "./outline-connector";
 
 const OUTLINE_URL = "https://app.getoutline.com";
@@ -971,6 +976,873 @@ describe("OutlineConnector", () => {
           // consume
         }
       }).rejects.toThrow(/Outline API error 500/);
+    });
+  });
+
+  // ===== Permission sync =====
+
+  type ContainerYield = Extract<PermissionSnapshotYield, { kind: "container" }>;
+  type DocumentYield = Extract<PermissionSnapshotYield, { kind: "document" }>;
+
+  type Route = {
+    method: string;
+    when?: (body: Record<string, unknown>) => boolean;
+    body?: unknown;
+    status?: number;
+  };
+
+  function installRoutes(connector: OutlineConnector, routes: Route[]) {
+    const calls: Array<{ method: string; body: Record<string, unknown> }> = [];
+    vi.spyOn(connector as unknown as SpyTarget, "rateLimit").mockResolvedValue(
+      undefined,
+    );
+    vi.spyOn(
+      connector as unknown as SpyTarget,
+      "fetchWithRetry",
+    ).mockImplementation(async (...args: unknown[]) => {
+      const url = args[0] as string;
+      const init = args[1] as { body?: string };
+      const method = url.slice(url.indexOf("/api/") + "/api/".length);
+      const body = init?.body
+        ? (JSON.parse(init.body) as Record<string, unknown>)
+        : {};
+      calls.push({ method, body });
+      const route = routes.find(
+        (candidate) =>
+          candidate.method === method &&
+          (!candidate.when || candidate.when(body)),
+      );
+      if (!route) {
+        throw new Error(`No route for ${method} ${JSON.stringify(body)}`);
+      }
+      if (route.status && route.status >= 400) {
+        return {
+          ok: false,
+          status: route.status,
+          json: async () => ({}),
+          text: async () => "boom",
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => route.body,
+        text: async () => "",
+      } as unknown as Response;
+    });
+    return calls;
+  }
+
+  const envelope = (data: unknown, nextPath?: string) => ({
+    ok: true,
+    data,
+    pagination: {
+      limit: 100,
+      offset: 0,
+      ...(nextPath ? { nextPath } : {}),
+    },
+  });
+
+  const apiUser = (
+    id: string,
+    email: string | null,
+    opts?: { name?: string; role?: string; isSuspended?: boolean },
+  ) => ({
+    id,
+    name: opts?.name ?? id,
+    email,
+    role: opts?.role ?? "member",
+    isSuspended: opts?.isSuspended ?? false,
+  });
+
+  const authRoute = (team?: { id: string; name: string } | null): Route => ({
+    method: "auth.info",
+    body: {
+      ok: true,
+      data: {
+        user: { id: "user-1", name: "Test User" },
+        ...(team === null
+          ? {}
+          : { team: team ?? { id: "team-1", name: "Test Team" } }),
+      },
+    },
+  });
+
+  const noSharesRoute: Route = { method: "shares.list", body: envelope([]) };
+
+  /**
+   * Outline serializes `email` only where the endpoint asks for it, and the
+   * membership endpoints do not: users nested in `collections.memberships`
+   * and `groups.memberships` arrive email-less however privileged the key
+   * is. Fixtures strip it so the suites exercise the real payload shape.
+   */
+  const withoutEmail = (users: ReturnType<typeof apiUser>[]) =>
+    users.map(({ email: _email, ...rest }) => rest);
+
+  /** `users.list` — the only endpoint that returns emails. */
+  const directoryRoute = (users: ReturnType<typeof apiUser>[]): Route => ({
+    method: "users.list",
+    when: (body) => body.filter === "all",
+    body: envelope(users),
+  });
+
+  /** `users.list` restricted to active members (workspace-default roster). */
+  const activeUsersRoute = (users: ReturnType<typeof apiUser>[]): Route => ({
+    method: "users.list",
+    when: (body) => body.filter === "active",
+    body: envelope(users),
+  });
+
+  const membershipsRoute = (
+    collectionId: string,
+    users: ReturnType<typeof apiUser>[],
+  ): Route => ({
+    method: "collections.memberships",
+    when: (body) => body.id === collectionId,
+    body: envelope({ users: withoutEmail(users), memberships: [] }),
+  });
+
+  const groupMembershipsRoute = (
+    collectionId: string,
+    groups: Array<{ id: string; name?: string }>,
+  ): Route => ({
+    method: "collections.group_memberships",
+    when: (body) => body.id === collectionId,
+    body: envelope({ groups, collectionGroupMemberships: [] }),
+  });
+
+  const collectionInfoRoute = (
+    collectionId: string,
+    permission: "read" | "read_write" | null,
+  ): Route => ({
+    method: "collections.info",
+    when: (body) => body.id === collectionId,
+    body: {
+      ok: true,
+      data: { id: collectionId, name: collectionId, permission },
+    },
+  });
+
+  const ingested = (
+    sourceId: string,
+    collectionId: string,
+    parentDocumentId: string | null = null,
+  ) => ({
+    sourceId,
+    metadata: { collectionId, parentDocumentId, urlId: sourceId.slice(0, 8) },
+  });
+
+  const readBack = (docs: ReturnType<typeof ingested>[]) =>
+    vi.fn(
+      async (args: {
+        metadataFilter?: Record<string, string>;
+        afterId?: string | null;
+        limit: number;
+      }) => {
+        const filtered = args.metadataFilter
+          ? docs.filter((doc) =>
+              Object.entries(
+                args.metadataFilter as Record<string, string>,
+              ).every(
+                ([key, value]) =>
+                  (doc.metadata as Record<string, unknown>)[key] === value,
+              ),
+            )
+          : docs;
+        const sorted = [...filtered].sort((a, b) =>
+          a.sourceId.localeCompare(b.sourceId),
+        );
+        const start = args.afterId
+          ? sorted.findIndex((doc) => doc.sourceId === args.afterId) + 1
+          : 0;
+        const page = sorted.slice(start, start + args.limit);
+        return {
+          documents: page,
+          nextAfterId: page.length ? page[page.length - 1].sourceId : null,
+        };
+      },
+    );
+
+  function snapshotParams(overrides?: {
+    config?: Record<string, unknown>;
+    docs?: ReturnType<typeof ingested>[];
+    cursor?: string | null;
+    scope?: { containerKeys: string[] };
+    resolveMappedEmail?: (externalAccountId: string) => string | null;
+  }): PermissionSyncParams {
+    return {
+      config: overrides?.config ?? { ...baseConfig, collectionIds: ["col-1"] },
+      credentials,
+      cursor: overrides?.cursor ?? null,
+      readIngestedDocuments: readBack(
+        overrides?.docs ?? [
+          ingested("doc-1", "col-1"),
+          ingested("doc-2", "col-1"),
+        ],
+      ),
+      ...(overrides?.scope ? { scope: overrides.scope } : {}),
+      ...(overrides?.resolveMappedEmail
+        ? { resolveMappedEmail: overrides.resolveMappedEmail }
+        : {}),
+    } as unknown as PermissionSyncParams;
+  }
+
+  async function collectSnapshot(gen: AsyncGenerator<PermissionSnapshotYield>) {
+    const order: PermissionSnapshotYield[] = [];
+    const containers = new Map<string, ContainerYield>();
+    const documents: DocumentYield[] = [];
+    for await (const item of gen) {
+      order.push(item);
+      if (item.kind === "container") containers.set(item.containerKey, item);
+      else documents.push(item);
+    }
+    return { order, containers, documents };
+  }
+
+  describe("syncPermissionSnapshot", () => {
+    it("resolves a private collection's audience from memberships and group memberships", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([
+          apiUser("u-1", "Alice@Example.com"),
+          apiUser("u-2", "bob@example.com"),
+          apiUser("u-suspended", "sue@example.com", { isSuspended: true }),
+          apiUser("u-hidden", null),
+        ]),
+        collectionInfoRoute("col-1", null),
+        membershipsRoute("col-1", [
+          apiUser("u-1", "Alice@Example.com"),
+          apiUser("u-2", "bob@example.com"),
+          apiUser("u-suspended", "sue@example.com", { isSuspended: true }),
+          apiUser("u-hidden", null),
+        ]),
+        groupMembershipsRoute("col-1", [{ id: "grp-b" }, { id: "grp-a" }]),
+      ]);
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams()),
+      );
+
+      const container = containers.get("collection:col-1");
+      expect(container?.permissions).toEqual({
+        isPublic: false,
+        users: ["alice@example.com", "bob@example.com"],
+        groups: ["grp-a", "grp-b"],
+      });
+      expect(container?.audienceResolutionFailed).toBe(false);
+      expect(documents.map((doc) => doc.sourceId)).toEqual(["doc-1", "doc-2"]);
+      expect(
+        documents.every((doc) => doc.containerKey === "collection:col-1"),
+      ).toBe(true);
+      expect(documents.every((doc) => doc.cursor === "collection:col-1")).toBe(
+        true,
+      );
+    });
+
+    it("recovers a hidden email through resolveMappedEmail", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([apiUser("u-hidden", null)]),
+        collectionInfoRoute("col-1", null),
+        membershipsRoute("col-1", [apiUser("u-hidden", null)]),
+        groupMembershipsRoute("col-1", []),
+      ]);
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(
+          snapshotParams({
+            resolveMappedEmail: (id) =>
+              id === "u-hidden" ? "Mapped@Example.com" : null,
+          }),
+        ),
+      );
+
+      expect(containers.get("collection:col-1")?.permissions.users).toEqual([
+        "mapped@example.com",
+      ]);
+    });
+
+    it("adds the workspace-scoped default group when the collection grants workspace-wide access", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([]),
+        collectionInfoRoute("col-1", "read"),
+        membershipsRoute("col-1", []),
+        groupMembershipsRoute("col-1", []),
+      ]);
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams()),
+      );
+
+      expect(containers.get("collection:col-1")?.permissions.groups).toEqual([
+        "workspace-default-team-1",
+      ]);
+    });
+
+    it("fail-closes the whole audience when a membership read fails, still yielding every document", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([]),
+        collectionInfoRoute("col-1", "read"),
+        {
+          method: "collections.memberships",
+          status: 500,
+        },
+        groupMembershipsRoute("col-1", [{ id: "grp-a" }]),
+      ]);
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams()),
+      );
+
+      const container = containers.get("collection:col-1");
+      expect(container?.permissions).toEqual({
+        isPublic: false,
+        users: [],
+        groups: [],
+      });
+      expect(container?.audienceResolutionFailed).toBe(true);
+      expect(documents.map((doc) => doc.sourceId)).toEqual(["doc-1", "doc-2"]);
+    });
+
+    it("emits an empty-corpus collection as a fail-closed boundary without resolving its audience", async () => {
+      const connector = new OutlineConnector();
+      const calls = installRoutes(connector, [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([]),
+      ]);
+
+      const { containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams({ docs: [] })),
+      );
+
+      const container = containers.get("collection:col-1");
+      expect(container?.permissions).toEqual({
+        isPublic: false,
+        users: [],
+        groups: [],
+      });
+      expect(container?.audienceResolutionFailed).toBe(false);
+      expect(documents).toEqual([]);
+      expect(
+        calls.filter((call) => call.method === "collections.info"),
+      ).toEqual([]);
+    });
+
+    it("drains paginated membership listings before building the audience", async () => {
+      const firstPage = Array.from({ length: 100 }, (_, i) =>
+        apiUser(`u-${String(i).padStart(3, "0")}`, `user${i}@example.com`),
+      );
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([...firstPage, apiUser("u-last", "last@example.com")]),
+        collectionInfoRoute("col-1", null),
+        {
+          method: "collections.memberships",
+          when: (body) => body.offset === 0,
+          body: {
+            ok: true,
+            data: { users: withoutEmail(firstPage), memberships: [] },
+            pagination: { limit: 100, offset: 0, nextPath: "/api/next" },
+          },
+        },
+        {
+          method: "collections.memberships",
+          when: (body) => body.offset === 100,
+          body: envelope({
+            users: withoutEmail([apiUser("u-last", "last@example.com")]),
+            memberships: [],
+          }),
+        },
+        groupMembershipsRoute("col-1", []),
+      ]);
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams()),
+      );
+
+      expect(
+        containers.get("collection:col-1")?.permissions.users,
+      ).toHaveLength(101);
+    });
+
+    it("marks a collection public when a published collection share exists", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        {
+          method: "shares.list",
+          body: envelope([
+            {
+              id: "s-1",
+              collectionId: "col-1",
+              documentId: null,
+              published: true,
+            },
+            {
+              id: "s-2",
+              collectionId: "col-9",
+              documentId: null,
+              published: false,
+            },
+          ]),
+        },
+        directoryRoute([]),
+        collectionInfoRoute("col-1", null),
+        membershipsRoute("col-1", []),
+        groupMembershipsRoute("col-1", []),
+      ]);
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams()),
+      );
+
+      expect(containers.get("collection:col-1")?.permissions.isPublic).toBe(
+        true,
+      );
+    });
+
+    it("assigns published documents and their included children to the public nested container", async () => {
+      const docs = [
+        ingested("doc-child", "col-1", "doc-root"),
+        ingested("doc-grandchild", "col-1", "doc-child"),
+        ingested("doc-other", "col-1"),
+        ingested("doc-solo", "col-1"),
+      ];
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        {
+          method: "shares.list",
+          body: envelope([
+            {
+              id: "s-1",
+              documentId: "doc-root",
+              collectionId: null,
+              published: true,
+              includeChildDocuments: true,
+            },
+            {
+              id: "s-2",
+              documentId: "doc-solo",
+              collectionId: null,
+              published: true,
+              includeChildDocuments: false,
+            },
+          ]),
+        },
+        directoryRoute([apiUser("u-1", "alice@example.com")]),
+        collectionInfoRoute("col-1", null),
+        membershipsRoute("col-1", [apiUser("u-1", "alice@example.com")]),
+        groupMembershipsRoute("col-1", []),
+      ]);
+
+      const { order, containers, documents } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams({ docs })),
+      );
+
+      const publicKey = "collection:col-1/public";
+      expect(containers.get(publicKey)?.permissions).toEqual({
+        isPublic: true,
+        users: [],
+        groups: [],
+      });
+      // The nested container is emitted before any document references it.
+      const publicContainerIndex = order.findIndex(
+        (item) => item.kind === "container" && item.containerKey === publicKey,
+      );
+      const firstPublicDocIndex = order.findIndex(
+        (item) => item.kind === "document" && item.containerKey === publicKey,
+      );
+      expect(publicContainerIndex).toBeGreaterThan(-1);
+      expect(publicContainerIndex).toBeLessThan(firstPublicDocIndex);
+
+      const byId = new Map(documents.map((doc) => [doc.sourceId, doc]));
+      expect(byId.get("doc-child")?.containerKey).toBe(publicKey);
+      expect(byId.get("doc-grandchild")?.containerKey).toBe(publicKey);
+      expect(byId.get("doc-solo")?.containerKey).toBe(publicKey);
+      expect(byId.get("doc-other")?.containerKey).toBe("collection:col-1");
+      // Nested yields still carry the TOP-LEVEL cursor.
+      expect(
+        [...containers.values(), ...documents].every(
+          (item) => item.cursor === "collection:col-1",
+        ),
+      ).toBe(true);
+    });
+
+    it("degrades to no public shares when shares.list fails", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        { method: "shares.list", status: 403 },
+        directoryRoute([apiUser("u-1", "alice@example.com")]),
+        collectionInfoRoute("col-1", null),
+        membershipsRoute("col-1", [apiUser("u-1", "alice@example.com")]),
+        groupMembershipsRoute("col-1", []),
+      ]);
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams()),
+      );
+
+      const container = containers.get("collection:col-1");
+      expect(container?.permissions.isPublic).toBe(false);
+      expect(container?.permissions.users).toEqual(["alice@example.com"]);
+      expect(container?.audienceResolutionFailed).toBe(false);
+    });
+
+    it("enumerates every visible collection sorted when no filter is configured", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([]),
+        {
+          method: "collections.list",
+          body: envelope([{ id: "col-b" }, { id: "col-a" }]),
+        },
+        collectionInfoRoute("col-a", null),
+        collectionInfoRoute("col-b", null),
+        membershipsRoute("col-a", []),
+        membershipsRoute("col-b", []),
+        groupMembershipsRoute("col-a", []),
+        groupMembershipsRoute("col-b", []),
+      ]);
+
+      const { order } = await collectSnapshot(
+        connector.syncPermissionSnapshot(
+          snapshotParams({
+            config: baseConfig,
+            docs: [ingested("doc-1", "col-a"), ingested("doc-2", "col-b")],
+          }),
+        ),
+      );
+
+      const containerKeys = order
+        .filter((item) => item.kind === "container")
+        .map((item) => item.containerKey);
+      expect(containerKeys).toEqual(["collection:col-a", "collection:col-b"]);
+    });
+
+    it("skips containers before the cursor and outside the scope", async () => {
+      const config = {
+        ...baseConfig,
+        collectionIds: ["col-a", "col-b", "col-c"],
+      };
+      const docs = [
+        ingested("doc-1", "col-a"),
+        ingested("doc-2", "col-b"),
+        ingested("doc-3", "col-c"),
+      ];
+      const routes: Route[] = [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([]),
+        ...["col-a", "col-b", "col-c"].flatMap((id) => [
+          collectionInfoRoute(id, null),
+          membershipsRoute(id, []),
+          groupMembershipsRoute(id, []),
+        ]),
+      ];
+
+      const cursorConnector = new OutlineConnector();
+      installRoutes(cursorConnector, routes);
+      const cursorRun = await collectSnapshot(
+        cursorConnector.syncPermissionSnapshot(
+          snapshotParams({ config, docs, cursor: "collection:col-b" }),
+        ),
+      );
+      expect([...cursorRun.containers.keys()]).toEqual([
+        "collection:col-b",
+        "collection:col-c",
+      ]);
+
+      const scopeConnector = new OutlineConnector();
+      installRoutes(scopeConnector, routes);
+      const scopedRun = await collectSnapshot(
+        scopeConnector.syncPermissionSnapshot(
+          snapshotParams({
+            config,
+            docs,
+            scope: { containerKeys: ["collection:col-c"] },
+          }),
+        ),
+      );
+      expect([...scopedRun.containers.keys()]).toEqual(["collection:col-c"]);
+    });
+
+    it("grants individually-shared members whose membership payload carries no email", async () => {
+      // Outline nests users in membership responses through a bare
+      // presentUser(), which omits `email` for every caller. Reading the
+      // email off that payload dropped every individual grantee, so a
+      // collection shared with named people resolved to its groups alone.
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([
+          apiUser("u-margaret", "Margaret@example.com"),
+          apiUser("u-mark", "mark@example.com"),
+        ]),
+        collectionInfoRoute("col-1", null),
+        membershipsRoute("col-1", [
+          apiUser("u-margaret", "Margaret@example.com"),
+          apiUser("u-mark", "mark@example.com"),
+        ]),
+        groupMembershipsRoute("col-1", [{ id: "grp-eng" }]),
+      ]);
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams()),
+      );
+
+      expect(containers.get("collection:col-1")?.permissions).toEqual({
+        isPublic: false,
+        users: ["margaret@example.com", "mark@example.com"],
+        groups: ["grp-eng"],
+      });
+    });
+
+    it("honors the directory's suspension state over the membership payload", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        noSharesRoute,
+        directoryRoute([
+          apiUser("u-1", "alice@example.com"),
+          apiUser("u-gone", "gone@example.com", { isSuspended: true }),
+        ]),
+        collectionInfoRoute("col-1", null),
+        // The membership payload predates the suspension and omits the flag.
+        membershipsRoute("col-1", [
+          apiUser("u-1", "alice@example.com"),
+          apiUser("u-gone", "gone@example.com"),
+        ]),
+        groupMembershipsRoute("col-1", []),
+      ]);
+
+      const { containers } = await collectSnapshot(
+        connector.syncPermissionSnapshot(snapshotParams()),
+      );
+
+      expect(containers.get("collection:col-1")?.permissions.users).toEqual([
+        "alice@example.com",
+      ]);
+    });
+
+    it("fails the pass when auth.info returns no workspace id", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [authRoute(null), noSharesRoute]);
+
+      await expect(
+        collectSnapshot(connector.syncPermissionSnapshot(snapshotParams())),
+      ).rejects.toThrow(/no workspace id/);
+    });
+  });
+
+  describe("syncGroups", () => {
+    it("yields workspace groups, the workspace-default group, and the direct-grants roster", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        directoryRoute([
+          apiUser("u-1", "Alice@Example.com"),
+          apiUser("u-2", "bob@example.com"),
+          apiUser("u-3", "carol@example.com", { role: "viewer" }),
+          apiUser("u-suspended", "sue@example.com", { isSuspended: true }),
+          apiUser("u-guest", "guest@example.com", { role: "guest" }),
+          apiUser("u-hidden", null),
+        ]),
+        {
+          method: "groups.list",
+          body: envelope({
+            groups: [
+              { id: "grp-b", name: "Beta" },
+              { id: "grp-a", name: "Alpha" },
+            ],
+            groupMemberships: [],
+          }),
+        },
+        {
+          method: "groups.memberships",
+          when: (body) => body.id === "grp-a",
+          body: envelope({
+            users: withoutEmail([
+              apiUser("u-2", "bob@example.com"),
+              apiUser("u-1", "Alice@Example.com"),
+              apiUser("u-suspended", "sue@example.com", { isSuspended: true }),
+            ]),
+            groupMemberships: [],
+          }),
+        },
+        {
+          method: "groups.memberships",
+          when: (body) => body.id === "grp-b",
+          body: envelope({ users: [], groupMemberships: [] }),
+        },
+        activeUsersRoute([
+          apiUser("u-1", "alice@example.com"),
+          apiUser("u-3", "carol@example.com", { role: "viewer" }),
+          apiUser("u-guest", "guest@example.com", { role: "guest" }),
+        ]),
+        membershipsRoute("col-1", [
+          apiUser("u-1", "alice@example.com"),
+          apiUser("u-hidden", null),
+        ]),
+      ]);
+
+      const groups: GroupMembershipYield[] = [];
+      for await (const group of connector.syncGroups(snapshotParams())) {
+        groups.push(group);
+      }
+
+      expect(groups.map((group) => group.groupId)).toEqual([
+        "grp-a",
+        "grp-b",
+        "workspace-default-team-1",
+        "direct-grants",
+      ]);
+      const alpha = groups[0];
+      expect(alpha.name).toBe("Alpha");
+      expect(alpha.members.map((member) => member.accountId)).toEqual([
+        "u-1",
+        "u-2",
+      ]);
+      expect(alpha.members[0].email).toBe("alice@example.com");
+
+      const defaults = groups[2];
+      expect(defaults.name).toBe("Test Team default access");
+      expect(defaults.members.map((member) => member.accountId)).toEqual([
+        "u-1",
+        "u-3",
+      ]);
+
+      const direct = groups[3];
+      expect(direct.members.map((member) => member.accountId)).toEqual([
+        "u-1",
+        "u-hidden",
+      ]);
+      expect(direct.members[1].email).toBeNull();
+    });
+
+    it("resolves group and direct-grant roster emails through the directory", async () => {
+      // Without the directory join every roster stored NULL emails, so no
+      // Archestra user could ever match into a group — the group token was
+      // in the ACL but granted nobody.
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        directoryRoute([
+          apiUser("u-eng", "eng@example.com"),
+          apiUser("u-direct", "direct@example.com"),
+        ]),
+        {
+          method: "groups.list",
+          body: envelope({
+            groups: [{ id: "grp-eng", name: "Engineering" }],
+            groupMemberships: [],
+          }),
+        },
+        {
+          method: "groups.memberships",
+          when: (body) => body.id === "grp-eng",
+          body: envelope({
+            users: withoutEmail([apiUser("u-eng", "eng@example.com")]),
+            groupMemberships: [],
+          }),
+        },
+        activeUsersRoute([]),
+        membershipsRoute("col-1", [apiUser("u-direct", "direct@example.com")]),
+      ]);
+
+      const groups: GroupMembershipYield[] = [];
+      for await (const group of connector.syncGroups(snapshotParams())) {
+        groups.push(group);
+      }
+
+      const engineering = groups.find((group) => group.groupId === "grp-eng");
+      expect(engineering?.members[0].email).toBe("eng@example.com");
+      const direct = groups.find((group) => group.groupId === "direct-grants");
+      expect(direct?.members[0].email).toBe("direct@example.com");
+    });
+
+    it("throws instead of yielding a truncated roster when a group read fails", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        directoryRoute([]),
+        {
+          method: "groups.list",
+          body: envelope({
+            groups: [{ id: "grp-a", name: "Alpha" }],
+            groupMemberships: [],
+          }),
+        },
+        { method: "groups.memberships", status: 500 },
+      ]);
+
+      await expect(async () => {
+        for await (const _ of connector.syncGroups(snapshotParams())) {
+          // consume
+        }
+      }).rejects.toThrow(/Outline API error 500/);
+    });
+
+    it("skips a collection whose membership read fails without losing the rest of the direct-grants roster", async () => {
+      const connector = new OutlineConnector();
+      installRoutes(connector, [
+        authRoute(),
+        directoryRoute([apiUser("u-1", "alice@example.com")]),
+        {
+          method: "groups.list",
+          body: envelope({ groups: [], groupMemberships: [] }),
+        },
+        activeUsersRoute([]),
+        {
+          method: "collections.memberships",
+          when: (body) => body.id === "col-a",
+          status: 500,
+        },
+        membershipsRoute("col-b", [apiUser("u-1", "alice@example.com")]),
+      ]);
+
+      const groups: GroupMembershipYield[] = [];
+      for await (const group of connector.syncGroups(
+        snapshotParams({
+          config: { ...baseConfig, collectionIds: ["col-a", "col-b"] },
+        }),
+      )) {
+        groups.push(group);
+      }
+
+      const direct = groups.find((group) => group.groupId === "direct-grants");
+      expect(direct?.members.map((member) => member.accountId)).toEqual([
+        "u-1",
+      ]);
+    });
+  });
+
+  describe("scopeKeyForDocument", () => {
+    it("maps collection metadata to the container key and everything else to null", () => {
+      const connector = new OutlineConnector();
+      expect(connector.scopeKeyForDocument({ collectionId: "col-1" })).toBe(
+        "collection:col-1",
+      );
+      expect(connector.scopeKeyForDocument({ collectionId: null })).toBeNull();
+      expect(connector.scopeKeyForDocument({ collectionId: "" })).toBeNull();
+      expect(connector.scopeKeyForDocument({})).toBeNull();
     });
   });
 });

--- a/platform/backend/src/knowledge-base/connectors/outline/outline-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/outline/outline-connector.ts
@@ -1,10 +1,17 @@
+import * as metrics from "@/observability/metrics";
 import type {
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorItemFailure,
   ConnectorSyncBatch,
+  DocumentPermissions,
+  GroupMembershipYield,
+  GroupMemberYield,
   OutlineCheckpoint,
   OutlineConfig,
+  PermissionSnapshotYield,
+  PermissionSyncParams,
+  ResolveMappedEmail,
 } from "@/types";
 import { OutlineConfigSchema } from "@/types";
 import { BaseConnector, extractErrorMessage } from "../base-connector";
@@ -69,6 +76,26 @@ function parseOutlineConfig(
 
 export class OutlineConnector extends BaseConnector {
   type = "outline" as const;
+  supportsPermissionSync = true;
+
+  // ----- Per-pass permission-sync state (armed by initPermissionPass) -----
+  private permConfig: OutlineConfig | null = null;
+  private permCredentials: ConnectorCredentials | null = null;
+  /** Workspace identity from auth.info; scopes every synthetic group id. */
+  private teamInfo: { id: string; name: string | null } | null = null;
+  /**
+   * Every workspace user by id, loaded once per pass. THE source of member
+   * emails: Outline serializes `email` only when the endpoint asks for it
+   * (`presentUser(user, { includeEmail, includeDetails })`), and only the
+   * `users.*` endpoints do. The user objects nested in `groups.memberships`
+   * and `collections.memberships` come from a bare `presentUser(user)`, so
+   * they NEVER carry an email — no matter how privileged the API key is.
+   */
+  private userDirectory: Map<string, OutlineApiUser> | null = null;
+  /** Published (public) share links, loaded once per pass. */
+  private publicShares: PublicShares | null = null;
+  private droppedPrincipals = 0;
+  private mappedEmailResolver: ResolveMappedEmail | null = null;
 
   async validateConfig(
     config: Record<string, unknown>,
@@ -426,8 +453,706 @@ export class OutlineConnector extends BaseConnector {
       };
     }
   }
+
+  // ===== Permission sync =====
+
+  /**
+   * Container model: `collection:<collectionId>` per collection —
+   * byte-matching the `metadata.collectionId` every ingested document
+   * already carries, so existing corpora need no re-ingestion and
+   * `scopeKeyForDocument` stays a pure metadata read.
+   *
+   * A collection's audience is its individual memberships (resolved to
+   * emails through the per-pass user directory — a membership payload
+   * never carries one), its group memberships (group
+   * refs resolved at query time through the roster `syncGroups`
+   * maintains), and — when the collection grants workspace-wide default
+   * access (`permission` = read/read_write) — the synthetic
+   * `workspace-default-<teamId>` group rostered from all active non-guest
+   * members. The team id comes from auth.info and scopes every synthetic
+   * group id: raw group tokens overlap across connectors of one type, so
+   * a constant id would leak grants between two Outline workspaces.
+   * Guests deliberately never ride the default group (Outline grants
+   * guests nothing implicitly); they appear only via explicit
+   * memberships.
+   *
+   * Published share links (shares.list) are the only public surface:
+   * a published collection share marks the collection audience
+   * `isPublic`; published document shares collect into one nested
+   * `collection:<id>/public` container per collection (child documents
+   * included when the share says so, closed over the ingested corpus's
+   * `parentDocumentId` chains — no per-document API calls). A failed
+   * share enumeration degrades to "no public shares": public access is
+   * purely additive, so missing it can only under-grant.
+   *
+   * Everything else fails closed: any error while resolving a
+   * collection's audience empties that audience (never a partial grant),
+   * and a missing workspace id fails the whole pass rather than minting
+   * collision-prone group ids.
+   */
+  async *syncPermissionSnapshot(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const config = parseOutlineConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid Outline configuration for permission sync");
+    }
+    this.initPermissionPass(config, params.credentials);
+    this.mappedEmailResolver = params.resolveMappedEmail ?? null;
+    await this.resolveTeam();
+    await this.loadUserDirectory();
+    await this.loadPublicShares();
+
+    const containers = (await this.listCollectionCandidateIds(config)).map(
+      (collectionId) => ({
+        collectionId,
+        key: containerKeyForCollection(collectionId),
+      }),
+    );
+    const scope = params.scope ? new Set(params.scope.containerKeys) : null;
+
+    for (const container of containers) {
+      if (scope && !scope.has(container.key)) continue;
+      // Resume: containers strictly before the cursor are done; the cursor
+      // container is re-processed (idempotent — same audiences).
+      if (params.cursor && container.key < params.cursor) continue;
+      yield* this.syncCollectionSnapshot(
+        container.collectionId,
+        container.key,
+        params,
+      );
+    }
+
+    this.reportDroppedPrincipals();
+  }
+
+  /**
+   * Group roster sync (Users/Groups tabs + member overrides). Yields every
+   * workspace group (groups.list expanded via groups.memberships), the
+   * synthetic workspace-default group (active non-guest members — the
+   * audience of collections with workspace-wide default access), and the
+   * synthetic direct-grants roster (every user holding an individual
+   * collection membership, so a member whose email is hidden stays visible
+   * and override-assignable). Every roster's members are resolved through
+   * the per-pass user directory, the only place Outline serializes emails.
+   * Group and user enumeration failures THROW —
+   * aborting the phase and keeping the previous rosters — rather than
+   * yielding truncated members: the pass replaces a yielded group's roster
+   * wholesale, so a partial yield would silently revoke the tail. Only the
+   * per-collection direct-grants reads degrade to a skip: that roster is
+   * visibility-only and never referenced by an audience.
+   */
+  async *syncGroups(
+    params: PermissionSyncParams,
+  ): AsyncGenerator<GroupMembershipYield> {
+    const config = parseOutlineConfig(params.config);
+    if (!config) {
+      throw new Error("Invalid Outline configuration for group sync");
+    }
+    this.initPermissionPass(config, params.credentials);
+    const team = await this.resolveTeam();
+    await this.loadUserDirectory();
+
+    const groups: OutlineGroup[] = [];
+    for await (const page of this.paginatePermissionApi<OutlineGroup>({
+      method: "groups.list",
+      extract: (data) => (data as { groups?: OutlineGroup[] }).groups,
+    })) {
+      groups.push(...page);
+    }
+    groups.sort((a, b) => a.id.localeCompare(b.id));
+    for (const group of groups) {
+      const members: GroupMemberYield[] = [];
+      for await (const page of this.paginatePermissionApi<OutlineApiUser>({
+        method: "groups.memberships",
+        body: { id: group.id },
+        extract: (data) => (data as { users?: OutlineApiUser[] }).users,
+      })) {
+        for (const membershipUser of page) {
+          const user = this.directoryUser(membershipUser);
+          if (user.isSuspended) continue;
+          members.push(memberYieldFromUser(user));
+        }
+      }
+      yield {
+        groupId: group.id,
+        name: group.name ?? null,
+        members: sortMembers(members),
+      };
+    }
+
+    const defaults: GroupMemberYield[] = [];
+    for await (const page of this.paginatePermissionApi<OutlineApiUser>({
+      method: "users.list",
+      body: { filter: "active" },
+      extract: (data) => data as OutlineApiUser[],
+    })) {
+      for (const user of page) {
+        // Guests get no workspace-default access in Outline — only explicit
+        // collection/group membership, which the audience path carries.
+        if (user.role === "guest") continue;
+        defaults.push(memberYieldFromUser(user));
+      }
+    }
+    yield {
+      groupId: workspaceDefaultGroupId(team.id),
+      name: team.name
+        ? `${team.name} default access`
+        : "Workspace default access",
+      members: sortMembers(defaults),
+    };
+
+    const direct = new Map<string, GroupMemberYield>();
+    for (const collectionId of await this.listCollectionCandidateIds(config)) {
+      try {
+        for await (const page of this.paginatePermissionApi<OutlineApiUser>({
+          method: "collections.memberships",
+          body: { id: collectionId },
+          extract: (data) => (data as { users?: OutlineApiUser[] }).users,
+        })) {
+          for (const membershipUser of page) {
+            const user = this.directoryUser(membershipUser);
+            if (user.isSuspended) continue;
+            direct.set(user.id, memberYieldFromUser(user));
+          }
+        }
+      } catch (error) {
+        this.log.warn(
+          { collectionId, error: extractErrorMessage(error) },
+          "Could not read a collection's memberships for the direct-grants roster; its members are skipped this pass",
+        );
+      }
+    }
+    if (direct.size > 0) {
+      yield {
+        groupId: DIRECT_GRANTS_GROUP_ID,
+        members: sortMembers([...direct.values()]),
+      };
+    }
+  }
+
+  /** `metadata.collectionId` → top-level container key (scoping only). */
+  scopeKeyForDocument(metadata: Record<string, unknown>): string | null {
+    const collectionId = metadata.collectionId;
+    return typeof collectionId === "string" && collectionId
+      ? containerKeyForCollection(collectionId)
+      : null;
+  }
+
+  // ===== Permission-sync internals =====
+
+  /** Arm (or re-arm) the per-pass state every permission hook shares. */
+  private initPermissionPass(
+    config: OutlineConfig,
+    credentials: ConnectorCredentials,
+  ): void {
+    this.permConfig = config;
+    this.permCredentials = credentials;
+    this.teamInfo = null;
+    this.userDirectory = null;
+    this.publicShares = null;
+    this.droppedPrincipals = 0;
+    this.mappedEmailResolver = null;
+  }
+
+  /**
+   * Every workspace user by id — guests, suspended, and not-yet-accepted
+   * invitees included, because any of them can hold an explicit grant whose
+   * email must still resolve. Loaded once per pass; a failure throws so the
+   * caller fail-closes rather than silently resolving nobody.
+   */
+  private async loadUserDirectory(): Promise<Map<string, OutlineApiUser>> {
+    if (this.userDirectory) return this.userDirectory;
+    const directory = new Map<string, OutlineApiUser>();
+    for await (const page of this.paginatePermissionApi<OutlineApiUser>({
+      method: "users.list",
+      body: { filter: "all" },
+      extract: (data) => data as OutlineApiUser[],
+    })) {
+      for (const user of page) directory.set(user.id, user);
+    }
+    this.userDirectory = directory;
+    return directory;
+  }
+
+  /**
+   * A membership entry's authoritative record: the directory copy when the
+   * pass could see it, else the (email-less) payload Outline nested in the
+   * membership response.
+   */
+  private directoryUser(user: OutlineApiUser): OutlineApiUser {
+    return this.userDirectory?.get(user.id) ?? user;
+  }
+
+  private async *syncCollectionSnapshot(
+    collectionId: string,
+    containerKey: string,
+    params: PermissionSyncParams,
+  ): AsyncGenerator<PermissionSnapshotYield> {
+    const docs: ReadbackDoc[] = [];
+    let afterId: string | null = null;
+    for (;;) {
+      const { documents, nextAfterId } = await params.readIngestedDocuments({
+        metadataFilter: { collectionId },
+        afterId,
+        limit: PERMISSION_READBACK_PAGE_SIZE,
+      });
+      for (const doc of documents) {
+        const parent = doc.metadata?.parentDocumentId;
+        docs.push({
+          sourceId: doc.sourceId,
+          parentDocumentId:
+            typeof parent === "string" && parent ? parent : null,
+        });
+      }
+      if (documents.length < PERMISSION_READBACK_PAGE_SIZE) break;
+      afterId = nextAfterId;
+    }
+    docs.sort((a, b) => (a.sourceId < b.sourceId ? -1 : 1));
+
+    if (docs.length === 0) {
+      // Empty corpus: emit the fail-closed boundary container WITHOUT
+      // resolving its audience (Jira precedent — not a resolution failure).
+      yield {
+        kind: "container",
+        containerKey,
+        permissions: emptyAudience(),
+        audienceResolutionFailed: false,
+        cursor: containerKey,
+      };
+      return;
+    }
+
+    const audience = await this.resolveCollectionAudience(collectionId);
+    yield {
+      kind: "container",
+      containerKey,
+      permissions: audience.permissions,
+      audienceResolutionFailed: audience.resolutionFailed,
+      cursor: containerKey,
+    };
+
+    // Published document shares are independently verified truth from
+    // shares.list, so they stay applied even when the collection audience
+    // fail-closed above.
+    const publicDocIds = collectPublicDocIds(docs, this.publicShares);
+    const publicKey = `${containerKey}/public`;
+    if (publicDocIds.size > 0) {
+      yield {
+        kind: "container",
+        containerKey: publicKey,
+        permissions: { isPublic: true, users: [], groups: [] },
+        audienceResolutionFailed: false,
+        cursor: containerKey,
+      };
+    }
+
+    for (const doc of docs) {
+      yield {
+        kind: "document",
+        sourceId: doc.sourceId,
+        containerKey: publicDocIds.has(doc.sourceId) ? publicKey : containerKey,
+        cursor: containerKey,
+      };
+    }
+  }
+
+  /**
+   * A collection's full audience, or the empty fail-closed audience when
+   * any part of it could not be read — never a partial grant.
+   */
+  private async resolveCollectionAudience(collectionId: string): Promise<{
+    permissions: DocumentPermissions;
+    resolutionFailed: boolean;
+  }> {
+    try {
+      const collection = await this.fetchCollectionInfo(collectionId);
+      const users = new Set<string>();
+      const groups = new Set<string>();
+
+      for await (const page of this.paginatePermissionApi<OutlineApiUser>({
+        method: "collections.memberships",
+        body: { id: collectionId },
+        extract: (data) => (data as { users?: OutlineApiUser[] }).users,
+      })) {
+        for (const membershipUser of page) {
+          // The membership payload carries no email (see userDirectory) —
+          // the directory record does.
+          const user = this.directoryUser(membershipUser);
+          if (user.isSuspended) continue;
+          const email = user.email?.trim().toLowerCase();
+          if (email) {
+            users.add(email);
+            continue;
+          }
+          const mapped = this.mappedEmailResolver?.(user.id);
+          if (mapped) {
+            users.add(mapped.trim().toLowerCase());
+          } else {
+            this.droppedPrincipals += 1;
+          }
+        }
+      }
+
+      for await (const page of this.paginatePermissionApi<OutlineGroup>({
+        method: "collections.group_memberships",
+        body: { id: collectionId },
+        extract: (data) => (data as { groups?: OutlineGroup[] }).groups,
+      })) {
+        for (const group of page) groups.add(group.id);
+      }
+
+      if (
+        collection.permission === "read" ||
+        collection.permission === "read_write"
+      ) {
+        groups.add(workspaceDefaultGroupId(this.requireTeam().id));
+      }
+
+      return {
+        permissions: {
+          isPublic: this.publicShares?.collectionIds.has(collectionId) ?? false,
+          users: [...users].sort(),
+          groups: [...groups].sort(),
+        },
+        resolutionFailed: false,
+      };
+    } catch (error) {
+      this.log.error(
+        { collectionId, error: extractErrorMessage(error) },
+        "Could not resolve an Outline collection's audience; its documents are fail-closed for this pass",
+      );
+      return { permissions: emptyAudience(), resolutionFailed: true };
+    }
+  }
+
+  private async fetchCollectionInfo(
+    collectionId: string,
+  ): Promise<OutlineCollection> {
+    const { config, credentials } = this.requirePass();
+    await this.rateLimit();
+    const response = await this.fetchWithRetry(
+      `${config.outlineUrl}/api/collections.info`,
+      {
+        method: "POST",
+        headers: buildHeaders(credentials),
+        body: JSON.stringify({ id: collectionId }),
+      },
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Outline API error ${response.status} on collections.info: ${text.slice(0, 200)}`,
+      );
+    }
+    const body = (await response.json()) as {
+      ok: boolean;
+      data?: OutlineCollection;
+    };
+    if (!body.ok || !body.data?.id) {
+      throw new Error("Unexpected Outline API response on collections.info");
+    }
+    return body.data;
+  }
+
+  /**
+   * The workspace identity every synthetic group id embeds. Missing means
+   * the pass cannot mint collision-safe ids, so it throws (previous
+   * snapshot retained) instead of degrading.
+   */
+  private async resolveTeam(): Promise<{ id: string; name: string | null }> {
+    if (this.teamInfo) return this.teamInfo;
+    const { config, credentials } = this.requirePass();
+    await this.rateLimit();
+    const response = await this.fetchWithRetry(
+      `${config.outlineUrl}/api/auth.info`,
+      {
+        method: "POST",
+        headers: buildHeaders(credentials),
+        body: JSON.stringify({}),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Outline API error ${response.status} on auth.info`);
+    }
+    const body = (await response.json()) as OutlineAuthResponse;
+    const team = body.ok ? body.data?.team : undefined;
+    if (!team?.id) {
+      throw new Error(
+        "Outline auth.info returned no workspace id; refusing to mint workspace-scoped group ids",
+      );
+    }
+    this.teamInfo = { id: team.id, name: team.name ?? null };
+    return this.teamInfo;
+  }
+
+  private requireTeam(): { id: string; name: string | null } {
+    if (!this.teamInfo) {
+      throw new Error("Outline permission pass not initialized (team)");
+    }
+    return this.teamInfo;
+  }
+
+  /**
+   * Published share links, loaded once per pass. Public access is purely
+   * additive, so a failed read degrades to "no public shares" (under-grant)
+   * instead of failing the pass.
+   */
+  private async loadPublicShares(): Promise<void> {
+    const collectionIds = new Set<string>();
+    const documentShares: PublicShares["documentShares"] = [];
+    try {
+      for await (const page of this.paginatePermissionApi<OutlineShare>({
+        method: "shares.list",
+        extract: (data) => data as OutlineShare[],
+      })) {
+        for (const share of page) {
+          if (!share.published) continue;
+          if (share.collectionId) {
+            collectionIds.add(share.collectionId);
+          } else if (share.documentId) {
+            documentShares.push({
+              documentId: share.documentId,
+              includeChildDocuments: share.includeChildDocuments ?? false,
+            });
+          }
+        }
+      }
+    } catch (error) {
+      this.log.warn(
+        { error: extractErrorMessage(error) },
+        "Could not enumerate Outline share links; publicly shared documents keep only their collection audience this pass",
+      );
+      collectionIds.clear();
+      documentShares.length = 0;
+    }
+    this.publicShares = { collectionIds, documentShares };
+  }
+
+  /**
+   * The container candidates: the configured collection filter, or every
+   * collection the credential can see. Sorted so container keys ascend
+   * (the monotonic-cursor contract). Documents whose collection fell out
+   * of this set are fail-closed by the pass's unassigned sweep.
+   */
+  private async listCollectionCandidateIds(
+    config: OutlineConfig,
+  ): Promise<string[]> {
+    if (config.collectionIds && config.collectionIds.length > 0) {
+      return [...new Set(config.collectionIds)].sort();
+    }
+    const ids = new Set<string>();
+    for await (const page of this.paginatePermissionApi<OutlineCollection>({
+      method: "collections.list",
+      extract: (data) => data as OutlineCollection[],
+    })) {
+      for (const collection of page) ids.add(collection.id);
+    }
+    return [...ids].sort();
+  }
+
+  /**
+   * Drain an offset-paginated Outline RPC endpoint. `extract` picks the
+   * page's primary item array out of the response's `data` (some endpoints
+   * wrap it: `{ users, memberships }`). Throws on any non-OK response —
+   * callers own fail-close/degrade semantics.
+   */
+  private async *paginatePermissionApi<T>(params: {
+    method: string;
+    body?: Record<string, unknown>;
+    extract: (data: unknown) => T[] | undefined;
+  }): AsyncGenerator<T[]> {
+    const { config, credentials } = this.requirePass();
+    let offset = 0;
+    for (;;) {
+      await this.rateLimit();
+      const response = await this.fetchWithRetry(
+        `${config.outlineUrl}/api/${params.method}`,
+        {
+          method: "POST",
+          headers: buildHeaders(credentials),
+          body: JSON.stringify({
+            ...params.body,
+            limit: PERMISSION_PAGE_SIZE,
+            offset,
+          }),
+        },
+      );
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(
+          `Outline API error ${response.status} on ${params.method}: ${text.slice(0, 200)}`,
+        );
+      }
+      const envelope = (await response.json()) as {
+        ok: boolean;
+        data?: unknown;
+        pagination?: { nextPath?: string };
+      };
+      if (!envelope.ok) {
+        throw new Error(
+          `Unexpected Outline API response format on ${params.method}`,
+        );
+      }
+      const items = params.extract(envelope.data);
+      if (!Array.isArray(items)) {
+        throw new Error(
+          `Unexpected Outline API response format on ${params.method}`,
+        );
+      }
+      yield items;
+      if (
+        items.length < PERMISSION_PAGE_SIZE ||
+        !envelope.pagination?.nextPath
+      ) {
+        break;
+      }
+      offset += PERMISSION_PAGE_SIZE;
+    }
+  }
+
+  private requirePass(): {
+    config: OutlineConfig;
+    credentials: ConnectorCredentials;
+  } {
+    if (!this.permConfig || !this.permCredentials) {
+      throw new Error("Outline permission pass not initialized");
+    }
+    return { config: this.permConfig, credentials: this.permCredentials };
+  }
+
+  /** Surface principals dropped this pass (fail-closed under-grant). */
+  private reportDroppedPrincipals(): void {
+    if (this.droppedPrincipals <= 0) return;
+    const count = this.droppedPrincipals;
+    this.droppedPrincipals = 0;
+    this.log.debug(
+      { count, connectorType: this.type },
+      "Dropped Outline principals that could not be resolved (fail-closed)",
+    );
+    metrics.rag.reportPermissionSyncDroppedPrincipals({
+      connectorType: this.type,
+      reason: "no_email",
+      count,
+    });
+  }
 }
 
 function buildDocumentUrl(baseUrl: string, urlId: string): string {
   return `${baseUrl}/doc/${urlId}`;
+}
+
+// ===== Permission-sync types & helpers =====
+
+const PERMISSION_PAGE_SIZE = 100;
+const PERMISSION_READBACK_PAGE_SIZE = 1000;
+/**
+ * Synthetic roster group for individual collection grantees. Roster-only —
+ * never referenced by an audience (direct grants carry emails inline), so
+ * the constant id cannot collide grants across connectors.
+ */
+const DIRECT_GRANTS_GROUP_ID = "direct-grants";
+
+type OutlineCollection = {
+  id: string;
+  name?: string;
+  permission?: "read" | "read_write" | null;
+};
+
+type OutlineApiUser = {
+  id: string;
+  name?: string;
+  email?: string | null;
+  role?: string;
+  isSuspended?: boolean;
+};
+
+type OutlineGroup = { id: string; name?: string };
+
+type OutlineShare = {
+  documentId?: string | null;
+  collectionId?: string | null;
+  published?: boolean;
+  includeChildDocuments?: boolean;
+};
+
+type PublicShares = {
+  collectionIds: Set<string>;
+  documentShares: Array<{
+    documentId: string;
+    includeChildDocuments: boolean;
+  }>;
+};
+
+/** One read-back document (id + the parent chain the public closure walks). */
+type ReadbackDoc = { sourceId: string; parentDocumentId: string | null };
+
+function containerKeyForCollection(collectionId: string): string {
+  return `collection:${collectionId}`;
+}
+
+/**
+ * Audience-referenced synthetic group id — MUST be workspace-scoped: raw
+ * group tokens overlap across connectors of one type, so a constant id
+ * would share grants between two Outline workspaces.
+ */
+function workspaceDefaultGroupId(teamId: string): string {
+  return `workspace-default-${teamId}`;
+}
+
+function emptyAudience(): DocumentPermissions {
+  return { isPublic: false, users: [], groups: [] };
+}
+
+function memberYieldFromUser(user: OutlineApiUser): GroupMemberYield {
+  return {
+    accountId: user.id,
+    displayName: user.name ?? null,
+    email: user.email ? user.email.trim().toLowerCase() : null,
+    accountType: user.role ?? null,
+  };
+}
+
+function sortMembers(members: GroupMemberYield[]): GroupMemberYield[] {
+  return members.sort((a, b) => a.accountId.localeCompare(b.accountId));
+}
+
+/**
+ * The ingested documents covered by a published document share: the shared
+ * document itself plus — when the share includes child documents — every
+ * ingested descendant, closed over the corpus's own `parentDocumentId`
+ * chains (the share root itself need not be ingested).
+ */
+function collectPublicDocIds(
+  docs: ReadbackDoc[],
+  shares: PublicShares | null,
+): Set<string> {
+  const result = new Set<string>();
+  if (!shares || shares.documentShares.length === 0) return result;
+
+  const inCollection = new Set(docs.map((doc) => doc.sourceId));
+  const childrenByParent = new Map<string, string[]>();
+  for (const doc of docs) {
+    if (!doc.parentDocumentId) continue;
+    const siblings = childrenByParent.get(doc.parentDocumentId);
+    if (siblings) siblings.push(doc.sourceId);
+    else childrenByParent.set(doc.parentDocumentId, [doc.sourceId]);
+  }
+
+  for (const share of shares.documentShares) {
+    if (inCollection.has(share.documentId)) result.add(share.documentId);
+    if (!share.includeChildDocuments) continue;
+    const queue = [share.documentId];
+    while (queue.length > 0) {
+      const parentId = queue.pop();
+      if (!parentId) break;
+      for (const childId of childrenByParent.get(parentId) ?? []) {
+        if (!result.has(childId)) {
+          result.add(childId);
+          queue.push(childId);
+        }
+      }
+    }
+  }
+  return result;
 }

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
@@ -352,6 +352,7 @@ const AUTO_SYNC_CONNECTOR_TYPES: ReadonlySet<ConnectorType> = new Set([
   "notion",
   "asana",
   "dropbox",
+  "outline",
 ]);
 
 export function connectorSupportsAutoSync(type: ConnectorType): boolean {
@@ -417,6 +418,8 @@ export function getPermissionSyncCredentialNote(
       return "Auto-sync permissions reads projects, memberships, teams, and member emails as this Personal Access Token's user. Use a token from a user who can see every synced project — typically a workspace admin or a dedicated service user — because audiences the token cannot read stay fail-closed.";
     case "dropbox":
       return "The access token needs team scopes to expand group members — with a regular member token, granted groups sync empty for manual assignment.";
+    case "outline":
+      return "Auto-sync permissions reads collection members, groups, and public share links through this API key. Use a workspace admin's API key: a member key may not see every share link or roster, and anything it cannot see stays unshared.";
     default:
       return null;
   }


### PR DESCRIPTION
Permission auto-sync for the Outline connector (part of #7154, [T-908]).

**Model:** container = collection (`collection:<collectionId>`), byte-matching the `metadata.collectionId` every ingested document already carries — existing corpora need no re-ingestion and `scopeKeyForDocument` stays a pure metadata read. A collection's audience is its individual members (`collections.memberships`), its granted groups (`collections.group_memberships`), and — when the collection grants workspace-wide default access (`permission` = `read`/`read_write`) — a synthetic `workspace-default-<teamId>` group rostered from every active non-guest member. Guests never ride that default group: Outline grants guests nothing implicitly, so they appear only through explicit memberships. The team id comes from `auth.info` and scopes the synthetic id, because raw group tokens overlap across connectors of one type.

**Emails come from the user directory, never from a membership payload.** Outline serializes `email` only where the endpoint asks for it — `users.list` presents users with `includeEmail`/`includeDetails`, while `collections.memberships` and `groups.memberships` nest them through a bare presenter. Those payloads carry no email for any caller, however privileged the key. The connector therefore loads the workspace's users once per pass (`filter: "all"`, so guests, suspended accounts and pending invitees still resolve) and joins every membership against it — the directory record also settles suspension state. Real-workspace QA caught this: reading the email off the membership payload dropped every individually-shared member from the audience and left every group roster unresolvable, so the group token in the ACL granted nobody.

**Public surface:** published share links only. A published collection share marks the collection audience public; published document shares collect into one nested `collection:<id>/public` container per collection, with child documents closed over the ingested corpus's own `parentDocumentId` chains — no per-document API calls. A failed share enumeration degrades to "no public shares", which is purely additive and so can only under-grant. Everything else fails closed: any error resolving a collection's audience empties that audience rather than granting partially, and a missing workspace id fails the whole pass rather than minting collision-prone group ids.

Rosters: every workspace group, the workspace-default group, and a synthetic `direct-grants` roster of individual collection grantees — so a member stays visible and override-assignable in the connector's Users and Groups tabs. Roster enumeration failures throw (keeping the previous rosters) instead of yielding a truncated roster that would silently revoke its tail.

Deliberate limitation, documented: per-document direct shares (`documents.memberships`) are not read — O(docs) API calls, and skipping them under-grants.

Live-verified end-to-end on a dev stack: mock-API QA (audience paths, public-share closure, suspended-user exclusion, fail-closed guards) and then a real Outline workspace, where ACLs, rosters, and the Users/Groups tabs were re-checked after the email fix.

Tests: 47 connector unit tests.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>