### PR TITLE
fix(docker): pin golang.org/x/mod to v0.40.0 for CVE-2026-56865

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -87,6 +87,11 @@ RUN git clone --depth 1 --branch "${DAGGER_VERSION}" https://github.com/dagger/d
     # cve-2026-46597: x/crypto issue fixed in >= 0.52.0; keep this after x/net.
     # Pinned to 0.53.0 for the same go-git 5.19.2 floor reason as x/net above.
     go get golang.org/x/crypto@v0.53.0 && \
+    # cve-2026-56865: x/mod/sumdb/tlog tile verification bypass (HIGH) fixed in >= 0.40.0.
+    # cve-2026-56864: x/mod/sumdb accepts unauthenticated hashes; same fix version.
+    # Arrives transitively (dagger and containerd both floor it at 0.36.0), so it needs
+    # an explicit requirement rather than a bump of any single dependency.
+    go get golang.org/x/mod@v0.40.0 && \
     go get github.com/moby/go-archive@v0.2.0 github.com/moby/profiles/seccomp@v0.2.3 github.com/moby/sys/reexec@v0.1.0 github.com/moby/sys/user@v0.4.0 && \
     # cve-2026-46680: containerd type confusion fixed in >= 2.2.4
     # cve-2026-53488/53492/53489: containerd injection/input-validation/symlink-following fixed in >= 2.2.5
@@ -111,6 +116,9 @@ RUN git clone --depth 1 --branch "${KUBECTL_VERSION}" https://github.com/kuberne
     # cve-2026-39821: x/net CRITICAL fixed in >= 0.55.0.
     # cve-2026-46600: x/net HIGH fixed in >= 0.56.0.
     go get golang.org/x/net@v0.56.0 && \
+    # cve-2026-56865: x/mod/sumdb/tlog tile verification bypass (HIGH) fixed in >= 0.40.0.
+    # cve-2026-56864: x/mod/sumdb accepts unauthenticated hashes; same fix version.
+    go get golang.org/x/mod@v0.40.0 && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=readonly \
     -ldflags "-X k8s.io/component-base/version.gitVersion=${KUBECTL_VERSION} -X k8s.io/component-base/version.gitCommit=${KUBECTL_COMMIT} -X k8s.io/component-base/version.gitTreeState=clean" \
     -o /kubectl-binary ./cmd/kubectl


### PR DESCRIPTION
Docker Scout started failing the merge queue on the Platform image:

```
0C 1H 0M 0L  golang.org/x/mod 0.37.0
  ✗ HIGH CVE-2026-56865   Affected range: <0.40.0   Fixed version: 0.40.0
```

`GO-2026-6179` / CVE-2026-56865 is a transparency-log tile verification bypass in `golang.org/x/mod/sumdb/tlog`; `GO-2026-6180` / CVE-2026-56864 (unauthenticated hashes accepted in `sumdb.Lookup`) lands in the same release. Both are fixed in **0.40.0** per [osv.dev](https://api.osv.dev/v1/vulns/GO-2026-6179).

Nothing in the pinned dependency set reaches 0.37.0 on its own — dagger v0.21.7 and containerd v2.2.5 both floor `x/mod` at 0.36.0, kubernetes v1.35.0 at 0.29.0 — so it arrives transitively and no single dependency bump clears it. This pins it explicitly in the two Go builder stages whose binaries carry it, matching the existing CVE-pin convention in this file.

Placement follows the ordering constraints already documented in the stage comments: in the Dagger stage the pin sits before the `google.golang.org/grpc` line, which must stay the last `go get` before `go mod tidy`; the kubectl stage has no such constraint. Maximum-version selection keeps 0.40.0 through the later `go get`s.

Validated with the `run-docker-scan` label rather than waiting for a merge-queue round trip.

This unblocks the queue for every PR, not just mine — no open or recently merged PR addressed it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>