### PR TITLE
fix(docker): pin python3 and postgresql to CVE-fixed Alpine versions

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -355,7 +355,8 @@ RUN apk --no-cache upgrade && \
     # CVE-2026-15742/15741, CVE-2026-14680/14679/14677/14676/14671/14670/14669/14668/14664/14662,
     # CVE-2026-6471, CVE-2026-6464) are fixed in 17.11-r0 and 18.5-r0. Both majors are pinned
     # because postgresql-pgvector depends on postgresql18, so that major lands in the image
-    # alongside the 17 we actually run. Same stale-layer hazard as the curl pin above: the bare
+    # alongside 17 and is scanned too. (postgresql18 in fact owns the /usr/bin/postgres symlink,
+    # so it is the major supervisor actually starts.) Same stale-layer hazard as the curl pin: the bare
     # `apk upgrade` cannot help a Docker-cached layer, so the explicit floors both guarantee the
     # fixed versions and bust the cache.
     apk add --no-cache --upgrade "postgresql17>=17.11-r0" "postgresql17-contrib>=17.11-r0" \

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -350,7 +350,16 @@ RUN apk --no-cache upgrade && \
     # Install PostgreSQL 17, pgvector, supervisord, and git.
     # The skill-marketplace clone endpoint needs the git CLI (materialize.ts) and
     # git-http-backend, the smart-HTTP CGI — which Alpine ships in git-daemon, not git.
-    apk add --no-cache postgresql17 postgresql17-contrib postgresql-pgvector su-exec git git-daemon && \
+    #
+    # 18 HIGH PostgreSQL CVEs (CVE-2026-19385, CVE-2026-18408, CVE-2026-16239/16238,
+    # CVE-2026-15742/15741, CVE-2026-14680/14679/14677/14676/14671/14670/14669/14668/14664/14662,
+    # CVE-2026-6471, CVE-2026-6464) are fixed in 17.11-r0 and 18.5-r0. Both majors are pinned
+    # because postgresql-pgvector depends on postgresql18, so that major lands in the image
+    # alongside the 17 we actually run. Same stale-layer hazard as the curl pin above: the bare
+    # `apk upgrade` cannot help a Docker-cached layer, so the explicit floors both guarantee the
+    # fixed versions and bust the cache.
+    apk add --no-cache --upgrade "postgresql17>=17.11-r0" "postgresql17-contrib>=17.11-r0" \
+        "postgresql18>=18.5-r0" postgresql-pgvector su-exec git git-daemon && \
     # Combine all CA bundles
     cat /tmp/aws-rds-ca.pem /tmp/gcloud-sql-ca.pem > /etc/ssl/certs/cloud-database-ca-bundle.pem && \
     rm -f /tmp/aws-rds-ca.pem /tmp/gcloud-sql-ca.pem && \
@@ -401,7 +410,11 @@ RUN chmod +x /usr/local/bin/dagger
 # point the SDK at the baked-in CLI so it never downloads one at runtime.
 ENV _EXPERIMENTAL_DAGGER_CLI_BIN=/usr/local/bin/dagger
 
-RUN apk add --no-cache supervisor && \
+# CVE-2026-6100 (CRITICAL) plus CVE-2026-15308, CVE-2026-11972, CVE-2026-11940, CVE-2026-4786
+# and CVE-2026-4519 (HIGH) in python3, all fixed in 3.12.14-r0. python3 arrives transitively via
+# supervisor, so pin an explicit floor here — the bare `apk upgrade` earlier in this stage runs
+# before python3 is installed and cannot lift it.
+RUN apk add --no-cache --upgrade supervisor "python3>=3.12.14-r0" && \
     # CVE-2026-24049: wheel 0.45.1 path traversal. Vendored inside py3-setuptools
     # (pulled in by supervisor); pip can't upgrade the vendored copy, so delete it.
     rm -rf /usr/lib/python*/site-packages/setuptools/_vendor/wheel \


### PR DESCRIPTION
## What

Docker Scout fails the merge queue on the Platform image with **42 vulnerabilities across 3 apk packages** — 1 CRITICAL and 41 HIGH. All three have fixes already published in Alpine 3.23, so this pins explicit version floors.

| Package | In image | Fixed in | Severity |
| --- | --- | --- | --- |
| `python3` | 3.12.13-r0 | 3.12.14-r0 | 1 CRITICAL (CVE-2026-6100) + 5 HIGH (CVE-2026-15308, CVE-2026-11972, CVE-2026-11940, CVE-2026-4786, CVE-2026-4519) |
| `postgresql17` | 17.10-r0 | 17.11-r0 | 18 HIGH |
| `postgresql18` | 18.4-r0 | 18.5-r0 | the same 18 HIGH |

## Why floors rather than relying on `apk upgrade`

This is the same stale-layer hazard already documented in this file for the curl pin: the bare `apk --no-cache upgrade` at the top of the stage cannot lift a `RUN` layer that Docker serves from cache on its unchanged instruction text. The explicit floors both guarantee the fixed versions and bust the stale cache.

`python3` needs its own floor in a separate layer because it arrives transitively via `supervisor`, i.e. after that `apk upgrade` has already run.

`postgresql18` is pinned alongside 17 because `postgresql-pgvector` depends on it, so both majors are present in the image and both get scanned.

## Verification

Replayed the apk layers against the pinned `node:24-alpine3.23` base and read back the installed versions:

- `postgresql17` **17.11-r0**, `postgresql17-contrib` **17.11-r0**, `postgresql18` **18.6-r0**, `python3` **3.12.14-r0** — all at or above the fixed versions
- `curl` / `libcurl` still **8.20.0-r0** — the existing pin is not regressed
- Functional checks still pass: `postgres --version`, `su-exec`, `git`, `git-http-backend` present, `supervisord --version`, and `import pkg_resources, setuptools` (the vendored-jaraco swap downstream is unaffected)
- Built the pre-change lines as a baseline: `postgres` resolves to `/usr/libexec/postgresql18/postgres` both before and after, so this changes package versions only, not runtime behavior

Labeled `run-docker-scan` so the real Scout verdict reports on this PR rather than being discovered in the merge queue.

## Note (not addressed here)

The baseline check surfaced a pre-existing quirk: although the stage comment says "Install PostgreSQL 17", `/usr/bin/postgres` resolves to the **18** binary, because `postgresql-pgvector` pulls in `postgresql18` and that package owns the symlink. Supervisor runs bare `postgres -D ...`, so 18 is what actually starts. That predates this change and is left alone here, but it looks worth a follow-up — either drop the now-vestigial 17 packages or pin the invocation to an explicit major.

Fixes the Docker Image Scanning (Platform) failure seen in the merge queue.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>