### PR TITLE
ci: stop the PR workflow assuming it only ever runs on a public repo

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -193,7 +193,14 @@ jobs:
 
   dependency-review:
     name: Dependency Review
-    if: ${{ github.event_name == 'pull_request' }}
+    # Public repos only. The dependency review API is a GitHub Advanced
+    # Security feature on private repositories, so in a private mirror of this
+    # repo (archestra-private, where task-env sessions open their PRs) the
+    # action refuses to run at all — "Dependency review is not supported on
+    # this repository" — and paints a red check that no code change can fix.
+    # Skipping is the honest outcome there: the canonical repo is public and
+    # runs this on the same commits before anything merges.
+    if: ${{ github.event_name == 'pull_request' && !github.event.repository.private }}
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for dependency-review-action to read the PR dependency graph via the API.
@@ -329,6 +336,28 @@ jobs:
       # "could not rename downloaded file".
       - name: Setup Rust
         run: rustup show
+
+      # check:commit runs the Drizzle migration linter, which diffs migrations
+      # against origin/<default branch>. The checkout above is depth-1 with
+      # persist-credentials: false, so that ref is absent AND git holds no
+      # credentials — the linter's own fallback fetch then goes out
+      # unauthenticated. On this repo that happens to work (public repos allow
+      # anonymous fetch); on a private mirror GitHub answers 401, git falls
+      # back to prompting, and the step dies with "could not read Username for
+      # 'https://github.com'" before it can lint anything. Fetching the ref
+      # here with the job token makes the linter's input exist in both cases.
+      # The credential helper is passed with -c so it applies to this one
+      # command only: the token stays in the environment, never reaching argv,
+      # .git/config, or any later step.
+      - name: Fetch base ref for the migration linter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
+              fetch --depth=1 origin \
+              "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
 
       # Backend unit tests run in the parallel sharded "Backend Unit Tests"
       # jobs below; here the backend runs check:commit (same checks minus
@@ -561,8 +590,13 @@ jobs:
     if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
     runs-on: ubuntu-latest
     # A full local suite run is ~4 min on comparable hardware; a shard is a
-    # sixteenth of that plus setup. 15 minutes means something is hung.
-    timeout-minutes: 15
+    # sixteenth of that plus setup. Sized for the slowest hardware this runs
+    # on rather than this repo's: ubuntu-latest is 4-vCPU/16-GB for public
+    # repos but 2-vCPU/7-GB for private ones, and on the private mirror where
+    # task-env sessions open their PRs the same shard takes ~2x as long (9-14
+    # min observed, against the 15 the public runners never came close to).
+    # Beyond this, something is hung.
+    timeout-minutes: 25
     permissions:
       contents: read
     defaults:

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -7,6 +7,38 @@ import { defineConfig } from "vitest/config";
 const isCI = process.env.CI === "true";
 
 /**
+ * Bound the fork count by BOTH cores and memory. CPU half: 50% of cores
+ * locally (leaves the other half for the human); CI runs all cores because the
+ * memory cap is the real limit there. Memory half: with the forks pool each
+ * worker loads the full module graph + its own PGlite (WASM) independently —
+ * up to ~3 GB RSS per fork, not shared like the threads pool's single address
+ * space — so cap at ~5 GB/fork or a shard OOM-kills the runner (cgroup OOM
+ * aborts a worker abruptly, not with a clean Vitest error). Yields 12 forks on
+ * the 16-vCPU / 64-GB CI runner, and half-cores (memory permitting) locally.
+ * Trusts os.totalmem() to report real available RAM — valid on the bare-VM CI
+ * runner, but it would over-report (and stop protecting) inside a
+ * cgroup-limited container.
+ */
+const MAX_WORKERS = Math.min(
+  isCI
+    ? os.availableParallelism()
+    : Math.max(1, Math.floor(os.availableParallelism() * 0.5)),
+  Math.max(1, Math.floor(os.totalmem() / (5 * 1024 ** 3))),
+);
+
+/**
+ * Per-fork V8 old-space ceiling, in MB — three quarters of RAM divided over
+ * the forks that share it, floored at V8's own 2 GB default so this can only
+ * ever raise the ceiling, never lower it. Kept below total memory so the
+ * kernel OOM killer (which kills abruptly, with no heap diagnostics) stays out
+ * of play even when every fork peaks together.
+ */
+const MAX_OLD_SPACE_MB = Math.max(
+  2048,
+  Math.floor((os.totalmem() * 0.75) / MAX_WORKERS / 1024 ** 2),
+);
+
+/**
  * Partition test files by whether they use Vitest module mocking.
  *
  * `vi.mock`/`vi.doMock` registrations live in the worker's shared module/mock
@@ -107,23 +139,27 @@ export default defineConfig({
     unstubGlobals: true,
     unstubEnvs: true,
 
-    // Bound the fork count by BOTH cores and memory. CPU half: 50% of cores
-    // locally (leaves the other half for the human); CI runs all cores because
-    // the memory cap below is the real limit there. Memory half: with the forks
-    // pool each worker loads the full module graph + its own PGlite (WASM)
-    // independently — up to ~3 GB RSS per fork, not shared like the threads
-    // pool's single address space — so cap at ~5 GB/fork or a shard OOM-kills
-    // the runner (cgroup OOM aborts a worker abruptly, not with a clean Vitest
-    // error). Yields 12 forks on the 16-vCPU / 64-GB CI runner, and half-cores
-    // (memory permitting) locally. The memory cap trusts os.totalmem() to report
-    // real available RAM — valid on the bare-VM CI runner, but it would
-    // over-report (and stop protecting) inside a cgroup-limited container.
-    maxWorkers: Math.min(
-      isCI
-        ? os.availableParallelism()
-        : Math.max(1, Math.floor(os.availableParallelism() * 0.5)),
-      Math.max(1, Math.floor(os.totalmem() / (5 * 1024 ** 3))),
-    ),
+    maxWorkers: MAX_WORKERS,
+
+    // Pin each fork's V8 old-space ceiling instead of inheriting it from the
+    // host's size. V8 derives its default from total system memory (~2 GB on a
+    // 7 GB machine, ~4 GB on 16 GB), and GitHub-hosted runner hardware depends
+    // on repository VISIBILITY: public repos get 4-vCPU/16-GB, private repos
+    // 2-vCPU/7-GB. So the same suite that fits comfortably here aborts with
+    // "FATAL ERROR: Ineffective mark-compacts near heap limit" on a private
+    // mirror of this repo, where the cap silently halves to 2 GB while
+    // MAX_WORKERS simultaneously collapses to 1 — concentrating every file in
+    // the shard into one long-lived heap (the mock-free project runs
+    // isolate: false, so module state accumulates across files by design).
+    // Deriving the ceiling from memory-per-fork keeps the value the big
+    // runners already get (~4 GB) and gives the small ones the headroom their
+    // single fork actually has.
+    //
+    // This is test.execArgv, NOT poolOptions.forks.execArgv: Vitest 4 composes
+    // a worker's arguments from the pool defaults, the resolve conditions and
+    // `project.config.execArgv`, so the poolOptions spelling silently does
+    // nothing here (verified: the flag never reaches the fork's process.execArgv).
+    execArgv: [`--max-old-space-size=${MAX_OLD_SPACE_MB}`],
 
     // Increase concurrency on CI for faster test execution
     maxConcurrency: isCI ? 12 : 6,


### PR DESCRIPTION
## Why

CI is red on every PR opened in the private mirror this repo is mirrored into (where task-env sessions push their work), and has been for as long as that mirror has existed. Five checks fail; none of them is an assertion failure, and no change on a branch can fix any of them.

All five come from the same blind spot: this workflow assumes it only ever runs on a **public** repository. Two consequences, both invisible here:

**Anonymous `git fetch` works on a public repo.** `check:commit` runs the Drizzle migration linter, which diffs migrations against `origin/<default branch>`. A depth-1 `persist-credentials: false` checkout doesn't have that ref, so the linter falls back to fetching it — with no credentials, because the checkout deliberately kept none. GitHub serves that fine for a public repo. A private one answers 401, git falls back to prompting, and the step dies before it lints anything:

```
fatal: could not read Username for 'https://github.com': No such device or address
Error: Command failed: git fetch --depth=1 origin main:refs/remotes/origin/main
```

Verified against the real repos, all three cases:

```
private, no creds  -> fatal: could not read Username for 'https://github.com'
private, job token -> 02d7794d...  refs/heads/main
public,  no creds  -> 02d7794d...  refs/heads/main     <- why this repo never noticed
```

**`ubuntu-latest` is not one machine.** GitHub gives public repos 4-vCPU/16-GB runners and private repos 2-vCPU/7-GB. That single fact explains the remaining checks:

- V8 sizes its default old-space cap from total system memory, so it halves to ~2 GB.
- `maxWorkers` (memory / 5 GB) simultaneously collapses to **1 fork**, funnelling every file in a shard into one long-lived heap — the mock-free project runs `isolate: false`, so module state accumulates across files by design.
- The two heaviest shards cross 2 GB and abort with `FATAL ERROR: Ineffective mark-compacts near heap limit`, every run, with zero assertion failures. The other fourteen fit under it.
- Shards also take ~2x as long there (9-14.2 min observed) against a `timeout-minutes: 15` sized for the faster runners — no margin left.

Dependency Review is the one genuinely unavailable feature: the dependency review API is GitHub Advanced Security on private repositories, so the action refuses to run at all ("Dependency review is not supported on this repository").

## What changed

- **Dependency Review** — restricted to public repos. The canonical repo still runs it on the same commits before anything merges, so nothing goes unreviewed; the alternative is buying GHAS for a mirror.
- **Migration linter base ref** — fetched up front with the job token, so the linter's input exists regardless of repo visibility. The credential helper is passed with `-c` so it applies to that one command: the token never reaches argv, `.git/config`, or a later step.
- **Per-fork heap ceiling** — derived from memory-per-fork instead of inherited from host size. Big runners keep exactly what they have today (3 x 4096 MB on 16 GB, 12 x 4096 on 64 GB); the small one gets the 5376 MB its single fork can actually use.
- **Shard timeout** 15 -> 25 min, sized for the slowest hardware this runs on rather than this repo's.

## Note for reviewers

The heap fix uses `test.execArgv`, **not** `poolOptions.forks.execArgv`. The latter is accepted by Vitest 4's types and then silently dropped — worker arguments are composed from the pool defaults, the resolve conditions and `project.config.execArgv`. Confirmed by probing `process.execArgv` and `heap_size_limit` inside a fork: with the `poolOptions` spelling the flag never arrives; with `test.execArgv` it does, and the heap limit moves with it.

## Testing

- Shard 11 (one of the two that OOM) run locally on the new config: 58 files, 1019 tests, all passing.
- `biome check` and `tsc --noEmit` clean.
- Workflow YAML parses; the new fetch step is ordered before the checks that need it.
- Credential-helper mechanism verified end-to-end against both repos (table above).

Not provable from here: whether 5376 MB is *enough* for those two shards on a 7-GB runner. They died at 2 GB and fourteen of sixteen shards fit under that, so the margin is large — but it is an inference until a mirror run confirms it.

## Known, not fixed here

`build-m-files-vaf-add-on.yml` carries the same anonymous-fetch assumption (`git fetch origin $BASE_SHA` after a `persist-credentials: false` checkout). It is path-filtered to `integrations/m-files-vaf-add-on/**`, so it will only bite on a PR touching that add-on. Left out to keep this focused; happy to fold it in.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>