### PR TITLE
fix(chatops): recognize the agent footer in the spelling providers return

### DIFF
--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -3961,6 +3961,16 @@ describe("ChatOpsManager attachment passthrough", () => {
         timestamp: new Date(Date.now() - 30_000),
         isFromBot: true,
       },
+      {
+        messageId: "bot-3",
+        senderId: "bot",
+        senderName: "Bot",
+        // How a Slack turn actually reads back: the API returns emoji in colon
+        // notation, and the model's own echo ran onto the end of its prose.
+        text: "The slot is free now. :robot_face: Sales Bot\n\n:robot_face: Sales Bot",
+        timestamp: new Date(Date.now() - 15_000),
+        isFromBot: true,
+      },
     ]);
 
     const manager = new ChatOpsManager();
@@ -3980,7 +3990,9 @@ describe("ChatOpsManager attachment passthrough", () => {
     const sent = JSON.stringify(executorSpy.mock.calls[0][0].message);
     expect(sent).toContain("The deploy finished.");
     expect(sent).toContain("Sorry, I encountered an error.");
+    expect(sent).toContain("The slot is free now.");
     expect(sent).not.toContain("🤖");
+    expect(sent).not.toContain("robot_face");
   });
 });
 

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -1312,6 +1312,46 @@ describe("SlackProvider.sendReply", () => {
     expect(text).toBe("Here you go.\n\n🤖 Agent");
   });
 
+  test.each([
+    // Slack stores emoji in colon notation, so the footer the model is replayed
+    // — and copies — is spelled ":robot_face:", not "🤖".
+    ["shortcode on its own line", "Here you go.\n\n:robot_face: Agent"],
+    ["run onto the last sentence", "Here you go. 🤖 Agent"],
+    ["both at once", "Here you go. :robot_face: Agent\n\n:robot_face: Agent"],
+  ])("renders one branding line when the model signed off with %s", async (_shape, replyText) => {
+    const provider = createProvider();
+    const postMessage = vi.fn().mockResolvedValue({ ts: "2222222222.000000" });
+    // biome-ignore lint/suspicious/noExplicitAny: test-only — mock Slack client
+    (provider as any).client = { chat: { postMessage } };
+
+    await provider.sendReply({
+      originalMessage: {
+        messageId: "1234567890.123456",
+        channelId: "C12345",
+        workspaceId: "T12345",
+        threadId: "1111111111.000000",
+        senderId: "U_SENDER",
+        senderName: "Test User",
+        text: "hello",
+        rawText: "hello",
+        timestamp: new Date(),
+        isThreadReply: false,
+      },
+      text: replyText,
+      footer: "🤖 Agent",
+    });
+
+    const { blocks, text } = postMessage.mock.calls[0][0];
+    expect(blocks).toEqual([
+      { type: "markdown", text: "Here you go." },
+      {
+        type: "context",
+        elements: [{ type: "plain_text", text: "🤖 Agent", emoji: true }],
+      },
+    ]);
+    expect(text).toBe("Here you go.\n\n🤖 Agent");
+  });
+
   test("posts the footer alone when the reply was nothing but an echoed footer", async () => {
     const provider = createProvider();
     const postMessage = vi.fn().mockResolvedValue({ ts: "2222222222.000000" });

--- a/platform/backend/src/agents/chatops/utils.test.ts
+++ b/platform/backend/src/agents/chatops/utils.test.ts
@@ -91,6 +91,40 @@ describe("stripDuplicateAgentFooter", () => {
       expect(stripDuplicateAgentFooter(text, footer)).toBe(text);
     }
   });
+
+  test("strips an echo spelled with the provider's emoji shortcode", () => {
+    // We post the literal glyph, but Slack stores emoji in colon notation, so
+    // that is the spelling the model is replayed — and the one it copies.
+    expect(
+      stripDuplicateAgentFooter(
+        "Here you go.\n\n:robot_face: Sales Bot",
+        footer,
+      ),
+    ).toBe("Here you go.");
+  });
+
+  test("strips an echo run onto the end of the last sentence", () => {
+    // The model does not always give its sign-off a line of its own; glued to
+    // the prose it renders as a second branding line just the same.
+    expect(
+      stripDuplicateAgentFooter("That's the whole plan. 🤖 Sales Bot", footer),
+    ).toBe("That's the whole plan.");
+    expect(
+      stripDuplicateAgentFooter(
+        "That's the whole plan. :robot_face: Sales Bot",
+        footer,
+      ),
+    ).toBe("That's the whole plan.");
+  });
+
+  test("strips a run-on echo and a lingering footer line together", () => {
+    expect(
+      stripDuplicateAgentFooter(
+        "That's the whole plan. :robot_face: Sales Bot\n\n:robot_face: Sales Bot",
+        footer,
+      ),
+    ).toBe("That's the whole plan.");
+  });
 });
 
 describe("stripAgentFooterChrome", () => {
@@ -130,6 +164,44 @@ describe("stripAgentFooterChrome", () => {
 
   test("strips a turn that is nothing but the footer", () => {
     expect(stripAgentFooterChrome("🤖 Sales Bot")).toBe("");
+  });
+
+  test("strips the footer in the spelling the provider actually returns", () => {
+    // Slack normalizes emoji on storage, so a bot turn read back through the
+    // API carries ":robot_face:" where we posted "🤖". Missing this spelling
+    // replays a footer to the model on every single Slack turn.
+    expect(
+      stripAgentFooterChrome("Here you go.\n\n:robot_face: Sales Bot"),
+    ).toBe("Here you go.");
+    expect(
+      stripAgentFooterChrome(
+        "Here you go.\n\n:robot_face: Sales Bot\n:robot_face: Sales Bot",
+      ),
+    ).toBe("Here you go.");
+  });
+
+  test("strips a sign-off run onto the end of the last sentence", () => {
+    expect(
+      stripAgentFooterChrome("That's the whole plan. :robot_face: Sales Bot"),
+    ).toBe("That's the whole plan.");
+  });
+
+  test("leaves no branding in a turn that already rendered two footers", () => {
+    // The exact shape a doubled Slack reply comes back as: the model's run-on
+    // echo, then the footer the platform appended.
+    const turn =
+      "It's purely an enrollment gate. :robot_face: Sales Bot\n\n:robot_face: Sales Bot";
+    const cleaned = stripAgentFooterChrome(turn);
+    expect(cleaned).toBe("It's purely an enrollment gate.");
+    expect(cleaned).not.toContain("robot_face");
+    expect(cleaned).not.toContain("🤖");
+  });
+
+  test("leaves no glyph behind on a final line that carries several", () => {
+    // Sanitation is worth nothing if it hands the model back something to copy.
+    expect(
+      stripAgentFooterChrome("Bots up: 🤖 alpha and 🤖 beta\n\n🤖 Sales Bot"),
+    ).toBe("Bots up:");
   });
 
   test("leaves a bot turn without chrome untouched", () => {

--- a/platform/backend/src/agents/chatops/utils.ts
+++ b/platform/backend/src/agents/chatops/utils.ts
@@ -178,21 +178,29 @@ export function buildAgentFooter(agentName: string, extra?: string): string {
  * footer". Since the footer is chrome the platform owns, the echo is the copy
  * that goes.
  *
- * Deliberately strict: only a trailing line that is exactly the footer about to
- * be appended (or its identity half, without the error detail) is removed, with
- * markdown emphasis and a horizontal rule above it tolerated. A line that merely
- * mentions the glyph is left alone — this runs on user-visible text, so a false
- * positive would silently delete an answer's last line.
+ * Deliberately strict: only the footer about to be appended (or its identity
+ * half, without the error detail) is removed, and only where a sign-off can sit
+ * — on its own trailing line, or run onto the end of the last line of prose —
+ * with markdown emphasis and a horizontal rule above it tolerated. A line that
+ * merely mentions the glyph is left alone: this runs on user-visible text, so a
+ * false positive would silently delete part of an answer.
+ *
+ * Both {@link agentFooterVariants} spellings are matched, because the echo comes
+ * back in whichever one the model was shown.
  */
 export function stripDuplicateAgentFooter(
   text: string,
   footer: string,
 ): string {
-  const identity = footer.split(FOOTER_DETAIL_SEPARATOR)[0].trim();
-  if (!identity.startsWith(AGENT_FOOTER_GLYPH)) return text;
+  const variants = agentFooterVariants(footer);
+  if (variants.length === 0) return text;
 
-  const duplicates = new Set([identity, footer.trim()]);
-  return stripTrailingChrome(text, (line) => duplicates.has(unemphasize(line)));
+  const withoutTrailingLine = stripTrailingChrome(text, (line) =>
+    variants.includes(unemphasize(line)),
+  );
+  return stripInlineFooter(withoutTrailingLine, (line) =>
+    matchFooterTail(line, variants),
+  );
 }
 
 /**
@@ -203,23 +211,28 @@ export function stripDuplicateAgentFooter(
  * Looser than {@link stripDuplicateAgentFooter} because this text is only ever
  * model context, never something a user reads: the responding agent of a past
  * message isn't known here (a thread can involve several), so any trailing line
- * leading with the glyph counts as a footer, and repeats are stripped until none
- * is left. An error footer's detail ("🤖 Name · <error>") can spill onto further
- * lines, and it is always the last thing in the message, so everything from such
- * a line onwards goes with it.
+ * leading with a footer glyph counts as a footer, and repeats are stripped until
+ * none is left. An error footer's detail ("🤖 Name · <error>") can spill onto
+ * further lines, and it is always the last thing in the message, so everything
+ * from such a line onwards goes with it. For the same reason a glyph appearing
+ * mid-line on the final line of prose is read as a run-on sign-off and takes the
+ * rest of the line with it — losing a few trailing words of context is cheaper
+ * than teaching the model to sign off, which is what leaves a user staring at
+ * two branding lines.
  */
 export function stripAgentFooterChrome(text: string): string {
   const lines = text.split("\n");
   const detailAt = lines.findLastIndex(
     (line) =>
-      unemphasize(line).startsWith(AGENT_FOOTER_GLYPH) &&
+      startsWithFooterGlyph(unemphasize(line)) &&
       line.includes(FOOTER_DETAIL_SEPARATOR),
   );
   const body = detailAt >= 0 ? lines.slice(0, detailAt).join("\n") : text;
 
-  return stripTrailingChrome(body, (line) =>
-    unemphasize(line).startsWith(AGENT_FOOTER_GLYPH),
-  ).trim();
+  const withoutTrailingLines = stripTrailingChrome(body, (line) =>
+    startsWithFooterGlyph(unemphasize(line)),
+  );
+  return stripInlineFooter(withoutTrailingLines, findTrailingGlyph).trim();
 }
 
 /**
@@ -247,8 +260,104 @@ export function errorMessage(error: unknown): string {
 /** The glyph every agent footer leads with, and how a footer is recognized. */
 const AGENT_FOOTER_GLYPH = "🤖";
 
+/**
+ * The same glyph in the colon notation chat providers use. We always *post* the
+ * literal glyph, but Slack normalizes emoji when it stores a message, so a reply
+ * read back through the API — and therefore replayed to the model as thread
+ * history — carries ":robot_face:" instead. The model then signs off in the
+ * spelling it was shown, so every footer check has to accept both.
+ *
+ * @see https://docs.slack.dev/messaging/formatting-message-text
+ */
+const AGENT_FOOTER_GLYPH_SHORTCODE = ":robot_face:";
+
 /** Separates the agent identity from any extra detail inside a footer. */
 const FOOTER_DETAIL_SEPARATOR = " · ";
+
+/** A footer glyph, in either spelling, run onto the end of a line of prose. */
+const INLINE_FOOTER_GLYPH_PATTERN = new RegExp(
+  `\\s(${AGENT_FOOTER_GLYPH}|${AGENT_FOOTER_GLYPH_SHORTCODE})`,
+);
+
+/** Whether a line opens with a footer glyph in either spelling. */
+function startsWithFooterGlyph(line: string): boolean {
+  return (
+    line.startsWith(AGENT_FOOTER_GLYPH) ||
+    line.startsWith(AGENT_FOOTER_GLYPH_SHORTCODE)
+  );
+}
+
+/**
+ * Every literal string a given footer can appear as: the whole thing and its
+ * identity half (an error footer's detail is not echoed back), each in both
+ * glyph spellings. Longest first, so an inline match consumes the fullest
+ * footer rather than stopping at its identity prefix. Empty when the input
+ * isn't a footer at all.
+ */
+function agentFooterVariants(footer: string): string[] {
+  const whole = footer.trim();
+  const identity = whole.split(FOOTER_DETAIL_SEPARATOR)[0].trim();
+  if (!identity.startsWith(AGENT_FOOTER_GLYPH)) return [];
+
+  const bases = whole === identity ? [identity] : [whole, identity];
+  return bases
+    .flatMap((base) => [
+      base,
+      base.replace(AGENT_FOOTER_GLYPH, AGENT_FOOTER_GLYPH_SHORTCODE),
+    ])
+    .sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Index at which a run-on footer starts on `line`, or -1. `locate` decides what
+ * counts; it only ever sees the final line of prose.
+ */
+type LocateFooterTail = (line: string) => number;
+
+/**
+ * Drop a footer the model ran onto the end of its last sentence ("…that's the
+ * plan. 🤖 Bot") rather than putting on a line of its own. Line-level stripping
+ * cannot see these, and they render as a second branding line just the same.
+ */
+function stripInlineFooter(text: string, locate: LocateFooterTail): string {
+  const lines = text.split("\n");
+  const last = lastContentIndex(lines, lines.length);
+  if (last < 0) return text;
+
+  const at = locate(lines[last]);
+  if (at < 0) return text;
+
+  lines[last] = lines[last].slice(0, at).trimEnd();
+  return lines
+    .slice(0, last + 1)
+    .join("\n")
+    .trimEnd();
+}
+
+/**
+ * Where one of `variants` ends `line`, preceded by whitespace so only a
+ * genuine sign-off matches and never a word the footer happens to end with.
+ */
+function matchFooterTail(line: string, variants: string[]): number {
+  for (const variant of variants) {
+    const at = line.length - variant.length;
+    if (at > 0 && line.endsWith(variant) && /\s/.test(line[at - 1])) return at;
+  }
+  return -1;
+}
+
+/**
+ * Where the FIRST whitespace-preceded footer glyph sits on `line`, or -1. Used
+ * only for history sanitation, where the agent name behind a past turn is
+ * unknown, so everything after the glyph is assumed to be its name. Taking the
+ * first rather than the last means a line carrying several glyphs comes back
+ * with none — leaving one behind would teach the sign-off this exists to stop.
+ */
+function findTrailingGlyph(line: string): number {
+  const match = INLINE_FOOTER_GLYPH_PATTERN.exec(line);
+  if (!match) return -1;
+  return match.index + match[0].length - match[1].length;
+}
 
 /**
  * Remove trailing lines the caller recognizes as chrome, plus the blank lines

--- a/platform/backend/src/routes/chatops.ts
+++ b/platform/backend/src/routes/chatops.ts
@@ -31,7 +31,12 @@ import {
   SLACK_DEFAULT_CONNECTION_MODE,
   TELEGRAM_LINK_CODE_TTL_MS,
 } from "@/agents/chatops/constants";
-import { EventDedupMap, errorMessage } from "@/agents/chatops/utils";
+import {
+  buildAgentFooter,
+  EventDedupMap,
+  errorMessage,
+  stripDuplicateAgentFooter,
+} from "@/agents/chatops/utils";
 import { isRateLimited } from "@/agents/utils";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { type AllowedCacheKey, CacheKey, cacheManager } from "@/cache-manager";
@@ -2107,9 +2112,14 @@ async function handleAgentSelection(
       });
 
       if (result.success && result.agentResponse) {
-        // Send agent response via turn context (ensures correct thread)
+        // Send agent response via turn context (ensures correct thread).
+        // This path composes the reply itself instead of going through
+        // sendReply, so it owes the same "exactly one footer" guarantee: build
+        // the footer from the one helper that defines it, and drop the model's
+        // own sign-off before appending it.
+        const footer = buildAgentFooter(agent.name);
         await context.sendActivity(
-          `${result.agentResponse}\n\n---\n\n🤖 ${agent.name}`,
+          `${stripDuplicateAgentFooter(result.agentResponse, footer)}\n\n---\n\n${footer}`,
         );
       } else if (!result.success && result.error) {
         // Send error message via turn context (ensures correct thread)


### PR DESCRIPTION
## The bug

A chatops reply can still render the branding line twice — two `🤖 <agent name>` lines instead of one — after #7280.

## Why the previous fix missed it

#7280 was right about the mechanism: the footer is chrome the platform appends at send time, and the second line is the model echoing a footer it saw on an earlier bot turn replayed as thread history. It closed the loop with two helpers in `agents/chatops/utils.ts` — `stripAgentFooterChrome` (sanitize history so the pattern is never taught) and `stripDuplicateAgentFooter` (drop an echo at composition time so exactly one footer is appended).

Both key on the literal `🤖` glyph. Two shapes get past that.

**1. The glyph is not what comes back.** Slack normalizes emoji when it stores a message: we post `🤖`, but a reply read back through the API carries `:robot_face:`. `SlackProvider.getThreadHistory` maps `text: msg.text` straight from `conversations.replies`, so the footer reaches `stripAgentFooterChrome` in colon notation and `startsWith(AGENT_FOOTER_GLYPH)` never fires — the sanitizer is a no-op on Slack, and every bot turn is replayed to the model with its footer intact. The model then signs off in the spelling it was shown, and `stripDuplicateAgentFooter` — comparing against `buildAgentFooter(agent.name)`, which is glyph-spelled — does not recognize it either. Both halves of #7280 fail on the same mismatch. ([Slack documents this](https://docs.slack.dev/messaging/formatting-message-text): emoji are published as literals but retrieved in colon format.)

**2. A sign-off does not always get its own line.** The strict guard walks trailing *lines* and matches a line that is exactly the footer. When the model runs the footer onto the end of its last sentence — `…that's the plan. 🤖 Agent` — there is no such line, the echo survives, and the appended footer renders under it.

The two shapes are independent: either alone produces the doubled render, and the first one also keeps the teaching loop alive, which is why it recurs per-thread rather than uniformly.

## Fix

**Accept both spellings.** `AGENT_FOOTER_GLYPH_SHORTCODE` sits next to `AGENT_FOOTER_GLYPH`, and every footer check goes through `startsWithFooterGlyph` / `agentFooterVariants`, which expands a footer into the strings it can appear as — the whole footer and its identity half (an error footer's `· <detail>` is not echoed back), each in both spellings, longest first so an inline match consumes the fullest footer rather than stopping at its identity prefix.

**Catch a run-on sign-off.** `stripInlineFooter` trims a footer off the end of the last line of prose. The two callers keep their existing asymmetry of intent:

- the strict guard (`matchFooterTail`) removes only an exact footer variant ending the line and preceded by whitespace. It runs on user-visible text, so a line that merely mentions the glyph is still left alone.
- history sanitation (`findTrailingGlyph`) takes everything from the *first* whitespace-preceded glyph on that line, since the agent behind a past turn isn't known — a thread can involve several. Taking the first rather than the last means a line carrying more than one glyph comes back with none; leaving one behind would teach exactly the sign-off this exists to stop. That text is only ever model context, never something a user reads, so losing a few trailing words is the cheaper side of the trade.

**Close the last unguarded send path.** The MS Teams turn-context branch in `routes/chatops.ts` composes its reply directly rather than through `sendReply`, hand-building `\n\n---\n\n🤖 ${agent.name}` with no duplicate guard — the one place the footer format was written out a second time. It now builds the footer with `buildAgentFooter` and strips a duplicate first, so "exactly one footer" holds on every path that sends.

## Tests

- `utils.test.ts` — both helpers against the shapes that got through: shortcode-spelled footer on its own line, a run-on sign-off in each spelling, both at once, and a final line carrying several glyphs (nothing glyph-like may survive sanitation). The existing pins on what the strict variant must *not* touch still hold: another agent's footer, a glyph mentioned mid-prose, content after the footer line.
- `slack-provider.test.ts` — table-driven over the three echo shapes; each posts one markdown block plus a single footer context block, with the notification fallback carrying the branding once.
- `chatops-manager.test.ts` — the history-replay test gains a turn in the form Slack actually returns (colon-spelled footer plus a run-on echo); the body reaches the executor intact with no branding in either spelling.

Full `agents/chatops` + `routes/chatops` suites pass (518 tests); type-check, biome and knip clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>