### PR TITLE
Closes #7200 : Frontend, depends on Part 1

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2889,6 +2889,10 @@ const config = {
         .ARCHESTRA_KNOWLEDGE_BASE_PERMISSION_SYNC_WORKER_MAX_CONCURRENT,
       1,
     ),
+    docReviewWorkerMaxConcurrent: parsePositiveInt(
+      process.env.ARCHESTRA_KNOWLEDGE_BASE_DOC_REVIEW_WORKER_MAX_CONCURRENT,
+      5,
+    ),
     taskWorkerShutdownTimeoutSeconds: parsePositiveInt(
       process.env.ARCHESTRA_KNOWLEDGE_BASE_TASK_WORKER_SHUTDOWN_TIMEOUT_SECONDS,
       30,

--- a/platform/backend/src/database/schemas/doc-review.ee.ts
+++ b/platform/backend/src/database/schemas/doc-review.ee.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import kbDocumentsTable from "./kb-document";
+import knowledgeBasesTable from "./knowledge-base";
+
+export type DocReviewOutputFormat =
+  | "text"
+  | "yes_no"
+  | "date"
+  | "number"
+  | "list"
+  | "json";
+
+export type DocReviewColumn = {
+  id: string;
+  title: string;
+  prompt: string;
+  outputFormat: DocReviewOutputFormat;
+  toolName?: string;
+  toolArgs?: Record<string, unknown>;
+};
+
+export type DocReviewStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type DocReviewRowStatus =
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed";
+
+export type DocReviewCellStatus =
+  | "pending"
+  | "generating"
+  | "completed"
+  | "error";
+
+export type DocReviewCitation = {
+  quote: string;
+  ref?: string;
+  documentId?: string;
+  title?: string;
+  sourceUrl?: string | null;
+  startOffset?: number;
+  endOffset?: number;
+};
+
+export const docReviewsTable = pgTable(
+  "doc_reviews",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    organizationId: text("organization_id").notNull(),
+    createdById: text("created_by_id").notNull(),
+    knowledgeBaseId: uuid("knowledge_base_id").references(
+      () => knowledgeBasesTable.id,
+      { onDelete: "set null" },
+    ),
+    name: text("name").notNull(),
+    description: text("description"),
+    columns: jsonb("columns").$type<DocReviewColumn[]>().notNull().default([]),
+    status: text("status").$type<DocReviewStatus>().notNull().default("pending"),
+    totalRows: integer("total_rows").notNull().default(0),
+    completedRows: integer("completed_rows").notNull().default(0),
+    totalCells: integer("total_cells").notNull().default(0),
+    completedCells: integer("completed_cells").notNull().default(0),
+    failedCells: integer("failed_cells").notNull().default(0),
+    leaseOwner: text("lease_owner"),
+    leaseExpiresAt: timestamp("lease_expires_at", { mode: "date" }),
+    leaseEpoch: bigint("lease_epoch", { mode: "number" }).notNull().default(0),
+    error: text("error"),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+    completedAt: timestamp("completed_at", { mode: "date" }),
+  },
+  (table) => [
+    index("doc_reviews_org_id_idx").on(table.organizationId),
+    index("doc_reviews_kb_id_idx").on(table.knowledgeBaseId),
+    index("doc_reviews_lease_expires_at_idx")
+      .on(table.leaseExpiresAt)
+      .where(sql`status = 'running'`),
+  ],
+);
+
+export const docReviewRowsTable = pgTable(
+  "doc_review_rows",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    reviewId: uuid("review_id")
+      .notNull()
+      .references(() => docReviewsTable.id, { onDelete: "cascade" }),
+    documentId: uuid("document_id")
+      .notNull()
+      .references(() => kbDocumentsTable.id, { onDelete: "cascade" }),
+    status: text("status")
+      .$type<DocReviewRowStatus>()
+      .notNull()
+      .default("pending"),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("doc_review_rows_review_doc_idx").on(
+      table.reviewId,
+      table.documentId,
+    ),
+    index("doc_review_rows_review_status_idx").on(
+      table.reviewId,
+      table.status,
+    ),
+  ],
+);
+
+export const docReviewCellsTable = pgTable(
+  "doc_review_cells",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    reviewId: uuid("review_id")
+      .notNull()
+      .references(() => docReviewsTable.id, { onDelete: "cascade" }),
+    rowId: uuid("row_id")
+      .notNull()
+      .references(() => docReviewRowsTable.id, { onDelete: "cascade" }),
+    columnId: text("column_id").notNull(),
+    documentId: uuid("document_id")
+      .notNull()
+      .references(() => kbDocumentsTable.id, { onDelete: "cascade" }),
+    status: text("status")
+      .$type<DocReviewCellStatus>()
+      .notNull()
+      .default("pending"),
+    value: jsonb("value").$type<unknown>(),
+    citations: jsonb("citations").$type<DocReviewCitation[]>().default([]),
+    error: text("error"),
+    tokensUsed: integer("tokens_used"),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("doc_review_cells_row_col_idx").on(
+      table.rowId,
+      table.columnId,
+    ),
+    index("doc_review_cells_review_status_idx").on(
+      table.reviewId,
+      table.status,
+    ),
+  ],
+);

--- a/platform/backend/src/database/schemas/index.ts
+++ b/platform/backend/src/database/schemas/index.ts
@@ -87,6 +87,11 @@ export {
 export { default as connectorRunsTable } from "./connector-run";
 // biome-ignore lint/style/noRestrictedImports: dual-licensed schema; inert without the feature
 export { default as contentEncryptionStateTable } from "./content-encryption-state.ee";
+export {
+  docReviewsTable,
+  docReviewRowsTable,
+  docReviewCellsTable,
+} from "./doc-review.ee";
 export { default as conversationsTable } from "./conversation";
 export { default as conversationAttachmentsTable } from "./conversation-attachment";
 export { default as conversationChatErrorsTable } from "./conversation-chat-error";

--- a/platform/backend/src/knowledge-base/doc-review-runner.ee.ts
+++ b/platform/backend/src/knowledge-base/doc-review-runner.ee.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+import { generateText } from "ai";
+import { createDirectLLMModel } from "@/clients/llm-client";
+import config from "@/config";
+import type {
+  DocReviewCitation,
+  DocReviewColumn,
+  DocReviewOutputFormat,
+} from "@/database/schemas/doc-review.ee";
+import logger from "@/logging";
+import type { KbDocument } from "@/types";
+import { resolveRerankerConfig } from "./kb-llm-client";
+
+export type CellExecutionResult = {
+  value: unknown;
+  citations: DocReviewCitation[];
+  tokensUsed?: number;
+};
+
+const SYSTEM_PROMPT_TEMPLATE = `You are a precise document review system. You are given a document and a specific question or field to extract.
+
+Answer the question strictly based on the document content provided.
+Output format required: {output_format_instruction}
+
+Format your output into two sections:
+[ANSWER]
+<The extracted answer adhering to the required format>
+[/ANSWER]
+
+[CITATIONS]
+<List 1 to 3 verbatim quotes from the document supporting your answer, one per line>
+[/CITATIONS]`;
+
+function getOutputFormatInstruction(format: DocReviewOutputFormat): string {
+  switch (format) {
+    case "yes_no":
+      return 'Respond with either "YES" or "NO" (or "UNKNOWN" if not stated in the document).';
+    case "date":
+      return 'Respond with a date in YYYY-MM-DD format (or "UNKNOWN" if no date is found).';
+    case "number":
+      return 'Respond with only the numeric value (e.g. 30, 100.50, or "UNKNOWN").';
+    case "list":
+      return 'Respond with a bulleted list of extracted items, one per line.';
+    case "json":
+      return "Respond with valid JSON object or array matching the requested schema.";
+    case "text":
+    default:
+      return "Respond with a clear, concise prose explanation or direct extract.";
+  }
+}
+
+function parseAnswerValue(
+  rawAnswer: string,
+  format: DocReviewOutputFormat,
+): unknown {
+  const trimmed = rawAnswer.trim();
+  switch (format) {
+    case "yes_no": {
+      const upper = trimmed.toUpperCase();
+      if (upper.includes("YES")) return true;
+      if (upper.includes("NO")) return false;
+      return trimmed;
+    }
+    case "number": {
+      const numMatch = trimmed.match(/-?\d+(?:\.\d+)?/);
+      if (numMatch) return Number(numMatch[0]);
+      return trimmed;
+    }
+    case "date": {
+      const dateMatch = trimmed.match(/\b\d{4}-\d{2}-\d{2}\b/);
+      if (dateMatch) return dateMatch[0];
+      return trimmed;
+    }
+    case "list": {
+      const lines = trimmed
+        .split("\n")
+        .map((l) => l.replace(/^[-*•\d+.]\s*/, "").trim())
+        .filter(Boolean);
+      return lines.length > 0 ? lines : [trimmed];
+    }
+    case "json": {
+      try {
+        const jsonMatch = trimmed.match(/\{[\s\S]*\}|\[[\s\S]*\]/);
+        if (jsonMatch) return JSON.parse(jsonMatch[0]);
+      } catch {
+        // Fall back to string if JSON parsing fails
+      }
+      return trimmed;
+    }
+    case "text":
+    default:
+      return trimmed;
+  }
+}
+
+function parseCitations(
+  citationsBlock: string,
+  document: KbDocument,
+): DocReviewCitation[] {
+  if (!citationsBlock.trim()) return [];
+
+  const quotes = citationsBlock
+    .split("\n")
+    .map((l) => l.replace(/^[-\d+."']+\s*/, "").replace(/["']+$/, "").trim())
+    .filter((q) => q.length > 5);
+
+  return quotes.map((quote) => {
+    const startOffset = document.content.indexOf(quote);
+    return {
+      quote,
+      documentId: document.id,
+      title: document.title,
+      sourceUrl: document.sourceUrl,
+      startOffset: startOffset >= 0 ? startOffset : undefined,
+      endOffset:
+        startOffset >= 0 ? startOffset + quote.length : undefined,
+    };
+  });
+}
+
+export async function executeReviewCell(params: {
+  organizationId: string;
+  document: KbDocument;
+  column: DocReviewColumn;
+}): Promise<CellExecutionResult> {
+  const { organizationId, document, column } = params;
+
+  // Resolve LLM model for the org
+  let llmModel: any = null;
+  try {
+    const rerankerConfig = await resolveRerankerConfig(organizationId);
+    if (rerankerConfig && rerankerConfig.kind === "llm") {
+      llmModel = rerankerConfig.llmModel;
+    }
+  } catch (err) {
+    logger.debug(
+      { organizationId, err },
+      "[DocReviewRunner] Could not resolve org reranker model, attempting fallback",
+    );
+  }
+
+  // Fall back to default Ollama / OpenAI model if none configured
+  if (!llmModel) {
+    llmModel = createDirectLLMModel({
+      provider: "openai",
+      modelName: "gpt-4o-mini",
+    });
+  }
+
+  const system = SYSTEM_PROMPT_TEMPLATE.replace(
+    "{output_format_instruction}",
+    getOutputFormatInstruction(column.outputFormat),
+  );
+
+  const prompt = `DOCUMENT TITLE: ${document.title}
+${document.sourceUrl ? `SOURCE URL: ${document.sourceUrl}\n` : ""}
+DOCUMENT CONTENT:
+${document.content.slice(0, 100_000)}
+
+---
+QUESTION / INSTRUCTION:
+${column.prompt}`;
+
+  const result = await generateText({
+    model: llmModel,
+    system,
+    prompt,
+  });
+
+  const fullText = result.text;
+  let rawAnswer = fullText;
+  let citationsBlock = "";
+
+  const answerMatch = fullText.match(/\[ANSWER\]([\s\S]*?)\[\/ANSWER\]/i);
+  if (answerMatch) {
+    rawAnswer = answerMatch[1].trim();
+  }
+
+  const citationMatch = fullText.match(/\[CITATIONS\]([\s\S]*?)\[\/CITATIONS\]/i);
+  if (citationMatch) {
+    citationsBlock = citationMatch[1].trim();
+  }
+
+  const parsedValue = parseAnswerValue(rawAnswer, column.outputFormat);
+  const citations = parseCitations(citationsBlock, document);
+
+  return {
+    value: parsedValue,
+    citations,
+    tokensUsed: result.usage?.totalTokens,
+  };
+}

--- a/platform/backend/src/models/doc-review.ee.ts
+++ b/platform/backend/src/models/doc-review.ee.ts
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import db, { schema } from "@/database";
+import type {
+  DocReviewCellStatus,
+  DocReviewCitation,
+  DocReviewColumn,
+  DocReviewRowStatus,
+  DocReviewStatus,
+} from "@/database/schemas/doc-review.ee";
+
+export type DocReview = typeof schema.docReviewsTable.$inferSelect;
+export type DocReviewRow = typeof schema.docReviewRowsTable.$inferSelect;
+export type DocReviewCell = typeof schema.docReviewCellsTable.$inferSelect;
+
+export type CreateDocReviewParams = {
+  organizationId: string;
+  createdById: string;
+  knowledgeBaseId?: string;
+  name: string;
+  description?: string;
+  columns: DocReviewColumn[];
+  documentIds: string[];
+};
+
+export type DocReviewGridCell = {
+  id: string;
+  rowId: string;
+  columnId: string;
+  documentId: string;
+  status: DocReviewCellStatus;
+  value: unknown;
+  citations: DocReviewCitation[];
+  error?: string | null;
+  tokensUsed?: number | null;
+};
+
+export type DocReviewGridRow = {
+  id: string;
+  documentId: string;
+  documentTitle: string;
+  documentSourceUrl?: string | null;
+  status: DocReviewRowStatus;
+  cells: Record<string, DocReviewGridCell>; // columnId -> cell
+};
+
+export type DocReviewGrid = {
+  review: DocReview;
+  columns: DocReviewColumn[];
+  rows: DocReviewGridRow[];
+};
+
+export class DocReviewModel {
+  static async create(params: CreateDocReviewParams): Promise<DocReview> {
+    return await db.transaction(async (tx) => {
+      const totalRows = params.documentIds.length;
+      const totalCells = totalRows * params.columns.length;
+
+      const [review] = await tx
+        .insert(schema.docReviewsTable)
+        .values({
+          organizationId: params.organizationId,
+          createdById: params.createdById,
+          knowledgeBaseId: params.knowledgeBaseId ?? null,
+          name: params.name,
+          description: params.description ?? null,
+          columns: params.columns,
+          status: "pending",
+          totalRows,
+          completedRows: 0,
+          totalCells,
+          completedCells: 0,
+          failedCells: 0,
+        })
+        .returning();
+
+      if (params.documentIds.length > 0) {
+        // Insert rows
+        const rowValues = params.documentIds.map((docId) => ({
+          reviewId: review.id,
+          documentId: docId,
+          status: "pending" as DocReviewRowStatus,
+        }));
+
+        const insertedRows = await tx
+          .insert(schema.docReviewRowsTable)
+          .values(rowValues)
+          .returning();
+
+        // Insert cells for each row and column
+        const cellValues: (typeof schema.docReviewCellsTable.$inferInsert)[] = [];
+        for (const row of insertedRows) {
+          for (const col of params.columns) {
+            cellValues.push({
+              reviewId: review.id,
+              rowId: row.id,
+              columnId: col.id,
+              documentId: row.documentId,
+              status: "pending",
+              citations: [],
+            });
+          }
+        }
+
+        if (cellValues.length > 0) {
+          await tx.insert(schema.docReviewCellsTable).values(cellValues);
+        }
+      }
+
+      return review;
+    });
+  }
+
+  static async findById(
+    id: string,
+    organizationId: string,
+  ): Promise<DocReview | null> {
+    const [review] = await db
+      .select()
+      .from(schema.docReviewsTable)
+      .where(
+        and(
+          eq(schema.docReviewsTable.id, id),
+          eq(schema.docReviewsTable.organizationId, organizationId),
+        ),
+      );
+
+    return review ?? null;
+  }
+
+  static async findByOrganization(
+    organizationId: string,
+    limit = 50,
+    offset = 0,
+  ): Promise<DocReview[]> {
+    return await db
+      .select()
+      .from(schema.docReviewsTable)
+      .where(eq(schema.docReviewsTable.organizationId, organizationId))
+      .orderBy(desc(schema.docReviewsTable.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+
+  static async findGrid(
+    reviewId: string,
+    organizationId: string,
+  ): Promise<DocReviewGrid | null> {
+    const review = await this.findById(reviewId, organizationId);
+    if (!review) return null;
+
+    const rowsWithDocs = await db
+      .select({
+        row: schema.docReviewRowsTable,
+        docTitle: schema.kbDocumentsTable.title,
+        docSourceUrl: schema.kbDocumentsTable.sourceUrl,
+      })
+      .from(schema.docReviewRowsTable)
+      .innerJoin(
+        schema.kbDocumentsTable,
+        eq(schema.docReviewRowsTable.documentId, schema.kbDocumentsTable.id),
+      )
+      .where(eq(schema.docReviewRowsTable.reviewId, reviewId))
+      .orderBy(schema.docReviewRowsTable.createdAt);
+
+    const cells = await db
+      .select()
+      .from(schema.docReviewCellsTable)
+      .where(eq(schema.docReviewCellsTable.reviewId, reviewId));
+
+    const cellsByRowId = new Map<string, Record<string, DocReviewGridCell>>();
+    for (const cell of cells) {
+      if (!cellsByRowId.has(cell.rowId)) {
+        cellsByRowId.set(cell.rowId, {});
+      }
+      cellsByRowId.get(cell.rowId)![cell.columnId] = {
+        id: cell.id,
+        rowId: cell.rowId,
+        columnId: cell.columnId,
+        documentId: cell.documentId,
+        status: cell.status,
+        value: cell.value,
+        citations: (cell.citations as DocReviewCitation[]) ?? [],
+        error: cell.error,
+        tokensUsed: cell.tokensUsed,
+      };
+    }
+
+    const gridRows: DocReviewGridRow[] = rowsWithDocs.map(
+      ({ row, docTitle, docSourceUrl }) => ({
+        id: row.id,
+        documentId: row.documentId,
+        documentTitle: docTitle,
+        documentSourceUrl: docSourceUrl,
+        status: row.status,
+        cells: cellsByRowId.get(row.id) ?? {},
+      }),
+    );
+
+    return {
+      review,
+      columns: (review.columns as DocReviewColumn[]) ?? [],
+      rows: gridRows,
+    };
+  }
+
+  static async findPendingCellRows(reviewId: string): Promise<string[]> {
+    const pendingCells = await db
+      .selectDistinct({ rowId: schema.docReviewCellsTable.rowId })
+      .from(schema.docReviewCellsTable)
+      .where(
+        and(
+          eq(schema.docReviewCellsTable.reviewId, reviewId),
+          inArray(schema.docReviewCellsTable.status, ["pending", "error"]),
+        ),
+      );
+
+    return pendingCells.map((c) => c.rowId);
+  }
+
+  static async findCellsByRow(rowId: string): Promise<DocReviewCell[]> {
+    return await db
+      .select()
+      .from(schema.docReviewCellsTable)
+      .where(eq(schema.docReviewCellsTable.rowId, rowId));
+  }
+
+  static async findCellById(cellId: string): Promise<DocReviewCell | null> {
+    const [cell] = await db
+      .select()
+      .from(schema.docReviewCellsTable)
+      .where(eq(schema.docReviewCellsTable.id, cellId));
+
+    return cell ?? null;
+  }
+
+  static async completeCell(
+    cellId: string,
+    params: {
+      value: unknown;
+      citations: DocReviewCitation[];
+      tokensUsed?: number;
+    },
+  ): Promise<void> {
+    await db.transaction(async (tx) => {
+      const [cell] = await tx
+        .select()
+        .from(schema.docReviewCellsTable)
+        .where(eq(schema.docReviewCellsTable.id, cellId));
+
+      if (!cell) return;
+
+      const wasAlreadyCompleted = cell.status === "completed";
+
+      await tx
+        .update(schema.docReviewCellsTable)
+        .set({
+          status: "completed",
+          value: params.value as any,
+          citations: params.citations,
+          tokensUsed: params.tokensUsed ?? null,
+          error: null,
+        })
+        .where(eq(schema.docReviewCellsTable.id, cellId));
+
+      if (!wasAlreadyCompleted) {
+        await tx
+          .update(schema.docReviewsTable)
+          .set({
+            completedCells: sql`${schema.docReviewsTable.completedCells} + 1`,
+            ...(cell.status === "error"
+              ? { failedCells: sql`${schema.docReviewsTable.failedCells} - 1` }
+              : {}),
+          })
+          .where(eq(schema.docReviewsTable.id, cell.reviewId));
+      }
+
+      await this.checkAndUpdateRowCompletion(tx, cell.rowId, cell.reviewId);
+    });
+  }
+
+  static async failCell(cellId: string, errorMessage: string): Promise<void> {
+    await db.transaction(async (tx) => {
+      const [cell] = await tx
+        .select()
+        .from(schema.docReviewCellsTable)
+        .where(eq(schema.docReviewCellsTable.id, cellId));
+
+      if (!cell) return;
+
+      const wasError = cell.status === "error";
+
+      await tx
+        .update(schema.docReviewCellsTable)
+        .set({
+          status: "error",
+          error: errorMessage,
+        })
+        .where(eq(schema.docReviewCellsTable.id, cellId));
+
+      if (!wasError) {
+        await tx
+          .update(schema.docReviewsTable)
+          .set({
+            failedCells: sql`${schema.docReviewsTable.failedCells} + 1`,
+          })
+          .where(eq(schema.docReviewsTable.id, cell.reviewId));
+      }
+
+      await this.checkAndUpdateRowCompletion(tx, cell.rowId, cell.reviewId);
+    });
+  }
+
+  private static async checkAndUpdateRowCompletion(
+    tx: any,
+    rowId: string,
+    reviewId: string,
+  ): Promise<void> {
+    const rowCells = await tx
+      .select()
+      .from(schema.docReviewCellsTable)
+      .where(eq(schema.docReviewCellsTable.rowId, rowId));
+
+    const allFinished = rowCells.every(
+      (c: DocReviewCell) => c.status === "completed" || c.status === "error",
+    );
+
+    if (allFinished) {
+      const hasErrors = rowCells.some((c: DocReviewCell) => c.status === "error");
+      const rowStatus: DocReviewRowStatus = hasErrors ? "failed" : "completed";
+
+      const [prevRow] = await tx
+        .select()
+        .from(schema.docReviewRowsTable)
+        .where(eq(schema.docReviewRowsTable.id, rowId));
+
+      await tx
+        .update(schema.docReviewRowsTable)
+        .set({ status: rowStatus })
+        .where(eq(schema.docReviewRowsTable.id, rowId));
+
+      if (prevRow?.status !== "completed" && rowStatus === "completed") {
+        await tx
+          .update(schema.docReviewsTable)
+          .set({
+            completedRows: sql`${schema.docReviewsTable.completedRows} + 1`,
+          })
+          .where(eq(schema.docReviewsTable.id, reviewId));
+      }
+    }
+
+    // Check overall review run completion
+    const allReviewCells = await tx
+      .select()
+      .from(schema.docReviewCellsTable)
+      .where(eq(schema.docReviewCellsTable.reviewId, reviewId));
+
+    const reviewFinished = allReviewCells.every(
+      (c: DocReviewCell) => c.status === "completed" || c.status === "error",
+    );
+
+    if (reviewFinished) {
+      const hasAnyFailures = allReviewCells.some(
+        (c: DocReviewCell) => c.status === "error",
+      );
+      const finalStatus: DocReviewStatus = hasAnyFailures
+        ? "completed" // completed with some cell errors, or completed
+        : "completed";
+
+      await tx
+        .update(schema.docReviewsTable)
+        .set({
+          status: finalStatus,
+          completedAt: new Date(),
+        })
+        .where(eq(schema.docReviewsTable.id, reviewId));
+    }
+  }
+
+  static async updateStatus(
+    id: string,
+    status: DocReviewStatus,
+    error?: string,
+  ): Promise<void> {
+    await db
+      .update(schema.docReviewsTable)
+      .set({
+        status,
+        ...(error !== undefined ? { error } : {}),
+        ...(status === "completed" || status === "failed" || status === "cancelled"
+          ? { completedAt: new Date() }
+          : {}),
+      })
+      .where(eq(schema.docReviewsTable.id, id));
+  }
+
+  static async retryCell(
+    cellId: string,
+    organizationId: string,
+  ): Promise<{ cell: DocReviewCell; review: DocReview } | null> {
+    const cell = await this.findCellById(cellId);
+    if (!cell) return null;
+
+    const review = await this.findById(cell.reviewId, organizationId);
+    if (!review) return null;
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.docReviewCellsTable)
+        .set({
+          status: "pending",
+          error: null,
+          value: null,
+          citations: [],
+        })
+        .where(eq(schema.docReviewCellsTable.id, cellId));
+
+      await tx
+        .update(schema.docReviewRowsTable)
+        .set({ status: "pending" })
+        .where(eq(schema.docReviewRowsTable.id, cell.rowId));
+
+      await tx
+        .update(schema.docReviewsTable)
+        .set({ status: "running" })
+        .where(eq(schema.docReviewsTable.id, review.id));
+    });
+
+    return { cell, review };
+  }
+
+  static async delete(id: string, organizationId: string): Promise<boolean> {
+    const result = await db
+      .delete(schema.docReviewsTable)
+      .where(
+        and(
+          eq(schema.docReviewsTable.id, id),
+          eq(schema.docReviewsTable.organizationId, organizationId),
+        ),
+      )
+      .returning();
+
+    return result.length > 0;
+  }
+}

--- a/platform/backend/src/models/index.ts
+++ b/platform/backend/src/models/index.ts
@@ -41,6 +41,7 @@ export { default as ConversationChatErrorModel } from "./conversation-chat-error
 export { default as ConversationCompactionModel } from "./conversation-compaction";
 export { default as ConversationEnabledToolModel } from "./conversation-enabled-tool";
 export { default as ConversationShareModel } from "./conversation-share";
+export { DocReviewModel } from "./doc-review.ee";
 export { default as EnvironmentModel } from "./environment";
 export { default as EnvironmentDefaultUserLimitModel } from "./environment-default-user-limit";
 export { default as EnvironmentResourceDefaultModel } from "./environment-resource-default";

--- a/platform/backend/src/routes/doc-review.ee.ts
+++ b/platform/backend/src/routes/doc-review.ee.ts
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+import type { FastifyPluginAsync } from "fastify";
+import { z } from "zod";
+import {
+  buildUserAccessControlList,
+} from "@/knowledge-base/source-access-control";
+import { DocReviewModel, KbDocumentModel } from "@/models";
+import { taskQueueService } from "@/task-queue";
+import { ApiError } from "@/types";
+
+const DocReviewColumnSchema = z.object({
+  id: z.string(),
+  title: z.string().min(1),
+  prompt: z.string().min(1),
+  outputFormat: z.enum([
+    "text",
+    "yes_no",
+    "date",
+    "number",
+    "list",
+    "json",
+  ]),
+  toolName: z.string().optional(),
+  toolArgs: z.record(z.unknown()).optional(),
+});
+
+const CreateDocReviewSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  knowledgeBaseId: z.string().uuid().optional(),
+  columns: z.array(DocReviewColumnSchema).min(1),
+  documentIds: z.array(z.string().uuid()).min(1),
+});
+
+const docReviewRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post(
+    "/api/doc-reviews",
+    {
+      schema: {
+        description: "Create and start a bulk document review table",
+        tags: ["Doc Reviews"],
+        body: CreateDocReviewSchema,
+      },
+    },
+    async (request, reply) => {
+      const { name, description, knowledgeBaseId, columns, documentIds } =
+        request.body as z.infer<typeof CreateDocReviewSchema>;
+      const organizationId = request.organizationId;
+      const user = request.user;
+
+      // 1. Resolve calling user's ACL
+      const userAcl = buildUserAccessControlList({
+        userEmail: user.email,
+        teamIds: [], // User team IDs resolved via auth if present
+      });
+
+      // 2. Fetch candidate documents and enforce ACL read permissions
+      const candidateDocs = await KbDocumentModel.findByIds(documentIds);
+      const accessibleDocIds = candidateDocs
+        .filter((doc) => {
+          if (doc.organizationId !== organizationId) return false;
+          // Check overlap between document ACL and user ACL
+          if (doc.acl.length === 0) return true; // org-wide default
+          return doc.acl.some((entry) => userAcl.includes(entry as any));
+        })
+        .map((doc) => doc.id);
+
+      if (accessibleDocIds.length === 0) {
+        throw new ApiError(
+          403,
+          "No accessible documents found for the requested document set",
+        );
+      }
+
+      // 3. Create review record and rows/cells
+      const review = await DocReviewModel.create({
+        organizationId,
+        createdById: user.id,
+        knowledgeBaseId,
+        name,
+        description,
+        columns,
+        documentIds: accessibleDocIds,
+      });
+
+      // 4. Enqueue background runner task
+      await taskQueueService.enqueue({
+        taskType: "doc_review_run",
+        payload: {
+          reviewId: review.id,
+        },
+      });
+
+      return reply.status(201).send({ review });
+    },
+  );
+
+  fastify.get(
+    "/api/doc-reviews",
+    {
+      schema: {
+        description: "List document reviews for organization",
+        tags: ["Doc Reviews"],
+        querystring: z.object({
+          limit: z.coerce.number().optional().default(50),
+          offset: z.coerce.number().optional().default(0),
+        }),
+      },
+    },
+    async (request, reply) => {
+      const { limit, offset } = request.query as {
+        limit: number;
+        offset: number;
+      };
+      const reviews = await DocReviewModel.findByOrganization(
+        request.organizationId,
+        limit,
+        offset,
+      );
+
+      return reply.send({ reviews });
+    },
+  );
+
+  fastify.get(
+    "/api/doc-reviews/:id",
+    {
+      schema: {
+        description: "Get document review by ID",
+        tags: ["Doc Reviews"],
+        params: z.object({ id: z.string().uuid() }),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const review = await DocReviewModel.findById(id, request.organizationId);
+      if (!review) {
+        throw new ApiError(404, "Document review not found");
+      }
+
+      return reply.send({ review });
+    },
+  );
+
+  fastify.get(
+    "/api/doc-reviews/:id/grid",
+    {
+      schema: {
+        description: "Get full review matrix grid",
+        tags: ["Doc Reviews"],
+        params: z.object({ id: z.string().uuid() }),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const grid = await DocReviewModel.findGrid(id, request.organizationId);
+      if (!grid) {
+        throw new ApiError(404, "Document review grid not found");
+      }
+
+      return reply.send(grid);
+    },
+  );
+
+  fastify.post(
+    "/api/doc-reviews/:id/resume",
+    {
+      schema: {
+        description: "Resume interrupted document review run",
+        tags: ["Doc Reviews"],
+        params: z.object({ id: z.string().uuid() }),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const review = await DocReviewModel.findById(id, request.organizationId);
+      if (!review) {
+        throw new ApiError(404, "Document review not found");
+      }
+
+      await DocReviewModel.updateStatus(id, "running");
+
+      await taskQueueService.enqueue({
+        taskType: "doc_review_run",
+        payload: { reviewId: id },
+      });
+
+      return reply.send({ success: true, status: "running" });
+    },
+  );
+
+  fastify.post(
+    "/api/doc-reviews/:id/cells/:cellId/retry",
+    {
+      schema: {
+        description: "Retry single cell execution in document review",
+        tags: ["Doc Reviews"],
+        params: z.object({ id: z.string().uuid(), cellId: z.string().uuid() }),
+      },
+    },
+    async (request, reply) => {
+      const { cellId } = request.params as { id: string; cellId: string };
+      const result = await DocReviewModel.retryCell(cellId, request.organizationId);
+      if (!result) {
+        throw new ApiError(404, "Review cell not found");
+      }
+
+      await taskQueueService.enqueue({
+        taskType: "doc_review_batch",
+        payload: {
+          reviewId: result.review.id,
+          rowIds: [result.cell.rowId],
+        },
+      });
+
+      return reply.send({ success: true, cell: result.cell });
+    },
+  );
+
+  fastify.delete(
+    "/api/doc-reviews/:id",
+    {
+      schema: {
+        description: "Delete document review table",
+        tags: ["Doc Reviews"],
+        params: z.object({ id: z.string().uuid() }),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const deleted = await DocReviewModel.delete(id, request.organizationId);
+      if (!deleted) {
+        throw new ApiError(404, "Document review not found");
+      }
+
+      return reply.send({ success: true });
+    },
+  );
+
+  fastify.get(
+    "/api/doc-reviews/:id/export",
+    {
+      schema: {
+        description: "Export review grid matrix to CSV or JSON",
+        tags: ["Doc Reviews"],
+        params: z.object({ id: z.string().uuid() }),
+        querystring: z.object({
+          format: z.enum(["csv", "json"]).optional().default("csv"),
+        }),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const { format } = request.query as { format: "csv" | "json" };
+
+      const grid = await DocReviewModel.findGrid(id, request.organizationId);
+      if (!grid) {
+        throw new ApiError(404, "Document review not found");
+      }
+
+      if (format === "json") {
+        return reply
+          .header(
+            "Content-Disposition",
+            `attachment; filename="${grid.review.name.toLowerCase().replace(/\s+/g, "_")}_review.json"`,
+          )
+          .send(grid);
+      }
+
+      // Generate CSV
+      const headers = ["Document Title", ...grid.columns.map((c) => c.title)];
+      const csvRows = [headers.map((h) => `"${h.replace(/"/g, '""')}"`).join(",")];
+
+      for (const row of grid.rows) {
+        const rowCells = [
+          `"${row.documentTitle.replace(/"/g, '""')}"`,
+          ...grid.columns.map((col) => {
+            const cell = row.cells[col.id];
+            const val = cell?.value !== undefined && cell?.value !== null
+              ? typeof cell.value === "object"
+                ? JSON.stringify(cell.value)
+                : String(cell.value)
+              : "";
+            return `"${val.replace(/"/g, '""')}"`;
+          }),
+        ];
+        csvRows.push(rowCells.join(","));
+      }
+
+      const csvContent = csvRows.join("\n");
+
+      return reply
+        .header("Content-Type", "text/csv")
+        .header(
+          "Content-Disposition",
+          `attachment; filename="${grid.review.name.toLowerCase().replace(/\s+/g, "_")}_review.csv"`,
+        )
+        .send(csvContent);
+    },
+  );
+};
+
+export default docReviewRoutes;

--- a/platform/backend/src/routes/doc-review.test.ts
+++ b/platform/backend/src/routes/doc-review.test.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+import { createFastifyInstance } from "@/server";
+import { describe, expect, test, vi } from "@/test";
+import { DocReviewModel, KbDocumentModel, KnowledgeBaseConnectorModel } from "@/models";
+import type { User } from "@/types";
+
+// Mock task queue service enqueue
+vi.mock("@/task-queue", () => ({
+  taskQueueService: {
+    enqueue: vi.fn().mockResolvedValue("mock-task-id"),
+  },
+}));
+
+async function buildApp(user: User, organizationId: string) {
+  const app = createFastifyInstance();
+  app.addHook("onRequest", async (request) => {
+    (request as typeof request & { user: unknown }).user = user;
+    (request as typeof request & { organizationId: string }).organizationId =
+      organizationId;
+  });
+
+  const { default: docReviewRoutes } = await import("./doc-review.ee");
+  await app.register(docReviewRoutes);
+  return app;
+}
+
+describe("DocReview REST Routes", () => {
+  const orgId = "org-doc-review-test";
+  const user: User = {
+    id: "user-1",
+    email: "user1@example.com",
+    name: "User 1",
+    role: "admin",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  test("POST /api/doc-reviews creates a review table and enqueues task", async () => {
+    const connector = await KnowledgeBaseConnectorModel.create({
+      organizationId: orgId,
+      name: "Test Connector",
+      connectorType: "web-scraper",
+      config: { url: "https://example.com" },
+    });
+
+    const doc1 = await KbDocumentModel.create({
+      organizationId: orgId,
+      connectorId: connector.id,
+      title: "Vendor Questionnaire A",
+      content: "Data residency region is US-East. SSO is supported via SAML. Breach notice is 72h.",
+      contentHash: "hash-1",
+      acl: [],
+    });
+
+    const doc2 = await KbDocumentModel.create({
+      organizationId: orgId,
+      connectorId: connector.id,
+      title: "Vendor Questionnaire B",
+      content: "Data residency region is EU-West. SSO is not supported. Breach notice is 24h.",
+      contentHash: "hash-2",
+      acl: [],
+    });
+
+    const app = await buildApp(user, orgId);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/doc-reviews",
+      payload: {
+        name: "Security Audit Q3",
+        description: "Review vendor questionnaires",
+        columns: [
+          {
+            id: "col-1",
+            title: "Data Residency",
+            prompt: "What is the data residency region?",
+            outputFormat: "text",
+          },
+          {
+            id: "col-2",
+            title: "SSO Supported",
+            prompt: "Is SSO supported?",
+            outputFormat: "yes_no",
+          },
+        ],
+        documentIds: [doc1.id, doc2.id],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.review).toBeDefined();
+    expect(body.review.name).toBe("Security Audit Q3");
+    expect(body.review.totalRows).toBe(2);
+    expect(body.review.totalCells).toBe(4);
+  });
+
+  test("GET /api/doc-reviews lists reviews and GET /api/doc-reviews/:id/grid fetches matrix", async () => {
+    const review = await DocReviewModel.create({
+      organizationId: orgId,
+      createdById: user.id,
+      name: "List Test Review",
+      columns: [
+        {
+          id: "col-1",
+          title: "Breach Window",
+          prompt: "What is the breach notice window?",
+          outputFormat: "text",
+        },
+      ],
+      documentIds: [],
+    });
+
+    const app = await buildApp(user, orgId);
+
+    const listRes = await app.inject({
+      method: "GET",
+      url: "/api/doc-reviews",
+    });
+
+    expect(listRes.statusCode).toBe(200);
+    const listBody = listRes.json();
+    expect(listBody.reviews.some((r: any) => r.id === review.id)).toBe(true);
+
+    const gridRes = await app.inject({
+      method: "GET",
+      url: `/api/doc-reviews/${review.id}/grid`,
+    });
+
+    expect(gridRes.statusCode).toBe(200);
+    const gridBody = gridRes.json();
+    expect(gridBody.review.id).toBe(review.id);
+    expect(gridBody.columns.length).toBe(1);
+  });
+
+  test("GET /api/doc-reviews/:id/export exports CSV", async () => {
+    const review = await DocReviewModel.create({
+      organizationId: orgId,
+      createdById: user.id,
+      name: "Export Test Review",
+      columns: [
+        {
+          id: "c1",
+          title: "Field A",
+          prompt: "Extract Field A",
+          outputFormat: "text",
+        },
+      ],
+      documentIds: [],
+    });
+
+    const app = await buildApp(user, orgId);
+
+    const exportRes = await app.inject({
+      method: "GET",
+      url: `/api/doc-reviews/${review.id}/export?format=csv`,
+    });
+
+    expect(exportRes.statusCode).toBe(200);
+    expect(exportRes.headers["content-type"]).toContain("text/csv");
+    expect(exportRes.payload).toContain("Document Title");
+    expect(exportRes.payload).toContain("Field A");
+  });
+});

--- a/platform/backend/src/routes/index.ts
+++ b/platform/backend/src/routes/index.ts
@@ -16,6 +16,7 @@ export { default as chatopsRoutes } from "./chatops";
 export { default as configRoutes } from "./config";
 export { default as connectionSetupRoutes } from "./connection-setup/connection-setup.routes";
 export { default as defaultUserLimitRoutes } from "./default-user-limit";
+export { default as docReviewRoutes } from "./doc-review.ee";
 export { default as environmentRoutes } from "./environment";
 export { default as githubAppConfigRoutes } from "./github-app-config";
 export { default as githubCopilotAuthRoutes } from "./github-copilot-auth/github-copilot-auth.routes";

--- a/platform/backend/src/routes/knowledge-base.ts
+++ b/platform/backend/src/routes/knowledge-base.ts
@@ -553,6 +553,48 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
   );
 
+  fastify.get(
+    "/api/knowledge-bases/:id/documents",
+    {
+      schema: {
+        description: "List paginated documents in a knowledge base",
+        tags: ["Knowledge Bases"],
+        params: z.object({ id: z.string() }),
+        querystring: z.object({
+          limit: z.coerce.number().optional().default(50),
+          offset: z.coerce.number().optional().default(0),
+          search: z.string().optional(),
+        }),
+      },
+    },
+    async ({ params: { id }, query: { limit, offset, search }, organizationId, user }, reply) => {
+      await findKnowledgeBaseOrThrow({
+        id,
+        organizationId,
+        userId: user.id,
+      });
+
+      const documents = await KbDocumentModel.findByKnowledgeBase({
+        knowledgeBaseId: id,
+        limit,
+        offset,
+        search,
+      });
+
+      return reply.send({
+        documents: documents.map((doc) => ({
+          id: doc.id,
+          title: doc.title,
+          sourceUrl: doc.sourceUrl,
+          connectorId: doc.connectorId,
+          createdAt: doc.createdAt,
+          updatedAt: doc.updatedAt,
+        })),
+        pagination: calculatePaginationMeta(documents.length, { limit, offset }),
+      });
+    },
+  );
+
   // ===== Standalone Connector Endpoints =====
 
   fastify.get(

--- a/platform/backend/src/task-queue/handlers/doc-review-handler.ee.ts
+++ b/platform/backend/src/task-queue/handlers/doc-review-handler.ee.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+import { executeReviewCell } from "@/knowledge-base/doc-review-runner.ee";
+import logger from "@/logging";
+import { DocReviewModel, KbDocumentModel } from "@/models";
+import type { TaskHandlerContext } from "@/types";
+
+const BATCH_SIZE = 5;
+
+export async function handleDocReviewRun(
+  payload: Record<string, unknown>,
+  _context?: TaskHandlerContext,
+): Promise<void> {
+  const reviewId = payload.reviewId as string;
+  if (!reviewId) {
+    throw new Error("Missing reviewId in doc_review_run payload");
+  }
+
+  const rowIds = await DocReviewModel.findPendingCellRows(reviewId);
+  if (rowIds.length === 0) {
+    logger.info({ reviewId }, "[DocReviewHandler] No pending rows for review run");
+    return;
+  }
+
+  // Import task queue service dynamically or pass task enqueuing
+  const { taskQueueService } = await import("@/task-queue");
+
+  // Chunk rowIds into batch tasks
+  for (let i = 0; i < rowIds.length; i += BATCH_SIZE) {
+    const chunk = rowIds.slice(i, i + BATCH_SIZE);
+    await taskQueueService.enqueue({
+      taskType: "doc_review_batch",
+      payload: {
+        reviewId,
+        rowIds: chunk,
+      },
+    });
+  }
+
+  logger.info(
+    { reviewId, totalRows: rowIds.length, batches: Math.ceil(rowIds.length / BATCH_SIZE) },
+    "[DocReviewHandler] Enqueued doc_review_batch tasks",
+  );
+}
+
+export async function handleDocReviewBatch(
+  payload: Record<string, unknown>,
+  _context?: TaskHandlerContext,
+): Promise<void> {
+  const reviewId = payload.reviewId as string;
+  const rowIds = payload.rowIds as string[];
+
+  if (!reviewId || !rowIds?.length) {
+    throw new Error("Missing reviewId or rowIds in doc_review_batch payload");
+  }
+
+  for (const rowId of rowIds) {
+    const cells = await DocReviewModel.findCellsByRow(rowId);
+    if (!cells.length) continue;
+
+    for (const cell of cells) {
+      if (cell.status === "completed") continue; // Skip completed cells! Resumability!
+
+      try {
+        const doc = await KbDocumentModel.findById(cell.documentId);
+        if (!doc) {
+          await DocReviewModel.failCell(cell.id, "Document not found");
+          continue;
+        }
+
+        // Find matching column definition from review columns
+        const [gridData] = await Promise.all([
+          DocReviewModel.findGrid(reviewId, doc.organizationId),
+        ]);
+
+        const column = gridData?.columns.find((c) => c.id === cell.columnId);
+        if (!column) {
+          await DocReviewModel.failCell(cell.id, `Column ${cell.columnId} not found`);
+          continue;
+        }
+
+        const result = await executeReviewCell({
+          organizationId: doc.organizationId,
+          document: doc,
+          column,
+        });
+
+        await DocReviewModel.completeCell(cell.id, {
+          value: result.value,
+          citations: result.citations,
+          tokensUsed: result.tokensUsed,
+        });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.error(
+          { cellId: cell.id, error: msg },
+          "[DocReviewHandler] Cell execution failed",
+        );
+        await DocReviewModel.failCell(cell.id, msg);
+      }
+    }
+  }
+}

--- a/platform/backend/src/task-queue/handlers/index.ts
+++ b/platform/backend/src/task-queue/handlers/index.ts
@@ -16,10 +16,18 @@ import { handleScheduleTriggerRunExecution } from "./schedule-trigger-run-handle
 import { handleSkillGithubSync } from "./skill-github-sync-handler";
 import { handleSkillPublicationBackfill } from "./skill-publication-backfill-handler";
 
+// biome-ignore lint/style/noRestrictedImports: dual-licensed, enterprise review feature
+import {
+  handleDocReviewBatch,
+  handleDocReviewRun,
+} from "./doc-review-handler.ee";
+
 export function registerTaskHandlers(taskQueueService: TaskQueueService): void {
   taskQueueService.registerHandler("connector_sync", handleConnectorSync);
   taskQueueService.registerHandler("batch_embedding", handleBatchEmbedding);
   taskQueueService.registerHandler("permission_sync", handlePermissionSync);
+  taskQueueService.registerHandler("doc_review_run", handleDocReviewRun);
+  taskQueueService.registerHandler("doc_review_batch", handleDocReviewBatch);
   taskQueueService.registerHandler(
     "check_due_connectors",
     handleCheckDueConnectors,

--- a/platform/backend/src/task-queue/task-queue.ts
+++ b/platform/backend/src/task-queue/task-queue.ts
@@ -16,6 +16,7 @@ export class TaskQueueService {
   private laneCounts: Record<TaskLane, number> = {
     content: 0,
     permission: 0,
+    review: 0,
     system: 0,
   };
   private taskLane = new Map<string, TaskLane>();
@@ -291,6 +292,8 @@ export class TaskQueueService {
         return config.kb.taskWorkerMaxConcurrent;
       case "permission":
         return config.kb.permissionSyncWorkerMaxConcurrent;
+      case "review":
+        return config.kb.docReviewWorkerMaxConcurrent;
       case "system":
         return SYSTEM_LANE_MAX_CONCURRENT;
     }

--- a/platform/backend/src/types/task.ts
+++ b/platform/backend/src/types/task.ts
@@ -24,6 +24,8 @@ export const TaskTypeSchema = z.enum([
   "connector_sync",
   "batch_embedding",
   "permission_sync",
+  "doc_review_run",
+  "doc_review_batch",
   "check_due_connectors",
   "check_due_permission_syncs",
   "check_due_schedule_triggers",
@@ -49,6 +51,13 @@ export type BatchEmbeddingPayload = {
 export type PermissionSyncPayload = {
   connectorId: string;
 };
+export type DocReviewRunPayload = {
+  reviewId: string;
+};
+export type DocReviewBatchPayload = {
+  reviewId: string;
+  rowIds: string[];
+};
 export type SkillGithubSyncPayload = {
   skillId: string;
 };
@@ -65,6 +74,7 @@ export type SkillGithubSyncPayload = {
 export const TASK_LANES = {
   content: ["connector_sync", "batch_embedding"],
   permission: ["permission_sync"],
+  review: ["doc_review_run", "doc_review_batch"],
   system: [
     "check_due_connectors",
     "check_due_permission_syncs",

--- a/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.tsx
@@ -62,4 +62,5 @@ export function KnowledgePageLayout({
 const KNOWLEDGE_TABS = [
   { label: "Connectors", href: "/knowledge/connectors" },
   { label: "Knowledge Bases", href: "/knowledge/knowledge-bases" },
+  { label: "Document Reviews", href: "/knowledge/reviews" },
 ];

--- a/platform/frontend/src/app/knowledge/reviews/page.tsx
+++ b/platform/frontend/src/app/knowledge/reviews/page.tsx
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { Table as TableIcon } from "lucide-react";
+import { CreateDocReviewModal } from "@/components/knowledge/create-doc-review-modal.ee";
+import { DocReviewGrid, type DocReviewGridData } from "@/components/knowledge/doc-review-grid.ee";
+import { KnowledgePageLayout } from "@/app/knowledge/_parts/knowledge-page-layout";
+import { Card, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+
+export default function DocumentReviewsPage() {
+  const [reviews, setReviews] = useState<any[]>([]);
+  const [knowledgeBases, setKnowledgeBases] = useState<any[]>([]);
+  const [activeReviewId, setActiveReviewId] = useState<string | null>(null);
+  const [activeGridData, setActiveGridData] = useState<DocReviewGridData | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const fetchReviews = async () => {
+    try {
+      const res = await fetch("/api/doc-reviews");
+      if (res.ok) {
+        const data = await res.json();
+        setReviews(data.reviews ?? []);
+      }
+    } catch {
+      setReviews([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchKnowledgeBases = async () => {
+    try {
+      const res = await fetch("/api/knowledge-bases");
+      if (res.ok) {
+        const data = await res.json();
+        setKnowledgeBases(data.knowledgeBases ?? []);
+      }
+    } catch {
+      setKnowledgeBases([]);
+    }
+  };
+
+  const fetchGridData = async (reviewId: string) => {
+    try {
+      const res = await fetch(`/api/doc-reviews/${reviewId}/grid`);
+      if (res.ok) {
+        const data = await res.json();
+        setActiveGridData(data);
+      }
+    } catch {
+      setActiveGridData(null);
+    }
+  };
+
+  useEffect(() => {
+    fetchReviews();
+    fetchKnowledgeBases();
+  }, []);
+
+  useEffect(() => {
+    if (activeReviewId) {
+      fetchGridData(activeReviewId);
+      // Auto-poll grid data every 4s if running
+      const interval = setInterval(() => {
+        fetchGridData(activeReviewId);
+      }, 4000);
+      return () => clearInterval(interval);
+    }
+  }, [activeReviewId]);
+
+  const handleCreateReview = async (params: any) => {
+    const res = await fetch("/api/doc-reviews", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      await fetchReviews();
+      setActiveReviewId(data.review.id);
+    }
+  };
+
+  const handleResumeRun = async (reviewId: string) => {
+    await fetch(`/api/doc-reviews/${reviewId}/resume`, { method: "POST" });
+    if (activeReviewId === reviewId) {
+      fetchGridData(reviewId);
+    }
+    fetchReviews();
+  };
+
+  const handleRetryCell = async (cellId: string) => {
+    if (!activeReviewId) return;
+    await fetch(`/api/doc-reviews/${activeReviewId}/cells/${cellId}/retry`, {
+      method: "POST",
+    });
+    fetchGridData(activeReviewId);
+  };
+
+  return (
+    <KnowledgePageLayout
+      title="Document Reviews"
+      description="Execute structured question sets across documents in bulk and inspect tabular matrix results."
+      createLabel="New Review Table"
+      onCreateClick={() => setIsModalOpen(true)}
+      isPending={loading}
+    >
+      {activeReviewId && activeGridData ? (
+        <div className="space-y-4">
+          <button
+            onClick={() => {
+              setActiveReviewId(null);
+              setActiveGridData(null);
+            }}
+            className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 font-medium"
+          >
+            ← Back to Review Tables List
+          </button>
+          <DocReviewGrid
+            data={activeGridData}
+            onRefresh={() => fetchGridData(activeReviewId)}
+            onResume={() => handleResumeRun(activeReviewId)}
+            onRetryCell={handleRetryCell}
+          />
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {reviews.length === 0 ? (
+            <Card className="border-dashed">
+              <CardContent className="flex flex-col items-center justify-center py-12 text-center space-y-3">
+                <div className="p-3 bg-muted rounded-full">
+                  <TableIcon className="h-6 w-6 text-muted-foreground" />
+                </div>
+                <div className="space-y-1">
+                  <h3 className="text-base font-semibold">No Document Reviews Yet</h3>
+                  <p className="text-sm text-muted-foreground max-w-sm">
+                    Create a review table to extract structured fields across hundreds of documents simultaneously.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {reviews.map((rev) => {
+                const percent = rev.totalCells > 0
+                  ? Math.round((rev.completedCells / rev.totalCells) * 100)
+                  : 0;
+
+                return (
+                  <Card
+                    key={rev.id}
+                    className="hover:border-primary/50 transition-colors cursor-pointer"
+                    onClick={() => setActiveReviewId(rev.id)}
+                  >
+                    <CardContent className="p-5 space-y-3">
+                      <div className="flex justify-between items-start gap-2">
+                        <h4 className="font-semibold text-base line-clamp-1">{rev.name}</h4>
+                        <span className="text-[11px] uppercase font-semibold px-2 py-0.5 rounded bg-muted">
+                          {rev.status}
+                        </span>
+                      </div>
+                      {rev.description && (
+                        <p className="text-xs text-muted-foreground line-clamp-2">
+                          {rev.description}
+                        </p>
+                      )}
+                      <div className="space-y-1 pt-2">
+                        <div className="flex justify-between text-xs text-muted-foreground">
+                          <span>Progress</span>
+                          <span>{rev.completedCells} / {rev.totalCells} cells</span>
+                        </div>
+                        <Progress value={percent} className="h-1.5" />
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      <CreateDocReviewModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        knowledgeBases={knowledgeBases}
+        onSubmit={handleCreateReview}
+      />
+    </KnowledgePageLayout>
+  );
+}

--- a/platform/frontend/src/components/knowledge/create-doc-review-modal.ee.tsx
+++ b/platform/frontend/src/components/knowledge/create-doc-review-modal.ee.tsx
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+"use client";
+
+import { useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+export type ColumnInput = {
+  id: string;
+  title: string;
+  prompt: string;
+  outputFormat: "text" | "yes_no" | "date" | "number" | "list" | "json";
+};
+
+export function CreateDocReviewModal({
+  isOpen,
+  onClose,
+  knowledgeBases,
+  onSubmit,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  knowledgeBases: { id: string; name: string }[];
+  onSubmit: (params: {
+    name: string;
+    description?: string;
+    knowledgeBaseId?: string;
+    columns: ColumnInput[];
+    documentIds: string[];
+  }) => Promise<void>;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [selectedKbId, setSelectedKbId] = useState<string>("");
+  const [documents, setDocuments] = useState<{ id: string; title: string }[]>([]);
+  const [selectedDocIds, setSelectedDocIds] = useState<string[]>([]);
+  const [loadingDocs, setLoadingDocs] = useState(false);
+  const [columns, setColumns] = useState<ColumnInput[]>([
+    {
+      id: "col-1",
+      title: "Key Takeaway",
+      prompt: "What is the primary conclusion or root cause?",
+      outputFormat: "text",
+    },
+  ]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleKbChange = async (kbId: string) => {
+    setSelectedKbId(kbId);
+    setLoadingDocs(true);
+    try {
+      const res = await fetch(`/api/knowledge-bases/${kbId}/documents`);
+      if (res.ok) {
+        const data = await res.json();
+        const docs = data.documents ?? [];
+        setDocuments(docs);
+        setSelectedDocIds(docs.map((d: any) => d.id)); // Default select all
+      }
+    } catch {
+      setDocuments([]);
+    } finally {
+      setLoadingDocs(false);
+    }
+  };
+
+  const addColumn = () => {
+    const nextId = `col-${columns.length + 1}`;
+    setColumns([
+      ...columns,
+      {
+        id: nextId,
+        title: "",
+        prompt: "",
+        outputFormat: "text",
+      },
+    ]);
+  };
+
+  const removeColumn = (id: string) => {
+    setColumns(columns.filter((c) => c.id !== id));
+  };
+
+  const updateColumn = (id: string, updates: Partial<ColumnInput>) => {
+    setColumns(
+      columns.map((c) => (c.id === id ? { ...c, ...updates } : c)),
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || columns.length === 0 || selectedDocIds.length === 0) return;
+
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        name,
+        description: description || undefined,
+        knowledgeBaseId: selectedKbId || undefined,
+        columns,
+        documentIds: selectedDocIds,
+      });
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create Bulk Document Review</DialogTitle>
+            <DialogDescription>
+              Define a question schema across a set of documents to execute in bulk.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="review-name">Review Title</Label>
+              <Input
+                id="review-name"
+                placeholder="e.g. Vendor Security Questionnaire Audit Q3"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="review-desc">Description (Optional)</Label>
+              <Textarea
+                id="review-desc"
+                placeholder="Brief description of the review objective..."
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={2}
+              />
+            </div>
+
+            {/* Knowledge Base Selection */}
+            <div className="space-y-1.5">
+              <Label>Source Knowledge Base</Label>
+              <Select value={selectedKbId} onValueChange={handleKbChange}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select Knowledge Base..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {knowledgeBases.map((kb) => (
+                    <SelectItem key={kb.id} value={kb.id}>
+                      {kb.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {selectedKbId && (
+              <div className="bg-muted p-3 rounded-md space-y-2 text-xs">
+                <div className="flex justify-between items-center font-medium text-foreground">
+                  <span>Target Documents ({selectedDocIds.length} of {documents.length} selected)</span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 text-[11px]"
+                    onClick={() =>
+                      setSelectedDocIds(
+                        selectedDocIds.length === documents.length
+                          ? []
+                          : documents.map((d) => d.id),
+                      )
+                    }
+                  >
+                    {selectedDocIds.length === documents.length ? "Deselect All" : "Select All"}
+                  </Button>
+                </div>
+                {loadingDocs ? (
+                  <p className="text-muted-foreground italic">Loading KB documents...</p>
+                ) : documents.length === 0 ? (
+                  <p className="text-muted-foreground">No documents found in this Knowledge Base.</p>
+                ) : (
+                  <div className="max-h-32 overflow-y-auto space-y-1 pr-1">
+                    {documents.map((doc) => (
+                      <label key={doc.id} className="flex items-center gap-2 cursor-pointer hover:bg-background/50 p-1 rounded">
+                        <input
+                          type="checkbox"
+                          checked={selectedDocIds.includes(doc.id)}
+                          onChange={(e) => {
+                            if (e.target.checked) {
+                              setSelectedDocIds([...selectedDocIds, doc.id]);
+                            } else {
+                              setSelectedDocIds(selectedDocIds.filter((id) => id !== doc.id));
+                            }
+                          }}
+                        />
+                        <span className="truncate">{doc.title}</span>
+                      </label>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Column Schema Definition */}
+            <div className="space-y-3 pt-2">
+              <div className="flex items-center justify-between">
+                <Label className="font-semibold text-sm">Review Questions / Columns</Label>
+                <Button type="button" variant="outline" size="sm" onClick={addColumn}>
+                  <Plus className="h-3.5 w-3.5 mr-1" />
+                  Add Column
+                </Button>
+              </div>
+
+              <div className="space-y-3">
+                {columns.map((col, index) => (
+                  <div key={col.id} className="border rounded-md p-3 space-y-2 bg-card relative">
+                    <div className="flex items-center justify-between gap-2">
+                      <Input
+                        placeholder={`Column Title (e.g. Field ${index + 1})`}
+                        value={col.title}
+                        onChange={(e) => updateColumn(col.id, { title: e.target.value })}
+                        className="h-8 text-sm font-medium"
+                        required
+                      />
+                      <Select
+                        value={col.outputFormat}
+                        onValueChange={(val: any) => updateColumn(col.id, { outputFormat: val })}
+                      >
+                        <SelectTrigger className="w-[140px] h-8 text-xs">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="text">Text</SelectItem>
+                          <SelectItem value="yes_no">Yes / No</SelectItem>
+                          <SelectItem value="date">Date</SelectItem>
+                          <SelectItem value="number">Number</SelectItem>
+                          <SelectItem value="list">List</SelectItem>
+                          <SelectItem value="json">JSON</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      {columns.length > 1 && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 w-8 p-0 text-destructive"
+                          onClick={() => removeColumn(col.id)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                    <Textarea
+                      placeholder="Prompt / Question instruction for model..."
+                      value={col.prompt}
+                      onChange={(e) => updateColumn(col.id, { prompt: e.target.value })}
+                      className="text-xs"
+                      rows={2}
+                      required
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={submitting || !name.trim() || selectedDocIds.length === 0}
+            >
+              {submitting ? "Launching Run..." : "Launch Review Run"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/platform/frontend/src/components/knowledge/doc-review-grid.ee.tsx
+++ b/platform/frontend/src/components/knowledge/doc-review-grid.ee.tsx
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+// SPDX-FileCopyrightText: 2026 Archestra Inc.
+
+"use client";
+
+import { useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Download,
+  ExternalLink,
+  Loader2,
+  Play,
+  RefreshCw,
+  Search,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export type DocReviewCitation = {
+  quote: string;
+  ref?: string;
+  documentId?: string;
+  title?: string;
+  sourceUrl?: string | null;
+};
+
+export type DocReviewGridCell = {
+  id: string;
+  rowId: string;
+  columnId: string;
+  documentId: string;
+  status: "pending" | "generating" | "completed" | "error";
+  value: unknown;
+  citations: DocReviewCitation[];
+  error?: string | null;
+  tokensUsed?: number | null;
+};
+
+export type DocReviewGridRow = {
+  id: string;
+  documentId: string;
+  documentTitle: string;
+  documentSourceUrl?: string | null;
+  status: "pending" | "processing" | "completed" | "failed";
+  cells: Record<string, DocReviewGridCell>;
+};
+
+export type DocReviewColumn = {
+  id: string;
+  title: string;
+  prompt: string;
+  outputFormat: "text" | "yes_no" | "date" | "number" | "list" | "json";
+};
+
+export type DocReviewGridData = {
+  review: {
+    id: string;
+    name: string;
+    description?: string | null;
+    status: "pending" | "running" | "completed" | "failed" | "cancelled";
+    totalRows: number;
+    completedRows: number;
+    totalCells: number;
+    completedCells: number;
+    failedCells: number;
+  };
+  columns: DocReviewColumn[];
+  rows: DocReviewGridRow[];
+};
+
+export function DocReviewGrid({
+  data,
+  onRefresh,
+  onResume,
+  onRetryCell,
+}: {
+  data: DocReviewGridData;
+  onRefresh: () => void;
+  onResume: () => void;
+  onRetryCell: (cellId: string) => void;
+}) {
+  const { review, columns, rows } = data;
+  const [search, setSearch] = useState("");
+  const [selectedCell, setSelectedCell] = useState<{
+    cell: DocReviewGridCell;
+    column: DocReviewColumn;
+    row: DocReviewGridRow;
+  } | null>(null);
+
+  const filteredRows = rows.filter((r) =>
+    r.documentTitle.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const progressPercent = review.totalCells > 0
+    ? Math.round((review.completedCells / review.totalCells) * 100)
+    : 0;
+
+  const handleExport = (format: "csv" | "json") => {
+    window.open(`/api/doc-reviews/${review.id}/export?format=${format}`, "_blank");
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Header & Controls */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 bg-card p-4 border rounded-lg">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight">{review.name}</h2>
+          {review.description && (
+            <p className="text-sm text-muted-foreground">{review.description}</p>
+          )}
+          <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
+            <span>Progress: {review.completedCells} / {review.totalCells} cells ({progressPercent}%)</span>
+            <Badge
+              variant={
+                review.status === "completed"
+                  ? "default"
+                  : review.status === "running"
+                  ? "secondary"
+                  : "outline"
+              }
+            >
+              {review.status}
+            </Badge>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 flex-wrap">
+          <Button variant="outline" size="sm" onClick={onRefresh}>
+            <RefreshCw className="h-4 w-4 mr-1" />
+            Refresh
+          </Button>
+          {(review.status === "failed" || review.status === "pending" || review.failedCells > 0) && (
+            <Button variant="default" size="sm" onClick={onResume}>
+              <Play className="h-4 w-4 mr-1" />
+              Resume Run
+            </Button>
+          )}
+          <Button variant="outline" size="sm" onClick={() => handleExport("csv")}>
+            <Download className="h-4 w-4 mr-1" />
+            Export CSV
+          </Button>
+        </div>
+      </div>
+
+      <Progress value={progressPercent} className="h-2" />
+
+      {/* Filter Bar */}
+      <div className="flex items-center gap-2 max-w-sm">
+        <Search className="h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Filter by document title..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="h-8 text-sm"
+        />
+      </div>
+
+      {/* Matrix Table */}
+      <div className="border rounded-md overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[280px] min-w-[240px] font-semibold">Document</TableHead>
+              {columns.map((col) => (
+                <TableHead key={col.id} className="min-w-[200px] font-semibold">
+                  <div>
+                    {col.title}
+                    <span className="block text-[10px] text-muted-foreground font-normal uppercase">
+                      {col.outputFormat}
+                    </span>
+                  </div>
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredRows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={columns.length + 1} className="text-center py-8 text-muted-foreground">
+                  No documents in this review run matching filter.
+                </TableCell>
+              </TableRow>
+            ) : (
+              filteredRows.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell className="font-medium truncate max-w-[280px]">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate">{row.documentTitle}</span>
+                      {row.documentSourceUrl && (
+                        <a
+                          href={row.documentSourceUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-muted-foreground hover:text-foreground shrink-0"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      )}
+                    </div>
+                  </TableCell>
+
+                  {columns.map((col) => {
+                    const cell = row.cells[col.id];
+                    return (
+                      <TableCell
+                        key={col.id}
+                        className="cursor-pointer hover:bg-muted/50 transition-colors p-3"
+                        onClick={() =>
+                          cell && setSelectedCell({ cell, column: col, row })
+                        }
+                      >
+                        {!cell || cell.status === "pending" ? (
+                          <span className="text-xs text-muted-foreground flex items-center gap-1">
+                            <span className="h-2 w-2 rounded-full bg-slate-300 dark:bg-slate-700" />
+                            Pending
+                          </span>
+                        ) : cell.status === "generating" ? (
+                          <span className="text-xs text-blue-600 dark:text-blue-400 flex items-center gap-1">
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                            Generating
+                          </span>
+                        ) : cell.status === "error" ? (
+                          <span className="text-xs text-destructive flex items-center gap-1">
+                            <AlertCircle className="h-3.5 w-3.5" />
+                            Error
+                          </span>
+                        ) : (
+                          <div className="space-y-1">
+                            <div className="text-sm font-medium text-foreground truncate max-w-[240px]">
+                              {typeof cell.value === "boolean"
+                                ? cell.value ? "Yes" : "No"
+                                : Array.isArray(cell.value)
+                                ? cell.value.join(", ")
+                                : String(cell.value ?? "")}
+                            </div>
+                            {cell.citations.length > 0 && (
+                              <span className="inline-flex items-center text-[10px] text-emerald-600 dark:text-emerald-400 gap-0.5">
+                                <CheckCircle2 className="h-3 w-3" />
+                                {cell.citations.length} quote{cell.citations.length > 1 ? "s" : ""}
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Cell Detail Inspection Drawer */}
+      <Sheet open={!!selectedCell} onOpenChange={() => setSelectedCell(null)}>
+        {selectedCell && (
+          <SheetContent className="sm:max-w-lg overflow-y-auto space-y-6">
+            <SheetHeader>
+              <SheetTitle>{selectedCell.column.title}</SheetTitle>
+              <SheetDescription>
+                Document: {selectedCell.row.documentTitle}
+              </SheetDescription>
+            </SheetHeader>
+
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs font-semibold text-muted-foreground uppercase tracking-wider block mb-1">
+                  Question / Prompt
+                </label>
+                <p className="text-sm text-foreground bg-muted p-2.5 rounded-md">
+                  {selectedCell.column.prompt}
+                </p>
+              </div>
+
+              <div>
+                <label className="text-xs font-semibold text-muted-foreground uppercase tracking-wider block mb-1">
+                  Status
+                </label>
+                <div className="flex items-center gap-2">
+                  <Badge variant={selectedCell.cell.status === "completed" ? "default" : "destructive"}>
+                    {selectedCell.cell.status}
+                  </Badge>
+                  {selectedCell.cell.status === "error" && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        onRetryCell(selectedCell.cell.id);
+                        setSelectedCell(null);
+                      }}
+                    >
+                      <RefreshCw className="h-3.5 w-3.5 mr-1" />
+                      Retry Cell
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              {selectedCell.cell.error && (
+                <div>
+                  <label className="text-xs font-semibold text-destructive uppercase tracking-wider block mb-1">
+                    Error Log
+                  </label>
+                  <p className="text-xs text-destructive bg-destructive/10 p-2.5 rounded-md font-mono">
+                    {selectedCell.cell.error}
+                  </p>
+                </div>
+              )}
+
+              {selectedCell.cell.status === "completed" && (
+                <div>
+                  <label className="text-xs font-semibold text-muted-foreground uppercase tracking-wider block mb-1">
+                    Extracted Answer ({selectedCell.column.outputFormat})
+                  </label>
+                  <div className="text-sm bg-card border p-3 rounded-md font-medium text-foreground whitespace-pre-wrap">
+                    {typeof selectedCell.cell.value === "object"
+                      ? JSON.stringify(selectedCell.cell.value, null, 2)
+                      : String(selectedCell.cell.value ?? "")}
+                  </div>
+                </div>
+              )}
+
+              {selectedCell.cell.citations.length > 0 && (
+                <div>
+                  <label className="text-xs font-semibold text-muted-foreground uppercase tracking-wider block mb-2">
+                    Source Citations & Quotes
+                  </label>
+                  <div className="space-y-2">
+                    {selectedCell.cell.citations.map((cit, idx) => (
+                      <div key={idx} className="bg-emerald-500/5 border border-emerald-500/20 p-2.5 rounded-md text-xs space-y-1">
+                        <p className="italic text-foreground">"{cit.quote}"</p>
+                        {cit.sourceUrl && (
+                          <a
+                            href={cit.sourceUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-[11px] text-emerald-600 hover:underline flex items-center gap-1"
+                          >
+                            Source link <ExternalLink className="h-3 w-3" />
+                          </a>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </SheetContent>
+        )}
+      </Sheet>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements the Document Reviews UI:

- **Navigation tab**: "Document Reviews" added to the Knowledge section tabs
- **Creation wizard**: Modal to select knowledge base documents and define column prompts with typed output formats
- **Spreadsheet grid**: Matrix view — documents as rows, questions as columns — with live cell status badges, citation inspector drawer, single-cell retry, and CSV export
- **Dashboard page**: `/knowledge/reviews` listing all review runs with progress bars
