### PR TITLE
fix(llm-providers): make the key dialog's endpoint field say what it means and sit where it belongs

### DIFF
--- a/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
@@ -453,17 +453,93 @@ describe("LlmProviderApiKeyForm", () => {
       );
     });
 
-    it("treats a server-wide vLLM endpoint as the default", async () => {
+    it("treats a server-wide vLLM endpoint as an overridable default", async () => {
       vi.mocked(useProviderBaseUrls).mockReturnValue({
         data: { vllm: "http://vllm:8000/v1" },
       } as unknown as ReturnType<typeof useProviderBaseUrls>);
 
       renderForm({ defaults: { provider: "vllm" }, progressive: true });
 
+      // The deployment's endpoint answers "where", so the field stops being
+      // required — but a second vLLM server is added by overriding it per key,
+      // so it stays visible with the inherited URL as its placeholder.
+      await waitFor(() => {
+        expect(screen.getByText("Base URL")).toBeInTheDocument();
+      });
+      expect(screen.getByText("Base URL").textContent).toContain("optional");
+      expect(
+        screen.getByLabelText(/Base URL/).getAttribute("placeholder"),
+      ).toBe("http://vllm:8000/v1");
+    });
+  });
+
+  describe("Base URL placement", () => {
+    /**
+     * A field rendered after the "Advanced settings" disclosure reads as part
+     * of it. For providers where the endpoint *is* the credential, that hid
+     * the one field the key cannot work without.
+     */
+    function baseUrlPrecedesAdvancedSettings(): boolean {
+      const baseUrl = screen.getByText("Base URL");
+      const advanced = screen.getByRole("button", {
+        name: /Advanced settings/,
+      });
+      return Boolean(
+        baseUrl.compareDocumentPosition(advanced) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    }
+
+    it.each([
+      "vllm",
+      "ollama",
+      "ollama-native",
+      "archestra",
+    ] as const)("shows the endpoint above Advanced settings for %s", async (provider) => {
+      renderForm({ defaults: { provider }, progressive: true });
+
+      await waitFor(() => {
+        expect(screen.getByText("Base URL")).toBeInTheDocument();
+      });
+      expect(baseUrlPrecedesAdvancedSettings()).toBe(true);
+    });
+
+    it("keeps the endpoint inside Advanced settings for a cloud provider", async () => {
+      const user = userEvent.setup();
+      renderForm({ defaults: { provider: "openai" }, progressive: true });
+
       await waitFor(() => {
         expect(screen.getByLabelText(/Name/)).toBeInTheDocument();
       });
       expect(screen.queryByText("Base URL")).not.toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole("button", { name: /Advanced settings/ }),
+      );
+      expect(baseUrlPrecedesAdvancedSettings()).toBe(false);
+    });
+
+    it("puts the Bedrock region above Advanced settings and its endpoint inside", async () => {
+      const user = userEvent.setup();
+      renderForm({ defaults: { provider: "bedrock" }, progressive: true });
+
+      await waitFor(() => {
+        expect(screen.getByText("Region")).toBeInTheDocument();
+      });
+      const advanced = screen.getByRole("button", {
+        name: /Advanced settings/,
+      });
+      expect(
+        screen.getByText("Region").compareDocumentPosition(advanced) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+
+      expect(screen.queryByText("Custom endpoint")).not.toBeInTheDocument();
+      await user.click(advanced);
+      expect(
+        screen.getByText("Custom endpoint").compareDocumentPosition(advanced) &
+          Node.DOCUMENT_POSITION_PRECEDING,
+      ).toBeTruthy();
     });
   });
 

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -495,6 +495,17 @@ export function LlmProviderApiKeyForm({
       : providerConfig.name;
   const isBaseUrlRequired =
     providerConfig.baseUrlRequired && !providerBaseUrls?.[provider];
+  /**
+   * Where the Base URL field belongs. For a self-hosted provider the endpoint
+   * *is* the credential — nothing about the key identifies which server it
+   * reaches — so it is a primary field and sits above "Advanced settings" with
+   * the rest of them, whether or not it is strictly required. Everywhere else
+   * the base URL only overrides a working default, which is what advanced
+   * means. Bedrock is deliberately excluded: its primary field is the region,
+   * and the endpoint that region writes stays advanced.
+   */
+  const showBaseUrlUpFront =
+    !isBedrock && (isBaseUrlRequired || isSelfHostedProvider(provider));
 
   // Bedrock's effective region, in the same precedence order the backend's
   // getBedrockRegion applies: this key's own endpoint, then the server-wide
@@ -815,6 +826,82 @@ export function LlmProviderApiKeyForm({
         }
       />
     );
+
+  // Rendered either above "Advanced settings" or inside it, depending on
+  // `showBaseUrlUpFront`, so the field itself is defined once.
+  const baseUrlField = (
+    <div className="space-y-2">
+      <Label htmlFor="llm-provider-api-key-base-url">
+        {isBedrock ? "Custom endpoint" : "Base URL"}{" "}
+        {!isBaseUrlRequired && (
+          <span className="font-normal text-muted-foreground">(optional)</span>
+        )}
+      </Label>
+      <p className="text-xs text-muted-foreground">
+        {isBedrock
+          ? "Filled in from the region above. Change it only for a VPC/PrivateLink endpoint or a Bedrock-compatible gateway."
+          : isVllm
+            ? "The server's OpenAI-compatible API. Every model it lists is added."
+            : "Override the default API endpoint. Useful for self-hosted or proxy setups."}
+      </p>
+      {isVllm && (
+        <p className="text-xs text-muted-foreground">
+          One URL per server. If you run more than one vLLM server, add each as
+          its own vLLM key — every model is routed to the server that hosts it.
+        </p>
+      )}
+      {isSelfHostedProvider(provider) && (
+        <p className="text-xs text-muted-foreground">
+          If this app runs in Docker, <code>localhost</code> points at the
+          container, not your host machine. Use{" "}
+          <code>host.docker.internal</code> instead
+          {dockerBaseUrlExample && (
+            <>
+              {" "}
+              (e.g. <code>{dockerBaseUrlExample}</code>)
+            </>
+          )}
+          .
+        </p>
+      )}
+      <Input
+        id="llm-provider-api-key-base-url"
+        type="url"
+        placeholder={
+          (isBedrock ? bedrockRuntimeBaseUrl(bedrockRegion) : "") ||
+          providerBaseUrls?.[provider] ||
+          DEFAULT_PROVIDER_BASE_URLS[provider] ||
+          "https://..."
+        }
+        disabled={isPending}
+        {...form.register("baseUrl", {
+          validate: (value) => {
+            if (!value) {
+              if (isBaseUrlRequired) {
+                return "Base URL is required for this provider";
+              }
+              return true;
+            }
+
+            try {
+              const url = new URL(value);
+              if (!["http:", "https:"].includes(url.protocol)) {
+                return "URL must use http or https protocol";
+              }
+              return true;
+            } catch {
+              return "Please enter a valid URL (e.g. https://api.example.com)";
+            }
+          },
+        })}
+      />
+      {form.formState.errors.baseUrl && (
+        <p className="text-xs text-destructive">
+          {form.formState.errors.baseUrl.message}
+        </p>
+      )}
+    </div>
+  );
 
   return (
     <div data-testid={E2eTestId.ChatApiKeyForm}>
@@ -1345,46 +1432,6 @@ export function LlmProviderApiKeyForm({
           </VisibilitySelector>
         )}
 
-        {progressive && !isSubscriptionFlow && (
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-auto w-full justify-between px-0 py-2 text-sm"
-            aria-expanded={advancedSettingsOpen}
-            onClick={() => setAdvancedSettingsOpen((open) => !open)}
-          >
-            Advanced settings
-            <ChevronDown
-              className={`size-4 transition-transform ${advancedSettingsOpen ? "rotate-180" : ""}`}
-            />
-          </Button>
-        )}
-
-        {showAdvancedSettings &&
-          !isSubscriptionFlow &&
-          !hideScopeAndPrimary && (
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label htmlFor="llm-provider-api-key-is-primary">
-                  Primary key
-                </Label>
-                <p className="text-xs text-muted-foreground">
-                  {existingPrimaryKey
-                    ? `"${existingPrimaryKey.name}" is already the primary key for this provider and scope`
-                    : "When multiple keys exist for the same provider and scope, the primary key is preferred"}
-                </p>
-              </div>
-              <Switch
-                id="llm-provider-api-key-is-primary"
-                checked={form.watch("isPrimary")}
-                onCheckedChange={(checked) =>
-                  form.setValue("isPrimary", checked, { shouldDirty: true })
-                }
-                disabled={isPending || Boolean(existingPrimaryKey)}
-              />
-            </div>
-          )}
-
         {/* Region is a primary Bedrock field, not an advanced one: AWS enables
             models per region, so a key is unusable until it points at the right
             one. The endpoint it writes lives under Advanced settings below. */}
@@ -1427,82 +1474,52 @@ export function LlmProviderApiKeyForm({
           </div>
         )}
 
-        {!isSubscriptionFlow && (isBaseUrlRequired || showAdvancedSettings) && (
-          <div className="space-y-2">
-            <Label htmlFor="llm-provider-api-key-base-url">
-              {isBedrock ? "Custom endpoint" : "Base URL"}{" "}
-              {!isBaseUrlRequired && (
-                <span className="font-normal text-muted-foreground">
-                  (optional)
-                </span>
-              )}
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              {isBedrock
-                ? "Filled in from the region above. Change it only for a VPC/PrivateLink endpoint or a Bedrock-compatible gateway."
-                : isVllm
-                  ? "The server's OpenAI-compatible API. Every model it lists is added."
-                  : "Override the default API endpoint. Useful for self-hosted or proxy setups."}
-            </p>
-            {isVllm && (
-              <p className="text-xs text-muted-foreground">
-                One URL per server. If you run more than one vLLM server, add
-                each as its own vLLM key — every model is routed to the server
-                that hosts it.
-              </p>
-            )}
-            {isSelfHostedProvider(provider) && (
-              <p className="text-xs text-muted-foreground">
-                If this app runs in Docker, <code>localhost</code> points at the
-                container, not your host machine. Use{" "}
-                <code>host.docker.internal</code> instead
-                {dockerBaseUrlExample && (
-                  <>
-                    {" "}
-                    (e.g. <code>{dockerBaseUrlExample}</code>)
-                  </>
-                )}
-                .
-              </p>
-            )}
-            <Input
-              id="llm-provider-api-key-base-url"
-              type="url"
-              placeholder={
-                (isBedrock ? bedrockRuntimeBaseUrl(bedrockRegion) : "") ||
-                providerBaseUrls?.[provider] ||
-                DEFAULT_PROVIDER_BASE_URLS[provider] ||
-                "https://..."
-              }
-              disabled={isPending}
-              {...form.register("baseUrl", {
-                validate: (value) => {
-                  if (!value) {
-                    if (isBaseUrlRequired) {
-                      return "Base URL is required for this provider";
-                    }
-                    return true;
-                  }
+        {!isSubscriptionFlow && showBaseUrlUpFront && baseUrlField}
 
-                  try {
-                    const url = new URL(value);
-                    if (!["http:", "https:"].includes(url.protocol)) {
-                      return "URL must use http or https protocol";
-                    }
-                    return true;
-                  } catch {
-                    return "Please enter a valid URL (e.g. https://api.example.com)";
-                  }
-                },
-              })}
+        {progressive && !isSubscriptionFlow && (
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-auto w-full justify-between px-0 py-2 text-sm"
+            aria-expanded={advancedSettingsOpen}
+            onClick={() => setAdvancedSettingsOpen((open) => !open)}
+          >
+            Advanced settings
+            <ChevronDown
+              className={`size-4 transition-transform ${advancedSettingsOpen ? "rotate-180" : ""}`}
             />
-            {form.formState.errors.baseUrl && (
-              <p className="text-xs text-destructive">
-                {form.formState.errors.baseUrl.message}
-              </p>
-            )}
-          </div>
+          </Button>
         )}
+
+        {showAdvancedSettings &&
+          !isSubscriptionFlow &&
+          !hideScopeAndPrimary && (
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="llm-provider-api-key-is-primary">
+                  Primary key
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  {existingPrimaryKey
+                    ? `"${existingPrimaryKey.name}" is already the primary key for this provider and scope`
+                    : "When multiple keys exist for the same provider and scope, the primary key is preferred"}
+                </p>
+              </div>
+              <Switch
+                id="llm-provider-api-key-is-primary"
+                checked={form.watch("isPrimary")}
+                onCheckedChange={(checked) =>
+                  form.setValue("isPrimary", checked, { shouldDirty: true })
+                }
+                disabled={isPending || Boolean(existingPrimaryKey)}
+              />
+            </div>
+          )}
+
+        {!isSubscriptionFlow &&
+          !showBaseUrlUpFront &&
+          showAdvancedSettings &&
+          baseUrlField}
 
         {!isSubscriptionFlow &&
           showAdvancedSettings &&

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -1446,9 +1446,9 @@ export function LlmProviderApiKeyForm({
             </p>
             {isVllm && (
               <p className="text-xs text-muted-foreground">
-                A vLLM server runs one model. To serve more, run more servers
-                and add each one here — a model always goes to the server that
-                hosts it.
+                One URL per server. If you run more than one vLLM server, add
+                each as its own vLLM key — every model is routed to the server
+                that hosts it.
               </p>
             )}
             {isSelfHostedProvider(provider) && (


### PR DESCRIPTION
Two problems with the same field, both reported as "I can't add a second vLLM server".

## 1. The hint pointed at the wrong control

The vLLM **Base URL** field read:

> A vLLM server runs one model. To serve more, run more servers and add each one here — a model always goes to the server that hosts it.

"here" is a single-URL text input. An operator running a second vLLM server reads that as *put both URLs in this field*, tries it, finds no way, and concludes multiple servers are unsupported. Routing underneath is already correct (#7284) — each server is registered as its own key and every model reaches the server that hosts it — but the copy described the outcome without naming the step. Now:

> One URL per server. If you run more than one vLLM server, add each as its own vLLM key — every model is routed to the server that hosts it.

"its own vLLM key" matches the button that does it (**Add API Key**). The dropped first clause ("A vLLM server runs one model") was a claim about vLLM the app can't guarantee — a router in front of a fleet lists many — and it framed multi-server as a workaround rather than the normal path.

## 2. Always-visible fields rendered after the "Advanced settings" header

Two fields sat *below* the disclosure button while being visible regardless of it: Bedrock's **Region**, and **Base URL** whenever a provider required it. Anything below that header reads as part of the section, so vLLM's required endpoint looked optional — and expanding the section wrapped it, Primary key above and Extra HTTP headers below, so one disclosure appeared to both contain and not contain the field. Ollama was inconsistent the other way: its endpoint really was inside Advanced settings, even though a self-hosted key is nothing *but* an endpoint.

Placement now follows one rule — **a provider whose base URL is the credential shows it up front**:

| Provider | Up front | Inside Advanced settings |
| --- | --- | --- |
| vLLM, Ollama (both transports), Archestra | Base URL | Primary key, Extra HTTP headers |
| Bedrock | Region | Custom endpoint, Primary key, headers |
| OpenAI, Anthropic, … | — | Base URL (override), Primary key, headers |

Everywhere else the base URL only overrides a working default, which is what advanced means. Bedrock keeps its existing split. The field is extracted into a single `baseUrlField` so both positions render identical markup.

### One behavior change

A self-hosted provider with a deployment-wide base URL (`ARCHESTRA_VLLM_BASE_URL` etc.) used to hide the field entirely. It now renders as optional with that URL as its placeholder, since overriding it per key is precisely how a second server gets added — and seeing the inherited endpoint beats guessing at it. The test that pinned the old behavior is updated rather than deleted.