### PR TITLE
fix(guardrails): tell same-named agent delegation tools apart

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -325109,6 +325109,37 @@
                               ],
                               "additionalProperties": false
                             }
+                          },
+                          "delegateToAgent": {
+                            "nullable": true,
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "scope": {
+                                "type": "string",
+                                "enum": [
+                                  "personal",
+                                  "team",
+                                  "org"
+                                ]
+                              },
+                              "ownerEmail": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "scope",
+                              "ownerEmail"
+                            ],
+                            "additionalProperties": false
                           }
                         },
                         "required": [
@@ -325123,7 +325154,8 @@
                           "policiesAutoConfiguredReasoning",
                           "policiesAutoConfiguredModel",
                           "assignmentCount",
-                          "assignments"
+                          "assignments",
+                          "delegateToAgent"
                         ],
                         "additionalProperties": false
                       }

--- a/platform/backend/src/models/tool.test.ts
+++ b/platform/backend/src/models/tool.test.ts
@@ -4313,6 +4313,77 @@ describe("ToolModel", () => {
       expect(afterRestore.data.map((tool) => tool.id)).toContain(ghostTool.id);
     });
 
+    test("attributes same-named delegation tools to their target's owner", async ({
+      makeAdmin,
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const admin = await makeAdmin();
+      const org = await makeOrganization();
+      const kim = await makeUser({ email: "kim@example.com" });
+      const sam = await makeUser({ email: "sam@example.com" });
+
+      // Personal agents are seeded one per member under the same name, so both
+      // mint a delegation tool called `agent__my_assistant`.
+      const kimsAgent = await makeAgent({
+        name: "My Assistant",
+        scope: "personal",
+        organizationId: org.id,
+        authorId: kim.id,
+      });
+      const samsAgent = await makeAgent({
+        name: "My Assistant",
+        scope: "personal",
+        organizationId: org.id,
+        authorId: sam.id,
+      });
+
+      const kimsTool = await ToolModel.findOrCreateDelegationTool(kimsAgent.id);
+      const samsTool = await ToolModel.findOrCreateDelegationTool(samsAgent.id);
+      expect(kimsTool.name).toBe(samsTool.name);
+
+      const result = await ToolModel.findAllWithAssignments({
+        pagination: { limit: 100, offset: 0 },
+        userId: admin.id,
+        isAgentAdmin: true,
+      });
+
+      const listedKims = result.data.find((tool) => tool.id === kimsTool.id);
+      const listedSams = result.data.find((tool) => tool.id === samsTool.id);
+
+      expect(listedKims?.delegateToAgent).toEqual({
+        id: kimsAgent.id,
+        name: "My Assistant",
+        scope: "personal",
+        ownerEmail: "kim@example.com",
+      });
+      expect(listedSams?.delegateToAgent).toEqual({
+        id: samsAgent.id,
+        name: "My Assistant",
+        scope: "personal",
+        ownerEmail: "sam@example.com",
+      });
+    });
+
+    test("leaves delegateToAgent null for tools that delegate to nothing", async ({
+      makeAdmin,
+      makeTool,
+    }) => {
+      const admin = await makeAdmin();
+      const tool = await makeTool({ name: "Bash" });
+
+      const result = await ToolModel.findAllWithAssignments({
+        pagination: { limit: 100, offset: 0 },
+        userId: admin.id,
+        isAgentAdmin: true,
+      });
+
+      expect(
+        result.data.find((entry) => entry.id === tool.id)?.delegateToAgent,
+      ).toBeNull();
+    });
+
     test("counts only assignments to agents that still exist", async ({
       makeAdmin,
       makeAgent,

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -59,6 +59,7 @@ import {
 } from "@/services/environments/environment-isolation";
 import type {
   Agent,
+  AgentScope,
   AssignedTool,
   ExtendedTool,
   InsertTool,
@@ -3817,6 +3818,17 @@ class ToolModel {
         break;
     }
 
+    // A delegation tool is named after its target agent, so personal agents —
+    // one "My Assistant" per member — mint identically named tools. Carry the
+    // target's identity so the listing can tell those rows apart. Both joins are
+    // many-to-one and LEFT, so they add no rows and drop none: most tools have
+    // no delegation target, and an agent whose author was deleted has no owner.
+    const delegateAgentAlias = alias(schema.agentsTable, "delegateAgent");
+    const delegateAgentOwnerAlias = alias(
+      schema.usersTable,
+      "delegateAgentOwner",
+    );
+
     // Query for tools that have at least one assignment
     // Secondary sort on id ensures deterministic ordering when primary sort values are equal
     // (e.g. bulk-inserted MCP tools share the same createdAt timestamp)
@@ -3836,8 +3848,20 @@ class ToolModel {
         policiesAutoConfiguredModel:
           schema.toolsTable.policiesAutoConfiguredModel,
         assignmentCount: assignmentCountSubquery,
+        delegateToAgentId: delegateAgentAlias.id,
+        delegateToAgentName: delegateAgentAlias.name,
+        delegateToAgentScope: delegateAgentAlias.scope,
+        delegateToAgentOwnerEmail: delegateAgentOwnerAlias.email,
       })
       .from(schema.toolsTable)
+      .leftJoin(
+        delegateAgentAlias,
+        eq(delegateAgentAlias.id, schema.toolsTable.delegateToAgentId),
+      )
+      .leftJoin(
+        delegateAgentOwnerAlias,
+        eq(delegateAgentOwnerAlias.id, delegateAgentAlias.authorId),
+      )
       .where(toolWhereClause)
       .orderBy(orderByClause, asc(schema.toolsTable.id))
       .limit(pagination.limit ?? 20)
@@ -3981,6 +4005,14 @@ class ToolModel {
         (tool.policiesAutoConfiguredModel as string | null) ?? null,
       assignmentCount: Number(tool.assignmentCount),
       assignments: assignmentsByToolId.get(tool.id as string) || [],
+      delegateToAgent: tool.delegateToAgentId
+        ? {
+            id: tool.delegateToAgentId,
+            name: tool.delegateToAgentName as string,
+            scope: tool.delegateToAgentScope as AgentScope,
+            ownerEmail: tool.delegateToAgentOwnerEmail,
+          }
+        : null,
     }));
 
     return createPaginatedResult(result, Number(total), {

--- a/platform/backend/src/types/tool.ts
+++ b/platform/backend/src/types/tool.ts
@@ -1,4 +1,8 @@
-import { ClientFilterSchema, TOOL_SEARCH_MAX_LENGTH } from "@archestra/shared";
+import {
+  ClientFilterSchema,
+  ResourceVisibilityScopeSchema,
+  TOOL_SEARCH_MAX_LENGTH,
+} from "@archestra/shared";
 import {
   createInsertSchema,
   createSelectSchema,
@@ -78,6 +82,21 @@ export const ToolAssignmentSchema = z.object({
   credentialResolutionMode: CredentialResolutionModeSchema,
 });
 
+/**
+ * The agent a delegation tool hands work to.
+ *
+ * A delegation tool is named after its target agent (`agent__<slug>`), so
+ * personal agents — seeded one per member, all called "My Assistant" — mint
+ * tools whose names collide. `scope` and `ownerEmail` are what tell those
+ * apart; without them the listing shows several identical rows.
+ */
+const ToolDelegationTargetSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  scope: ResourceVisibilityScopeSchema,
+  ownerEmail: z.string().nullable(),
+});
+
 // Tool with embedded assignments schema
 export const ToolWithAssignmentsSchema = z.object({
   id: z.string(),
@@ -94,6 +113,8 @@ export const ToolWithAssignmentsSchema = z.object({
   policiesAutoConfiguredModel: z.string().nullable(),
   assignmentCount: z.number(),
   assignments: z.array(ToolAssignmentSchema),
+  /** Set only for agent delegation tools; null for catalog and observed tools. */
+  delegateToAgent: ToolDelegationTargetSchema.nullable(),
 });
 
 // Filter schema for tools with assignments

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-agent-usage.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-agent-usage.ts
@@ -55,18 +55,10 @@ export function deriveAgentUsage(
 }
 
 /**
- * Personal agents are auto-seeded one per member, so every member's copy
- * carries the same name — a list of them reads as repeated "My Assistant" /
- * "My Gateway" rows. Attribute those to their owner; agents with a name their
- * author chose need no qualifier.
+ * Re-exported for this route's existing callers. It moved to `@/lib` once the
+ * guardrails table needed the same owner qualifier for delegation tools.
  */
-export function agentOwnerLabel(agent: {
-  scope: string;
-  ownerEmail: string | null;
-}): string | null {
-  if (agent.scope !== "personal") return null;
-  return agent.ownerEmail;
-}
+export { agentOwnerLabel } from "@/lib/agent-owner-label";
 
 /** Human-readable kind, for the usage table's Type column. */
 export function agentTypeLabel(agentType: string): string {

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
@@ -440,6 +440,11 @@ export function AssignedToolsTable({
           const displayName = row.original.catalogId
             ? parseFullToolName(row.original.name).toolName || row.original.name
             : row.original.name;
+          // A delegation tool is named after its target agent, so the personal
+          // agents seeded one per member all mint an `agent__my_assistant`.
+          // The owner is the only thing separating those rows.
+          const source = getToolSource(row.original, internalMcpCatalogItems);
+          const owner = source.kind === "agent" ? source.ownerEmail : null;
           return (
             <div className="max-w-[260px] md:max-w-none truncate">
               <TruncatedText
@@ -447,6 +452,11 @@ export function AssignedToolsTable({
                 className="break-all"
                 maxLength={60}
               />
+              {owner && (
+                <div className="truncate text-xs text-muted-foreground">
+                  {owner}
+                </div>
+              )}
             </div>
           );
         },
@@ -548,7 +558,10 @@ export function AssignedToolsTable({
                     </Badge>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>Delegates to {source.agentName} agent</p>
+                    <p>
+                      Delegates to {source.agentName} agent
+                      {source.ownerEmail ? ` (${source.ownerEmail})` : ""}
+                    </p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.utils.test.ts
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.utils.test.ts
@@ -114,8 +114,66 @@ describe("getToolSource", () => {
 
   it("labels a delegation tool with the agent it delegates to", () => {
     expect(
+      getToolSource(
+        {
+          catalogId: null,
+          name: "agent__my_assistant",
+          delegateToAgent: {
+            id: "agent-1",
+            name: "My Assistant",
+            scope: "team",
+            ownerEmail: "kim@example.com",
+          },
+        },
+        [],
+      ),
+    ).toEqual({ kind: "agent", agentName: "My Assistant", ownerEmail: null });
+  });
+
+  // Personal agents are seeded one per member, so every member's copy mints an
+  // `agent__my_assistant`. Without the owner those rows are indistinguishable.
+  it("qualifies a delegation tool by owner when its target is personal", () => {
+    const source = getToolSource(
+      {
+        catalogId: null,
+        name: "agent__my_assistant",
+        delegateToAgent: {
+          id: "agent-1",
+          name: "My Assistant",
+          scope: "personal",
+          ownerEmail: "kim@example.com",
+        },
+      },
+      [],
+    );
+    const other = getToolSource(
+      {
+        catalogId: null,
+        name: "agent__my_assistant",
+        delegateToAgent: {
+          id: "agent-2",
+          name: "My Assistant",
+          scope: "personal",
+          ownerEmail: "sam@example.com",
+        },
+      },
+      [],
+    );
+
+    expect(source).toEqual({
+      kind: "agent",
+      agentName: "My Assistant",
+      ownerEmail: "kim@example.com",
+    });
+    expect(source).not.toEqual(other);
+  });
+
+  // Endpoints that do not resolve the target still slugify the agent's name
+  // into the tool name; nothing there says which agent, so no owner is claimed.
+  it("falls back to the slugified name when no target is resolved", () => {
+    expect(
       getToolSource({ catalogId: null, name: "agent__my_assistant" }, []),
-    ).toEqual({ kind: "agent", agentName: "my assistant" });
+    ).toEqual({ kind: "agent", agentName: "my assistant", ownerEmail: null });
   });
 
   it("labels a tool with no catalog as observed", () => {

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.utils.ts
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.utils.ts
@@ -4,6 +4,7 @@ import {
   type archestraApiTypes,
   isAgentTool,
 } from "@archestra/shared";
+import { agentOwnerLabel } from "@/lib/agent-owner-label";
 
 type InternalMcpCatalogItem =
   archestraApiTypes.GetInternalMcpCatalogResponses["200"][number];
@@ -31,11 +32,19 @@ export const APP_ORIGIN_FILTER_VALUE = "app";
 export type ToolSource =
   | { kind: "app"; appName: string }
   | { kind: "mcp"; catalogItem: InternalMcpCatalogItem | undefined }
-  | { kind: "agent"; agentName: string }
+  | { kind: "agent"; agentName: string; ownerEmail: string | null }
   | { kind: "observed" };
 
+type ToolDelegationTarget = NonNullable<
+  archestraApiTypes.GetToolsWithAssignmentsResponses["200"]["data"][number]["delegateToAgent"]
+>;
+
 export function getToolSource(
-  tool: { catalogId: string | null; name: string },
+  tool: {
+    catalogId: string | null;
+    name: string;
+    delegateToAgent?: ToolDelegationTarget | null;
+  },
   catalogItems?: InternalMcpCatalogItem[],
 ): ToolSource {
   if (tool.catalogId) {
@@ -48,10 +57,23 @@ export function getToolSource(
     return { kind: "mcp", catalogItem };
   }
 
+  if (tool.delegateToAgent) {
+    return {
+      kind: "agent",
+      agentName: tool.delegateToAgent.name,
+      ownerEmail: agentOwnerLabel(tool.delegateToAgent),
+    };
+  }
+
+  // Endpoints that do not resolve the delegation target still have the agent's
+  // name slugified into the tool name. Nothing there identifies *which* agent,
+  // so callers on that path keep the pre-existing ambiguity rather than gaining
+  // a wrong owner.
   if (isAgentTool(tool.name)) {
     return {
       kind: "agent",
       agentName: tool.name.slice(AGENT_TOOL_PREFIX.length).replaceAll("_", " "),
+      ownerEmail: null,
     };
   }
 

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/tool-details-dialog.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/tool-details-dialog.tsx
@@ -127,6 +127,17 @@ export function ToolDetailsDialog({
                   {displayName}
                 </DialogTitle>
               )}
+              {/*
+                Delegation tools are named after their target agent, so the
+                personal agents seeded one per member all open a dialog titled
+                `agent__my_assistant` and described "Delegate task to agent: My
+                Assistant". The owner is what says which one this is.
+              */}
+              {source.kind === "agent" && source.ownerEmail && (
+                <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                  {source.ownerEmail}
+                </p>
+              )}
               {tool.description && (
                 <TruncatedText
                   message={tool.description}
@@ -188,7 +199,10 @@ export function ToolDetailsDialog({
                           </Badge>
                         </TooltipTrigger>
                         <TooltipContent>
-                          <p>Delegates to {source.agentName} agent</p>
+                          <p>
+                            Delegates to {source.agentName} agent
+                            {source.ownerEmail ? ` (${source.ownerEmail})` : ""}
+                          </p>
                         </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>

--- a/platform/frontend/src/lib/agent-owner-label.ts
+++ b/platform/frontend/src/lib/agent-owner-label.ts
@@ -1,0 +1,16 @@
+/**
+ * Personal agents are auto-seeded one per member, so every member's copy
+ * carries the same name — a list of them reads as repeated "My Assistant" /
+ * "My Gateway" rows. Attribute those to their owner; agents with a name their
+ * author chose need no qualifier.
+ *
+ * The owner is spelled as an email rather than a display name because display
+ * names collide too, which would leave the rows just as indistinguishable.
+ */
+export function agentOwnerLabel(agent: {
+  scope: string;
+  ownerEmail: string | null;
+}): string | null {
+  if (agent.scope !== "personal") return null;
+  return agent.ownerEmail;
+}

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -83848,6 +83848,12 @@ export type GetToolsWithAssignmentsResponses = {
                 executionOwnerEmail: string | null;
                 credentialResolutionMode: 'static' | 'dynamic' | 'enterprise_managed';
             }>;
+            delegateToAgent: {
+                id: string;
+                name: string;
+                scope: 'personal' | 'team' | 'org';
+                ownerEmail: string | null;
+            } | null;
         }>;
         pagination: {
             currentPage: number;


### PR DESCRIPTION
## Problem

A delegation tool is named after the agent it targets (`agent__<slug>`), and personal agents are seeded one per member — every one of them called **My Assistant**. So each member's copy mints a tool named `agent__my_assistant`, and the Guardrails listing renders them as several byte-identical rows:

- same tool name
- same `Agent` badge
- same `Delegates to my assistant agent` tooltip
- same `Delegate task to agent: My Assistant` description in the details dialog

Only the opaque tool id differs, so there is no way to tell which row configures whose agent — the rows read as duplicates or as a bug, and picking the right one to set a policy on is guesswork.

The listing had nothing to work with. `getToolSource` derived the agent name by de-slugifying the tool's *own* name, and `GET /api/tools/with-assignments` returned neither the delegation target nor its owner.

## Change

**Backend** — `GET /api/tools/with-assignments` now carries the delegation target:

```ts
delegateToAgent: { id, name, scope, ownerEmail } | null
```

resolved with two many-to-one `LEFT JOIN`s (tool → target agent → author). Both are LEFT and many-to-one, so they add no rows and drop none: most tools have no delegation target, and an agent whose author was deleted has no owner. `null` for every non-delegation tool.

**Frontend** — the row is qualified by its owner, following the pattern the MCP registry already uses for same-named personal agents: a muted `text-xs` line under the tool name, shown **only** when the target is personal-scope. Team- and org-scoped agents have a name their author chose and need no qualifier. The source badge and details-dialog tooltips also name the owner.

Deliberately subtle: no new column, no change to non-delegation rows, no extra visual weight.

`agentOwnerLabel` moves from the registry's `_parts` to `@/lib/agent-owner-label` so both surfaces share one definition of the rule instead of duplicating it.

## Before / after

Same five rows, same data, same page.

| | |
|---|---|
| **Before** | five identical `agent__my_assistant` rows |
| **After** | each row carries its owner (`admin@example.com`, `member-1@example.com`, …) |

## Tests

- `models/tool.test.ts` — two same-named delegation tools whose targets differ resolve to their respective owners; `delegateToAgent` is `null` for a tool that delegates to nothing.
- `assigned-tools-table.utils.test.ts` — personal targets get an owner and two same-named tools no longer compare equal; team/org targets get none; the no-target path still falls back to the slugified name and claims no owner.

Verified in Chrome against a dev database that reproduces the collision (five `agent__my_assistant` tools, one per user): all five rows render distinctly in the table, and the details dialog shows the owner under the title. Checked side by side against an unpatched instance, which still shows five identical rows.

`pnpm type-check`, `pnpm knip` (dev + production), `biome ci`, and the touched test files all pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>