### PR TITLE
fix(apps): let the creating session build an app the new-app default disabled

### DIFF
--- a/docs/pages/platform-apps.md
+++ b/docs/pages/platform-apps.md
@@ -46,9 +46,11 @@ A locked app is immutable. Agents refuse every change to it — edits, tool assi
 
 Two settings in **Settings → Chat** govern how new apps start. Both are off by default. Flipping them never touches existing apps.
 
-**New apps are disabled by default** creates every new app disabled. The app stays author-only and invisible to agents until you enable it in App settings.
+**New apps are disabled by default** creates every new app disabled. The app stays author-only and cannot be run until you enable it in App settings.
 
-**New apps are locked by default** creates every new app [locked](#locking-an-app). The chat that created the app can finish building it, so a new app never arrives frozen as an empty shell. Every other chat is refused from the first moment. Locking or unlocking the app yourself ends that one exception.
+**New apps are locked by default** creates every new app [locked](#locking-an-app).
+
+Under either setting, the chat that created the app can finish building it. A new app never arrives frozen as an empty shell — you enable or unlock a finished app, not a starter template. Every other chat meets the setting from the app's first moment, and a disabled app is not even acknowledged there. Locking or disabling the app yourself ends that one exception.
 
 ## Labels
 

--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -1911,7 +1911,7 @@ describe("org new-app defaults (disabled/locked by default)", () => {
     expect((edit.content[0] as any).text).toContain("locked");
   });
 
-  test("scaffold honors disabled-by-default: the app is born disabled and invisible to chat", async () => {
+  test("scaffold honors disabled-by-default: with no session behind the call, the app is born disabled and invisible to every chat", async () => {
     await OrganizationModel.patch(organizationId, {
       newAppsDisabledByDefault: true,
     });
@@ -1927,7 +1927,8 @@ describe("org new-app defaults (disabled/locked by default)", () => {
     expect((created.content[0] as any).text).toContain("disabled");
 
     // The T-980 contract applies from birth: the disabled app reads as
-    // nonexistent to chat tools.
+    // nonexistent to chat tools. Nothing identifies a creating session here,
+    // so there is no one to grace and the disable binds from the first moment.
     const read = await executeArchestraTool(
       getArchestraToolFullName(TOOL_READ_APP_SHORT_NAME),
       { appId },
@@ -2086,6 +2087,206 @@ describe("locked-by-default: the creating session keeps building", () => {
     );
     expect(edit.isError).toBe(true);
   });
+});
+
+describe("disabled-by-default: the creating session keeps building", () => {
+  let organizationId: string;
+  let buildContext: ArchestraContext;
+  let otherChatContext: ArchestraContext;
+  const buildSession = crypto.randomUUID();
+
+  beforeEach(async ({ makeAgent, makeUser, makeMember }) => {
+    const agent = await makeAgent({ name: "Disabled Grace Agent" });
+    organizationId = agent.organizationId;
+    const user = await makeUser();
+    await makeMember(user.id, organizationId, { role: ADMIN_ROLE_NAME });
+    buildContext = {
+      agent: { id: agent.id, name: agent.name },
+      organizationId,
+      userId: user.id,
+      conversationId: buildSession,
+      isolationKey: buildSession,
+    };
+    const otherSession = crypto.randomUUID();
+    otherChatContext = {
+      ...buildContext,
+      conversationId: otherSession,
+      isolationKey: otherSession,
+    };
+    await OrganizationModel.patch(organizationId, {
+      newAppsDisabledByDefault: true,
+    });
+  });
+
+  async function scaffold(name: string): Promise<string> {
+    const created = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_SCAFFOLD_APP_SHORT_NAME),
+      { name },
+      buildContext,
+    );
+    expect(created.isError).toBe(false);
+    return structured(created).id as string;
+  }
+
+  test("the conversation that scaffolded the app can still build it, and is told so", async () => {
+    const created = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_SCAFFOLD_APP_SHORT_NAME),
+      { name: "Shell" },
+      buildContext,
+    );
+    expect(created.isError).toBe(false);
+    const appId = structured(created).id as string;
+    // The app is genuinely disabled — the grace is an exception for one
+    // session, not a quieter setting.
+    expect((await AppModel.findById(appId))?.enabled).toBe(false);
+    // ...so the note must keep the model building instead of handing back an
+    // empty shell, while still naming what the user has to do at the end.
+    const note = (created.content[0] as any).text as string;
+    expect(note).toContain("disabled");
+    expect(note).not.toContain("do not try to edit or render it");
+    expect(note).toContain("enable it in App settings");
+
+    // The whole staged authoring flow works, reads included, deletion last.
+    const authoring: Array<[string, Record<string, unknown>]> = [
+      [TOOL_READ_APP_SHORT_NAME, { appId }],
+      [
+        TOOL_REFINE_APP_SHORT_NAME,
+        { appId, spec: { summary: "s", features: [], tools: [] } },
+      ],
+      [TOOL_SET_APP_TOOLS_SHORT_NAME, { appId, tools: [] }],
+      [
+        TOOL_EDIT_APP_SHORT_NAME,
+        { appId, baseVersion: 1, replacementHtml: "<h1>built</h1>" },
+      ],
+      [TOOL_DELETE_APP_SHORT_NAME, { appId }],
+    ];
+    for (const [tool, args] of authoring) {
+      const result = await executeArchestraTool(
+        getArchestraToolFullName(
+          tool as Parameters<typeof getArchestraToolFullName>[0],
+        ),
+        args,
+        buildContext,
+      );
+      expect(result.isError, tool).toBe(false);
+    }
+  });
+
+  test("every other conversation is told the app does not exist", async () => {
+    const appId = await scaffold("Shell Elsewhere");
+
+    const refused: Array<[string, Record<string, unknown>]> = [
+      [TOOL_READ_APP_SHORT_NAME, { appId }],
+      [
+        TOOL_EDIT_APP_SHORT_NAME,
+        { appId, baseVersion: 1, replacementHtml: "<h1>nope</h1>" },
+      ],
+    ];
+    for (const [tool, args] of refused) {
+      const result = await executeArchestraTool(
+        getArchestraToolFullName(
+          tool as Parameters<typeof getArchestraToolFullName>[0],
+        ),
+        args,
+        otherChatContext,
+      );
+      expect(result.isError, tool).toBe(true);
+      expect((result.content[0] as any).text, tool).toContain("No app found");
+    }
+    expect((await AppModel.findById(appId))?.latestVersion).toBe(1);
+  });
+
+  test("the grace does not put the app back in list_apps, for the building conversation either", async () => {
+    const appId = await scaffold("Unlisted While Disabled");
+
+    const listed = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_LIST_APPS_SHORT_NAME),
+      {},
+      buildContext,
+    );
+    expect(listed.isError).toBe(false);
+    const ids = (structured(listed).apps as Array<{ id: string }>).map(
+      (app) => app.id,
+    );
+    expect(ids).not.toContain(appId);
+  });
+
+  test("a deliberate disable ends the grace, so the creating conversation loses the app", async () => {
+    const appId = await scaffold("Enabled Then Pulled");
+
+    // Enabling is a relaxation: with no lock in play the grace has nothing
+    // left to cover, and the app is plainly visible to everyone who may see it.
+    await AppModel.setEnabled(appId, true);
+    // Disabling it again is the deliberate act T-980 exists for, and it must
+    // hold against the session that created the app too.
+    await AppModel.setEnabled(appId, false);
+
+    const read = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_READ_APP_SHORT_NAME),
+      { appId },
+      buildContext,
+    );
+    expect(read.isError).toBe(true);
+    expect((read.content[0] as any).text).toContain("No app found");
+  });
+
+  // With both defaults on, either restriction alone is enough to shut the
+  // creating session out — so relaxing one must not settle the grace while the
+  // other is still holding the app, or the build dies halfway through.
+  test("unlocking an app that is still disabled keeps the build alive", async () => {
+    const appId = await scaffoldLockedAndDisabled();
+
+    const unlocked = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_SET_APP_LOCK_SHORT_NAME),
+      { appId, locked: false },
+      buildContext,
+    );
+    expect(unlocked.isError).toBe(false);
+    expect((await AppModel.findById(appId))?.enabled).toBe(false);
+
+    const edit = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_EDIT_APP_SHORT_NAME),
+      { appId, baseVersion: 1, replacementHtml: "<h1>built</h1>" },
+      buildContext,
+    );
+    expect(edit.isError).toBe(false);
+  });
+
+  test("enabling an app that is still locked keeps the build alive", async () => {
+    const appId = await scaffoldLockedAndDisabled();
+
+    await AppModel.setEnabled(appId, true);
+    expect((await AppModel.findById(appId))?.locked).toBe(true);
+
+    const edit = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_EDIT_APP_SHORT_NAME),
+      { appId, baseVersion: 1, replacementHtml: "<h1>built</h1>" },
+      buildContext,
+    );
+    expect(edit.isError).toBe(false);
+
+    // ...and any other conversation still meets the lock the app was born with.
+    const elsewhere = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_EDIT_APP_SHORT_NAME),
+      { appId, baseVersion: 2, replacementHtml: "<h1>nope</h1>" },
+      otherChatContext,
+    );
+    expect(elsewhere.isError).toBe(true);
+    expect((elsewhere.content[0] as any).text).toContain("locked");
+  });
+
+  async function scaffoldLockedAndDisabled(): Promise<string> {
+    await OrganizationModel.patch(organizationId, {
+      newAppsLockedByDefault: true,
+    });
+    const appId = await scaffold(
+      `Locked And Disabled ${crypto.randomUUID().slice(0, 8)}`,
+    );
+    const born = await AppModel.findById(appId);
+    expect(born?.locked).toBe(true);
+    expect(born?.enabled).toBe(false);
+    return appId;
+  }
 });
 
 describe("preview_app_tool", () => {

--- a/platform/backend/src/archestra-mcp-server/apps.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.ts
@@ -562,12 +562,14 @@ const registry = defineArchestraTools([
             templateId: DEFAULT_APP_TEMPLATE_ID,
             enabled: lifecycleDefaults.enabled,
             locked: lifecycleDefaults.locked,
-            // Born locked by the org default: this conversation still has to
-            // build the app it just scaffolded, so the lock spares it (and it
-            // alone) until someone sets the lock deliberately.
-            lockGraceSessionKey: lifecycleDefaults.locked
-              ? (sessionKey ?? null)
-              : null,
+            // Born locked or disabled by an org default: this conversation
+            // still has to build the app it just scaffolded, so those defaults
+            // spare it (and it alone) until someone sets the lifecycle
+            // deliberately.
+            creationGraceSessionKey:
+              lifecycleDefaults.locked || !lifecycleDefaults.enabled
+                ? (sessionKey ?? null)
+                : null,
           },
           payload,
         });
@@ -644,14 +646,17 @@ const registry = defineArchestraTools([
       const seededHtmlNote = `\nSeeded from the default starter template; current HTML (build it up via edit_app):\n${fencedBlock(payload.html, "html")}`;
       const warningsNote = formatWarningsNote(warnings);
       const toolsParts = toolsResultParts(resolvedTools);
-      // The org's new-app defaults can make the app un-editable from chat the
-      // moment it exists (disabled = invisible to chat tools; locked = every
-      // modification refused). Say so in the result, or the model walks into
-      // refusals it has no way to explain to the user.
+      // The org's new-app defaults change what the app is the moment it exists
+      // (disabled = invisible to every other conversation and runnable by
+      // nobody; locked = every other conversation's modifications refused).
+      // Say so in the result, or the model either walks into refusals it has
+      // no way to explain or hands over an app the user cannot open.
       const lifecycleNotes: string[] = [];
       if (!lifecycleDefaults.enabled) {
         lifecycleNotes.push(
-          "This organization creates new apps disabled: from now on this app is invisible to chat tools (do not try to edit or render it). Tell the user to enable it in App settings on the Apps page to keep building it.",
+          sessionKey
+            ? "This organization creates new apps disabled: the app is invisible to every other conversation and nobody can run it yet, but this one may finish building it — keep going with edit_app/set_app_tools as usual. When you hand it over, tell the user to enable it in App settings on the Apps page before anyone can open it."
+            : "This organization creates new apps disabled: from now on this app is invisible to chat tools (do not try to edit or render it). Tell the user to enable it in App settings on the Apps page to keep building it.",
         );
       }
       if (lifecycleDefaults.locked) {
@@ -1736,9 +1741,9 @@ type AuthedCaller = {
    * The authoring session this call belongs to — the conversation in UI chat,
    * the execution key in a headless run, undefined where neither exists (an
    * external MCP client on the gateway). Carried alongside the caller's ids
-   * because an app's creation-time lock grace is granted to a session, not to
-   * a person: it rides every `loadApp` spread so no authoring tool can forget
-   * to present it.
+   * because an app's creation-time grace is granted to a session, not to a
+   * person: it rides every `loadApp` spread so no authoring tool can forget to
+   * present it.
    */
   sessionKey: string | undefined;
 };
@@ -1760,7 +1765,7 @@ function requireAuthed(
 
 /**
  * The key identifying the session an app tool call is made from, for the
- * creation-time lock grace (`apps.lock_grace_session_key`). `isolationKey` is
+ * creation-time grace (`apps.lock_grace_session_key`). `isolationKey` is
  * the conversation id in UI chat and a per-execution id in headless runs, so
  * one value covers both; it is stored as an opaque key and never read back as
  * a conversation reference.
@@ -1861,8 +1866,8 @@ async function loadApp(params: {
   appId: string;
   /**
    * The calling session, from {@link requireAuthed}. Consulted only by the
-   * lock check, to recognize the session an app was created from when the
-   * organization's new-app default is what locked it.
+   * lifecycle checks, to recognize the session an app was created from when an
+   * organization new-app default is what locked or disabled it.
    */
   sessionKey?: string;
   modify?: boolean;
@@ -1875,12 +1880,24 @@ async function loadApp(params: {
     userId: params.userId,
     isAppAdmin: await callerIsAppAdmin(params.userId, params.organizationId),
   });
+  // The session an app was created from keeps building it through the
+  // restrictions the organization's new-app defaults applied at that moment —
+  // otherwise those defaults turn on the very agent that just scaffolded the
+  // app, stranding it as an empty shell nobody asked to freeze (T-1089). The
+  // grace covers this one session; every other session meets the lock and the
+  // disable from the app's first moment, and a deliberate restriction ends it.
+  const graced =
+    !!app &&
+    params.sessionKey !== undefined &&
+    app.creationGraceSessionKey === params.sessionKey;
   // A disabled app does not exist as far as chat is concerned (T-980): every
   // id-scoped tool reports it exactly like a missing id — for its author too,
   // and for reads as much as writes, so a conversation holding a pre-disable
   // snapshot learns nothing and can do nothing. The author sees and manages
-  // it on the Apps page (REST), where re-enabling lives.
-  if (!app || !app.enabled) {
+  // it on the Apps page (REST), where re-enabling lives. The graced session is
+  // the one exception, and only ever for an app born disabled: it is building
+  // that app right now, and it is the only session that can see it at all.
+  if (!app || (!app.enabled && !graced)) {
     return { error: errorResult(`No app found with id ${params.appId}.`) };
   }
   if (params.modify) {
@@ -1897,6 +1914,11 @@ async function loadApp(params: {
           authorId: app.authorId,
           enabled: app.enabled,
         },
+        // Same exception, at the disabled-app freeze inside the assertion: the
+        // creating session may finish its build. Nothing else about the gate
+        // is relaxed — the caller still has to be someone who could author the
+        // app if it were live.
+        creationGraceSession: graced,
         resourceTeamIds: await AppAccessModel.getTeamsForApp(app.id),
       });
     } catch (error) {
@@ -1904,15 +1926,6 @@ async function loadApp(params: {
         return { error: errorResult(error.message) };
       throw error;
     }
-    // The session an app was created from keeps its build rights over a lock
-    // the organization's new-app default applied — otherwise that default
-    // refuses the very agent that just scaffolded the app, stranding it as an
-    // empty shell nobody asked to freeze (T-1089). The grace covers this one
-    // session; every other session sees the lock from the app's first moment,
-    // and any deliberate lock clears it.
-    const graced =
-      params.sessionKey !== undefined &&
-      app.lockGraceSessionKey === params.sessionKey;
     if (app.locked && !params.allowLocked && !graced) {
       return {
         error: errorResult(

--- a/platform/backend/src/database/schemas/app.ts
+++ b/platform/backend/src/database/schemas/app.ts
@@ -90,23 +90,34 @@ const appsTable = softDeletablePgTable(
      */
     locked: boolean("locked").notNull().default(false),
     /**
-     * The one authoring session the `locked` flag above does NOT refuse: the
-     * chat conversation (or headless execution) an app was created from while
-     * the organization's "new apps are locked by default" setting was on.
-     * Without it that setting locks an app against the very agent that just
-     * scaffolded it, so a build cannot get past its empty shell.
+     * The one authoring session the two flags above do NOT shut out: the chat
+     * conversation (or headless execution) an app was created from while an
+     * organization default — "new apps are locked by default", "new apps are
+     * disabled by default", or both — was what locked or disabled it. Without
+     * it those defaults turn on the very agent that just scaffolded the app:
+     * `locked` refuses its edits and `enabled: false` hides the app from it
+     * entirely, so a build cannot get past its empty shell.
      *
      * An opaque per-execution key (`isolationKey ?? conversationId`), never a
      * conversation foreign key — the same value in UI chat, a generated id in
-     * headless runs. Null for every app not born locked, and for one created
-     * where no session identifies the creator (e.g. an external MCP client on
-     * the gateway), which stays locked to everyone from birth.
+     * headless runs. Null for every app born live and unlocked, and for one
+     * created where no session identifies the creator (e.g. an external MCP
+     * client on the gateway), which meets both defaults from birth.
      *
-     * Cleared the moment anyone sets the lock explicitly (App settings or
-     * `set_app_lock`), so a deliberate lock freezes the app for its creating
-     * session too.
+     * Cleared the moment anyone restricts the app deliberately (App settings
+     * or `set_app_lock`): a lock or a disable someone asked for holds against
+     * the creating session too. A deliberate *relaxation* keeps it, so
+     * unlocking an app that is still disabled (or enabling one still locked)
+     * does not strand the build halfway.
+     *
+     * The column is still named `lock_grace_session_key`: it was added for the
+     * lock alone, and renaming a live column is not rollout-safe (old pods
+     * would read a column that no longer exists mid-deploy), which the
+     * migration linter rejects. The property carries the accurate name; a
+     * physical rename would have to go add → backfill → drop across releases,
+     * which this value — an opaque, short-lived build key — does not justify.
      */
-    lockGraceSessionKey: text("lock_grace_session_key"),
+    creationGraceSessionKey: text("lock_grace_session_key"),
     createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .notNull()

--- a/platform/backend/src/models/app.ts
+++ b/platform/backend/src/models/app.ts
@@ -7,6 +7,8 @@ import {
   getTableColumns,
   inArray,
   or,
+  type SQL,
+  sql,
 } from "drizzle-orm";
 import db, { schema, type Transaction, withDbTransaction } from "@/database";
 import { notDeleted } from "@/database/schemas/soft-deletable-table";
@@ -56,6 +58,36 @@ function appWithCatalogQuery() {
       schema.internalMcpCatalogTable,
       eq(schema.mcpServersTable.catalogId, schema.internalMcpCatalogTable.id),
     );
+}
+
+/**
+ * What `creationGraceSessionKey` becomes when someone sets `locked` or
+ * `enabled` deliberately — the write that ends the window an org default's
+ * creating session was building in.
+ *
+ * Restricting (locking, or disabling) always ends it: a lock or a disable a
+ * person asked for must hold against every session, the app's creator
+ * included. Relaxing ends it too — *unless the other flag still shuts that
+ * session out*, because unlocking an app that is still disabled (or enabling
+ * one still locked) is not the moment to take the build away from the chat
+ * that is halfway through it. Left set, the key costs nothing: the next
+ * deliberate restriction clears it.
+ *
+ * Evaluated in the same UPDATE that flips the flag, so the two are decided
+ * against one consistent row rather than a read the write could race.
+ */
+function settledGrace(
+  change: { locked: boolean } | { enabled: boolean },
+): SQL<string | null> | null {
+  const stillRestricted =
+    "locked" in change
+      ? // Unlocking: the disable default may still be holding the app shut.
+        sql`NOT ${schema.appsTable.enabled}`
+      : // Enabling: the lock default may still be refusing every edit.
+        sql`${schema.appsTable.locked}`;
+  const restricting = "locked" in change ? change.locked : !change.enabled;
+  if (restricting) return null;
+  return sql`CASE WHEN ${stillRestricted} THEN ${schema.appsTable.creationGraceSessionKey} ELSE NULL END`;
 }
 
 function buildOrgFilters(params: {
@@ -477,11 +509,15 @@ class AppModel {
    * catalog, so disable→re-enable is non-destructive (a since-hidden launch
    * tool reappears wherever it was assigned). Returns the updated app, or null if
    * the app is gone/soft-deleted.
+   *
+   * Deliberately setting the state also settles any creation-time grace
+   * (`creationGraceSessionKey`) — see {@link setLocked} for the rule both
+   * setters share.
    */
   static async setEnabled(id: string, enabled: boolean): Promise<App | null> {
     const [row] = await db
       .update(schema.appsTable)
-      .set({ enabled })
+      .set({ enabled, creationGraceSessionKey: settledGrace({ enabled }) })
       .where(and(eq(schema.appsTable.id, id), notDeleted(schema.appsTable)))
       .returning({ id: schema.appsTable.id });
     return row ? await AppModel.findById(id) : null;
@@ -492,34 +528,35 @@ class AppModel {
    * `setEnabled`: locked refuses every agent-driven mutation until unlocked,
    * while viewing and running stay unaffected.
    *
-   * Setting the lock deliberately also ends any creation-time grace
-   * (`lockGraceSessionKey`), on lock and unlock alike: a lock someone asked
-   * for holds against the session that created the app too, and an unlocked
-   * app carries no exception into whatever lock comes next.
+   * Setting the lock deliberately also settles any creation-time grace
+   * (`creationGraceSessionKey`): a lock someone asked for holds against the
+   * session that created the app too, and an app left both unlocked and
+   * enabled carries no exception into whatever lock comes next. See
+   * {@link settledGrace} for the one case a relaxation keeps.
    */
   static async setLocked(id: string, locked: boolean): Promise<App | null> {
     const [row] = await db
       .update(schema.appsTable)
-      .set({ locked, lockGraceSessionKey: null })
+      .set({ locked, creationGraceSessionKey: settledGrace({ locked }) })
       .where(and(eq(schema.appsTable.id, id), notDeleted(schema.appsTable)))
       .returning({ id: schema.appsTable.id });
     return row ? await AppModel.findById(id) : null;
   }
 
   /**
-   * Let one authoring session keep modifying an app its creation locked, for
-   * creation paths that only learn the session after the app row exists (the
-   * Apps page seeds the app's chat conversation once the app is created).
-   * Creation paths that know it upfront pass `lockGraceSessionKey` to
-   * {@link create} instead.
+   * Let one authoring session keep building an app its creation locked or
+   * disabled, for creation paths that only learn the session after the app row
+   * exists (the Apps page seeds the app's chat conversation once the app is
+   * created). Creation paths that know it upfront pass
+   * `creationGraceSessionKey` to {@link create} instead.
    */
-  static async setLockGraceSessionKey(
+  static async setCreationGraceSessionKey(
     id: string,
     sessionKey: string,
   ): Promise<void> {
     await db
       .update(schema.appsTable)
-      .set({ lockGraceSessionKey: sessionKey })
+      .set({ creationGraceSessionKey: sessionKey })
       .where(and(eq(schema.appsTable.id, id), notDeleted(schema.appsTable)));
   }
 

--- a/platform/backend/src/routes/app/app.routes.ts
+++ b/platform/backend/src/routes/app/app.routes.ts
@@ -584,15 +584,17 @@ const appRoutes: FastifyPluginAsyncZod = async (fastify) => {
             // The agent whose environment the app was just bound to, so the
             // chat that builds it runs as that agent (see `builderAgentId`).
             ...(builderAgentId ? { agentId: builderAgentId } : {}),
+            creationBuildChat: true,
           }));
           // The Apps page creates a blank app and drops the user straight into
-          // this conversation to build it. When the organization's default is
-          // what locked the app, that build has to be able to start, so the
-          // conversation gets the same creation-time grace `scaffold_app`
-          // gives its own (chat carries the conversation id as its session
-          // key). Everyone else meets the lock immediately.
-          if (lifecycleDefaults.locked) {
-            await AppModel.setLockGraceSessionKey(app.id, conversationId);
+          // this conversation to build it. When an organization default is
+          // what locked or disabled the app, that build has to be able to
+          // start, so the conversation gets the same creation-time grace
+          // `scaffold_app` gives its own (chat carries the conversation id as
+          // its session key). Everyone else meets both from the app's first
+          // moment.
+          if (lifecycleDefaults.locked || !lifecycleDefaults.enabled) {
+            await AppModel.setCreationGraceSessionKey(app.id, conversationId);
           }
         } catch (error) {
           logger.warn(

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -838,6 +838,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
               openedApp: openedAppRef,
               userId: user.id,
               organizationId,
+              ...(conversationId ? { sessionKey: conversationId } : {}),
             }).catch((error) => {
               logger.warn(
                 { error, conversationId },

--- a/platform/backend/src/services/apps/app-authorization.ts
+++ b/platform/backend/src/services/apps/app-authorization.ts
@@ -155,9 +155,11 @@ export async function assertCallerMayModifyApp(params: {
  *
  * A disabled app is additionally frozen for authoring — for its author too
  * (T-980: a parallel chat of the author rebuilt an app the user had just
- * disabled). Chat tools never reach this branch (their loader reports a
- * disabled app as not found); it guards the REST html rewrite, where the
- * author can see the app but must re-enable it before changing its content.
+ * disabled). It guards the REST html rewrite, where the author can see the app
+ * but must re-enable it before changing its content; chat tools reach it only
+ * for an app born disabled by an organization default, whose creating session
+ * their loader marks with `creationGraceSession` (every other chat caller is
+ * already reported a disabled app as not found).
  */
 export async function assertCallerMayAuthorApp(params: {
   userId: string;
@@ -168,6 +170,14 @@ export async function assertCallerMayAuthorApp(params: {
     authorId: string | null;
     enabled: boolean;
   };
+  /**
+   * Set by the chat loader when this call comes from the session an app was
+   * created in while an organization new-app default disabled it. That session
+   * is building the app right now, so the disabled freeze below does not apply
+   * to it; every other caller, and every app someone disabled deliberately,
+   * meets the freeze as before.
+   */
+  creationGraceSession?: boolean;
   resourceTeamIds: string[];
 }): Promise<void> {
   // "Reachable without the admin bypass" is exactly "not oversight-only": the
@@ -192,7 +202,7 @@ export async function assertCallerMayAuthorApp(params: {
       "You can view this app and change its settings, but only its owner can modify the app itself via chat.",
     );
   }
-  if (!params.app.enabled) {
+  if (!params.app.enabled && !params.creationGraceSession) {
     throw new ApiError(
       403,
       "This app is disabled: its content cannot be changed until it is re-enabled.",

--- a/platform/backend/src/services/apps/app-chat-conversation.ts
+++ b/platform/backend/src/services/apps/app-chat-conversation.ts
@@ -49,6 +49,14 @@ export async function createSeededAppConversation(params: {
    * about which agent is building the app. Omitted, it is resolved here.
    */
   agentId?: string;
+  /**
+   * This conversation is the app's own creation-time build chat, and its caller
+   * grants it the app's creation grace the moment it has an id. An app an
+   * organization default disabled at birth is therefore seeded rather than
+   * refused: the authoring tools will answer this one conversation. Deep links
+   * to an existing app never set it, and so still meet the T-980 refusal below.
+   */
+  creationBuildChat?: boolean;
 }): Promise<{ conversationId: string }> {
   const { appId, userId, organizationId, agentId } = params;
 
@@ -61,8 +69,10 @@ export async function createSeededAppConversation(params: {
   // A disabled app does not exist for chat (T-980) — deep-link seeding
   // included, or the seeded render would hand the model the very app every
   // chat tool refuses to acknowledge. Its author previews it from the Apps
-  // page instead.
-  if (!app || !app.enabled) {
+  // page instead. The app's own build chat is the exception: there the tools
+  // do answer this conversation, so seeding it hands the model an app it can
+  // actually work on.
+  if (!app || (!app.enabled && !params.creationBuildChat)) {
     throw new ApiError(404, `No app found with id ${appId}.`);
   }
 

--- a/platform/backend/src/services/apps/opened-app-context.ts
+++ b/platform/backend/src/services/apps/opened-app-context.ts
@@ -81,6 +81,14 @@ export async function resolveOpenedApp(params: {
   };
   userId: string;
   organizationId: string;
+  /**
+   * The conversation this turn belongs to, matched against the app's
+   * creation-time grace so a chat building an app an organization default
+   * disabled at birth still gets it restated in the system prompt — the
+   * authoring tools answer that conversation, so the prompt must not pretend
+   * the app is not there.
+   */
+  sessionKey?: string;
 }): Promise<OpenedApp | undefined> {
   const { openedApp, userId, organizationId } = params;
 
@@ -93,7 +101,13 @@ export async function resolveOpenedApp(params: {
     });
     // A disabled app must not reach the model at all (T-980) — dropping the
     // injection here matches the chat tools, which report it as not found.
-    if (!app || !app.enabled) return undefined;
+    // Both make the same exception for the session an org default disabled the
+    // app against at birth, so the prompt and the tools agree either way.
+    if (!app) return undefined;
+    const graced =
+      params.sessionKey !== undefined &&
+      app.creationGraceSessionKey === params.sessionKey;
+    if (!app.enabled && !graced) return undefined;
     const name = promptSafe(app.name);
     // A name that sanitizes away leaves nothing to call the app by, so there is
     // no block worth writing.

--- a/platform/backend/src/types/app.ts
+++ b/platform/backend/src/types/app.ts
@@ -247,12 +247,12 @@ export const SelectAppSchema = createSelectSchema(schema.appsTable, {
 });
 
 /**
- * The app as REST hands it out. `lockGraceSessionKey` is internal bookkeeping
- * for the authoring gate — an opaque execution key no API consumer acts on —
- * so it is dropped here rather than published in every app payload.
+ * The app as REST hands it out. `creationGraceSessionKey` is internal
+ * bookkeeping for the authoring gate — an opaque execution key no API consumer
+ * acts on — so it is dropped here rather than published in every app payload.
  */
 export const PublicAppSchema = SelectAppSchema.omit({
-  lockGraceSessionKey: true,
+  creationGraceSessionKey: true,
 });
 // `latestVersion` is owned by AppModel (set on create, bumped on fork); omit it
 // from external insert payloads alongside the generated/managed columns.

--- a/platform/frontend/src/app/settings/agents/page.tsx
+++ b/platform/frontend/src/app/settings/agents/page.tsx
@@ -398,9 +398,10 @@ export default function AgentSettingsPage() {
         title="New Apps Are Disabled by Default"
         description={
           <>
-            Create every new app disabled: author-only and invisible to agents
-            until its author enables it in App settings. Existing apps are
-            unaffected.{" "}
+            Create every new app disabled: author-only, invisible to agents and
+            runnable by nobody until its author enables it in App settings. The
+            chat it was created in can finish building it first, so a new app is
+            not stranded as an empty shell. Existing apps are unaffected.{" "}
             <ExternalDocsLink
               href={getDocsUrl(DocsPage.PlatformApps, "defaults-for-new-apps")}
               className="text-primary hover:underline"


### PR DESCRIPTION
## Problem

With **Settings → Chat → \"New apps are disabled by default\"** on, an agent can create an app and then do nothing with it — including look at it again.

`scaffold_app` writes the row with `enabled: false` (`resolveNewAppLifecycleDefaults` → `AppModel.create`), and the next call in the same conversation meets the chat loader's T-980 gate in `archestra-mcp-server/apps.ts`:

```ts
if (!app || !app.enabled) {
  return { error: errorResult(`No app found with id ${params.appId}.`) };
}
```

A disabled app reports as a missing id — for its author as much as anyone, for reads as much as writes. So the agent that just created the app is told the app does not exist, the staged build stops at the starter template, and the scaffold note told the model to give up: *"from now on this app is invisible to chat tools (do not try to edit or render it)"*. The user is asked to go enable an empty shell.

This is the same defect #7286 fixed for the **lock** default, one flag over. That fix gave the creating session a grace over the lock; an organization with both settings on simply met the disable instead.

The Apps page had it too: `POST /api/apps` with `openInChat` creates the app, then `createSeededAppConversation` refuses to seed a chat for a disabled app — so under this setting the create silently lands the user back on the Apps page with no build chat at all.

## Fix

The creation-time grace now covers both defaults. `apps.lock_grace_session_key` becomes `creationGraceSessionKey` in code, and is written whenever an organization default locked **or** disabled the new app.

- **`loadApp`** resolves the grace before the `enabled` gate, so the creating session sees and authors the app; it passes `creationGraceSession` down so `assertCallerMayAuthorApp` skips its own disabled freeze (that assertion is what actually bites on the modify path). Nothing else about the gate is relaxed — the caller still has to be someone who could author the app if it were live.
- **`setEnabled`/`setLocked`** settle the grace in the same UPDATE that flips the flag. A deliberate lock or disable ends it outright. A relaxation ends it too, *unless the other flag still shuts that session out* — unlocking an app that is still disabled (or enabling one still locked) must not take the build away from the chat halfway through it. Evaluated as a SQL `CASE` against the same row, so the two decisions cannot race.
- **The Apps-page path** seeds its build chat (`creationBuildChat`) and grants it the same grace, so a born-disabled app opens in chat instead of 404ing.
- **`resolveOpenedApp`** restates a graced app in the system prompt, so the prompt and the tools agree about whether the app is there.
- **`scaffold_app`'s note** now says what is true for that case, including the part the user has to do: this conversation may finish building, and tell the user to enable it in App settings before anyone can open it. A creator with no session behind it (an external MCP client on the gateway) keeps the old note and the old refusal — there is nothing to recognize later.

## What the setting still buys

The grace is authoring only, for one session, and only ever for an app an org default disabled at birth. The app is genuinely disabled the whole time: unlisted in `list_apps` (for the building conversation too), invisible to every other conversation, its `<name>__open` launch tool withheld from every agent and gateway surface, and not runnable by anyone until someone enables it. Enabling stays the human step the setting exists for. An app someone disabled deliberately is untouched — that is T-980 and it still holds against the author's own parallel chats.

## Column name

The property is `creationGraceSessionKey`; the column stays `lock_grace_session_key`. Renaming it is not rollout-safe — old pods would read a column that no longer exists mid-deploy — and the repo's migration linter rejects renames for exactly that reason. Doing it properly (add → backfill → drop across releases) is not worth it for an opaque, short-lived build key, so the property carries the accurate name and the schema comment explains the lag. No migration in this PR.

## Tests

`archestra-mcp-server/apps.test.ts` gains a `disabled-by-default` suite mirroring the lock one: the creating conversation runs `read_app` → `refine_app` → `set_app_tools` → `edit_app` → `delete_app` on a born-disabled app; every other conversation gets "No app found" from both read and write; `list_apps` still omits it for the building conversation; an enable/disable round trip ends the grace. Two more pin the coupling with both settings on — unlocking a still-disabled app, and enabling a still-locked one, each keep the build alive while every other conversation still meets the lock. The existing born-disabled test keeps its refusal and now says why (that context carries no session at all).

547 tests pass across `archestra-mcp-server/apps.test.ts`, `routes/app`, and `services/apps`.

## Verified in a browser

Against a running stack with the setting on and the lock default off, driving a real chat turn end to end:

- **Before** (this branch's merge-base): `scaffold_app` created the app, and the very next `edit_app` from the same conversation returned `Error: No app found with id <id>`. The app sat at `enabled=false`, `latest_version=1`.
- **After**: the same turn built the app — `edit_app` applied the document, the app reached version 2 and rendered live in the chat's Apps panel, while the panel badge still read **Disabled** and the row still had `enabled=false`, with the grace key equal to that conversation's id.
- A **second** conversation asked to edit the same app and was told `No app found with id <id>`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>