### PR TITLE
fix(dev): unwedge db:clean, openapi codegen, the API client input, and the mock seed

### DIFF
--- a/platform/backend/src/standalone-scripts/clean-db-on-dev.ts
+++ b/platform/backend/src/standalone-scripts/clean-db-on-dev.ts
@@ -72,7 +72,46 @@ export const clearDb = async (): Promise<void> => {
     await db.execute(dropEnumQuery);
   }
 
-  logger.info("✅ Database completely cleared (all tables and enums dropped)!");
+  /**
+   * Drop functions the migrations own, too.
+   *
+   * Without this the clean is silently incomplete: a migration that does a bare
+   * `CREATE FUNCTION` (not `CREATE OR REPLACE`) fails on the re-run, and because
+   * the CREATE TABLE statements before it have already committed, the migration
+   * aborts without recording itself. Every later attempt then dies on
+   * "relation ... already exists" — pointing at a table that is not the problem,
+   * and surviving `tilt down` and a full Docker prune because the data lives in
+   * a Kubernetes volume.
+   *
+   * Extension-owned functions (pgvector, pg_trgm) are excluded via `depend`:
+   * dropping those would break the extension.
+   */
+  logger.info("🗑️  Dropping all functions in public schema...");
+  const functionQuery = sql<string>`SELECT p.oid::regprocedure AS signature
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public'
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_depend d
+          WHERE d.objid = p.oid AND d.deptype = 'e'
+        );
+    `;
+
+  const functionResult = await db.execute(functionQuery);
+  const functions = functionResult.rows as Array<{ signature: string }>;
+
+  logger.info(`📋 Found ${functions.length} functions to drop`);
+
+  for (const routine of functions) {
+    logger.info(`  🗑️  Dropping function: ${routine.signature}`);
+    await db.execute(
+      sql.raw(`DROP FUNCTION IF EXISTS ${routine.signature} CASCADE;`),
+    );
+  }
+
+  logger.info(
+    "✅ Database completely cleared (all tables, enums and functions dropped)!",
+  );
   logger.info("💡 Run 'pnpm db:migrate' to recreate tables from migrations");
 };
 

--- a/platform/backend/src/standalone-scripts/codegen-openapi.ts
+++ b/platform/backend/src/standalone-scripts/codegen-openapi.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { initializeDatabase } from "@/database";
 import logger from "@/logging";
 import { enrichOpenApiWithRbac } from "@/openapi/enrich-openapi-with-rbac";
 import {
@@ -13,9 +14,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 async function generateOpenApiSpec() {
-  const fastify = createFastifyInstance();
-
   logger.info("📄 Generating OpenAPI specification...");
+
+  // Routes are not purely declarative: some run a query while registering (the
+  // skill marketplace sweeps orphaned repos at boot), so the connection has to
+  // exist before `registerApiRoutes` even though nothing here reads the schema.
+  await initializeDatabase();
+
+  const fastify = createFastifyInstance();
 
   // Note: registerOpenApiSchemas() is called at module load time in server.ts,
   // so we don't need to call it again here

--- a/platform/backend/src/standalone-scripts/seed-mock-data.ts
+++ b/platform/backend/src/standalone-scripts/seed-mock-data.ts
@@ -16,6 +16,7 @@ import {
   OrganizationModel,
   TeamModel,
 } from "@/models";
+import type { TeamMemberRole } from "@/types/team-role";
 import { isUniqueConstraintError } from "@/utils/db";
 import {
   generateMockAgents,
@@ -119,7 +120,11 @@ async function seedMockData() {
    * (team, user) unique index. Seeding must stay re-runnable, so an existing
    * membership is not an error.
    */
-  const addMember = async (teamId: string, userId: string, role: string) => {
+  const addMember = async (
+    teamId: string,
+    userId: string,
+    role: TeamMemberRole,
+  ) => {
     try {
       await TeamModel.addMember(teamId, userId, role);
     } catch (error) {

--- a/platform/backend/src/standalone-scripts/seed-mock-data.ts
+++ b/platform/backend/src/standalone-scripts/seed-mock-data.ts
@@ -4,6 +4,8 @@ import {
   EDITOR_ROLE_NAME,
   MEMBER_ROLE_NAME,
 } from "@archestra/shared";
+import { getTableName, sql } from "drizzle-orm";
+import type { PgTable } from "drizzle-orm/pg-core";
 import db, { initializeDatabase, schema } from "@/database";
 import { seedDefaultUserAndOrg } from "@/database/seed";
 import logger from "@/logging";
@@ -14,6 +16,7 @@ import {
   OrganizationModel,
   TeamModel,
 } from "@/models";
+import { isUniqueConstraintError } from "@/utils/db";
 import {
   generateMockAgents,
   generateMockInteractions,
@@ -30,11 +33,20 @@ async function seedMockData() {
 
   await initializeDatabase();
 
-  // Step 0: Clean existing mock data (in correct order due to foreign keys)
+  // Step 0: Clean existing data.
+  //
+  // One TRUNCATE ... CASCADE rather than a DELETE per table: the per-table loop
+  // ran in schema-export order, which is not a valid FK order, so it failed as
+  // soon as the database held rows the backend creates on boot (deleting
+  // internal_mcp_catalog while an mcp_server still referenced it violates that
+  // table's NOT NULL). CASCADE makes the order irrelevant.
   logger.info("Cleaning existing data...");
-  for (const table of Object.values(schema)) {
-    await db.delete(table);
-  }
+  const tableNames = Object.values(schema)
+    .map((table) => `"${getTableName(table as PgTable)}"`)
+    .join(", ");
+  await db.execute(
+    sql.raw(`TRUNCATE TABLE ${tableNames} RESTART IDENTITY CASCADE;`),
+  );
   logger.info("✅ Cleaned existing data");
 
   // Step 1: Create users
@@ -99,30 +111,33 @@ async function seedMockData() {
     createdBy: defaultAdmin.id,
   });
 
-  // Add members to teams
-  await TeamModel.addMember(teamA.id, defaultAdmin.id, ADMIN_ROLE_NAME);
-  await TeamModel.addMember(teamA.id, editorUser.id, MEMBER_ROLE_NAME);
-  await TeamModel.addMember(teamB.id, defaultAdmin.id, ADMIN_ROLE_NAME);
-  await TeamModel.addMember(teamB.id, member1User.id, MEMBER_ROLE_NAME);
-  await TeamModel.addMember(
-    managementTeam.id,
-    defaultAdmin.id,
-    ADMIN_ROLE_NAME,
-  );
-  await TeamModel.addMember(managementTeam.id, admin2User.id, ADMIN_ROLE_NAME);
-  await TeamModel.addMember(marketingTeam.id, defaultAdmin.id, ADMIN_ROLE_NAME);
-  await TeamModel.addMember(marketingTeam.id, member1User.id, MEMBER_ROLE_NAME);
-  await TeamModel.addMember(marketingTeam.id, member2User.id, MEMBER_ROLE_NAME);
-  await TeamModel.addMember(
-    engineeringTeam.id,
-    defaultAdmin.id,
-    ADMIN_ROLE_NAME,
-  );
-  await TeamModel.addMember(
-    engineeringTeam.id,
-    editorUser.id,
-    MEMBER_ROLE_NAME,
-  );
+  /**
+   * Add members to teams.
+   *
+   * Creating a team now adds its creator as an admin automatically, so every
+   * explicit add for `defaultAdmin` below is a duplicate and trips the
+   * (team, user) unique index. Seeding must stay re-runnable, so an existing
+   * membership is not an error.
+   */
+  const addMember = async (teamId: string, userId: string, role: string) => {
+    try {
+      await TeamModel.addMember(teamId, userId, role);
+    } catch (error) {
+      if (!isUniqueConstraintError(error)) throw error;
+    }
+  };
+
+  await addMember(teamA.id, defaultAdmin.id, ADMIN_ROLE_NAME);
+  await addMember(teamA.id, editorUser.id, MEMBER_ROLE_NAME);
+  await addMember(teamB.id, defaultAdmin.id, ADMIN_ROLE_NAME);
+  await addMember(teamB.id, member1User.id, MEMBER_ROLE_NAME);
+  await addMember(managementTeam.id, defaultAdmin.id, ADMIN_ROLE_NAME);
+  await addMember(managementTeam.id, admin2User.id, ADMIN_ROLE_NAME);
+  await addMember(marketingTeam.id, defaultAdmin.id, ADMIN_ROLE_NAME);
+  await addMember(marketingTeam.id, member1User.id, MEMBER_ROLE_NAME);
+  await addMember(marketingTeam.id, member2User.id, MEMBER_ROLE_NAME);
+  await addMember(engineeringTeam.id, defaultAdmin.id, ADMIN_ROLE_NAME);
+  await addMember(engineeringTeam.id, editorUser.id, MEMBER_ROLE_NAME);
 
   logger.info("✅ Created 5 teams with members");
 

--- a/platform/shared/hey-api/openapi-ts.ts
+++ b/platform/shared/hey-api/openapi-ts.ts
@@ -1,22 +1,22 @@
 import { pathToFileURL } from "node:url";
 import { createClient, defineConfig } from "@hey-api/openapi-ts";
-import {
-  DEFAULT_INTERNAL_API_BASE_URL,
-  MCP_CATALOG_API_BASE_URL,
-} from "../consts";
+import { MCP_CATALOG_API_BASE_URL } from "../consts";
 
 /**
- * During `pnpm codegen` (CODEGEN=true), use the generated docs/openapi.json file
- * which includes all enterprise routes regardless of local .env settings.
- * For manual regeneration, read it off a running dev server on the loopback API.
+ * Always the generated `docs/openapi.json`, never a running server.
+ *
+ * Reading it off the loopback API used to be the fallback when `CODEGEN=true`
+ * was not set, and it produced a subtly wrong client two ways. The spec
+ * declares no `servers`, so generating from a URL makes hey-api infer one from
+ * the address it fetched — baking `baseUrl: 'http://127.0.0.1:9000'` into the
+ * shared client that ships to every deployment. It also omits enterprise routes
+ * whenever the local .env has no license, silently shrinking the client.
+ *
+ * Regenerate the spec first (`pnpm --dir backend codegen:openapi`) if it is
+ * stale; `pnpm codegen` from the root already does that in order.
  */
-const archestraApiInput =
-  process.env.CODEGEN === "true"
-    ? "../../docs/openapi.json"
-    : `${DEFAULT_INTERNAL_API_BASE_URL}/openapi.json`;
-
 const archestraApiConfig = await defineConfig({
-  input: archestraApiInput,
+  input: "../../docs/openapi.json",
   output: {
     path: "./hey-api/clients/api",
     clean: false,


### PR DESCRIPTION
Three papercuts in the local dev loop. Each one reproduces on a clean checkout of `main` — none is caused by a feature branch.

## `db:clean` left functions behind, which wedged migrations

`clean-db-on-dev.ts` dropped tables but not functions. A migration that creates a table and then a function (0410, for example) would commit the table, fail on `CREATE FUNCTION` because one already existed, and never record itself — so the next `db:migrate` replayed it, hit "relation already exists", and looped. `tilt down` and `docker system prune` do not help, because the data lives in a PVC.

Functions in `public` are dropped now, excluding extension-owned ones via `pg_depend` — dropping those would break `pgvector` and friends.

## `codegen:openapi` could not run at all

Route registration queries the database, so `createFastifyInstance()` threw `Database not initialized` before the spec was written. `initializeDatabase()` is called first now.

## `codegen:api-client` baked localhost into the shipped client

The spec input fell back to the loopback API unless `CODEGEN=true` was set. The spec declares no `servers`, so generating from a URL makes hey-api infer one from the address it fetched, writing `baseUrl: 'http://127.0.0.1:9000'` into `client.gen.ts` and `types.gen.ts` — the shared client every deployment ships.

Nothing catches it locally: the runtime `createClientConfig` overwrites `baseUrl` on every request, so the baked value is inert until it shows up as a bad diff someone has to notice. The same fallback also omits enterprise routes when the local `.env` has no license.

Both paths read `docs/openapi.json` now, so they produce the same client.

## `seed-mock-data` was not re-runnable

A second run failed on duplicate members. It truncates with `RESTART IDENTITY CASCADE` instead of a per-table delete loop, and adding a member is idempotent.

## Verification

Ran `pnpm --dir shared codegen:api-client` directly — the command that used to poison the client — and the generated files came back byte-identical to what is committed, with no localhost anywhere. `codegen:openapi` writes the spec. Type-checks and lint pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>