### PR TITLE
fix(oauth): recover dynamic client registration when configured scopes are rejected

### DIFF
--- a/mcp-catalog/data/mcp-evaluations/posthog__remote-mcp.json
+++ b/mcp-catalog/data/mcp-evaluations/posthog__remote-mcp.json
@@ -107,9 +107,9 @@
     "server_url": "https://mcp.posthog.com/mcp",
     "client_id": "",
     "redirect_uris": ["http://localhost:8080/oauth/callback"],
-    "scopes": ["read", "write"],
+    "scopes": [],
     "description": "PostHog MCP Server (dynamic registration)",
-    "default_scopes": ["read", "write"],
+    "default_scopes": [],
     "supports_resource_metadata": true
   },
   "readme": null,

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -1642,3 +1642,188 @@ describe("OAuth dynamic client registration client name", () => {
     }
   });
 });
+
+describe("OAuth dynamic client registration scope fallback", () => {
+  const ctx = useRouteTestApp(oauthRoutes);
+  const originalFetch = globalThis.fetch;
+  const REGISTRATION_ENDPOINT = "https://auth.example.com/register";
+
+  beforeEach(() => {
+    cacheManager.start();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // A catalog item without a client_id whose configured scopes have gone stale
+  // relative to what the authorization server accepts today.
+  const makeStaleScopeCatalog = (
+    makeInternalMcpCatalog: (
+      overrides?: Record<string, unknown>,
+    ) => Promise<{ id: string; name: string }>,
+  ) =>
+    makeInternalMcpCatalog({
+      organizationId: ctx.organizationId,
+      name: "Stale Scope MCP",
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com/mcp",
+      oauthConfig: {
+        name: "Stale Scope MCP",
+        server_url: "https://mcp.example.com/mcp",
+        grant_type: "authorization_code",
+        client_id: "",
+        redirect_uris: ["http://localhost:3000/oauth-callback"],
+        scopes: ["read", "write"],
+        default_scopes: ["read", "write"],
+        supports_resource_metadata: false,
+      },
+    });
+
+  /**
+   * Metadata requests advertise a registration endpoint; the registration
+   * POST behavior is delegated to `onRegister` so each test can shape the
+   * server's scope policy.
+   */
+  const mockAuthServer = (
+    onRegister: (body: Record<string, unknown>) => {
+      ok: boolean;
+      status?: number;
+      payload: Record<string, unknown>;
+    },
+  ): Mock => {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === REGISTRATION_ENDPOINT) {
+          const body = JSON.parse(String(init?.body));
+          const result = onRegister(body);
+          return {
+            ok: result.ok,
+            status: result.status ?? (result.ok ? 201 : 400),
+            json: async () => result.payload,
+            text: async () => JSON.stringify(result.payload),
+          };
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            authorization_endpoint: "https://auth.example.com/authorize",
+            token_endpoint: "https://auth.example.com/token",
+            registration_endpoint: REGISTRATION_ENDPOINT,
+          }),
+        };
+      },
+    ) as Mock;
+    globalThis.fetch = fetchMock;
+    return fetchMock;
+  };
+
+  const initiate = (catalogId: string) =>
+    ctx.app.inject({
+      method: "POST",
+      url: "/api/oauth/initiate",
+      payload: { catalogId },
+    });
+
+  test("retries registration without scope when the server rejects the scope list and authorizes with the granted scope", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeStaleScopeCatalog(makeInternalMcpCatalog);
+    const fetchMock = mockAuthServer((body) =>
+      "scope" in body
+        ? {
+            ok: false,
+            payload: {
+              error: "invalid_client_metadata",
+              error_description:
+                "None of the requested scopes are available to self-registered clients. Omit `scope` to register with the default scope set.",
+            },
+          }
+        : {
+            ok: true,
+            payload: { client_id: "dyn-client", scope: "things:read" },
+          },
+    );
+
+    const response = await initiate(catalog.id);
+
+    expect(response.statusCode, response.body).toBe(200);
+    const authorizationUrl = new URL(response.json().authorizationUrl);
+    expect(authorizationUrl.searchParams.get("client_id")).toBe("dyn-client");
+    // The rejected configured scopes must not reach the authorization
+    // endpoint; the server-granted scope set takes their place.
+    expect(authorizationUrl.searchParams.get("scope")).toBe("things:read");
+
+    const registrationCalls = fetchMock.mock.calls.filter(
+      ([input]) => String(input) === REGISTRATION_ENDPOINT,
+    );
+    expect(registrationCalls).toHaveLength(2);
+    expect(
+      JSON.parse(String(registrationCalls[1]?.[1]?.body)),
+    ).not.toHaveProperty("scope");
+  });
+
+  test("omits the scope parameter entirely when the scope-less registration reports no granted scope", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeStaleScopeCatalog(makeInternalMcpCatalog);
+    mockAuthServer((body) =>
+      "scope" in body
+        ? { ok: false, payload: { error: "invalid_client_metadata" } }
+        : { ok: true, payload: { client_id: "dyn-client" } },
+    );
+
+    const response = await initiate(catalog.id);
+
+    expect(response.statusCode, response.body).toBe(200);
+    const authorizationUrl = new URL(response.json().authorizationUrl);
+    expect(authorizationUrl.searchParams.get("client_id")).toBe("dyn-client");
+    // No granted scope reported: defer to the server's default scope set for
+    // this client instead of re-sending the scopes it just rejected.
+    expect(authorizationUrl.searchParams.has("scope")).toBe(false);
+  });
+
+  test("prefers the granted scope from a first-attempt registration response", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeStaleScopeCatalog(makeInternalMcpCatalog);
+    const fetchMock = mockAuthServer(() => ({
+      ok: true,
+      payload: { client_id: "dyn-client", scope: "read" },
+    }));
+
+    const response = await initiate(catalog.id);
+
+    expect(response.statusCode, response.body).toBe(200);
+    const authorizationUrl = new URL(response.json().authorizationUrl);
+    // RFC 7591: the registration response's `scope` is what the client may
+    // use — requesting more would fail at the authorization endpoint.
+    expect(authorizationUrl.searchParams.get("scope")).toBe("read");
+    expect(
+      fetchMock.mock.calls.filter(
+        ([input]) => String(input) === REGISTRATION_ENDPOINT,
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("surfaces the registration failure when both attempts fail", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeStaleScopeCatalog(makeInternalMcpCatalog);
+    mockAuthServer(() => ({
+      ok: false,
+      payload: {
+        error: "invalid_client_metadata",
+        error_description: "Registration is disabled for this tenant.",
+      },
+    }));
+
+    const response = await initiate(catalog.id);
+
+    expect(response.statusCode, response.body).toBe(400);
+    const message = response.json().error.message as string;
+    expect(message).toContain("dynamic client registration failed");
+    expect(message).toContain("Registration is disabled for this tenant.");
+  });
+});

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -1692,6 +1692,7 @@ describe("OAuth dynamic client registration scope fallback", () => {
       status?: number;
       payload: Record<string, unknown>;
     },
+    metadataExtra: Record<string, unknown> = {},
   ): Mock => {
     const fetchMock = vi.fn(
       async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1711,6 +1712,7 @@ describe("OAuth dynamic client registration scope fallback", () => {
             authorization_endpoint: "https://auth.example.com/authorize",
             token_endpoint: "https://auth.example.com/token",
             registration_endpoint: REGISTRATION_ENDPOINT,
+            ...metadataExtra,
           }),
         };
       },
@@ -1762,6 +1764,46 @@ describe("OAuth dynamic client registration scope fallback", () => {
     expect(
       JSON.parse(String(registrationCalls[1]?.[1]?.body)),
     ).not.toHaveProperty("scope");
+  });
+
+  test("retries with the server's advertised scopes when the configured scopes are rejected", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeStaleScopeCatalog(makeInternalMcpCatalog);
+    const fetchMock = mockAuthServer(
+      (body) => {
+        const scope = body.scope as string | undefined;
+        if (scope === "things:read things:write") {
+          return {
+            ok: true,
+            payload: { client_id: "dyn-client", scope: "things:read" },
+          };
+        }
+        return {
+          ok: false,
+          payload: {
+            error: "invalid_client_metadata",
+            error_description: "Requested scopes are not available.",
+          },
+        };
+      },
+      { scopes_supported: ["things:read", "things:write"] },
+    );
+
+    const response = await initiate(catalog.id);
+
+    expect(response.statusCode, response.body).toBe(200);
+    const authorizationUrl = new URL(response.json().authorizationUrl);
+    expect(authorizationUrl.searchParams.get("client_id")).toBe("dyn-client");
+    // The advertised-scope registration succeeded and the server narrowed the
+    // grant, so the authorization request uses the granted set.
+    expect(authorizationUrl.searchParams.get("scope")).toBe("things:read");
+
+    const registrationCalls = fetchMock.mock.calls.filter(
+      ([input]) => String(input) === REGISTRATION_ENDPOINT,
+    );
+    // Configured attempt, then advertised-scope retry — no scope-less attempt.
+    expect(registrationCalls).toHaveLength(2);
   });
 
   test("omits the scope parameter entirely when the scope-less registration reports no granted scope", async ({

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -860,10 +860,13 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         );
 
         // Discover actual scopes from the OAuth server (like desktop app does)
-        const { configuredScopes, discoveredScopes, scopesToUse } =
-          await resolveOAuthScopesForAuthorization({
-            oauthConfig,
-          });
+        const resolvedScopes = await resolveOAuthScopesForAuthorization({
+          oauthConfig,
+        });
+        const { configuredScopes, discoveredScopes } = resolvedScopes;
+        // Mutable: a successful dynamic registration may narrow this to the
+        // scope set the server actually granted the client (RFC 7591).
+        let scopesToUse = resolvedScopes.scopesToUse;
 
         fastify.log.info(
           {
@@ -944,40 +947,82 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
         // If we don't have client credentials and registration endpoint is available, try dynamic registration
         let registrationResult: Record<string, unknown> | undefined;
+        let registrationError: string | undefined;
         if (!clientId && registrationEndpoint) {
+          const registrationMetadata = {
+            client_name: `${await resolveOAuthClientBrandName(organizationId)} - ${catalogItem.name}`,
+            redirect_uris: [redirectUri],
+            grant_types: ["authorization_code", "refresh_token"],
+            response_types: ["code"],
+            // SEP-837: OIDC servers default an omitted application_type to
+            // "web", which then rejects the localhost-style redirect URIs a
+            // self-hosted deployment uses. Non-OIDC servers ignore it.
+            application_type: "native" as const,
+          };
           try {
             fastify.log.info(
               { registrationEndpoint },
               "Attempting dynamic client registration",
             );
-            registrationResult = await registerOAuthClient(
-              registrationEndpoint,
-              {
-                client_name: `${await resolveOAuthClientBrandName(organizationId)} - ${catalogItem.name}`,
-                redirect_uris: [redirectUri],
-                grant_types: ["authorization_code", "refresh_token"],
-                response_types: ["code"],
-                // SEP-837: OIDC servers default an omitted application_type to
-                // "web", which then rejects the localhost-style redirect URIs a
-                // self-hosted deployment uses. Non-OIDC servers ignore it.
-                application_type: "native",
-                scope: scopesToUse.join(" "),
-              },
-            );
+            let registeredWithoutScope = false;
+            try {
+              registrationResult = await registerOAuthClient(
+                registrationEndpoint,
+                {
+                  ...registrationMetadata,
+                  scope: scopesToUse.join(" "),
+                },
+              );
+            } catch (error) {
+              // RFC 7591 makes `scope` optional, and servers that restrict
+              // which scopes dynamically registered clients may request reject
+              // the whole registration when the requested list has gone stale
+              // (e.g. an auth server that migrated to a new scope scheme).
+              // Retry without `scope` so the server assigns its default scope
+              // set instead of dead-ending the install.
+              fastify.log.warn(
+                {
+                  error: error instanceof Error ? error.message : String(error),
+                  scopes: scopesToUse,
+                },
+                "Dynamic registration with explicit scope failed, retrying without scope",
+              );
+              registrationResult = await registerOAuthClient(
+                registrationEndpoint,
+                registrationMetadata,
+              );
+              registeredWithoutScope = true;
+            }
 
             clientId = registrationResult?.client_id as string;
             clientSecret = registrationResult?.client_secret as
               | string
               | undefined;
 
+            // RFC 7591: a `scope` in the registration response is the scope
+            // set the client is allowed to use. Prefer it for the
+            // authorization request so we don't ask for scopes the server
+            // just told us this client cannot have.
+            const grantedScope = registrationResult?.scope;
+            if (typeof grantedScope === "string" && grantedScope.trim()) {
+              scopesToUse = grantedScope.split(/\s+/).filter(Boolean);
+            } else if (registeredWithoutScope) {
+              // The explicit scope list was rejected and the server did not
+              // report what it granted: send no scope at all and let the
+              // server apply the client's default scope set.
+              scopesToUse = [];
+            }
+
             fastify.log.info(
-              { client_id: clientId },
+              { client_id: clientId, scopes: scopesToUse },
               "Dynamic registration successful",
             );
           } catch (error) {
+            registrationError =
+              error instanceof Error ? error.message : String(error);
             fastify.log.warn(
               {
-                error: error instanceof Error ? error.message : String(error),
+                error: registrationError,
                 stack: error instanceof Error ? error.stack : undefined,
               },
               "Dynamic registration failed, continuing with default client_id",
@@ -990,7 +1035,9 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         if (!clientId) {
           throw new ApiError(
             400,
-            "No client ID available. Configure a client_id in the catalog item or ensure the OAuth server supports dynamic client registration.",
+            registrationError
+              ? `No client ID available: dynamic client registration failed (${registrationError}). Configure a client_id in the catalog item or fix the OAuth scope configuration.`
+              : "No client ID available. Configure a client_id in the catalog item or ensure the OAuth server supports dynamic client registration.",
           );
         }
 
@@ -1017,7 +1064,11 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         authUrl.searchParams.set("code_challenge", codeChallenge);
         authUrl.searchParams.set("code_challenge_method", "S256");
         authUrl.searchParams.set("state", state);
-        authUrl.searchParams.set("scope", scopesToUse.join(" "));
+        // An empty scope list means "let the server apply the client's
+        // default scope set" — omit the parameter rather than sending scope=""
+        if (scopesToUse.length > 0) {
+          authUrl.searchParams.set("scope", scopesToUse.join(" "));
+        }
         authUrl.searchParams.set("redirect_uri", redirectUri);
 
         // RFC 8707: Include resource parameter for audience binding

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -974,24 +974,67 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 },
               );
             } catch (error) {
-              // RFC 7591 makes `scope` optional, and servers that restrict
-              // which scopes dynamically registered clients may request reject
-              // the whole registration when the requested list has gone stale
-              // (e.g. an auth server that migrated to a new scope scheme).
-              // Retry without `scope` so the server assigns its default scope
-              // set instead of dead-ending the install.
+              // Servers that restrict which scopes dynamically registered
+              // clients may request reject the whole registration when the
+              // requested list has gone stale (e.g. an auth server that
+              // migrated to a granular scope scheme). Retry with the scopes
+              // the server currently advertises, so the resulting token
+              // carries real API scopes.
               fastify.log.warn(
                 {
                   error: error instanceof Error ? error.message : String(error),
                   scopes: scopesToUse,
                 },
-                "Dynamic registration with explicit scope failed, retrying without scope",
+                "Dynamic registration with configured scopes failed, retrying with advertised scopes",
               );
-              registrationResult = await registerOAuthClient(
-                registrationEndpoint,
-                registrationMetadata,
-              );
-              registeredWithoutScope = true;
+              const advertisedScopes =
+                configuredScopes.length > 0
+                  ? await discoverScopes(
+                      oauthConfig.server_url,
+                      oauthConfig.supports_resource_metadata || false,
+                      [],
+                      {
+                        authServerUrl: oauthConfig.auth_server_url,
+                        resourceMetadataUrl: oauthConfig.resource_metadata_url,
+                        wellKnownUrl: oauthConfig.well_known_url,
+                      },
+                    )
+                  : []; // scopes already came from discovery; nothing new to try
+              if (
+                advertisedScopes.length > 0 &&
+                advertisedScopes.join(" ") !== scopesToUse.join(" ")
+              ) {
+                try {
+                  registrationResult = await registerOAuthClient(
+                    registrationEndpoint,
+                    {
+                      ...registrationMetadata,
+                      scope: advertisedScopes.join(" "),
+                    },
+                  );
+                  scopesToUse = advertisedScopes;
+                } catch (retryError) {
+                  fastify.log.warn(
+                    {
+                      error:
+                        retryError instanceof Error
+                          ? retryError.message
+                          : String(retryError),
+                    },
+                    "Dynamic registration with advertised scopes failed, retrying without scope",
+                  );
+                }
+              }
+              if (!registrationResult) {
+                // Last resort: RFC 7591 makes `scope` optional — let the
+                // server assign its default scope set instead of dead-ending
+                // the install.
+                registrationResult = await registerOAuthClient(
+                  registrationEndpoint,
+                  registrationMetadata,
+                );
+                registeredWithoutScope = true;
+              }
             }
 
             clientId = registrationResult?.client_id as string;


### PR DESCRIPTION
## Problem

Installing a remote MCP server whose catalog entry has no pre-configured OAuth `client_id` dead-ends with:

> No client ID available. Configure a client_id in the catalog item or ensure the OAuth server supports dynamic client registration.

even though the authorization server *does* support dynamic client registration (RFC 7591). Root cause: some authorization servers restrict which scopes dynamically registered clients may request, and reject the entire registration when the catalog's configured scope list has gone stale (e.g. a provider that migrated from coarse `read`/`write` scopes to a granular scope scheme). The registration failure was swallowed and surfaced as the misleading "no client ID" error.

A naive retry without `scope` isn't enough either: the server then assigns its *default* scope set, which can be identity-only (`openid profile email`), producing a token the MCP endpoint rejects at connect time (`Invalid API key`).

## Fix

In the OAuth initiate flow's dynamic-registration step:

1. **Retry with the server's advertised scopes.** When registration with the resolved scopes fails, re-discover the scopes the server currently advertises (resource metadata → authorization server metadata) and retry with those. The server grants the subset it allows.
2. **Fall back to a scope-less registration** (RFC 7591 makes `scope` optional) only as a last resort.
3. **Prefer the granted `scope` from the registration response** when building the authorization URL — per RFC 7591 it is the scope set the client may use, so re-sending rejected scopes to the authorization endpoint is avoided. When no granted scope is known, the `scope` parameter is omitted so the server applies the client's defaults.
4. **Surface the registration failure** in the 400 error instead of the generic "no client ID" message when registration was attempted and failed.

Also drops the stale `read`/`write` scopes from the one catalog entry that carried them, so fresh installs resolve scopes via discovery.

## Verification

- Unit tests for the retry ladder, granted-scope preference, scope omission, and error surfacing (`backend/src/routes/oauth.test.ts`).
- Verified end-to-end in a browser against the live provider: pre-patch reproduces the "No client ID available" error; post-patch the install completes — registration (configured scopes rejected → advertised-scope retry granted) → consent shows the granular permissions → callback stores the token → remote MCP tool discovery succeeds with it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>