### PR TITLE
feat(knowledge): surface text-only embedding limitations

### DIFF
--- a/platform/frontend/src/app/knowledge/_parts/embedding-model-image-support-notice.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/embedding-model-image-support-notice.tsx
@@ -33,25 +33,54 @@ export function EmbeddingModelImageSupportNotice({
   const modelKey = `${provider}/${modelId}`;
   const storageKey = `${DISMISSED_MODEL_STORAGE_PREFIX}:${dismissalScope}`;
   const dismissalId = `${storageKey}:${modelKey}`;
-  const [dismissedId, setDismissedId] = useState(() =>
-    readDismissedModelKey(storageKey) === modelKey ? dismissalId : null,
-  );
+  const [dismissalState, setDismissalState] = useState<{
+    id: string;
+    fingerprint: string | null;
+    dismissed: boolean;
+  } | null>(null);
 
   useEffect(() => {
-    const storedModelKey = readDismissedModelKey(storageKey);
-    if (storedModelKey && storedModelKey !== modelKey) {
-      clearDismissedModelKey(storageKey);
-      setDismissedId(null);
-      return;
-    }
-    setDismissedId(storedModelKey === modelKey ? dismissalId : null);
+    let cancelled = false;
+    getModelFingerprint(modelKey)
+      .then((fingerprint) => {
+        if (cancelled) return;
+        const storedFingerprint = readDismissedModelFingerprint(storageKey);
+        if (storedFingerprint && storedFingerprint !== fingerprint) {
+          clearDismissedModelFingerprint(storageKey);
+        }
+        setDismissalState({
+          id: dismissalId,
+          fingerprint,
+          dismissed: storedFingerprint === fingerprint,
+        });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDismissalState({
+            id: dismissalId,
+            fingerprint: null,
+            dismissed: false,
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [dismissalId, modelKey, storageKey]);
 
-  if (supportsImages !== false || dismissedId === dismissalId) return null;
+  if (
+    supportsImages !== false ||
+    dismissalState?.id !== dismissalId ||
+    dismissalState.dismissed
+  ) {
+    return null;
+  }
 
   const handleDismiss = () => {
-    writeDismissedModelKey(storageKey, modelKey);
-    setDismissedId(dismissalId);
+    if (dismissalState.fingerprint) {
+      writeDismissedModelFingerprint(storageKey, dismissalState.fingerprint);
+    }
+    setDismissalState({ ...dismissalState, dismissed: true });
   };
 
   return (
@@ -109,7 +138,7 @@ export function embeddingModelSupportsImages(
   );
 }
 
-function readDismissedModelKey(storageKey: string): string | null {
+function readDismissedModelFingerprint(storageKey: string): string | null {
   if (typeof window === "undefined") return null;
   try {
     return localStorage.getItem(storageKey);
@@ -118,18 +147,31 @@ function readDismissedModelKey(storageKey: string): string | null {
   }
 }
 
-function writeDismissedModelKey(storageKey: string, modelKey: string) {
+function writeDismissedModelFingerprint(
+  storageKey: string,
+  fingerprint: string,
+) {
   try {
-    localStorage.setItem(storageKey, modelKey);
+    localStorage.setItem(storageKey, fingerprint);
   } catch {
     // Keep the in-memory dismissal when browser storage is unavailable.
   }
 }
 
-function clearDismissedModelKey(storageKey: string) {
+function clearDismissedModelFingerprint(storageKey: string) {
   try {
     localStorage.removeItem(storageKey);
   } catch {
     // A blocked storage backend is already equivalent to no persisted dismissal.
   }
+}
+
+async function getModelFingerprint(modelKey: string) {
+  const digest = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(modelKey),
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
 }

--- a/platform/frontend/src/app/knowledge/_parts/embedding-model-image-support-notice.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/embedding-model-image-support-notice.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import {
+  DocsPage,
+  getDocsUrl,
+  type SupportedProvider,
+} from "@archestra/shared";
+import { Info, Settings2 } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { ModelWithApiKeys } from "@/lib/llm-models.query";
+import { cn } from "@/lib/utils";
+
+const DISMISSED_MODEL_STORAGE_PREFIX =
+  "knowledge-image-embedding-notice-dismissed-model";
+
+export function EmbeddingModelImageSupportNotice({
+  modelId,
+  provider,
+  dismissalScope,
+  supportsImages,
+  showSettingsLink = true,
+  className,
+}: {
+  modelId: string;
+  provider: SupportedProvider;
+  dismissalScope: string;
+  supportsImages: boolean | null;
+  showSettingsLink?: boolean;
+  className?: string;
+}) {
+  const modelKey = `${provider}/${modelId}`;
+  const storageKey = `${DISMISSED_MODEL_STORAGE_PREFIX}:${dismissalScope}`;
+  const dismissalId = `${storageKey}:${modelKey}`;
+  const [dismissedId, setDismissedId] = useState(() =>
+    readDismissedModelKey(storageKey) === modelKey ? dismissalId : null,
+  );
+
+  useEffect(() => {
+    const storedModelKey = readDismissedModelKey(storageKey);
+    if (storedModelKey && storedModelKey !== modelKey) {
+      clearDismissedModelKey(storageKey);
+      setDismissedId(null);
+      return;
+    }
+    setDismissedId(storedModelKey === modelKey ? dismissalId : null);
+  }, [dismissalId, modelKey, storageKey]);
+
+  if (supportsImages !== false || dismissedId === dismissalId) return null;
+
+  const handleDismiss = () => {
+    writeDismissedModelKey(storageKey, modelKey);
+    setDismissedId(dismissalId);
+  };
+
+  return (
+    <div
+      role="note"
+      className={cn(
+        "flex flex-col gap-3 rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-sm text-muted-foreground sm:flex-row sm:items-center",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-start gap-2">
+        <Info className="mt-0.5 size-4 shrink-0" />
+        <p className="leading-relaxed">
+          <span className="font-medium text-foreground">
+            <code>{modelKey}</code>
+          </span>{" "}
+          handles text only. Choose a multimodal embedding model to sync
+          supported image files.{" "}
+          <a
+            href={getDocsUrl(DocsPage.PlatformKnowledge, "image-embedding")}
+            target="_blank"
+            rel="noreferrer"
+            className="text-foreground underline decoration-dotted underline-offset-4 hover:decoration-solid"
+          >
+            Learn more
+          </a>
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-1 self-end sm:self-auto">
+        {showSettingsLink && (
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/settings/knowledge#embedding-configuration">
+              <Settings2 className="size-3.5" />
+              <span>Embedding settings</span>
+            </Link>
+          </Button>
+        )}
+        <Button variant="ghost" size="sm" onClick={handleDismiss}>
+          <span>Dismiss</span>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function embeddingModelSupportsImages(
+  model: Pick<
+    ModelWithApiKeys,
+    "inputModalities" | "embeddingClientImageCapable"
+  >,
+): boolean {
+  return (
+    model.inputModalities?.includes("image") === true &&
+    model.embeddingClientImageCapable !== false
+  );
+}
+
+function readDismissedModelKey(storageKey: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage.getItem(storageKey);
+  } catch {
+    return null;
+  }
+}
+
+function writeDismissedModelKey(storageKey: string, modelKey: string) {
+  try {
+    localStorage.setItem(storageKey, modelKey);
+  } catch {
+    // Keep the in-memory dismissal when browser storage is unavailable.
+  }
+}
+
+function clearDismissedModelKey(storageKey: string) {
+  try {
+    localStorage.removeItem(storageKey);
+  } catch {
+    // A blocked storage backend is already equivalent to no persisted dismissal.
+  }
+}

--- a/platform/frontend/src/app/knowledge/connectors/[id]/page.client.test.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/[id]/page.client.test.tsx
@@ -63,6 +63,10 @@ vi.mock("@/app/knowledge/connectors/_parts/connector-documents-table", () => ({
   ConnectorDocumentsTable: () => null,
 }));
 vi.mock(
+  "@/app/knowledge/connectors/_parts/connector-embedding-model-notice",
+  () => ({ ConnectorEmbeddingModelNotice: () => null }),
+);
+vi.mock(
   "@/app/knowledge/connectors/_parts/connector-user-groups-table",
   () => ({ ConnectorUserGroupsTable: () => <div>groups-table</div> }),
 );

--- a/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
@@ -24,6 +24,7 @@ import { useSearchParams } from "next/navigation";
 import { Fragment, useCallback, useMemo, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { ConnectorDocumentsTable } from "@/app/knowledge/connectors/_parts/connector-documents-table";
+import { ConnectorEmbeddingModelNotice } from "@/app/knowledge/connectors/_parts/connector-embedding-model-notice";
 import { ConnectorMembersTable } from "@/app/knowledge/connectors/_parts/connector-members-table";
 import { ConnectorRunDetailsDialog } from "@/app/knowledge/connectors/_parts/connector-run-details-dialog";
 import { ConnectorUnassignedUsersAlert } from "@/app/knowledge/connectors/_parts/connector-unassigned-users-alert";
@@ -655,6 +656,10 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
             )}
           </div>
         </div>
+
+        <ConnectorEmbeddingModelNotice
+          connectorType={connector.connectorType}
+        />
 
         {/* Visible on EVERY tab: an admin landing anywhere on the page
             learns about unassigned users without drilling into the Users

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-embedding-model-notice.test.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-embedding-model-notice.test.tsx
@@ -1,0 +1,176 @@
+import { DocsPage, getDocsUrl } from "@archestra/shared";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSession } from "@/lib/auth/auth.query";
+import { useModelsWithApiKeys } from "@/lib/llm-models.query";
+import { useOrganization } from "@/lib/organization.query";
+import { ConnectorEmbeddingModelNotice } from "./connector-embedding-model-notice";
+
+vi.mock("@/lib/llm-models.query");
+vi.mock("@/lib/organization.query");
+vi.mock("@/lib/auth/auth.query");
+
+const EMBEDDING_API_KEY_ID = "embedding-key";
+const EMBEDDING_MODEL_ID = "text-embedding-model";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.mocked(useOrganization).mockReturnValue({
+    data: {
+      id: "organization-1",
+      embeddingChatApiKeyId: EMBEDDING_API_KEY_ID,
+      embeddingModel: EMBEDDING_MODEL_ID,
+    },
+  } as ReturnType<typeof useOrganization>);
+  vi.mocked(useSession).mockReturnValue({
+    data: { user: { id: "user-1" } },
+  } as ReturnType<typeof useSession>);
+});
+
+describe("ConnectorEmbeddingModelNotice", () => {
+  it("shows a quiet note with settings and documentation links for a text-only model", () => {
+    mockEmbeddingModel({
+      inputModalities: ["text"],
+      embeddingClientImageCapable: false,
+    });
+
+    render(<ConnectorEmbeddingModelNotice connectorType="gdrive" />);
+
+    expect(screen.getByRole("note")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByRole("note")).toHaveTextContent(
+      "openai/text-embedding-model handles text only",
+    );
+    expect(
+      screen.getByText(/choose a multimodal embedding model/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Embedding settings" }),
+    ).toHaveAttribute("href", "/settings/knowledge#embedding-configuration");
+    expect(screen.getByRole("link", { name: "Learn more" })).toHaveAttribute(
+      "href",
+      getDocsUrl(DocsPage.PlatformKnowledge, "image-embedding"),
+    );
+  });
+
+  it("warns when model metadata declares images but its embedding client cannot send them", () => {
+    mockEmbeddingModel({
+      inputModalities: ["text", "image"],
+      embeddingClientImageCapable: false,
+    });
+
+    render(<ConnectorEmbeddingModelNotice connectorType="gdrive" />);
+
+    expect(screen.getByRole("note")).toBeInTheDocument();
+  });
+
+  it("renders nothing for image-capable embedding models", () => {
+    for (const embeddingClientImageCapable of [true, null]) {
+      mockEmbeddingModel({
+        inputModalities: ["text", "image"],
+        embeddingClientImageCapable,
+      });
+
+      const { container, unmount } = render(
+        <ConnectorEmbeddingModelNotice connectorType="gdrive" />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+      unmount();
+    }
+  });
+
+  it("renders nothing until the configured model can be resolved", () => {
+    vi.mocked(useModelsWithApiKeys).mockReturnValue({
+      data: undefined,
+    } as ReturnType<typeof useModelsWithApiKeys>);
+
+    const { container } = render(
+      <ConnectorEmbeddingModelNotice connectorType="gdrive" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("keeps the note dismissed until the embedding model changes", async () => {
+    const user = userEvent.setup();
+    mockEmbeddingModel({
+      inputModalities: ["text"],
+      embeddingClientImageCapable: false,
+    });
+
+    const { unmount } = render(
+      <ConnectorEmbeddingModelNotice connectorType="gdrive" />,
+    );
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+
+    unmount();
+    const { rerender } = render(
+      <ConnectorEmbeddingModelNotice connectorType="gdrive" />,
+    );
+    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+
+    vi.mocked(useOrganization).mockReturnValue({
+      data: {
+        id: "organization-1",
+        embeddingChatApiKeyId: EMBEDDING_API_KEY_ID,
+        embeddingModel: "replacement-model",
+      },
+    } as ReturnType<typeof useOrganization>);
+    mockEmbeddingModel({
+      modelId: "replacement-model",
+      inputModalities: ["text"],
+      embeddingClientImageCapable: false,
+    });
+    rerender(<ConnectorEmbeddingModelNotice connectorType="gdrive" />);
+
+    expect(screen.getByRole("note")).toBeInTheDocument();
+  });
+
+  it("does not show on connectors that cannot ingest images", () => {
+    const { container } = render(
+      <ConnectorEmbeddingModelNotice connectorType="jira" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("scopes dismissal to the signed-in user", async () => {
+    const user = userEvent.setup();
+    mockEmbeddingModel({
+      inputModalities: ["text"],
+      embeddingClientImageCapable: false,
+    });
+    const { rerender } = render(
+      <ConnectorEmbeddingModelNotice connectorType="gdrive" />,
+    );
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "user-2" } },
+    } as ReturnType<typeof useSession>);
+    rerender(<ConnectorEmbeddingModelNotice connectorType="gdrive" />);
+
+    expect(screen.getByRole("note")).toBeInTheDocument();
+  });
+});
+
+function mockEmbeddingModel(params: {
+  modelId?: string;
+  inputModalities: Array<"text" | "image">;
+  embeddingClientImageCapable: boolean | null;
+}) {
+  vi.mocked(useModelsWithApiKeys).mockReturnValue({
+    data: [
+      {
+        modelId: params.modelId ?? EMBEDDING_MODEL_ID,
+        provider: "openai",
+        apiKeys: [{ id: EMBEDDING_API_KEY_ID }],
+        inputModalities: params.inputModalities,
+        embeddingClientImageCapable: params.embeddingClientImageCapable,
+      },
+    ],
+  } as ReturnType<typeof useModelsWithApiKeys>);
+}

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-embedding-model-notice.test.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-embedding-model-notice.test.tsx
@@ -1,7 +1,7 @@
 import { DocsPage, getDocsUrl } from "@archestra/shared";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSession } from "@/lib/auth/auth.query";
 import { useModelsWithApiKeys } from "@/lib/llm-models.query";
 import { useOrganization } from "@/lib/organization.query";
@@ -16,6 +16,18 @@ const EMBEDDING_MODEL_ID = "text-embedding-model";
 
 beforeEach(() => {
   localStorage.clear();
+  vi.stubGlobal("crypto", {
+    subtle: {
+      digest: vi.fn(
+        async (_algorithm: AlgorithmIdentifier, data: BufferSource) => {
+          const bytes = ArrayBuffer.isView(data)
+            ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+            : new Uint8Array(data);
+          return Uint8Array.from(bytes, (byte) => byte ^ 0xff).buffer;
+        },
+      ),
+    },
+  });
   vi.mocked(useOrganization).mockReturnValue({
     data: {
       id: "organization-1",
@@ -28,8 +40,12 @@ beforeEach(() => {
   } as ReturnType<typeof useSession>);
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("ConnectorEmbeddingModelNotice", () => {
-  it("shows a quiet note with settings and documentation links for a text-only model", () => {
+  it("shows a quiet note with settings and documentation links for a text-only model", async () => {
     mockEmbeddingModel({
       inputModalities: ["text"],
       embeddingClientImageCapable: false,
@@ -37,7 +53,7 @@ describe("ConnectorEmbeddingModelNotice", () => {
 
     render(<ConnectorEmbeddingModelNotice connectorType="gdrive" />);
 
-    expect(screen.getByRole("note")).toBeInTheDocument();
+    expect(await screen.findByRole("note")).toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(screen.getByRole("note")).toHaveTextContent(
       "openai/text-embedding-model handles text only",
@@ -54,7 +70,7 @@ describe("ConnectorEmbeddingModelNotice", () => {
     );
   });
 
-  it("warns when model metadata declares images but its embedding client cannot send them", () => {
+  it("warns when model metadata declares images but its embedding client cannot send them", async () => {
     mockEmbeddingModel({
       inputModalities: ["text", "image"],
       embeddingClientImageCapable: false,
@@ -62,7 +78,7 @@ describe("ConnectorEmbeddingModelNotice", () => {
 
     render(<ConnectorEmbeddingModelNotice connectorType="gdrive" />);
 
-    expect(screen.getByRole("note")).toBeInTheDocument();
+    expect(await screen.findByRole("note")).toBeInTheDocument();
   });
 
   it("renders nothing for image-capable embedding models", () => {
@@ -103,13 +119,19 @@ describe("ConnectorEmbeddingModelNotice", () => {
     const { unmount } = render(
       <ConnectorEmbeddingModelNotice connectorType="gdrive" />,
     );
-    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    await user.click(await screen.findByRole("button", { name: "Dismiss" }));
     expect(screen.queryByRole("note")).not.toBeInTheDocument();
+    const storedFingerprint = localStorage.getItem(localStorage.key(0) ?? "");
+    expect(storedFingerprint).toMatch(/^[0-9a-f]+$/);
+    expect(storedFingerprint).not.toContain(EMBEDDING_MODEL_ID);
 
     unmount();
     const { rerender } = render(
       <ConnectorEmbeddingModelNotice connectorType="gdrive" />,
     );
+    await waitFor(() => {
+      expect(globalThis.crypto.subtle.digest).toHaveBeenCalledTimes(2);
+    });
     expect(screen.queryByRole("note")).not.toBeInTheDocument();
 
     vi.mocked(useOrganization).mockReturnValue({
@@ -126,7 +148,7 @@ describe("ConnectorEmbeddingModelNotice", () => {
     });
     rerender(<ConnectorEmbeddingModelNotice connectorType="gdrive" />);
 
-    expect(screen.getByRole("note")).toBeInTheDocument();
+    expect(await screen.findByRole("note")).toBeInTheDocument();
   });
 
   it("does not show on connectors that cannot ingest images", () => {
@@ -146,14 +168,14 @@ describe("ConnectorEmbeddingModelNotice", () => {
     const { rerender } = render(
       <ConnectorEmbeddingModelNotice connectorType="gdrive" />,
     );
-    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    await user.click(await screen.findByRole("button", { name: "Dismiss" }));
 
     vi.mocked(useSession).mockReturnValue({
       data: { user: { id: "user-2" } },
     } as ReturnType<typeof useSession>);
     rerender(<ConnectorEmbeddingModelNotice connectorType="gdrive" />);
 
-    expect(screen.getByRole("note")).toBeInTheDocument();
+    expect(await screen.findByRole("note")).toBeInTheDocument();
   });
 });
 

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-embedding-model-notice.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-embedding-model-notice.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { ConnectorType } from "@archestra/shared";
+import {
+  EmbeddingModelImageSupportNotice,
+  embeddingModelSupportsImages,
+} from "@/app/knowledge/_parts/embedding-model-image-support-notice";
+import { useSession } from "@/lib/auth/auth.query";
+import { useModelsWithApiKeys } from "@/lib/llm-models.query";
+import { useOrganization } from "@/lib/organization.query";
+
+const IMAGE_CAPABLE_CONNECTOR_TYPES = new Set<ConnectorType>([
+  "dropbox",
+  "gdrive",
+  "mfiles",
+  "onedrive",
+  "sharepoint",
+]);
+
+export function ConnectorEmbeddingModelNotice({
+  connectorType,
+}: {
+  connectorType: ConnectorType;
+}) {
+  if (!IMAGE_CAPABLE_CONNECTOR_TYPES.has(connectorType)) return null;
+  return <CurrentEmbeddingModelNotice />;
+}
+
+function CurrentEmbeddingModelNotice() {
+  const { data: organization } = useOrganization();
+  const { data: session } = useSession();
+  const { data: models } = useModelsWithApiKeys({ toastOnError: false });
+  const embeddingApiKeyId = organization?.embeddingChatApiKeyId;
+  const embeddingModelId = organization?.embeddingModel;
+
+  const dismissalScope =
+    organization?.id && session?.user.id
+      ? `${organization.id}:${session.user.id}`
+      : null;
+
+  if (!embeddingApiKeyId || !embeddingModelId || !models || !dismissalScope) {
+    return null;
+  }
+
+  const embeddingModel = models.find(
+    (model) =>
+      model.modelId === embeddingModelId &&
+      model.apiKeys.some((apiKey) => apiKey.id === embeddingApiKeyId),
+  );
+  if (!embeddingModel) return null;
+
+  return (
+    <EmbeddingModelImageSupportNotice
+      modelId={embeddingModel.modelId}
+      provider={embeddingModel.provider}
+      dismissalScope={dismissalScope}
+      supportsImages={embeddingModelSupportsImages(embeddingModel)}
+    />
+  );
+}

--- a/platform/frontend/src/app/settings/knowledge/page.test.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCapabilities } from "@/lib/llm-models.query";
 
 // Radix Popper / floating-ui needs ResizeObserver
 global.ResizeObserver = class ResizeObserver {
@@ -81,6 +82,18 @@ let mockEmbeddingModels: Array<{
   provider: string;
   displayName: string;
   embeddingDimensions: 3072 | 1536 | 768 | null;
+  capabilities?: ModelCapabilities;
+  embeddingClientImageCapable?: boolean | null;
+  isFree?: boolean;
+  isBest?: boolean;
+}> = [];
+let mockLlmModels: Array<{
+  id: string;
+  provider: string;
+  displayName: string;
+  capabilities?: ModelCapabilities;
+  isFree?: boolean;
+  isBest?: boolean;
 }> = [];
 
 vi.mock("@/lib/llm-provider-api-keys.query", () => ({
@@ -96,14 +109,7 @@ vi.mock("@/lib/llm-provider-api-keys.query", () => ({
 
 vi.mock("@/lib/llm-models.query", () => ({
   useLlmModels: () => ({
-    data: [
-      { id: "gpt-4o", provider: "openai", displayName: "GPT-4o" },
-      {
-        id: "claude-3-opus",
-        provider: "anthropic",
-        displayName: "Claude 3 Opus",
-      },
-    ],
+    data: mockLlmModels,
     isPending: false,
   }),
   useEmbeddingModels: () => ({
@@ -113,8 +119,14 @@ vi.mock("@/lib/llm-models.query", () => ({
   useModelsWithApiKeys: () => ({
     data: mockEmbeddingModels.map((m) => ({
       id: m.id,
+      modelId: m.id,
       provider: m.provider,
       embeddingDimensions: m.embeddingDimensions,
+      inputModalities: m.capabilities?.inputModalities ?? null,
+      embeddingClientImageCapable:
+        m.embeddingClientImageCapable === undefined
+          ? false
+          : m.embeddingClientImageCapable,
       apiKeys: mockApiKeys
         .filter((k) => k.provider === m.provider)
         .map((k) => ({ id: k.id })),
@@ -144,6 +156,7 @@ vi.mock("@/lib/auth/auth.query");
 import {
   useHasPermissions,
   useMissingPermissions,
+  useSession,
 } from "@/lib/auth/auth.query";
 
 vi.mock("@/lib/clients/auth/auth-client");
@@ -176,8 +189,41 @@ function getEmbeddingModelTrigger() {
   return modelTrigger;
 }
 
+function getRerankerModelTrigger() {
+  const modelTrigger = screen
+    .getAllByRole("combobox")
+    .find((el) => el.textContent?.includes("Select reranking model"));
+
+  if (!modelTrigger) {
+    throw new Error("Reranking model trigger not found");
+  }
+
+  return modelTrigger;
+}
+
+function makeCapabilities(
+  overrides: Partial<ModelCapabilities> = {},
+): ModelCapabilities {
+  return {
+    contextLength: 128000,
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    supportsToolCalling: true,
+    recommendedForAgents: true,
+    pricePerMillionInput: null,
+    pricePerMillionOutput: null,
+    isCustomPrice: false,
+    priceSource: "default",
+    pricePerMillionCacheRead: null,
+    pricePerMillionCacheWrite: null,
+    cachePriceSource: "default",
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
   vi.mocked(useAppName).mockReturnValue("Archestra");
   mockUpdateKnowledgeSettings = vi.fn();
   mockOrganization = null;
@@ -189,6 +235,14 @@ beforeEach(() => {
       provider: "openai",
       displayName: "text-embedding-3-small",
       embeddingDimensions: 1536,
+    },
+  ];
+  mockLlmModels = [
+    { id: "gpt-4o", provider: "openai", displayName: "GPT-4o" },
+    {
+      id: "claude-3-opus",
+      provider: "anthropic",
+      displayName: "Claude 3 Opus",
     },
   ];
 
@@ -237,6 +291,9 @@ beforeEach(() => {
   vi.mocked(useMissingPermissions).mockReturnValue(
     [] as unknown as ReturnType<typeof useMissingPermissions>,
   );
+  vi.mocked(useSession).mockReturnValue({
+    data: { user: { id: "test-user" } },
+  } as ReturnType<typeof useSession>);
 
   vi.mocked(authClient.useSession).mockReturnValue({
     data: {
@@ -388,6 +445,169 @@ describe("KnowledgeSettingsPage", () => {
           name: /Sync models and configure embedding dimensions/,
         }),
       ).toHaveAttribute("href", "/llm/models");
+    });
+  });
+
+  describe("model capability metadata", () => {
+    it("shows embedding model modalities and context in the dropdown", async () => {
+      const user = userEvent.setup();
+      mockOrganization = {
+        embeddingChatApiKeyId: "key-1",
+        embeddingModel: null,
+        rerankerChatApiKeyId: null,
+        rerankerModel: null,
+      };
+      mockApiKeys = [
+        {
+          id: "key-1",
+          name: "Embedding Key",
+          provider: "openai",
+          scope: "org",
+        },
+      ];
+      mockEmbeddingModels = [
+        {
+          id: "multimodal-embedding",
+          provider: "openai",
+          displayName: "Multimodal Embedding",
+          embeddingDimensions: 1536,
+          capabilities: makeCapabilities({
+            inputModalities: ["text", "image"],
+          }),
+          embeddingClientImageCapable: true,
+        },
+      ];
+      renderPage();
+
+      await user.click(getEmbeddingModelTrigger());
+
+      expect(screen.getByLabelText("Supports text input")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Supports vision (images)"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("128,000 token context window"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows reranking model modalities and capabilities in the dropdown", async () => {
+      const user = userEvent.setup();
+      mockOrganization = {
+        embeddingChatApiKeyId: null,
+        embeddingModel: null,
+        rerankerChatApiKeyId: "key-1",
+        rerankerModel: null,
+      };
+      mockApiKeys = [
+        {
+          id: "key-1",
+          name: "Reranking Key",
+          provider: "openai",
+          scope: "org",
+        },
+      ];
+      mockLlmModels = [
+        {
+          id: "vision-reranker",
+          provider: "openai",
+          displayName: "Vision Reranker",
+          capabilities: makeCapabilities({
+            inputModalities: ["text", "image"],
+            supportsToolCalling: true,
+          }),
+        },
+      ];
+      renderPage();
+
+      await user.click(getRerankerModelTrigger());
+
+      expect(screen.getByLabelText("Supports text input")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Supports vision (images)"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Supports tool calling"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("embedding image support note", () => {
+    it("shows a dismissible note inside the embedding settings card", async () => {
+      const user = userEvent.setup();
+      mockOrganization = {
+        id: "organization-1",
+        embeddingChatApiKeyId: "key-1",
+        embeddingModel: "text-embedding-model",
+        rerankerChatApiKeyId: null,
+        rerankerModel: null,
+      };
+      mockApiKeys = [
+        {
+          id: "key-1",
+          name: "Embedding Key",
+          provider: "openai",
+          scope: "org",
+        },
+      ];
+      mockEmbeddingModels = [
+        {
+          id: "text-embedding-model",
+          provider: "openai",
+          displayName: "Text Embedding Model",
+          embeddingDimensions: 1536,
+          capabilities: makeCapabilities({
+            inputModalities: ["text"],
+            supportsToolCalling: null,
+          }),
+          embeddingClientImageCapable: false,
+        },
+      ];
+      renderPage();
+
+      const note = screen.getByRole("note");
+      expect(note.closest("#embedding-configuration")).toBeInTheDocument();
+      expect(
+        within(note).queryByRole("link", { name: "Embedding settings" }),
+      ).not.toBeInTheDocument();
+      expect(
+        within(note).getByRole("link", { name: "Learn more" }),
+      ).toBeInTheDocument();
+
+      await user.click(within(note).getByRole("button", { name: "Dismiss" }));
+      expect(screen.queryByRole("note")).not.toBeInTheDocument();
+    });
+
+    it("does not show the note for an image-capable embedding model", () => {
+      mockOrganization = {
+        id: "organization-1",
+        embeddingChatApiKeyId: "key-1",
+        embeddingModel: "multimodal-embedding",
+        rerankerChatApiKeyId: null,
+        rerankerModel: null,
+      };
+      mockApiKeys = [
+        {
+          id: "key-1",
+          name: "Embedding Key",
+          provider: "openai",
+          scope: "org",
+        },
+      ];
+      mockEmbeddingModels = [
+        {
+          id: "multimodal-embedding",
+          provider: "openai",
+          displayName: "Multimodal Embedding",
+          embeddingDimensions: 1536,
+          capabilities: makeCapabilities({
+            inputModalities: ["text", "image"],
+          }),
+          embeddingClientImageCapable: true,
+        },
+      ];
+      renderPage();
+
+      expect(screen.queryByRole("note")).not.toBeInTheDocument();
     });
   });
 

--- a/platform/frontend/src/app/settings/knowledge/page.test.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.test.tsx
@@ -564,7 +564,7 @@ describe("KnowledgeSettingsPage", () => {
       ];
       renderPage();
 
-      const note = screen.getByRole("note");
+      const note = await screen.findByRole("note");
       expect(note.closest("#embedding-configuration")).toBeInTheDocument();
       expect(
         within(note).queryByRole("link", { name: "Embedding settings" }),

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -16,6 +16,10 @@ import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
+import {
+  EmbeddingModelImageSupportNotice,
+  embeddingModelSupportsImages,
+} from "@/app/knowledge/_parts/embedding-model-image-support-notice";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { FormDialog } from "@/components/form-dialog";
 import { LlmModelSearchableSelect } from "@/components/llm-model-select";
@@ -49,6 +53,7 @@ import {
   DialogStickyFooter,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { isPersonalSubscription } from "@/lib/llm-key-subscription";
 import {
@@ -392,7 +397,12 @@ function RerankerModelSelector({
   const rerankerItems = models.map((model) => ({
     value: model.id,
     model: model.displayName ?? model.id,
+    modelId: model.id,
     provider: model.provider,
+    description: model.displayName === model.id ? undefined : model.id,
+    capabilities: model.capabilities,
+    isFree: model.isFree,
+    isBest: model.isBest,
   }));
 
   return (
@@ -473,6 +483,7 @@ function TestConnectionIcon({ status }: { status: ConnectionStatus }) {
 
 function KnowledgeSettingsContent() {
   const { data: organization, isPending } = useOrganization();
+  const { data: session } = useSession();
   const {
     data: apiKeys,
     isPending: areApiKeysPending,
@@ -540,6 +551,12 @@ function KnowledgeSettingsContent() {
     () => embeddingModels?.find((model) => model.id === embeddingModel) ?? null,
     [embeddingModels, embeddingModel],
   );
+  const selectedEmbeddingCatalogModel =
+    modelsWithApiKeys?.find(
+      (model) =>
+        model.modelId === embeddingModel &&
+        model.apiKeys.some((apiKey) => apiKey.id === embeddingChatApiKeyId),
+    ) ?? null;
   const selectedEmbeddingProvider =
     selectedEmbeddingApiKey?.provider ??
     selectedEmbeddingModel?.provider ??
@@ -547,6 +564,10 @@ function KnowledgeSettingsContent() {
   const embeddingEmptyMessage = selectedEmbeddingApiKey
     ? `No embedding models detected for "${selectedEmbeddingApiKey.name}".`
     : "Select an embedding API key first.";
+  const noticeDismissalScope =
+    organization?.id && session?.user.id
+      ? `${organization.id}:${session.user.id}`
+      : null;
 
   useEffect(() => {
     if (organization) {
@@ -741,7 +762,7 @@ function KnowledgeSettingsContent() {
       loadingFallback={<LoadingSpinner />}
     >
       <SettingsSectionStack>
-        <Card>
+        <Card id="embedding-configuration">
           <CardHeader>
             <CardTitle>Embedding Configuration</CardTitle>
             <CardDescription className="leading-relaxed">
@@ -778,8 +799,14 @@ function KnowledgeSettingsContent() {
                       onValueChange={(v) => setEmbeddingModel(v || null)}
                       options={(embeddingModels ?? []).map((model) => ({
                         value: model.id,
-                        model: model.id,
+                        model: model.displayName ?? model.id,
+                        modelId: model.id,
                         provider: model.provider,
+                        description:
+                          model.displayName === model.id ? undefined : model.id,
+                        capabilities: model.capabilities,
+                        isFree: model.isFree,
+                        isBest: model.isBest,
                         badge: model.embeddingDimensions
                           ? `${model.embeddingDimensions} dims`
                           : undefined,
@@ -814,6 +841,24 @@ function KnowledgeSettingsContent() {
                       <ArrowUpRight className="h-3.5 w-3.5" />
                     </Link>
                   </p>
+                  {embeddingModel &&
+                    selectedEmbeddingProvider &&
+                    noticeDismissalScope && (
+                      <EmbeddingModelImageSupportNotice
+                        modelId={embeddingModel}
+                        provider={selectedEmbeddingProvider}
+                        dismissalScope={noticeDismissalScope}
+                        supportsImages={
+                          selectedEmbeddingCatalogModel
+                            ? embeddingModelSupportsImages(
+                                selectedEmbeddingCatalogModel,
+                              )
+                            : null
+                        }
+                        showSettingsLink={false}
+                        className="sm:ml-28"
+                      />
+                    )}
                   {selectedEmbeddingProvider === "gemini" &&
                     selectedEmbeddingModel?.embeddingDimensions === 1536 && (
                       <p className="flex items-start gap-2 text-xs text-muted-foreground sm:pl-28">

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -16,7 +16,6 @@ import {
   DollarSign,
   FileText,
   ImageIcon,
-  Layers,
   Loader2,
   Mic,
   Settings2,
@@ -41,11 +40,12 @@ import {
   ConnectAccountBadge,
   FreeModelBadge,
   LatestModelBadge,
-  NoToolsBadge,
-  NotRecommendedForAgentsBadge,
   OldModelBadge,
-  UnknownCapabilitiesBadge,
 } from "@/components/model-badges";
+import {
+  ModelCapabilityBadges,
+  ModelContextLengthIndicator,
+} from "@/components/model-capability-indicators";
 import { Button } from "@/components/ui/button";
 import { DialogClose } from "@/components/ui/dialog";
 import { Toggle } from "@/components/ui/toggle";
@@ -57,14 +57,10 @@ import {
 } from "@/components/ui/tooltip";
 import { resolveAutoSelectedModel } from "@/lib/chat/use-chat-preferences";
 import { copyToClipboard } from "@/lib/clipboard";
-import {
-  type LlmModel,
-  type ModelCapabilities,
-  useLlmModelsByProvider,
-} from "@/lib/llm-models.query";
+import { type LlmModel, useLlmModelsByProvider } from "@/lib/llm-models.query";
 import { formatPricePerMillion } from "@/lib/model-price-format";
 import { providerToLogoProvider } from "@/lib/provider-logos";
-import { cn, formatContextLength } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
 /** Modalities that can be filtered (excludes "text" since all models support it) */
 type FilterableModality = Exclude<ModelInputModality, "text">;
@@ -195,136 +191,6 @@ function providerModelSections(
     { key: provider, heading: providerDisplayNames[provider], models },
   ];
   return sections.filter((section) => section.models.length > 0);
-}
-
-/**
- * Capability icon component - matches Vercel AI Elements style.
- * Small, compact icons that show model capabilities.
- */
-function CapabilityIcon({
-  icon: Icon,
-  label,
-  className,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  className?: string;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className={cn(
-            "inline-flex items-center justify-center size-4 rounded-sm bg-muted/50",
-            className,
-          )}
-        >
-          <Icon className="size-2.5 text-muted-foreground" />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="text-xs">
-        {label}
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-/**
- * Displays capability icons for a model in a compact row.
- * Style inspired by Vercel AI Elements model selector.
- */
-function ModelCapabilityBadges({
-  capabilities,
-}: {
-  capabilities?: ModelCapabilities;
-}) {
-  const hasVision = capabilities?.inputModalities?.includes("image");
-  const hasAudio = capabilities?.inputModalities?.includes("audio");
-  const hasVideo = capabilities?.inputModalities?.includes("video");
-  const hasPdf = capabilities?.inputModalities?.includes("pdf");
-  const hasToolCalling = capabilities?.supportsToolCalling;
-
-  // An explicit false, as opposed to null/undefined ("unknown"): the model is
-  // known to take no tools, which gets its own marker below.
-  const lacksToolCalling = capabilities?.supportsToolCalling === false;
-
-  // Derived by the sync, independently of the capability fields, so it is
-  // usually the only marker an Ollama row carries: those models sync with an
-  // inferred "text" modality and no tool-calling verdict (models.dev lists no
-  // Ollama entry to supply one), which without this would render nothing.
-  // Strictly `=== false` — `true` is the column default and says nothing. The
-  // verdict is not itself capability data, so a row carrying only one still
-  // falls to the unknown badge below.
-  const notRecommended = capabilities?.recommendedForAgents === false;
-
-  const hasAnyCapability =
-    hasVision || hasAudio || hasVideo || hasPdf || hasToolCalling;
-
-  // "Unknown" strictly means no capability data was recorded. An explicit
-  // `supportsToolCalling: false` or a recorded modality list is known data —
-  // a text-only, tool-less model (e.g. the Perplexity sonar family) is marked
-  // as such rather than claiming ignorance.
-  const hasCapabilityData =
-    capabilities != null &&
-    (capabilities.inputModalities != null ||
-      capabilities.supportsToolCalling != null);
-  if (!hasCapabilityData) {
-    return <UnknownCapabilitiesBadge />;
-  }
-  if (!hasAnyCapability && !lacksToolCalling && !notRecommended) {
-    return null;
-  }
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <div className="flex items-center gap-0.5">
-        {hasVision && (
-          <CapabilityIcon icon={ImageIcon} label="Supports vision (images)" />
-        )}
-        {hasAudio && <CapabilityIcon icon={Mic} label="Supports audio input" />}
-        {hasVideo && (
-          <CapabilityIcon icon={Video} label="Supports video input" />
-        )}
-        {hasPdf && (
-          <CapabilityIcon icon={FileText} label="Supports PDF input" />
-        )}
-        {notRecommended && <NotRecommendedForAgentsBadge />}
-        {lacksToolCalling && <NoToolsBadge />}
-        {hasToolCalling && (
-          <CapabilityIcon icon={Settings2} label="Supports tool calling" />
-        )}
-      </div>
-    </TooltipProvider>
-  );
-}
-
-/**
- * Displays the context window size with a tooltip.
- */
-function ContextLengthIndicator({
-  contextLength,
-}: {
-  contextLength: number | null | undefined;
-}) {
-  if (!contextLength) {
-    return null;
-  }
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="inline-flex items-center gap-0.5 text-xs text-muted-foreground font-mono">
-            <Layers className="size-3" />
-            {formatContextLength(contextLength)}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          {contextLength.toLocaleString()} token context window
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
 }
 
 /**
@@ -996,7 +862,7 @@ function ModelSelectorDialogBody({
                       <ModelCapabilityBadges
                         capabilities={model.capabilities}
                       />
-                      <ContextLengthIndicator
+                      <ModelContextLengthIndicator
                         contextLength={model.capabilities?.contextLength}
                       />
                       <PricingIndicator

--- a/platform/frontend/src/components/llm-model-select.test.tsx
+++ b/platform/frontend/src/components/llm-model-select.test.tsx
@@ -152,6 +152,51 @@ describe("LlmModelSearchableSelect", () => {
     expect(screen.getByText("Latest")).toBeInTheDocument();
   });
 
+  it("renders model modalities, tool support, and context in option rows", async () => {
+    const user = userEvent.setup();
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        options={[
+          {
+            value: "vision-model",
+            model: "Vision Model",
+            modelId: "vision-model-v1",
+            description: "vision-model-v1",
+            provider: "openai",
+            capabilities: {
+              contextLength: 128000,
+              inputModalities: ["text", "image"],
+              outputModalities: ["text"],
+              supportsToolCalling: true,
+              recommendedForAgents: true,
+              pricePerMillionInput: null,
+              pricePerMillionOutput: null,
+              isCustomPrice: false,
+              priceSource: "default",
+              pricePerMillionCacheRead: null,
+              pricePerMillionCacheWrite: null,
+              cachePriceSource: "default",
+            },
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByLabelText("Supports text input")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Supports vision (images)"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Supports tool calling")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("128,000 token context window"),
+    ).toHaveTextContent("128K");
+    expect(screen.getAllByText("vision-model-v1")).toHaveLength(1);
+  });
+
   it("pins the routers to the top of the list", async () => {
     const user = userEvent.setup();
     render(

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -11,11 +11,16 @@ import type { PopoverContentProps } from "@radix-ui/react-popover";
 import { Layers, Sparkles } from "lucide-react";
 import Image from "next/image";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
+import {
+  ModelCapabilityBadges,
+  ModelContextLengthIndicator,
+} from "@/components/model-capability-indicators";
 import { SearchableMultiSelect } from "@/components/searchable-multi-select";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { Switch } from "@/components/ui/switch";
+import type { ModelCapabilities } from "@/lib/llm-models.query";
 import { formatPricePerMillion } from "@/lib/model-price-format";
 import { providerLogoUrl } from "@/lib/provider-logos";
 import { cn } from "@/lib/utils";
@@ -38,6 +43,8 @@ export type LlmModelSelectOption = {
   isFree?: boolean;
   /** Provider's highest-quality ("recommended") model — sorted near the top. */
   isBest?: boolean;
+  /** Input modalities, tool support, and context shown in rich option rows. */
+  capabilities?: ModelCapabilities;
 };
 
 /** The provider's native model id, used for badge detection and ordering. */
@@ -94,15 +101,29 @@ export function LlmModelOptionLabel({
         className="shrink-0 rounded dark:invert"
       />
       <div className="min-w-0 flex-1 flex flex-col">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
           <span
             className={cn(
-              truncateModelName ? "truncate" : "whitespace-normal break-words",
+              "min-w-0 flex-1",
+              truncateModelName
+                ? "truncate"
+                : "basis-40 whitespace-normal break-words",
             )}
           >
             {option.model}
           </span>
           <ModelBadges option={option} />
+          {option.capabilities && (
+            <div className="ml-auto flex max-w-full shrink-0 items-center gap-2">
+              <ModelCapabilityBadges
+                capabilities={option.capabilities}
+                showTextInput
+              />
+              <ModelContextLengthIndicator
+                contextLength={option.capabilities.contextLength}
+              />
+            </div>
+          )}
         </div>
         {showPricing && (
           <div className="truncate text-xs text-muted-foreground">
@@ -305,7 +326,7 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
         ...visibleOptions.map((option) => ({
           value: option.value,
           label: option.model,
-          searchText: `${providerDisplayNames[option.provider]} ${option.model}`,
+          searchText: `${providerDisplayNames[option.provider]} ${option.model} ${modelIdOf(option)} ${option.description ?? ""}`,
           content: (
             <LlmModelOptionLabel
               option={option}
@@ -348,8 +369,7 @@ export function LlmModelSearchableSelect(props: LlmModelSearchableSelectProps) {
         ...visibleOptions.map((option) => ({
           value: option.value,
           label: option.model,
-          searchText: `${providerDisplayNames[option.provider]} ${option.model}`,
-          description: option.description,
+          searchText: `${providerDisplayNames[option.provider]} ${option.model} ${modelIdOf(option)} ${option.description ?? ""}`,
           content: (
             <LlmModelOptionLabel
               option={option}

--- a/platform/frontend/src/components/model-capability-indicators.tsx
+++ b/platform/frontend/src/components/model-capability-indicators.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import {
+  FileText,
+  ImageIcon,
+  Layers,
+  Mic,
+  Settings2,
+  Type,
+  Video,
+} from "lucide-react";
+import {
+  NoToolsBadge,
+  NotRecommendedForAgentsBadge,
+  UnknownCapabilitiesBadge,
+} from "@/components/model-badges";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ModelCapabilities } from "@/lib/llm-models.query";
+import { cn, formatContextLength } from "@/lib/utils";
+
+export function ModelCapabilityBadges({
+  capabilities,
+  showTextInput = false,
+}: {
+  capabilities?: ModelCapabilities;
+  showTextInput?: boolean;
+}) {
+  const hasText =
+    showTextInput && capabilities?.inputModalities?.includes("text");
+  const hasVision = capabilities?.inputModalities?.includes("image");
+  const hasAudio = capabilities?.inputModalities?.includes("audio");
+  const hasVideo = capabilities?.inputModalities?.includes("video");
+  const hasPdf = capabilities?.inputModalities?.includes("pdf");
+  const hasToolCalling = capabilities?.supportsToolCalling;
+  const lacksToolCalling = capabilities?.supportsToolCalling === false;
+  const notRecommended = capabilities?.recommendedForAgents === false;
+  const hasAnyCapability =
+    hasText || hasVision || hasAudio || hasVideo || hasPdf || hasToolCalling;
+  const hasCapabilityData =
+    capabilities != null &&
+    (capabilities.inputModalities != null ||
+      capabilities.supportsToolCalling != null);
+
+  if (!hasCapabilityData) return <UnknownCapabilitiesBadge />;
+  if (!hasAnyCapability && !lacksToolCalling && !notRecommended) return null;
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="flex max-w-full flex-wrap items-center justify-end gap-0.5">
+        {hasText && <CapabilityIcon icon={Type} label="Supports text input" />}
+        {hasVision && (
+          <CapabilityIcon icon={ImageIcon} label="Supports vision (images)" />
+        )}
+        {hasAudio && <CapabilityIcon icon={Mic} label="Supports audio input" />}
+        {hasVideo && (
+          <CapabilityIcon icon={Video} label="Supports video input" />
+        )}
+        {hasPdf && (
+          <CapabilityIcon icon={FileText} label="Supports PDF input" />
+        )}
+        {notRecommended && <NotRecommendedForAgentsBadge />}
+        {lacksToolCalling && <NoToolsBadge />}
+        {hasToolCalling && (
+          <CapabilityIcon icon={Settings2} label="Supports tool calling" />
+        )}
+      </div>
+    </TooltipProvider>
+  );
+}
+
+export function ModelContextLengthIndicator({
+  contextLength,
+}: {
+  contextLength: number | null | undefined;
+}) {
+  if (!contextLength) return null;
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            role="img"
+            aria-label={`${contextLength.toLocaleString()} token context window`}
+            className="inline-flex items-center gap-0.5 font-mono text-xs text-muted-foreground"
+          >
+            <Layers className="size-3" />
+            <span>{formatContextLength(contextLength)}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {contextLength.toLocaleString()} token context window
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function CapabilityIcon({
+  icon: Icon,
+  label,
+  className,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          role="img"
+          aria-label={label}
+          className={cn(
+            "inline-flex size-4 items-center justify-center rounded-sm bg-muted/50",
+            className,
+          )}
+        >
+          <Icon className="size-2.5 text-muted-foreground" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
Task: [T-1081](https://archestra.slack.com/archives/C090CHBKQBK/p1784808077657439)

## Problem

Knowledge sources such as Google Drive, SharePoint, OneDrive, M-Files, and Dropbox can contain images, but administrators get no guidance when the configured embedding model only accepts text. The embedding and reranking selectors also hide useful models.dev capability metadata.

## Fix

- Show a neutral notice on image-capable connector pages and in Knowledge settings when the configured embedding model lacks image input support. The notice names the exact `provider/model`, links to the image-embedding docs and settings, and can be dismissed per organization, user, and configured model.
- Enrich embedding and reranking options with display names, native model IDs, modalities, tool support, context length, dimensions, and free/best indicators.
- Extract the existing chat capability indicators into a shared component so selectors present model metadata consistently.
- Keep this frontend-only: no ingestion behavior, database schema, migrations, or skip counters change.

## Verification

- 87 focused Vitest tests across connector notices/pages, Knowledge settings, and model selectors.
- Frontend TypeScript check.
- Scoped Biome check on all 11 changed files.
- Frontend Knip check.
- Live browser verification at desktop and 390px mobile widths.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>