### PR TITLE
fix: address five recurring production error hotspots

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -307548,7 +307548,9 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "id",
@@ -308207,7 +308209,9 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "id",
@@ -308773,7 +308777,9 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "id",
@@ -309047,7 +309053,9 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "id",
@@ -310392,7 +310400,9 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "id",
@@ -310960,7 +310970,9 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "id",
@@ -311233,7 +311245,9 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "id",
@@ -311836,7 +311850,9 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "id",

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -1489,30 +1489,35 @@ class InteractionModel {
     // We filter in JS (much faster than SQL text scanning for the title/prompt checks)
     const INTERACTIONS_PER_SESSION = 20;
 
-    // Build the WHERE clause using Drizzle's sql template
-    const sessionCondition =
-      sessionKeys.length > 0
-        ? sql`session_id IN (${sql.join(
-            sessionKeys.map((k) => sql`${k}`),
-            sql`, `,
-          )})`
-        : null;
-
-    const uuidCondition =
+    // Per-key top-N via LATERAL instead of one `session_id IN (...) OR
+    // id IN (...)` query ranked with ROW_NUMBER(): the window form had to
+    // materialize and sort EVERY interaction of every listed session —
+    // request/response payloads included — before discarding all but the
+    // first N, which pushed busy organizations into statement timeout. The
+    // LATERAL branch is one (session_id, created_at DESC) index descent per
+    // key that stops after N rows; sessionless interaction ids are a separate
+    // primary-key lookup (each such row is its own "session", so N does not
+    // apply). A uuid key that matches a row owned by a *different* session is
+    // no longer fetched — the JS below grouped such rows under a key nobody
+    // asked for and never read them.
+    const sessionKeyList = sql.join(
+      sessionKeys.map((k) => sql`${k}`),
+      sql`, `,
+    );
+    const sessionlessBranch =
       uuidKeys.length > 0
-        ? sql`id IN (${sql.join(
-            uuidKeys.map((k) => sql`${k}::uuid`),
-            sql`, `,
-          )})`
-        : null;
+        ? sql`
+      UNION ALL
+      SELECT id, session_id, thread_id, request, response, type, created_at,
+             locked_chat_conversation_id
+      FROM interactions
+      WHERE id IN (${sql.join(
+        uuidKeys.map((k) => sql`${k}::uuid`),
+        sql`, `,
+      )})
+        AND session_id IS NULL`
+        : sql``;
 
-    const whereConditions = [sessionCondition, uuidCondition].filter(Boolean);
-    const whereClause =
-      whereConditions.length === 1
-        ? whereConditions[0]
-        : sql.join(whereConditions as SQL[], sql` OR `);
-
-    // Use ROW_NUMBER() to limit interactions per session.
     // thread_id is selected so the chosen tip can be reconstructed from deltas.
     const interactionsResult = await db.execute<{
       id: string;
@@ -1533,18 +1538,18 @@ class InteractionModel {
       -- preview. Ids are monotonic UUIDv7, so they settle the tie by true
       -- insertion order (the same tiebreak the write path already uses to
       -- resolve a delta parent).
-      WITH ranked AS (
-        SELECT
-          id, session_id, thread_id, request, response, type, created_at,
-          locked_chat_conversation_id,
-          ROW_NUMBER() OVER (PARTITION BY COALESCE(session_id, id::text) ORDER BY created_at DESC, id DESC) as rn
+      SELECT t.id, t.session_id, t.thread_id, t.request, t.response, t.type,
+             t.created_at, t.locked_chat_conversation_id
+      FROM (SELECT DISTINCT k.key FROM unnest(ARRAY[${sessionKeyList}]::text[]) AS k(key)) keys
+      CROSS JOIN LATERAL (
+        SELECT id, session_id, thread_id, request, response, type, created_at,
+               locked_chat_conversation_id
         FROM interactions
-        WHERE ${whereClause}
-      )
-      SELECT id, session_id, thread_id, request, response, type, created_at,
-             locked_chat_conversation_id
-      FROM ranked
-      WHERE rn <= ${INTERACTIONS_PER_SESSION}
+        WHERE session_id = keys.key
+        ORDER BY created_at DESC, id DESC
+        LIMIT ${INTERACTIONS_PER_SESSION}
+      ) t
+      ${sessionlessBranch}
       ORDER BY session_id, created_at DESC, id DESC
     `);
 

--- a/platform/backend/src/observability/error-tracking-policy.test.ts
+++ b/platform/backend/src/observability/error-tracking-policy.test.ts
@@ -233,4 +233,14 @@ describe("classifyErrorForTracking", () => {
     expect(decision.tags?.secrets_backend_error).toHaveLength(200);
     expect(decision.tags?.secrets_backend_error).toMatch(/^500: x+$/);
   });
+  test("drops a deployment failure whose wrapper lost the error name", () => {
+    // Several report paths persist or re-wrap the runtime's
+    // McpServerDeploymentFailedError as a plain Error, losing the name the
+    // unreachable-server set matches on. The stable message prefix still
+    // identifies the user's container failing, not a crash of ours.
+    const rewrapped = new Error(
+      "Deployment mcp-example-server-abc123 failed: CrashLoopBackOff - back-off 10s restarting failed container",
+    );
+    expect(classifyErrorForTracking(rewrapped)).toEqual({ report: false });
+  });
 });

--- a/platform/backend/src/observability/error-tracking-policy.ts
+++ b/platform/backend/src/observability/error-tracking-policy.ts
@@ -140,6 +140,16 @@ function isNonActionableError(error: unknown): boolean {
     return true;
   }
 
+  // The same deployment failures matched by message shape: several report
+  // paths re-wrap the runtime's error (or persist and re-surface its message),
+  // which loses the error name the set above matches on. The message prefix
+  // is stable — every McpServerDeploymentFailedError is built as
+  // "Deployment <name> failed: <reason>" (k8s-deployment.ts) — and describes
+  // the state of the user's container, not a crash of ours.
+  if (error instanceof Error && /^Deployment .+ failed: /.test(error.message)) {
+    return true;
+  }
+
   // Low-level connectivity failures that reach the handler unmapped: an
   // undici connect/headers/body timeout or a dropped connection from an
   // outbound fetch, or @fastify/reply-from's upstream-failure errors

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -40,7 +40,11 @@ export async function fetchAnthropicModels(
 
   return data.data.map((model) => ({
     id: model.id,
-    displayName: model.display_name,
+    // Fall back to the id: with a base-URL override the upstream may be an
+    // OpenAI-compatible or otherwise non-Anthropic-shaped server whose model
+    // rows carry no display_name — leaving it undefined made the proxy's
+    // /v1/models response fail its own schema (a 500 for every listing).
+    displayName: model.display_name ?? model.id,
     provider: "anthropic",
     createdAt: model.created_at,
   }));

--- a/platform/backend/src/routes/interaction.test.ts
+++ b/platform/backend/src/routes/interaction.test.ts
@@ -636,6 +636,65 @@ describe("interaction routes", () => {
     expect(response.json().pagination.total).toBe(4);
   });
 
+  test("derives the newest preview for long sessions and for sessionless interactions", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({
+      organizationId,
+      authorId: currentUser.id,
+      scope: "org",
+    });
+
+    const make = (sessionId: string | null, text: string, second: number) =>
+      InteractionModel.create({
+        profileId: agent.id,
+        sessionId,
+        source: "api",
+        request: {
+          model: "gpt-4",
+          messages: [{ role: "user", content: text }],
+        } as unknown as InsertInteraction["request"],
+        response: {
+          id: "r",
+          object: "chat.completion" as const,
+          created: Date.now(),
+          model: "gpt-4",
+          choices: [],
+        } as unknown as InsertInteraction["response"],
+        type: "openai:chatCompletions",
+        // Explicit distinct timestamps: the per-session window ranks by
+        // created_at and defaultNow() can tie within one millisecond.
+        createdAt: new Date(2020, 0, 1, 0, 0, second),
+      });
+
+    // More interactions than the per-session fetch window (20), so the
+    // preview provably comes from a top-N scan that keeps the NEWEST rows —
+    // the pre-LATERAL bug class was ranking/sort mistakes across big
+    // sessions timing out or picking stale rows.
+    for (let i = 0; i < 25; i++) {
+      await make("busy-session", `message ${i}`, i);
+    }
+    const solo = await make(null, "solo message", 30);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/interactions/sessions?limit=10&offset=0",
+    });
+    expect(response.statusCode).toBe(200);
+    const rows = response.json().data as Array<{
+      sessionId: string | null;
+      interactionId: string | null;
+      lastUserMessagePreview: string | null;
+    }>;
+
+    const busy = rows.find((r) => r.sessionId === "busy-session");
+    expect(busy?.lastUserMessagePreview).toBe("message 24");
+
+    // A sessionless interaction is its own "session" and still gets a preview.
+    const soloRow = rows.find((r) => r.interactionId === solo.id);
+    expect(soloRow?.lastUserMessagePreview).toBe("solo message");
+  });
+
   test("hides an agent-less interaction from a non-agent-admin", async ({
     makeUser,
     makeMember,

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -1147,3 +1147,61 @@ describe("handleError", () => {
     );
   });
 });
+
+describe("handleError upstream marking", () => {
+  function makeReply() {
+    const replyShape = {
+      header: () => replyShape,
+      status: () => replyShape,
+      send: () => replyShape,
+      raw: { headersSent: false, write: () => true, end: () => {} },
+    };
+    return replyShape as unknown as FastifyReply;
+  }
+
+  const extractMessage = (error: unknown) =>
+    error instanceof Error ? error.message : "Internal server error";
+
+  function thrownFor(error: unknown): ApiError {
+    try {
+      handleError(error, makeReply(), extractMessage, false, () => undefined);
+    } catch (thrown) {
+      return thrown as ApiError;
+    }
+    throw new Error("handleError did not throw");
+  }
+
+  test("marks a relayed Bedrock 5xx (statusCode + responseBody shape) as upstream", () => {
+    // clients/bedrock-client.ts errors carry the provider's raw body as
+    // `responseBody` rather than a parsed `error` member; these relays used
+    // to be captured as crashes of ours.
+    const error = new Error(
+      "Bedrock API error (500): The system encountered an unexpected error during processing. Try your request again.",
+    );
+    (error as Error & { statusCode: number }).statusCode = 500;
+    (error as Error & { responseBody: string }).responseBody =
+      '{"message":"The system encountered an unexpected error during processing. Try your request again."}';
+
+    const thrown = thrownFor(error);
+    expect(thrown.statusCode).toBe(500);
+    expect(thrown.upstream).toBe(true);
+  });
+
+  test("marks a status-less SDK connection failure as upstream alongside its 502 mapping", () => {
+    // The OpenAI SDK's APIConnectionError ("Connection error.") carries no
+    // HTTP status and no provider body — classified as a 502 relay, it must
+    // also be marked upstream so error tracking drops it.
+    const error = new Error("Connection error.");
+    error.name = "APIConnectionError";
+
+    const thrown = thrownFor(error);
+    expect(thrown.statusCode).toBe(502);
+    expect(thrown.upstream).toBe(true);
+  });
+
+  test("does not mark our own unclassified 500s as upstream", () => {
+    const thrown = thrownFor(new Error("something internal exploded"));
+    expect(thrown.statusCode).toBe(500);
+    expect(thrown.upstream).not.toBe(true);
+  });
+});

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -436,6 +436,7 @@ export function handleError(
   }
 
   // Some SDK transport and streaming failures do not carry an HTTP status.
+  let isClassifiedTransportFailure = false;
   if (!hasExplicitStatus) {
     if (isClientAbortError(error)) {
       // The proxy client disconnected and the disconnect was propagated to
@@ -449,6 +450,13 @@ export function handleError(
       const upstreamStatus = classifyTransientUpstreamError(error);
       if (upstreamStatus !== undefined) {
         statusCode = upstreamStatus;
+        // A status-less SDK connection/timeout failure ("Connection error.",
+        // "fetch failed", ETIMEDOUT) is by definition the upstream being
+        // unreachable, not a crash of ours — but it carries neither a parsed
+        // provider body nor response headers, so the provider-shape check
+        // below cannot mark it. Mark it here so error tracking drops the
+        // relay while clients still get the mapped 502/504.
+        isClassifiedTransportFailure = true;
       }
     }
   }
@@ -558,7 +566,10 @@ export function handleError(
   // Headers not sent yet - throw ApiError to let central handler return proper status code
   // This matches V1 handler behavior and ensures clients receive correct HTTP status
   const apiError = new ApiError(statusCode, errorMessage, internalCode);
-  apiError.upstream = isUpstreamProviderFailure || isUpstreamOverload;
+  apiError.upstream =
+    isUpstreamProviderFailure ||
+    isUpstreamOverload ||
+    isClassifiedTransportFailure;
   throw apiError;
 }
 
@@ -569,7 +580,16 @@ export function handleError(
  */
 function hasProviderHttpErrorShape(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  return "error" in error || "headers" in error || "$metadata" in error;
+  return (
+    "error" in error ||
+    "headers" in error ||
+    "$metadata" in error ||
+    // The Bedrock client's non-OK errors carry the provider's raw body as
+    // `responseBody` (see clients/bedrock-client.ts) rather than a parsed
+    // `error` member — without this, a relayed Bedrock 500/502 was treated
+    // as a crash of ours.
+    "responseBody" in error
+  );
 }
 
 /**

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.test.ts
@@ -39,6 +39,10 @@ import { fetchOpenAiModels } from "@/routes/chat/model-fetchers/openai";
 import anthropicProxyRoutes from "./anthropic";
 import githubCopilotProxyRoutes from "./github-copilot";
 import openAiProxyRoutes from "./openai";
+import {
+  AnthropicModelsListResponseSchema,
+  toAnthropicModelsList,
+} from "./proxy-model-listing";
 
 async function buildApp(
   plugin:
@@ -522,5 +526,24 @@ describe("provider-specific proxy GET /models (virtual-key-aware)", () => {
 
     expect(response.statusCode).toBe(401);
     expect(fetchOpenAiModels).not.toHaveBeenCalled();
+  });
+});
+
+describe("toAnthropicModelsList display_name fallback", () => {
+  test("falls back to the model id when displayName is missing at runtime", () => {
+    // Rows built from a non-Anthropic-shaped upstream listing (base-URL
+    // override) can lack display_name; one bare row used to fail the whole
+    // response against AnthropicModelsListResponseSchema as a 500.
+    const models = [
+      { id: "claude-sonnet-5", provider: "anthropic" },
+      { id: "custom-model", displayName: "Custom", provider: "anthropic" },
+    ] as unknown as Parameters<typeof toAnthropicModelsList>[0];
+
+    const listed = toAnthropicModelsList(models);
+    expect(listed.data.map((m) => m.display_name)).toEqual([
+      "claude-sonnet-5",
+      "Custom",
+    ]);
+    expect(() => AnthropicModelsListResponseSchema.parse(listed)).not.toThrow();
   });
 });

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
@@ -203,7 +203,11 @@ export function toAnthropicModelsList(models: ModelInfo[]) {
     data: models.map((model) => ({
       type: "model" as const,
       id: model.id,
-      display_name: model.displayName,
+      // ModelInfo types displayName as required, but rows built from
+      // non-Anthropic-shaped upstream listings can leave it undefined at
+      // runtime — the response schema requires a string, so a single bare
+      // row used to fail the whole listing with a serialization 500.
+      display_name: model.displayName ?? model.id,
       created_at: model.createdAt,
     })),
     has_more: false,

--- a/platform/backend/src/routes/skill/get.skill.route.test.ts
+++ b/platform/backend/src/routes/skill/get.skill.route.test.ts
@@ -43,4 +43,16 @@ describe("GET /api/skills/:id", () => {
     });
     expect(deleteResponse.statusCode).toBe(404);
   });
+
+  test("a non-uuid id (e.g. a skill name) is rejected as 400, not a database 500", async () => {
+    // Callers pass skill names here; the raw string used to reach Postgres
+    // and fail with `invalid input syntax for type uuid` as a 500.
+    for (const url of [
+      "/api/skills/agent-builder",
+      "/api/skills/agent-builder/usage-statistics",
+    ]) {
+      const response = await ctx.app.inject({ method: "GET", url });
+      expect(response.statusCode, url).toBe(400);
+    }
+  });
 });

--- a/platform/backend/src/routes/skill/skill.routes.ts
+++ b/platform/backend/src/routes/skill/skill.routes.ts
@@ -717,7 +717,11 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         operationId: RouteId.GetSkill,
         description: "Get a skill with its resource files",
         tags: ["Skills"],
-        params: z.object({ id: z.string() }),
+        // UuidIdSchema (not z.string()): a non-uuid id — callers pass skill
+        // names here — used to flow into the model and fail in Postgres with
+        // "invalid input syntax for type uuid" as a 500. Reject at the
+        // boundary as a 400 instead; names are not valid skill ids.
+        params: z.object({ id: UuidIdSchema }),
         response: constructResponseSchema(SkillDetailSchema),
       },
     },
@@ -739,7 +743,7 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         description:
           "Per-user activation counts for a skill over the last 30 days",
         tags: ["Skills"],
-        params: z.object({ id: z.string() }),
+        params: z.object({ id: UuidIdSchema }),
         response: constructResponseSchema(SkillUsageStatisticsSchema),
       },
     },
@@ -837,7 +841,7 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         operationId: RouteId.UpdateSkill,
         description: "Update a skill's SKILL.md, resource files, and scope",
         tags: ["Skills"],
-        params: z.object({ id: z.string() }),
+        params: z.object({ id: UuidIdSchema }),
         body: SkillManifestUpdateSchema,
         response: constructResponseSchema(SkillDetailSchema),
       },
@@ -1008,7 +1012,7 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         operationId: RouteId.DeleteSkill,
         description: "Delete a skill and its resource files",
         tags: ["Skills"],
-        params: z.object({ id: z.string() }),
+        params: z.object({ id: UuidIdSchema }),
         response: constructResponseSchema(DeleteObjectResponseSchema),
       },
     },
@@ -1032,7 +1036,7 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         operationId: RouteId.RestoreSkill,
         description: "Restore a soft-deleted skill",
         tags: ["Skills"],
-        params: z.object({ id: z.string() }),
+        params: z.object({ id: UuidIdSchema }),
         response: constructResponseSchema(SkillDetailSchema),
       },
     },
@@ -1096,7 +1100,7 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "soft-deleted row is what stops the seeder recreating them on the " +
           "next restart. Restore wins a race.",
         tags: ["Skills"],
-        params: z.object({ id: z.string() }),
+        params: z.object({ id: UuidIdSchema }),
         response: constructResponseSchema(DeleteObjectResponseSchema),
       },
     },
@@ -1162,7 +1166,7 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
         description:
           "Reset a built-in skill to its shipped default SKILL.md and resource files. Only applies to skills with sourceType `built_in`.",
         tags: ["Skills"],
-        params: z.object({ id: z.string() }),
+        params: z.object({ id: UuidIdSchema }),
         response: constructResponseSchema(SkillDetailSchema),
       },
     },
@@ -1218,7 +1222,7 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "(interval null) — a disconnected skill keeps its content and " +
           "provenance and becomes editable in the app.",
         tags: ["Skills"],
-        params: z.object({ id: z.string() }),
+        params: z.object({ id: UuidIdSchema }),
         body: z
           .object({
             interval: SkillGithubSyncIntervalSchema.optional().describe(


### PR DESCRIPTION
Triage of the most frequent recurring backend errors in production telemetry over the last two weeks. Five distinct failure classes, each reproduced with a pinning test that fails on `main` (verified by running the new tests against the unfixed sources).

## 1. Sessions listing statement timeout (ongoing, affects real users daily)

`InteractionModel.getLastInteractionsForSessions` fetched previews with `WHERE session_id IN (…100 keys) OR id IN (…)` + `ROW_NUMBER() OVER (PARTITION BY …)` — which materializes and sorts **every** interaction of every listed session, full request/response payloads included, before discarding all but the newest 20 per session. On busy organizations this exceeded `statement_timeout` and 500'd the sessions page.

Rewritten as a per-key `LATERAL` top-N descent on the `(session_id, created_at)` index plus a primary-key branch for sessionless interaction ids. Behavior parity pinned by a new test (long session → newest preview; sessionless id → own row), and the existing sessions/preview suite passes unchanged.

## 2. Skill routes 500 on non-UUID ids

`GET /api/skills/:id` (and 7 sibling routes) declared `id` as a plain string; callers passing a skill *name* (observed: an agent retry-looping on it) sent the raw string into Postgres, failing with `invalid input syntax for type uuid` as a 500 burst. All skill `:id` params now validate as UUIDs and reject with a 400 at the boundary — same convention as the app-id routes (#7010).

## 3. Streaming proxy: provider outages captured as our crashes

Two classification gaps in the streaming error path let relayed provider failures into error tracking as platform exceptions:
- Bedrock client errors carry the provider body as `responseBody` (not a parsed `error` member), so `hasProviderHttpErrorShape` didn't recognize a relayed Bedrock 5xx.
- Status-less SDK transport failures ("Connection error.", `fetch failed`) get mapped to 502/504 but were never marked `upstream`.

Both now set the upstream marker (clients keep the mapped status; the tracking policy already drops marked relays).

## 4. Container-deployment failures reported as our exceptions

The tracking policy drops `McpServerDeploymentFailedError` by name, but several report paths re-wrap or re-surface the message as a plain `Error`, losing the name — so a user's crash-looping container ("Deployment … failed: CrashLoopBackOff") kept reporting as a platform bug. The policy now also matches the stable message shape.

## 5. Model listing serialization 500

With a base-URL override, the upstream `/v1/models` can be a non-Anthropic-shaped server whose rows carry no `display_name`; the fetcher stored `undefined` and the whole listing then failed its own response schema ("Response doesn't match the schema") — breaking model discovery for the requesting client. The fetcher and serializer now fall back to the model id.

## Not addressed (deliberately)

The single highest-volume issue is transient DB connectivity (`ECONNREFUSED`) during availability blips, already grouped under a stable fingerprint by the existing policy — that's an infra/capacity track, not error handling. A stale-MCP-session inspect failure also showed up but was already fixed by #7195 (one residual event since).

## Testing

- 7 new pinning tests; 5 fail against unfixed sources, all pass with the fixes
- Full suites for every touched area pass (interaction routes, skill routes, proxy helpers/routes, tracking policy, models)
- `tsc` and biome clean; the 17 local failures in untouched model tests reproduce identically on pristine `main` (local-env baseline)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>