### PR TITLE
ci: skip the Archestra banner job on private mirrors

### DIFF
--- a/.github/workflows/add-archestra-banner.yml
+++ b/.github/workflows/add-archestra-banner.yml
@@ -15,6 +15,11 @@ concurrency:
 jobs:
   add-banner:
     name: Add Archestra banner
+    # The banner is contributor onboarding for the public repo. In private
+    # mirrors (e.g. archestra-ai/archestra-private, where task-env sessions
+    # open their PRs) the GitHub App secrets don't exist, so the job could
+    # only ever fail red — skip it there.
+    if: ${{ !github.event.repository.private }}
     runs-on: ubuntu-latest
     permissions:
       issues: write # edit issue body


### PR DESCRIPTION
## Problem

`Add Archestra banner` runs on every opened PR with no repo guard, but it needs the `ARCHESTRA_CONTRIBUTOR_PR_BOT_GITHUB_APP_ID`/`_PRIVATE_KEY` org secrets, which only exist for the public repo. On the private mirror (`archestra-ai/archestra-private`, where task-env sessions open their PRs) it therefore fails **every** PR with:

> The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string

That permanent red check trips up the task-env sessions, which are told to monitor CI and keep all jobs green — e.g. [this bot comment](https://github.com/archestra-ai/archestra-private/pull/27#issuecomment-5319030584) spent its time explaining the failure away.

## Fix

Gate the job on the repo being public: `if: ${{ !github.event.repository.private }}` — the same guard the mirror-CI-green pass (#7282) used for Dependency Review. In the mirror the job now shows as *skipped* instead of failed; on the public repo nothing changes. The banner is public contributor onboarding anyway, so it has no business running on mirrors.

Takes effect in the mirror once this merges to main and the mirror syncs.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>