### PR TITLE
ci: stop auto-assigning reviewers to task-env bot PRs

### DIFF
--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -23,6 +23,9 @@ permissions: {}
 env:
   ASSIGNEE_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","divineforest"]'
   CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk","divineforest","arsenyinfo"]'
+  # PRs opened by these bot accounts already have an owner shepherding them
+  # (e.g. the task-env pipeline's requester), so skip reviewer auto-assignment.
+  REVIEW_REQUEST_EXEMPT_LOGINS: '["archestra-task-envs[bot]"]'
 
 concurrency:
   group: random-issue-pr-assignee-${{ github.event.issue.number || github.ref }}
@@ -120,6 +123,7 @@ jobs:
           script: |
             const owners = JSON.parse(process.env.ASSIGNEE_LOGINS);
             const coreTeam = JSON.parse(process.env.CORE_TEAM_LOGINS);
+            const exemptLogins = JSON.parse(process.env.REVIEW_REQUEST_EXEMPT_LOGINS);
             const isManualBackfill = context.eventName === 'workflow_dispatch';
             const updatedSince = isManualBackfill
               ? null
@@ -176,6 +180,11 @@ jobs:
 
                   if (coreTeam.includes(pr.user.login)) {
                     console.log(`Skipping reviewer request because ${pr.user.login} is on the core team`);
+                    continue;
+                  }
+
+                  if (exemptLogins.includes(pr.user.login)) {
+                    console.log(`Skipping reviewer request because ${pr.user.login} is exempt from review assignment`);
                     continue;
                   }
 


### PR DESCRIPTION
## What
Exempts PRs authored by `archestra-task-envs[bot]` from the scheduled random reviewer assignment in `random-issue-pr-assignee.yml`, via a new `REVIEW_REQUEST_EXEMPT_LOGINS` list checked alongside the existing core-team skip.

## Why
Requested in https://github.com/archestra-ai/archestra/pull/7322#issuecomment-5321273362 — task-env pipeline PRs are already shepherded by the teammate who requested the task, so the job was assigning a random core-team reviewer (e.g. #7322) for nothing.

The job's existing skip only covers PRs *authored by* core-team members; the bot isn't (and shouldn't be) on that list, so its PRs always matched. Other bots (dependabot, release-please) keep their current behavior — only the task-env bot is exempted.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>