### PR TITLE
fix(auth): don't mint personal user tokens for service-account principals

### DIFF
--- a/platform/backend/src/auth/__mocks__/utils.ts
+++ b/platform/backend/src/auth/__mocks__/utils.ts
@@ -9,3 +9,8 @@ import { vi } from "vitest";
 export const hasPermission = vi.fn();
 export const userHasPermission = vi.fn();
 export const getPermissionsForUserContext = vi.fn();
+
+// Real (pure) implementation: behavior-relevant predicate, not an auth boundary.
+// Kept in sync with `isServiceAccountUserId` in ../utils.ts.
+export const isServiceAccountUserId = (userId: string): boolean =>
+  userId.startsWith("service-account:");

--- a/platform/backend/src/auth/utils.ts
+++ b/platform/backend/src/auth/utils.ts
@@ -23,6 +23,14 @@ type PermissionCheckResult = {
   missingPermissions?: Permissions;
 };
 
+/**
+ * Whether a user id is the synthetic id minted for service-account principals
+ * (`service-account:<id>`, see fastify-plugin/middleware.ts). Such ids have no
+ * `users` row, so anything that writes a `user_id` foreign key must not use them.
+ */
+export const isServiceAccountUserId = (userId: string): boolean =>
+  userId.startsWith(SERVICE_ACCOUNT_USER_ID_PREFIX);
+
 export const hasPermission = async (
   permissions: Permissions,
   requestHeaders: IncomingHttpHeaders,
@@ -295,14 +303,17 @@ function getMissingPermissions(
   return missing;
 }
 
+const SERVICE_ACCOUNT_USER_ID_PREFIX = "service-account:";
+
 async function getServiceAccountFromSyntheticUserId(params: {
   userId: string;
   organizationId: string;
 }): Promise<SelectServiceAccount | null> {
-  const prefix = "service-account:";
-  if (!params.userId.startsWith(prefix)) return null;
+  if (!isServiceAccountUserId(params.userId)) return null;
 
-  const serviceAccountId = params.userId.slice(prefix.length);
+  const serviceAccountId = params.userId.slice(
+    SERVICE_ACCOUNT_USER_ID_PREFIX.length,
+  );
   const serviceAccount = await ServiceAccountModel.findById(
     serviceAccountId,
     params.organizationId,

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -12,6 +12,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { jsonSchema, type Tool } from "ai";
 import { beforeEach, vi } from "vitest";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
+import db, { schema } from "@/database";
 import { AgentModel, TeamTokenModel } from "@/models";
 import { resolveSessionExternalIdpToken } from "@/services/identity-providers/session-token";
 import { describe, expect, test } from "@/test";
@@ -2701,5 +2702,49 @@ describe("throwIfApprovalRequired", () => {
       toolName: "workspace__export",
       toolInput: { destination: "external" },
     });
+  });
+});
+
+describe("selectMCPGatewayToken synthetic principals", () => {
+  test("service-account principal does not mint a personal user token and falls back to the org token", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({ organizationId: org.id });
+    await TeamTokenModel.create({
+      organizationId: org.id,
+      isOrganizationToken: true,
+      name: "Org Token",
+    });
+
+    const result = await chatClient.selectMCPGatewayToken(
+      agent.id,
+      `service-account:${crypto.randomUUID()}`,
+      org.id,
+    );
+
+    expect(result).toMatchObject({ isOrganizationToken: true });
+
+    // No personal user token row may be created for the synthetic principal
+    // (previously this path failed on the user_id foreign key).
+    const userTokens = await db.select().from(schema.userTokensTable);
+    expect(userTokens).toHaveLength(0);
+  });
+
+  test("service-account principal without any org token gets null instead of an error", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({ organizationId: org.id });
+
+    const result = await chatClient.selectMCPGatewayToken(
+      agent.id,
+      `service-account:${crypto.randomUUID()}`,
+      org.id,
+    );
+
+    expect(result).toBeNull();
   });
 });

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -20,6 +20,7 @@ import {
   getAgentTools,
   getSkillDelegationTools,
 } from "@/archestra-mcp-server";
+import { isServiceAccountUserId } from "@/auth/utils";
 import { CacheKey, LRUCacheManager } from "@/cache-manager";
 import type { ChatMcpElicitationBridge } from "@/clients/chat-mcp-elicitation";
 import type { ChatTaskBridge } from "@/clients/chat-task-bridge";
@@ -310,11 +311,15 @@ export async function selectMCPGatewayToken(
   const profileTeamIds = await AgentTeamModel.getTeamsForAgent(agentId);
   const commonTeamIds = userTeamIds.filter((id) => profileTeamIds.includes(id));
 
+  // Synthetic principals ("system" for internal/public email security modes,
+  // "service-account:<id>" for service-account callers) have no users row, so
+  // they can never own a personal user token — attempting to create one fails
+  // on the user_id foreign key. They fall back to org/team tokens below.
+  const isSyntheticUser = userId === "system" || isServiceAccountUserId(userId);
+
   // 1. Always try to get/create a personal user token first
   // This ensures userId is available in the token for global catalog tools
-  // Skip when userId is "system" (e.g., internal/public email security modes)
-  // since "system" is not a real user and cannot have a user token
-  if (userId !== "system") {
+  if (!isSyntheticUser) {
     // Ensure user has a token (creates one if missing)
     const userToken = await UserTokenModel.ensureUserToken(
       userId,
@@ -343,9 +348,9 @@ export async function selectMCPGatewayToken(
   // Get all team tokens for this organization
   const tokens = await TeamTokenModel.findAll(organizationId);
 
-  // 2. System user has no team memberships so it can never match a team token.
-  //    Fall back to the organization token to preserve tool access.
-  if (userId === "system") {
+  // 2. Synthetic principals have no team memberships so they can never match a
+  //    team token. Fall back to the organization token to preserve tool access.
+  if (isSyntheticUser) {
     const orgToken = tokens.find((t) => t.isOrganizationToken);
     if (orgToken) {
       const tokenValue = await TeamTokenModel.getTokenValue(orgToken.id);

--- a/platform/backend/src/models/user-token.test.ts
+++ b/platform/backend/src/models/user-token.test.ts
@@ -70,6 +70,33 @@ describe("UserTokenModel", () => {
         .where(eq(schema.secretsTable.name, secretName));
       expect(secrets).toHaveLength(1);
     });
+
+    test("failed insert (no users row for userId) rethrows and cleans up its secret", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+      // Synthetic principals (e.g. service-account callers) have no users row,
+      // so the insert fails on the user_id foreign key.
+      const syntheticUserId = `service-account:${crypto.randomUUID()}`;
+
+      // Drizzle wraps the pg error ("Failed query: ...") with the foreign-key
+      // detail on `cause`.
+      await expect(
+        UserTokenModel.create(syntheticUserId, org.id),
+      ).rejects.toSatisfy((error: unknown) =>
+        String((error as Error).cause ?? error).includes(
+          "violates foreign key constraint",
+        ),
+      );
+
+      // the failed create must not leak the secret it minted before the insert.
+      const secretName = `user-token-${syntheticUserId}-${org.id}`;
+      const secrets = await db
+        .select()
+        .from(schema.secretsTable)
+        .where(eq(schema.secretsTable.name, secretName));
+      expect(secrets).toHaveLength(0);
+    });
   });
 
   describe("findById", () => {

--- a/platform/backend/src/models/user-token.ts
+++ b/platform/backend/src/models/user-token.ts
@@ -82,22 +82,38 @@ class UserTokenModel {
 
     // Create token record. onConflictDoNothing makes the UNIQUE(org, user) constraint race-safe:
     // concurrent first-time creates no longer 500, the loser just gets no row back.
-    const [token] = await db
-      .insert(schema.userTokensTable)
-      .values({
-        userId,
-        organizationId,
-        name,
-        secretId: secret.id,
-        tokenStart,
-      })
-      .onConflictDoNothing({
-        target: [
-          schema.userTokensTable.organizationId,
-          schema.userTokensTable.userId,
-        ],
-      })
-      .returning();
+    let token: SelectUserToken | undefined;
+    try {
+      [token] = await db
+        .insert(schema.userTokensTable)
+        .values({
+          userId,
+          organizationId,
+          name,
+          secretId: secret.id,
+          tokenStart,
+        })
+        .onConflictDoNothing({
+          target: [
+            schema.userTokensTable.organizationId,
+            schema.userTokensTable.userId,
+          ],
+        })
+        .returning();
+    } catch (error) {
+      // Insert failed outright (e.g. a foreign-key violation for a userId with
+      // no users row). The secret we minted references no token, so delete it
+      // before rethrowing -- otherwise it leaks.
+      await secretManager()
+        .deleteSecret(secret.id)
+        .catch((cleanupError) =>
+          logger.error(
+            { userId, organizationId, secretId: secret.id, cleanupError },
+            "UserTokenModel.create: failed to clean up secret after insert failure",
+          ),
+        );
+      throw error;
+    }
 
     if (!token) {
       // Lost the race: the secret we minted now references no token, so delete it before surfacing

--- a/platform/backend/src/routes/user-token.test.ts
+++ b/platform/backend/src/routes/user-token.test.ts
@@ -2,7 +2,7 @@ import { ARCHESTRA_TOKEN_PREFIX } from "@archestra/shared";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
-import type { User } from "@/types";
+import type { SelectServiceAccount, User } from "@/types";
 
 describe("user token routes", () => {
   let app: FastifyInstanceWithZod;
@@ -141,5 +141,43 @@ describe("user token routes", () => {
 
     expect(response.statusCode).toBe(404);
     expect(response.json().error.message).toContain("Personal token not found");
+  });
+});
+
+describe("user token routes for service-account callers", () => {
+  test("all personal-token endpoints reject service accounts with 400", async ({
+    makeOrganization,
+  }) => {
+    const organization = await makeOrganization();
+    const serviceAccountId = crypto.randomUUID();
+
+    const app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      // Mirror the auth middleware's service-account population: a synthetic
+      // `service-account:<id>` user (no users row) plus request.serviceAccount.
+      Object.assign(request, {
+        user: { id: `service-account:${serviceAccountId}` } as User,
+        organizationId: organization.id,
+        serviceAccount: { id: serviceAccountId } as SelectServiceAccount,
+      });
+    });
+    const { default: userTokenRoutes } = await import("./user-token");
+    await app.register(userTokenRoutes);
+
+    try {
+      for (const [method, url] of [
+        ["GET", "/api/user-tokens/me"],
+        ["GET", "/api/user-tokens/me/value"],
+        ["POST", "/api/user-tokens/me/rotate"],
+      ] as const) {
+        const response = await app.inject({ method, url });
+        expect(response.statusCode).toBe(400);
+        expect(response.json().error.message).toContain(
+          "Service accounts do not have personal user tokens",
+        );
+      }
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/platform/backend/src/routes/user-token.ts
+++ b/platform/backend/src/routes/user-token.ts
@@ -1,4 +1,5 @@
 import { RouteId } from "@archestra/shared";
+import type { FastifyRequest } from "fastify";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { UserTokenModel } from "@/models";
@@ -26,6 +27,7 @@ const userTokenRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async (request, reply) => {
       const { user, organizationId } = request;
+      assertNotServiceAccount(request);
 
       // Ensure token exists (creates if not)
       const token = await UserTokenModel.ensureUserToken(
@@ -58,6 +60,7 @@ const userTokenRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async (request, reply) => {
       const { user, organizationId } = request;
+      assertNotServiceAccount(request);
 
       const token = await UserTokenModel.findByUserAndOrg(
         user.id,
@@ -92,6 +95,7 @@ const userTokenRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async (request, reply) => {
       const { user, organizationId } = request;
+      assertNotServiceAccount(request);
 
       const token = await UserTokenModel.findByUserAndOrg(
         user.id,
@@ -125,3 +129,18 @@ const userTokenRoutes: FastifyPluginAsyncZod = async (fastify) => {
 };
 
 export default userTokenRoutes;
+
+/**
+ * Personal user tokens are keyed to a real `users` row. Service-account
+ * callers authenticate with a synthetic principal that has no such row, so
+ * these endpoints can never apply to them -- fail fast with a clear error
+ * instead of surfacing a foreign-key violation from token auto-creation.
+ */
+function assertNotServiceAccount(request: FastifyRequest): void {
+  if (request.serviceAccount) {
+    throw new ApiError(
+      400,
+      "Service accounts do not have personal user tokens",
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Service accounts authenticate with a synthetic `service-account:<id>` user id that has no `users` row. Any code path that auto-creates a personal user token for the current caller therefore fails on the `user_token.user_id` foreign key when the caller is a service account.

## Changes

- **`selectMCPGatewayToken`** (chat MCP client): treat service-account principals like the existing `system` principal — skip personal-token creation and fall back to the organization token, so service-account-driven agent runs keep tool access instead of erroring. Added a shared `isServiceAccountUserId` predicate in `@/auth/utils` (also used by the existing synthetic-id resolution there).
- **`/api/user-tokens/me`, `/me/value`, `/me/rotate`**: reject service-account callers with a clear 400 ("Service accounts do not have personal user tokens") instead of surfacing a database error from token auto-creation.
- **`UserTokenModel.create`**: if the token insert fails outright, delete the secret minted just before it — previously only the lost-race conflict path cleaned up, so a failed insert leaked an orphaned secret row.

## Tests

- Model: failed insert (no `users` row for the user id) rethrows and cleans up its secret.
- Chat MCP client: service-account principal falls back to the org token without creating a `user_token` row; returns `null` (not an error) when no org token exists.
- Routes: all three personal-token endpoints return 400 for service-account callers.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>