### PR TITLE
chore(tests): mute console output from passing tests across all workspaces

### DIFF
--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { vitestLogPolicy } from "../vitest.shared";
 
 const isCI = process.env.CI === "true";
 
@@ -97,6 +98,7 @@ export default defineConfig({
     },
   },
   test: {
+    ...vitestLogPolicy,
     globals: true,
     environment: "node",
     // Build the migrated schema once and snapshot it (see global-setup.ts); each test

--- a/platform/frontend/vitest.config.ts
+++ b/platform/frontend/vitest.config.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
+import { vitestLogPolicy } from "../vitest.shared";
 
 const isCI = process.env.CI === "true";
 
@@ -29,6 +30,7 @@ export default defineConfig({
     },
   },
   test: {
+    ...vitestLogPolicy,
     globals: true,
     include: ["./src/**/*.test.{ts,tsx}"],
     environment: "jsdom",

--- a/platform/shared/vitest.config.ts
+++ b/platform/shared/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import { vitestLogPolicy } from "../vitest.shared";
+
+// Default discovery and environment are fine for this workspace; the config
+// exists to apply the shared log policy (see ../vitest.shared.ts).
+export default defineConfig({
+  test: {
+    ...vitestLogPolicy,
+  },
+});

--- a/platform/vitest.shared.ts
+++ b/platform/vitest.shared.ts
@@ -1,0 +1,18 @@
+/**
+ * Log policy shared by every workspace's Vitest config (backend, frontend,
+ * shared) — the single place that decides what test runs print.
+ *
+ * Tests and the code they exercise emit a lot of *expected* noise — error-path
+ * console.error, library warnings, request/JSON log lines — and Vitest echoes
+ * each one as a per-test `stdout | … > …` block, burying real failures in
+ * local and CI output. `passed-only` mutes console output from passing tests
+ * while keeping exactly the output that matters: failing tests still print
+ * everything they logged.
+ *
+ * Set `ARCHESTRA_TEST_VERBOSE_LOGS=true` to print all test console output
+ * again while debugging a specific run.
+ */
+export const vitestLogPolicy: { silent: boolean | "passed-only" } = {
+  silent:
+    process.env.ARCHESTRA_TEST_VERBOSE_LOGS === "true" ? false : "passed-only",
+};


### PR DESCRIPTION
## Why

Test runs — locally and in CI — are drowned in per-test `stdout | … > …` / `stderr | …` echo blocks from *expected* noise: error-path `console.error`, library warnings, request logging exercised by the tests themselves. When a job actually fails, the real error is buried in hundreds of these blocks.

## What

One shared policy, applied in one place per workspace:

- **`platform/vitest.shared.ts`** — exports `vitestLogPolicy` with `silent: 'passed-only'`: Vitest mutes console output from **passing** tests but still prints everything a **failing** test logged, so failures keep their full context.
- Spread into `backend/vitest.config.ts`, `frontend/vitest.config.ts`, and a new minimal `shared/vitest.config.ts` (that workspace previously ran vitest with no config at all).
- Escape hatch: `ARCHESTRA_TEST_VERBOSE_LOGS=true` restores all output for a debugging run.

Backend pino logging was already silenced in test setup (`ARCHESTRA_LOGGING_LEVEL=silent`); this covers the console/`stdout`-echo layer that remained.

## Verified

- Noisy **passing** test: no echo blocks with the policy; blocks return with `ARCHESTRA_TEST_VERBOSE_LOGS=true`.
- Noisy **failing** test: its console output still prints in the failure report.
- Full runs green in all three workspaces with the policy active (backend targeted suites, frontend 4162 tests, shared 808 tests); `pnpm lint` and `pnpm type-check` clean.

No behavior test added — this is test-runner presentation config; asserting on reporter output would be brittle meta-testing.

The env var is deliberately not in `.env.example`/deployment docs: it's a test-runner toggle like `ARCHESTRA_TEST_SHARED_WORKERS`, not application configuration.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>