### PR TITLE
fix(helm): isolate runtime owner RBAC

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1413,7 +1413,7 @@ A2A task streams work across replicas. A client can subscribe on one replica whi
   - Point it at a static private mirror when your cluster cannot pull from Docker Hub.
 
 - **`ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE`** - Same-namespace Role used to remove runtime-created MCP resources on uninstall.
-  - The chart sets this automatically when it creates orchestrator RBAC.
+  - The chart creates and sets a dedicated Role when it manages orchestrator RBAC.
   - With external RBAC, use a readable Role with the same name in every runtime namespace.
   - Delete each external Role during uninstall to remove its runtime resources.
 

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -391,7 +391,7 @@ ARCHESTRA_ORCHESTRATOR_ENVIRONMENT_NAMESPACES=
 # MCP server base image, whose contents are an operator's choice. Point it at
 # your mirror on clusters that cannot pull from Docker Hub.
 # ARCHESTRA_ORCHESTRATOR_MCP_IMAGE_PREPULL_BOOTSTRAP_IMAGE=docker.io/library/busybox:1.36-musl
-# Helm sets this to its manager Role in each MCP runtime namespace for cleanup.
+# Helm sets this to a dedicated Role in each MCP runtime namespace for cleanup.
 # ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE=
 # SPDX-SnippetEnd
 

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -23,9 +23,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
-{{/* Helm-managed same-namespace Role that owns runtime-created MCP resources. */}}
-{{- define "archestra-platform.mcpRuntimeOwnerRoleName" -}}
+{{/* Broad Role used by the platform to manage MCP runtime resources. */}}
+{{- define "archestra-platform.mcpManagerRoleName" -}}
 {{- printf "%s-mcp-manager" (include "archestra-platform.fullname" .) }}
+{{- end }}
+
+{{/* Narrow Helm-managed Role that owns runtime-created MCP resources. */}}
+{{- define "archestra-platform.mcpRuntimeOwnerRoleName" -}}
+{{- printf "%s-mcp-runtime-owner" (include "archestra-platform.fullname" .) }}
 {{- end }}
 
 {{/*
@@ -468,10 +473,6 @@ by the release-namespace Role and the per-namespace Roles generated from
 rbac.environmentNamespaces, so both grant exactly the same access (no drift).
 */}}
 {{- define "archestra-platform.mcpManagerRules" -}}
-{{- $runtimeOwnerRoleName := include "archestra-platform.mcpRuntimeOwnerRoleName" . -}}
-{{- if hasKey .Values.archestra.env "ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE" -}}
-{{- $runtimeOwnerRoleName = toString (get .Values.archestra.env "ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE") -}}
-{{- end -}}
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
@@ -505,14 +506,6 @@ rbac.environmentNamespaces, so both grant exactly the same access (no drift).
 - apiGroups: ["apps"]
   resources: ["daemonsets"]
   verbs: ["get", "list", "create", "update", "patch", "delete"]
-# The Helm-managed manager Role is also the same-namespace owner for resources
-# created at runtime. Reading it supplies the UID required by ownerReferences.
-{{- if $runtimeOwnerRoleName }}
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["roles"]
-  resourceNames: [{{ $runtimeOwnerRoleName | quote }}]
-  verbs: ["get"]
-{{- end }}
 # Standard Kubernetes NetworkPolicy for IP/CIDR egress rules.
 - apiGroups: ["networking.k8s.io"]
   resources: ["networkpolicies"]

--- a/platform/helm/archestra/templates/serviceaccount.yaml
+++ b/platform/helm/archestra/templates/serviceaccount.yaml
@@ -16,11 +16,20 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 {{- if .Values.archestra.orchestrator.kubernetes.rbac.create }}
+{{- $defaultRuntimeOwnerRoleName := include "archestra-platform.mcpRuntimeOwnerRoleName" . }}
+{{- $runtimeOwnerRoleName := $defaultRuntimeOwnerRoleName }}
+{{- if hasKey .Values.archestra.env "ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE" }}
+{{- $runtimeOwnerRoleName = trim (toString (default "" (get .Values.archestra.env "ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE"))) }}
+{{- end }}
+{{- $runtimeOwnerRoleNames := list $defaultRuntimeOwnerRoleName }}
+{{- if and $runtimeOwnerRoleName (ne $runtimeOwnerRoleName $defaultRuntimeOwnerRoleName) }}
+{{- $runtimeOwnerRoleNames = append $runtimeOwnerRoleNames $runtimeOwnerRoleName }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "archestra-platform.mcpRuntimeOwnerRoleName" . }}
+  name: {{ include "archestra-platform.mcpManagerRoleName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "archestra-platform.labels" . | nindent 4 }}
@@ -30,7 +39,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "archestra-platform.mcpRuntimeOwnerRoleName" . }}
+  name: {{ include "archestra-platform.mcpManagerRoleName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "archestra-platform.labels" . | nindent 4 }}
@@ -40,7 +49,41 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "archestra-platform.mcpRuntimeOwnerRoleName" . }}
+  name: {{ include "archestra-platform.mcpManagerRoleName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- /*
+This narrow Role owns runtime resources by default and grants the platform read
+access to an explicitly configured external owner. It remains during handoff so
+deleting its UID cannot garbage-collect existing runtime resources.
+*/}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $defaultRuntimeOwnerRoleName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "archestra-platform.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles"]
+  resourceNames: {{ $runtimeOwnerRoleNames | toJson }}
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $defaultRuntimeOwnerRoleName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "archestra-platform.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "archestra-platform.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ $defaultRuntimeOwnerRoleName }}
   apiGroup: rbac.authorization.k8s.io
 {{- /*
 Grant the platform ServiceAccount the same MCP-manager permissions in additional
@@ -57,7 +100,7 @@ already created above, and re-emitting it would collide on name.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "archestra-platform.mcpRuntimeOwnerRoleName" $ }}
+  name: {{ include "archestra-platform.mcpManagerRoleName" $ }}
   namespace: {{ $ns }}
   labels:
     {{- include "archestra-platform.labels" $ | nindent 4 }}
@@ -67,7 +110,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "archestra-platform.mcpRuntimeOwnerRoleName" $ }}
+  name: {{ include "archestra-platform.mcpManagerRoleName" $ }}
   namespace: {{ $ns }}
   labels:
     {{- include "archestra-platform.labels" $ | nindent 4 }}
@@ -77,7 +120,36 @@ subjects:
   namespace: {{ $.Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "archestra-platform.mcpRuntimeOwnerRoleName" $ }}
+  name: {{ include "archestra-platform.mcpManagerRoleName" $ }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $defaultRuntimeOwnerRoleName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "archestra-platform.labels" $ | nindent 4 }}
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles"]
+  resourceNames: {{ $runtimeOwnerRoleNames | toJson }}
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $defaultRuntimeOwnerRoleName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "archestra-platform.labels" $ | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "archestra-platform.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ $defaultRuntimeOwnerRoleName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -473,7 +473,7 @@ tests:
             - name: ARCHESTRA_ORCHESTRATOR_HELM_RELEASE_NAME
               value: RELEASE-NAME
             - name: ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE
-              value: RELEASE-NAME-archestra-platform-mcp-manager
+              value: RELEASE-NAME-archestra-platform-mcp-runtime-owner
             - name: ARCHESTRA_ORCHESTRATOR_MCP_IMAGE_PREPULL_BOOTSTRAP_IMAGE
               value: "docker.io/library/busybox:1.36-musl"
             - name: ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER
@@ -906,7 +906,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE
-            value: "my-release-archestra-platform-mcp-manager"
+            value: "my-release-archestra-platform-mcp-runtime-owner"
 
   - it: should not configure a Helm owner when chart RBAC is disabled
     documentIndex: 1

--- a/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
@@ -17,7 +17,7 @@ tests:
       archestra.orchestrator.kubernetes.serviceAccount.create: false
     asserts:
       - hasDocuments:
-          count: 2  # MCP Role + MCP RoleBinding
+          count: 4  # Manager and runtime-owner Role/RoleBinding pairs
 
   - it: should use custom ServiceAccount name when provided
     set:
@@ -172,16 +172,50 @@ tests:
             resources: ["daemonsets"]
             verbs: ["get", "list", "create", "update", "patch", "delete"]
 
-  - it: should be readable as the owner of runtime-created resources
+  - it: should keep owner read permission out of the MCP Manager Role
     documentIndex: 1
     asserts:
-      - contains:
+      - lengthEqual:
+          path: rules
+          count: 13
+      - notContains:
           path: rules
           content:
             apiGroups: ["rbac.authorization.k8s.io"]
             resources: ["roles"]
-            resourceNames: ["RELEASE-NAME-archestra-platform-mcp-manager"]
+            resourceNames: ["RELEASE-NAME-archestra-platform-mcp-runtime-owner"]
             verbs: ["get"]
+
+  - it: should create a narrow Role as the runtime resource owner
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: "RELEASE-NAME-archestra-platform-mcp-runtime-owner"
+      - equal:
+          path: rules
+          value:
+            - apiGroups: ["rbac.authorization.k8s.io"]
+              resources: ["roles"]
+              resourceNames: ["RELEASE-NAME-archestra-platform-mcp-runtime-owner"]
+              verbs: ["get"]
+
+  - it: should bind the runtime owner Role to the platform ServiceAccount
+    documentIndex: 4
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: roleRef.name
+          value: "RELEASE-NAME-archestra-platform-mcp-runtime-owner"
+      - equal:
+          path: subjects[0].name
+          value: "RELEASE-NAME-archestra-platform"
+      - equal:
+          path: subjects[0].namespace
+          value: NAMESPACE
 
   - it: should preserve the existing manager Role name for long fullnames
     set:
@@ -192,33 +226,52 @@ tests:
           path: metadata.name
           value: "123456789012345678901234567890123456789012345678901234567890123-mcp-manager"
 
-  - it: should scope owner read permission to an explicitly configured Role
+  - it: should grant access to an external owner without replacing the default owner
     set:
       archestra.env:
         ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE: "external-runtime-owner"
-    documentIndex: 1
+    documentIndex: 3
     asserts:
-      - contains:
+      - equal:
+          path: metadata.name
+          value: "RELEASE-NAME-archestra-platform-mcp-runtime-owner"
+      - equal:
           path: rules
-          content:
-            apiGroups: ["rbac.authorization.k8s.io"]
-            resources: ["roles"]
-            resourceNames: ["external-runtime-owner"]
-            verbs: ["get"]
+          value:
+            - apiGroups: ["rbac.authorization.k8s.io"]
+              resources: ["roles"]
+              resourceNames:
+                - "RELEASE-NAME-archestra-platform-mcp-runtime-owner"
+                - "external-runtime-owner"
+              verbs: ["get"]
+
+  - it: should trim an explicitly configured owner Role
+    set:
+      archestra.env:
+        ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE: "  external-runtime-owner  "
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: rules[0].resourceNames
+          value:
+            - "RELEASE-NAME-archestra-platform-mcp-runtime-owner"
+            - "external-runtime-owner"
 
   - it: should omit owner read permission when ownership is explicitly disabled
     set:
       archestra.env:
         ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE: ""
-    documentIndex: 1
     asserts:
-      - notContains:
-          path: rules
-          content:
-            apiGroups: ["rbac.authorization.k8s.io"]
-            resources: ["roles"]
-            resourceNames: [""]
-            verbs: ["get"]
+      - hasDocuments:
+          count: 5  # The default owner remains to preserve existing dependents
+
+  - it: should treat a whitespace-only owner override as disabled
+    set:
+      archestra.env:
+        ARCHESTRA_ORCHESTRATOR_MCP_RUNTIME_OWNER_ROLE: "   "
+    asserts:
+      - hasDocuments:
+          count: 5
 
   - it: should have network policy permissions in MCP Manager Role
     documentIndex: 1
@@ -314,7 +367,7 @@ tests:
   - it: should create all resources with default values
     asserts:
       - hasDocuments:
-          count: 3
+          count: 5
 
   - it: should create only ServiceAccount when RBAC is disabled
     set:
@@ -328,7 +381,7 @@ tests:
       archestra.orchestrator.kubernetes.serviceAccount.create: false
     asserts:
       - hasDocuments:
-          count: 2
+          count: 4
 
   - it: should create no resources when both are disabled
     set:
@@ -367,12 +420,12 @@ tests:
           value: "custom-archestra-sa"
 
   # environmentNamespaces tests
-  # Default rendering is 3 docs (SA, Role, RoleBinding). Each additional namespace
-  # appends a Role then a RoleBinding, so [staging, prod-ns] => indexes 3..6.
+  # Default rendering is 5 docs: SA plus manager and owner Role/RoleBinding pairs.
+  # Each additional namespace appends the same four RBAC resources.
   - it: should not create extra RBAC for environmentNamespaces by default
     asserts:
       - hasDocuments:
-          count: 3
+          count: 5
 
   - it: should create a Role and RoleBinding per additional namespace
     set:
@@ -381,14 +434,14 @@ tests:
         - prod-ns
     asserts:
       - hasDocuments:
-          count: 7  # SA + release Role/RoleBinding + 2 namespaces * (Role + RoleBinding)
+          count: 13  # SA + 3 namespaces * (manager and owner Role/RoleBinding pairs)
 
   - it: additional namespace Role targets that namespace
     set:
       archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
         - prod-ns
-    documentIndex: 3
+    documentIndex: 5
     asserts:
       - isKind:
           of: Role
@@ -404,7 +457,7 @@ tests:
       archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
         - prod-ns
-    documentIndex: 4
+    documentIndex: 6
     asserts:
       - isKind:
           of: RoleBinding
@@ -433,7 +486,7 @@ tests:
       archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
         - prod-ns
-    documentIndex: 5
+    documentIndex: 9
     asserts:
       - isKind:
           of: Role
@@ -445,7 +498,7 @@ tests:
     set:
       archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
-    documentIndex: 3
+    documentIndex: 5
     asserts:
       - contains:
           path: rules
@@ -459,12 +512,12 @@ tests:
             apiGroups: ["apps"]
             resources: ["daemonsets"]
             verbs: ["get", "list", "create", "update", "patch", "delete"]
-      - contains:
+      - notContains:
           path: rules
           content:
             apiGroups: ["rbac.authorization.k8s.io"]
             resources: ["roles"]
-            resourceNames: ["RELEASE-NAME-archestra-platform-mcp-manager"]
+            resourceNames: ["RELEASE-NAME-archestra-platform-mcp-runtime-owner"]
             verbs: ["get"]
       - contains:
           path: rules
@@ -497,6 +550,28 @@ tests:
             resources: ["secrets"]
             verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
 
+  - it: additional namespace gets a narrow runtime owner Role
+    set:
+      archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
+        - staging
+    documentIndex: 7
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: staging
+      - equal:
+          path: metadata.name
+          value: "RELEASE-NAME-archestra-platform-mcp-runtime-owner"
+      - equal:
+          path: rules
+          value:
+            - apiGroups: ["rbac.authorization.k8s.io"]
+              resources: ["roles"]
+              resourceNames: ["RELEASE-NAME-archestra-platform-mcp-runtime-owner"]
+              verbs: ["get"]
+
   - it: should not create additional-namespace RBAC when rbac.create is false
     set:
       archestra.orchestrator.kubernetes.rbac.create: false
@@ -513,7 +588,7 @@ tests:
         - NAMESPACE
     asserts:
       - hasDocuments:
-          count: 3  # No duplicate Role/RoleBinding for the release namespace
+          count: 5  # No duplicate RBAC pairs for the release namespace
 
   - it: should skip only the release namespace from a mixed list
     set:
@@ -522,14 +597,14 @@ tests:
         - staging
     asserts:
       - hasDocuments:
-          count: 5  # SA + release Role/RoleBinding + staging Role/RoleBinding
+          count: 9  # SA + release and staging manager/owner RBAC pairs
 
   - it: additional namespace RoleBinding honors a custom ServiceAccount name
     set:
       archestra.orchestrator.kubernetes.serviceAccount.name: "custom-sa-name"
       archestra.orchestrator.kubernetes.rbac.environmentNamespaces:
         - staging
-    documentIndex: 4
+    documentIndex: 6
     asserts:
       - equal:
           path: subjects[0].name
@@ -538,7 +613,7 @@ tests:
   - it: custom MCP namespace automatically receives manager RBAC
     set:
       archestra.orchestrator.kubernetes.namespace: mcp-runtime
-    documentIndex: 3
+    documentIndex: 5
     asserts:
       - isKind:
           of: Role
@@ -549,7 +624,7 @@ tests:
   - it: custom MCP namespace RoleBinding points to the release ServiceAccount
     set:
       archestra.orchestrator.kubernetes.namespace: mcp-runtime
-    documentIndex: 4
+    documentIndex: 6
     asserts:
       - isKind:
           of: RoleBinding
@@ -567,4 +642,4 @@ tests:
         - mcp-runtime
     asserts:
       - hasDocuments:
-          count: 5
+          count: 9


### PR DESCRIPTION
## Summary

- keep the existing broad MCP manager Roles unchanged during upgrades
- create a dedicated narrow Role in each runtime namespace for owner references
- grant that Role read access to itself and an optional trimmed external owner
- preserve the default owner Role during external-owner handoffs to avoid garbage collection

## Context

PR #7325 removed the ConfigMap anchor that the staging deploy identity could not read. Its replacement added `roles/get` to the existing broad manager Role. The next staging upgrade then failed Kubernetes RBAC escalation checks while patching that Role: https://github.com/archestra-ai/archestra/actions/runs/32152944860/job/95768214700

This follow-up renders the staging manager Roles byte-for-byte identically to their pre-#7325 manifests and puts ownership access in a separate narrow Role.

## Validation

- `helm unittest helm/archestra` (453 tests)
- `helm lint helm/archestra --values ../.github/values-staging.yaml`
- staging-values and external-owner `helm template` renders
- exact canonical comparison of staging manager Roles against `6f5013a307add1c769aea7aaf802fa29a49308a3`
- `ARCHESTRA_DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm commit:check`
- independent review: no findings or blockers

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>