### PR TITLE
fix(chat): keep the composer on Send when a follow-up can be queued

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -201,11 +201,18 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
   PromptInputSubmit: ({
     status,
     disabled,
+    onClick,
   }: {
     status?: string;
     disabled?: boolean;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
   }) => (
-    <button data-testid="prompt-submit" type="submit" disabled={disabled}>
+    <button
+      data-testid="prompt-submit"
+      type="submit"
+      disabled={disabled}
+      onClick={onClick}
+    >
       Submit {status ?? "unset"}
     </button>
   ),
@@ -236,7 +243,7 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
       setInput: mockTextInputSetInput,
       clear: mockTextInputClear,
     },
-    attachments: { files: [] },
+    attachments: { files: mockControllerState.files },
   }),
   usePromptInputAttachments: () => ({
     openFileDialog: vi.fn(),
@@ -1522,6 +1529,103 @@ describe("ArchestraPromptInput", () => {
       });
 
       expect(onStop).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("queue affordance on the submit button", () => {
+    // The composer's Send/Stop face is the only thing announcing what Enter
+    // will do mid-stream: with a queueable draft the submit stays an ordinary
+    // Send button (status "ready") instead of turning into Stop.
+    const getSubmitButton = () =>
+      screen.getByTestId("prompt-submit") as HTMLButtonElement;
+
+    it("keeps the Send face while a response streams and the composer holds a queueable draft", () => {
+      mockControllerState.value = "follow-up";
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          status="streaming"
+          onStop={vi.fn()}
+          conversationId="conv-queue-face"
+        />,
+      );
+
+      expect(getSubmitButton()).toHaveTextContent("Submit ready");
+      // ...and with it the ordinary Send tooltip, not the Stop one.
+      expect(screen.getByText(/^Send$/)).toBeInTheDocument();
+      expect(screen.queryByText(/^Stop$/)).not.toBeInTheDocument();
+    });
+
+    it("clicking the Send face queues instead of stopping", () => {
+      const onStop = vi.fn();
+      const onSubmit = vi.fn();
+      mockControllerState.value = "follow-up";
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          onSubmit={onSubmit}
+          status="streaming"
+          onStop={onStop}
+          conversationId="conv-queue-click"
+        />,
+      );
+
+      fireEvent.click(getSubmitButton());
+
+      expect(onStop).not.toHaveBeenCalled();
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the Stop face while streaming with an empty composer", () => {
+      const onStop = vi.fn();
+      mockControllerState.value = "";
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          status="streaming"
+          onStop={onStop}
+          conversationId="conv-stop-face"
+        />,
+      );
+
+      expect(getSubmitButton()).toHaveTextContent("Submit streaming");
+      expect(screen.getByText(/^Stop$/)).toBeInTheDocument();
+
+      fireEvent.click(getSubmitButton());
+      expect(onStop).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the Stop face when attachments are staged, since they cannot be queued", () => {
+      mockControllerState.value = "follow-up";
+      mockControllerState.files = [{ url: "blob:attachment" }];
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          status="streaming"
+          onStop={vi.fn()}
+          conversationId="conv-queue-attachments"
+        />,
+      );
+
+      expect(getSubmitButton()).toHaveTextContent("Submit streaming");
+    });
+
+    it("keeps the Stop face on the new-chat composer, which has no conversation to queue into", () => {
+      mockControllerState.value = "first message";
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          status="streaming"
+          onStop={vi.fn()}
+        />,
+      );
+
+      expect(getSubmitButton()).toHaveTextContent("Submit streaming");
     });
   });
 

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -707,8 +707,22 @@ const PromptInputContent = ({
     [storageByteLimit],
   );
 
-  const submitStatus = status === "error" ? "ready" : status;
   const isResponseInFlight = status === "submitted" || status === "streaming";
+  // Mid-stream a submit queues the message instead of sending it (see
+  // classifyChatSubmitAction), but only when there is something queueable: a
+  // conversation to queue into and typed text. Attachments cannot be queued
+  // (the page rejects them with a toast), so staged files keep the Stop face
+  // rather than promising a queue that would fail.
+  const isQueueingSubmit =
+    isResponseInFlight &&
+    !!conversationId &&
+    controller.textInput.value.trim().length > 0 &&
+    controller.attachments.files.length === 0;
+  // A queueable draft puts the button back on its ordinary Send face, so what
+  // Enter is about to do is visible before pressing it; left on Stop, nothing
+  // said the message could be queued at all.
+  const submitStatus =
+    status === "error" || isQueueingSubmit ? "ready" : status;
 
   // Context compaction normally locks the composer, but when queueing can
   // absorb the message (live conversation, response in flight) the composer
@@ -1031,7 +1045,9 @@ const PromptInputContent = ({
                     // While a response is in-flight the button shows Stop; a
                     // click stops the stream instead of submitting the form
                     // (which would queue the typed text — see onStop docs).
-                    if (onStop && isResponseInFlight) {
+                    // With a queueable draft the button is a Send button, so
+                    // the click must submit (and queue) instead; Esc stops.
+                    if (onStop && isResponseInFlight && !isQueueingSubmit) {
                       event.preventDefault();
                       onStop();
                     }
@@ -1043,7 +1059,7 @@ const PromptInputContent = ({
                   <span>
                     Connect the subscription or choose another credential
                   </span>
-                ) : isResponseInFlight && onStop ? (
+                ) : isResponseInFlight && onStop && !isQueueingSubmit ? (
                   <span className="flex items-center gap-1.5">
                     Stop <Kbd>Esc</Kbd>
                   </span>


### PR DESCRIPTION
While a response is streaming, typing a follow-up and pressing Enter queues it — but the composer's submit button stayed on its Stop face, so nothing indicated the message could be queued at all.

With a queueable draft (a live conversation, text typed, and no attachments — those cannot be queued) the button now shows its ordinary Send face and Send/Enter tooltip, and a click submits (queues) instead of stopping the stream. An empty composer keeps the Stop face, and Esc still stops in both cases.

Archestra PM task: T-1102.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>