### PR TITLE
fix(chat): match the composer group radius to the controls it clips

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -661,7 +661,11 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
               <ModelSelectorLogo provider={logoProvider} className="size-4" />
             </Button>
           ) : (
-            <div className="flex items-center h-8 rounded-full bg-muted/50 overflow-hidden">
+            /* Same radius as the controls it clips: they are full-height and
+               sit flush against the group's end caps, so a wider group radius
+               rounds their outer corners while the inner ones keep the button
+               radius — a lopsided hover shape (T-1088). */
+            <div className="flex items-center h-8 rounded-md bg-muted/50 overflow-hidden">
               {(conversationId || onApiKeyChange) && (
                 <LlmProviderApiKeySelector
                   conversationId={conversationId}


### PR DESCRIPTION
The key and model triggers in the chat composer hover as rounded rectangles, like the composer's other buttons. The group wrapping them was `rounded-full` with `overflow-hidden`, and both controls are full-height and sit flush against the group's end caps — so the cap rounded the key button's outer corners while its inner ones kept the 6px button radius, giving a lopsided hover shape.

The group now carries the same radius as the controls it clips, so the clip falls exactly on their own corners and stops being visible. Hover shapes themselves are unchanged; the group's resting silhouette goes from a pill to a rounded rectangle (barely perceptible in dark mode, visible in light).

Verified live on a dev stack: before, the key button measured `border-radius: 6px` flush at the group's left edge and rendered lopsided; after, group and button both compute to `6px` and the hover fill is a symmetric rounded square in both themes.

Fixes T-1088

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>