### PR TITLE
ci: swap divineforest for piercypixel in reviewer/assignee rotation

### DIFF
--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -23,9 +23,10 @@ permissions: {}
 env:
   ASSIGNEE_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","divineforest"]'
   CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk","divineforest","arsenyinfo"]'
-  # PRs opened by these bot accounts already have an owner shepherding them
-  # (e.g. the task-env pipeline's requester), so skip reviewer auto-assignment.
-  REVIEW_REQUEST_EXEMPT_LOGINS: '["archestra-task-envs[bot]"]'
+  # PRs opened by these accounts already have an owner shepherding them
+  # (e.g. the task-env pipeline's requester, or contributors who arrange their
+  # own reviews), so skip reviewer auto-assignment.
+  REVIEW_REQUEST_EXEMPT_LOGINS: '["archestra-task-envs[bot]","piercypixel"]'
 
 concurrency:
   group: random-issue-pr-assignee-${{ github.event.issue.number || github.ref }}

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -21,12 +21,11 @@ on:
 permissions: {}
 
 env:
-  ASSIGNEE_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","divineforest"]'
-  CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk","divineforest","arsenyinfo"]'
-  # PRs opened by these accounts already have an owner shepherding them
-  # (e.g. the task-env pipeline's requester, or contributors who arrange their
-  # own reviews), so skip reviewer auto-assignment.
-  REVIEW_REQUEST_EXEMPT_LOGINS: '["archestra-task-envs[bot]","piercypixel"]'
+  ASSIGNEE_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","piercypixel"]'
+  CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk","piercypixel","arsenyinfo"]'
+  # PRs opened by these bot accounts already have an owner shepherding them
+  # (e.g. the task-env pipeline's requester), so skip reviewer auto-assignment.
+  REVIEW_REQUEST_EXEMPT_LOGINS: '["archestra-task-envs[bot]"]'
 
 concurrency:
   group: random-issue-pr-assignee-${{ github.event.issue.number || github.ref }}


### PR DESCRIPTION
## What

In the random issue-assignee / PR-reviewer workflow:

- Replaces `divineforest` with `piercypixel` in `ASSIGNEE_LOGINS` (issue assignment + reviewer pool) and `CORE_TEAM_LOGINS`
- `REVIEW_REQUEST_EXEMPT_LOGINS` stays bot-only

## Why

Mark is part of the core team, so his PRs skip reviewer auto-assignment via the core-team check (e.g. #7335 randomly tagged a reviewer), and he joins the assignee/reviewer rotation in divineforest's place.