### PR TITLE
fix(costs): stop People table badges overprinting, and restore the Models chart

### DIFF
--- a/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
@@ -202,6 +202,80 @@ describe("StatisticsPage", () => {
     expect(getByText("Subscription")).toBeInTheDocument();
   });
 
+  it("shows a metered person's cost as money, not a savings percentage", async () => {
+    mockUseUserStatistics.mockReturnValue({
+      data: {
+        data: [
+          {
+            userId: "user-2",
+            userName: "Joey Orlando",
+            userEmail: "joey@example.com",
+            requests: 15260,
+            inputTokens: 19000000,
+            outputTokens: 572756,
+            cacheReadTokens: 0,
+            totalTokens: 19572756,
+            // Pay-as-you-go: everything is billed, nothing subscription-covered.
+            billedCost: 41.4405,
+            subscriptionCost: 0,
+            activeDays: 8,
+            lastActiveAt: "2026-08-11T14:41:00.000Z",
+            models: [{ model: "anthropic/claude-opus-4.8", requests: 15260 }],
+          },
+        ],
+        pagination: { total: 1 },
+      },
+    });
+
+    const { findByText, queryByText } = render(<StatisticsPage />);
+
+    // The Cost column must read as spend. It rendered the savings percentage
+    // ("0%") for everyone without subscription usage while `tooltip` was left
+    // at its "never" default.
+    expect(await findByText("$41.4405")).toBeInTheDocument();
+    expect(queryByText("0%")).not.toBeInTheDocument();
+  });
+
+  it("reserves width for the People columns that carry badges", async () => {
+    mockUseUserStatistics.mockReturnValue({
+      data: {
+        data: [
+          {
+            userId: "user-3",
+            userName: "Ildar Iskhakov",
+            userEmail: "ildar@example.com",
+            requests: 118,
+            inputTokens: 3000000,
+            outputTokens: 883994,
+            cacheReadTokens: 0,
+            totalTokens: 3883994,
+            billedCost: 1.5,
+            subscriptionCost: 0,
+            activeDays: 6,
+            lastActiveAt: "2026-08-11T14:38:00.000Z",
+            models: [{ model: "anthropic/claude-opus-4.8", requests: 118 }],
+          },
+        ],
+        pagination: { total: 1 },
+      },
+    });
+
+    const { findByText, container } = render(<StatisticsPage />);
+    await findByText("Ildar Iskhakov");
+
+    // `table-fixed` splits width equally without explicit widths, which left
+    // the Models and Cost columns narrower than their badges — the badges then
+    // overflowed onto the neighbouring column.
+    const peopleTable = container.querySelector("table.min-w-\\[900px\\]");
+    expect(peopleTable).not.toBeNull();
+
+    const headers = Array.from(peopleTable?.querySelectorAll("thead th") ?? []);
+    expect(headers).toHaveLength(7);
+    for (const header of headers) {
+      expect(header.className).toMatch(/w-\[\d+%\]/);
+    }
+  });
+
   it("renders statistics tables inside capped scroll containers", () => {
     mockUseTeamStatistics.mockReturnValue({
       data: [

--- a/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
@@ -47,7 +47,11 @@ vi.mock("@/lib/statistics.query", () => ({
 
 vi.mock("recharts", () => ({
   CartesianGrid: () => null,
-  Line: () => null,
+  // Expose what each series was given so tests can check the chart wiring
+  // without rendering SVG.
+  Line: ({ dataKey, stroke }: { dataKey: string; stroke: string }) => (
+    <div data-testid="chart-line" data-key={dataKey} data-stroke={stroke} />
+  ),
   LineChart: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -56,8 +60,16 @@ vi.mock("recharts", () => ({
 }));
 
 vi.mock("@/components/ui/chart", () => ({
-  ChartContainer: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+  ChartContainer: ({
+    config,
+    children,
+  }: {
+    config: Record<string, { label: string }>;
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="chart" data-config={JSON.stringify(config)}>
+      {children}
+    </div>
   ),
   ChartLegend: () => null,
   ChartLegendContent: () => null,
@@ -273,6 +285,65 @@ describe("StatisticsPage", () => {
     expect(headers).toHaveLength(7);
     for (const header of headers) {
       expect(header.className).toMatch(/w-\[\d+%\]/);
+    }
+  });
+
+  it("charts the five costliest models under CSS-safe series keys", () => {
+    // Six models, deliberately NOT in cost order: the API returns entities in
+    // first-seen order, and the chart used to slice that order while claiming
+    // "top 5 by cost".
+    const model = (name: string, cost: number) => ({
+      model: name,
+      requests: 1,
+      inputTokens: 10,
+      outputTokens: 5,
+      cost,
+      percentage: 0,
+      timeSeries: [{ timestamp: "2026-08-11T00:00:00.000Z", value: cost }],
+    });
+    mockUseModelStatistics.mockReturnValue({
+      data: [
+        model("google/gemini-3-pro-preview", 0.1),
+        model("anthropic/claude-opus-4.8", 46),
+        model("moonshotai/kimi-k2-thinking", 0.64),
+        model("openrouter/auto", 4.21),
+        model("deepseek/deepseek-v3.1-terminus", 5),
+        model("z-ai/glm-4.6", 1.64),
+      ],
+    });
+
+    const { getAllByTestId } = render(<StatisticsPage />);
+
+    // The Models chart is the one whose config labels are model ids.
+    const chart = getAllByTestId("chart").find((el) =>
+      (el.getAttribute("data-config") ?? "").includes("claude-opus-4.8"),
+    );
+    expect(chart).toBeDefined();
+    const config = JSON.parse(chart?.getAttribute("data-config") ?? "{}");
+
+    // Top 5 by cost, costliest first — gemini ($0.10) must be the one left out.
+    expect(
+      Object.values(config).map((c) => (c as { label: string }).label),
+    ).toEqual([
+      "anthropic/claude-opus-4.8",
+      "deepseek/deepseek-v3.1-terminus",
+      "openrouter/auto",
+      "z-ai/glm-4.6",
+      "moonshotai/kimi-k2-thinking",
+    ]);
+
+    // Series keys become CSS custom-property names (`--color-<key>`). Model
+    // ids contain `/` and `.`, which are not valid there, so keying by the raw
+    // id gave every line an unresolvable stroke and no colour anywhere.
+    const lines = Array.from(
+      chart?.querySelectorAll("[data-testid='chart-line']") ?? [],
+    );
+    expect(lines).toHaveLength(5);
+    for (const line of lines) {
+      const key = line.getAttribute("data-key") ?? "";
+      expect(key).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(config[key]).toBeDefined();
+      expect(line.getAttribute("data-stroke")).toBe(`var(--color-${key})`);
     }
   });
 

--- a/platform/frontend/src/app/llm/(costs)/costs/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.tsx
@@ -1218,28 +1218,34 @@ export default function StatisticsPage() {
         </CardHeader>
         <CardContent>
           <StatisticsTablePanel>
-            <Table>
+            {/*
+              `table-fixed` splits width equally without explicit widths, and
+              badges neither wrap nor shrink — too narrow a share and they
+              overflow their cell onto the next column. The floor width makes
+              the panel scroll rather than crush the columns.
+            */}
+            <Table className="min-w-[900px]">
               <TableHeader>
                 <TableRow>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className="bg-card sticky top-0 z-10 w-[18%]">
                     User
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className="bg-card sticky top-0 z-10 w-[10%]">
                     Requests
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className="bg-card sticky top-0 z-10 w-[13%]">
                     Tokens Used
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className="bg-card sticky top-0 z-10 w-[21%]">
                     Models
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className="bg-card sticky top-0 z-10 w-[11%]">
                     Active Days
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className="bg-card sticky top-0 z-10 w-[16%]">
                     Cost
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead className="bg-card sticky top-0 z-10 w-[11%] text-right">
                     Last Active
                   </TableHead>
                 </TableRow>
@@ -1258,8 +1264,16 @@ export default function StatisticsPage() {
                   userStatistics.map((user) => (
                     <TableRow key={user.userId}>
                       <TableCell>
-                        <div className="font-medium">{user.userName}</div>
-                        <div className="text-xs text-muted-foreground">
+                        <div
+                          className="font-medium truncate"
+                          title={user.userName}
+                        >
+                          {user.userName}
+                        </div>
+                        <div
+                          className="text-xs text-muted-foreground truncate"
+                          title={user.userEmail}
+                        >
                           {user.userEmail}
                         </div>
                       </TableCell>
@@ -1275,6 +1289,8 @@ export default function StatisticsPage() {
                           billedCost={String(user.billedCost)}
                           subscriptionCost={String(user.subscriptionCost)}
                           baselineCost={String(user.billedCost)}
+                          tooltip="hover"
+                          className="flex-wrap"
                         />
                       </TableCell>
                       <TableCell className="text-right text-muted-foreground">
@@ -1597,8 +1613,13 @@ function UserModelBadges({
   return (
     <div className="flex flex-wrap items-center gap-1">
       {shown.map((model) => (
-        <Badge key={model.model} variant="secondary" className="font-normal">
-          {model.model}
+        <Badge
+          key={model.model}
+          variant="secondary"
+          className="font-normal max-w-full"
+          title={model.model}
+        >
+          <span className="truncate">{model.model}</span>
         </Badge>
       ))}
       {remaining > 0 && (

--- a/platform/frontend/src/app/llm/(costs)/costs/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.tsx
@@ -118,6 +118,15 @@ const USER_STATISTICS_PAGE_SIZE = 10;
 const USER_MODEL_BADGE_LIMIT = 2;
 /** Apps and skills are paginated for the same reason as people. */
 const ENTITY_STATISTICS_PAGE_SIZE = 10;
+/**
+ * Recharts series keys double as CSS custom-property names (`--color-<key>`,
+ * see ChartStyle in components/ui/chart). Model ids such as
+ * `anthropic/claude-opus-4.8` contain `/` and `.`, which are not valid in a
+ * property name, so a chart keyed by the raw id gets no line stroke, black
+ * dots and colourless legend/tooltip swatches. Model series are keyed by
+ * rank instead; the chart config carries the real id as the label.
+ */
+const modelSeriesKey = (rank: number) => `model-${rank}`;
 
 export default function StatisticsPage() {
   const router = useRouter();
@@ -291,42 +300,6 @@ export default function StatisticsPage() {
     [timeframe],
   );
 
-  // Convert team statistics to recharts format
-  const teamChartData = useMemo(() => {
-    if (teamStatistics.length === 0) return [];
-
-    const allTimestamps = [
-      ...new Set(
-        teamStatistics.flatMap((stat) =>
-          stat.timeSeries.map((point) => point.timestamp),
-        ),
-      ),
-    ].sort();
-
-    return allTimestamps.map((timestamp) => {
-      const dataPoint: Record<string, string | number> = {
-        timestamp,
-        label: formatTimestamp(timestamp),
-      };
-      teamStatistics.slice(0, 5).forEach((team) => {
-        const point = team.timeSeries.find((p) => p.timestamp === timestamp);
-        dataPoint[team.teamId] = point ? point.value : 0;
-      });
-      return dataPoint;
-    });
-  }, [teamStatistics, formatTimestamp]);
-
-  const teamChartConfig = useMemo(() => {
-    const config: ChartConfig = {};
-    teamStatistics.slice(0, 5).forEach((team, index) => {
-      config[team.teamId] = {
-        label: team.teamName,
-        color: `var(--chart-${index + 1})`,
-      };
-    });
-    return config;
-  }, [teamStatistics]);
-
   // Filter agent statistics by type
   const chatAgentStatistics = useMemo(
     () => agentStatistics.filter((stat) => stat.agentType === "agent"),
@@ -337,13 +310,32 @@ export default function StatisticsPage() {
     [agentStatistics],
   );
 
-  // Convert agent statistics to recharts format
-  const agentChartData = useMemo(() => {
-    if (chatAgentStatistics.length === 0) return [];
+  // The API returns entities in first-seen order, not by cost. Both the
+  // tables and the "top 5 by cost" charts below need the cost order.
+  const sortedTeamStatistics = useMemo(
+    () => [...teamStatistics].sort((a, b) => b.cost - a.cost),
+    [teamStatistics],
+  );
+  const sortedChatAgentStatistics = useMemo(
+    () => [...chatAgentStatistics].sort((a, b) => b.cost - a.cost),
+    [chatAgentStatistics],
+  );
+  const sortedLlmProxyStatistics = useMemo(
+    () => [...llmProxyStatistics].sort((a, b) => b.cost - a.cost),
+    [llmProxyStatistics],
+  );
+  const sortedModelStatistics = useMemo(
+    () => [...modelStatistics].sort((a, b) => b.cost - a.cost),
+    [modelStatistics],
+  );
+
+  // Convert team statistics to recharts format
+  const teamChartData = useMemo(() => {
+    if (sortedTeamStatistics.length === 0) return [];
 
     const allTimestamps = [
       ...new Set(
-        chatAgentStatistics.flatMap((stat) =>
+        sortedTeamStatistics.flatMap((stat) =>
           stat.timeSeries.map((point) => point.timestamp),
         ),
       ),
@@ -354,32 +346,68 @@ export default function StatisticsPage() {
         timestamp,
         label: formatTimestamp(timestamp),
       };
-      chatAgentStatistics.slice(0, 5).forEach((agent) => {
+      sortedTeamStatistics.slice(0, 5).forEach((team) => {
+        const point = team.timeSeries.find((p) => p.timestamp === timestamp);
+        dataPoint[team.teamId] = point ? point.value : 0;
+      });
+      return dataPoint;
+    });
+  }, [sortedTeamStatistics, formatTimestamp]);
+
+  const teamChartConfig = useMemo(() => {
+    const config: ChartConfig = {};
+    sortedTeamStatistics.slice(0, 5).forEach((team, index) => {
+      config[team.teamId] = {
+        label: team.teamName,
+        color: `var(--chart-${index + 1})`,
+      };
+    });
+    return config;
+  }, [sortedTeamStatistics]);
+
+  // Convert agent statistics to recharts format
+  const agentChartData = useMemo(() => {
+    if (sortedChatAgentStatistics.length === 0) return [];
+
+    const allTimestamps = [
+      ...new Set(
+        sortedChatAgentStatistics.flatMap((stat) =>
+          stat.timeSeries.map((point) => point.timestamp),
+        ),
+      ),
+    ].sort();
+
+    return allTimestamps.map((timestamp) => {
+      const dataPoint: Record<string, string | number> = {
+        timestamp,
+        label: formatTimestamp(timestamp),
+      };
+      sortedChatAgentStatistics.slice(0, 5).forEach((agent) => {
         const point = agent.timeSeries.find((p) => p.timestamp === timestamp);
         dataPoint[agent.agentId] = point ? point.value : 0;
       });
       return dataPoint;
     });
-  }, [chatAgentStatistics, formatTimestamp]);
+  }, [sortedChatAgentStatistics, formatTimestamp]);
 
   const agentChartConfig = useMemo(() => {
     const config: ChartConfig = {};
-    chatAgentStatistics.slice(0, 5).forEach((agent, index) => {
+    sortedChatAgentStatistics.slice(0, 5).forEach((agent, index) => {
       config[agent.agentId] = {
         label: agent.agentName,
         color: `var(--chart-${index + 1})`,
       };
     });
     return config;
-  }, [chatAgentStatistics]);
+  }, [sortedChatAgentStatistics]);
 
   // Convert LLM proxy statistics to recharts format
   const llmProxyChartData = useMemo(() => {
-    if (llmProxyStatistics.length === 0) return [];
+    if (sortedLlmProxyStatistics.length === 0) return [];
 
     const allTimestamps = [
       ...new Set(
-        llmProxyStatistics.flatMap((stat) =>
+        sortedLlmProxyStatistics.flatMap((stat) =>
           stat.timeSeries.map((point) => point.timestamp),
         ),
       ),
@@ -390,32 +418,32 @@ export default function StatisticsPage() {
         timestamp,
         label: formatTimestamp(timestamp),
       };
-      llmProxyStatistics.slice(0, 5).forEach((agent) => {
+      sortedLlmProxyStatistics.slice(0, 5).forEach((agent) => {
         const point = agent.timeSeries.find((p) => p.timestamp === timestamp);
         dataPoint[agent.agentId] = point ? point.value : 0;
       });
       return dataPoint;
     });
-  }, [llmProxyStatistics, formatTimestamp]);
+  }, [sortedLlmProxyStatistics, formatTimestamp]);
 
   const llmProxyChartConfig = useMemo(() => {
     const config: ChartConfig = {};
-    llmProxyStatistics.slice(0, 5).forEach((agent, index) => {
+    sortedLlmProxyStatistics.slice(0, 5).forEach((agent, index) => {
       config[agent.agentId] = {
         label: agent.agentName,
         color: `var(--chart-${index + 1})`,
       };
     });
     return config;
-  }, [llmProxyStatistics]);
+  }, [sortedLlmProxyStatistics]);
 
   // Convert model statistics to recharts format
   const modelChartData = useMemo(() => {
-    if (modelStatistics.length === 0) return [];
+    if (sortedModelStatistics.length === 0) return [];
 
     const allTimestamps = [
       ...new Set(
-        modelStatistics.flatMap((stat) =>
+        sortedModelStatistics.flatMap((stat) =>
           stat.timeSeries.map((point) => point.timestamp),
         ),
       ),
@@ -426,24 +454,24 @@ export default function StatisticsPage() {
         timestamp,
         label: formatTimestamp(timestamp),
       };
-      modelStatistics.slice(0, 5).forEach((model) => {
+      sortedModelStatistics.slice(0, 5).forEach((model, rank) => {
         const point = model.timeSeries.find((p) => p.timestamp === timestamp);
-        dataPoint[model.model] = point ? point.value : 0;
+        dataPoint[modelSeriesKey(rank)] = point ? point.value : 0;
       });
       return dataPoint;
     });
-  }, [modelStatistics, formatTimestamp]);
+  }, [sortedModelStatistics, formatTimestamp]);
 
   const modelChartConfig = useMemo(() => {
     const config: ChartConfig = {};
-    modelStatistics.slice(0, 5).forEach((model, index) => {
-      config[model.model] = {
+    sortedModelStatistics.slice(0, 5).forEach((model, rank) => {
+      config[modelSeriesKey(rank)] = {
         label: model.model,
-        color: `var(--chart-${index + 1})`,
+        color: `var(--chart-${rank + 1})`,
       };
     });
     return config;
-  }, [modelStatistics]);
+  }, [sortedModelStatistics]);
 
   // Cost savings chart data
   const costSavingsChartData = useMemo(() => {
@@ -508,24 +536,6 @@ export default function StatisticsPage() {
       color: "var(--chart-3)",
     },
   };
-
-  // Sort statistics by cost for table display
-  const sortedTeamStatistics = useMemo(
-    () => [...teamStatistics].sort((a, b) => b.cost - a.cost),
-    [teamStatistics],
-  );
-  const sortedChatAgentStatistics = useMemo(
-    () => [...chatAgentStatistics].sort((a, b) => b.cost - a.cost),
-    [chatAgentStatistics],
-  );
-  const sortedLlmProxyStatistics = useMemo(
-    () => [...llmProxyStatistics].sort((a, b) => b.cost - a.cost),
-    [llmProxyStatistics],
-  );
-  const sortedModelStatistics = useMemo(
-    () => [...modelStatistics].sort((a, b) => b.cost - a.cost),
-    [modelStatistics],
-  );
 
   useEffect(() => {
     setActionButton(
@@ -771,7 +781,7 @@ export default function StatisticsPage() {
                   />
                   <ChartTooltip content={CostChartTooltip} />
                   <ChartLegend content={<ChartLegendContent />} />
-                  {teamStatistics.slice(0, 5).map((team) => (
+                  {sortedTeamStatistics.slice(0, 5).map((team) => (
                     <Line
                       key={team.teamId}
                       dataKey={team.teamId}
@@ -888,7 +898,7 @@ export default function StatisticsPage() {
                   />
                   <ChartTooltip content={CostChartTooltip} />
                   <ChartLegend content={<ChartLegendContent />} />
-                  {chatAgentStatistics.slice(0, 5).map((agent) => (
+                  {sortedChatAgentStatistics.slice(0, 5).map((agent) => (
                     <Line
                       key={agent.agentId}
                       dataKey={agent.agentId}
@@ -1007,7 +1017,7 @@ export default function StatisticsPage() {
                   />
                   <ChartTooltip content={CostChartTooltip} />
                   <ChartLegend content={<ChartLegendContent />} />
-                  {llmProxyStatistics.slice(0, 5).map((proxy) => (
+                  {sortedLlmProxyStatistics.slice(0, 5).map((proxy) => (
                     <Line
                       key={proxy.agentId}
                       dataKey={proxy.agentId}
@@ -1120,17 +1130,17 @@ export default function StatisticsPage() {
                   />
                   <ChartTooltip content={CostChartTooltip} />
                   <ChartLegend content={<ChartLegendContent />} />
-                  {modelStatistics.slice(0, 5).map((model) => (
+                  {sortedModelStatistics.slice(0, 5).map((model, rank) => (
                     <Line
                       key={model.model}
-                      dataKey={model.model}
+                      dataKey={modelSeriesKey(rank)}
                       type="monotone"
-                      stroke={`var(--color-${model.model})`}
+                      stroke={`var(--color-${modelSeriesKey(rank)})`}
                       strokeWidth={2}
                       dot={{
                         strokeWidth: 0,
                         r: 3,
-                        fill: `var(--color-${model.model})`,
+                        fill: `var(--color-${modelSeriesKey(rank)})`,
                       }}
                       activeDot={{ strokeWidth: 0, r: 5 }}
                     />


### PR DESCRIPTION
Fixes three defects on the Costs page, all visible in the report on [T-1064](https://slack.com/archives/C0B2AGC0AFQ/p1786473744100829?thread_ts=1786473716.353769&cid=C0B2AGC0AFQ).

### People table badges painted over the next column

The shared `Table` is `table-fixed`, so without explicit widths its seven columns split the width equally. `Badge` is `inline-flex whitespace-nowrap shrink-0`, and `<td>` overflow is visible, so once a column was narrower than its badge the badge painted straight over its neighbour — the Active Days count landed inside a model chip and Last Active inside the "Subscription" badge. It only appears below ~900px of table width, which is why a maximised window looks fine.

Columns now carry explicit widths, the table has a floor width so the panel scrolls rather than crushing them, and over-long model chips and email addresses ellipsize instead of breaking mid-word. Scoped to this page — `table.tsx` is shared by 10 tables and is left alone.

### Cost column showed `0%` instead of a cost

`BilledCost`'s `tooltip` prop defaults to `"never"`, which renders the *savings percentage* rather than a cost. Every other call site passes `tooltip="hover"`; this one didn't, so anyone without subscription usage saw `0%` where a dollar amount belongs. The existing test only covered a subscription-funded user, which takes the badge branch and never hits this path.

### Models chart had no lines, black dots and colourless swatches

Recharts series keys are reused as CSS custom-property names (`--color-<key>`, via `ChartStyle`). The Models chart keyed series by the raw model id, and ids like `anthropic/claude-opus-4.8` contain `/` and `.`, which are not valid in a property name — `var(--color-anthropic/claude-opus-4.8)` never resolved, so every line computed to `stroke: none`, dots fell back to SVG-default black, and legend/tooltip swatches were transparent, leaving a tooltip of unlabelled numbers. Teams/Agents/Proxies key by UUID and were unaffected. Model series are now keyed by rank, with the id kept as the config label.

Separately, all four charts captioned "Chart shows top 5 by cost" sliced the API's unsorted array — the backend returns entities in first-seen order and only the tables used the cost-sorted copies, so with more than five entities the charts showed an arbitrary five. They now slice the same sorted arrays the tables use.

### Verification

Checked on a dev stack seeded to match the reported screenshot (15,260 requests / 9 models / 8 active days for the heaviest user):

- DOM geometry measured at 970px, 1280px and 1440px: no cell content overflows its column anywhere on the page (before: 7 overflows, up to 152px)
- all five chart strokes resolve to real colours; chart legend order equals the table's top five
- 10 tests pass in `costs/page.test.tsx`; the three new tests were each confirmed to fail with the fix reverted

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>