### PR TITLE
fix(llm-proxy): dispatch direct tool calls through run_tool instead of dead-ending

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai.ts
@@ -29,6 +29,9 @@ class AnthropicOpenaiResponseAdapter
 {
   readonly provider = "anthropic" as const;
   private inner: LLMResponseAdapter<AnthropicResponse>;
+  // The inner (logged-shape) response after a dispatch-mode repair, so
+  // getLoggedResponse persists the rewritten turn rather than the original.
+  private rewrittenInner: AnthropicResponse | null = null;
   private ctx: AnthropicOpenaiContext;
 
   constructor(response: AnthropicResponse, ctx: AnthropicOpenaiContext) {
@@ -70,11 +73,30 @@ class AnthropicOpenaiResponseAdapter
   }
 
   getLoggedResponse(): AnthropicResponse {
-    return this.inner.getOriginalResponse();
+    return this.rewrittenInner ?? this.inner.getOriginalResponse();
   }
 
   getFinishReasons(): string[] {
     return this.inner.getFinishReasons();
+  }
+
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): AnthropicResponse {
+    // Rewrite in the inner wire shape (which is what gets logged), then
+    // translate for the client exactly as getOriginalResponse does. If the
+    // inner adapter cannot rewrite, hand back the untouched translation — the
+    // handler only reaches here when the planner produced a rewrite, and a
+    // silent no-op would strand the client with a call it cannot execute; but
+    // every inner adapter this wraps does implement it.
+    const inner =
+      this.inner.withRewrittenToolCalls?.(toolCalls) ??
+      this.inner.getOriginalResponse();
+    this.rewrittenInner = inner;
+    return anthropicResponseToOpenai(
+      inner,
+      this.ctx,
+    ) as unknown as AnthropicResponse;
   }
 
   toRefusalResponse(
@@ -171,6 +193,30 @@ class AnthropicOpenaiStreamAdapter
     // once it has handed them over, and this is that moment.
     this.inner.getRawToolCallEvents();
     return [...this.pendingToolCallEvents];
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // The inner (Anthropic-shaped) read is for its side effect only — it marks
+    // the calls as handed over so inner.toProviderResponse() names them — while
+    // the wire events below are the OpenAI-shaped ones this surface speaks.
+    // Mirrors getRawToolCallEvents above; the buffered OpenAI events are
+    // dropped rather than replayed, because they name the tool the model called
+    // directly and that is the call being repaired.
+    this.inner.formatToolCallsSSE?.(toolCalls);
+    this.pendingToolCallEvents = [];
+    return [
+      this.formatChunk({
+        delta: {
+          tool_calls: toolCalls.map((toolCall, index) => ({
+            index,
+            id: toolCall.id,
+            type: "function" as const,
+            function: { name: toolCall.name, arguments: toolCall.arguments },
+          })),
+        },
+        finishReason: null,
+      }),
+    ];
   }
 
   formatCompleteTextSSE(text: string): string[] {

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -575,6 +575,25 @@ class AnthropicResponseAdapter
     return reason ? [reason] : [];
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): AnthropicResponse {
+    // Positional: one rewritten entry per call this response carries, in
+    // order, so ids the client correlates by are untouched.
+    let next = 0;
+    const content = this.response.content.map((block) => {
+      if (block.type !== "tool_use") return block;
+      const rewritten = toolCalls[next++];
+      if (!rewritten) return block;
+      return {
+        ...block,
+        name: rewritten.name,
+        input: parseArgs(rewritten.arguments),
+      };
+    });
+    return { ...this.response, content };
+  }
+
   toRefusalResponse(
     _refusalMessage: string,
     contentMessage: string,
@@ -796,6 +815,59 @@ class AnthropicStreamAdapter
       );
       return `event: ${renumbered.type}\ndata: ${JSON.stringify(renumbered)}\n\n`;
     });
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // Same release semantics as getRawToolCallEvents: these blocks are becoming
+    // the client's, so toProviderResponse must name them. The buffered raw
+    // events are deliberately NOT replayed — they carry the tool the model
+    // named directly, which is the call being repaired — so these blocks get
+    // freshly allocated output indices instead of going through the upstream
+    // index mapping.
+    this.toolCallsReleased = true;
+    const events: string[] = [];
+    for (const toolCall of toolCalls) {
+      const index = this.nextOutIndex++;
+      let input: Record<string, unknown> = {};
+      try {
+        input = JSON.parse(toolCall.arguments);
+      } catch {
+        // A call whose arguments do not parse is never rewritten upstream of
+        // here; keep the block well-formed rather than emitting invalid JSON.
+      }
+      events.push(
+        `event: content_block_start\ndata: ${JSON.stringify({
+          type: "content_block_start",
+          index,
+          content_block: {
+            type: "tool_use",
+            id: toolCall.id,
+            name: toolCall.name,
+            input: {},
+          },
+        })}\n\n`,
+      );
+      // Anthropic streams tool input as `partial_json` fragments that the
+      // client concatenates and parses; one fragment carrying the whole object
+      // is the valid degenerate case.
+      events.push(
+        `event: content_block_delta\ndata: ${JSON.stringify({
+          type: "content_block_delta",
+          index,
+          delta: {
+            type: "input_json_delta",
+            partial_json: JSON.stringify(input),
+          },
+        })}\n\n`,
+      );
+      events.push(
+        `event: content_block_stop\ndata: ${JSON.stringify({
+          type: "content_block_stop",
+          index,
+        })}\n\n`,
+      );
+    }
+    return events;
   }
 
   formatCompleteTextSSE(text: string): string[] {
@@ -1488,4 +1560,18 @@ function createAnthropicAzureFoundryFetch(
       headers,
     });
   };
+}
+
+/** Rewritten arguments arrive as the JSON string the model emitted; this wire
+ * shape carries them as an object. A repaired call always parses (the planner
+ * refuses to rewrite otherwise), so the fallback is defensive only. */
+function parseArgs(argumentsJson: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(argumentsJson);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
+  } catch {
+    return {};
+  }
 }

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.ts
@@ -34,6 +34,7 @@ import type {
   LLMRequestAdapter,
   LLMResponseAdapter,
   LLMStreamAdapter,
+  StreamAccumulatorState,
   ToolCompressionStats,
   UsageView,
 } from "@/types";
@@ -43,6 +44,11 @@ import {
   extractCommonToolCallArguments,
 } from "@/types";
 import { formatResponsesStreamErrorFrame } from "./responses-stream-error-frame";
+import {
+  formatResponsesFunctionCallFrames,
+  rewriteResponsesOutput,
+  toSse,
+} from "./responses-tool-call-rewrite";
 import { fromResponsesUsage, toResponsesUsage } from "./responses-usage";
 import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
@@ -416,6 +422,15 @@ class AzureResponsesResponseAdapter
     return [this.response.status ?? "completed"];
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): AzureResponsesResponse {
+    return {
+      ...this.response,
+      output: rewriteResponsesOutput(this.response.output, toolCalls),
+    } as unknown as AzureResponsesResponse;
+  }
+
   toRefusalResponse(
     refusalMessage: string,
     contentMessage: string,
@@ -653,6 +668,40 @@ class AzureResponsesStreamAdapter
   formatCompleteTextSSE(text: string): string[] {
     this.replacedText = text;
     return [this.formatTextDeltaSSE(text)];
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // The upstream `response.completed` envelope has already been streamed and
+    // it names the calls the model made directly. The client keeps the LAST
+    // completed envelope, so the repair ends by re-issuing one that names the
+    // rewritten calls — the same trick the refusal path relies on. That
+    // envelope also becomes the persisted one, so the interaction log matches
+    // what the client reconstructs.
+    const base = this.completedResponse ?? this.toProviderResponse();
+    const upstreamOutput = Array.isArray(base.output) ? base.output : [];
+    const firstOutputIndex = upstreamOutput.filter(
+      (item) => item.type !== "function_call",
+    ).length;
+    let sequence = Date.now();
+    const frames = formatResponsesFunctionCallFrames({
+      toolCalls,
+      firstOutputIndex,
+      nextSequenceNumber: () => sequence++,
+    });
+    const rewritten = {
+      ...base,
+      output: rewriteResponsesOutput(upstreamOutput, toolCalls),
+      usage: base.usage ?? toResponsesUsage(this.state.usage),
+    } as unknown as AzureResponsesResponse;
+    this.completedResponse = rewritten;
+    frames.push(
+      toSse({
+        type: "response.completed",
+        sequence_number: sequence++,
+        response: rewritten,
+      }),
+    );
+    return frames;
   }
 
   formatEndSSE(): string {
@@ -904,10 +953,6 @@ function isResponsesToolCallChunk(
     chunk.type === "response.function_call_arguments.delta" ||
     chunk.type === "response.function_call_arguments.done"
   );
-}
-
-function toSse(event: unknown): string {
-  return `data: ${JSON.stringify(event)}\n\n`;
 }
 
 function getToolCallsByCallId(

--- a/platform/backend/src/routes/proxy/adapters/azure.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.ts
@@ -37,6 +37,7 @@ import type {
   LLMRequestAdapter,
   LLMResponseAdapter,
   LLMStreamAdapter,
+  StreamAccumulatorState,
 } from "@/types";
 import { ApiError } from "@/types";
 import type { ReasoningEffort } from "@/types/model";
@@ -158,6 +159,11 @@ class AzureResponseAdapter implements LLMResponseAdapter<AzureResponse> {
   toRefusalResponse(refusalMessage: string, contentMessage: string) {
     return this.delegate.toRefusalResponse(refusalMessage, contentMessage);
   }
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ) {
+    return this.delegate.withRewrittenToolCalls(toolCalls);
+  }
 }
 
 class AzureStreamAdapter
@@ -188,6 +194,9 @@ class AzureStreamAdapter
   }
   formatCompleteTextSSE(text: string) {
     return this.delegate.formatCompleteTextSSE(text);
+  }
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]) {
+    return this.delegate.formatToolCallsSSE(toolCalls);
   }
   formatEndSSE() {
     return this.delegate.formatEndSSE();

--- a/platform/backend/src/routes/proxy/adapters/bedrock-invoke.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock-invoke.ts
@@ -305,6 +305,15 @@ class BedrockInvokeResponseAdapter
     return this.inner.getFinishReasons();
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): AnthropicResponse {
+    return (
+      this.inner.withRewrittenToolCalls?.(toolCalls) ??
+      this.inner.getOriginalResponse()
+    );
+  }
+
   toRefusalResponse(
     refusalMessage: string,
     contentMessage: string,
@@ -372,6 +381,14 @@ class BedrockInvokeStreamAdapter
     return this.inner
       .formatCompleteTextSSE(text)
       .map((event) => sseToInvokeEventStream(innerSse(event)));
+  }
+
+  formatToolCallsSSE(
+    toolCalls: StreamAccumulatorState["toolCalls"],
+  ): Uint8Array[] {
+    return (this.inner.formatToolCallsSSE?.(toolCalls) ?? []).map((event) =>
+      sseToInvokeEventStream(innerSse(event)),
+    );
   }
 
   formatEndSSE(): Uint8Array {

--- a/platform/backend/src/routes/proxy/adapters/bedrock-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock-openai-translator.ts
@@ -213,6 +213,12 @@ export interface ConverseToOpenaiSseEncoder {
   formatEnd(): Uint8Array;
   formatTextDelta(text: string): Uint8Array;
   formatCompleteText(text: string): Uint8Array[];
+  /**
+   * The turn's tool calls as one complete OpenAI tool_calls delta chunk, for
+   * the proxy's dispatch-mode repair (see `planDispatchModeToolCallRewrites`).
+   * The finish reason stays held for formatEnd, as for a live tool call.
+   */
+  formatToolCalls(toolCalls: StreamAccumulatorState["toolCalls"]): Uint8Array[];
   buildFinalResponseFromState(state: StreamAccumulatorState): OpenAiResponse;
 }
 
@@ -373,6 +379,29 @@ export function createConverseToOpenaiSseEncoder(
     ];
   }
 
+  function formatToolCalls(
+    toolCalls: StreamAccumulatorState["toolCalls"],
+  ): Uint8Array[] {
+    const parts: Uint8Array[] = [];
+    if (!rolePrepended) {
+      parts.push(sse(envelope({ role: "assistant" })));
+      rolePrepended = true;
+    }
+    parts.push(
+      sse(
+        envelope({
+          tool_calls: toolCalls.map((toolCall, index) => ({
+            index,
+            id: toolCall.id,
+            type: "function",
+            function: { name: toolCall.name, arguments: toolCall.arguments },
+          })),
+        }),
+      ),
+    );
+    return parts;
+  }
+
   function buildFinalResponseFromState(
     state: StreamAccumulatorState,
   ): OpenAiResponse {
@@ -413,6 +442,7 @@ export function createConverseToOpenaiSseEncoder(
     formatEnd,
     formatTextDelta,
     formatCompleteText,
+    formatToolCalls,
     buildFinalResponseFromState,
   };
 }

--- a/platform/backend/src/routes/proxy/adapters/bedrock-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock-openai.ts
@@ -45,6 +45,9 @@ class BedrockOpenaiResponseAdapter
 {
   readonly provider = "bedrock" as const;
   private inner: LLMResponseAdapter<BedrockResponse>;
+  // The inner (logged-shape) response after a dispatch-mode repair, so
+  // getLoggedResponse persists the rewritten turn rather than the original.
+  private rewrittenInner: BedrockResponse | null = null;
   private ctx: OpenaiContext;
 
   constructor(response: BedrockResponse, ctx: OpenaiContext) {
@@ -90,7 +93,7 @@ class BedrockOpenaiResponseAdapter
   }
 
   getLoggedResponse(): BedrockResponse {
-    return this.inner.getOriginalResponse();
+    return this.rewrittenInner ?? this.inner.getOriginalResponse();
   }
 
   /**
@@ -98,6 +101,25 @@ class BedrockOpenaiResponseAdapter
    * the Bedrock-style refusal shape would not round-trip correctly through
    * OpenAI SDK parsers.
    */
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): BedrockResponse {
+    // Rewrite in the inner wire shape (which is what gets logged), then
+    // translate for the client exactly as getOriginalResponse does. If the
+    // inner adapter cannot rewrite, hand back the untouched translation — the
+    // handler only reaches here when the planner produced a rewrite, and a
+    // silent no-op would strand the client with a call it cannot execute; but
+    // every inner adapter this wraps does implement it.
+    const inner =
+      this.inner.withRewrittenToolCalls?.(toolCalls) ??
+      this.inner.getOriginalResponse();
+    this.rewrittenInner = inner;
+    return converseResponseToOpenai(
+      inner,
+      this.ctx,
+    ) as unknown as BedrockResponse;
+  }
+
   toRefusalResponse(
     _refusalMessage: string,
     contentMessage: string,
@@ -208,6 +230,18 @@ class BedrockOpenaiStreamAdapter
     // already emits a self-contained "stop" finish for the wire.
     this.inner.formatCompleteTextSSE(text);
     return this.encoder.formatCompleteText(text);
+  }
+
+  formatToolCallsSSE(
+    toolCalls: StreamAccumulatorState["toolCalls"],
+  ): Uint8Array[] {
+    // Inner read for its side effect only (release semantics for the persisted
+    // Converse-shape turn); the wire bytes are the OpenAI-shaped ones. The
+    // cached translated events name the calls the model made directly and are
+    // dropped — that is the call being repaired.
+    this.inner.formatToolCallsSSE?.(toolCalls);
+    this.pendingToolCallEventBytes = [];
+    return this.encoder.formatToolCalls(toolCalls);
   }
 
   formatEndSSE(): Uint8Array {

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -963,6 +963,36 @@ class BedrockResponseAdapter implements LLMResponseAdapter<BedrockResponse> {
     return reason ? [reason] : [];
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): BedrockResponse {
+    // Positional: one rewritten entry per call this response carries, in
+    // order, so ids the client correlates by are untouched.
+    const outputMessage = this.response.output?.message;
+    if (!outputMessage?.content) return this.response;
+    let next = 0;
+    const content = outputMessage.content.map((block) => {
+      if (!isToolUseBlock(block)) return block;
+      const rewritten = toolCalls[next++];
+      if (!rewritten) return block;
+      return {
+        ...block,
+        toolUse: {
+          ...block.toolUse,
+          name: rewritten.name,
+          input: parseArgs(rewritten.arguments),
+        },
+      };
+    });
+    return {
+      ...this.response,
+      output: {
+        ...this.response.output,
+        message: { ...outputMessage, content },
+      },
+    };
+  }
+
   toRefusalResponse(
     _refusalMessage: string,
     contentMessage: string,
@@ -1339,6 +1369,62 @@ class BedrockStreamAdapter
       }
     }
 
+    return result;
+  }
+
+  formatToolCallsSSE(
+    toolCalls: StreamAccumulatorState["toolCalls"],
+  ): Uint8Array[] {
+    // The planner rewrites 1:1 in order, so each rewritten call reuses the
+    // contentBlockIndex of the tool_use block it replaces — those blocks were
+    // held, never streamed, so the indices are free. Same three-frame shape as
+    // a live tool_use block; input rides as one whole JSON string delta.
+    const heldBlockIndices: number[] = [];
+    for (const rawEvent of this.state.rawToolCallEvents) {
+      const event = rawEvent as BedrockStreamEventWithRaw;
+      if (
+        "contentBlockStart" in event &&
+        event.contentBlockStart?.start &&
+        "toolUse" in event.contentBlockStart.start &&
+        event.contentBlockStart.contentBlockIndex !== undefined
+      ) {
+        heldBlockIndices.push(event.contentBlockStart.contentBlockIndex);
+      }
+    }
+    const result: Uint8Array[] = [];
+    toolCalls.forEach((toolCall, position) => {
+      const contentBlockIndex =
+        heldBlockIndices[position] ??
+        (heldBlockIndices.length > 0
+          ? Math.max(...heldBlockIndices) + 1 + position
+          : position);
+      result.push(
+        encodeEventStreamMessage("contentBlockStart", {
+          contentBlockIndex,
+          start: {
+            toolUse: { toolUseId: toolCall.id, name: toolCall.name },
+          },
+        }),
+        encodeEventStreamMessage("contentBlockDelta", {
+          contentBlockIndex,
+          delta: { toolUse: { input: toolCall.arguments } },
+        }),
+        encodeEventStreamMessage("contentBlockStop", { contentBlockIndex }),
+      );
+    });
+
+    // The buffered terminal events (messageStop, metadata) travel with the
+    // tool events on the normal path, so they must follow here as well.
+    for (const finalEvent of this.bedrockState.pendingFinalEvents) {
+      const event = finalEvent as BedrockStreamEventWithRaw;
+      if (event.__rawBytes) {
+        result.push(event.__rawBytes);
+      } else if ("messageStop" in event && event.messageStop) {
+        result.push(encodeEventStreamMessage("messageStop", event.messageStop));
+      } else if ("metadata" in event && event.metadata) {
+        result.push(encodeEventStreamMessage("metadata", event.metadata));
+      }
+    }
     return result;
   }
 
@@ -1959,3 +2045,17 @@ export const bedrockAdapterFactory: LLMProvider<
     return "Internal server error";
   },
 };
+
+/** Rewritten arguments arrive as the JSON string the model emitted; this wire
+ * shape carries them as an object. A repaired call always parses (the planner
+ * refuses to rewrite otherwise), so the fallback is defensive only. */
+function parseArgs(argumentsJson: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(argumentsJson);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/platform/backend/src/routes/proxy/adapters/cohere-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere-openai.ts
@@ -29,6 +29,9 @@ class CohereOpenaiResponseAdapter
 {
   readonly provider = "cohere" as const;
   private inner: LLMResponseAdapter<CohereResponse>;
+  // The inner (logged-shape) response after a dispatch-mode repair, so
+  // getLoggedResponse persists the rewritten turn rather than the original.
+  private rewrittenInner: CohereResponse | null = null;
   private ctx: CohereOpenaiContext;
 
   constructor(response: CohereResponse, ctx: CohereOpenaiContext) {
@@ -68,11 +71,27 @@ class CohereOpenaiResponseAdapter
   }
 
   getLoggedResponse(): CohereResponse {
-    return this.inner.getOriginalResponse();
+    return this.rewrittenInner ?? this.inner.getOriginalResponse();
   }
 
   getFinishReasons(): string[] {
     return this.inner.getFinishReasons();
+  }
+
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): CohereResponse {
+    // Rewrite in the inner wire shape (which is what gets logged), then
+    // translate for the client exactly as getOriginalResponse does. If the
+    // inner adapter cannot rewrite, hand back the untouched translation — the
+    // handler only reaches here when the planner produced a rewrite, and a
+    // silent no-op would strand the client with a call it cannot execute; but
+    // every inner adapter this wraps does implement it.
+    const inner =
+      this.inner.withRewrittenToolCalls?.(toolCalls) ??
+      this.inner.getOriginalResponse();
+    this.rewrittenInner = inner;
+    return cohereResponseToOpenai(inner, this.ctx) as unknown as CohereResponse;
   }
 
   toRefusalResponse(
@@ -141,6 +160,26 @@ class CohereOpenaiStreamAdapter
 
   getRawToolCallEvents(): string[] {
     return [];
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // The inner (Cohere-shaped) read is a side effect only — it marks the calls
+    // as handed over so inner.toProviderResponse() names them — while the wire
+    // event below is the OpenAI-shaped one this surface speaks.
+    this.inner.formatToolCallsSSE?.(toolCalls);
+    return [
+      this.formatChunk({
+        delta: {
+          tool_calls: toolCalls.map((toolCall, index) => ({
+            index,
+            id: toolCall.id,
+            type: "function" as const,
+            function: { name: toolCall.name, arguments: toolCall.arguments },
+          })),
+        },
+        finishReason: null,
+      }),
+    ];
   }
 
   formatCompleteTextSSE(text: string): string[] {

--- a/platform/backend/src/routes/proxy/adapters/cohere.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere.ts
@@ -349,6 +349,31 @@ class CohereResponseAdapter implements LLMResponseAdapter<CohereResponse> {
     return this.response;
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): CohereResponse {
+    // Positional: one rewritten entry per call this response carries, in
+    // order, so ids the client correlates by are untouched.
+    const existing = this.response?.message?.tool_calls;
+    if (!existing) return this.response;
+    const tool_calls = existing.map((toolCall, index) => {
+      const rewritten = toolCalls[index];
+      if (!rewritten) return toolCall;
+      return {
+        ...toolCall,
+        function: {
+          ...toolCall.function,
+          name: rewritten.name,
+          arguments: rewritten.arguments,
+        },
+      };
+    });
+    return {
+      ...this.response,
+      message: { ...this.response.message, tool_calls },
+    };
+  }
+
   toRefusalResponse(
     _refusalMessage: string,
     contentMessage: string,
@@ -624,6 +649,35 @@ class CohereStreamAdapter
     return this.state.rawToolCallEvents.map(
       (event) => `data: ${JSON.stringify(event)}\n\n`,
     );
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // The same three-frame shape processChunk builds for a live call
+    // (start carries id/name, delta carries the whole argument string, end
+    // closes it), so @ai-sdk/cohere accumulates it identically.
+    return toolCalls.flatMap((toolCall) => [
+      `data: ${JSON.stringify({
+        type: "tool-call-start",
+        delta: {
+          message: {
+            tool_calls: {
+              id: toolCall.id,
+              type: "function",
+              function: { name: toolCall.name, arguments: "" },
+            },
+          },
+        },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "tool-call-delta",
+        delta: {
+          message: {
+            tool_calls: { function: { arguments: toolCall.arguments } },
+          },
+        },
+      })}\n\n`,
+      `data: ${JSON.stringify({ type: "tool-call-end" })}\n\n`,
+    ]);
   }
 
   formatCompleteTextSSE(text: string): string[] {

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
@@ -36,6 +36,9 @@ class GeminiOpenaiResponseAdapter
 {
   readonly provider = "gemini" as const;
   private inner: LLMResponseAdapter<GeminiResponse>;
+  // The inner (logged-shape) response after a dispatch-mode repair, so
+  // getLoggedResponse persists the rewritten turn rather than the original.
+  private rewrittenInner: GeminiResponse | null = null;
   private ctx: GeminiOpenaiContext;
 
   constructor(response: GeminiResponse, ctx: GeminiOpenaiContext) {
@@ -75,11 +78,27 @@ class GeminiOpenaiResponseAdapter
   }
 
   getLoggedResponse(): GeminiResponse {
-    return this.inner.getOriginalResponse();
+    return this.rewrittenInner ?? this.inner.getOriginalResponse();
   }
 
   getFinishReasons(): string[] {
     return this.inner.getFinishReasons();
+  }
+
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): GeminiResponse {
+    // Rewrite in the inner wire shape (which is what gets logged), then
+    // translate for the client exactly as getOriginalResponse does. If the
+    // inner adapter cannot rewrite, hand back the untouched translation — the
+    // handler only reaches here when the planner produced a rewrite, and a
+    // silent no-op would strand the client with a call it cannot execute; but
+    // every inner adapter this wraps does implement it.
+    const inner =
+      this.inner.withRewrittenToolCalls?.(toolCalls) ??
+      this.inner.getOriginalResponse();
+    this.rewrittenInner = inner;
+    return geminiResponseToOpenai(inner, this.ctx) as unknown as GeminiResponse;
   }
 
   toRefusalResponse(
@@ -159,6 +178,29 @@ class GeminiOpenaiStreamAdapter
 
   getRawToolCallEvents(): string[] {
     return this.pendingToolCallEvents;
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // The inner (Gemini-shaped) read is a side effect only — it marks the calls
+    // as handed over so inner.toProviderResponse() names them — while the wire
+    // event below is the OpenAI-shaped one this surface speaks. The buffered
+    // OpenAI events are dropped rather than replayed: they name the tool the
+    // model called directly, which is the call being repaired.
+    this.inner.formatToolCallsSSE?.(toolCalls);
+    this.pendingToolCallEvents = [];
+    return [
+      this.formatChunk({
+        delta: {
+          tool_calls: toolCalls.map((toolCall, index) => ({
+            index,
+            id: toolCall.id,
+            type: "function" as const,
+            function: { name: toolCall.name, arguments: toolCall.arguments },
+          })),
+        },
+        finishReason: null,
+      }),
+    ];
   }
 
   formatCompleteTextSSE(text: string): string[] {

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -588,6 +588,36 @@ class GeminiResponseAdapter implements LLMResponseAdapter<GeminiResponse> {
     return reason ? [reason] : [];
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): GeminiResponse {
+    // Positional: one rewritten entry per call this response carries, in
+    // order, so ids the client correlates by are untouched.
+    const candidate = this.response.candidates?.[0];
+    if (!candidate?.content?.parts) return this.response;
+    let next = 0;
+    const parts = candidate.content.parts.map((part) => {
+      if (!("functionCall" in part) || !part.functionCall) return part;
+      const rewritten = toolCalls[next++];
+      if (!rewritten) return part;
+      return {
+        ...part,
+        functionCall: {
+          ...part.functionCall,
+          name: rewritten.name,
+          args: parseArgs(rewritten.arguments),
+        },
+      };
+    });
+    return {
+      ...this.response,
+      candidates: [
+        { ...candidate, content: { ...candidate.content, parts } },
+        ...(this.response.candidates?.slice(1) ?? []),
+      ],
+    };
+  }
+
   toRefusalResponse(
     _refusalMessage: string,
     contentMessage: string,
@@ -786,6 +816,33 @@ class GeminiStreamAdapter
       );
       return `data: ${JSON.stringify(restChunk)}\n\n`;
     });
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // One REST-shaped chunk carrying every call as a functionCall part —
+    // exactly how the upstream delivers whole (non-incremental) calls, so the
+    // client accumulates it the same way. No finishReason: formatEndSSE closes
+    // the turn.
+    const chunk: GeminiResponse = {
+      candidates: [
+        {
+          content: {
+            parts: toolCalls.map((toolCall) => ({
+              functionCall: {
+                id: toolCall.id,
+                name: toolCall.name,
+                args: parseArgs(toolCall.arguments),
+              },
+            })),
+            role: "model",
+          },
+          index: 0,
+        },
+      ],
+      modelVersion: this.state.model || this.model,
+      responseId: this.state.responseId || `gemini-${Date.now()}`,
+    };
+    return [`data: ${JSON.stringify(chunk)}\n\n`];
   }
 
   formatCompleteTextSSE(text: string): string[] {
@@ -1577,3 +1634,17 @@ export const geminiAdapterFactory: LLMProvider<
     return "Internal server error";
   },
 };
+
+/** Rewritten arguments arrive as the JSON string the model emitted; this wire
+ * shape carries them as an object. A repaired call always parses (the planner
+ * refuses to rewrite otherwise), so the fallback is defensive only. */
+function parseArgs(argumentsJson: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(argumentsJson);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/platform/backend/src/routes/proxy/adapters/groq.ts
+++ b/platform/backend/src/routes/proxy/adapters/groq.ts
@@ -26,6 +26,7 @@ import type {
   LLMRequestAdapter,
   LLMResponseAdapter,
   LLMStreamAdapter,
+  StreamAccumulatorState,
 } from "@/types";
 import {
   OpenAIRequestAdapter,
@@ -137,6 +138,11 @@ class GroqResponseAdapter implements LLMResponseAdapter<GroqResponse> {
   toRefusalResponse(refusalMessage: string, contentMessage: string) {
     return this.delegate.toRefusalResponse(refusalMessage, contentMessage);
   }
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ) {
+    return this.delegate.withRewrittenToolCalls(toolCalls);
+  }
 }
 
 class GroqStreamAdapter
@@ -167,6 +173,9 @@ class GroqStreamAdapter
   }
   formatCompleteTextSSE(text: string) {
     return this.delegate.formatCompleteTextSSE(text);
+  }
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]) {
+    return this.delegate.formatToolCallsSSE(toolCalls);
   }
   formatEndSSE() {
     return this.delegate.formatEndSSE();

--- a/platform/backend/src/routes/proxy/adapters/minimax.ts
+++ b/platform/backend/src/routes/proxy/adapters/minimax.ts
@@ -554,6 +554,34 @@ class MinimaxResponseAdapter implements LLMResponseAdapter<MinimaxResponse> {
    * Convert response to refusal format for blocked tool calls
    * MiniMax doesn't have a refusal field, so we use content only
    */
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): MinimaxResponse {
+    // Positional: one rewritten entry per call this response carries, in
+    // order, so ids the client correlates by are untouched.
+    const choice = this.response.choices[0];
+    if (!choice?.message.tool_calls) return this.response;
+    const tool_calls = choice.message.tool_calls.map((toolCall, index) => {
+      const rewritten = toolCalls[index];
+      if (!rewritten || toolCall.type !== "function") return toolCall;
+      return {
+        ...toolCall,
+        function: {
+          ...toolCall.function,
+          name: rewritten.name,
+          arguments: rewritten.arguments,
+        },
+      };
+    });
+    return {
+      ...this.response,
+      choices: [
+        { ...choice, message: { ...choice.message, tool_calls } },
+        ...this.response.choices.slice(1),
+      ],
+    };
+  }
+
   toRefusalResponse(
     _refusalMessage: string,
     contentMessage: string,
@@ -774,6 +802,34 @@ class MinimaxStreamAdapter
     return this.state.rawToolCallEvents.map((chunk) => {
       return `data: ${JSON.stringify(chunk)}\n\n`;
     });
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // OpenAI-chat-shaped wire: one chunk carrying every call complete.
+    const chunk: MinimaxStreamChunk = {
+      id: this.state.responseId || `chatcmpl-${Date.now()}`,
+      model: this.state.model || "minimax",
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: toolCalls.map((toolCall, index) => ({
+              index,
+              id: toolCall.id,
+              type: "function" as const,
+              function: {
+                name: toolCall.name,
+                arguments: toolCall.arguments,
+              },
+            })),
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return [`data: ${JSON.stringify(chunk)}\n\n`];
   }
 
   formatCompleteTextSSE(text: string): string[] {

--- a/platform/backend/src/routes/proxy/adapters/mistral.ts
+++ b/platform/backend/src/routes/proxy/adapters/mistral.ts
@@ -26,6 +26,7 @@ import type {
   LLMResponseAdapter,
   LLMStreamAdapter,
   Mistral,
+  StreamAccumulatorState,
 } from "@/types";
 import {
   OpenAIRequestAdapter,
@@ -144,6 +145,11 @@ class MistralResponseAdapter implements LLMResponseAdapter<MistralResponse> {
   toRefusalResponse(refusalMessage: string, contentMessage: string) {
     return this.delegate.toRefusalResponse(refusalMessage, contentMessage);
   }
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ) {
+    return this.delegate.withRewrittenToolCalls(toolCalls);
+  }
 }
 
 /**
@@ -177,6 +183,9 @@ class MistralStreamAdapter
   }
   formatCompleteTextSSE(text: string) {
     return this.delegate.formatCompleteTextSSE(text);
+  }
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]) {
+    return this.delegate.formatToolCallsSSE(toolCalls);
   }
   formatEndSSE() {
     return this.delegate.formatEndSSE();

--- a/platform/backend/src/routes/proxy/adapters/ollama-native.ts
+++ b/platform/backend/src/routes/proxy/adapters/ollama-native.ts
@@ -395,6 +395,31 @@ class OllamaNativeResponseAdapter
     return [this.response.done_reason ?? "stop"];
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): NativeResponse {
+    // Positional: one rewritten entry per call this response carries, in
+    // order, so ids the client correlates by are untouched.
+    const existing = this.response.message.tool_calls;
+    if (!existing) return this.response;
+    const tool_calls = existing.map((toolCall, index) => {
+      const rewritten = toolCalls[index];
+      if (!rewritten) return toolCall;
+      return {
+        ...toolCall,
+        function: {
+          ...toolCall.function,
+          name: rewritten.name,
+          arguments: parseArgs(rewritten.arguments),
+        },
+      };
+    });
+    return {
+      ...this.response,
+      message: { ...this.response.message, tool_calls },
+    };
+  }
+
   toRefusalResponse(
     _refusalMessage: string,
     contentMessage: string,
@@ -566,6 +591,30 @@ class OllamaNativeStreamAdapter
 
   getRawToolCallEvents(): string[] {
     return this.rawToolCallLines;
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // Ollama delivers tool calls whole on one line; mirror that. `done` stays
+    // false and the counters are omitted, exactly as the buffered replay does,
+    // because formatEndSSE emits the terminating frame.
+    return [
+      ndjsonLine({
+        model: this.state.model,
+        created_at: this.createdAt,
+        message: {
+          role: "assistant",
+          content: "",
+          tool_calls: toolCalls.map((toolCall) => ({
+            id: toolCall.id || undefined,
+            function: {
+              name: toolCall.name,
+              arguments: parseArgs(toolCall.arguments),
+            },
+          })),
+        },
+        done: false,
+      }),
+    ];
   }
 
   formatCompleteTextSSE(text: string): string[] {
@@ -1017,3 +1066,17 @@ function toToolArgsObject(
 
 /** Key holding tool-call argument text that could not be read as an object. */
 const UNPARSED_TOOL_ARGS_KEY = "__archestra_unparsed_arguments";
+
+/** Rewritten arguments arrive as the JSON string the model emitted; this wire
+ * shape carries them as an object. A repaired call always parses (the planner
+ * refuses to rewrite otherwise), so the fallback is defensive only. */
+function parseArgs(argumentsJson: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(argumentsJson);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/platform/backend/src/routes/proxy/adapters/openai-responses-from-chat.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses-from-chat.ts
@@ -7,6 +7,7 @@ import type {
   LLMResponseAdapter,
   LLMStreamAdapter,
   OpenAi,
+  StreamAccumulatorState,
   UsageView,
 } from "@/types";
 import {
@@ -14,6 +15,7 @@ import {
   type OpenaiResponsesContext,
 } from "./openai-responses-translator";
 import { formatResponsesStreamErrorFrame } from "./responses-stream-error-frame";
+import { formatResponsesFunctionCallFrames } from "./responses-tool-call-rewrite";
 import { toResponsesUsage } from "./responses-usage";
 
 type OpenAiResponse = OpenAi.Types.ChatCompletionsResponse;
@@ -23,6 +25,8 @@ class ResponsesFromChatAdapter<TResponse>
 {
   readonly provider: SupportedProvider;
   private inner: LLMResponseAdapter<TResponse>;
+  // The inner (logged-shape) response after a dispatch-mode repair.
+  private rewrittenInner: TResponse | null = null;
   private ctx: OpenaiResponsesContext;
 
   constructor(
@@ -66,9 +70,25 @@ class ResponsesFromChatAdapter<TResponse>
   }
 
   getLoggedResponse(): TResponse {
+    if (this.rewrittenInner !== null) {
+      return this.rewrittenInner;
+    }
     return this.inner.getLoggedResponse
       ? this.inner.getLoggedResponse()
       : this.inner.getOriginalResponse();
+  }
+
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): TResponse {
+    const inner =
+      this.inner.withRewrittenToolCalls?.(toolCalls) ??
+      this.inner.getOriginalResponse();
+    this.rewrittenInner = inner;
+    return chatCompletionToResponses(
+      inner as unknown as OpenAiResponse,
+      this.ctx,
+    ) as unknown as TResponse;
   }
 
   getFinishReasons(): string[] {
@@ -233,6 +253,32 @@ class ResponsesFromChatStreamAdapter<TChunk, TResponse>
     ];
   }
 
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // completeOutput() has already written a `response.completed` naming the
+    // calls the model made directly (it fires on the inner stream's final
+    // chunk, before the gate decides). The client keeps the LAST completed
+    // envelope, so the repair ends by re-issuing one that names the rewritten
+    // calls. Text keeps output index 0 (the message item), so the calls start
+    // at 1 — the same layout getRawToolCallEvents produces.
+    this.inner.formatToolCallsSSE?.(toolCalls);
+    const frames = formatResponsesFunctionCallFrames({
+      toolCalls,
+      firstOutputIndex: 1,
+      nextSequenceNumber: () => this.nextSequenceNumber(),
+    });
+    frames.push(
+      this.toSse({
+        type: "response.completed",
+        sequence_number: this.nextSequenceNumber(),
+        response: {
+          ...this.buildResponsesResponse(toolCalls),
+          usage: toResponsesUsage(this.state.usage),
+        },
+      }),
+    );
+    return frames;
+  }
+
   formatEndSSE(): string {
     return "data: [DONE]\n\n";
   }
@@ -349,7 +395,9 @@ class ResponsesFromChatStreamAdapter<TChunk, TResponse>
     ].join("");
   }
 
-  private buildResponsesResponse() {
+  private buildResponsesResponse(
+    toolCallsOverride?: StreamAccumulatorState["toolCalls"],
+  ) {
     const output = [];
 
     // On a refusal the blocked tool calls are dropped and the refusal message
@@ -373,7 +421,7 @@ class ResponsesFromChatStreamAdapter<TChunk, TResponse>
 
     if (this.replacedText === null) {
       output.push(
-        ...this.state.toolCalls.map((toolCall) => ({
+        ...(toolCallsOverride ?? this.state.toolCalls).map((toolCall) => ({
           id: toolCall.id,
           call_id: toolCall.id,
           type: "function_call",

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -29,6 +29,7 @@ import type {
   LLMResponseAdapter,
   LLMStreamAdapter,
   OpenAi,
+  StreamAccumulatorState,
   ToolCompressionStats,
   UsageView,
 } from "@/types";
@@ -39,6 +40,11 @@ import {
 } from "@/types";
 import { createOpenAiCodexResponsesClient } from "./openai-codex-responses-client";
 import { formatResponsesStreamErrorFrame } from "./responses-stream-error-frame";
+import {
+  formatResponsesFunctionCallFrames,
+  rewriteResponsesOutput,
+  toSse,
+} from "./responses-tool-call-rewrite";
 import { fromResponsesUsage, toResponsesUsage } from "./responses-usage";
 import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 import { subscriptionAuthRequiredCode } from "./subscription-auth-error";
@@ -412,6 +418,15 @@ class OpenAiResponsesResponseAdapter
     return [this.response.status ?? "completed"];
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): OpenAiResponsesResponse {
+    return {
+      ...this.response,
+      output: rewriteResponsesOutput(this.response.output, toolCalls),
+    } as unknown as OpenAiResponsesResponse;
+  }
+
   toRefusalResponse(
     refusalMessage: string,
     contentMessage: string,
@@ -650,6 +665,40 @@ class OpenAiResponsesStreamAdapter
   formatCompleteTextSSE(text: string): string[] {
     this.replacedText = text;
     return [this.formatTextDeltaSSE(text)];
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // The upstream `response.completed` envelope has already been streamed and
+    // it names the calls the model made directly. The client keeps the LAST
+    // completed envelope, so the repair ends by re-issuing one that names the
+    // rewritten calls — the same trick the refusal path relies on. That
+    // envelope also becomes the persisted one, so the interaction log matches
+    // what the client reconstructs.
+    const base = this.completedResponse ?? this.toProviderResponse();
+    const upstreamOutput = Array.isArray(base.output) ? base.output : [];
+    const firstOutputIndex = upstreamOutput.filter(
+      (item) => item.type !== "function_call",
+    ).length;
+    let sequence = Date.now();
+    const frames = formatResponsesFunctionCallFrames({
+      toolCalls,
+      firstOutputIndex,
+      nextSequenceNumber: () => sequence++,
+    });
+    const rewritten = {
+      ...base,
+      output: rewriteResponsesOutput(upstreamOutput, toolCalls),
+      usage: base.usage ?? toResponsesUsage(this.state.usage),
+    } as unknown as OpenAiResponsesResponse;
+    this.completedResponse = rewritten;
+    frames.push(
+      toSse({
+        type: "response.completed",
+        sequence_number: sequence++,
+        response: rewritten,
+      }),
+    );
+    return frames;
   }
 
   formatEndSSE(): string {
@@ -921,10 +970,6 @@ function isResponsesToolCallChunk(
     chunk.type === "response.function_call_arguments.delta" ||
     chunk.type === "response.function_call_arguments.done"
   );
-}
-
-function toSse(event: unknown): string {
-  return `data: ${JSON.stringify(event)}\n\n`;
 }
 
 function getToolCallsByCallId(

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -977,6 +977,31 @@ export class OpenAIResponseAdapter
     return reason ? [reason] : [];
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): OpenAiResponse {
+    const choice = this.response.choices[0];
+    return {
+      ...this.response,
+      choices: [
+        {
+          ...choice,
+          message: {
+            ...choice.message,
+            tool_calls: toolCalls.map((toolCall) => ({
+              id: toolCall.id,
+              type: "function" as const,
+              function: {
+                name: toolCall.name,
+                arguments: toolCall.arguments,
+              },
+            })),
+          },
+        },
+      ],
+    };
+  }
+
   toRefusalResponse(
     _refusalMessage: string,
     contentMessage: string,
@@ -1211,6 +1236,39 @@ export class OpenAIStreamAdapter
           delta: {
             role: "assistant",
             content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return [`data: ${JSON.stringify(chunk)}\n\n`];
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // One chunk carrying every call, complete: name and the whole argument
+    // string in a single delta. The wire format allows it (arguments are
+    // concatenated across deltas, and one delta is a valid degenerate case),
+    // and it keeps the rewrite from having to reproduce the upstream's
+    // fragmentation. `index` is the call's position, which is what clients
+    // accumulate by.
+    const chunk: OpenAiStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: toolCalls.map((toolCall, index) => ({
+              index,
+              id: toolCall.id,
+              type: "function" as const,
+              function: {
+                name: toolCall.name,
+                arguments: toolCall.arguments,
+              },
+            })),
           },
           finish_reason: null,
         },

--- a/platform/backend/src/routes/proxy/adapters/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.ts
@@ -138,6 +138,11 @@ class OpenrouterResponseAdapter
   toRefusalResponse(refusalMessage: string, contentMessage: string) {
     return this.delegate.toRefusalResponse(refusalMessage, contentMessage);
   }
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ) {
+    return this.delegate.withRewrittenToolCalls(toolCalls);
+  }
 }
 
 class OpenrouterStreamAdapter
@@ -170,6 +175,9 @@ class OpenrouterStreamAdapter
   }
   formatCompleteTextSSE(text: string) {
     return this.delegate.formatCompleteTextSSE(text);
+  }
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]) {
+    return this.delegate.formatToolCallsSSE(toolCalls);
   }
   formatEndSSE() {
     return this.delegate.formatEndSSE();

--- a/platform/backend/src/routes/proxy/adapters/responses-tool-call-rewrite.ts
+++ b/platform/backend/src/routes/proxy/adapters/responses-tool-call-rewrite.ts
@@ -1,0 +1,118 @@
+/**
+ * Responses-API wire helpers for re-emitting a turn's tool calls after the
+ * proxy repaired a dispatch-mode direct call into `run_tool` (see
+ * `planDispatchModeToolCallRewrites`). Shared by the native OpenAI/Azure
+ * Responses adapters and the Responses-from-chat translator so the three
+ * surfaces emit byte-identical frame shapes.
+ *
+ * Two facts about the Responses stream drive the shape:
+ *
+ * - A function call is four frames: `response.output_item.added` (the item,
+ *   with `arguments` still empty), `response.function_call_arguments.delta`
+ *   (the client concatenates these), `response.function_call_arguments.done`,
+ *   and `response.output_item.done` (the completed item). One delta carrying
+ *   the whole argument string is the valid degenerate case.
+ * - The client keeps the LAST `response.completed` it sees — the SDK
+ *   accumulator overwrites its snapshot on each one — and reconstructs the
+ *   turn from that envelope's `output`. So a repair is not complete until a
+ *   completed envelope naming the rewritten calls has been written after any
+ *   envelope the upstream already produced (which named the originals).
+ */
+
+type RewrittenToolCall = { id: string; name: string; arguments: string };
+
+/** The `function_call` output item as the Responses API renders it. */
+export function responsesFunctionCallItem(toolCall: RewrittenToolCall) {
+  return {
+    id: `fc_${toolCall.id}`,
+    call_id: toolCall.id,
+    type: "function_call" as const,
+    name: toolCall.name,
+    arguments: toolCall.arguments,
+    status: "completed" as const,
+  };
+}
+
+/**
+ * The four streaming frames per call, as SSE strings, output indices
+ * continuing from `firstOutputIndex` so they do not collide with items the
+ * turn already streamed (text, reasoning).
+ */
+export function formatResponsesFunctionCallFrames(params: {
+  toolCalls: RewrittenToolCall[];
+  firstOutputIndex: number;
+  nextSequenceNumber: () => number;
+}): string[] {
+  const { toolCalls, firstOutputIndex, nextSequenceNumber } = params;
+  return toolCalls.flatMap((toolCall, offset) => {
+    const outputIndex = firstOutputIndex + offset;
+    const item = responsesFunctionCallItem(toolCall);
+    return [
+      toSse({
+        type: "response.output_item.added",
+        output_index: outputIndex,
+        sequence_number: nextSequenceNumber(),
+        item: { ...item, arguments: "", status: "in_progress" },
+      }),
+      toSse({
+        type: "response.function_call_arguments.delta",
+        item_id: item.id,
+        output_index: outputIndex,
+        sequence_number: nextSequenceNumber(),
+        delta: toolCall.arguments,
+      }),
+      toSse({
+        type: "response.function_call_arguments.done",
+        item_id: item.id,
+        output_index: outputIndex,
+        sequence_number: nextSequenceNumber(),
+        name: toolCall.name,
+        arguments: toolCall.arguments,
+      }),
+      toSse({
+        type: "response.output_item.done",
+        output_index: outputIndex,
+        sequence_number: nextSequenceNumber(),
+        item,
+      }),
+    ];
+  });
+}
+
+/**
+ * A response `output` with its function-call items replaced by the rewritten
+ * calls, matched by `call_id` so ids — what the client correlates tool results
+ * by — are untouched. Non-call items (text, reasoning) pass through in place; a
+ * rewritten call with no upstream item to replace is appended.
+ */
+export function rewriteResponsesOutput<TItem extends { type?: string }>(
+  output: readonly TItem[],
+  toolCalls: RewrittenToolCall[],
+): Array<TItem | ReturnType<typeof responsesFunctionCallItem>> {
+  const byCallId = new Map(toolCalls.map((call) => [call.id, call]));
+  const replaced = new Set<string>();
+  const next: Array<TItem | ReturnType<typeof responsesFunctionCallItem>> = [];
+  for (const item of output) {
+    if (item.type === "function_call") {
+      const callId = (item as { call_id?: unknown }).call_id;
+      const rewritten =
+        typeof callId === "string" ? byCallId.get(callId) : undefined;
+      if (rewritten) {
+        replaced.add(rewritten.id);
+        next.push(responsesFunctionCallItem(rewritten));
+        continue;
+      }
+    }
+    next.push(item);
+  }
+  for (const call of toolCalls) {
+    if (!replaced.has(call.id)) {
+      next.push(responsesFunctionCallItem(call));
+    }
+  }
+  return next;
+}
+
+export function toSse(event: unknown): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}

--- a/platform/backend/src/routes/proxy/adapters/tool-call-rewrite-sweep.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/tool-call-rewrite-sweep.test.ts
@@ -1,0 +1,705 @@
+/**
+ * `formatToolCallsSSE` / `withRewrittenToolCalls` across every remaining wire
+ * format — the adapter halves of the proxy's dispatch-mode repair (see
+ * `planDispatchModeToolCallRewrites`). tool-call-rewrite.test.ts covers the
+ * OpenAI chat, Anthropic and ZhipuAI shapes; this file covers the rest.
+ *
+ * Each case pins the frame a real client of that wire format needs in order to
+ * accumulate the rewritten call — because a malformed stream here fails
+ * silently (the client drops it or reconstructs the wrong turn) rather than
+ * throwing anywhere a test would notice.
+ */
+
+import { EventStreamCodec } from "@smithy/eventstream-codec";
+import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
+import { describe, expect, test } from "@/test";
+import type { Anthropic, Bedrock, Gemini, OpenAi } from "@/types";
+import { anthropicAdapterFactory } from "./anthropic";
+import { azureResponsesAdapterFactory } from "./azure-responses";
+import { bedrockAdapterFactory } from "./bedrock";
+import { makeBedrockOpenaiAdapterFactory } from "./bedrock-openai";
+import { cohereAdapterFactory } from "./cohere";
+import { geminiAdapterFactory } from "./gemini";
+import { minimaxAdapterFactory } from "./minimax";
+import { ollamaNativeAdapterFactory } from "./ollama-native";
+import { openaiAdapterFactory } from "./openai";
+import { openAiResponsesAdapterFactory } from "./openai-responses";
+import { makeResponsesFromChatAdapterFactory } from "./openai-responses-from-chat";
+
+const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
+
+const REWRITTEN = [
+  {
+    id: "call_0",
+    name: "archestra__run_tool",
+    arguments: JSON.stringify({
+      tool_name: "gh-developer-agent__pull_request_read",
+      tool_args: { pullNumber: 7 },
+    }),
+  },
+];
+const REWRITTEN_ARGS_OBJECT = JSON.parse(REWRITTEN[0].arguments);
+
+/** `data: {...}` payloads out of SSE frames (strings or UTF-8 bytes). */
+function sseData<TFrame>(frames: (string | Uint8Array)[]): TFrame[] {
+  return frames
+    .map((frame) =>
+      typeof frame === "string" ? frame : new TextDecoder().decode(frame),
+    )
+    .flatMap((frame) => frame.split("\n"))
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice("data: ".length))
+    .filter((payload) => payload !== "[DONE]")
+    .map((payload) => JSON.parse(payload) as TFrame);
+}
+
+/** One NDJSON line per element. */
+function ndjson<TFrame>(frames: (string | Uint8Array)[]): TFrame[] {
+  return frames
+    .map(String)
+    .flatMap((frame) => frame.split("\n"))
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as TFrame);
+}
+
+type ResponsesFrame = {
+  type: string;
+  output_index?: number;
+  item?: { type: string; call_id?: string; name?: string; arguments?: string };
+  delta?: string;
+  name?: string;
+  arguments?: string;
+  response?: {
+    output: Array<{ type: string; name?: string; call_id?: string }>;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Responses API — native OpenAI and Azure (same code path), plus the
+// Responses-from-chat translator.
+// ---------------------------------------------------------------------------
+describe.each([
+  ["OpenAI Responses", openAiResponsesAdapterFactory],
+  ["Azure Responses", azureResponsesAdapterFactory],
+] as const)("%s formatToolCallsSSE", (_label, factory) => {
+  test("emits the four call frames and a trailing completed envelope naming the rewrite", () => {
+    const adapter = factory.createStreamAdapter();
+    // What the upstream already streamed: a completed envelope naming the
+    // ORIGINAL call. The client keeps the last completed envelope it sees.
+    adapter.processChunk({
+      type: "response.completed",
+      sequence_number: 1,
+      response: {
+        id: "resp_1",
+        object: "response",
+        created_at: 0,
+        model: "gpt-x",
+        status: "completed",
+        output: [
+          {
+            id: "fc_orig",
+            call_id: "call_0",
+            type: "function_call",
+            name: "gh-developer-agent__pull_request_read",
+            arguments: '{"pullNumber":7}',
+            status: "completed",
+          },
+        ],
+      },
+    } as never);
+
+    const events = sseData<ResponsesFrame>(
+      adapter.formatToolCallsSSE?.(REWRITTEN) ?? [],
+    );
+
+    expect(events.map((e) => e.type)).toEqual([
+      "response.output_item.added",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+    expect(events[0].item).toMatchObject({
+      type: "function_call",
+      call_id: "call_0",
+      name: "archestra__run_tool",
+    });
+    expect(events[1].delta).toBe(REWRITTEN[0].arguments);
+    expect(events[3].item?.arguments).toBe(REWRITTEN[0].arguments);
+
+    // The envelope the client reconstructs from must name the rewrite — and
+    // keep the call id, which the client's tool result is correlated by.
+    const completed = events[4].response?.output ?? [];
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      type: "function_call",
+      call_id: "call_0",
+      name: "archestra__run_tool",
+    });
+
+    // And the persisted turn matches the client's view.
+    const persisted = adapter.toProviderResponse() as {
+      output: Array<{ name?: string }>;
+    };
+    expect(persisted.output[0].name).toBe("archestra__run_tool");
+  });
+
+  test("non-streaming: rewrites the function_call item in place by call_id", () => {
+    const adapter = factory.createResponseAdapter({
+      id: "resp_1",
+      object: "response",
+      created_at: 0,
+      model: "gpt-x",
+      status: "completed",
+      output: [
+        {
+          id: "msg_1",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "On it.", annotations: [] }],
+        },
+        {
+          id: "fc_orig",
+          call_id: "call_0",
+          type: "function_call",
+          name: "gh-developer-agent__pull_request_read",
+          arguments: '{"pullNumber":7}',
+          status: "completed",
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    } as never);
+
+    const rewritten = adapter.withRewrittenToolCalls?.(REWRITTEN) as {
+      output: Array<{ type: string; name?: string; call_id?: string }>;
+    };
+
+    expect(rewritten.output.map((item) => item.type)).toEqual([
+      "message",
+      "function_call",
+    ]);
+    expect(rewritten.output[1]).toMatchObject({
+      call_id: "call_0",
+      name: "archestra__run_tool",
+    });
+  });
+});
+
+describe("Responses-from-chat translator formatToolCallsSSE", () => {
+  const ctx = { responseId: "resp_t", createdUnix: 0, requestedModel: "gpt-x" };
+
+  test("emits the call frames then a completed envelope naming the rewrite", () => {
+    const factory = makeResponsesFromChatAdapterFactory(
+      openaiAdapterFactory,
+      ctx,
+    );
+    const adapter = factory.createStreamAdapter();
+
+    const events = sseData<ResponsesFrame>(
+      adapter.formatToolCallsSSE?.(REWRITTEN) ?? [],
+    );
+
+    expect(events.map((e) => e.type)).toEqual([
+      "response.output_item.added",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+    // Text owns output index 0 on this surface; calls start at 1.
+    expect(events[0].output_index).toBe(1);
+    expect(events[4].response?.output).toContainEqual(
+      expect.objectContaining({
+        type: "function_call",
+        call_id: "call_0",
+        name: "archestra__run_tool",
+      }),
+    );
+  });
+
+  test("non-streaming: translates the inner rewrite and logs the inner shape", () => {
+    const factory = makeResponsesFromChatAdapterFactory(
+      openaiAdapterFactory,
+      ctx,
+    );
+    const chat: OpenAi.Types.ChatCompletionsResponse = {
+      id: "chatcmpl-1",
+      object: "chat.completion",
+      created: 0,
+      model: "gpt-x",
+      choices: [
+        {
+          index: 0,
+          logprobs: null,
+          finish_reason: "tool_calls",
+          message: {
+            role: "assistant",
+            content: null,
+            refusal: null,
+            tool_calls: [
+              {
+                id: "call_0",
+                type: "function",
+                function: {
+                  name: "gh-developer-agent__pull_request_read",
+                  arguments: '{"pullNumber":7}',
+                },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+    const adapter = factory.createResponseAdapter(chat);
+
+    const wire = adapter.withRewrittenToolCalls?.(REWRITTEN) as unknown as {
+      output: Array<{ type: string; name?: string }>;
+    };
+    expect(wire.output).toContainEqual(
+      expect.objectContaining({
+        type: "function_call",
+        name: "archestra__run_tool",
+      }),
+    );
+
+    // The interaction log stores the inner (chat) shape — and it must be the
+    // rewritten one, not the original the provider sent.
+    const logged = adapter.getLoggedResponse?.() as typeof chat;
+    const [loggedCall] = logged.choices[0].message.tool_calls ?? [];
+    expect(loggedCall?.type === "function" && loggedCall.function.name).toBe(
+      "archestra__run_tool",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gemini
+// ---------------------------------------------------------------------------
+describe("Gemini formatToolCallsSSE / withRewrittenToolCalls", () => {
+  type GeminiFrame = {
+    candidates: Array<{
+      content: {
+        parts: Array<{ functionCall?: { name: string; args: unknown } }>;
+      };
+      finishReason?: string;
+    }>;
+  };
+
+  test("emits one chunk with a functionCall part per call and no finishReason", () => {
+    const adapter = geminiAdapterFactory.createStreamAdapter();
+    const [event] = sseData<GeminiFrame>(
+      adapter.formatToolCallsSSE?.(REWRITTEN) ?? [],
+    );
+
+    expect(event.candidates[0].content.parts).toEqual([
+      {
+        functionCall: {
+          id: "call_0",
+          name: "archestra__run_tool",
+          args: REWRITTEN_ARGS_OBJECT,
+        },
+      },
+    ]);
+    expect(event.candidates[0].finishReason).toBeUndefined();
+  });
+
+  test("non-streaming: rewrites functionCall parts positionally", () => {
+    const adapter = geminiAdapterFactory.createResponseAdapter({
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              { text: "On it." },
+              {
+                functionCall: {
+                  name: "gh-developer-agent__pull_request_read",
+                  args: { pullNumber: 7 },
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+          index: 0,
+        },
+      ],
+    } as unknown as Gemini.Types.GenerateContentResponse);
+
+    const rewritten = adapter.withRewrittenToolCalls?.(
+      REWRITTEN,
+    ) as unknown as GeminiFrame;
+    const parts = rewritten.candidates[0].content.parts;
+    expect(parts[0]).toEqual({ text: "On it." });
+    expect(parts[1].functionCall).toMatchObject({
+      name: "archestra__run_tool",
+      args: REWRITTEN_ARGS_OBJECT,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cohere v2
+// ---------------------------------------------------------------------------
+describe("Cohere formatToolCallsSSE / withRewrittenToolCalls", () => {
+  type CohereFrame = {
+    type: string;
+    delta?: {
+      message?: {
+        tool_calls?: {
+          id?: string;
+          function?: { name?: string; arguments?: string };
+        };
+      };
+    };
+  };
+
+  test("emits start/delta/end in the shape @ai-sdk/cohere accumulates", () => {
+    const adapter = cohereAdapterFactory.createStreamAdapter();
+    const events = sseData<CohereFrame>(
+      adapter.formatToolCallsSSE?.(REWRITTEN) ?? [],
+    );
+
+    expect(events.map((e) => e.type)).toEqual([
+      "tool-call-start",
+      "tool-call-delta",
+      "tool-call-end",
+    ]);
+    expect(events[0].delta?.message?.tool_calls).toMatchObject({
+      id: "call_0",
+      function: { name: "archestra__run_tool" },
+    });
+    expect(events[1].delta?.message?.tool_calls?.function?.arguments).toBe(
+      REWRITTEN[0].arguments,
+    );
+  });
+
+  test("non-streaming: rewrites message.tool_calls positionally", () => {
+    const adapter = cohereAdapterFactory.createResponseAdapter({
+      id: "c1",
+      finish_reason: "TOOL_CALL",
+      message: {
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "call_0",
+            type: "function",
+            function: {
+              name: "gh-developer-agent__pull_request_read",
+              arguments: '{"pullNumber":7}',
+            },
+          },
+        ],
+      },
+    } as never);
+    const rewritten = adapter.withRewrittenToolCalls?.(REWRITTEN) as {
+      message: {
+        tool_calls: Array<{ id: string; function: { name: string } }>;
+      };
+    };
+    expect(rewritten.message.tool_calls[0]).toMatchObject({
+      id: "call_0",
+      function: { name: "archestra__run_tool" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ollama native (NDJSON)
+// ---------------------------------------------------------------------------
+describe("Ollama native formatToolCallsSSE / withRewrittenToolCalls", () => {
+  type OllamaFrame = {
+    done: boolean;
+    message: {
+      tool_calls?: Array<{ function: { name: string; arguments: unknown } }>;
+    };
+  };
+
+  test("emits one non-final line with the calls whole", () => {
+    const adapter = ollamaNativeAdapterFactory.createStreamAdapter();
+    const [line] = ndjson<OllamaFrame>(
+      adapter.formatToolCallsSSE?.(REWRITTEN) ?? [],
+    );
+
+    expect(line.done).toBe(false);
+    expect(line.message.tool_calls).toEqual([
+      {
+        id: "call_0",
+        function: {
+          name: "archestra__run_tool",
+          arguments: REWRITTEN_ARGS_OBJECT,
+        },
+      },
+    ]);
+  });
+
+  test("non-streaming: rewrites message.tool_calls positionally", () => {
+    const adapter = ollamaNativeAdapterFactory.createResponseAdapter({
+      model: "llama",
+      created_at: "0",
+      done: true,
+      message: {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            function: {
+              name: "gh-developer-agent__pull_request_read",
+              arguments: { pullNumber: 7 },
+            },
+          },
+        ],
+      },
+    } as never);
+    const rewritten = adapter.withRewrittenToolCalls?.(
+      REWRITTEN,
+    ) as unknown as OllamaFrame;
+    expect(rewritten.message.tool_calls?.[0].function).toEqual({
+      name: "archestra__run_tool",
+      arguments: REWRITTEN_ARGS_OBJECT,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Minimax (OpenAI-chat-shaped)
+// ---------------------------------------------------------------------------
+describe("Minimax formatToolCallsSSE", () => {
+  test("emits one complete tool_calls delta chunk", () => {
+    const adapter = minimaxAdapterFactory.createStreamAdapter();
+    const [event] = sseData<{
+      choices: Array<{
+        delta: {
+          tool_calls?: Array<{ id: string; function: { name: string } }>;
+        };
+        finish_reason: string | null;
+      }>;
+    }>(adapter.formatToolCallsSSE?.(REWRITTEN) ?? []);
+
+    expect(event.choices[0].delta.tool_calls?.[0]).toMatchObject({
+      id: "call_0",
+      function: { name: "archestra__run_tool" },
+    });
+    expect(event.choices[0].finish_reason).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anthropic — non-streaming half (streaming is in tool-call-rewrite.test.ts)
+// ---------------------------------------------------------------------------
+describe("Anthropic withRewrittenToolCalls", () => {
+  test("rewrites tool_use blocks positionally, keeping ids and text", () => {
+    const adapter = anthropicAdapterFactory.createResponseAdapter({
+      id: "msg_1",
+      type: "message",
+      role: "assistant",
+      model: "claude",
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      content: [
+        { type: "text", text: "On it." },
+        {
+          type: "tool_use",
+          id: "call_0",
+          name: "gh-developer-agent__pull_request_read",
+          input: { pullNumber: 7 },
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    } as unknown as Anthropic.Types.MessagesResponse);
+
+    const rewritten = adapter.withRewrittenToolCalls?.(REWRITTEN) as {
+      content: Array<{
+        type: string;
+        id?: string;
+        name?: string;
+        input?: unknown;
+      }>;
+    };
+    expect(rewritten.content[0]).toEqual({ type: "text", text: "On it." });
+    expect(rewritten.content[1]).toMatchObject({
+      type: "tool_use",
+      id: "call_0",
+      name: "archestra__run_tool",
+      input: REWRITTEN_ARGS_OBJECT,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bedrock — Converse binary event stream, and the Converse→OpenAI translator
+// ---------------------------------------------------------------------------
+function decodeBedrockFrames(frames: (string | Uint8Array)[]) {
+  return frames.map((frame) => {
+    const decoded = eventStreamCodec.decode(frame as Uint8Array);
+    const eventType = (decoded.headers[":event-type"] as { value: string })
+      .value;
+    const bodyText =
+      typeof decoded.body === "string" ? decoded.body : toUtf8(decoded.body);
+    return { eventType, body: JSON.parse(bodyText) as Record<string, unknown> };
+  });
+}
+
+describe("Bedrock formatToolCallsSSE / withRewrittenToolCalls", () => {
+  test("emits a tool_use block per call, reusing the held block index, then the terminal events", () => {
+    const adapter = bedrockAdapterFactory.createStreamAdapter();
+    // Live turn: a held tool_use block at contentBlockIndex 1 (index 0 was
+    // text), then the terminal events the adapter buffers behind the gate.
+    adapter.processChunk({
+      contentBlockStart: {
+        contentBlockIndex: 1,
+        start: {
+          toolUse: {
+            toolUseId: "call_0",
+            name: "gh-developer-agent__pull_request_read",
+          },
+        },
+      },
+    } as never);
+    adapter.processChunk({
+      contentBlockDelta: {
+        contentBlockIndex: 1,
+        delta: { toolUse: { input: '{"pullNumber":7}' } },
+      },
+    } as never);
+    adapter.processChunk({
+      contentBlockStop: { contentBlockIndex: 1 },
+    } as never);
+    adapter.processChunk({ messageStop: { stopReason: "tool_use" } } as never);
+    adapter.processChunk({
+      metadata: { usage: { inputTokens: 1, outputTokens: 1 } },
+    } as never);
+
+    const frames = decodeBedrockFrames(
+      adapter.formatToolCallsSSE?.(REWRITTEN) ?? [],
+    );
+
+    expect(frames.map((f) => f.eventType)).toEqual([
+      "contentBlockStart",
+      "contentBlockDelta",
+      "contentBlockStop",
+      "messageStop",
+      "metadata",
+    ]);
+    // toMatchObject: the encoder adds Bedrock's `p` padding field to every
+    // event, exactly as it does for the live and refusal frames.
+    expect(frames[0].body).toMatchObject({
+      contentBlockIndex: 1,
+      start: { toolUse: { toolUseId: "call_0", name: "archestra__run_tool" } },
+    });
+    expect(frames[1].body).toMatchObject({
+      contentBlockIndex: 1,
+      delta: { toolUse: { input: REWRITTEN[0].arguments } },
+    });
+  });
+
+  test("non-streaming: rewrites toolUse blocks positionally", () => {
+    const adapter = bedrockAdapterFactory.createResponseAdapter({
+      output: {
+        message: {
+          role: "assistant",
+          content: [
+            { text: "On it." },
+            {
+              toolUse: {
+                toolUseId: "call_0",
+                name: "gh-developer-agent__pull_request_read",
+                input: { pullNumber: 7 },
+              },
+            },
+          ],
+        },
+      },
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    } as unknown as Bedrock.Types.ConverseResponse);
+
+    const rewritten = adapter.withRewrittenToolCalls?.(REWRITTEN) as {
+      output: {
+        message: {
+          content: Array<{
+            text?: string;
+            toolUse?: { toolUseId: string; name: string; input: unknown };
+          }>;
+        };
+      };
+    };
+    const content = rewritten.output.message.content;
+    expect(content[0]).toEqual({ text: "On it." });
+    expect(content[1].toolUse).toEqual({
+      toolUseId: "call_0",
+      name: "archestra__run_tool",
+      input: REWRITTEN_ARGS_OBJECT,
+    });
+  });
+});
+
+describe("Bedrock→OpenAI translator formatToolCallsSSE / withRewrittenToolCalls", () => {
+  const ctx = {
+    chatcmplId: "chatcmpl-b",
+    createdUnix: 0,
+    requestedModel: "m",
+    includeUsageInStream: false,
+  };
+
+  test("emits an OpenAI tool_calls delta and holds the finish reason", () => {
+    const factory = makeBedrockOpenaiAdapterFactory(ctx);
+    const adapter = factory.createStreamAdapter(undefined);
+    const events = sseData<{
+      choices: Array<{
+        delta: {
+          role?: string;
+          tool_calls?: Array<{ id: string; function: { name: string } }>;
+        };
+        finish_reason: string | null;
+      }>;
+    }>(adapter.formatToolCallsSSE?.(REWRITTEN) ?? []);
+
+    const toolCallChunk = events.find((e) => e.choices[0].delta.tool_calls);
+    expect(toolCallChunk?.choices[0].delta.tool_calls?.[0]).toMatchObject({
+      id: "call_0",
+      function: { name: "archestra__run_tool" },
+    });
+    for (const event of events) {
+      expect(event.choices[0].finish_reason).toBeNull();
+    }
+  });
+
+  test("non-streaming: client gets OpenAI shape, log gets rewritten Converse shape", () => {
+    const factory = makeBedrockOpenaiAdapterFactory(ctx);
+    const adapter = factory.createResponseAdapter({
+      output: {
+        message: {
+          role: "assistant",
+          content: [
+            {
+              toolUse: {
+                toolUseId: "call_0",
+                name: "gh-developer-agent__pull_request_read",
+                input: { pullNumber: 7 },
+              },
+            },
+          ],
+        },
+      },
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    } as unknown as Bedrock.Types.ConverseResponse);
+
+    const wire = adapter.withRewrittenToolCalls?.(
+      REWRITTEN,
+    ) as unknown as OpenAi.Types.ChatCompletionsResponse;
+    const [wireCall] = wire.choices[0].message.tool_calls ?? [];
+    expect(wireCall?.type === "function" && wireCall.function.name).toBe(
+      "archestra__run_tool",
+    );
+
+    const logged = adapter.getLoggedResponse?.() as unknown as {
+      output: { message: { content: Array<{ toolUse?: { name: string } }> } };
+    };
+    expect(logged.output.message.content[0].toolUse?.name).toBe(
+      "archestra__run_tool",
+    );
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/tool-call-rewrite.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/tool-call-rewrite.test.ts
@@ -1,0 +1,212 @@
+/**
+ * `formatToolCallsSSE` — the adapter half of repairing a dispatch-mode agent's
+ * direct tool call by re-addressing it to `run_tool`.
+ *
+ * The proxy cannot edit the buffered raw events: they are provider-native
+ * fragments with the name and the argument JSON split across chunks. So each
+ * adapter re-emits the turn's calls in its own wire format, and these tests pin
+ * that the emitted frames are ones a client can actually accumulate — the
+ * failure mode being a silently malformed stream rather than a thrown error.
+ */
+
+import { describe, expect, test } from "@/test";
+import { anthropicAdapterFactory } from "./anthropic";
+import { openaiAdapterFactory } from "./openai";
+import { zhipuaiAdapterFactory } from "./zhipuai";
+
+type SseToolCall = {
+  index: number;
+  id: string;
+  type: string;
+  function: { name: string; arguments: string };
+};
+
+/** The OpenAI chat-completions frame shape these assertions read. */
+type OpenAiFrame = {
+  choices: Array<{
+    delta: { tool_calls?: SseToolCall[] };
+    finish_reason: string | null;
+  }>;
+};
+
+/** The Anthropic messages frame shape these assertions read. */
+type AnthropicFrame = {
+  type: string;
+  index: number;
+  content_block?: { type: string; id: string; name: string };
+  delta?: { type: string; partial_json: string };
+};
+
+const REWRITTEN = [
+  {
+    id: "call_0",
+    name: "archestra__run_tool",
+    arguments: JSON.stringify({
+      tool_name: "gh-developer-agent__pull_request_read",
+      tool_args: { pullNumber: 7 },
+    }),
+  },
+];
+
+/** Parse `data: {...}` payloads out of an SSE frame string. */
+function sseData<TFrame>(frames: (string | Uint8Array)[]): TFrame[] {
+  return frames
+    .flatMap((frame) => String(frame).split("\n"))
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice("data: ".length))
+    .filter((payload) => payload !== "[DONE]")
+    .map((payload) => JSON.parse(payload));
+}
+
+describe("OpenAI chat formatToolCallsSSE", () => {
+  test("emits one complete tool call the client can accumulate", () => {
+    const adapter = openaiAdapterFactory.createStreamAdapter();
+
+    const events = sseData<OpenAiFrame>(
+      adapter.formatToolCallsSSE?.(REWRITTEN) ?? [],
+    );
+
+    expect(events).toHaveLength(1);
+    const toolCalls = events[0].choices[0].delta.tool_calls;
+    expect(toolCalls).toEqual([
+      {
+        index: 0,
+        id: "call_0",
+        type: "function",
+        function: {
+          name: "archestra__run_tool",
+          arguments: REWRITTEN[0].arguments,
+        },
+      },
+    ]);
+    // A delta chunk must not also close the turn — formatEndSSE owns the
+    // finish reason, and two of them desynchronize every OpenAI client.
+    expect(events[0].choices[0].finish_reason).toBeNull();
+  });
+
+  test("indexes parallel calls in order", () => {
+    const adapter = openaiAdapterFactory.createStreamAdapter();
+    const calls = [
+      { id: "a", name: "archestra__run_tool", arguments: '{"tool_name":"x"}' },
+      { id: "b", name: "archestra__run_tool", arguments: '{"tool_name":"y"}' },
+    ];
+
+    const [event] = sseData<OpenAiFrame>(
+      adapter.formatToolCallsSSE?.(calls) ?? [],
+    );
+
+    expect(
+      event.choices[0].delta.tool_calls?.map((tc) => [tc.index, tc.id]),
+    ).toEqual([
+      [0, "a"],
+      [1, "b"],
+    ]);
+  });
+
+  test("the reconstructed turn names the rewritten call, not the original", () => {
+    const adapter = openaiAdapterFactory.createStreamAdapter();
+    adapter.state.toolCalls.push({
+      id: "call_0",
+      name: "gh-developer-agent__pull_request_read",
+      arguments: '{"pullNumber":7}',
+    });
+    adapter.formatToolCallsSSE?.(REWRITTEN);
+
+    // The handler keeps state in step with what went out; toProviderResponse
+    // reads that state, so the interaction log matches the client's view.
+    adapter.state.toolCalls.splice(
+      0,
+      adapter.state.toolCalls.length,
+      ...REWRITTEN,
+    );
+
+    const response = adapter.toProviderResponse();
+    const [toolCall] = response.choices[0].message.tool_calls ?? [];
+    expect(toolCall?.type === "function" && toolCall.function.name).toBe(
+      "archestra__run_tool",
+    );
+  });
+});
+
+describe("Anthropic formatToolCallsSSE", () => {
+  test("emits a well-formed tool_use block per call", () => {
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+
+    const frames = adapter.formatToolCallsSSE?.(REWRITTEN) ?? [];
+    const events = sseData<AnthropicFrame>(frames);
+
+    expect(events.map((e) => e.type)).toEqual([
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+    ]);
+    expect(events[0].content_block).toMatchObject({
+      type: "tool_use",
+      id: "call_0",
+      name: "archestra__run_tool",
+    });
+    // Anthropic streams tool input as partial_json the client concatenates;
+    // one fragment carrying the whole object is the valid degenerate case.
+    expect(JSON.parse(events[1].delta?.partial_json ?? "{}")).toEqual({
+      tool_name: "gh-developer-agent__pull_request_read",
+      tool_args: { pullNumber: 7 },
+    });
+  });
+
+  test("gives each parallel call its own content-block index", () => {
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+    const calls = [
+      { id: "a", name: "archestra__run_tool", arguments: "{}" },
+      { id: "b", name: "archestra__run_tool", arguments: "{}" },
+    ];
+
+    const events = sseData<AnthropicFrame>(
+      adapter.formatToolCallsSSE?.(calls) ?? [],
+    );
+    const indices = events.map((e) => e.index);
+
+    expect(new Set(indices).size).toBe(2);
+    expect(indices).toEqual([0, 0, 0, 1, 1, 1]);
+  });
+
+  test("releasing the calls lets the reconstructed turn name them", () => {
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+    adapter.state.toolCalls.push(...REWRITTEN);
+
+    // Before release, toProviderResponse must not claim tool calls the client
+    // never received; formatToolCallsSSE is that release.
+    expect(adapter.toProviderResponse().content).toHaveLength(0);
+    adapter.formatToolCallsSSE?.(REWRITTEN);
+    expect(adapter.toProviderResponse().content).toContainEqual(
+      expect.objectContaining({
+        type: "tool_use",
+        name: "archestra__run_tool",
+      }),
+    );
+  });
+});
+
+describe("ZhipuAI formatToolCallsSSE", () => {
+  // OpenAI-chat-shaped wire; the same accumulate-by-index contract applies.
+  test("emits one complete tool call the client can accumulate", () => {
+    const adapter = zhipuaiAdapterFactory.createStreamAdapter();
+
+    const events = sseData<OpenAiFrame>(
+      adapter.formatToolCallsSSE?.(REWRITTEN) ?? [],
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].choices[0].delta.tool_calls).toEqual([
+      {
+        index: 0,
+        id: "call_0",
+        type: "function",
+        function: {
+          name: "archestra__run_tool",
+          arguments: REWRITTEN[0].arguments,
+        },
+      },
+    ]);
+    expect(events[0].choices[0].finish_reason).toBeNull();
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/xai.ts
+++ b/platform/backend/src/routes/proxy/adapters/xai.ts
@@ -32,6 +32,7 @@ import {
   type LLMRequestAdapter,
   type LLMResponseAdapter,
   type LLMStreamAdapter,
+  type StreamAccumulatorState,
   type Xai,
 } from "@/types";
 import {
@@ -143,6 +144,11 @@ class XaiResponseAdapter implements LLMResponseAdapter<XaiResponse> {
   toRefusalResponse(refusalMessage: string, contentMessage: string) {
     return this.delegate.toRefusalResponse(refusalMessage, contentMessage);
   }
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ) {
+    return this.delegate.withRewrittenToolCalls(toolCalls);
+  }
 }
 
 class XaiStreamAdapter
@@ -173,6 +179,9 @@ class XaiStreamAdapter
   }
   formatCompleteTextSSE(text: string) {
     return this.delegate.formatCompleteTextSSE(text);
+  }
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]) {
+    return this.delegate.formatToolCallsSSE(toolCalls);
   }
   formatEndSSE() {
     return this.delegate.formatEndSSE();

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.ts
@@ -560,6 +560,31 @@ class ZhipuaiResponseAdapter implements LLMResponseAdapter<ZhipuaiResponse> {
     return this.response;
   }
 
+  withRewrittenToolCalls(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): ZhipuaiResponse {
+    const choice = this.response.choices[0];
+    return {
+      ...this.response,
+      choices: [
+        {
+          ...choice,
+          message: {
+            ...choice.message,
+            tool_calls: toolCalls.map((toolCall) => ({
+              id: toolCall.id,
+              type: "function" as const,
+              function: {
+                name: toolCall.name,
+                arguments: toolCall.arguments,
+              },
+            })),
+          },
+        },
+      ],
+    };
+  }
+
   toRefusalResponse(
     _refusalMessage: string,
     contentMessage: string,
@@ -762,6 +787,35 @@ class ZhipuaiStreamAdapter
           delta: {
             role: "assistant",
             content: text,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return [`data: ${JSON.stringify(chunk)}\n\n`];
+  }
+
+  formatToolCallsSSE(toolCalls: StreamAccumulatorState["toolCalls"]): string[] {
+    // Mirrors the OpenAI chat adapter: one chunk carrying every call complete,
+    // which is a valid degenerate case of the concatenated-deltas wire format.
+    const chunk: ZhipuaiStreamChunk = {
+      id: this.state.responseId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.state.model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: toolCalls.map((toolCall, index) => ({
+              index,
+              id: toolCall.id,
+              type: "function" as const,
+              function: {
+                name: toolCall.name,
+                arguments: toolCall.arguments,
+              },
+            })),
           },
           finish_reason: null,
         },

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -107,12 +107,14 @@ import {
   virtualKeyRateLimiter,
 } from "./llm-proxy-auth";
 import {
+  type AccumulatedToolCall,
   applyInputTokenFallback,
   buildInteractionRecord,
   calculateInteractionCosts,
   canonicalizeCommonMessageToolNames,
   handleError,
   normalizeToolCallsForPolicy,
+  planDispatchModeToolCallRewrites,
   recordBlockedToolCallMetrics,
   shouldForwardAnthropicBeta,
   toSpanUserInfo,
@@ -1688,7 +1690,17 @@ async function handleStreaming<
     let toolInvocationRefusal: utils.toolInvocation.PolicyBlockResult | null =
       null;
 
+    let rewrittenToolCalls: AccumulatedToolCall[] | null = null;
+
     if (toolCalls.length > 0) {
+      rewrittenToolCalls = planDispatchRewrites({
+        supported: streamAdapter.formatToolCallsSSE !== undefined,
+        toolCalls,
+        enabledToolNames,
+        canonicalizeToolName,
+        providerName,
+      });
+
       logger.info(
         {
           toolCallCount: toolCalls.length,
@@ -1697,8 +1709,15 @@ async function handleStreaming<
         "Evaluating tool invocation policies",
       );
 
+      // Policies are evaluated against the rewritten calls, which
+      // `normalizeToolCallsForPolicy` unwraps straight back to the same
+      // targets — so a repaired call faces exactly the gate a `run_tool`
+      // dispatch the model wrote itself would have faced.
       toolInvocationRefusal = await utils.toolInvocation.evaluatePolicies(
-        normalizeToolCallsForPolicy(toolCalls, canonicalizeToolName),
+        normalizeToolCallsForPolicy(
+          rewrittenToolCalls ?? toolCalls,
+          canonicalizeToolName,
+        ),
         agent.id,
         {
           teamIds: teamIds ?? [],
@@ -1753,7 +1772,23 @@ async function handleStreaming<
       // already hung up must not read at all — the write would go to a closed
       // socket and the reconstructed turn would claim a delivery.
       if (!reply.raw.destroyed) {
-        const allEvents = streamAdapter.getRawToolCallEvents();
+        // A repaired batch replaces the buffered events wholesale: the raw
+        // fragments still name the tool the model called directly, which is the
+        // call the client cannot execute. `state.toolCalls` is updated to match
+        // what actually went out, so the persisted interaction and
+        // `toProviderResponse()` describe the turn the client saw rather than
+        // the one the model first wrote.
+        const allEvents =
+          rewrittenToolCalls && streamAdapter.formatToolCallsSSE
+            ? streamAdapter.formatToolCallsSSE(rewrittenToolCalls)
+            : streamAdapter.getRawToolCallEvents();
+        if (rewrittenToolCalls) {
+          streamAdapter.state.toolCalls.splice(
+            0,
+            streamAdapter.state.toolCalls.length,
+            ...rewrittenToolCalls,
+          );
+        }
         if (allEvents.length > 0) {
           ensureStreamHeaders();
           for (const event of allEvents) {
@@ -2126,9 +2161,29 @@ async function handleNonStreaming<
   );
 
   // Evaluate tool invocation policies
+  let rewrittenToolCalls: AccumulatedToolCall[] | null = null;
   if (toolCalls.length > 0) {
+    rewrittenToolCalls = planDispatchRewrites({
+      supported: responseAdapter.withRewrittenToolCalls !== undefined,
+      toolCalls: toolCalls.map((toolCall) => ({
+        id: toolCall.id,
+        name: toolCall.name,
+        arguments: JSON.stringify(toolCall.arguments),
+      })),
+      enabledToolNames,
+      canonicalizeToolName,
+      providerName,
+    });
+
     const toolInvocationRefusal = await utils.toolInvocation.evaluatePolicies(
-      normalizeToolCallsForPolicy(toolCalls, canonicalizeToolName),
+      normalizeToolCallsForPolicy(
+        rewrittenToolCalls ??
+          toolCalls.map((toolCall) => ({
+            name: toolCall.name,
+            arguments: toolCall.arguments,
+          })),
+        canonicalizeToolName,
+      ),
       agent.id,
       {
         teamIds: teamIds ?? [],
@@ -2238,6 +2293,14 @@ async function handleNonStreaming<
 
   // Tool calls allowed (or no tool calls) - return response.
   // `usage` (corrected for zero-input above) is reused here.
+  //
+  // Computed once: a translator adapter that rewrites remembers the inner
+  // (logged) shape it produced, so `getLoggedResponse` below must observe the
+  // same call that produced the client response.
+  const clientResponse =
+    rewrittenToolCalls && responseAdapter.withRewrittenToolCalls
+      ? responseAdapter.withRewrittenToolCalls(rewrittenToolCalls)
+      : responseAdapter.getOriginalResponse();
 
   // Note: Token metrics are reported by getObservableFetch() in the HTTP layer
   // for non-streaming requests. We only report cost here to avoid double counting.
@@ -2296,9 +2359,11 @@ async function handleNonStreaming<
       processedRequest: request,
       // Bedrock<->OpenAI compat need to return OpenAI response to client, but store bedrock response for interaction log.
       // Providers which need this behavior should implement getLoggedResponse() for persisting interaction and getOriginalResponse() for returning to client.
-      response:
-        responseAdapter.getLoggedResponse?.() ??
-        responseAdapter.getOriginalResponse(),
+      //
+      // A repaired batch logs what the client actually received. `getLoggedResponse`
+      // still wins where it exists: those adapters log a different wire shape on
+      // purpose, and after a rewrite they hand back that shape's rewritten form.
+      response: responseAdapter.getLoggedResponse?.() ?? clientResponse,
       actualModel,
       baselineModel,
       usage,
@@ -2320,7 +2385,45 @@ async function handleNonStreaming<
     );
   }
 
-  return reply.send(responseAdapter.getOriginalResponse());
+  return reply.send(clientResponse);
+}
+
+/**
+ * Plan the dispatch-mode repair for one turn's tool calls, and record it when
+ * there is one. Shared by the streaming and non-streaming paths so the two
+ * surfaces stay in step.
+ *
+ * `supported` is the adapter's ability to re-emit the rewritten calls in its
+ * own wire format; without it the repair could never reach the client, so that
+ * provider keeps the pre-existing refusal-with-steer behavior.
+ */
+function planDispatchRewrites(params: {
+  supported: boolean;
+  toolCalls: AccumulatedToolCall[];
+  enabledToolNames: Set<string>;
+  canonicalizeToolName: utils.gatewayToolNames.ToolNameCanonicalizer;
+  providerName: string;
+}): AccumulatedToolCall[] | null {
+  if (!params.supported) {
+    return null;
+  }
+
+  const rewritten = planDispatchModeToolCallRewrites({
+    toolCalls: params.toolCalls,
+    enabledToolNames: params.enabledToolNames,
+    canonicalizeToolName: params.canonicalizeToolName,
+  });
+
+  if (rewritten) {
+    logger.info(
+      {
+        toolNames: params.toolCalls.map((toolCall) => toolCall.name),
+        provider: params.providerName,
+      },
+      "Re-addressing direct tool calls through run_tool (dispatch mode)",
+    );
+  }
+  return rewritten;
 }
 
 function normalizeVirtualKeyCandidate(

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -84,6 +84,7 @@ import {
   calculateInteractionCosts,
   handleError,
   normalizeToolCallsForPolicy,
+  planDispatchModeToolCallRewrites,
   recordBlockedToolCallMetrics,
   shouldForwardAnthropicBeta,
   toSpanUserInfo,
@@ -105,6 +106,181 @@ describe("toSpanUserInfo", () => {
 
   test.each([null, undefined])("returns null for %s input", (input) => {
     expect(toSpanUserInfo(input)).toBeNull();
+  });
+});
+
+// --------------------------------------------------------------------------
+// planDispatchModeToolCallRewrites
+// --------------------------------------------------------------------------
+describe("planDispatchModeToolCallRewrites", () => {
+  const DISPATCH_PAIR = new Set([
+    "archestra__search_tools",
+    "archestra__run_tool",
+  ]);
+
+  test("re-addresses a direct call to run_tool, preserving id and arguments", () => {
+    const result = planDispatchModeToolCallRewrites({
+      toolCalls: [
+        {
+          id: "call_1",
+          name: "gh-developer-agent__pull_request_read",
+          arguments: '{"pullNumber":7}',
+        },
+      ],
+      enabledToolNames: DISPATCH_PAIR,
+    });
+
+    expect(result).toEqual([
+      {
+        id: "call_1",
+        name: "archestra__run_tool",
+        arguments: JSON.stringify({
+          tool_name: "gh-developer-agent__pull_request_read",
+          tool_args: { pullNumber: 7 },
+        }),
+      },
+    ]);
+  });
+
+  test("rewrites only the direct calls in a mixed batch, keeping order", () => {
+    const result = planDispatchModeToolCallRewrites({
+      toolCalls: [
+        {
+          id: "a",
+          name: "archestra__search_tools",
+          arguments: '{"query":"pr"}',
+        },
+        { id: "b", name: "gh__read", arguments: "{}" },
+      ],
+      enabledToolNames: DISPATCH_PAIR,
+    });
+
+    expect(result?.map((call) => [call.id, call.name])).toEqual([
+      ["a", "archestra__search_tools"],
+      ["b", "archestra__run_tool"],
+    ]);
+  });
+
+  // Two calls at the same tool is the shape the original report showed; both
+  // must be repaired, not deduplicated — they carry different arguments.
+  test("rewrites repeated calls at the same tool independently", () => {
+    const result = planDispatchModeToolCallRewrites({
+      toolCalls: [
+        { id: "a", name: "gh__read", arguments: '{"n":1}' },
+        { id: "b", name: "gh__read", arguments: '{"n":2}' },
+      ],
+      enabledToolNames: DISPATCH_PAIR,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(JSON.parse(result?.[0].arguments ?? "{}").tool_args).toEqual({
+      n: 1,
+    });
+    expect(JSON.parse(result?.[1].arguments ?? "{}").tool_args).toEqual({
+      n: 2,
+    });
+  });
+
+  // `full` exposure: a tool missing from the list really is disabled there, and
+  // run_tool is not the answer — the existing refusal must stand.
+  test("returns null when the tool list carries no dispatch pair", () => {
+    expect(
+      planDispatchModeToolCallRewrites({
+        toolCalls: [{ id: "a", name: "gh__read", arguments: "{}" }],
+        enabledToolNames: new Set(["gh__write"]),
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when search_tools is present without run_tool", () => {
+    expect(
+      planDispatchModeToolCallRewrites({
+        toolCalls: [{ id: "a", name: "gh__read", arguments: "{}" }],
+        enabledToolNames: new Set(["archestra__search_tools"]),
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when every call is already directly callable", () => {
+    expect(
+      planDispatchModeToolCallRewrites({
+        toolCalls: [
+          { id: "a", name: "archestra__search_tools", arguments: "{}" },
+        ],
+        enabledToolNames: DISPATCH_PAIR,
+      }),
+    ).toBeNull();
+  });
+
+  test("does not wrap a genuine run_tool dispatch a second time", () => {
+    expect(
+      planDispatchModeToolCallRewrites({
+        toolCalls: [
+          {
+            id: "a",
+            name: "archestra__run_tool",
+            arguments: '{"tool_name":"gh__read","tool_args":{}}',
+          },
+        ],
+        enabledToolNames: DISPATCH_PAIR,
+      }),
+    ).toBeNull();
+  });
+
+  // `tool_args` has to be an object; anything else cannot be re-wrapped
+  // faithfully, so the call is left for the existing steer rather than
+  // dispatched in a shape the model did not ask for.
+  test.each([
+    ["unparsable arguments", "not json"],
+    ["a JSON array", "[1,2]"],
+    ["a JSON scalar", '"hello"'],
+  ])("leaves a call with %s untouched", (_label, args) => {
+    expect(
+      planDispatchModeToolCallRewrites({
+        toolCalls: [{ id: "a", name: "gh__read", arguments: args }],
+        enabledToolNames: DISPATCH_PAIR,
+      }),
+    ).toBeNull();
+  });
+
+  // `run_tool` expands a bare Archestra short name to its built-in, so
+  // dispatching one would run a different — and policy-bypassed — tool than the
+  // model named. Refusing is the safe outcome.
+  test("leaves a name that collides with an Archestra short name untouched", () => {
+    expect(
+      planDispatchModeToolCallRewrites({
+        toolCalls: [
+          {
+            id: "a",
+            name: "read_file",
+            arguments: '{"file_path":"/etc/passwd"}',
+          },
+        ],
+        enabledToolNames: DISPATCH_PAIR,
+      }),
+    ).toBeNull();
+  });
+
+  test("treats empty arguments as an empty object", () => {
+    const result = planDispatchModeToolCallRewrites({
+      toolCalls: [{ id: "a", name: "gh__read", arguments: "" }],
+      enabledToolNames: DISPATCH_PAIR,
+    });
+    expect(JSON.parse(result?.[0].arguments ?? "{}")).toEqual({
+      tool_name: "gh__read",
+      tool_args: {},
+    });
+  });
+
+  test("canonicalizes a client-decorated name before dispatching it", () => {
+    const result = planDispatchModeToolCallRewrites({
+      toolCalls: [{ id: "a", name: "mcp__gw__gh__read", arguments: "{}" }],
+      enabledToolNames: DISPATCH_PAIR,
+      canonicalizeToolName: (name) => name.replace("mcp__gw__", ""),
+    });
+    expect(JSON.parse(result?.[0].arguments ?? "{}").tool_name).toBe(
+      "gh__read",
+    );
   });
 });
 

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -12,12 +12,16 @@ import {
   type InteractionSource,
   type SupportedProvider,
   type SupportedProviderDiscriminator,
+  TOOL_RUN_TOOL_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_SHORT_NAME,
 } from "@archestra/shared";
 import { context as otelContext } from "@opentelemetry/api";
 import type { FastifyReply } from "fastify";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import {
   resolveRunToolDispatch,
   resolveRunToolTarget,
+  resolveRunToolTargetName,
 } from "@/archestra-mcp-server/run-tool-target";
 import { isNativeAnthropicModelShape } from "@/clients/anthropic-endpoint";
 import logger from "@/logging";
@@ -123,6 +127,133 @@ export function normalizeToolCallsForPolicy(
     }
     return { toolCallName: canonicalName, toolCallArgs: argsString };
   });
+}
+
+/**
+ * A tool call as the stream/response adapters accumulate it, in the shape
+ * {@link planDispatchModeToolCallRewrites} reads and rewrites.
+ */
+export interface AccumulatedToolCall {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+/**
+ * Rewrite a dispatch-mode agent's *direct* tool calls into `run_tool` calls.
+ *
+ * In `search_and_run_only` exposure (which Auto tool mode implies) every
+ * third-party tool is reachable through `run_tool` but deliberately absent from
+ * the request's tool list. When the model calls one directly — which it does
+ * routinely, because it learned the exact name from `search_tools`, a skill
+ * body, or its own earlier turn — the name is not in `enabledToolNames` and the
+ * guardrail drops the whole batch, ending the turn with a steer the user reads
+ * as an assistant message. The tool was never unreachable; only the calling
+ * convention was wrong.
+ *
+ * So repair the convention instead of refusing: re-address the call to
+ * `run_tool` with the model's own name and arguments moved into `tool_name` /
+ * `tool_args`. Nothing about enforcement changes — `normalizeToolCallsForPolicy`
+ * unwraps the rewritten call straight back to the same target, so it is policy-
+ * evaluated exactly like a `run_tool` dispatch the model had written itself.
+ *
+ * Returns `null` when there is nothing to do — no dispatch pair in the tool
+ * list (`full` exposure, where a missing tool really is disabled), or every
+ * call already directly callable — so callers keep the untouched raw events.
+ *
+ * The call's `id` is preserved: the client correlates its tool result by id,
+ * and the rewrite must be invisible to that bookkeeping.
+ */
+export function planDispatchModeToolCallRewrites(params: {
+  toolCalls: AccumulatedToolCall[];
+  enabledToolNames: Set<string>;
+  canonicalizeToolName?: ToolNameCanonicalizer;
+}): AccumulatedToolCall[] | null {
+  const { toolCalls, enabledToolNames } = params;
+  const canonicalizeToolName = params.canonicalizeToolName ?? ((name) => name);
+
+  const runToolName = findRunToolName(enabledToolNames);
+  if (!runToolName || !hasSearchToolsName(enabledToolNames)) {
+    return null;
+  }
+
+  let rewroteAny = false;
+  const rewritten = toolCalls.map((toolCall) => {
+    const canonicalName = canonicalizeToolName(toolCall.name);
+
+    // Already callable, or one of the built-ins that bypass the enabled-tools
+    // filter entirely (`run_tool` itself included — a genuine dispatch must not
+    // be wrapped a second time).
+    if (
+      archestraMcpBranding.isToolName(canonicalName) ||
+      enabledToolNames.has(canonicalName)
+    ) {
+      return toolCall;
+    }
+
+    // `run_tool` expands a bare Archestra short name to its built-in
+    // (`read_file` -> `archestra__read_file`). A third-party tool whose
+    // unprefixed name collides with one of those would therefore come out of
+    // the wrapper as a DIFFERENT tool than the model asked for — and a
+    // policy-bypassed built-in at that. Refusing such a call is the safe
+    // outcome; silently retargeting it is not.
+    if (resolveRunToolTargetName(canonicalName) !== canonicalName) {
+      return toolCall;
+    }
+
+    // Arguments the model did not emit as a JSON object cannot be re-wrapped
+    // faithfully — `tool_args` has to be that object. Leave the call alone and
+    // let the guardrail refuse it with the existing steer rather than invent a
+    // shape and dispatch something the model did not ask for.
+    let toolArgs: unknown;
+    try {
+      toolArgs = JSON.parse(toolCall.arguments || "{}");
+    } catch {
+      return toolCall;
+    }
+    if (
+      typeof toolArgs !== "object" ||
+      toolArgs === null ||
+      Array.isArray(toolArgs)
+    ) {
+      return toolCall;
+    }
+
+    rewroteAny = true;
+    return {
+      id: toolCall.id,
+      name: runToolName,
+      arguments: JSON.stringify({
+        tool_name: canonicalName,
+        tool_args: toolArgs,
+      }),
+    };
+  });
+
+  return rewroteAny ? rewritten : null;
+}
+
+function findRunToolName(declaredToolNames: Set<string>): string | null {
+  for (const name of declaredToolNames) {
+    if (
+      archestraMcpBranding.getToolShortName(name) === TOOL_RUN_TOOL_SHORT_NAME
+    ) {
+      return name;
+    }
+  }
+  return null;
+}
+
+function hasSearchToolsName(declaredToolNames: Set<string>): boolean {
+  for (const name of declaredToolNames) {
+    if (
+      archestraMcpBranding.getToolShortName(name) ===
+      TOOL_SEARCH_TOOLS_SHORT_NAME
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/platform/backend/src/routes/proxy/llm-proxy-tool-invocation.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-tool-invocation.test.ts
@@ -54,6 +54,41 @@ const READ_FILE_TOOL = {
   },
 };
 
+/**
+ * The two tools a `search_and_run_only` agent actually advertises. Every
+ * third-party tool is reachable through `run_tool` but deliberately absent from
+ * the list, which is the whole condition this repair keys off.
+ */
+const DISPATCH_PAIR_TOOLS = [
+  {
+    type: "function" as const,
+    function: {
+      name: "archestra__search_tools",
+      description: "Find tools by capability",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "archestra__run_tool",
+      description: "Run a tool by exact name",
+      parameters: {
+        type: "object",
+        properties: {
+          tool_name: { type: "string" },
+          tool_args: { type: "object" },
+        },
+        required: ["tool_name"],
+      },
+    },
+  },
+];
+
 type StubToolCall = { name: string; arguments: string };
 
 /** OpenAI client stub whose completion returns the configured tool calls. */
@@ -246,6 +281,153 @@ describe("LLM Proxy tool-invocation policy (OpenAI)", () => {
     );
     expect(JSON.parse(readFile.function.arguments).file_path).toBe(
       "/etc/passwd",
+    );
+  });
+  // T-1111: in dispatch mode the model routinely calls a reachable tool by its
+  // exact name — learned from search_tools, a skill body, or its own earlier
+  // turn — and the batch used to be dropped, ending the turn with an internal
+  // steer the user read as an assistant message. The call is now re-addressed
+  // to run_tool instead of refused.
+  test("re-addresses a direct tool call through run_tool in dispatch mode", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({
+      name: "Dispatch Mode Agent",
+      agentType: "llm_proxy",
+    });
+
+    stubToolCalls = [
+      {
+        name: "gh-developer-agent__pull_request_read",
+        arguments: '{"pullNumber":7}',
+      },
+    ];
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-key",
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "read PR 7" }],
+        tools: DISPATCH_PAIR_TOOLS,
+        stream: false,
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const message = response.json().choices[0].message;
+
+    // The turn still carries a tool call the client can execute — not a refusal.
+    expect(message.content).toBeNull();
+    expect(message.tool_calls).toHaveLength(1);
+    expect(message.tool_calls[0].function.name).toBe("archestra__run_tool");
+    expect(JSON.parse(message.tool_calls[0].function.arguments)).toEqual({
+      tool_name: "gh-developer-agent__pull_request_read",
+      tool_args: { pullNumber: 7 },
+    });
+
+    // The interaction log describes the turn the client received.
+    const interactions = await db
+      .select()
+      .from(schema.interactionsTable)
+      .where(eq(schema.interactionsTable.profileId, agent.id));
+    expect(JSON.stringify(interactions[0].response)).toContain(
+      "archestra__run_tool",
+    );
+  });
+
+  // `full` exposure: a tool missing from the list really is disabled there, so
+  // the pre-existing refusal must survive untouched.
+  test("still refuses a disabled tool when the list has no dispatch pair", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({
+      name: "Full Exposure Agent",
+      agentType: "llm_proxy",
+    });
+
+    stubToolCalls = [
+      { name: "gh-developer-agent__pull_request_read", arguments: "{}" },
+    ];
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-key",
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "read PR 7" }],
+        tools: [READ_FILE_TOOL],
+        stream: false,
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const message = response.json().choices[0].message;
+    expect(message.tool_calls).toBeUndefined();
+    expect(message.content).toContain("not enabled for this conversation");
+  });
+
+  // The repaired call faces the same gate a run_tool dispatch the model wrote
+  // itself would face — the rewrite must not become a policy bypass.
+  test("still enforces the target tool's policy on a repaired call", async ({
+    makeOrganization,
+    makeAgent,
+    makeTool,
+    makeToolPolicy,
+  }) => {
+    const organization = await makeOrganization();
+    const agent = await makeAgent({
+      name: "Dispatch Mode Policy Agent",
+      organizationId: organization.id,
+      agentType: "llm_proxy",
+      considerContextUntrusted: true,
+    });
+
+    // A server-prefixed name, as every third-party tool actually has: a bare
+    // name colliding with an Archestra short name is deliberately never
+    // rewritten (see llm-proxy-helpers.test.ts).
+    const tool = await makeTool({ name: "files__read", agentId: agent.id });
+    await makeToolPolicy(tool.id, {
+      conditions: [{ key: "file_path", operator: "contains", value: "/etc/" }],
+      action: "block_always",
+      reason: "Reading /etc/ files is not allowed for security reasons",
+    });
+
+    stubToolCalls = [
+      { name: "files__read", arguments: '{"file_path":"/etc/passwd"}' },
+    ];
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-key",
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "UNTRUSTED_DATA: read it" }],
+        tools: DISPATCH_PAIR_TOOLS,
+        stream: false,
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const message = response.json().choices[0].message;
+    expect(message.tool_calls).toBeUndefined();
+    expect(message.refusal || message.content).toContain(
+      "Archestra LLM Proxy blocked unsafe tool call",
     );
   });
 });

--- a/platform/backend/src/skills/__snapshots__/skill-activation.test.ts.snap
+++ b/platform/backend/src/skills/__snapshots__/skill-activation.test.ts.snap
@@ -7,7 +7,7 @@ Do research.
 <skill_compatibility>Python 3.11</skill_compatibility>
 If this environment cannot meet that requirement, tell the user and proceed with what is possible.
 <skill_allowed_tools>slack__send jira__create</skill_allowed_tools>
-This skill expects these tools; enable any that are not already active.
+These are the tools this skill uses. Reach each one the same way you reach any other tool in this conversation; a name listed here is not necessarily directly callable.
 <skill_resources>
 references/REF.md (reference)
 scripts/run.py (script)

--- a/platform/backend/src/skills/skill-activation.ts
+++ b/platform/backend/src/skills/skill-activation.ts
@@ -104,9 +104,17 @@ export function formatSkillActivation({
       "and proceed with what is possible."
     : "";
 
+  // "enable any that are not already active" asked for something the model
+  // cannot do — nothing enables tools mid-conversation — and, worse, it implied
+  // the named tools were directly callable, which invites exactly the direct
+  // call a dispatch-mode agent cannot make. State what the names are for and
+  // leave the calling convention to the tool-loading instructions, which are
+  // the only place that knows whether this agent dispatches or calls directly.
   const allowedTools = skill.allowedTools
     ? `\n<skill_allowed_tools>${neutralizeFrameTags(skill.allowedTools)}</skill_allowed_tools>\n` +
-      "This skill expects these tools; enable any that are not already active."
+      "These are the tools this skill uses. Reach each one the same way you " +
+      "reach any other tool in this conversation; a name listed here is not " +
+      "necessarily directly callable."
     : "";
 
   return (

--- a/platform/backend/src/types/llm-provider.ts
+++ b/platform/backend/src/types/llm-provider.ts
@@ -224,6 +224,24 @@ export interface LLMResponseAdapter<TResponse> {
    */
   getLoggedResponse?(): TResponse;
 
+  /**
+   * Return this response with its tool calls replaced, for the non-streaming
+   * counterpart of {@link LLMStreamAdapter.formatToolCallsSSE}: the proxy
+   * repairs a dispatch-mode agent's direct tool call by re-addressing it to
+   * `run_tool` (see `planDispatchModeToolCallRewrites`).
+   *
+   * `toolCalls` is positional — one entry per call this response already
+   * carries, in order — so an adapter rewrites in place and preserves each
+   * call's id, which is what the client correlates its tool result by.
+   *
+   * Optional, on the same terms as `formatToolCallsSSE`: an adapter that does
+   * not implement it keeps the pre-existing refusal-with-steer behavior for its
+   * provider, so no response shape is ever rewritten speculatively.
+   */
+  withRewrittenToolCalls?(
+    toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  ): TResponse;
+
   /** Get finish reasons array for OTEL tracing (e.g., ["stop"], ["tool_calls"]) */
   getFinishReasons(): string[];
 
@@ -345,6 +363,28 @@ export interface LLMStreamAdapter<TChunk, TResponse> {
    * Returns provider-specific events that form a valid complete response.
    */
   formatCompleteTextSSE(text: string): (string | Uint8Array)[];
+
+  /**
+   * Re-emit this turn's tool calls as SSE, replacing the buffered raw events.
+   *
+   * Used when the proxy repairs a dispatch-mode agent's *direct* tool call by
+   * re-addressing it to `run_tool` (see `planDispatchModeToolCallRewrites`).
+   * The buffered events cannot simply be edited: they are provider-native
+   * fragments, with the name and the argument JSON split across chunks.
+   *
+   * Emits ONLY the tool-call portion of the message. Any text the model
+   * produced in the same turn has already been streamed to the client, so this
+   * must continue that message rather than open a new one — unlike
+   * {@link formatCompleteTextSSE}, which replaces the response wholesale.
+   *
+   * Optional: an adapter that does not implement it keeps the pre-existing
+   * behavior for its provider (the calls are refused with the
+   * "cannot be called directly" steer), so coverage can grow one wire format at
+   * a time without any provider silently emitting a malformed stream.
+   */
+  formatToolCallsSSE?(
+    toolCalls: StreamAccumulatorState["toolCalls"],
+  ): (string | Uint8Array)[];
 
   /** Format the stream end marker */
   formatEndSSE(): string | Uint8Array;


### PR DESCRIPTION
## The bug

An agent in `search_and_run_only` exposure — which **Auto tool mode implies** — advertises only the `search_tools` / `run_tool` pair. Every third-party tool is reachable *through* `run_tool` but deliberately absent from the request's tool list. The model calls one **directly** anyway, routinely: it has the exact name from `search_tools`, a skill body, or its own earlier turn.

`enabledToolNames` is built only from the tools declared in the request body, so that name isn't in it, and the guardrail drops **the whole batch** and writes the recovery steer as assistant **text**. With no tool calls left, the agent loop ends — the user reads an internal steer as a chat message, and the "retry through `run_tool`" advice cannot be acted on until they type again.

#7239 fixed that message's *wording*. This fixes the dead end underneath it.

## The fix

The tool was never unreachable; only the calling convention was wrong. So repair the convention instead of refusing: re-address the call to `run_tool`, moving the model's own name and arguments into `tool_name` / `tool_args`.

Enforcement is unchanged — `normalizeToolCallsForPolicy` unwraps the rewritten call straight back to the same target, so it faces exactly the gate a `run_tool` dispatch the model wrote itself would face. There's a test asserting a repaired call is still blocked by a `block_always` policy.

Two guards keep the repair from inventing a call the model did not make:
- arguments that aren't a JSON object can't be re-wrapped faithfully (`tool_args` has to be that object);
- a bare name colliding with an Archestra short name (`read_file`) would come out of the wrapper as a different — and **policy-bypassed** — built-in.

Both fall through to the pre-existing refusal.

## Coverage

The buffered raw events can't simply be edited (provider-native fragments, name and argument JSON split across chunks), so adapters re-emit the calls in their own wire format via `formatToolCallsSSE` / `withRewrittenToolCalls`. Both are optional on the interface: an adapter that doesn't implement them keeps today's exact behavior, so no provider can emit a malformed stream.

Every adapter that can carry a tool call now implements both:

- OpenAI chat + every OpenAI-compatible provider (Azure, Groq, Mistral, OpenRouter, xAI, Cerebras, DeepSeek, Kimi, vLLM, Ollama-compat, GitHub Copilot, M365 Copilot)
- Responses API: native OpenAI, Azure, and the from-chat translator (Perplexity-Responses, Copilot-Responses). The client keeps the **last** `response.completed` envelope it sees, so the repair re-issues one naming the rewritten calls — the same ordering constraint `responses-refusal-order.test.ts` pins for refusals.
- Anthropic, Bedrock Converse (binary event stream), Bedrock-Invoke, and the Converse→OpenAI translator
- Gemini, Cohere v2, Ollama native (NDJSON), Minimax, ZhipuAI
- the Anthropic/Cohere/Gemini→OpenAI translators — these log a *different* wire shape than they send, so they remember the inner rewritten response and `getLoggedResponse` returns it

Perplexity's chat-completions route carries no tool calls at all, so there is nothing to rewrite there.

Also rewords the skill `allowed-tools` activation line — the follow-up #7239 deferred. "enable any that are not already active" asked for something no model can do, and implied the named tools were directly callable, which invites the very call this repairs.

## Verification

Live on a dev stack, end to end through the real chat surface: a stub upstream that always emits a direct call to a hidden tool → proxy logs `Re-addressing direct tool calls through run_tool` → the chat stream carries `archestra__run_tool` with `tool_name` set to the hidden tool → it dispatches, runs, and the turn continues normally. Before the fix that exact turn produced only the refusal text and stopped.

Worth noting: current frontier models (GPT-5.4, GPT-5.4-mini, Kimi K2.6) now *refuse* to emit the direct call when asked to, which is why the live proof needed a deterministic stub. The failure remains real for models that don't know the convention — which is what the reporting customer is hitting.

## Checks

`tsc` · `biome ci` · `knip` clean. `routes/proxy` + `guardrails` + `skills`: **110 files, 1875 passed, 64 skipped**.

Task: T-1111

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>