### PR TITLE
docs: clarify agent access vs MCP server access precedence

### DIFF
--- a/docs/pages/platform-access-control.md
+++ b/docs/pages/platform-access-control.md
@@ -3,7 +3,7 @@ title: "Access Control"
 category: Administration
 description: "Role-based access control (RBAC) system for managing user permissions in Archestra"
 order: 1
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-19
 ---
 <!--
 GENERATED FILE — edit codegen-access-control-docs.ts, not this page.
@@ -432,9 +432,17 @@ New users are automatically added to the "Default Team" when they accept an invi
 
 **For MCP Servers:**
 
-- Users can only access MCP servers assigned to teams they belong to
+- Users can only see, install, and manage MCP servers assigned to teams they belong to
 - Exception: Users with `mcpServerInstallation:admin` permission can access all MCP servers
 - Exception: MCP servers with no team assignment are accessible to all users
+
+#### Agent Access vs MCP Server Access
+
+The two team assignments gate different things. Agent access decides who can call the agent's tools. MCP server access decides who can see, install, and manage the server in the registry.
+
+In **Custom** tool mode, sharing an agent shares its assigned tools. A user with agent access can call an assigned tool even when its MCP server is not shared with them. [Credential resolution](/docs/mcp-authentication#credential-resolution) decides whose connection serves each call: a pinned connection serves every caller, and resolve-at-call-time looks for a connection the caller can reach.
+
+In **Auto** tool mode, each caller can only discover and run tools from MCP servers they can access themselves — plus any tools explicitly assigned to the agent. See [Tool Access Modes](/docs/platform-agents#tool-access-modes).
 
 **Associated Artifacts:**
 

--- a/docs/pages/platform-agents.md
+++ b/docs/pages/platform-agents.md
@@ -20,22 +20,25 @@ An agent can include:
 - a **Subagents** setting: **Auto** (delegate to any agent the chatting user can access, minus a disabled list) or **Custom** (only assigned delegation targets)
 - one or more assigned knowledge sources
 
-## Load Tools When Needed
+## Tool Access Modes
 
-By default, an agent exposes every assigned tool through MCP `tools/list`.
+An agent's **Tools & Knowledge Sources** setting is **Auto** or **Custom** — tabs in the agent dialog. The tabs govern both tools and [knowledge sources](#knowledge-sources); this section covers the tools half.
 
-For larger toolsets, enable **Load tools when needed**. This keeps the initial tool list small. MCP clients see the built-in [`search_tools`](/docs/platform-archestra-mcp-server#search_tools) and [`run_tool`](/docs/platform-archestra-mcp-server#run_tool) tools first. Those two tools are enabled implicitly and do not need normal tool assignment.
+### Custom Mode
 
-- `search_tools` can still discover them
-- `run_tool` can still execute them
+In **Custom** mode the agent uses only its explicitly assigned tools. New agents get a default set assigned by the backend, and the create form pre-selects that same set. Assignments resolve credentials at call time by default; you can pin a specific connection per server instead.
 
-Use this when the full tool menu is too large to send to the model on every turn, but you still want the agent to keep access to the same assigned toolset.
+Sharing the agent shares its assigned tools. A teammate with agent access can call an assigned tool even when its MCP server is not shared with them — the server's own team assignment governs the [registry](/docs/platform-private-registry), not tool calls through the agent. [Credential resolution](/docs/mcp-authentication#credential-resolution) decides whose connection serves each call: a pinned connection serves every caller, and resolve-at-call-time looks for a connection the caller can reach.
 
-An agent's **Tools & Knowledge Sources** setting is **Auto** or **Custom** — tabs in the agent dialog. The tabs govern both tools and [knowledge sources](#knowledge-sources); this section covers the tools half. In **Custom** mode the agent uses only its explicitly assigned tools; new agents get a default set assigned by the backend, and the create form pre-selects that same set. Custom assignments resolve credentials at call time by default; you can pin a specific connection per server instead. In **Auto** mode, discovery is not limited to assigned tools: `search_tools` can find and `run_tool` can run every tool the signed-in user can access — Archestra built-in tools and tools from MCP servers — except tools on the agent's [exclusion list](#excluding-servers-and-tools). User permissions still apply. `run_tool` executes such a tool directly with credentials resolved at call time, following the MCP server's **Default credential** setting: on behalf of the user by default (each person's own connection), or one shared account when the server is configured that way. A caller without a connection gets an actionable prompt to connect — nothing is borrowed from team or organization credentials. Nothing is assigned to the agent, so no permission to modify the agent is involved. This lets [Agent Skills](/docs/platform-agent-skills) reference tools without pre-assigning every tool to every agent.
+### Auto Mode
+
+In **Auto** mode, discovery is not limited to assigned tools: `search_tools` can find and `run_tool` can run every tool the signed-in user can access — Archestra built-in tools and tools from MCP servers — except tools on the agent's [exclusion list](#excluding-servers-and-tools). User permissions still apply, so each caller of a shared agent may reach a different toolset. Tools explicitly assigned to the agent stay available to every caller.
+
+`run_tool` executes a discovered tool directly with [credentials resolved at call time](/docs/mcp-authentication#resolve-at-call-time), following the MCP server's **Default credential** setting: on behalf of the user by default, or one shared account when the server is configured that way. A caller with no reachable connection gets an actionable prompt to connect — another person's personal connection is never used.
+
+Nothing is assigned to the agent, so no permission to modify the agent is involved. This lets [Agent Skills](/docs/platform-agent-skills) reference tools without pre-assigning every tool to every agent.
 
 Tool call policies still apply to the target tool. If the model calls `run_tool` to execute `send_email`, Archestra evaluates policies for `send_email` with the same arguments and context it would use for a direct tool call. See [AI Tool Guardrails - Load Tools When Needed](/docs/platform-ai-tool-guardrails#load-tools-when-needed).
-
-See [MCP Gateway - Load Tools When Needed](/docs/platform-mcp-gateway#load-tools-when-needed) for the MCP-client-facing behavior and the same mode on gateways.
 
 ### Excluding Servers and Tools
 
@@ -53,6 +56,19 @@ Only `search_tools` and `run_tool` can never be excluded; everything else can. A
 
 Exclusions are stored per agent and have no effect in **Custom** mode. Cloning an agent copies them. Agent export does not carry them — server and tool IDs are not portable across organizations — so an imported agent starts with no exclusions and they must be re-created. Exclusions track the specific tool record: if an MCP server renames a tool, the renamed tool counts as new and is no longer excluded.
 
+## Load Tools When Needed
+
+By default, an agent exposes every assigned tool through MCP `tools/list`.
+
+For larger toolsets, enable **Load tools when needed**. This keeps the initial tool list small. MCP clients see the built-in [`search_tools`](/docs/platform-archestra-mcp-server#search_tools) and [`run_tool`](/docs/platform-archestra-mcp-server#run_tool) tools first. Those two tools are enabled implicitly and do not need normal tool assignment.
+
+- `search_tools` can still discover them
+- `run_tool` can still execute them
+
+Use this when the full tool menu is too large to send to the model on every turn, but you still want the agent to keep access to the same assigned toolset.
+
+See [MCP Gateway - Load Tools When Needed](/docs/platform-mcp-gateway#load-tools-when-needed) for the MCP-client-facing behavior and the same mode on gateways.
+
 ## Missing Tool Connections
 
 An agent's tools can come from MCP servers that each person connects with their own account. Share that agent, and a teammate who has not connected one of those servers finds out only when a tool from it runs.
@@ -65,7 +81,7 @@ An agent's tools can come from MCP servers that each person connects with their 
 
 A server counts as connected when the person's own connection covers it, when a team or organization connection does, or when the agent pins one shared account. Servers that need no credentials never count as missing.
 
-The setting does nothing in **Auto** mode, where each caller's tools come from what they can already reach.
+The setting does nothing in [**Auto** mode](#auto-mode), where each caller's tools come from what they can already reach.
 
 ## Invocation Paths
 

--- a/docs/pages/platform-mcp-gateway.md
+++ b/docs/pages/platform-mcp-gateway.md
@@ -3,7 +3,7 @@ title: MCP Gateway
 category: MCP
 order: 1
 description: Unified access point for all MCP servers
-lastUpdated: 2026-08-10
+lastUpdated: 2026-08-19
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -138,6 +138,8 @@ A gateway can also publish your organization's skills to connecting clients as `
 Gateway access depends on both the caller and the gateway configuration. A user must be allowed to see the MCP Gateway, usually through organization visibility or team membership, and the gateway must have the specific tool assigned to it.
 
 If a gateway is scoped to one team, members outside that team cannot use it even if the underlying MCP server exists in the registry. This lets admins approve MCP servers centrally while still exposing different tool sets to different teams or clients.
+
+The reverse also holds: a caller with gateway access can call its assigned tools even when a tool's MCP server is not shared with them. The server's team assignment governs the registry, not tool calls. See [Agent Access vs MCP Server Access](/docs/platform-access-control#agent-access-vs-mcp-server-access).
 
 See [Access Control](/docs/platform-access-control) for the permission model.
 

--- a/platform/backend/src/standalone-scripts/codegen-access-control-docs.ts
+++ b/platform/backend/src/standalone-scripts/codegen-access-control-docs.ts
@@ -294,9 +294,17 @@ New users are automatically added to the "Default Team" when they accept an invi
 
 **For MCP Servers:**
 
-- Users can only access MCP servers assigned to teams they belong to
+- Users can only see, install, and manage MCP servers assigned to teams they belong to
 - Exception: Users with \`mcpServerInstallation:admin\` permission can access all MCP servers
 - Exception: MCP servers with no team assignment are accessible to all users
+
+#### Agent Access vs MCP Server Access
+
+The two team assignments gate different things. Agent access decides who can call the agent's tools. MCP server access decides who can see, install, and manage the server in the registry.
+
+In **Custom** tool mode, sharing an agent shares its assigned tools. A user with agent access can call an assigned tool even when its MCP server is not shared with them. [Credential resolution](/docs/mcp-authentication#credential-resolution) decides whose connection serves each call: a pinned connection serves every caller, and resolve-at-call-time looks for a connection the caller can reach.
+
+In **Auto** tool mode, each caller can only discover and run tools from MCP servers they can access themselves — plus any tools explicitly assigned to the agent. See [Tool Access Modes](/docs/platform-agents#tool-access-modes).
 
 **Associated Artifacts:**
 


### PR DESCRIPTION
## Why

A user question surfaced that our docs never answer: *if an agent is shared with a teammate, but one of its tools comes from an MCP server whose team assignment does not include that teammate, can they call the tool?* The answer (yes — agent access wins; the MCP server's team assignment governs the registry, not tool calls) had to be stitched together from four pages, and the Access Control page flatly claimed the opposite.

## What changed

**Access Control page** (via `codegen-access-control-docs.ts` — the page is generated):
- The MCP server team rule now says what it actually gates: *see, install, and manage* — not "access"
- New **Agent Access vs MCP Server Access** section stating the precedence rule for Custom and Auto tool modes, linking to credential resolution

**Agents page**:
- The Auto/Custom explanation was one wall-of-text paragraph buried mid-way inside "Load Tools When Needed". It is now a dedicated **Tool Access Modes** section (`### Custom Mode` / `### Auto Mode`) placed first, with the sharing semantics of each mode spelled out
- Fixed an incorrect claim: call-time resolution *does* fall back to team and organization connections (`pickInstallForCaller`: own → team → org), matching the MCP Authentication page and the code. The old text said "nothing is borrowed from team or organization credentials". What is never used is another person's *personal* connection — the text now says that instead
- "Load Tools When Needed" keeps its own section and anchor (linked from the guardrails page)

**MCP Gateway page**:
- Access Control section states the converse case (gateway access ⇒ assigned tools callable regardless of server team assignment) and cross-links the new section

## Behavior verified against code

- `tools/call` authorizes purely on agent assignment: `clients/mcp-client.ts` `validateAndGetTool` → `ToolModel.getMcpToolsAssignedToAgent` (no caller/catalog-team predicate)
- Catalog team checks (`getUserAccessibleCatalogIds`/`userHasCatalogAccess`) only appear on registry/discovery/UI paths
- Call-time credential order: `pickInstallForCaller` (own → team → org), pinned by `auth-at-call-time.test.ts`
- Auto-mode discovery corpus is caller-scoped via `getMcpToolsAccessibleToUser`; assigned tools are added unconditionally (`search-tools.ts`)

Docs link check passes (`check-docs-links.py`).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>