### PR TITLE
fix(frontend): let list-page filter bars wrap so the search box survives a phone width

### DIFF
--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -526,7 +526,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
         <div>
           <div>
             <div className="mb-6 flex flex-col gap-2">
-              <div className="flex items-center gap-4">
+              <div className="flex flex-wrap items-center gap-4">
                 <SearchInput
                   objectNamePlural="agents"
                   searchFields={["name"]}

--- a/platform/frontend/src/app/knowledge/connectors/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/page.client.tsx
@@ -350,8 +350,11 @@ function ConnectorsList() {
     >
       <div>
         <div className="mb-6 flex flex-col gap-2">
-          <div className="flex items-center gap-4">
-            <SearchInput paramName="search" className="relative w-[330px]" />
+          <div className="flex flex-wrap items-center gap-4">
+            <SearchInput
+              paramName="search"
+              className="relative w-full sm:w-[330px]"
+            />
             <Select
               value={connectorTypeFilter}
               onValueChange={handleConnectorTypeChange}

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -332,8 +332,11 @@ function KnowledgeBasesList() {
     >
       <div>
         <div className="mb-6 flex flex-col gap-2">
-          <div className="flex items-center gap-4">
-            <SearchInput paramName="search" className="relative w-[370px]" />
+          <div className="flex flex-wrap items-center gap-4">
+            <SearchInput
+              paramName="search"
+              className="relative w-full sm:w-[370px]"
+            />
             <ResourceDeletedStatusFilter
               deletePermission={{ knowledgeSource: ["delete"] }}
             />

--- a/platform/frontend/src/app/llm/proxies/page.client.tsx
+++ b/platform/frontend/src/app/llm/proxies/page.client.tsx
@@ -414,7 +414,7 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
         <div>
           <div>
             <div className="mb-6 flex flex-col gap-2">
-              <div className="flex items-center gap-4">
+              <div className="flex flex-wrap items-center gap-4">
                 <SearchInput
                   objectNamePlural="proxies"
                   searchFields={["name"]}

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -537,7 +537,7 @@ function McpGateways({
         <div>
           <div>
             <div className="mb-6 flex flex-col gap-2">
-              <div className="flex items-center gap-4">
+              <div className="flex flex-wrap items-center gap-4">
                 <SearchInput
                   objectNamePlural="gateways"
                   searchFields={["name"]}

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -965,7 +965,7 @@ export function InternalMCPCatalog({
         />
       ) : (
         <>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <SearchInput
               objectNamePlural="MCP servers"
               searchFields={["name"]}

--- a/platform/frontend/src/components/resource-scope-filter.tsx
+++ b/platform/frontend/src/components/resource-scope-filter.tsx
@@ -208,7 +208,10 @@ export function ResourceScopeFilter({
   );
 
   return (
-    <div className="flex items-center gap-2">
+    // Wraps: at a phone width the fixed-width selects below overflow one row,
+    // and this group shares that row with a list page's search box, which is
+    // then squeezed to its magnifier with no room left to show what was typed.
+    <div className="flex flex-wrap items-center gap-2">
       <Select value={scope ?? "all"} onValueChange={handleScopeChange}>
         <SelectTrigger aria-label="Filter by type" className="w-[180px]">
           <SelectValue />

--- a/platform/frontend/src/components/roles/roles-list.ee.tsx
+++ b/platform/frontend/src/components/roles/roles-list.ee.tsx
@@ -365,8 +365,11 @@ export function RolesList({ headerAction }: { headerAction?: ReactNode }) {
   return (
     <>
       <div className="space-y-6">
-        <div className="flex items-center gap-4">
-          <div className="flex-1 min-w-0">
+        <div className="flex flex-wrap items-center gap-4">
+          {/* `flex-1` alone lays out from a zero basis, so the search box kept
+              sharing the row with the action however little room was left. The
+              min-width is what makes the row break instead. */}
+          <div className="flex-1 min-w-[220px]">
             <SearchInput
               objectNamePlural="roles"
               searchFields={["name"]}

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -251,7 +251,10 @@ export function TeamsList() {
     <>
       <div className="space-y-6">
         <div className="flex items-center justify-between gap-4">
-          <div className="flex items-center gap-2">
+          {/* `flex-1`: without it this row is shrink-to-fit, so the search box
+              resolves its `w-full` against its own intrinsic width and stays a
+              stub of the column instead of filling it. */}
+          <div className="flex flex-1 flex-wrap items-center gap-2">
             <SearchInput objectNamePlural="teams" searchFields={["name"]} />
             <LabelSelect
               labelKeys={labelKeys}

--- a/platform/frontend/src/mocks/handlers.ts
+++ b/platform/frontend/src/mocks/handlers.ts
@@ -212,6 +212,9 @@ export const handlers: HttpHandler[] = [
   ...getJson("/api/agents/:id/delegations", []),
   ...getJson("/api/agents/default-mcp-gateway", null),
   ...getJson("/api/agents/default-llm-proxy", null),
+  // The agents list asks which of the caller's agents is their personal
+  // default; unmocked, it reaches the real backend and trips the leak guard.
+  ...getJson("/api/members/default-agent", { defaultAgentId: null }),
   ...postJson("/api/agents", makeAgent()),
   ...postJson(
     "/api/agents/:id/clone",

--- a/platform/frontend/tests-integration/list-filter-bar-mobile.spec.ts
+++ b/platform/frontend/tests-integration/list-filter-bar-mobile.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * A list page's filter bar packs a search box, the scope/label selects and a
+ * status select onto one row. The row did not wrap, and the selects hold fixed
+ * widths, so at a phone width the search box absorbed the whole shortfall and
+ * collapsed to its magnifier — still focusable, and the keyboard still opened,
+ * but with no room left to show or edit what had been typed. The filters past
+ * it were clipped off the side of the screen at the same time.
+ *
+ * These assert the geometry rather than the styling: a class-name check would
+ * have passed throughout the bug, because the classes were reasonable and only
+ * the arithmetic was wrong.
+ */
+
+// A Pixel-class phone, which is the width the bug was reported from.
+test.use({ viewport: { width: 360, height: 740 } });
+
+/** Reads the search box and its filter row straight out of the layout. */
+async function measureFilterBar(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const input = document.querySelector<HTMLElement>(
+      'input[placeholder^="Search"]',
+    );
+    if (!input) throw new Error("no search box on the page");
+
+    // The filter row is the nearest flex ancestor holding more than the search
+    // box alone — i.e. the row the search box shares with the filters.
+    let row: HTMLElement | null = null;
+    for (let el = input.parentElement; el; el = el.parentElement) {
+      if (getComputedStyle(el).display === "flex" && el.children.length > 1) {
+        row = el;
+        break;
+      }
+    }
+    if (!row) throw new Error("search box is not in a filter row");
+
+    const rowRect = row.getBoundingClientRect();
+    const clipped: string[] = [];
+    for (const child of Array.from(row.children)) {
+      const r = child.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) continue;
+      if (Math.round(r.right - rowRect.right) > 0) {
+        clipped.push((child.textContent ?? "").replace(/\s+/g, " ").trim());
+      }
+    }
+
+    return {
+      searchWidth: input.getBoundingClientRect().width,
+      rowWidth: rowRect.width,
+      clipped,
+    };
+  });
+}
+
+test.describe("List filter bar at a phone width", () => {
+  test("the search box keeps room to show what was typed", async ({
+    agentsPage,
+    page,
+  }) => {
+    await agentsPage.goto();
+    await expect(agentsPage.heading).toBeVisible();
+    await expect(page.locator('input[placeholder^="Search"]')).toBeVisible();
+
+    const { searchWidth, rowWidth } = await measureFilterBar(page);
+
+    // Collapsed, the box was the magnifier and its padding — about a sixth of
+    // the row. Filling its own line, it is the whole row. Half is far outside
+    // either case, so this pins the behaviour without pinning the layout.
+    expect(searchWidth).toBeGreaterThan(rowWidth / 2);
+  });
+
+  test("no filter is clipped off the side of the row", async ({
+    agentsPage,
+    page,
+  }) => {
+    await agentsPage.goto();
+    await expect(agentsPage.heading).toBeVisible();
+    await expect(page.locator('input[placeholder^="Search"]')).toBeVisible();
+
+    const { clipped } = await measureFilterBar(page);
+
+    expect(clipped).toEqual([]);
+  });
+});


### PR DESCRIPTION
On a phone, a list page's filter bar packed the search box, the scope/label selects and the status select onto one row that could not wrap. The selects hold fixed widths, so the search box absorbed the whole shortfall and collapsed to its magnifier — still focusable, and the keyboard still opened, but with no room left to see or edit what had been typed, while the filters past it were clipped off the side of the screen.

Measured on the agents page at 360px: the search box was **50px** wide (14px of text room behind the magnifier) and "Active" laid out past the row. It is now **312px** — the full content column — with the filters stacked underneath and nothing clipped.

The row now wraps. `SearchInput` already asks for the full width below `sm`, so it takes a line of its own and the filters fall beneath it; an A/B at 1440px is identical with and without the wrap, so the desktop layout is untouched.

Two rows needed more than wrapping to move:

- Roles lays its search box out with `flex-1`, which sizes from a zero basis and so never breaks the line however little room is left — a min-width is what makes it wrap.
- Teams lays its row out shrink-to-fit, so the search box resolved its `w-full` against its own intrinsic width and sat at 224px of a 360px column; `flex-1` on the row lets it fill.

The two knowledge pages also pinned their search box to a fixed 370px/330px — wider than the whole content column on a 360px screen — so those widths now start at `sm`.

The guard asserts geometry rather than styling: the search box must keep more than half its row, and no filter may lay out past the row's edge. A class-name check would have passed throughout the bug, because the classes were reasonable and only the arithmetic was wrong. It follows the `mcp-registry-layout` spec's precedent. Mocking `/api/members/default-agent` goes with it — the agents list asks for the caller's personal default agent, and unmocked that request reaches the real backend and trips the suite's leak guard.

Verified live at 360px on agents, MCP gateways, LLM proxies, the MCP registry and teams. The two knowledge pages carry the same change but could not be exercised on a fresh stack, which shows their onboarding empty state instead of the toolbar.

Task: T-1128

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>