### PR TITLE
fix(settings): stop the selected theme's checkmark overlapping its label

### DIFF
--- a/platform/frontend/src/app/settings/appearance/_components/theme-selector.tsx
+++ b/platform/frontend/src/app/settings/appearance/_components/theme-selector.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { OrganizationTheme } from "@archestra/shared";
-import { Check } from "lucide-react";
 import { WithPermissions } from "@/components/roles/with-permissions";
 import { SettingsCardHeader } from "@/components/settings/settings-block";
 import { Button } from "@/components/ui/button";
@@ -62,14 +61,18 @@ function ThemeOption({
   onClick,
   disabled,
 }: ThemeOptionProps) {
+  // Selection is the filled variant plus `aria-pressed`, deliberately without a
+  // corner check: an icon positioned over a centered, full-width label lands on
+  // the glyphs of any name wide enough to reach the tile edge, and the widest
+  // name — "Caffeine (Default)" — is also the default selection.
   return (
     <Button
       variant={isSelected ? "default" : "outline"}
-      className="h-auto p-3 flex-col items-center gap-2 relative w-full"
+      className="h-auto p-3 flex-col items-center gap-2 w-full"
       onClick={onClick}
       disabled={disabled}
+      aria-pressed={isSelected}
     >
-      {isSelected && <Check className="h-4 w-4 absolute top-2 right-2" />}
       <span className="text-sm font-medium text-center w-full">
         {theme.name}
       </span>


### PR DESCRIPTION
## What

The Color Theme tiles in Settings → Appearance marked the selected theme with a `Check` pinned at `absolute top-2 right-2` over a centered, full-width label. The icon reserves no space, so any theme name wide enough to reach the tile edge runs underneath it — the tick is drawn straight through the glyphs.

Measured headless at four phone widths: at 412×915 the default selection `"Caffeine (Default)"` overlapped by **10.8px**, at 430×932 by 6.3px. That name is the worst case twice over — `themes.ts` appends `" (Default)"` to the default theme, making it the widest label in the grid *and* the one selected in every fresh organization. It is not only the default: at 360/390 the label wraps and escapes, but Vintage Paper, Modern Minimal and Cosmic Night collide there if selected.

The tile already flips to the filled `default` button variant when selected, so the icon was redundant for sighted users — and being a bare lucide SVG it carried no accessible name, so selection was not exposed to assistive tech at all. This drops the icon and marks the button `aria-pressed`, which is what the sibling theme picker in `sidebar-user-menu.tsx` already does.

Reserving label width instead would have fixed the overlap too, but at the cost of wrapping long names earlier on every tile; measured tile geometry is now identical before and after at 360/390/412/430px.

## Why

Reported from a phone: the tick reads as a stray slash through "(Default)". Internal task T-1127.

## Testing

- Reproduced and verified on a dev stack with headless Chromium at 360×800, 390×844, 412×915 and 430×932: overlap 10.8px → 0 and 6.3px → 0, no reflow, no earlier wrapping.
- `pnpm type-check` (frontend), biome clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>