### PR TITLE
fix(knowledge): keep retrieved-image parts to model-facing callers, inline base64 for the rest

### DIFF
--- a/platform/backend/src/archestra-mcp-server/knowledge-management.test.ts
+++ b/platform/backend/src/archestra-mcp-server/knowledge-management.test.ts
@@ -181,6 +181,131 @@ describe("knowledge-management tool execution", () => {
       querySpy.mockRestore();
     });
 
+    test("hands a media chunk to a raw MCP caller inline, as the stored data URL", async ({
+      makeAgent,
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeKnowledgeBase,
+      makeKnowledgeBaseConnector,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id, { role: "admin" });
+      const kb = await makeKnowledgeBase(org.id);
+      await makeKnowledgeBaseConnector(kb.id, org.id);
+
+      const agentWithKb = await makeAgent({
+        name: "Agent With KB (raw caller)",
+        organizationId: org.id,
+        knowledgeBaseIds: [kb.id],
+      });
+
+      const payload = "UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4H";
+      const querySpy = vi.spyOn(queryService, "query").mockResolvedValueOnce([
+        {
+          chunkId: "chunk-media",
+          content: "[image: lobsters.webp (image/webp)]",
+          score: 0.9,
+          media: { kind: "image", mimeType: "image/webp", data: payload },
+        },
+      ] as any);
+
+      // The gateway's context (routes/mcp-gateway/utils.ts) sets no
+      // `deliversMediaAsImageParts` — an external MCP client gets the payload
+      // where this tool has always put it, not as an image part it never
+      // asked for.
+      const result = await executeArchestraTool(
+        t("query_knowledge_sources"),
+        { query: "lobsters" },
+        {
+          agent: { id: agentWithKb.id, name: agentWithKb.name },
+          organizationId: org.id,
+          userId: user.id,
+        },
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toHaveLength(1);
+      expect(result.content.every((part: any) => part.type === "text")).toBe(
+        true,
+      );
+
+      const parsed = JSON.parse((result.content[0] as any).text);
+      expect(parsed.results[0].content).toBe(
+        `data:image/webp;base64,${payload}`,
+      );
+      expect(parsed.results[0].media).toBeUndefined();
+      expect((result.structuredContent as any).results[0].content).toBe(
+        `data:image/webp;base64,${payload}`,
+      );
+      // The media escape hatch belongs to the image-part path only.
+      expect(parsed.citationInstruction).toBe(QUOTE_CITATION_INSTRUCTION);
+
+      querySpy.mockRestore();
+    });
+
+    test("hands a media chunk to the chat pipeline as an image part with a descriptor", async ({
+      makeAgent,
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeKnowledgeBase,
+      makeKnowledgeBaseConnector,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id, { role: "admin" });
+      const kb = await makeKnowledgeBase(org.id);
+      await makeKnowledgeBaseConnector(kb.id, org.id);
+
+      const agentWithKb = await makeAgent({
+        name: "Agent With KB (chat caller)",
+        organizationId: org.id,
+        knowledgeBaseIds: [kb.id],
+      });
+
+      const payload = "UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4H";
+      const querySpy = vi.spyOn(queryService, "query").mockResolvedValueOnce([
+        {
+          chunkId: "chunk-media",
+          content: "[image: lobsters.webp (image/webp)]",
+          score: 0.9,
+          media: { kind: "image", mimeType: "image/webp", data: payload },
+        },
+      ] as any);
+
+      const result = await executeArchestraTool(
+        t("query_knowledge_sources"),
+        { query: "lobsters" },
+        {
+          agent: { id: agentWithKb.id, name: agentWithKb.name },
+          organizationId: org.id,
+          userId: user.id,
+          deliversMediaAsImageParts: true,
+        },
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toHaveLength(2);
+      expect(result.content[1]).toEqual({
+        type: "image",
+        data: payload,
+        mimeType: "image/webp",
+      });
+
+      const parsed = JSON.parse((result.content[0] as any).text);
+      expect(parsed.results[0].content).toBe(
+        "[image: lobsters.webp (image/webp)]",
+      );
+      expect((result.content[0] as any).text).not.toContain(payload);
+      expect(parsed.results[0].media).toBeUndefined();
+      expect(parsed.citationInstruction).toContain(QUOTE_CITATION_INSTRUCTION);
+      expect(parsed.citationInstruction).not.toBe(QUOTE_CITATION_INSTRUCTION);
+
+      querySpy.mockRestore();
+    });
+
     test("omits the citation instruction when quote verification is disabled", async ({
       makeAgent,
       makeOrganization,

--- a/platform/backend/src/archestra-mcp-server/knowledge-management.ts
+++ b/platform/backend/src/archestra-mcp-server/knowledge-management.ts
@@ -692,11 +692,20 @@ async function handleQueryKnowledgeSources(params: {
     // the same flag as the verification pass — disabling the feature must also
     // stop asking the model to quote, not just skip the check. Omitted for an
     // empty result — there is nothing to quote.
-    // A media chunk's payload never goes into the JSON text: a 180KB base64
-    // image is ~45-60k tokens the model cannot read anyway. It rides as an MCP
-    // image part instead, so a vision-capable model actually sees the picture,
-    // while `content` keeps the short "[image: title (mime)]" descriptor for
-    // models (and transports) that cannot take one.
+    // How a media chunk's payload leaves this tool depends on who is asking.
+    //
+    // A caller that feeds the result to a model through the chat pipeline gets
+    // the payload as an MCP image part, with `content` keeping only the short
+    // "[image: title (mime)]" descriptor: a 180KB base64 blob is ~45-60k tokens
+    // the model cannot read anyway, and that pipeline bounds, strips and
+    // persists the part properly.
+    //
+    // Everyone else — an external MCP client on the gateway, the app proxy —
+    // gets the chunk exactly as it is stored and as this tool has always
+    // returned it: the `data:<mime>;base64,<payload>` URL inline in
+    // `results[].content`. Those surfaces hand the result straight back to
+    // their caller, so an image part would be a wire-contract change for a
+    // client that never asked for one.
     const imageParts: Array<{
       type: "image";
       data: string;
@@ -705,6 +714,9 @@ async function handleQueryKnowledgeSources(params: {
     const wireResults = results.map((result) => {
       if (!result.media) return result;
       const { media, ...rest } = result;
+      if (!context.deliversMediaAsImageParts) {
+        return { ...rest, content: toMediaDataUrl(media) };
+      }
       if (
         imageParts.length < MAX_INLINE_RESULT_IMAGES &&
         media.data.length <= MAX_INLINE_RESULT_IMAGE_BASE64_CHARS
@@ -1584,6 +1596,16 @@ async function findManageableConnector(params: {
  */
 const MEDIA_CITATION_NOTE =
   "Results whose content reads `[image: ...]` are pictures, delivered as image attachments on this tool result — describe them from what you see and cite them by ref instead of quoting.";
+
+/**
+ * Rebuild the stored data URL for a caller that takes its payloads inline.
+ * `queryService` splits a media chunk into a descriptor plus `media` for the
+ * image-part path; joining them back is exactly the string the chunk holds
+ * (`chunk-and-store.ts` writes `data:<mime>;base64,<data>`).
+ */
+function toMediaDataUrl(media: { mimeType: string; data: string }): string {
+  return `data:${media.mimeType};base64,${media.data}`;
+}
 
 /** At most this many retrieved images ride along as inline image parts. */
 const MAX_INLINE_RESULT_IMAGES = 3;

--- a/platform/backend/src/archestra-mcp-server/types.ts
+++ b/platform/backend/src/archestra-mcp-server/types.ts
@@ -122,4 +122,18 @@ export interface ArchestraContext {
    * its content permanently.
    */
   lockedChatAudit?: LockedChatAuditContext | null;
+  /**
+   * The caller feeds this tool result to a model through the chat tool
+   * pipeline, which bounds, strips and persists inline images
+   * (`chat-tool-builder.ts` for the model-bound copy,
+   * `strip-images-from-messages.ts` for the persisted one).
+   *
+   * Only such a caller may be handed binary payloads as MCP image parts. Raw
+   * MCP/API surfaces — the gateway serving an external client, the app proxy —
+   * hand a tool result back verbatim with none of that machinery, so for them a
+   * payload must stay where it has always been: inside the JSON, as the data
+   * URL the chunk is stored as. Optional and read as false when absent, so a
+   * new call site is image-free until it opts in deliberately.
+   */
+  deliversMediaAsImageParts?: boolean;
 }

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -289,6 +289,11 @@ export function buildMcpGatewayTool(params: {
                 // needs the caller's ancestors for the executor's cycle check.
                 delegationChain: ctx.delegationChain,
                 approvalRequiredPoliciesHandled: true,
+                // Every runner that drives an agent lands here — web
+                // chat, A2A, ChatOps, schedule triggers, incoming email
+                // — and all of them put the result through this file's
+                // bounded media extraction before a model sees it.
+                deliversMediaAsImageParts: true,
                 // LockedChat: a run_tool dispatch persists via mcpClient, so
                 // its stored row needs the same treatment as a direct call —
                 // encrypted under the conversation key, not redacted.

--- a/platform/backend/src/routes/mcp-gateway/knowledge-media.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/knowledge-media.test.ts
@@ -1,0 +1,127 @@
+import {
+  ARCHESTRA_MCP_SERVER_NAME,
+  MCP_SERVER_TOOL_NAME_SEPARATOR,
+} from "@archestra/shared";
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { vi } from "vitest";
+import { queryService } from "@/knowledge-base";
+import { UserTokenModel } from "@/models";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import mcpGatewayRoutes from "./index";
+
+/**
+ * An external MCP client reaches `query_knowledge_sources` through this route,
+ * and whatever the tool puts on `content` is handed back to it verbatim. So the
+ * decision "may this caller be given binary payloads as MCP image parts" has to
+ * hold at the route, not just at the tool: these tests drive the real HTTP
+ * surface rather than `executeArchestraTool`, because the gateway building its
+ * context without `deliversMediaAsImageParts` is the whole mechanism.
+ */
+
+const IMAGE_PAYLOAD = "UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4H";
+const MIME = "image/webp";
+
+function makeMcpHeaders(token: string): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    authorization: `Bearer ${token}`,
+  };
+}
+
+describe("MCP gateway knowledge media payloads", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    await app.register(mcpGatewayRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test("returns a retrieved image inline as its data URL, never as an image part", async ({
+    makeAgent,
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    const kb = await makeKnowledgeBase(org.id);
+    await makeKnowledgeBaseConnector(kb.id, org.id);
+    const agent = await makeAgent({
+      name: "Gateway KB Agent",
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      knowledgeBaseIds: [kb.id],
+      accessAllTools: true,
+    });
+    const token = await UserTokenModel.create(user.id, org.id);
+
+    // The query service always splits a media chunk into descriptor + payload;
+    // who gets which shape is decided downstream of it.
+    const querySpy = vi.spyOn(queryService, "query").mockResolvedValueOnce([
+      {
+        content: `[image: lobsters.webp (${MIME})]`,
+        score: 0.95,
+        chunkIndex: 0,
+        metadata: {},
+        ref: "doc-1#0",
+        citation: {
+          title: "lobsters.webp",
+          sourceUrl: null,
+          documentId: "doc-1",
+          sourceId: null,
+          connectorType: "jira",
+        },
+        media: { kind: "image", mimeType: MIME, data: IMAGE_PAYLOAD },
+      },
+    ] as never);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders(token.value),
+      payload: {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          name: `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}query_knowledge_sources`,
+          arguments: { query: "lobsters" },
+        },
+        id: 2,
+      },
+    });
+    querySpy.mockRestore();
+
+    const content = response.json().result.content as Array<{
+      type: string;
+      text?: string;
+    }>;
+
+    // One text block — an external client's parser is not handed a content
+    // block kind it never saw from this tool before.
+    expect(content).toHaveLength(1);
+    expect(content[0].type).toBe("text");
+
+    const parsed = JSON.parse(content[0].text as string);
+    expect(parsed.results[0].content).toBe(
+      `data:${MIME};base64,${IMAGE_PAYLOAD}`,
+    );
+    // `media` is an internal carrier between the query service and this
+    // decision; it must not reach the wire in either shape.
+    expect(parsed.results[0].media).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

#7355 moved a retrieved image's payload out of `query_knowledge_sources`' JSON and onto the tool result as an MCP image part, with `content` keeping a short `[image: title (mime)]` descriptor. That was unconditional, so it changed the wire contract for callers that never asked for it: an external MCP client on the gateway, or the MCP app proxy, hands a tool result straight back to its caller and suddenly got `{type:"image"}` blocks where the payload had always been a `data:<mime>;base64,<payload>` URL in `results[].content`.

The image part is only safe where the chat tool pipeline follows it — that pipeline is what bounds it for the model (`chat-tool-builder.ts`, 2 images / 2M base64 chars), strips it from the model-bound copy and preserves it on the persisted one (`strip-images-from-messages.ts`). Nothing downstream of the gateway does any of that.

So the choice now rides on the tool context as `deliversMediaAsImageParts`, set at the one construction site whose results reach a model through that pipeline (`chat-tool-builder.ts` — web chat, and equally A2A, ChatOps, schedule triggers and incoming email, which all land on the same literal). It is optional and read as false when absent, so every raw MCP/API surface returns the pre-#7355 shape without having to know the flag exists, and a new call site is image-free until it opts in deliberately. `run_tool` forwards the caller's context by reference, so it inherits the right behavior on both sides.

Chat is deliberately untouched: descriptor in the text, payload as an image part, the picture still rendered beside its sources and still there after a reload.

## Why

Two surfaces, two different needs. A model-facing caller wants the picture out of the text — 180KB of base64 is ~45-60k tokens it cannot read anyway. An API caller wants the response shape it has always parsed. Restoring the old shape for everyone would have put the base64 back into the prompt on the tool turn *and* every replayed turn, and dropped the size caps, which are all keyed on image blocks.

## Testing

- Two tool-level tests in `knowledge-management.test.ts` (raw caller → data URL inline, no image part, no internal `media` key; chat caller → descriptor + image part + the media citation note).
- One route-level test, `mcp-gateway/knowledge-media.test.ts`, driving `POST /v1/mcp/:agentId` as an external client would, because the gateway building its context without the flag is the whole mechanism.
- Each of the three proven by deleting the gate and watching them fail.
- 228 tests across the affected suites (`knowledge-management`, `knowledge-media`, `chat-mcp-client`, `run-tool`), `pnpm type-check`, `pnpm knip`, biome clean.

Follow-up to T-1044 / #7163.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>