### PR TITLE
fix(settings): keep the save bar floating for the whole settings page

### DIFF
--- a/platform/frontend/src/components/settings/settings-block.test.tsx
+++ b/platform/frontend/src/components/settings/settings-block.test.tsx
@@ -1,6 +1,14 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { SettingsCardHeader } from "./settings-block";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import {
+  SettingsCardHeader,
+  SettingsSaveBar,
+  SettingsSectionStack,
+} from "./settings-block";
+
+vi.mock("@/lib/auth/auth.query");
 
 describe("SettingsCardHeader", () => {
   it("adds spacing between the title and description", () => {
@@ -26,5 +34,84 @@ describe("SettingsCardHeader", () => {
 
     expect(container.querySelector(".items-center")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Reset" })).toBeVisible();
+  });
+});
+
+describe("SettingsSaveBar", () => {
+  beforeEach(() => {
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+      isPending: false,
+    } as ReturnType<typeof useHasPermissions>);
+  });
+
+  const renderStack = (ui: React.ReactNode) =>
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <SettingsSectionStack>{ui}</SettingsSectionStack>
+      </QueryClientProvider>,
+    );
+
+  const bar = (label: string) => (
+    <SettingsSaveBar
+      hasChanges
+      isSaving={false}
+      permissions={{ organizationSettings: ["update"] }}
+      onSave={() => {}}
+      onCancel={() => {}}
+      key={label}
+    />
+  );
+
+  it("renders nothing until there is something to save", () => {
+    const { container } = renderStack(
+      <SettingsSaveBar
+        hasChanges={false}
+        isSaving={false}
+        permissions={{ organizationSettings: ["update"] }}
+        onSave={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    // The slot collapses rather than leaving a gap at the foot of the page.
+    expect(container.querySelector(".sticky")?.childElementCount ?? 0).toBe(0);
+  });
+
+  it("floats at the foot of the stack, not where the page declared it", () => {
+    // A page that declares its save bar between two sections — the shape that
+    // stopped the bar floating, because `position: sticky` only lifts a box
+    // that would otherwise fall below the viewport.
+    const { container } = renderStack(
+      <>
+        <div data-testid="first-section" />
+        {bar("page")}
+        <div data-testid="trailing-section" />
+      </>,
+    );
+
+    const stack = container.firstElementChild as HTMLElement;
+    const last = stack.lastElementChild as HTMLElement;
+
+    expect(last.className).toContain("sticky");
+    expect(last).toContainElement(screen.getByRole("button", { name: "Save" }));
+    expect(
+      screen.getByTestId("trailing-section").compareDocumentPosition(last),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("stacks two bars in one slot instead of piling them at the same offset", () => {
+    renderStack(
+      <>
+        {bar("first")}
+        <div data-testid="between" />
+        {bar("second")}
+      </>,
+    );
+
+    const saves = screen.getAllByRole("button", { name: "Save" });
+    expect(saves).toHaveLength(2);
+    expect(saves[0].closest(".sticky")).toBe(saves[1].closest(".sticky"));
   });
 });

--- a/platform/frontend/src/components/settings/settings-block.tsx
+++ b/platform/frontend/src/components/settings/settings-block.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import type { Permissions } from "@archestra/shared";
 import type { ReactNode } from "react";
+import { createContext, useContext, useState } from "react";
+import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -88,10 +92,12 @@ export function SettingsSaveBar({
   onCancel,
   disabledSave,
 }: SettingsSaveBarProps) {
+  const slot = useContext(SaveBarSlotContext);
+
   if (!hasChanges) return null;
 
-  return (
-    <div className="flex gap-3 sticky bottom-4 bg-background p-4 rounded-lg border border-border shadow-lg">
+  const bar = (
+    <div className="flex gap-3 bg-background p-4 rounded-lg border border-border shadow-lg">
       <PermissionButton
         permissions={permissions}
         onClick={onSave}
@@ -104,6 +110,15 @@ export function SettingsSaveBar({
       </Button>
     </div>
   );
+
+  // Inside a stack the bar belongs to the stack's slot, not to wherever the
+  // page declared it. Outside one there is nothing to move it into, so it
+  // sticks from where it stands.
+  return slot ? (
+    createPortal(bar, slot)
+  ) : (
+    <div className="sticky bottom-4 z-10">{bar}</div>
+  );
 }
 
 interface SettingsSectionStackProps {
@@ -115,5 +130,31 @@ export function SettingsSectionStack({
   children,
   className,
 }: SettingsSectionStackProps) {
-  return <div className={cn("space-y-5", className)}>{children}</div>;
+  const [slot, setSlot] = useState<HTMLDivElement | null>(null);
+
+  return (
+    <div className={cn("space-y-5", className)}>
+      <SaveBarSlotContext.Provider value={slot}>
+        {children}
+      </SaveBarSlotContext.Provider>
+      {/* Every save bar on the page renders here rather than at its own place
+          in the stack. `position: sticky` with a `bottom` offset only lifts a
+          box that would otherwise fall below the viewport, so a bar declared
+          between two sections floats only until you scroll level with it and
+          then rides away with the section above — and a second bar declared
+          further down pins to the same offset and covers it. One slot at the
+          end of the stack keeps every bar floating for the whole page and
+          stacks them instead. */}
+      <div
+        ref={setSlot}
+        className="sticky bottom-4 z-10 space-y-3 empty:hidden"
+      />
+    </div>
+  );
 }
+
+/**
+ * The stack's save-bar slot, or null for a bar rendered outside any stack.
+ * Read by {@link SettingsSaveBar}; there is nothing for a page to set.
+ */
+const SaveBarSlotContext = createContext<HTMLDivElement | null>(null);


### PR DESCRIPTION
## Problem

On `/settings/agents` the save bar doesn't float — it sits stranded between the **Chat File Uploads** and **Available messaging channels** cards instead of hugging the bottom edge.

`SettingsSaveBar` is `position: sticky; bottom: 1rem`. Sticky with a `bottom` offset only lifts a box that would *otherwise fall below the viewport*; once you scroll level with the bar's place in the flow, it stops being lifted and rides up and away with the section above it. So a bar declared mid-stack floats near the top of the page and then quietly leaves.

Three pages render content after their save bar and are affected:

| page | what follows the bar |
| --- | --- |
| `/settings/agents` | `IntegrationAvailabilitySection` (messaging channels) |
| `/settings/knowledge` | `IntegrationAvailabilitySection` (connectors) |
| `/settings/llm` | `DefaultUserLimitsSection`, `ModelProvidersSection` |

`appearance`, `auth`, `mcp`, `skills`, `apps` and `security` already have the bar as their last child and are unaffected; the service-account detail page has only dialogs after it, which contribute nothing in flow.

`/settings/llm` is the worst of the three. Distance from the Save button to the bottom of the scrollport, unsaved change pending, 960px viewport:

| scroll | before | after |
| --- | --- | --- |
| 0% | 434px | 33px |
| 25% | 728px | 33px |
| 50% | **1022px — off-screen** | 33px |
| 75% | **1315px — off-screen** | 33px |
| 100% | **1609px — off-screen** | 89px, below the last card |

Scroll halfway down `/settings/llm` with an unsaved change and the Save button is simply gone.

Second, related defect: where a page carries two bars — its own plus the one `IntegrationAvailabilitySection` brings — both pin to the same `bottom-4` offset and render on top of each other (measured: identical rects).

## Fix

`SettingsSectionStack` now owns a single sticky slot as its last child, and `SettingsSaveBar` portals into it. Because the slot is genuinely last, it stays pinned across the page's whole scroll range, and two bars stack inside it (`space-y-3`) instead of overlapping. The slot is `empty:hidden`, so it costs no layout when nothing is dirty.

A bar rendered outside any stack (the connection settings form) keeps the old inline sticky behaviour, which is already correct there since it's last in its own container.

Portaling moves the real DOM node rather than reordering visually, so focus order continues to match reading order.

## Verification

- Reproduced and fixed in the running app on `/settings/agents` and `/settings/llm` (MSW-backed frontend) — every number above is measured from the real page via `getBoundingClientRect()`, before and after, same page and same edit.
- Three new tests in `settings-block.test.tsx`: the bar lands at the foot of the stack rather than where it was declared, two bars share one slot, and the slot collapses when there's nothing to save. All three fail against the pre-fix component.
- `pnpm type-check` clean; `pnpm lint` unchanged from the baseline on `main` (8 pre-existing warnings, none in the touched file).
- `vitest run src/app/settings src/components/settings` — 205 passed / 23 files.