### PR TITLE
fix(llm-models): disambiguate colliding model names at read time

### DIFF
--- a/platform/backend/src/routes/llm-provider-models.test.ts
+++ b/platform/backend/src/routes/llm-provider-models.test.ts
@@ -181,6 +181,76 @@ describe("chat model routes", () => {
     ]);
   });
 
+  test("GET /api/llm-models/available disambiguates stored names that still collide", async ({
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    // Rows written before sync-time name disambiguation existed — or refreshed
+    // by a key whose catalog lists only one member of the pair — still share a
+    // description in the database. The response must tell them apart anyway.
+    const secret = await makeSecret({ secret: { apiKey: "test-key" } });
+    const apiKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+      provider: "openai",
+      scope: "personal",
+      userId: user.id,
+    });
+
+    const base = {
+      provider: "openai" as const,
+      contextLength: 128_000,
+      inputModalities: ["text" as const],
+      outputModalities: ["text" as const],
+      supportsToolCalling: true,
+      promptPricePerToken: "0.000001",
+      completionPricePerToken: "0.000002",
+      ignored: false,
+      lastSyncedAt: new Date(),
+    };
+    const models = await Promise.all([
+      ModelModel.create({
+        ...base,
+        externalId: "openai/gpt-4.1",
+        modelId: "gpt-4.1",
+        description: "GPT-4.1",
+      }),
+      ModelModel.create({
+        ...base,
+        externalId: "openai/gpt-4.1-2025-04-14",
+        modelId: "gpt-4.1-2025-04-14",
+        description: "GPT-4.1",
+      }),
+      ModelModel.create({
+        ...base,
+        externalId: "openai/gpt-4.1-mini",
+        modelId: "gpt-4.1-mini",
+        description: "GPT-4.1 mini",
+      }),
+    ]);
+
+    await LlmProviderApiKeyModelLinkModel.syncModelsForApiKey(
+      apiKey.id,
+      models.map((model) => ({ id: model.id, modelId: model.modelId })),
+      "openai",
+    );
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/llm-models/available",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const displayNamesById = Object.fromEntries(
+      response
+        .json<Array<{ id: string; displayName: string }>>()
+        .map((model) => [model.id, model.displayName]),
+    );
+    expect(displayNamesById).toEqual({
+      "gpt-4.1": "GPT-4.1",
+      "gpt-4.1-2025-04-14": "GPT-4.1 (2025-04-14)",
+      "gpt-4.1-mini": "GPT-4.1 mini",
+    });
+  });
+
   test("GET /api/llm-models/available?isEmbedding=true only returns embedding models with configured dimensions", async ({
     makeSecret,
     makeLlmProviderApiKey,

--- a/platform/backend/src/routes/llm-provider-models.ts
+++ b/platform/backend/src/routes/llm-provider-models.ts
@@ -33,7 +33,10 @@ import {
   TeamModel,
 } from "@/models";
 import { getSecretValueForLlmProviderApiKey } from "@/secrets-manager";
-import { modelSyncService } from "@/services/model-sync";
+import {
+  modelSyncService,
+  withDistinctDisplayNames,
+} from "@/services/model-sync";
 import { systemKeyManager } from "@/services/system-key-manager";
 import {
   ApiError,
@@ -278,7 +281,11 @@ const llmModelsRoutes: FastifyPluginAsyncZod = async (fastify) => {
         "Returning available LLM models from database",
       );
 
-      return reply.send(visibleModels);
+      // Stored descriptions can still collide at read time — rows synced
+      // before names were disambiguated, or keys whose catalogs each contain
+      // only one member of a colliding pair — so the response gets its own
+      // pass to keep picker rows tellable-apart.
+      return reply.send(withDistinctDisplayNames(visibleModels));
     },
   );
 

--- a/platform/backend/src/services/model-sync.test.ts
+++ b/platform/backend/src/services/model-sync.test.ts
@@ -14,6 +14,7 @@ import {
   buildModelsToUpsert,
   modelSyncService,
   resolveModelCapabilities,
+  withDistinctDisplayNames,
 } from "./model-sync";
 
 // Mock only the network boundary (the client singleton's fetch); keep the real
@@ -1462,6 +1463,47 @@ describe("ModelSyncService", () => {
     expect(built.map((model) => model.description)).toEqual([
       "Foo Bar (foo-bar)",
       "Foo Bar (foo.bar)",
+    ]);
+  });
+});
+
+describe("withDistinctDisplayNames", () => {
+  test("suffixes response rows that share a display name within one provider", () => {
+    // The read-time counterpart of the sync-time pass: stored descriptions can
+    // still collide (rows synced before names were disambiguated, or keys
+    // whose catalogs each contain only one member of the pair).
+    const models = withDistinctDisplayNames([
+      { id: "gpt-4.1", provider: "openai" as const, displayName: "GPT-4.1" },
+      {
+        id: "gpt-4.1-2025-04-14",
+        provider: "openai" as const,
+        displayName: "GPT-4.1",
+      },
+      {
+        id: "gpt-4.1-mini",
+        provider: "openai" as const,
+        displayName: "GPT-4.1 mini",
+      },
+    ]);
+
+    expect(models.map((model) => model.displayName)).toEqual([
+      "GPT-4.1",
+      "GPT-4.1 (2025-04-14)",
+      "GPT-4.1 mini",
+    ]);
+  });
+
+  test("a name shared across providers is not a collision", () => {
+    // The UI groups the list by provider, so these are never shown side by
+    // side under one name — and their ids only mean anything per provider.
+    const models = withDistinctDisplayNames([
+      { id: "gpt-4o", provider: "openai" as const, displayName: "GPT-4o" },
+      { id: "gpt-4o", provider: "azure" as const, displayName: "GPT-4o" },
+    ]);
+
+    expect(models.map((model) => model.displayName)).toEqual([
+      "GPT-4o",
+      "GPT-4o",
     ]);
   });
 });

--- a/platform/backend/src/services/model-sync.ts
+++ b/platform/backend/src/services/model-sync.ts
@@ -421,6 +421,65 @@ export function buildModelsToUpsert(params: {
 }
 
 /**
+ * Give every model in a picker response a display name of its own, using the
+ * same suffix convention as the sync-time pass below.
+ *
+ * The sync-time pass alone can't guarantee distinct names at read time: it
+ * only sees one API key's catalog per sync, while `models` rows are global.
+ * Two keys of the same provider can serve different subsets — one catalog
+ * lists only `gpt-4.1`, another lists it beside `gpt-4.1-2025-04-14` — so a
+ * sync can refresh one member of a colliding pair without ever seeing the
+ * other, and rows written before the sync-time pass existed keep their
+ * colliding names until their next sync. This pass runs on what a response
+ * actually offers side by side, so the picker never renders two rows a user
+ * can't tell apart, whatever vintage the stored names are.
+ *
+ * Grouped per provider: model ids are only unique within a provider, and the
+ * UI groups the list by provider, so a name shared across providers (openai
+ * and azure both serving "GPT-4o") is not a collision.
+ */
+export function withDistinctDisplayNames<
+  T extends {
+    /** The provider-facing model id (`gpt-4.1-2025-04-14`). */
+    id: string;
+    provider: SupportedProvider;
+    displayName: string;
+  },
+>(models: T[]): T[] {
+  const entriesByProvider = new Map<
+    SupportedProvider,
+    Array<{ modelId: string; name: string }>
+  >();
+  for (const { provider, id, displayName } of models) {
+    const entries = entriesByProvider.get(provider);
+    const entry = { modelId: id, name: displayName };
+    if (entries) {
+      entries.push(entry);
+    } else {
+      entriesByProvider.set(provider, [entry]);
+    }
+  }
+
+  const suffixesByProvider = new Map<SupportedProvider, Map<string, string>>();
+  for (const [provider, entries] of entriesByProvider) {
+    const suffixes = contestedNameSuffixes(entries);
+    if (suffixes.size > 0) {
+      suffixesByProvider.set(provider, suffixes);
+    }
+  }
+  if (suffixesByProvider.size === 0) {
+    return models;
+  }
+
+  return models.map((model) => {
+    const suffix = suffixesByProvider.get(model.provider)?.get(model.id);
+    return suffix
+      ? { ...model, displayName: `${model.displayName} (${suffix})` }
+      : model;
+  });
+}
+
+/**
  * Give every model in a provider's catalog a display name of its own.
  *
  * Two rows arrive sharing a name from two directions. The registry keys a model
@@ -445,41 +504,60 @@ export function buildModelsToUpsert(params: {
  * previously stored one — so a decoration can never stack up across syncs.
  */
 function withDistinctDescriptions(models: CreateModel[]): CreateModel[] {
-  const modelIdsByDescription = new Map<string, string[]>();
-  for (const { description, modelId } of models) {
-    if (!description) {
-      // A nameless row already falls back to its own id for display.
-      continue;
-    }
-    const modelIds = modelIdsByDescription.get(description);
-    if (modelIds) {
-      modelIds.push(modelId);
-    } else {
-      modelIdsByDescription.set(description, [modelId]);
-    }
-  }
-
-  const distinguishersByDescription = new Map<string, Map<string, string>>();
-  for (const [description, modelIds] of modelIdsByDescription) {
-    if (modelIds.length > 1) {
-      distinguishersByDescription.set(
-        description,
-        distinguishModelIds(modelIds),
-      );
-    }
-  }
-  if (distinguishersByDescription.size === 0) {
+  const suffixes = contestedNameSuffixes(
+    models.map(({ modelId, description }) => ({
+      modelId,
+      name: description ?? null,
+    })),
+  );
+  if (suffixes.size === 0) {
     return models;
   }
 
   return models.map((model) => {
-    const distinguisher = model.description
-      ? distinguishersByDescription.get(model.description)?.get(model.modelId)
-      : undefined;
-    return distinguisher
-      ? { ...model, description: `${model.description} (${distinguisher})` }
+    const suffix = suffixes.get(model.modelId);
+    return suffix
+      ? { ...model, description: `${model.description} (${suffix})` }
       : model;
   });
+}
+
+/**
+ * The distinguisher each contested row should be suffixed with, keyed by model
+ * id — empty for uncontested rows and for the row whose id is exactly the
+ * group's shared stem (it keeps the bare name). Callers pass one provider's
+ * rows at a time: model ids are only unique within a provider, and models from
+ * different providers are never shown side by side under one name.
+ */
+function contestedNameSuffixes(
+  entries: Array<{ modelId: string; name: string | null }>,
+): Map<string, string> {
+  const modelIdsByName = new Map<string, string[]>();
+  for (const { name, modelId } of entries) {
+    if (!name) {
+      // A nameless row already falls back to its own id for display.
+      continue;
+    }
+    const modelIds = modelIdsByName.get(name);
+    if (modelIds) {
+      modelIds.push(modelId);
+    } else {
+      modelIdsByName.set(name, [modelId]);
+    }
+  }
+
+  const suffixes = new Map<string, string>();
+  for (const modelIds of modelIdsByName.values()) {
+    if (modelIds.length <= 1) {
+      continue;
+    }
+    for (const [modelId, distinguisher] of distinguishModelIds(modelIds)) {
+      if (distinguisher) {
+        suffixes.set(modelId, distinguisher);
+      }
+    }
+  }
+  return suffixes;
 }
 
 /**


### PR DESCRIPTION
## The bug

#7372 shipped sync-time name disambiguation, but the pickers on staging still offered "o3-mini", "o3-pro", "o4-mini" (and friends) twice after it deployed.

## Why the sync-time pass wasn't enough

`withDistinctDescriptions` sees **one API key's catalog per sync**, while `models` rows are **global**. Both gaps were live on staging:

- Two same-day OpenAI syncs each wrote half of the colliding pairs: one key's `/v1/models` returned the dated snapshots (written 12:08), another key's returned only the aliases (written 19:46). Different OpenAI keys get different model subsets, so no single sync ever saw a colliding pair side by side, and the pass never fired.
- Names only self-heal on the next sync, and the lazy-sync TTL is a day for most providers — so even for a key whose catalog does contain both members, a deployed name fix lags up to a day behind.

## The fix

`GET /api/llm-models/available` — the endpoint behind every model picker — now runs its response through `withDistinctDisplayNames` before sending. It is the read-time counterpart of the sync pass, built on the same shared core (`contestedNameSuffixes` / `distinguishModelIds`), so the suffix convention is identical: the row whose id is the group's shared stem keeps the bare name, the others get the id tail they don't share — "GPT-4.1" beside "GPT-4.1 (2025-04-14)".

Two scoping choices worth calling out:

- **Grouped per provider.** Model ids are only unique within a provider, and the UI groups the picker by provider, so openai and azure both serving "GPT-4o" is not a collision.
- **Already-distinct names pass through untouched.** Once syncs have rewritten stored descriptions with #7372's suffixes, the read-time pass sees no contested name and changes nothing — no double-suffixing, idempotent by construction.

The sync-time pass stays: it keeps the stored descriptions correct for every other surface, and the read-time pass guarantees the picker regardless of the stored rows' vintage.

## Tests

- Route integration test: two linked models sharing a stored description come back with distinct `displayName`s, an uncontested sibling untouched.
- Unit tests on `withDistinctDisplayNames`: within-provider suffixing, and a name shared across providers left alone.

## Rollout

No migration, no sync needed — names are correct in the first response after deploy.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>