### PR TITLE
fix(docker): bump moby/go-archive to 0.3.0 for CVE-2026-17106

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -49,6 +49,8 @@ RUN git clone --depth 1 --branch "${DOCKER_CLI_VERSION}" https://github.com/dock
     go get go.opentelemetry.io/otel/sdk@v1.43.0 && \
     # CVE-2026-34986: go-jose uncaught exception fixed in >= 4.1.4
     go get github.com/go-jose/go-jose/v4@v4.1.4 && \
+    # CVE-2026-17106: go-archive path traversal fixed in >= 0.3.0 (vendor.mod floors it at 0.2.0)
+    go get github.com/moby/go-archive@v0.3.0 && \
     # x/sys/x/term must be pinned for `go mod vendor` to find windows/registry and plan9 sub-pkgs.
     # Versions must satisfy x/net@v0.56.0 requirements: x/sys >= v0.46.0, x/term >= v0.44.0.
     go get golang.org/x/sys@v0.46.0 && \
@@ -92,7 +94,10 @@ RUN git clone --depth 1 --branch "${DAGGER_VERSION}" https://github.com/dagger/d
     # Arrives transitively (dagger and containerd both floor it at 0.36.0), so it needs
     # an explicit requirement rather than a bump of any single dependency.
     go get golang.org/x/mod@v0.40.0 && \
-    go get github.com/moby/go-archive@v0.2.0 github.com/moby/profiles/seccomp@v0.2.3 github.com/moby/sys/reexec@v0.1.0 github.com/moby/sys/user@v0.4.0 && \
+    # cve-2026-17106: go-archive path traversal fixed in >= 0.3.0 (matches dockercompat's floor).
+    # sys/user must be >= 0.4.1 here — go-archive 0.3.0 requires it, and asking for 0.4.0 in the
+    # same `go get` would make go resolve the conflict by downgrading go-archive below 0.3.0.
+    go get github.com/moby/go-archive@v0.3.0 github.com/moby/profiles/seccomp@v0.2.3 github.com/moby/sys/reexec@v0.1.0 github.com/moby/sys/user@v0.4.1 && \
     # cve-2026-46680: containerd type confusion fixed in >= 2.2.4
     # cve-2026-53488/53492/53489: containerd injection/input-validation/symlink-following fixed in >= 2.2.5
     go get github.com/containerd/containerd/v2@v2.2.5 && \


### PR DESCRIPTION
## Summary

The merge queue's `Docker Image Scanning (Platform)` job is failing ([example run](https://github.com/archestra-ai/archestra/actions/runs/32421641452/job/96594740743)) on **CVE-2026-17106** — HIGH, path traversal in `github.com/moby/go-archive` 0.2.0, fixed in 0.3.0.

Two `go-builder` stages in `platform/Dockerfile` embed the vulnerable version:

- **docker-cli** — `vendor.mod` floors `go-archive` at 0.2.0; this PR adds an explicit `go get github.com/moby/go-archive@v0.3.0` (placed before the x/sys/x/term/x/net pins so the final x/net pin stays last).
- **dagger** — the moby pin line asked for `go-archive@v0.2.0` directly. The local `dockercompat` replace module already required 0.3.0, but the explicit 0.2.0 get was winning the resolution. Bumped to 0.3.0, and `moby/sys/user` had to rise 0.4.0 → 0.4.1 in the same `go get` — go-archive 0.3.0 requires it, and keeping the lower explicit pin would make go resolve the conflict by silently downgrading go-archive back below 0.3.0.

## Verification

Replayed both stages' exact `go get` sequences locally (module resolution is what Scout reads from the embedded build info):

- docker-cli: `go mod vendor` succeeds; `go list -m` shows `go-archive v0.3.0`, with `x/net 0.56.0`, `grpc 1.82.1`, `otel/sdk 1.43.0`, `go-jose 4.1.4`, `x/sys 0.46.0`, `x/term 0.44.0` all still at their CVE floors.
- dagger: `go mod tidy` succeeds; `go list -m` shows `go-archive v0.3.0`, with `go-git 5.19.2`, `go-billy 5.9.0`, `x/mod 0.40.0`, `containerd 2.2.5`, `grpc 1.82.1` intact (`x/net`/`x/crypto` resolve above their floors).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>