### PR TITLE
fix(gemini): reach Vertex AI models the configured region does not serve

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -115,6 +115,9 @@ archestra:
     ARCHESTRA_GEMINI_VERTEX_AI_ENABLED: "true"
     ARCHESTRA_GEMINI_VERTEX_AI_PROJECT: "friendly-path-465518-r6"
     ARCHESTRA_GEMINI_VERTEX_AI_LOCATION: "us-central1"
+    # Staging has no data-residency requirement, so it takes the global endpoint
+    # for the Gemini 3+ generations us-central1 does not serve.
+    ARCHESTRA_GEMINI_VERTEX_AI_ALLOW_GLOBAL_ENDPOINT: "true"
     ARCHESTRA_BEDROCK_BASE_URL: "https://bedrock-runtime.eu-north-1.amazonaws.com"
     ARCHESTRA_BEDROCK_INFERENCE_PROFILE_PREFIX: "eu"
     ARCHESTRA_AUTH_COOKIE_DOMAIN: ".archestra.dev"

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1217,6 +1217,13 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Example: `us-central1`, `europe-west1`, `asia-northeast1`
   - In our testing, `us-central1` and `global` returned the most reliable Gemini publisher model listings. Some regions, including `us-east1`, may return incomplete model catalogs from Vertex AI model discovery APIs.
 
+- **`ARCHESTRA_GEMINI_VERTEX_AI_ALLOW_GLOBAL_ENDPOINT`** - Use Vertex AI's global endpoint for models that only it serves.
+  - Default: `false`
+  - Vertex AI serves Gemini 3 and newer generations only from `global`. A request pinned to an ordinary region returns 404, so those models stay out of the model catalog while this is off.
+  - Set to `true` to reach them. Models the configured region serves — Gemma, `gemini-embedding-001`, the Gemini 2.5 family — keep using `ARCHESTRA_GEMINI_VERTEX_AI_LOCATION`.
+  - Leave it off when the region was chosen for data residency. The global endpoint routes to any region, and you cannot control or see which one handles a request.
+  - Has no effect when `ARCHESTRA_GEMINI_VERTEX_AI_LOCATION` is already `global`.
+
 - **`ARCHESTRA_GEMINI_VERTEX_AI_CREDENTIALS_FILE`** - Path to Google Cloud service account JSON key file.
   - Optional: Only needed when running outside of GCP or without Workload Identity
   - Example: `/path/to/service-account-key.json`

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -15,6 +15,15 @@ ARCHESTRA_ANTHROPIC_BASE_URL=https://api.anthropic.com
 # ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic.com/token
 # ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN=
 ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
+# Gemini via Vertex AI instead of Google AI Studio (uses ADC, not an API key)
+# ARCHESTRA_GEMINI_VERTEX_AI_ENABLED=true
+# ARCHESTRA_GEMINI_VERTEX_AI_PROJECT=my-gcp-project
+# ARCHESTRA_GEMINI_VERTEX_AI_LOCATION=us-central1
+# ARCHESTRA_GEMINI_VERTEX_AI_CREDENTIALS_FILE=/path/to/service-account-key.json
+# Reach models Vertex AI serves only from its global endpoint (Gemini 3 and
+# newer) while the location above still serves everything else. Leave off if the
+# region was chosen for data residency: the global endpoint picks any region.
+# ARCHESTRA_GEMINI_VERTEX_AI_ALLOW_GLOBAL_ENDPOINT=true
 # Cohere Base URL (uses https://api.cohere.ai by default)
 ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai
 # Ollama Base URL (uncomment if using Ollama)

--- a/platform/backend/src/clients/gemini-client.test.ts
+++ b/platform/backend/src/clients/gemini-client.test.ts
@@ -1,0 +1,82 @@
+import {
+  isVertexModelReachable,
+  resolveVertexLocation,
+} from "@/clients/gemini-client";
+import config from "@/config";
+import { beforeEach, describe, expect, test } from "@/test";
+
+/**
+ * A single Vertex location cannot serve the whole Gemini catalog — the 3.x
+ * generations are global-only, while Gemma MaaS and `gemini-embedding-001` are
+ * regional-only — so these two functions decide where each model is addressed
+ * and whether it can be offered at all.
+ */
+describe("Vertex AI location resolution", () => {
+  beforeEach(() => {
+    // The shared setup restores the pristine config after every test.
+    config.llm.gemini.vertexAi.location = "us-central1";
+    config.llm.gemini.vertexAi.allowGlobalEndpoint = false;
+  });
+
+  describe("with a pinned region and the global endpoint disallowed", () => {
+    test("keeps every model on the configured region", () => {
+      expect(resolveVertexLocation("gemini-2.5-pro")).toBe("us-central1");
+      // Routing a global-only model to the region would 404, but sending it to
+      // `global` unasked would move traffic out of the pinned region; the model
+      // is dropped from the catalog instead.
+      expect(resolveVertexLocation("gemini-3.5-flash")).toBe("us-central1");
+    });
+
+    test("reports global-only models as unreachable", () => {
+      expect(isVertexModelReachable("gemini-3.5-flash")).toBe(false);
+      expect(isVertexModelReachable("gemini-embedding-2")).toBe(false);
+      expect(isVertexModelReachable("gemini-2.5-pro")).toBe(true);
+      expect(isVertexModelReachable("gemini-embedding-001")).toBe(true);
+      expect(isVertexModelReachable("gemma-4-26b-a4b-it-maas")).toBe(true);
+    });
+  });
+
+  describe("with a pinned region and the global endpoint allowed", () => {
+    beforeEach(() => {
+      config.llm.gemini.vertexAi.allowGlobalEndpoint = true;
+    });
+
+    test("sends only global-only models to the global endpoint", () => {
+      expect(resolveVertexLocation("gemini-3.5-flash")).toBe("global");
+      expect(resolveVertexLocation("gemini-embedding-2")).toBe("global");
+      // Everything the region can serve stays in the region, so enabling the
+      // fallback does not relocate traffic that had no need to move.
+      expect(resolveVertexLocation("gemini-2.5-pro")).toBe("us-central1");
+      expect(resolveVertexLocation("gemini-embedding-001")).toBe("us-central1");
+      expect(resolveVertexLocation("gemma-4-26b-a4b-it-maas")).toBe(
+        "us-central1",
+      );
+    });
+
+    test("reports every model as reachable", () => {
+      expect(isVertexModelReachable("gemini-3.5-flash")).toBe(true);
+      expect(isVertexModelReachable("gemini-2.5-pro")).toBe(true);
+    });
+  });
+
+  describe("with the configured location already global", () => {
+    beforeEach(() => {
+      config.llm.gemini.vertexAi.location = "global";
+    });
+
+    test("addresses everything globally without needing the opt-in", () => {
+      expect(resolveVertexLocation("gemini-3.5-flash")).toBe("global");
+      expect(resolveVertexLocation("gemini-2.5-pro")).toBe("global");
+      expect(isVertexModelReachable("gemini-3.5-flash")).toBe(true);
+    });
+  });
+
+  test("falls back to the configured location when no model is given", () => {
+    // Catalog-listing calls are not about one model.
+    expect(resolveVertexLocation()).toBe("us-central1");
+    expect(resolveVertexLocation(null)).toBe("us-central1");
+
+    config.llm.gemini.vertexAi.allowGlobalEndpoint = true;
+    expect(resolveVertexLocation()).toBe("us-central1");
+  });
+});

--- a/platform/backend/src/clients/gemini-client.ts
+++ b/platform/backend/src/clients/gemini-client.ts
@@ -1,6 +1,10 @@
+import { requiresGlobalVertexEndpoint } from "@archestra/shared";
 import { GoogleGenAI } from "@google/genai";
 import config from "@/config";
 import logger from "@/logging";
+
+/** Vertex AI's worldwide endpoint, addressed as a location like any region. */
+export const VERTEX_GLOBAL_LOCATION = "global";
 
 /**
  * Creates a GoogleGenAI client based on configuration.
@@ -16,6 +20,11 @@ import logger from "@/logging";
  *
  * @param apiKey - API key (optional when Vertex AI is enabled)
  * @param logPrefix - Prefix for log messages (e.g., "[GeminiProxy]", "[dualLlmClient]")
+ * @param baseUrlOverride - Base URL override (API key mode only)
+ * @param modelId - Model the client will be used for, so Vertex AI mode can
+ *   pick the location that actually serves it (see {@link resolveVertexLocation}).
+ *   Omitting it keeps the configured location, which is right for
+ *   catalog-listing calls that are not about one model.
  * @returns GoogleGenAI client instance
  * @throws Error if Vertex AI is enabled but project is not set
  * @throws Error if API key is not provided when Vertex AI is disabled
@@ -24,6 +33,7 @@ export function createGoogleGenAIClient(
   apiKey: string | undefined,
   logPrefix = "[Gemini]",
   baseUrlOverride?: string | null,
+  modelId?: string | null,
 ): GoogleGenAI {
   const { vertexAi } = config.llm.gemini;
 
@@ -34,32 +44,11 @@ export function createGoogleGenAIClient(
       );
     }
 
-    const hasCredentialsFile = vertexAi.credentialsFile !== "";
-
-    logger.debug(
-      {
-        project: vertexAi.project,
-        location: vertexAi.location,
-        hasCredentialsFile,
-      },
-      `${logPrefix} Initializing GoogleGenAI with Vertex AI mode`,
+    return createVertexClientForLocation(
+      resolveVertexLocation(modelId),
+      logPrefix,
+      modelId,
     );
-
-    // Build the client config
-    // Always pass projectId in googleAuthOptions to ensure the correct GCP project is used
-    // for API calls. Without this, ADC may use a different project from the credentials.
-    // If credentialsFile is provided, also pass it via keyFilename.
-    return new GoogleGenAI({
-      vertexai: true,
-      project: vertexAi.project,
-      location: vertexAi.location,
-      googleAuthOptions: {
-        projectId: vertexAi.project,
-        ...(hasCredentialsFile && {
-          keyFilename: vertexAi.credentialsFile,
-        }),
-      },
-    });
   }
 
   // API key mode (default) - requires API key
@@ -84,8 +73,97 @@ export function createGoogleGenAIClient(
 }
 
 /**
+ * Build a Vertex AI client pinned to an explicit location, for callers that
+ * address a location directly rather than deriving one from a model — the model
+ * fetcher, which lists each location's catalog and probes candidates at the
+ * location they would actually be served from.
+ *
+ * @throws Error if Vertex AI is enabled but project is not set
+ */
+export function createVertexClientForLocation(
+  location: string,
+  logPrefix = "[Gemini]",
+  modelId?: string | null,
+): GoogleGenAI {
+  const { vertexAi } = config.llm.gemini;
+
+  if (!vertexAi.project) {
+    throw new Error(
+      "Vertex AI is enabled but ARCHESTRA_GEMINI_VERTEX_AI_PROJECT is not set",
+    );
+  }
+
+  const hasCredentialsFile = vertexAi.credentialsFile !== "";
+
+  logger.debug(
+    {
+      project: vertexAi.project,
+      location,
+      configuredLocation: vertexAi.location,
+      modelId,
+      hasCredentialsFile,
+    },
+    `${logPrefix} Initializing GoogleGenAI with Vertex AI mode`,
+  );
+
+  // Always pass projectId in googleAuthOptions to ensure the correct GCP project
+  // is used for API calls. Without this, ADC may use a different project from the
+  // credentials. If credentialsFile is provided, also pass it via keyFilename.
+  return new GoogleGenAI({
+    vertexai: true,
+    project: vertexAi.project,
+    location,
+    googleAuthOptions: {
+      projectId: vertexAi.project,
+      ...(hasCredentialsFile && {
+        keyFilename: vertexAi.credentialsFile,
+      }),
+    },
+  });
+}
+
+/**
  * Check if Vertex AI mode is enabled
  */
 export function isVertexAiEnabled(): boolean {
   return config.llm.gemini.vertexAi.enabled;
+}
+
+/**
+ * The Vertex AI location a model should be addressed at: the configured one,
+ * except for models Vertex serves only from `global` — those go to `global`
+ * when the deployment allows it.
+ *
+ * A single configured location cannot serve the whole catalog: from Gemini 3 on
+ * the generations are global-only, while Gemma MaaS and `gemini-embedding-001`
+ * are regional-only and absent from the global catalog. Resolving per model is
+ * what lets one deployment reach both sets.
+ */
+export function resolveVertexLocation(modelId?: string | null): string {
+  const { location, allowGlobalEndpoint } = config.llm.gemini.vertexAi;
+
+  if (location === VERTEX_GLOBAL_LOCATION) {
+    return location;
+  }
+  if (!modelId || !allowGlobalEndpoint) {
+    return location;
+  }
+  return requiresGlobalVertexEndpoint(modelId)
+    ? VERTEX_GLOBAL_LOCATION
+    : location;
+}
+
+/**
+ * Whether a model is reachable at all under the current Vertex configuration.
+ * False only for a global-only model on a deployment that pinned a region and
+ * has not opted into the global endpoint — the case where the catalog should
+ * leave the model out rather than advertise one every request would 404 on.
+ */
+export function isVertexModelReachable(modelId: string): boolean {
+  const { location, allowGlobalEndpoint } = config.llm.gemini.vertexAi;
+
+  if (location === VERTEX_GLOBAL_LOCATION || allowGlobalEndpoint) {
+    return true;
+  }
+  return !requiresGlobalVertexEndpoint(modelId);
 }

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -59,7 +59,10 @@ import {
   buildBedrockProvider,
   isBedrockIamAuthEnabled,
 } from "@/clients/bedrock-credentials";
-import { isVertexAiEnabled } from "@/clients/gemini-client";
+import {
+  isVertexAiEnabled,
+  resolveVertexLocation,
+} from "@/clients/gemini-client";
 import { getLlmUpstreamDispatcher } from "@/clients/llm-upstream-dispatcher";
 import { openRouterAttributionHeaders } from "@/clients/openrouter-attribution";
 import { createResponseHealingFetch } from "@/clients/openrouter-response-healing";
@@ -1040,7 +1043,7 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
         const { vertexAi } = config.llm.gemini;
         return createVertex({
           project: vertexAi.project,
-          location: vertexAi.location,
+          location: resolveVertexLocation(modelName),
           googleAuthOptions: {
             projectId: vertexAi.project,
             ...(vertexAi.credentialsFile && {

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2264,6 +2264,20 @@ const config = {
         project: process.env.ARCHESTRA_GEMINI_VERTEX_AI_PROJECT || "",
         location:
           process.env.ARCHESTRA_GEMINI_VERTEX_AI_LOCATION || "us-central1",
+        /**
+         * Whether models Vertex AI serves only from `locations/global` (the
+         * Gemini 3+ generations) may be reached there while `location` stays
+         * pinned to an ordinary region for everything else.
+         *
+         * Off by default and deliberately opt-in: the global endpoint gives up
+         * any control over which region processes a request, so turning it on
+         * for a deployment that pinned a region for data-residency reasons
+         * would quietly move part of its traffic offshore. Left off, global-only
+         * models simply stay out of the catalog.
+         */
+        allowGlobalEndpoint:
+          process.env.ARCHESTRA_GEMINI_VERTEX_AI_ALLOW_GLOBAL_ENDPOINT ===
+          "true",
         // Path to service account JSON key file for authentication (optional)
         // If not set, uses default ADC (Workload Identity, attached service account, etc.)
         credentialsFile:

--- a/platform/backend/src/knowledge-base/embedding-clients/gemini.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/gemini.ts
@@ -34,9 +34,14 @@ export async function callGeminiEmbedding(params: {
 }): Promise<EmbeddingApiResponse> {
   const { inputs, model, apiKey, baseUrl, dimensions } = params;
 
-  const client = createGoogleGenAIClient(apiKey, "[GeminiEmbedding]", baseUrl);
-
   const modelId = getGeminiEmbeddingModelId(model);
+
+  const client = createGoogleGenAIClient(
+    apiKey,
+    "[GeminiEmbedding]",
+    baseUrl,
+    modelId,
+  );
 
   // Map EmbeddingInput[] to ContentListUnion (PartUnion[]).
   // Strings pass through as-is; image inputs become Part objects with inlineData.

--- a/platform/backend/src/routes/chat/model-fetchers/gemini.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/gemini.test.ts
@@ -11,13 +11,21 @@ beforeEach(() => {
   vi.stubGlobal("fetch", mockFetch);
 });
 
-vi.mock("@/clients/gemini-client", () => ({
+// Only the client constructors are faked: `resolveVertexLocation` and
+// `isVertexModelReachable` stay real so the tests exercise the actual
+// location-routing rules, driven by the config mutations below.
+vi.mock("@/clients/gemini-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/clients/gemini-client")>()),
   createGoogleGenAIClient: vi.fn(),
+  createVertexClientForLocation: vi.fn(),
 }));
 
-import { createGoogleGenAIClient } from "@/clients/gemini-client";
+import { createVertexClientForLocation } from "@/clients/gemini-client";
+import config from "@/config";
 
-const mockCreateGoogleGenAIClient = vi.mocked(createGoogleGenAIClient);
+const mockCreateVertexClientForLocation = vi.mocked(
+  createVertexClientForLocation,
+);
 
 describe("gemini model fetchers", () => {
   beforeEach(() => {
@@ -140,6 +148,13 @@ describe("gemini model fetchers", () => {
   });
 
   describe("fetchGeminiModelsViaVertexAi", () => {
+    beforeEach(() => {
+      // These tests are about catalog assembly, not location routing, so every
+      // model stays reachable. The nested suite below sets its own values.
+      config.llm.gemini.vertexAi.location = "us-central1";
+      config.llm.gemini.vertexAi.allowGlobalEndpoint = true;
+    });
+
     test("fetches Gemini catalog entries using Vertex AI SDK format", async () => {
       const mockModels = [
         {
@@ -190,7 +205,7 @@ describe("gemini model fetchers", () => {
         },
       } as unknown as GoogleGenAI;
 
-      mockCreateGoogleGenAIClient.mockReturnValue(mockClient);
+      mockCreateVertexClientForLocation.mockReturnValue(mockClient);
 
       const models = await fetchGeminiModelsViaVertexAi();
 
@@ -270,7 +285,7 @@ describe("gemini model fetchers", () => {
         },
       } as unknown as GoogleGenAI;
 
-      mockCreateGoogleGenAIClient.mockReturnValue(mockClient);
+      mockCreateVertexClientForLocation.mockReturnValue(mockClient);
 
       const models = await fetchGeminiModelsViaVertexAi();
 
@@ -334,7 +349,7 @@ describe("gemini model fetchers", () => {
         },
       } as unknown as GoogleGenAI;
 
-      mockCreateGoogleGenAIClient.mockReturnValue(mockClient);
+      mockCreateVertexClientForLocation.mockReturnValue(mockClient);
 
       const models = await fetchGeminiModelsViaVertexAi();
 
@@ -418,7 +433,7 @@ describe("gemini model fetchers", () => {
         },
       } as unknown as GoogleGenAI;
 
-      mockCreateGoogleGenAIClient.mockReturnValue(mockClient);
+      mockCreateVertexClientForLocation.mockReturnValue(mockClient);
 
       const models = await fetchGeminiModelsViaVertexAi();
 
@@ -461,7 +476,7 @@ describe("gemini model fetchers", () => {
         },
       } as unknown as GoogleGenAI;
 
-      mockCreateGoogleGenAIClient.mockReturnValue(mockClient);
+      mockCreateVertexClientForLocation.mockReturnValue(mockClient);
 
       const models = await fetchGeminiModelsViaVertexAi();
 
@@ -472,6 +487,110 @@ describe("gemini model fetchers", () => {
         "gemini-2.5-flash",
         "gemini-embedding-001",
       ]);
+    });
+
+    describe("global-only generations", () => {
+      /** A Vertex client whose catalog is exactly `modelIds`. */
+      function vertexClientListing(modelIds: string[]): GoogleGenAI {
+        return {
+          models: {
+            list: vi.fn().mockResolvedValue({
+              [Symbol.asyncIterator]: async function* () {
+                for (const id of modelIds) {
+                  yield {
+                    name: `publishers/google/models/${id}`,
+                    version: "default",
+                    tunedModelInfo: {},
+                  };
+                }
+              },
+            }),
+            get: vi.fn(),
+            countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+          },
+        } as unknown as GoogleGenAI;
+      }
+
+      beforeEach(() => {
+        config.llm.gemini.vertexAi.location = "us-central1";
+      });
+
+      test("drops Gemini 3+ models when the global endpoint is not allowed", async () => {
+        config.llm.gemini.vertexAi.allowGlobalEndpoint = false;
+
+        // The regional Model Garden catalog lists the newer generations even
+        // though a regional host 404s on them, which is the trap here.
+        const client = vertexClientListing([
+          "gemini-2.5-pro",
+          "gemini-3-flash-preview",
+          "gemini-3.5-flash",
+          "gemini-embedding-001",
+          "gemini-embedding-2",
+        ]);
+        mockCreateVertexClientForLocation.mockReturnValue(client);
+
+        const models = await fetchGeminiModelsViaVertexAi();
+
+        expect(models.map((model) => model.id)).toEqual([
+          "gemini-2.5-pro",
+          "gemini-embedding-001",
+        ]);
+        // Unreachable models are dropped before the probe, not by it: the
+        // global endpoint is never contacted at all.
+        expect(
+          mockCreateVertexClientForLocation.mock.calls.map(
+            ([location]) => location,
+          ),
+        ).not.toContain("global");
+      });
+
+      test("serves each model from the location that has it when global is allowed", async () => {
+        config.llm.gemini.vertexAi.allowGlobalEndpoint = true;
+
+        // Neither catalog contains the other: Gemma MaaS and embedding-001 are
+        // regional, the 3.x generations global.
+        const regionalClient = vertexClientListing([
+          "gemini-2.5-pro",
+          "gemini-embedding-001",
+          "gemma-4-26b-a4b-it-maas",
+        ]);
+        const globalClient = vertexClientListing([
+          "gemini-2.5-pro",
+          "gemini-3.5-flash",
+          "gemini-embedding-2",
+        ]);
+        mockCreateVertexClientForLocation.mockImplementation((location) =>
+          location === "global" ? globalClient : regionalClient,
+        );
+
+        const models = await fetchGeminiModelsViaVertexAi();
+
+        expect(models.map((model) => model.id).sort()).toEqual([
+          "gemini-2.5-pro",
+          "gemini-3.5-flash",
+          "gemini-embedding-001",
+          "gemini-embedding-2",
+          "gemma-4-26b-a4b-it-maas",
+        ]);
+
+        const probedAt = (client: GoogleGenAI) =>
+          vi
+            .mocked(client.models.countTokens)
+            .mock.calls.map(([params]) => params.model)
+            .sort();
+
+        // Each model is probed at the location it would actually be routed to,
+        // so the catalog cannot advertise a model the proxy would 404 on.
+        expect(probedAt(globalClient)).toEqual([
+          "gemini-3.5-flash",
+          "gemini-embedding-2",
+        ]);
+        expect(probedAt(regionalClient)).toEqual([
+          "gemini-2.5-pro",
+          "gemini-embedding-001",
+          "gemma-4-26b-a4b-it-maas",
+        ]);
+      });
     });
   });
 });

--- a/platform/backend/src/routes/chat/model-fetchers/gemini.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/gemini.ts
@@ -1,5 +1,11 @@
 import { isUsableGeminiCatalogModel } from "@archestra/shared";
-import { createGoogleGenAIClient } from "@/clients/gemini-client";
+import type { GoogleGenAI } from "@google/genai";
+import {
+  createVertexClientForLocation,
+  isVertexModelReachable,
+  resolveVertexLocation,
+  VERTEX_GLOBAL_LOCATION,
+} from "@/clients/gemini-client";
 import config from "@/config";
 import logger from "@/logging";
 import type { Gemini } from "@/types";
@@ -54,24 +60,15 @@ export async function fetchGeminiModels(
 }
 
 export async function fetchGeminiModelsViaVertexAi(): Promise<ModelInfo[]> {
+  const { project, location, allowGlobalEndpoint } = config.llm.gemini.vertexAi;
+
   logger.debug(
-    {
-      project: config.llm.gemini.vertexAi.project,
-      location: config.llm.gemini.vertexAi.location,
-    },
+    { project, location, allowGlobalEndpoint },
     "Fetching Gemini models via Vertex AI SDK",
   );
 
-  const ai = createGoogleGenAIClient(undefined, "[ChatModels]");
-  const pager = await ai.models.list({ config: { pageSize: 100 } });
-  const discoveredModels: ModelInfo[] = [];
-
-  for await (const model of pager) {
-    const modelInfo = extractVertexGeminiModel(model);
-    if (modelInfo) {
-      discoveredModels.push(modelInfo);
-    }
-  }
+  const clientForModel = createVertexClientResolver();
+  const discoveredModels = await listVertexGeminiModels();
 
   logger.debug(
     { modelCount: discoveredModels.length },
@@ -79,7 +76,7 @@ export async function fetchGeminiModelsViaVertexAi(): Promise<ModelInfo[]> {
   );
 
   const fallbackModels = await fetchVertexGeminiFallbackModels({
-    ai,
+    clientForModel,
     existingModelIds: new Set(discoveredModels.map((model) => model.id)),
     shouldRunFallback:
       discoveredModels.length === 0 ||
@@ -93,14 +90,16 @@ export async function fetchGeminiModelsViaVertexAi(): Promise<ModelInfo[]> {
     ...discoveredModels,
     ...fallbackModels,
   ]);
+  const reachableModels = filterToConfiguredVertexLocations(candidateModels);
   const accessibleModels = await filterToAccessibleVertexModels({
-    ai,
-    models: candidateModels,
+    clientForModel,
+    models: reachableModels,
   });
 
   logger.info(
     {
       candidateCount: candidateModels.length,
+      reachableCount: reachableModels.length,
       accessibleCount: accessibleModels.length,
     },
     "Filtered Vertex AI Gemini models to those the project can access",
@@ -116,6 +115,113 @@ const VERTEX_GEMINI_FALLBACK_MODEL_IDS = [
   "gemini-2.5-flash",
   "gemini-2.5-flash-lite",
 ];
+
+type VertexClientResolver = (modelId: string) => GoogleGenAI;
+
+/**
+ * One client per Vertex location, built on first use and reused for every model
+ * that resolves to it. Two at most — the configured location and `global` — so
+ * a refresh does not rebuild an authenticated client per model.
+ */
+function createVertexClientResolver(): VertexClientResolver {
+  const clientsByLocation = new Map<string, GoogleGenAI>();
+
+  return (modelId: string) => {
+    const location = resolveVertexLocation(modelId);
+    const existing = clientsByLocation.get(location);
+    if (existing) {
+      return existing;
+    }
+
+    const client = createVertexClientForLocation(
+      location,
+      "[ChatModels]",
+      modelId,
+    );
+    clientsByLocation.set(location, client);
+    return client;
+  };
+}
+
+/**
+ * Every Gemini-family model the configured locations publish. The regional and
+ * global catalogs are not nested — Gemma MaaS and `gemini-embedding-001` appear
+ * only regionally, and a global-only generation may be listed only globally —
+ * so both are read and merged when the global endpoint is in play.
+ */
+async function listVertexGeminiModels(): Promise<ModelInfo[]> {
+  const { location, allowGlobalEndpoint } = config.llm.gemini.vertexAi;
+  const locations = new Set([location]);
+  if (allowGlobalEndpoint) {
+    locations.add(VERTEX_GLOBAL_LOCATION);
+  }
+
+  const perLocation = await Promise.all(
+    [...locations].map(async (vertexLocation) => {
+      const client = createVertexClientForLocation(
+        vertexLocation,
+        "[ChatModels]",
+      );
+      const models: ModelInfo[] = [];
+      try {
+        const pager = await client.models.list({ config: { pageSize: 100 } });
+        for await (const model of pager) {
+          const modelInfo = extractVertexGeminiModel(model);
+          if (modelInfo) {
+            models.push(modelInfo);
+          }
+        }
+      } catch (error) {
+        // One unreachable location must not empty the catalog: the other still
+        // has models, and the accessibility probe vets whatever comes back.
+        logger.warn(
+          {
+            location: vertexLocation,
+            errorMessage:
+              error instanceof Error ? error.message : String(error),
+          },
+          "Failed to list Vertex AI Gemini models for location",
+        );
+      }
+      return models;
+    }),
+  );
+
+  return dedupeModelsById(perLocation.flat());
+}
+
+/**
+ * Drops models no configured location can serve. Without the global endpoint
+ * enabled, that is every Gemini 3+ generation — they are listed in the regional
+ * Model Garden catalog but 404 on use, which is precisely the trap this filter
+ * exists to avoid. Logged by name, because "the new Gemini models are missing"
+ * is otherwise indistinguishable from a broken key.
+ */
+function filterToConfiguredVertexLocations(models: ModelInfo[]): ModelInfo[] {
+  const reachable: ModelInfo[] = [];
+  const globalOnly: string[] = [];
+
+  for (const model of models) {
+    if (isVertexModelReachable(model.id)) {
+      reachable.push(model);
+    } else {
+      globalOnly.push(model.id);
+    }
+  }
+
+  if (globalOnly.length > 0) {
+    logger.info(
+      {
+        modelIds: globalOnly,
+        configuredLocation: config.llm.gemini.vertexAi.location,
+      },
+      "Skipping Vertex AI Gemini models that only the global endpoint serves; " +
+        "set ARCHESTRA_GEMINI_VERTEX_AI_ALLOW_GLOBAL_ENDPOINT=true to use them",
+    );
+  }
+
+  return reachable;
+}
 
 function extractVertexGeminiModel(model: {
   name?: string | null;
@@ -134,11 +240,11 @@ function extractVertexGeminiModel(model: {
 }
 
 async function fetchVertexGeminiFallbackModels(params: {
-  ai: ReturnType<typeof createGoogleGenAIClient>;
+  clientForModel: VertexClientResolver;
   existingModelIds: Set<string>;
   shouldRunFallback: boolean;
 }): Promise<ModelInfo[]> {
-  const { ai, existingModelIds, shouldRunFallback } = params;
+  const { clientForModel, existingModelIds, shouldRunFallback } = params;
   if (!shouldRunFallback) {
     return [];
   }
@@ -154,7 +260,9 @@ async function fetchVertexGeminiFallbackModels(params: {
 
   const results = await Promise.allSettled(
     candidateModelIds.map(async (modelId) => {
-      const model = await ai.models.get({ model: modelId });
+      const model = await clientForModel(modelId).models.get({
+        model: modelId,
+      });
       return extractVertexGeminiModel({
         name: model.name,
         displayName: model.displayName,
@@ -208,15 +316,15 @@ async function fetchVertexGeminiFallbackModels(params: {
  * catalog — every non-404 outcome keeps the model.
  */
 async function filterToAccessibleVertexModels(params: {
-  ai: ReturnType<typeof createGoogleGenAIClient>;
+  clientForModel: VertexClientResolver;
   models: ModelInfo[];
 }): Promise<ModelInfo[]> {
-  const { ai, models } = params;
+  const { clientForModel, models } = params;
 
   const probed = await Promise.all(
     models.map(async (model) => {
       try {
-        await ai.models.countTokens({
+        await clientForModel(model.id).models.countTokens({
           model: model.id,
           contents: "access probe",
         });
@@ -224,7 +332,7 @@ async function filterToAccessibleVertexModels(params: {
       } catch (error) {
         if (isVertexModelInaccessibleError(error)) {
           logger.info(
-            { modelId: model.id },
+            { modelId: model.id, location: resolveVertexLocation(model.id) },
             "Dropping Vertex AI Gemini model the project cannot access",
           );
           return null;

--- a/platform/backend/src/routes/proxy/adapters/gemini-embeddings.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-embeddings.ts
@@ -91,6 +91,7 @@ export const geminiEmbeddingsAdapterFactory: LLMProvider<
       apiKey,
       "[GeminiEmbeddingProxy]",
       options.baseUrl,
+      options.model ? getGeminiEmbeddingModelId(options.model) : undefined,
     );
   },
 

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -1516,6 +1516,7 @@ export const geminiAdapterFactory: LLMProvider<
       apiKey,
       "[GeminiProxyV2]",
       options.baseUrl,
+      options.model,
     );
 
     // Wrap with observability for request duration metrics

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -1229,6 +1229,7 @@ export async function handleLLMProxy<
       agent: resolvedAgent,
       abortSignal,
       source,
+      model: requestAdapter.getModel(),
       defaultHeaders:
         Object.keys(mergedHeaders).length > 0 ? mergedHeaders : undefined,
       llmProviderApiKeyId: perKeyChatApiKeyId,

--- a/platform/backend/src/types/llm-provider.ts
+++ b/platform/backend/src/types/llm-provider.ts
@@ -76,6 +76,12 @@ export interface CreateClientOptions {
    * finishes. Provider clients may forward it to their upstream requests.
    */
   abortSignal?: AbortSignal;
+  /**
+   * Model the client is being built for. Only providers whose endpoint depends
+   * on the model read it — Gemini in Vertex AI mode, where the location that
+   * serves a model varies by generation and is fixed at client construction.
+   */
+  model?: string;
 }
 
 /**

--- a/platform/shared/gemini-models.test.ts
+++ b/platform/shared/gemini-models.test.ts
@@ -3,6 +3,7 @@ import {
   geminiThinkingConfigForEffort,
   isLegacyGeminiModel,
   isUsableGeminiCatalogModel,
+  requiresGlobalVertexEndpoint,
   supportsGeminiThinkingEffort,
   supportsGeminiThoughtSummaries,
 } from "./gemini-models";
@@ -175,5 +176,43 @@ describe("isLegacyGeminiModel", () => {
     ["aqa", false],
   ])("%s -> legacy=%s", (modelId, expected) => {
     expect(isLegacyGeminiModel(modelId)).toBe(expected);
+  });
+});
+
+describe("requiresGlobalVertexEndpoint", () => {
+  test.each([
+    // Vertex serves 3.0+ chat generations only from `global`; a regional host
+    // 404s on them.
+    ["gemini-3-pro-preview", true],
+    ["gemini-3-flash-preview", true],
+    ["gemini-3.1-pro-preview", true],
+    ["gemini-3.5-flash", true],
+    ["gemini-3.7-flash", true],
+    // Anything above the threshold is covered without touching the constant.
+    ["gemini-4-pro", true],
+    // The 2.5 family answers regionally as well, so it keeps the configured
+    // location and its data residency.
+    ["gemini-2.5-pro", false],
+    ["gemini-2.5-flash", false],
+    ["gemini-2.5-flash-lite", false],
+    // Tuple comparison, not parseFloat: 2.10 is below 3.0.
+    ["gemini-2.10-flash", false],
+    // Gemma MaaS is regional only and absent from the global catalog, whatever
+    // generation number it carries.
+    ["gemma-4-26b-a4b-it-maas", false],
+    ["gemma-3-27b-it", false],
+    // Embeddings version separately: -001 is regional, -2 global.
+    ["gemini-embedding-001", false],
+    ["gemini-embedding-2", true],
+    // Unparsable / unbranded ids stay on the configured location.
+    ["gemini-pro", false],
+    ["text-embedding-005", false],
+    ["aqa", false],
+  ])("%s -> global=%s", (modelId, expected) => {
+    expect(requiresGlobalVertexEndpoint(modelId)).toBe(expected);
+  });
+
+  test("is case-insensitive", () => {
+    expect(requiresGlobalVertexEndpoint("Gemini-3.5-Flash")).toBe(true);
   });
 });

--- a/platform/shared/gemini-models.ts
+++ b/platform/shared/gemini-models.ts
@@ -29,6 +29,23 @@ const GEMINI_EMBEDDING_PREFIX = "gemini-embedding-";
 const RETIRED_GEMINI_EMBEDDING_MODELS = new Set(["gemini-embedding-2-preview"]);
 
 /**
+ * Lowest chat generation Vertex AI serves only from its `global` endpoint. The
+ * 2.5 family answers on both global and ordinary regions; from 3.0 on, a
+ * regional host replies 404 ("not found or your project does not have access
+ * to it") and only `locations/global` works. Bumping this is not needed when a
+ * new generation ships — anything above the threshold is already covered.
+ */
+const GEMINI_GLOBAL_ENDPOINT_MIN_VERSION: GeminiVersion = [3, 0];
+
+/**
+ * Lowest `gemini-embedding-N` generation that is global-only. `-001` is served
+ * regionally and is absent from the global catalog; `-2` is the reverse. The
+ * embedding ids carry no dotted version, so they are versioned separately from
+ * {@link GEMINI_GLOBAL_ENDPOINT_MIN_VERSION}.
+ */
+const GEMINI_GLOBAL_ENDPOINT_MIN_EMBEDDING_VERSION = 2;
+
+/**
  * Lowest generation whose chat models think by default. Deliberately its own
  * constant: catalog policy ({@link GEMINI_FAMILY_MIN_VERSION}) can move
  * independently of the thinking capability boundary.
@@ -64,6 +81,46 @@ export function isUsableGeminiCatalogModel(modelId: string): boolean {
   const version = parseGeminiFamilyVersion(id);
   return (
     version !== null && compareVersion(version, GEMINI_FAMILY_MIN_VERSION) >= 0
+  );
+}
+
+/**
+ * True when Vertex AI serves this model only from its `global` endpoint, so a
+ * request pinned to an ordinary region (`us-central1`, …) would 404.
+ *
+ * Three families, three answers, each matching what Vertex actually serves:
+ * - `gemma-*` — Model Garden MaaS, regional only, absent from the global
+ *   catalog entirely. Never global, whatever generation number it carries.
+ * - `gemini-embedding-N` — global from
+ *   {@link GEMINI_GLOBAL_ENDPOINT_MIN_EMBEDDING_VERSION} on.
+ * - `gemini-<major>.<minor>` chat models — global from
+ *   {@link GEMINI_GLOBAL_ENDPOINT_MIN_VERSION} on.
+ *
+ * Only meaningful in Vertex AI mode; the Gemini API (API-key mode) has one
+ * global host and no notion of a location.
+ */
+export function requiresGlobalVertexEndpoint(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+
+  if (!id.startsWith("gemini-")) {
+    return false;
+  }
+
+  if (id.startsWith(GEMINI_EMBEDDING_PREFIX)) {
+    const generation = Number.parseInt(
+      id.slice(GEMINI_EMBEDDING_PREFIX.length),
+      10,
+    );
+    return (
+      Number.isFinite(generation) &&
+      generation >= GEMINI_GLOBAL_ENDPOINT_MIN_EMBEDDING_VERSION
+    );
+  }
+
+  const version = parseGeminiFamilyVersion(id);
+  return (
+    version !== null &&
+    compareVersion(version, GEMINI_GLOBAL_ENDPOINT_MIN_VERSION) >= 0
   );
 }
 


### PR DESCRIPTION
## The problem

Staging's Vertex AI provider stopped at the Gemini 2.5 family — no 3.x models at all ([Slack](https://archestra-ai.slack.com/archives/C0B2AGC0AFQ/p1787227891901339)).

Not a broken key. Vertex AI serves **Gemini 3 and newer only from its `global` endpoint**, while **Gemma MaaS and `gemini-embedding-001` are regional-only** and absent from the global catalog. A deployment pinned to a single location cannot see the whole catalog.

Staging runs `ARCHESTRA_GEMINI_VERTEX_AI_LOCATION: us-central1`. The regional Model Garden catalog *lists* the 3.x models, but they 404 on use there — so the accessibility probe in the model fetcher correctly dropped every one of them. The probe was doing its job; it was just asking the wrong host.

Confirmed against the staging project (`countTokens`, same probe the fetcher uses):

| model | `us-central1` | `global` |
|---|---|---|
| `gemini-2.5-pro` | 200 | 200 |
| `gemini-3-flash-preview` | 404 | 200 |
| `gemini-3.1-pro-preview` | 404 | 200 |
| `gemini-3.5-flash` / `3.6` / `3.7` | 404 | 200 |
| `gemini-embedding-001` | 400 (exists) | 404 |
| `gemma-4-26b-a4b-it-maas` | 200 | 404 |

Neither location is a superset, so simply flipping the location to `global` would have traded the 3.x models for the embedding and Gemma entries. Google documents [the same conflict](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations).

## The fix

Resolve the Vertex location **per model** rather than per deployment.

- `createGoogleGenAIClient` takes the model it is being built for and picks the location that serves it. Every Vertex call already funnels through it, so the proxy, chat, embeddings, and knowledge-base paths are all covered by threading the model in — no migration and no per-request DB lookup.
- The fetcher lists each location's catalog, merges them, and probes every candidate **at the location it would actually be routed to** — preserving the existing invariant that the catalog never advertises a model the proxy would 404 on.
- The routing rule lives in `shared/gemini-models.ts` beside the existing generation thresholds. It is written as `>= 3.0`, so future generations are covered without editing the constant.

## Default is off, on purpose

`ARCHESTRA_GEMINI_VERTEX_AI_ALLOW_GLOBAL_ENDPOINT` defaults to `false`. The global endpoint gives up any control over which region processes a request, so turning it on by default would quietly move part of a data-residency-pinned deployment's traffic offshore. Staging sets it to `true` (no residency requirement), which fixes the reported symptom.

When a model is skipped for want of the flag, it is now **logged by name** — "the new Gemini models are missing" was otherwise indistinguishable from a broken key, which is what made this take a while to pin down.

## Verification

Ran the real fetcher against the staging project with ADC:

- **Flag on:** 13 models — every 3.x generation appears, **and** `gemini-embedding-001` + `gemma-4-26b-a4b-it-maas` are retained.
- **Flag off (default):** exactly the 5 models in the original screenshot. Behavior is unchanged for every existing deployment.

`gemini-3-pro-preview` stays absent in both: it 404s even on `global` for this project (genuinely gated), and the accessibility probe correctly filters it. That one *is* a real key/project limitation.

Tests: new unit tests for the routing rule (`shared`) and the resolver (`backend`), plus two behavioral fetcher tests asserting each model is probed at the location it would be served from. `type-check`, `lint`, and `knip` are clean; the 7 failures in `mcp-client.test.ts` / `llm-resolution.test.ts` on this branch reproduce identically on `main` with the changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>