### PR TITLE
ci: give Platform Lint and Unit Tests room to finish on the private mirror

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -267,9 +267,16 @@ jobs:
     # under 10m, but leaked test-runner processes (vitest fork workers /
     # esbuild) occasionally orphan and hold the step's log pipe open, leaving
     # a *finished* job hanging until GitHub's 6h default. Fail fast instead.
-    # 30 (not 20) because fork PRs run without cache secrets and pay a full
-    # cold build on a 4vcpu runner.
-    timeout-minutes: 30
+    # 30 was sized for fork PRs, which run without cache secrets and pay a
+    # full cold build on a 4vcpu runner. That is too tight for the private
+    # mirror, where task-env sessions open their PRs: ubuntu-latest is
+    # 4-vCPU/16-GB for public repos but 2-vCPU/7-GB for private ones, and the
+    # job that finishes in ~5 min here needed 22m28s on its one clean mirror
+    # run while 9 of the other 11 burned the whole budget (30m19s-30m42s,
+    # including one run started after remote caching was configured there).
+    # So those cancellations were the ceiling, not a hang. Sized for the
+    # slowest hardware this runs on, as backend-unit-tests below already is.
+    timeout-minutes: 45
     permissions:
       contents: write # Required to push generated code updates back to release-please PRs.
     defaults:


### PR DESCRIPTION
## What

Raises `platform-lint-and-unit-tests`'s `timeout-minutes` from 30 to 45.

## Why

The 30-minute budget was sized for fork PRs, which run without cache secrets and pay a full cold build on a public 4-vCPU runner. Private repos get 2-vCPU/7-GB runners instead, and on the private mirror — where task-env sessions open their PRs — the job does not fit in 30 minutes.

Measured across the 11 most recent `on-pull-requests.yml` runs on the mirror:

| outcome | count | duration |
| --- | --- | --- |
| killed at the ceiling | 9 | 30m19s – 30m42s |
| finished | 1 | 22m28s |
| superseded early | 1 | 17m06s |

The single clean run at **22m28s** is the important one: the job is slow on that hardware, not hung. Everything else simply ran out of budget.

One of the nine ceiling hits started *after* remote caching had been configured on the mirror and still burned the full 30 minutes, so enabling the cache there does not by itself close the gap.

The practical effect was that this job was near-permanently red on the mirror, and because a `timeout-minutes` kill is reported as `cancelled`, the failures looked like hangs or flakes rather than the ceiling they were.

## Why 45 and not a conditional

`backend-unit-tests` already sets its budget this way — one constant sized for the slowest hardware the job runs on, with a comment saying so. Matching that keeps the file consistent and avoids a `github.event.repository.private` expression whose value on `merge_group` payloads isn't exercised anywhere in this workflow today. The existing use of that field at line ~203 is guarded by `github.event_name == 'pull_request'`.

## What this does not change

The reason the timeout exists is unaffected: an orphaned vitest fork worker or esbuild process can hold the step's log pipe open and leave a *finished* job hanging until GitHub's 6h default. That backstop still trips — 15 minutes later than before.

Public-repo runs of this job take ~5 min, so the raised budget is not expected to be reached here.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>