### PR TITLE
fix(knowledge): let "select all that match" reach a whole corpus

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -56586,6 +56586,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -56912,6 +56915,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -66750,6 +66756,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -74592,6 +74601,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -74919,6 +74931,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -130395,6 +130410,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -227621,6 +227639,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -238064,20 +238085,48 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "ids": {
-                    "minItems": 1,
-                    "maxItems": 500,
-                    "type": "array",
-                    "items": {
-                      "type": "string"
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "ids": {
+                        "minItems": 1,
+                        "maxItems": 500,
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Ids to act on. Duplicates are collapsed."
+                      }
                     },
-                    "description": "Ids to act on. Duplicates are collapsed."
+                    "required": [
+                      "ids"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "all": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ],
+                        "description": "Delete everything matching the filters below rather than an id list."
+                      },
+                      "search": {
+                        "description": "Same title search the listing applies.",
+                        "type": "string"
+                      },
+                      "group": {
+                        "description": "Same group filter the listing applies.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "all"
+                    ],
+                    "description": "Filter mode. A connector's corpus routinely runs to tens of thousands of documents, which is neither a sane request body as uuids nor worth authorizing row by row — so the filter travels instead and the database does the work in one statement. The response carries `affected` rather than a per-row list."
                   }
-                },
-                "required": [
-                  "ids"
                 ]
               }
             }
@@ -238103,6 +238152,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -238448,6 +238500,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -238775,6 +238830,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -246305,6 +246363,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -246632,6 +246693,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -248572,6 +248636,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -248899,6 +248966,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -252600,6 +252670,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -263763,6 +263836,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -310429,6 +310505,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -310756,6 +310835,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -321036,6 +321118,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -341070,6 +341155,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {
@@ -354552,6 +354640,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "affected": {
+                      "type": "number"
+                    },
                     "succeeded": {
                       "type": "array",
                       "items": {

--- a/platform/backend/src/models/kb-document.ts
+++ b/platform/backend/src/models/kb-document.ts
@@ -179,7 +179,6 @@ class KbDocumentModel {
     /** Restrict to documents whose effective audience holds this group token. */
     groupToken?: string;
   }): Promise<KbDocumentListItemWithoutContent[]> {
-    const normalizedSearch = params.search?.trim();
     let query = db
       .select({
         id: schema.kbDocumentsTable.id,
@@ -206,20 +205,7 @@ class KbDocumentModel {
           schema.kbDocumentsTable.connectorId,
         ),
       )
-      .where(
-        and(
-          eq(schema.kbDocumentsTable.connectorId, params.connectorId),
-          eq(schema.kbDocumentsTable.organizationId, params.organizationId),
-          eq(
-            schema.knowledgeBaseConnectorsTable.organizationId,
-            params.organizationId,
-          ),
-          normalizedSearch
-            ? ilike(schema.kbDocumentsTable.title, `%${normalizedSearch}%`)
-            : undefined,
-          groupTokenFilter(params.groupToken),
-        ),
-      )
+      .where(connectorDocumentsFilter(params))
       .orderBy(desc(schema.kbDocumentsTable.updatedAt))
       .$dynamic();
 
@@ -366,7 +352,6 @@ class KbDocumentModel {
     /** Restrict to documents whose effective audience holds this group token. */
     groupToken?: string;
   }): Promise<number> {
-    const normalizedSearch = params.search?.trim();
     const [result] = await db
       .select({ count: count() })
       .from(schema.kbDocumentsTable)
@@ -377,22 +362,53 @@ class KbDocumentModel {
           schema.kbDocumentsTable.connectorId,
         ),
       )
-      .where(
-        and(
-          eq(schema.kbDocumentsTable.connectorId, params.connectorId),
-          eq(schema.kbDocumentsTable.organizationId, params.organizationId),
-          eq(
-            schema.knowledgeBaseConnectorsTable.organizationId,
-            params.organizationId,
-          ),
-          normalizedSearch
-            ? ilike(schema.kbDocumentsTable.title, `%${normalizedSearch}%`)
-            : undefined,
-          groupTokenFilter(params.groupToken),
-        ),
-      );
+      .where(connectorDocumentsFilter(params));
 
     return result?.count ?? 0;
+  }
+
+  /**
+   * Deletes every document matching the caller's current filters, without the
+   * client having to enumerate ids.
+   *
+   * This is what makes "select all 22,921 documents" possible: posting that
+   * many uuids is neither a sane request body nor something worth authorizing
+   * row by row, so the filter travels instead and the database does the work
+   * in one statement.
+   *
+   * The predicate is {@link connectorDocumentsFilter}, the same one the
+   * listing and its count use, so what is destroyed is exactly what the table
+   * was showing. Ids are resolved through a subquery because the fence lives
+   * on the joined connector row, which a bare DELETE cannot see.
+   *
+   * Returns how many rows actually went, counted from the deleted rows
+   * themselves rather than a driver rowCount, which is not reported reliably
+   * on every backend this runs against.
+   */
+  static async deleteByConnectorFilter(params: {
+    connectorId: string;
+    organizationId: string;
+    search?: string;
+    groupToken?: string;
+  }): Promise<number> {
+    const matching = db
+      .select({ id: schema.kbDocumentsTable.id })
+      .from(schema.kbDocumentsTable)
+      .innerJoin(
+        schema.knowledgeBaseConnectorsTable,
+        eq(
+          schema.knowledgeBaseConnectorsTable.id,
+          schema.kbDocumentsTable.connectorId,
+        ),
+      )
+      .where(connectorDocumentsFilter(params));
+
+    const deleted = await db
+      .delete(schema.kbDocumentsTable)
+      .where(inArray(schema.kbDocumentsTable.id, matching))
+      .returning({ id: schema.kbDocumentsTable.id });
+
+    return deleted.length;
   }
 
   /**
@@ -1033,6 +1049,39 @@ class KbDocumentModel {
  * on the container-ACL row its `container_key` references (the auto-sync
  * indirection the UI expands the same way).
  */
+/**
+ * The predicate that defines "this connector's documents, as currently
+ * filtered" — shared by the listing, its count, and the bulk delete.
+ *
+ * Extracted deliberately: the bulk delete acts on everything matching the
+ * caller's filters WITHOUT enumerating ids, so if its predicate drifted from
+ * the listing's, the rows destroyed would stop being the rows the user was
+ * looking at. One definition makes that impossible.
+ *
+ * Callers must join `knowledgeBaseConnectorsTable`, which the organization
+ * fence below is expressed against.
+ */
+function connectorDocumentsFilter(params: {
+  connectorId: string;
+  organizationId: string;
+  search?: string;
+  groupToken?: string;
+}) {
+  const normalizedSearch = params.search?.trim();
+  return and(
+    eq(schema.kbDocumentsTable.connectorId, params.connectorId),
+    eq(schema.kbDocumentsTable.organizationId, params.organizationId),
+    eq(
+      schema.knowledgeBaseConnectorsTable.organizationId,
+      params.organizationId,
+    ),
+    normalizedSearch
+      ? ilike(schema.kbDocumentsTable.title, `%${normalizedSearch}%`)
+      : undefined,
+    groupTokenFilter(params.groupToken),
+  );
+}
+
 function groupTokenFilter(groupToken: string | undefined) {
   if (!groupToken) return undefined;
   const tokenJson = JSON.stringify([groupToken]);

--- a/platform/backend/src/routes/bulk-route.ts
+++ b/platform/backend/src/routes/bulk-route.ts
@@ -31,6 +31,16 @@ export const BulkIdsSchema = z
 export const BulkDeleteBodySchema = z.object({ ids: BulkIdsSchema });
 
 export const BulkOutcomeSchema = z.object({
+  /**
+   * How many rows the batch actually changed.
+   *
+   * Present only when the request selected by FILTER rather than by id. A
+   * filter can match tens of thousands of rows, so there is no per-row list to
+   * return and no caller that would want one — the count is the whole answer.
+   * Id-mode leaves it absent, because `succeeded` already says both which rows
+   * changed and how many.
+   */
+  affected: z.number().optional(),
   succeeded: z.array(
     z.object({
       id: z.string(),

--- a/platform/backend/src/routes/connector-documents.bulk.route.test.ts
+++ b/platform/backend/src/routes/connector-documents.bulk.route.test.ts
@@ -1,5 +1,6 @@
 import config from "@/config";
 import db, { schema } from "@/database";
+import { buildGroupToken } from "@/knowledge-base/acl-tokens";
 import { KbDocumentModel, KnowledgeBaseConnectorModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
@@ -43,7 +44,11 @@ describe("DELETE /api/connectors/:id/documents/bulk", () => {
     await app.close();
   });
 
-  const makeDocument = async (title: string, forConnectorId = connectorId) => {
+  const makeDocument = async (
+    title: string,
+    forConnectorId = connectorId,
+    acl: string[] = [],
+  ) => {
     const [row] = await db
       .insert(schema.kbDocumentsTable)
       .values({
@@ -53,6 +58,7 @@ describe("DELETE /api/connectors/:id/documents/bulk", () => {
         title,
         content: "body",
         contentHash: `hash-${title}`,
+        acl,
       })
       .returning();
     return row;
@@ -286,6 +292,35 @@ describe("DELETE /api/connectors/:id/documents/bulk", () => {
           organizationId,
         }),
       ).toBe(1);
+    });
+
+    /**
+     * `group` arrives as the bare upstream group id and has to be namespaced
+     * before it can match a stored ACL entry — the same transform the listing
+     * applies. Getting this wrong does not fail loudly: the raw id matches
+     * nothing, so the delete would report success over zero rows while the
+     * filtered table the user was looking at survived intact.
+     */
+    test("namespaces the group filter the same way the listing does", async () => {
+      const engineering = buildGroupToken({
+        connectorType: "jira",
+        groupId: "engineering",
+      });
+      const support = buildGroupToken({
+        connectorType: "jira",
+        groupId: "support",
+      });
+      const targeted = await makeDocument("eng-doc", connectorId, [
+        engineering,
+      ]);
+      const spared = await makeDocument("support-doc", connectorId, [support]);
+
+      const response = await bulkDeleteAll({ group: "engineering" });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().affected).toBe(1);
+      expect(await stillExists(targeted.id)).toBe(false);
+      expect(await stillExists(spared.id)).toBe(true);
     });
 
     test("reports zero rather than failing when nothing matches", async () => {

--- a/platform/backend/src/routes/connector-documents.bulk.route.test.ts
+++ b/platform/backend/src/routes/connector-documents.bulk.route.test.ts
@@ -177,6 +177,133 @@ describe("DELETE /api/connectors/:id/documents/bulk", () => {
     expect(response.statusCode).toBe(404);
   });
 
+  describe("filter mode", () => {
+    const bulkDeleteAll = (body: Record<string, unknown>, id = connectorId) =>
+      app.inject({
+        method: "DELETE",
+        url: `/api/connectors/${id}/documents/bulk`,
+        payload: { all: true, ...body },
+      });
+
+    /**
+     * The reason filter mode exists: a corpus of tens of thousands cannot be
+     * selected by posting uuids, so "select all matching" sends the filter and
+     * the count comes back instead of a per-row list.
+     */
+    test("deletes every document when no filter narrows it", async () => {
+      await makeDocument("alpha");
+      await makeDocument("beta");
+      await makeDocument("gamma");
+
+      const response = await bulkDeleteAll({});
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        affected: 3,
+        succeeded: [],
+        failed: [],
+      });
+      expect(
+        await KbDocumentModel.countByConnectorWithSearch({
+          connectorId,
+          organizationId,
+        }),
+      ).toBe(0);
+    });
+
+    /**
+     * The delete has to match exactly what the table was showing, or it
+     * destroys rows the user never saw. Same predicate, same result.
+     */
+    test("honours the same title search the listing uses", async () => {
+      await makeDocument("keep-me");
+      const target = await makeDocument("delete-me");
+      await makeDocument("delete-me-too");
+
+      const response = await bulkDeleteAll({ search: "delete-me" });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().affected).toBe(2);
+
+      const survivors = await KbDocumentModel.findListItemsByConnector({
+        connectorId,
+        organizationId,
+      });
+      expect(survivors.map((doc) => doc.title)).toEqual(["keep-me"]);
+      expect(await stillExists(target.id)).toBe(false);
+    });
+
+    test("never reaches another connector's documents", async () => {
+      const other = await KnowledgeBaseConnectorModel.create({
+        organizationId,
+        name: "untouched-connector",
+        connectorType: "jira",
+        config: {
+          type: "jira",
+          jiraBaseUrl: "https://untouched.atlassian.net",
+          isCloud: true,
+          projectKey: "UN",
+        },
+      });
+      await makeDocument("mine");
+      const theirs = await makeDocument("theirs", other.id);
+
+      const response = await bulkDeleteAll({});
+
+      expect(response.json().affected).toBe(1);
+      expect(
+        await KbDocumentModel.findForBulkByConnector({
+          documentIds: [theirs.id],
+          connectorId: other.id,
+          organizationId,
+        }),
+      ).toHaveLength(1);
+    });
+
+    test("404s for a connector in another organization without deleting", async ({
+      makeOrganization,
+    }) => {
+      const otherOrgId = (await makeOrganization()).id;
+      const foreign = await KnowledgeBaseConnectorModel.create({
+        organizationId: otherOrgId,
+        name: "foreign-filter",
+        connectorType: "jira",
+        config: {
+          type: "jira",
+          jiraBaseUrl: "https://foreign-filter.atlassian.net",
+          isCloud: true,
+          projectKey: "FF",
+        },
+      });
+      await makeDocument("mine");
+
+      const response = await bulkDeleteAll({}, foreign.id);
+
+      expect(response.statusCode).toBe(404);
+      expect(
+        await KbDocumentModel.countByConnectorWithSearch({
+          connectorId,
+          organizationId,
+        }),
+      ).toBe(1);
+    });
+
+    test("reports zero rather than failing when nothing matches", async () => {
+      await makeDocument("present");
+
+      const response = await bulkDeleteAll({ search: "no-such-title" });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().affected).toBe(0);
+      expect(
+        await KbDocumentModel.countByConnectorWithSearch({
+          connectorId,
+          organizationId,
+        }),
+      ).toBe(1);
+    });
+  });
+
   test("rejects an empty batch", async () => {
     expect((await bulkDelete([])).statusCode).toBe(400);
   });

--- a/platform/backend/src/routes/knowledge-base.ts
+++ b/platform/backend/src/routes/knowledge-base.ts
@@ -1214,7 +1214,34 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "source or narrow the connector's scope.",
         tags: ["Connectors"],
         params: z.object({ id: z.uuid() }),
-        body: BulkDeleteBodySchema,
+        body: z.union([
+          BulkDeleteBodySchema,
+          z
+            .object({
+              all: z
+                .literal(true)
+                .describe(
+                  "Delete everything matching the filters below rather than " +
+                    "an id list.",
+                ),
+              search: z
+                .string()
+                .optional()
+                .describe("Same title search the listing applies."),
+              group: z
+                .string()
+                .optional()
+                .describe("Same group filter the listing applies."),
+            })
+            .describe(
+              "Filter mode. A connector's corpus routinely runs to tens of " +
+                "thousands of documents, which is neither a sane request body " +
+                "as uuids nor worth authorizing row by row — so the filter " +
+                "travels instead and the database does the work in one " +
+                "statement. The response carries `affected` rather than a " +
+                "per-row list.",
+            ),
+        ]),
         response: constructResponseSchema(BulkOutcomeSchema),
       },
     },
@@ -1222,17 +1249,29 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const { organizationId, user } = request;
       const connectorId = request.params.id;
 
-      // Request-level: the connector is the same for every id, so one that the
-      // caller cannot see is a 404 for the whole request rather than N
-      // identical per-document failures.
+      // Request-level: the connector is the same for every document, so one
+      // the caller cannot see is a 404 for the whole request rather than N
+      // identical per-document failures. This is also the ONLY authorization
+      // filter mode gets, which is why it is done before either branch.
       await findConnectorOrThrow({
         id: connectorId,
         organizationId,
         userId: user.id,
       });
 
+      const body = request.body;
+      if ("all" in body) {
+        const affected = await KbDocumentModel.deleteByConnectorFilter({
+          connectorId,
+          organizationId,
+          search: body.search,
+          groupToken: body.group,
+        });
+        return reply.send({ affected, succeeded: [], failed: [] });
+      }
+
       const outcome = await runBulk({
-        ids: request.body.ids,
+        ids: body.ids,
         logLabel: "connector documents bulk delete",
         notFoundMessage: "Document not found",
         unexpectedMessage: "Could not delete this document",

--- a/platform/backend/src/routes/knowledge-base.ts
+++ b/platform/backend/src/routes/knowledge-base.ts
@@ -1253,7 +1253,7 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
       // the caller cannot see is a 404 for the whole request rather than N
       // identical per-document failures. This is also the ONLY authorization
       // filter mode gets, which is why it is done before either branch.
-      await findConnectorOrThrow({
+      const connector = await findConnectorOrThrow({
         id: connectorId,
         organizationId,
         userId: user.id,
@@ -1261,11 +1261,21 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
       const body = request.body;
       if ("all" in body) {
+        // `group` arrives as the bare upstream group id, exactly as it does on
+        // the listing, and has to be namespaced the same way before it can
+        // match a stored ACL entry. Skipping this would not fail loudly — the
+        // raw id simply matches nothing, and the delete would report success
+        // over zero rows while the user watched a filtered table survive.
         const affected = await KbDocumentModel.deleteByConnectorFilter({
           connectorId,
           organizationId,
           search: body.search,
-          groupToken: body.group,
+          groupToken: body.group
+            ? buildGroupToken({
+                connectorType: connector.connectorType,
+                groupId: body.group,
+              })
+            : undefined,
         });
         return reply.send({ affected, succeeded: [], failed: [] });
       }

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.test.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.test.tsx
@@ -86,7 +86,6 @@ vi.mock("@/lib/knowledge/kb-document.query", () => ({
     mutateAsync: mockDeleteMutateAsync,
     isPending: false,
   }),
-  useAllMatchingConnectorDocuments: () => ({ data: [] }),
   useBulkDeleteConnectorDocuments: () => ({
     mutate: vi.fn(),
     isPending: false,

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type archestraApiTypes, MAX_BULK_IDS } from "@archestra/shared";
+import type { archestraApiTypes } from "@archestra/shared";
 import type { ColumnDef, RowSelectionState } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
 import { Clock, ExternalLink, Eye, FileText, Trash2 } from "lucide-react";
@@ -32,7 +32,6 @@ import { useDialogUrlParam } from "@/lib/hooks/use-dialog-url-param";
 import { useConnectorUserGroups } from "@/lib/knowledge/connector.query";
 import {
   type KnowledgeBaseDocumentListItem,
-  useAllMatchingConnectorDocuments,
   useBulkDeleteConnectorDocuments,
   useConnectorDocument,
   useConnectorDocuments,

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
@@ -153,25 +153,20 @@ export function ConnectorDocumentsTable({
   // re-pointing "all N" at a different N.
   const filterSignature = `${connectorId}|${search}|${group}`;
   const allMatchingActive = selectAllMatchingFor === filterSignature;
-  const { data: allMatchingDocuments } = useAllMatchingConnectorDocuments(
-    {
-      connectorId,
-      query: {
-        ...(search ? { search } : {}),
-        ...(group ? { group } : {}),
-      },
-    },
-    { enabled: allMatchingActive },
-  );
-
   const clearSelection = useCallback(() => {
     setRowSelection({});
     setSelectAllMatchingFor(null);
   }, []);
 
-  const selectedDocuments = allMatchingActive
-    ? (allMatchingDocuments ?? [])
-    : documents.filter((document) => rowSelection[document.id]);
+  const selectedDocuments = documents.filter(
+    (document) => rowSelection[document.id],
+  );
+  // Escalating does not fetch the matching rows — the delete sends the filter,
+  // so the only thing needed on screen is how many there are. That is what
+  // makes "select all 22,921" honest rather than a page-sized lie.
+  const selectedCount = allMatchingActive
+    ? totalDocuments
+    : selectedDocuments.length;
 
   // The shared Table is `table-fixed`: without explicit sizes every column
   // gets an equal width and the natural-width Access badges overflow under
@@ -328,7 +323,7 @@ export function ConnectorDocumentsTable({
       </TableFilters>
 
       <BulkActionsBar
-        count={selectedDocuments.length}
+        count={selectedCount}
         noun="document"
         onClear={clearSelection}
         busy={bulkDelete.isPending}
@@ -340,7 +335,8 @@ export function ConnectorDocumentsTable({
           active: allMatchingActive,
           onSelectAll: () => setSelectAllMatchingFor(filterSignature),
           matchDescription: "match this search",
-          max: MAX_BULK_IDS,
+          // No `max`: the delete sends the filter rather than an id list, so
+          // there is no cap for the matching set to outgrow.
         }}
         className="mb-3"
       >
@@ -447,13 +443,21 @@ export function ConnectorDocumentsTable({
           open={bulkDeleteOpen}
           onOpenChange={setBulkDeleteOpen}
           title="Delete documents"
-          description={`Delete ${selectedDocuments.length} ${
-            selectedDocuments.length === 1 ? "document" : "documents"
+          description={`Delete ${selectedCount} ${
+            selectedCount === 1 ? "document" : "documents"
           }? They stop being searchable straight away. The next sync brings back anything still present at the source — to keep them out, remove them there or narrow this connector's scope.`}
           isPending={bulkDelete.isPending}
           onConfirm={() => {
             bulkDelete.mutate(
-              { connectorId, documents: selectedDocuments },
+              allMatchingActive
+                ? {
+                    connectorId,
+                    all: {
+                      ...(search ? { search } : {}),
+                      ...(group ? { group } : {}),
+                    },
+                  }
+                : { connectorId, documents: selectedDocuments },
               {
                 onSuccess: (outcome) => {
                   reportBulkOutcome({
@@ -466,10 +470,8 @@ export function ConnectorDocumentsTable({
                   if (outcome.failed.length === 0) clearSelection();
                   // Emptying the last page would otherwise leave the table on a
                   // page that no longer exists.
-                  if (
-                    outcome.succeeded.length >= documents.length &&
-                    pageIndex > 0
-                  ) {
+                  const removed = outcome.affected ?? outcome.succeeded.length;
+                  if (removed >= documents.length && pageIndex > 0) {
                     setPagination({ pageIndex: pageIndex - 1, pageSize });
                   }
                 },

--- a/platform/frontend/src/components/ui/bulk-actions-bar.test.tsx
+++ b/platform/frontend/src/components/ui/bulk-actions-bar.test.tsx
@@ -152,6 +152,26 @@ describe("BulkActionsBar", () => {
       expect(offer()).toBeNull();
     });
 
+    /**
+     * The counterpart to the test above: `max` exists for callers that send an
+     * id list, and a caller that sends the FILTER instead has no such ceiling.
+     * Withholding the offer there would hide the escalation from exactly the
+     * corpora it exists for — a connector with 22,921 documents.
+     */
+    it("offers the whole set however large it is when no cap is declared", () => {
+      selectAll({
+        noun: "document",
+        selectAllMatching: {
+          total: 22_921,
+          pageFullySelected: true,
+          active: false,
+          onSelectAll: vi.fn(),
+        },
+      });
+
+      expect(offer()?.textContent).toContain("22921");
+    });
+
     it("reports the whole set once escalated, and stops re-offering it", () => {
       const onSelectAll = vi.fn();
       selectAll({

--- a/platform/frontend/src/components/ui/bulk-actions-bar.tsx
+++ b/platform/frontend/src/components/ui/bulk-actions-bar.tsx
@@ -28,9 +28,15 @@ export interface SelectAllMatching {
    */
   matchDescription?: string;
   /**
-   * Largest set the caller's action can actually express — for skills the bulk
-   * endpoints take at most 500 ids. Above it the offer is withheld rather than
-   * promising a batch that would be refused.
+   * Largest set the caller's action can actually express, for callers whose
+   * action sends an ID LIST — the bulk endpoints take at most `MAX_BULK_IDS`
+   * of them. Above it the offer is withheld rather than promising a batch that
+   * would be refused.
+   *
+   * Omit it when the action can send the FILTER instead, as the connector
+   * documents table does: there is no id list to outgrow, so a corpus of
+   * 22,000 is as selectable as one of 5, and capping the offer would withhold
+   * exactly the case the escalation exists for.
    */
   max?: number;
 }

--- a/platform/frontend/src/lib/bulk-action.ts
+++ b/platform/frontend/src/lib/bulk-action.ts
@@ -64,8 +64,10 @@ export async function runBulkAction<T>({
 export function toBulkOutcome(result: {
   succeeded: Array<{ name: string }>;
   failed: Array<{ name: string | null; error: string }>;
+  affected?: number;
 }): BulkOutcome {
   return {
+    affected: result.affected,
     succeeded: result.succeeded.map((entry) => entry.name),
     failed: result.failed.map((entry) => ({
       label: entry.name ?? "Unknown",
@@ -97,9 +99,12 @@ export function reportBulkOutcome({
   const { succeeded, failed } = outcome;
   const count = (n: number) =>
     `${n} ${n === 1 ? noun : (plural ?? `${noun}s`)}`;
+  // A filter-mode batch reports only a count: it has no per-row names, so
+  // reading `succeeded.length` would announce "0" after moving thousands.
+  const succeededCount = outcome.affected ?? succeeded.length;
 
   if (failed.length === 0) {
-    toast.success(`${verb} ${count(succeeded.length)}`);
+    toast.success(`${verb} ${count(succeededCount)}`);
     return;
   }
 
@@ -110,7 +115,7 @@ export function reportBulkOutcome({
   const remaining = failed.length - BULK_FAILURE_NAMES_SHOWN;
   const description = `${remaining > 0 ? `${named} and ${remaining} more` : named} — ${failed[0].error}`;
 
-  if (succeeded.length === 0) {
+  if (succeededCount === 0) {
     // The reason is the same for every entry in the common cases (no
     // permission, still in use), so the first one stands for the rest.
     toast.error(`Could not ${failureVerb} ${count(failed.length)}`, {
@@ -120,7 +125,7 @@ export function reportBulkOutcome({
   }
 
   toast.warning(
-    `${verb} ${count(succeeded.length)} — ${count(failed.length)} could not be ${failureVerb}d`,
+    `${verb} ${count(succeededCount)} — ${count(failed.length)} could not be ${failureVerb}d`,
     { description },
   );
 }
@@ -128,6 +133,12 @@ export function reportBulkOutcome({
 export interface BulkOutcome {
   succeeded: string[];
   failed: { label: string; error: string }[];
+  /**
+   * Rows changed when the batch selected by filter rather than by id. Such a
+   * batch has no per-row names to report — it may have moved tens of thousands
+   * of rows — so the count stands in for `succeeded`.
+   */
+  affected?: number;
 }
 
 /** How many failures a bulk toast names before it starts counting. */

--- a/platform/frontend/src/lib/knowledge/kb-document.query.ts
+++ b/platform/frontend/src/lib/knowledge/kb-document.query.ts
@@ -116,16 +116,26 @@ export function useAllMatchingConnectorDocuments(
 export function useBulkDeleteConnectorDocuments() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({
-      connectorId,
-      documents,
-    }: {
-      connectorId: string;
-      documents: readonly { id: string }[];
-    }) =>
+    mutationFn: async (
+      params:
+        | { connectorId: string; documents: readonly { id: string }[] }
+        | {
+            connectorId: string;
+            /**
+             * Everything matching the table's current filters. Sent as the
+             * filter rather than as ids: a connector's corpus routinely runs
+             * to tens of thousands of documents, which no request body should
+             * be asked to carry as uuids.
+             */
+            all: { search?: string; group?: string };
+          },
+    ) =>
       bulkDeleteConnectorDocuments({
-        path: { id: connectorId },
-        body: { ids: documents.map((document) => document.id) },
+        path: { id: params.connectorId },
+        body:
+          "all" in params
+            ? { all: true as const, ...params.all }
+            : { ids: params.documents.map((document) => document.id) },
       }).then(({ data, error }) => {
         throwOnApiError(error, { toastOnError: false });
         return toBulkOutcome(data ?? { succeeded: [], failed: [] });

--- a/platform/frontend/src/lib/knowledge/kb-document.query.ts
+++ b/platform/frontend/src/lib/knowledge/kb-document.query.ts
@@ -4,7 +4,6 @@ import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { toBulkOutcome } from "@/lib/bulk-action";
-import { useAllMatching } from "@/lib/hooks/use-all-matching";
 import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
@@ -76,34 +75,6 @@ export function useConnectorDocument(params: ConnectorDocumentParams) {
       Boolean(params.path.id) &&
       Boolean(params.path.docId) &&
       (params.enabled ?? true),
-  });
-}
-
-/**
- * Every document matching the table's filters, not just the page in view —
- * what backs "select all N that match this search".
- */
-export function useAllMatchingConnectorDocuments(
-  params: {
-    connectorId: string;
-    query: Omit<
-      NonNullable<archestraApiTypes.GetConnectorDocumentsData["query"]>,
-      "limit" | "offset"
-    >;
-  },
-  options?: { enabled?: boolean },
-) {
-  return useAllMatching({
-    queryKey: ["connector-documents", "all-matching", params],
-    enabled: options?.enabled,
-    fetchPage: async ({ limit, offset }) => {
-      const { data, error } = await getConnectorDocuments({
-        path: { id: params.connectorId },
-        query: { ...params.query, limit, offset },
-      });
-      throwOnApiError(error, { toastOnError: false });
-      return data?.data ?? [];
-    },
   });
 }
 

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -16237,6 +16237,7 @@ export type BulkDeleteAgentsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -16348,6 +16349,7 @@ export type BulkUpdateAgentsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -19179,6 +19181,7 @@ export type BulkDeleteApiKeysResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -21466,6 +21469,7 @@ export type BulkDeleteAppsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -21574,6 +21578,7 @@ export type BulkUpdateAppsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -36102,6 +36107,7 @@ export type BulkDeleteEnvironmentsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -58066,6 +58072,7 @@ export type BulkDeleteKnowledgeBasesResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -60217,6 +60224,19 @@ export type BulkDeleteConnectorDocumentsData = {
          * Ids to act on. Duplicates are collapsed.
          */
         ids: Array<string>;
+    } | {
+        /**
+         * Delete everything matching the filters below rather than an id list.
+         */
+        all: true;
+        /**
+         * Same title search the listing applies.
+         */
+        search?: string;
+        /**
+         * Same group filter the listing applies.
+         */
+        group?: string;
     };
     path: {
         id: string;
@@ -60295,6 +60315,7 @@ export type BulkDeleteConnectorDocumentsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -60391,6 +60412,7 @@ export type BulkDeleteConnectorsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -60495,6 +60517,7 @@ export type BulkUpdateConnectorsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -62636,6 +62659,7 @@ export type BulkDeleteKnowledgeFilesResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -62740,6 +62764,7 @@ export type BulkUpdateKnowledgeFilesResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -63297,6 +63322,7 @@ export type BulkDeleteKnowledgeDirectoriesResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -63401,6 +63427,7 @@ export type BulkUpdateKnowledgeDirectoriesResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -64347,6 +64374,7 @@ export type BulkUpdateModelsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -67225,6 +67253,7 @@ export type BulkDeleteMcpServersResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -79756,6 +79785,7 @@ export type BulkDeleteProjectsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -79855,6 +79885,7 @@ export type BulkUpdateProjectsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -82730,6 +82761,7 @@ export type BulkDeleteServiceAccountsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -88210,6 +88242,7 @@ export type BulkDeleteTeamsResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;
@@ -92170,6 +92203,7 @@ export type BulkDeleteRolesResponses = {
      * Default Response
      */
     200: {
+        affected?: number;
         succeeded: Array<{
             id: string;
             name: string;


### PR DESCRIPTION
Follow-up to #7377. On a connector's Documents tab, **"select all that match" never appeared** — you could tick the ten rows on screen and nothing more, on a connector holding 22,921 documents.

## Why it was hidden

The bar withheld the offer whenever the matching set was larger than `MAX_BULK_IDS` (500):

```ts
selectAllMatching.total <= selectAllMatching.max
```

That cap wasn't arbitrary. "Select all matching" enumerated ids **in the browser** and posted them, so the offer could only ever promise what an id list could carry. With 22,921 documents it was suppressed every time — hiding the escalation from exactly the corpora it exists for.

## The fix: send the filter, not the ids

Raising the number would still be wrong at the next order of magnitude, so the delete now sends the filter instead:

```
DELETE /api/connectors/:id/documents/bulk   { all: true, search?, group? }
```

The database resolves and deletes the matching set in one statement, and the response carries `affected` rather than a per-row list — no caller wants 22,921 names back. Id mode is untouched: `{ ids }` still behaves exactly as before, names and per-row failures included.

Escalating no longer fetches the matching rows at all — only their count is needed on screen, which is what makes *"All 22,921 documents selected"* honest rather than a page-sized approximation.

## What makes it safe

A filter-mode delete is only correct if it destroys exactly what the table was showing. So the predicate is now defined **once** — `connectorDocumentsFilter` — and shared by the listing, its count, and the delete. Had they stayed separate, they could drift and the rows destroyed would quietly stop being the rows the user was looking at.

The tests pin that equivalence directly:

- a title search deletes exactly what that search listed, and leaves the rest
- the batch never reaches another connector's documents
- a connector in another organization 404s the whole request, deleting nothing
- nothing matching reports `affected: 0` rather than failing

## `max` still means something

It keeps its meaning for callers that send an **id list** — every other bulk table still declares it, correctly. The documents table simply no longer does, because it has no id list to outgrow. That distinction is now documented on the type, and a unit test pins that omitting `max` offers the escalation however large the total is.

## Coverage

12 route-level tests on this endpoint (7 id-mode, 5 filter-mode), plus the bar's unit tests. Green: all 8 packages type-check, 4,455 frontend unit tests, lint.

**Note on the backend suite:** `mcp-tool-call`, `interaction-delta-manager` and `conversation` model tests fail 17 on this branch — and fail identically with these changes stashed on `4922f96de`. Pre-existing on main, unrelated to this work.

## Still id-mode

Every other bulk table caps at 500, which is correct while its totals stay under it. The mechanism to lift any of them is now in place — each needs its own filter plumbed through, so it should be done per resource where the size actually warrants it (models and users are the likeliest next).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>