### PR TITLE
fix(llm-proxy): stop a blocked tool call from ending an agent's turn

### DIFF
--- a/platform/backend/src/guardrails/tool-invocation.test.ts
+++ b/platform/backend/src/guardrails/tool-invocation.test.ts
@@ -31,10 +31,14 @@ describe("evaluatePolicies", () => {
     expect(result).toBeNull();
   });
 
-  test("returns block result when tool is not in enabledToolNames", async ({
+  test("hands an undeclared tool call back rather than ending the turn", async ({
     makeAgent,
   }) => {
     const agent = await makeAgent();
+    // The caller declared `allowed_tool` and nothing else, so it will not run
+    // `disabled_tool` whatever the proxy says. Refusing here would drop the
+    // call and end the turn, stranding an unattended agent loop; handing it
+    // back lets the caller reject it and the model carry on.
     const enabledTools = new Set(["allowed_tool"]);
 
     const result = await evaluatePolicies(
@@ -43,6 +47,25 @@ describe("evaluatePolicies", () => {
       { teamIds: [] },
       true,
       enabledTools,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("still refuses an unassigned tool on the gateway surface", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    // On the gateway the enabled set is the agent's *assigned* tools, not a
+    // caller declaration, so a missing name is a real authorization miss and
+    // the gateway is the party that would otherwise execute it.
+    const result = await evaluatePolicies(
+      [{ toolCallName: "disabled_tool", toolCallArgs: "{}" }],
+      agent.id,
+      { teamIds: [] },
+      true,
+      new Set(["allowed_tool"]),
+      { surface: "mcp-gateway" },
     );
 
     expect(result).not.toBeNull();
@@ -157,6 +180,7 @@ describe("evaluatePolicies", () => {
     const agent = await makeAgent();
     // `full` exposure hides the meta tools, so a tool missing from the list
     // really was disabled for the conversation — run_tool is not the answer.
+    // Asserted on the gateway surface, the one that still refuses.
     const enabledTools = new Set(["github__list_repos"]);
 
     const result = await evaluatePolicies(
@@ -165,6 +189,7 @@ describe("evaluatePolicies", () => {
       { teamIds: [] },
       true,
       enabledTools,
+      { surface: "mcp-gateway" },
     );
 
     expect(result?.reason).toBe(
@@ -189,6 +214,7 @@ describe("evaluatePolicies", () => {
       { teamIds: [] },
       true,
       enabledTools,
+      { surface: "mcp-gateway" },
     );
 
     expect(result?.reason).toBe(
@@ -424,6 +450,7 @@ describe("evaluatePolicies", () => {
       { teamIds: [] },
       true,
       enabledTools,
+      { surface: "mcp-gateway" },
     );
 
     expect(result).not.toBeNull();

--- a/platform/backend/src/guardrails/tool-invocation.test.ts
+++ b/platform/backend/src/guardrails/tool-invocation.test.ts
@@ -52,6 +52,40 @@ describe("evaluatePolicies", () => {
     expect(result).toBeNull();
   });
 
+  // Regression from a real dead-ended run. An external client decorates the
+  // gateway's tools with its own alias (`mcp__<alias>__<advertised name>`), so
+  // the declared list carries no recognizable dispatch pair and this takes the
+  // no-dispatch-pair path. The model, having lost its shell to an unrelated
+  // failure, reached for a client built-in this request never declared.
+  // Refusing dropped the call and ended the turn, and with no human present to
+  // type again, the run stopped there for hours.
+  test("hands back a client built-in the request never declared", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    const declared = new Set([
+      "mcp__archestra__acme_gateway__run_tool",
+      "mcp__archestra__acme_gateway__search_tools",
+      "Bash",
+      "Skill",
+    ]);
+
+    const result = await evaluatePolicies(
+      [
+        {
+          toolCallName: "Grep",
+          toolCallArgs: JSON.stringify({ pattern: "x" }),
+        },
+      ],
+      agent.id,
+      { teamIds: [] },
+      true,
+      declared,
+    );
+
+    expect(result).toBeNull();
+  });
+
   test("still refuses an unassigned tool on the gateway surface", async ({
     makeAgent,
   }) => {

--- a/platform/backend/src/guardrails/tool-invocation.ts
+++ b/platform/backend/src/guardrails/tool-invocation.ts
@@ -251,25 +251,35 @@ export const evaluatePolicies = async (
   // disabled — so the model is told how to reach them through run_tool instead
   // of being told to stop. Mirrors the same discrimination the chat surface
   // makes for nonexistent-tool errors (`routes/chat/errors.ts`).
+  //
+  // The no-dispatch-pair case is handed back to the caller instead of refused —
+  // see `refusalWouldStrandTheCaller` for why refusing it ends the session.
   if (disabledToolNames.length > 0) {
     const dispatchPair = findDispatchToolNames(enabledToolNames);
-    const message = dispatchPair
-      ? toolsRequireRunToolMessage({
-          toolNames: disabledToolNames,
-          ...dispatchPair,
-        })
-      : disabledToolsNotRunMessage(disabledToolNames);
-    const reason = dispatchPair
-      ? TOOL_INVOCATION_NOT_DIRECTLY_CALLABLE_REASON
-      : TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON;
-    return {
-      refusalMessage: message,
-      contentMessage: message,
-      reason,
-      blockedToolName: disabledToolNames[0],
-      toolInput: {},
-      allToolCallNames: disabledToolNames,
-    };
+    if (!dispatchPair && refusalWouldStrandTheCaller(enforcement.surface)) {
+      logger.info(
+        { undeclaredTools: disabledToolNames },
+        "[toolInvocation] evaluatePolicies: undeclared tool calls handed back to the caller",
+      );
+    } else {
+      const message = dispatchPair
+        ? toolsRequireRunToolMessage({
+            toolNames: disabledToolNames,
+            ...dispatchPair,
+          })
+        : disabledToolsNotRunMessage(disabledToolNames);
+      const reason = dispatchPair
+        ? TOOL_INVOCATION_NOT_DIRECTLY_CALLABLE_REASON
+        : TOOL_INVOCATION_DISABLED_FOR_CONVERSATION_REASON;
+      return {
+        refusalMessage: message,
+        contentMessage: message,
+        reason,
+        blockedToolName: disabledToolNames[0],
+        toolInput: {},
+        allToolCallNames: disabledToolNames,
+      };
+    }
   }
 
   // If all tools were filtered out, nothing to evaluate
@@ -339,6 +349,45 @@ export const evaluatePolicies = async (
 const MCP_GATEWAY_ENFORCEMENT: PolicyEnforcementContext = {
   surface: "mcp-gateway",
 };
+
+/**
+ * Whether refusing a call to an undeclared tool would strand the caller.
+ *
+ * Refusing is terminal. The proxy drops the turn's tool calls and replaces the
+ * whole assistant message with the refusal text, so the turn carries no tool
+ * call at all — and every agent loop reads that as "the assistant is finished"
+ * and hands control back to a human. With a human watching that is invisible:
+ * they read the steer and type again. With nobody watching it is fatal. An
+ * unattended run — CI, a scheduled job, a chat-ops session, a delegated
+ * sub-agent — simply stops, with no error, no exit and nothing to retry. Every
+ * recovery instruction the refusal carries asks for a next model turn that, by
+ * construction, never happens.
+ *
+ * Nothing is bought in exchange. The names that reach this branch are the ones
+ * absent from the caller's own tool list, and no caller executes a tool it did
+ * not declare: an external client dispatches from the list it sent, and chat
+ * dispatches through the AI SDK, which raises `NoSuchToolError` for anything
+ * unregistered (`routes/chat/errors.ts` already turns that into a model-visible
+ * message). Handing the call back is therefore inert — the caller answers it
+ * the way it answers any unknown tool, with an error result the model reads and
+ * adapts to, and the loop keeps going. Enforcement that decides what may
+ * actually run — conversation tool selection, assignment, RBAC, invocation
+ * policies — lives on the execution path in `run_tool` and the gateway, and is
+ * untouched by this.
+ *
+ * Two cases deliberately keep the refusal. A request advertising the
+ * search_tools/run_tool dispatch pair does offer the model a real route to the
+ * tool, so its steer is actionable and worth ending the turn for (and
+ * `planDispatchModeToolCallRewrites` has already repaired the calls it safely
+ * can before reaching here). And on the gateway surface the enabled set is the
+ * agent's *assigned* tools rather than a caller declaration, so a missing name
+ * is a genuine authorization miss.
+ */
+function refusalWouldStrandTheCaller(
+  surface: ToolInvocationEnforcementSurface,
+): boolean {
+  return surface === "llm-proxy";
+}
 
 /**
  * The search_tools/run_tool pair as it appears in the request's tool list, or

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -1235,9 +1235,18 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
     });
 
     // The other half of the contract: widening what counts as declared must not
-    // hollow out the check. A tool the caller never declared is still refused,
-    // which is what per-conversation tool selection relies on.
-    test("a tool the caller never declared is still refused", async () => {
+    // hollow out the check — `enabledToolNames` must still hold exactly what
+    // this request declared and nothing else.
+    //
+    // What that buys has changed. An undeclared name is now handed back rather
+    // than refused: refusing dropped the call and ended the turn, which reads
+    // to an agent loop as "the assistant is finished" and strands an
+    // unattended run. Nothing executes either way, because the caller cannot
+    // run a tool it never declared. Per-conversation tool selection is still
+    // enforced where the tool would actually run — chat's AI SDK raises
+    // NoSuchToolError for anything unregistered, and run_tool applies the
+    // conversation gate on the dispatch path.
+    test("a tool the caller never declared is handed back, not refused", async () => {
       openAiStubOptions.includeToolCalls = true;
       const { evaluatePolicies } = await vi.importActual<
         typeof import("@/guardrails/tool-invocation")
@@ -1266,8 +1275,11 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       const enabledToolNames = mockEvaluatePolicies.mock
         .calls[0][4] as Set<string>;
       expect([...enabledToolNames]).toEqual(["something_else"]);
-      expect(response.body).toContain("are not enabled for this");
-      expect(response.body).not.toContain('"finish_reason":"tool_calls"');
+      expect(response.body).not.toContain("are not enabled for this");
+      // The turn still ends on the tool call, so the loop keeps going and the
+      // caller is the one that rejects the name.
+      expect(response.body).toContain("get_weather");
+      expect(response.body).toContain('"finish_reason":"tool_calls"');
     });
 
     // The refusal sibling above only pins that a refused call is absent, which

--- a/platform/backend/src/routes/proxy/llm-proxy-tool-invocation.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-tool-invocation.test.ts
@@ -341,9 +341,12 @@ describe("LLM Proxy tool-invocation policy (OpenAI)", () => {
     );
   });
 
-  // `full` exposure: a tool missing from the list really is disabled there, so
-  // the pre-existing refusal must survive untouched.
-  test("still refuses a disabled tool when the list has no dispatch pair", async ({
+  // `full` exposure, no dispatch pair: the name is absent from the caller's own
+  // tool list, so no caller would execute it anyway. Refusing dropped the tool
+  // call and ended the turn, which an agent loop reads as "the assistant is
+  // finished" — fatal for an unattended run. The call is handed back instead,
+  // and the caller rejects it the way it rejects any unknown tool.
+  test("hands an undeclared tool call back instead of ending the turn", async ({
     makeAgent,
   }) => {
     const agent = await makeAgent({
@@ -372,9 +375,18 @@ describe("LLM Proxy tool-invocation policy (OpenAI)", () => {
     });
 
     expect(response.statusCode, response.body).toBe(200);
-    const message = response.json().choices[0].message;
-    expect(message.tool_calls).toBeUndefined();
-    expect(message.content).toContain("not enabled for this conversation");
+    const choice = response.json().choices[0];
+
+    // The turn still ends on the tool call. `stop` here is the bug: it is what
+    // makes an agent loop hand control back to a human who may not be there.
+    expect(choice.finish_reason).toBe("tool_calls");
+    expect(choice.message.tool_calls).toHaveLength(1);
+    expect(choice.message.tool_calls[0].function.name).toBe(
+      "gh-developer-agent__pull_request_read",
+    );
+    expect(choice.message.content ?? "").not.toContain(
+      "not enabled for this conversation",
+    );
   });
 
   // The repaired call faces the same gate a run_tool dispatch the model wrote


### PR DESCRIPTION
## The bug

When the LLM proxy blocks a tool call because the name is absent from the request's own tool list, it drops the turn's tool calls and replaces the assistant message with the refusal text (`llm-proxy-handler.ts`: *"the tool-call events were held back, so they are simply dropped and the client is sent the refusal alone"*). The turn then carries no tool call, so the adapters force an end-of-turn stop reason — e.g. `anthropic.ts`:

```ts
stop_reason: this.responseReplacedWithText ? "end_turn" : (this.state.stopReason ?? "end_turn"),
```

Every agent loop reads a turn with no tool call as *"the assistant is finished"* and hands control back to a human.

With a human watching, that is invisible — they read the steer and type again. With nobody watching it is fatal: an unattended run (CI, a scheduled job, a chat-ops session, a delegated sub-agent) simply **stops**, with no error, no exit and nothing to retry. The session looks alive and idle forever.

The sharp edge is that every recovery instruction these refusals carry — *"call search_tools to discover the tools you can use"*, *"retry by calling run_tool…"*, and especially *"Do not call them again here"* — asks for a **next model turn that, by construction, never happens**. Successive fixes have improved the wording of that message; the message was never the thing that was broken.

## The fix

Hand the call back instead of refusing it.

Nothing is given up by doing so, because **no caller executes a tool it did not declare**:

- an external client dispatches from the tool list it sent;
- chat dispatches through the AI SDK, which raises `NoSuchToolError` for anything unregistered — `routes/chat/errors.ts` already turns that into a model-visible message.

So handing the call back is inert. The caller answers it the way it answers any unknown tool, with an error result the model reads and adapts to, and the loop keeps going.

Two cases deliberately keep the refusal:

- **A request advertising the `search_tools`/`run_tool` dispatch pair.** There the platform does offer the model a real route to the tool, so the steer is actionable and worth ending the turn for — and `planDispatchModeToolCallRewrites` has already repaired the calls it safely can before reaching this branch. Auto/dispatch-mode behaviour is untouched.
- **The MCP gateway surface.** There the enabled set is the agent's *assigned* tools rather than a caller declaration, so a missing name is a genuine authorization miss, and the gateway is the party that would otherwise execute it.

Enforcement of what may actually run — conversation tool selection, assignment, RBAC, tool-invocation policies — lives on the execution path in `run_tool` and the gateway, and is unchanged by this.

## Behaviour change worth flagging

A call that is now handed back no longer records a blocked-tool-call metric under *"not enabled for this conversation"*. That count was arguably always overstated: nothing was going to run either way. The names are still logged at `info` on the proxy path.

## Tests

- `llm-proxy-tool-invocation.test.ts` — the end-to-end case is rewritten to pin the actual contract: the response keeps `finish_reason: "tool_calls"` and the tool call, instead of a `stop` with the call dropped. `stop` there *is* the bug.
- `tool-invocation.test.ts` — new coverage for the hand-back, plus the existing refusal assertions re-pointed at the gateway surface, which still refuses.

Backend `type-check`, `lint` and `knip` are clean. `src/routes/proxy` + `src/archestra-mcp-server/run-tool.test.ts` show the same 2 failing files before and after the change (pre-existing, unrelated to this diff).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>