### PR TITLE
fix(llm-proxy): see through a client alias when unwrapping a run_tool dispatch

### DIFF
--- a/platform/backend/src/archestra-mcp-server/run-tool-target.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool-target.ts
@@ -2,6 +2,7 @@ import {
   ARCHESTRA_TOOL_SHORT_NAMES,
   type ArchestraToolShortName,
   getArchestraToolFullName,
+  MCP_SERVER_TOOL_NAME_SEPARATOR,
   TOOL_RUN_TOOL_SHORT_NAME,
 } from "@archestra/shared";
 
@@ -61,11 +62,45 @@ type RunToolDispatch =
  * policies evaluate the tool that actually produced the data instead of the
  * built-in wrapper.
  */
-/** True when the (canonical) tool name is the `run_tool` dispatch wrapper. */
+/**
+ * True when the tool name is the `run_tool` dispatch wrapper, including when an
+ * MCP client has decorated it with its own label.
+ *
+ * Clients namespace a gateway's tools with the alias they were registered
+ * under: Claude Code turns what the gateway advertised into
+ * `mcp__<alias>__<advertised name>`. That alias is free text typed at
+ * `claude mcp add` time, so it routinely matches no name the platform knows,
+ * and the gateway's own branded prefix then sits a segment deeper than the
+ * decoration-stripping canonicalizer reaches. A strict match misses the wrapper
+ * entirely — and a missed wrapper is not a harmless miss: the dispatch is never
+ * unwrapped, so policies are evaluated against an opaque name that matches no
+ * `tools` row and **fail open**, instead of against the tool the call runs.
+ *
+ * Matching loosely is safe here, and only here. Recognizing a dispatch can only
+ * ADD enforcement: it hands the target tool to policy evaluation in place of a
+ * name nothing speaks for. It routes no call anywhere — a loosely matched name
+ * is never used as a rewrite target, which stays strict in
+ * `planDispatchModeToolCallRewrites` — and it confers no built-in policy
+ * bypass, which stays on `archestraMcpBranding.isToolName`. That keeps the
+ * standing rule in `branding.ts` intact: a loose match must not drive dispatch,
+ * RBAC, or bypass decisions.
+ *
+ * Only suffixes that still carry a server prefix are considered, so a
+ * third-party tool merely named `run_tool` is not mistaken for the wrapper —
+ * the prefix has to be one the branding recognizes as ours.
+ */
 function isRunToolName(toolName: string): boolean {
-  return (
-    archestraMcpBranding.getToolShortName(toolName) === TOOL_RUN_TOOL_SHORT_NAME
-  );
+  const segments = toolName.split(MCP_SERVER_TOOL_NAME_SEPARATOR);
+  for (let i = 0; i < segments.length - 1; i++) {
+    const candidate = segments.slice(i).join(MCP_SERVER_TOOL_NAME_SEPARATOR);
+    if (
+      archestraMcpBranding.getToolShortName(candidate) ===
+      TOOL_RUN_TOOL_SHORT_NAME
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function resolveRunToolDispatch(

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -32,6 +32,7 @@ import {
   propagation,
 } from "@opentelemetry/api";
 import type { FastifyReply, FastifyRequest } from "fastify";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
@@ -45,7 +46,6 @@ import {
   type DualLlmProgressEvent,
   dualLlmProgressBus,
 } from "@/guardrails/dual-llm-progress-bus";
-import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import logger from "@/logging";
 import {
   AgentTeamModel,

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -45,6 +45,7 @@ import {
   type DualLlmProgressEvent,
   dualLlmProgressBus,
 } from "@/guardrails/dual-llm-progress-bus";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import logger from "@/logging";
 import {
   AgentTeamModel,
@@ -1257,6 +1258,29 @@ export async function handleLLMProxy<
         .collectDeclaredToolNames(requestAdapter.getOriginalRequest())
         .map(canonicalizeToolName),
     );
+
+    // A gateway tool name the client decorated with an alias the platform does
+    // not recognize survives canonicalization untouched, and every guardrail
+    // downstream then reasons about the decoration rather than the tool. That
+    // degradation is otherwise completely silent, which is why it can sit in a
+    // deployment indefinitely — so say so once per request, naming the tool, so
+    // it is greppable and the gateway can be re-registered under the name the
+    // connection-setup script derives (`toMcpClientServerName`).
+    const unrecognizedGatewayToolNames = [...enabledToolNames].filter(
+      (toolName) =>
+        archestraMcpBranding.isLikelyToolName(toolName) &&
+        !archestraMcpBranding.isToolName(toolName),
+    );
+    if (unrecognizedGatewayToolNames.length > 0) {
+      logger.warn(
+        {
+          agentId: resolvedAgent.id,
+          organizationId: resolvedAgent.organizationId,
+          toolNames: unrecognizedGatewayToolNames,
+        },
+        `[${providerName}Proxy] Gateway tool names carry a client alias this organization does not know; guardrails cannot resolve the tools behind them`,
+      );
+    }
 
     // Convert headers to Record<string, string> for policy evaluation context
     const headersRecord: Record<string, string> = {};

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -288,6 +288,47 @@ describe("planDispatchModeToolCallRewrites", () => {
 // normalizeToolCallsForPolicy
 // --------------------------------------------------------------------------
 describe("normalizeToolCallsForPolicy", () => {
+  // Regression: an MCP client namespaces the gateway's tools with the alias it
+  // was registered under, and that alias is free text typed at `claude mcp add`
+  // time — so the gateway's own branded prefix ends up a segment deeper than
+  // the decoration-stripping canonicalizer reaches, and a strict match misses
+  // the wrapper. A missed wrapper is not a harmless miss: the dispatch is never
+  // unwrapped, so policies are evaluated against a name that matches no `tools`
+  // row and fail open instead of against the tool the call actually runs.
+  test("unwraps a run_tool dispatch decorated with an alias the platform does not know", () => {
+    const result = normalizeToolCallsForPolicy([
+      {
+        name: "mcp__some_local_alias__archestra__run_tool",
+        arguments: JSON.stringify({
+          tool_name: "github__create_or_update_file",
+          tool_args: { path: "README.md" },
+        }),
+      },
+    ]);
+
+    expect(result[0].toolCallName).toBe("github__create_or_update_file");
+    expect(result[0].isRunToolDispatchTarget).toBe(true);
+    expect(JSON.parse(result[0].toolCallArgs)).toEqual({ path: "README.md" });
+  });
+
+  // The loosening must stay anchored on a prefix the branding recognizes as
+  // ours: a third-party tool that happens to be called `run_tool` is an
+  // ordinary tool, and treating it as the wrapper would hand policy evaluation
+  // whatever that server put in `tool_name`.
+  test("does not treat a third-party tool named run_tool as a dispatch", () => {
+    const result = normalizeToolCallsForPolicy([
+      {
+        name: "mcp__some_local_alias__github__run_tool",
+        arguments: JSON.stringify({ tool_name: "anything__at_all" }),
+      },
+    ]);
+
+    expect(result[0].toolCallName).toBe(
+      "mcp__some_local_alias__github__run_tool",
+    );
+    expect(result[0].isRunToolDispatchTarget).toBeUndefined();
+  });
+
   test("passes through valid JSON string arguments", () => {
     const result = normalizeToolCallsForPolicy([
       { name: "tool1", arguments: '{"key":"value"}' },


### PR DESCRIPTION
## The bug

An MCP client namespaces a gateway's tools with the alias it was registered under. Claude Code turns what the gateway advertised into `mcp__<alias>__<advertised name>` — and our gateway advertises its built-ins *already branded*, so a real name looks like:

```
mcp__<client alias>__<org brand>__run_tool
```

`buildGatewayToolNameCanonicalizer` strips that decoration only when one of the **first two** segments is a gateway name the organization knows (`GATEWAY_LABEL_MAX_INDEX = 1`). But the alias is free text typed at `claude mcp add` time — it has no reason to equal the gateway's platform name, and when it doesn't, it matches nothing at any index. The branded prefix is then buried a segment deeper than anything looks, and canonicalization silently no-ops.

The sharp consequence is on `run_tool`. `isRunToolName` matched strictly, so a decorated wrapper was not recognized as a dispatch:

- the call was never unwrapped to its target;
- so tool-invocation policies were evaluated against the opaque wrapper name;
- which matches no `tools` row, and **an unknown name fails open**.

The MCP gateway still evaluates policy at execution time, so this was a loss of defense in depth rather than a full bypass. But it applied to *every* client whose alias didn't happen to equal the gateway's name, and nothing surfaced it.

## The fix

Recognize the wrapper through the decoration, scanning suffixes for one the branding accepts as ours.

The loosening is deliberately confined to this single predicate, because `branding.ts` already carries a standing rule — its loose recognizer `isLikelyToolName` is documented *"never use for dispatch, RBAC, or policy decisions — those must stay strict."* That rule is honored here: loosening this one check can only **add** enforcement, since it hands the target tool to policy evaluation in place of a name nothing speaks for. It does not:

- **route anything** — a loosely matched name is never used as a rewrite target; `planDispatchModeToolCallRewrites` stays strict, so a call is never re-addressed to a name we matched loosely;
- **confer policy bypass** — built-in bypass stays on the strict `archestraMcpBranding.isToolName` path.

Only suffixes that still carry a server prefix are considered, so a third-party tool merely *named* `run_tool` is not mistaken for the wrapper — the prefix has to be one the branding recognizes.

Also adds a warning when a request declares gateway tool names carrying an alias the organization doesn't know. This degradation was previously invisible, which is precisely why it can sit in a deployment indefinitely; the log names the tools so it's greppable and the gateway can be re-registered under the name the connection-setup script derives (`toMcpClientServerName`).

## Scope — what this does not fix

Direct calls to *third-party* gateway tools under an unknown alias (`mcp__<alias>__github__list_repos`) still don't canonicalize, so proxy-side policy lookup for those still fails open. Closing that needs an anchor that a directly-connected hostile MCP server cannot forge by naming its tools to look like ours — the exact spoof the canonicalizer's doc comment guards against — and it deserves its own change rather than a widened match here.

## Tests

- `llm-proxy-helpers.test.ts` — a decorated dispatch unwraps to its target with `isRunToolDispatchTarget` set and the target's own args preserved. Verified load-bearing: reverting `run-tool-target.ts` to `main` fails this test.
- A negative test pins the anchor: a third-party `run_tool` under a foreign server prefix is left alone, not treated as a dispatch.

Backend `type-check`, `lint` and `knip` clean. Across `src/routes/proxy`, `src/guardrails` and `run-tool.test.ts`: 4 failing tests before and after this change (pre-existing and unrelated — they assert on plaintext interaction bodies, which a local `.env` encrypts), with +2 passing from the new tests.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>