### PR TITLE
fix(llm-proxy): hand back a direct call in dispatch mode too, rather than ending the turn

### DIFF
--- a/platform/backend/src/guardrails/tool-invocation.test.ts
+++ b/platform/backend/src/guardrails/tool-invocation.test.ts
@@ -171,6 +171,38 @@ describe("evaluatePolicies", () => {
     expect(result).toBeNull();
   });
 
+  // Reported from production more than once: a `search_and_run_only` agent
+  // emits a third-party tool's raw name instead of wrapping it, the steer
+  // replaces the whole turn, and the run ends — including on scheduled agents
+  // with nobody there to read it. The steer is correct and still unusable: it
+  // asks the model to retry through run_tool in a turn that has just been
+  // ended. `planDispatchModeToolCallRewrites` has already repaired what it
+  // safely can upstream, so what reaches here is exactly the batch that could
+  // not be auto-corrected — hand it back and let the caller's own unknown-tool
+  // error keep the loop alive.
+  test("hands back a direct call even when the dispatch pair is advertised", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    const enabledTools = new Set([
+      archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME),
+      archestraMcpBranding.getToolName(TOOL_RUN_TOOL_SHORT_NAME),
+    ]);
+
+    const result = await evaluatePolicies(
+      [{ toolCallName: "github__list_issues", toolCallArgs: "{}" }],
+      agent.id,
+      { teamIds: [] },
+      true,
+      enabledTools,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  // Asserted on the gateway surface: the LLM proxy no longer refuses these at
+  // all (it hands them back so the run can continue), so the gateway is where
+  // choosing correctly between the two steers still matters.
   test("steers to run_tool instead of 'not enabled' when the tool list advertises the dispatch pair", async ({
     makeAgent,
   }) => {
@@ -193,6 +225,7 @@ describe("evaluatePolicies", () => {
       { teamIds: [] },
       true,
       enabledTools,
+      { surface: "mcp-gateway" },
     );
 
     expect(result).not.toBeNull();
@@ -283,6 +316,7 @@ describe("evaluatePolicies", () => {
       { teamIds: [] },
       true,
       new Set([brandedSearchTools, brandedRunTool]),
+      { surface: "mcp-gateway" },
     );
 
     // Naming the canonical `archestra__*` form would point the model at a tool

--- a/platform/backend/src/guardrails/tool-invocation.ts
+++ b/platform/backend/src/guardrails/tool-invocation.ts
@@ -242,26 +242,25 @@ export const evaluatePolicies = async (
     }
   }
 
-  // If any tools were disabled, return distinct message about them.
+  // Tools the caller never declared.
   //
-  // Two different situations reach here, and they need different steers. When
-  // the request's tool list carries the search_tools/run_tool dispatch pair the
-  // agent is in `search_and_run_only` exposure (which Auto tool mode implies),
-  // where third-party tools are deliberately absent from the list rather than
-  // disabled — so the model is told how to reach them through run_tool instead
-  // of being told to stop. Mirrors the same discrimination the chat surface
-  // makes for nonexistent-tool errors (`routes/chat/errors.ts`).
-  //
-  // The no-dispatch-pair case is handed back to the caller instead of refused —
-  // see `refusalWouldStrandTheCaller` for why refusing it ends the session.
+  // On the LLM proxy these are handed back rather than refused — see
+  // `refusalWouldStrandTheCaller` for why refusing them ends the run. The
+  // gateway still refuses, and picks between two steers: a request whose tool
+  // list carries the search_tools/run_tool dispatch pair is in
+  // `search_and_run_only` exposure, where third-party tools are deliberately
+  // absent from the list rather than disabled, so the model is told how to
+  // reach them through run_tool instead of being told to stop. Mirrors the
+  // discrimination the chat surface makes for nonexistent-tool errors
+  // (`routes/chat/errors.ts`).
   if (disabledToolNames.length > 0) {
-    const dispatchPair = findDispatchToolNames(enabledToolNames);
-    if (!dispatchPair && refusalWouldStrandTheCaller(enforcement.surface)) {
+    if (refusalWouldStrandTheCaller(enforcement.surface)) {
       logger.info(
         { undeclaredTools: disabledToolNames },
         "[toolInvocation] evaluatePolicies: undeclared tool calls handed back to the caller",
       );
     } else {
+      const dispatchPair = findDispatchToolNames(enabledToolNames);
       const message = dispatchPair
         ? toolsRequireRunToolMessage({
             toolNames: disabledToolNames,
@@ -375,13 +374,22 @@ const MCP_GATEWAY_ENFORCEMENT: PolicyEnforcementContext = {
  * policies — lives on the execution path in `run_tool` and the gateway, and is
  * untouched by this.
  *
- * Two cases deliberately keep the refusal. A request advertising the
- * search_tools/run_tool dispatch pair does offer the model a real route to the
- * tool, so its steer is actionable and worth ending the turn for (and
- * `planDispatchModeToolCallRewrites` has already repaired the calls it safely
- * can before reaching here). And on the gateway surface the enabled set is the
+ * This holds even when the request advertises the search_tools/run_tool dispatch
+ * pair. That steer names a real route to the tool, which makes it *correct* —
+ * but correctness is not the problem: it asks the model to "retry through
+ * run_tool" in a turn that has just been ended, so it is read by a human or by
+ * nobody. `planDispatchModeToolCallRewrites` has already repaired the calls it
+ * safely can before reaching here, so what is left is precisely the batch that
+ * could not be auto-corrected, and ending the turn on it is what turns a wrong
+ * calling convention into a lost run. Handed back, the caller answers with its
+ * own unknown-tool error — on the chat surface that is
+ * `unavailableToolDispatchModeMessage`, which states the same convention as a
+ * tool result the model can act on.
+ *
+ * Only the gateway surface keeps the refusal: there the enabled set is the
  * agent's *assigned* tools rather than a caller declaration, so a missing name
- * is a genuine authorization miss.
+ * is a genuine authorization miss, and the gateway is itself the party that
+ * would otherwise execute it.
  */
 function refusalWouldStrandTheCaller(
   surface: ToolInvocationEnforcementSurface,


### PR DESCRIPTION
Follow-up to #7382, which stopped a blocked tool call from ending an agent's turn — but only for requests with **no** `search_tools`/`run_tool` dispatch pair.

## Why that carve-out was wrong

The reasoning was: where a dispatch pair exists, the steer names a real route to the tool, so it is actionable and worth ending the turn for.

Correctness was never the problem. The steer does name the route — and it asks the model to *"retry by calling run_tool"* in a turn that has just been ended. There is no model turn left in which to retry, so the message reaches a human or nobody at all.

For an unattended agent — a scheduled trigger, a chat-ops session, a delegated sub-agent — the run stops and emits the guardrail text as its answer. For any agent whose correct output is sometimes *nothing*, that is **indistinguishable from a healthy run** from the outside: same finish reason, no error, no signal. Field reports show this recurring on exactly that shape of workload, with prompt-level warnings added after each occurrence and the failure continuing regardless — prose cannot fix a terminal guard.

## What changes

`planDispatchModeToolCallRewrites` already repairs the calls it safely can before this point. What reaches the refusal is therefore precisely the batch that could **not** be auto-corrected — the case where ending the turn costs the entire run and buys nothing, since the caller was never going to execute a tool it did not declare.

Hand those back. The caller answers with its own unknown-tool error; on the chat surface that is `unavailableToolDispatchModeMessage`, which states the same calling convention as a **tool result the model can act on**. Same steer, delivered where it can be used.

The gateway surface still refuses, and still chooses between the two steers: there the enabled set is the agent's *assigned* tools rather than a caller declaration, so a missing name is a genuine authorization miss and the gateway is the party that would otherwise execute it.

## Tests

- New: a direct call is handed back even when the dispatch pair is advertised.
- The two message-selection tests move to the gateway surface — the only place that still refuses — with a comment saying why.

Backend `type-check`, `lint`, `knip` clean. Same 4 pre-existing failures before and after (they assert on plaintext interaction bodies, which a local `.env` encrypts).

## Known gaps, not addressed here

Worth separate issues — both apply to the paths that still refuse:

1. **The model's own output is discarded.** `toProviderResponse()` drops `state.text` and every `thinking` block when the response is replaced, so a turn's reasoning and partial answer are erased from history, not merely interrupted. A subsequent turn resumes from a conversation in which they never existed.
2. **A blocked turn is not distinguishable in telemetry.** It persists with a normal finish reason and no marker, so headless runs that died this way look successful.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>