### PR TITLE
fix(llm-proxy): learn a client's gateway label instead of assuming it

### DIFF
--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -1008,10 +1008,18 @@ export async function handleLLMProxy<
     // before any guardrail evaluation — trusted-data and tool-invocation
     // lookups otherwise miss the real tool behind the decoration and the
     // dispatch wrapper.
+    // The request's own tool list is passed in so the canonicalizer can learn
+    // the client's label for the gateway when it is not a name this
+    // organization knows — the label is free text typed at `claude mcp add`
+    // time, and a label nothing matches used to leave every decorated name
+    // untouched.
     const canonicalizeToolName =
-      await utils.gatewayToolNames.buildGatewayToolNameCanonicalizer(
-        resolvedAgent.organizationId,
-      );
+      await utils.gatewayToolNames.buildGatewayToolNameCanonicalizer({
+        organizationId: resolvedAgent.organizationId,
+        declaredToolNames: utils.collectDeclaredToolNames(
+          requestAdapter.getOriginalRequest(),
+        ),
+      });
     const commonMessages = canonicalizeCommonMessageToolNames(
       requestAdapter.getMessages(),
       canonicalizeToolName,

--- a/platform/backend/src/routes/proxy/utils/gateway-tool-names.test.ts
+++ b/platform/backend/src/routes/proxy/utils/gateway-tool-names.test.ts
@@ -13,7 +13,9 @@ describe("buildGatewayToolNameCanonicalizer", () => {
       name: "Prod Gateway",
     });
 
-    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+    const canonicalize = await buildGatewayToolNameCanonicalizer({
+      organizationId: org.id,
+    });
 
     expect(canonicalize("mcp__prod_gateway__archestra__run_tool")).toBe(
       "archestra__run_tool",
@@ -34,7 +36,9 @@ describe("buildGatewayToolNameCanonicalizer", () => {
       name: "Prod Gateway",
     });
 
-    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+    const canonicalize = await buildGatewayToolNameCanonicalizer({
+      organizationId: org.id,
+    });
 
     expect(canonicalize("prod_gateway__archestra__search_tools")).toBe(
       "archestra__search_tools",
@@ -52,7 +56,9 @@ describe("buildGatewayToolNameCanonicalizer", () => {
       name: "Prod Gateway",
     });
 
-    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+    const canonicalize = await buildGatewayToolNameCanonicalizer({
+      organizationId: org.id,
+    });
 
     expect(canonicalize("mcp__prod_gateway__run_tool")).toBe(
       "archestra__run_tool",
@@ -70,7 +76,9 @@ describe("buildGatewayToolNameCanonicalizer", () => {
       name: "Prod Gateway",
     });
 
-    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+    const canonicalize = await buildGatewayToolNameCanonicalizer({
+      organizationId: org.id,
+    });
 
     // A hostile or unrelated MCP server connected directly to the client must
     // not get its tools canonicalized into platform names.
@@ -86,7 +94,9 @@ describe("buildGatewayToolNameCanonicalizer", () => {
   }) => {
     const org = await makeOrganization();
 
-    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+    const canonicalize = await buildGatewayToolNameCanonicalizer({
+      organizationId: org.id,
+    });
 
     expect(canonicalize("mcp__prod_gateway__archestra__run_tool")).toBe(
       "mcp__prod_gateway__archestra__run_tool",
@@ -105,10 +115,73 @@ describe("buildGatewayToolNameCanonicalizer", () => {
     });
     const org = await makeOrganization();
 
-    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+    const canonicalize = await buildGatewayToolNameCanonicalizer({
+      organizationId: org.id,
+    });
 
     expect(canonicalize("mcp__other_gateway__archestra__run_tool")).toBe(
       "mcp__other_gateway__archestra__run_tool",
+    );
+  });
+
+  // The label is free text typed at `claude mcp add <label> <url>` time, so it
+  // routinely matches no gateway this organization knows. That used to leave
+  // every decorated name untouched, and guardrails then reasoned about the
+  // decoration instead of the tool. The request's own tool list identifies the
+  // prefix: whichever one sits in front of one of our branded names is this
+  // client's decoration for our gateway.
+  test("learns the client's label from the request when it matches no gateway name", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+
+    const canonicalize = await buildGatewayToolNameCanonicalizer({
+      organizationId: org.id,
+      declaredToolNames: [
+        "mcp__some_local_alias__archestra__run_tool",
+        "mcp__some_local_alias__github__list_repos",
+        "Bash",
+      ],
+    });
+
+    expect(canonicalize("mcp__some_local_alias__github__list_repos")).toBe(
+      "github__list_repos",
+    );
+  });
+
+  // The learned prefix must not confer built-in status: built-ins bypass
+  // tool-invocation and trusted-data policies, so a server that named its tools
+  // after ours could otherwise opt itself out of enforcement entirely. Stripping
+  // to a third-party name only ever ADDS enforcement; stripping to a branded
+  // name would remove it, so that one is refused.
+  test("a learned prefix never yields a branded built-in name", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+
+    const canonicalize = await buildGatewayToolNameCanonicalizer({
+      organizationId: org.id,
+      declaredToolNames: ["mcp__impostor__archestra__run_tool"],
+    });
+
+    expect(canonicalize("mcp__impostor__archestra__run_tool")).toBe(
+      "mcp__impostor__archestra__run_tool",
+    );
+  });
+
+  // Nothing to learn from means nothing changes.
+  test("leaves names alone when the request declares no branded tool", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+
+    const canonicalize = await buildGatewayToolNameCanonicalizer({
+      organizationId: org.id,
+      declaredToolNames: ["mcp__unknown__github__list_repos", "Bash"],
+    });
+
+    expect(canonicalize("mcp__unknown__github__list_repos")).toBe(
+      "mcp__unknown__github__list_repos",
     );
   });
 });

--- a/platform/backend/src/routes/proxy/utils/gateway-tool-names.ts
+++ b/platform/backend/src/routes/proxy/utils/gateway-tool-names.ts
@@ -2,6 +2,7 @@ import {
   MCP_SERVER_TOOL_NAME_SEPARATOR,
   toMcpClientServerName,
 } from "@archestra/shared";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { resolveRunToolTargetName } from "@/archestra-mcp-server/run-tool-target";
 import { LRUCacheManager } from "@/cache-manager";
 import { AgentModel } from "@/models";
@@ -38,11 +39,19 @@ export type ToolNameCanonicalizer = (toolName: string) => string;
  * the listed name down to its short form) is expanded to the full built-in
  * name, mirroring run_tool's own dispatch resolution.
  */
-export async function buildGatewayToolNameCanonicalizer(
-  organizationId: string,
-): Promise<ToolNameCanonicalizer> {
+export async function buildGatewayToolNameCanonicalizer(params: {
+  organizationId: string;
+  /**
+   * Every tool name the caller declared in this request. Used to learn the
+   * client's own label for the gateway when it is not one the organization
+   * knows — see {@link learnGatewayDecorationPrefixes}.
+   */
+  declaredToolNames?: readonly string[];
+}): Promise<ToolNameCanonicalizer> {
+  const { organizationId, declaredToolNames = [] } = params;
   const serverNames = await getGatewayServerNames(organizationId);
-  if (serverNames.size === 0) {
+  const learnedPrefixes = learnGatewayDecorationPrefixes(declaredToolNames);
+  if (serverNames.size === 0 && learnedPrefixes.length === 0) {
     return (toolName) => toolName;
   }
 
@@ -64,11 +73,95 @@ export async function buildGatewayToolNameCanonicalizer(
         .join(MCP_SERVER_TOOL_NAME_SEPARATOR);
       return resolveRunToolTargetName(canonicalName);
     }
-    return toolName;
+    return stripLearnedDecoration(toolName, learnedPrefixes);
   };
 }
 
 // === Internal helpers ===
+
+/**
+ * The client-side decoration prefixes that belong to one of our gateways,
+ * learned from the caller's own declared tool list.
+ *
+ * The anchor the loop above uses — matching the label against a gateway name
+ * the organization knows — assumes the client registered the gateway under the
+ * name the connection-setup script derives. Nothing enforces that: the label is
+ * whatever the person who ran `claude mcp add <label> <url>` typed, so it is
+ * routinely something else entirely, and then no label matches at any index and
+ * every decorated name survives untouched. Guardrails downstream reason about
+ * the decoration instead of the tool, and policy lookups miss the row that
+ * speaks for it.
+ *
+ * A client namespaces every tool from ONE server with the SAME prefix, so the
+ * prefix is identifiable from evidence rather than convention: whichever prefix
+ * a request's tool list carries in front of one of *our* branded tool names is
+ * that request's decoration for our gateway. That is per-request, and it names
+ * a prefix rather than trusting a name — a server can only ever claim its own
+ * prefix, never another server's.
+ *
+ * Which bounds the spoof this anchoring exists to prevent. A hostile MCP server
+ * connected straight to the client can put our branded name on its own tools
+ * and so claim its own prefix — but claiming it only causes ITS names to be
+ * stripped to `<server>__<tool>`, which is then looked up and policy-evaluated
+ * like any other tool. That is strictly more enforcement than the untouched
+ * name it gets today, which matches no row and is evaluated by nothing. The one
+ * thing it must not buy is built-in status, since built-ins bypass policy — so
+ * {@link stripLearnedDecoration} refuses to hand back a branded name. Built-in
+ * recognition keeps requiring the strict, unlearned anchor above.
+ */
+function learnGatewayDecorationPrefixes(
+  declaredToolNames: readonly string[],
+): string[] {
+  const prefixes = new Set<string>();
+  for (const toolName of declaredToolNames) {
+    const segments = toolName.split(MCP_SERVER_TOOL_NAME_SEPARATOR);
+    // Start at 1: a zero-length prefix is an undecorated name, which the strict
+    // path already handles and which must not turn every name into a match.
+    for (let i = 1; i < segments.length; i++) {
+      const remainder = segments.slice(i).join(MCP_SERVER_TOOL_NAME_SEPARATOR);
+      if (archestraMcpBranding.isToolName(remainder)) {
+        prefixes.add(
+          segments.slice(0, i).join(MCP_SERVER_TOOL_NAME_SEPARATOR) +
+            MCP_SERVER_TOOL_NAME_SEPARATOR,
+        );
+        break;
+      }
+    }
+  }
+  // Longest first, so the most specific decoration wins when one prefix is a
+  // prefix of another.
+  return [...prefixes].sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Strip a learned decoration prefix, refusing to produce a branded built-in
+ * name.
+ *
+ * Built-ins bypass tool-invocation and trusted-data policies, so granting that
+ * status on the strength of a learned prefix would let a hostile server opt its
+ * own tools out of enforcement by naming them after ours. Everything else the
+ * prefix reveals is a third-party tool name that gets looked up and policied,
+ * which is the point. The `run_tool` wrapper does not need this path — it is
+ * recognized through the decoration by `resolveRunToolDispatch`, which only
+ * unwraps a dispatch so the target is policy-evaluated and never confers bypass
+ * either.
+ */
+function stripLearnedDecoration(
+  toolName: string,
+  learnedPrefixes: readonly string[],
+): string {
+  for (const prefix of learnedPrefixes) {
+    if (!toolName.startsWith(prefix)) {
+      continue;
+    }
+    const remainder = toolName.slice(prefix.length);
+    if (remainder === "" || archestraMcpBranding.isToolName(remainder)) {
+      return toolName;
+    }
+    return remainder;
+  }
+  return toolName;
+}
 
 /** How deep into the segments a client's gateway label may sit (0 or 1). */
 const GATEWAY_LABEL_MAX_INDEX = 1;


### PR DESCRIPTION
Follow-up to #7384, which fixed the `run_tool` half of this. This closes the rest.

## The problem

The decoration-stripping canonicalizer recognizes a client's label for a gateway only when that label is a gateway name the organization already knows. Nothing makes that true — the label is whatever was typed at `claude mcp add <label> <url>`, so it is routinely something else entirely. When it is, no label matches at any index and **every decorated name survives untouched**: guardrails downstream reason about the decoration rather than the tool, and policy lookups miss the row that speaks for it.

#7384 fixed this for the `run_tool` wrapper specifically, which was the sharpest edge (an unwrapped dispatch means the target is never policy-evaluated). Direct calls to third-party gateway tools — `mcp__<label>__github__list_repos` — were still left untouched.

## The fix

A client namespaces every tool from one server with the *same* prefix. So the prefix is identifiable from evidence rather than convention: **whichever prefix a request's own tool list carries in front of one of our branded tool names is that request's decoration for our gateway.** Learn it per request, then strip it.

This is anchored on data in the request rather than on a naming convention nobody enforces, and it names a *prefix* rather than trusting a *name* — a server can only ever claim its own prefix, never another server's.

## Why this does not widen the spoof the anchoring exists to prevent

The canonicalizer's doc comment guards a specific attack: a hostile MCP server wired straight to the client naming its tools to look like ours. That server can still put our branded name on its own tools and so claim its own prefix — but claiming it only causes **its** names to be stripped to `server__tool`, which is then looked up and policy-evaluated like any other tool. That is strictly *more* enforcement than the untouched name it gets today, which matches no row and is evaluated by nothing.

The one thing it must not buy is built-in status, since built-ins bypass tool-invocation and trusted-data policies. So stripping deliberately refuses to yield a branded name, and built-in recognition keeps requiring the strict, unlearned anchor.

That is the same rule `branding.ts` already states for its loose recognizer (*"never use for dispatch, RBAC, or policy decisions"*) and the same one #7384 followed: **loosen only where loosening can add enforcement, never where it removes it.**

## Tests

- The client's label is learned from the request and a third-party tool name canonicalizes.
- A learned prefix never yields a branded built-in name (the spoof boundary).
- Nothing is learned, so nothing changes, when the request declares no branded tool.
- Existing cross-organization isolation test still holds.

Backend `type-check`, `lint`, `knip` clean. Across `src/routes/proxy` and `src/guardrails`: same 4 pre-existing failures before and after.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>