### PR TITLE
fix(llm-proxy): keep the model's own output when a refusal replaces the turn

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -1210,7 +1210,12 @@ describe("AnthropicStreamAdapter policy refusal terminal", () => {
     ).toMatchObject([{ id: "toolu_1", name: "list" }]);
   });
 
-  test("toProviderResponse persists the refusal, not the blocked tool call", () => {
+  // The record has to describe the turn the CLIENT saw. "let me check" was
+  // streamed live and the refusal was appended after it as a further block, so
+  // both belong. Keeping only the refusal deleted the model's own answer from
+  // history — a later reader (conversation replay, a summarizer, a human
+  // debugging the run) then saw a turn in which the model never spoke.
+  test("toProviderResponse keeps the streamed text and appends the refusal", () => {
     const adapter = streamBlockedToolTurn();
 
     adapter.formatCompleteTextSSE("blocked message");
@@ -1218,8 +1223,10 @@ describe("AnthropicStreamAdapter policy refusal terminal", () => {
 
     expect(response.stop_reason).toBe("end_turn");
     expect(response.content).toEqual([
+      { type: "text", text: "let me check", citations: null },
       { type: "text", text: "blocked message", citations: null },
     ]);
+    // The blocked call was never delivered, so it must not appear in the record.
     expect(response.content.some((block) => block.type === "tool_use")).toBe(
       false,
     );

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -919,19 +919,6 @@ class AnthropicStreamAdapter
   }
 
   toProviderResponse(): AnthropicResponse {
-    if (this.replacedText !== null) {
-      return {
-        id: this.state.responseId,
-        type: "message",
-        role: "assistant",
-        content: [{ type: "text", text: this.replacedText, citations: null }],
-        model: this.state.model,
-        stop_reason: "end_turn",
-        stop_sequence: null,
-        usage: this.responseUsage(),
-      };
-    }
-
     const content: AnthropicResponse["content"] = [];
 
     // Add text block if we have text
@@ -960,6 +947,19 @@ class AnthropicStreamAdapter
       });
     }
 
+    // A refusal does not erase what the model already said. Its text streamed as
+    // it arrived and the refusal was appended after it as a further content
+    // block, so the client holds both — and the reconstructed turn has to say
+    // the same thing. Returning the refusal alone drops the model's own answer
+    // from the record, and whatever reads the turn back later (conversation
+    // history, a summarizer, a human debugging a failed run) then sees a turn
+    // in which the model never spoke. The withheld tool calls stay withheld:
+    // `toolCallsReleased` is false on this path, so the loop above skipped
+    // them, which is right — the client never received them.
+    if (this.replacedText !== null) {
+      content.push({ type: "text", text: this.replacedText, citations: null });
+    }
+
     const upstreamStopReason = this.state
       .stopReason as AnthropicResponse["stop_reason"];
     // A turn that delivered no tool call cannot owe a tool result. Upstream may
@@ -968,7 +968,8 @@ class AnthropicStreamAdapter
     // that contradicts its own content.
     const hasToolUse = content.some((block) => block.type === "tool_use");
     const stopReason =
-      upstreamStopReason === "tool_use" && !hasToolUse
+      this.responseReplacedWithText ||
+      (upstreamStopReason === "tool_use" && !hasToolUse)
         ? "end_turn"
         : (upstreamStopReason ?? "end_turn");
 

--- a/platform/backend/src/routes/proxy/adapters/gemini.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.test.ts
@@ -645,6 +645,58 @@ describe("geminiAdapterFactory", () => {
 });
 
 describe("GeminiStreamAdapter", () => {
+  // The model's text streamed live and the refusal was appended after it, so
+  // the record has to carry both. Reporting the refusal alone erased the
+  // model's own answer — the loss that makes a refused turn unreadable after
+  // the fact. The withheld function call stays withheld: it never reached the
+  // client, and recording it would leave a turn owing a response nothing sends.
+  describe("policy refusal", () => {
+    test("toProviderResponse keeps streamed text, drops the withheld call, appends the refusal", () => {
+      const adapter = geminiAdapterFactory.createStreamAdapter();
+      adapter.processChunk({
+        candidates: [
+          {
+            content: { role: "model", parts: [{ text: "let me check" }] },
+            index: 0,
+          },
+        ],
+        modelVersion: "gemini-2.5-pro",
+        responseId: "test-response",
+      } as GeminiStreamChunk);
+      adapter.processChunk({
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [
+                {
+                  functionCall: {
+                    name: "test_tool",
+                    id: "call_123",
+                    args: {},
+                  },
+                },
+              ],
+            },
+            index: 0,
+          },
+        ],
+        modelVersion: "gemini-2.5-pro",
+        responseId: "test-response",
+      } as unknown as GeminiStreamChunk);
+
+      adapter.formatCompleteTextSSE("blocked message");
+      const response = adapter.toProviderResponse();
+
+      const parts = response.candidates?.[0]?.content?.parts ?? [];
+      expect(
+        parts.map((part) => ("text" in part ? part.text : undefined)),
+      ).toEqual(["let me check", "blocked message"]);
+      expect(parts.some((part) => "functionCall" in part)).toBe(false);
+      expect(response.candidates?.[0]?.finishReason).toBe("STOP");
+    });
+  });
+
   describe("processChunk", () => {
     test("processes text chunks correctly", () => {
       const adapter = geminiAdapterFactory.createStreamAdapter();

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -869,28 +869,6 @@ class GeminiStreamAdapter
   }
 
   toProviderResponse(): GeminiResponse {
-    if (this.replacedText !== null) {
-      return {
-        candidates: [
-          {
-            content: { parts: [{ text: this.replacedText }], role: "model" },
-            finishReason: "STOP",
-            index: 0,
-          },
-        ],
-        usageMetadata: this.state.usage
-          ? {
-              promptTokenCount: this.state.usage.inputTokens,
-              candidatesTokenCount: this.state.usage.outputTokens,
-              totalTokenCount:
-                this.state.usage.inputTokens + this.state.usage.outputTokens,
-            }
-          : undefined,
-        modelVersion: this.state.model,
-        responseId: this.state.responseId || `gemini-${Date.now()}`,
-      };
-    }
-
     const parts: Gemini.Types.MessagePart[] = [];
 
     // Add thought text part if present (separate from output text).
@@ -922,9 +900,16 @@ class GeminiStreamAdapter
       parts.push(inlineDataPart);
     }
 
-    // Add function calls with thoughtSignature preserved
-    for (let i = 0; i < this.state.toolCalls.length; i++) {
-      const toolCall = this.state.toolCalls[i];
+    // Add function calls with thoughtSignature preserved.
+    //
+    // Skipped entirely when a refusal replaced the response: those calls were
+    // held back and never reached the client, so recording them would describe
+    // a turn that did not happen — and would leave a record owing function
+    // responses that nothing will ever send.
+    const emittedToolCalls =
+      this.replacedText === null ? this.state.toolCalls : [];
+    for (let i = 0; i < emittedToolCalls.length; i++) {
+      const toolCall = emittedToolCalls[i];
       let parsedArgs: Record<string, unknown> = {};
       try {
         parsedArgs = JSON.parse(toolCall.arguments);
@@ -943,6 +928,15 @@ class GeminiStreamAdapter
       });
     }
 
+    // A refusal does not erase what the model already said — its thought and
+    // answer text streamed as they arrived, and the refusal was appended after
+    // them, so the client holds all of it. Recording the refusal alone drops
+    // the model's own output from the record, and whatever reads the turn back
+    // later then sees a turn in which the model never spoke.
+    if (this.replacedText !== null) {
+      parts.push({ text: this.replacedText });
+    }
+
     return {
       candidates: [
         {
@@ -951,7 +945,10 @@ class GeminiStreamAdapter
             role: "model",
           },
           finishReason:
-            (this.state.stopReason as Gemini.Types.FinishReason) ?? "STOP",
+            this.replacedText !== null
+              ? "STOP"
+              : ((this.state.stopReason as Gemini.Types.FinishReason) ??
+                "STOP"),
           index: 0,
         },
       ],

--- a/platform/backend/src/routes/proxy/adapters/openai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.test.ts
@@ -826,6 +826,31 @@ describe("OpenAIStreamAdapter", () => {
     return (JSON.parse(firstData) as { usage?: unknown }).usage;
   }
 
+  // The refusal is emitted as a further delta, which clients concatenate onto
+  // the content they have accumulated — so the client holds the model's text
+  // AND the refusal. Reporting the refusal alone dropped the model's own answer
+  // from the record, leaving later readers a turn in which it never spoke.
+  test("toProviderResponse keeps streamed content and appends the refusal", () => {
+    const adapter = openaiAdapterFactory.createStreamAdapter();
+    adapter.processChunk({
+      id: "chatcmpl-1",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "gpt-x",
+      choices: [
+        { index: 0, delta: { content: "let me check" }, finish_reason: null },
+      ],
+    } as Chunk);
+
+    adapter.formatCompleteTextSSE("blocked message");
+    const response = adapter.toProviderResponse();
+
+    expect(response.choices[0].message.content).toBe(
+      "let me checkblocked message",
+    );
+    expect(response.choices[0].finish_reason).toBe("stop");
+  });
+
   test("carries the trailing usage chunk into the final SSE (net of cache)", () => {
     const adapter = openaiAdapterFactory.createStreamAdapter();
     adapter.processChunk({

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -1039,6 +1039,24 @@ export class OpenAIStreamAdapter
   // the upstream "tool_calls" finish reason (a text-only turn ending in
   // "tool_calls" with no tool_calls makes agent harnesses retry), and
   // toProviderResponse persists the refusal rather than the blocked tool calls.
+  /**
+   * The assistant text as the CLIENT received it.
+   *
+   * A refusal does not erase what the model already said: its text was streamed
+   * as it arrived, and the refusal is appended afterwards as one more delta,
+   * which clients concatenate onto the content they are accumulating. So the
+   * reconstructed turn has to carry both, in that order — reporting the refusal
+   * alone loses the model's own answer from the record, and anything that later
+   * reads the turn back (conversation history, a summarizer, a human debugging
+   * it) sees a turn in which the model never spoke.
+   */
+  private contentWithAnyReplacement(): string | null {
+    if (this.replacedText === null) {
+      return this.state.text || null;
+    }
+    return `${this.state.text}${this.replacedText}`;
+  }
+
   private replacedText: string | null = null;
   private get responseReplacedWithText(): boolean {
     return this.replacedText !== null;
@@ -1327,7 +1345,7 @@ export class OpenAIStreamAdapter
           index: 0,
           message: {
             role: "assistant",
-            content: this.replacedText ?? (this.state.text || null),
+            content: this.contentWithAnyReplacement(),
             refusal: null,
             tool_calls: toolCalls,
           },

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -1534,7 +1534,10 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
     // A refusal replaces the recorded turn with the refusal text alone, so the
     // text the client already saw streaming is not in the record. Pinned as the
     // existing behaviour: withholding tool calls does not change it either way.
-    test("a streamed refusal records the refusal text alone", async () => {
+    // Both text blocks streamed live to the client before the gate refused the
+    // call between them, so the record has to carry them and then the refusal.
+    // Recording the refusal alone erased the model's own answer from history.
+    test("a streamed refusal keeps the text the client already received", async () => {
       anthropicStubOptions.toolUseBetweenText = true;
       anthropicStubOptions.streamStopReason = "tool_use";
 
@@ -1570,8 +1573,13 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
         content: { type: string; text?: string }[];
       };
       expect(logged.content.map((block) => block.text)).toEqual([
+        "Let me check.Then I will summarise.",
         "Tool get_weather is not enabled here",
       ]);
+      // The blocked call was never delivered, so it stays out of the record.
+      expect(logged.content.some((block) => block.type === "tool_use")).toBe(
+        false,
+      );
     });
 
     // Holding tool calls until the gate decides moves them behind any text that


### PR DESCRIPTION
## The bug

When a guardrail refusal replaces a turn, the turn is recorded as **the refusal text and nothing else**. Whatever the model had already said is deleted from the record, not merely interrupted.

That contradicts what the client actually received. The model's text streams as it arrives; the refusal is appended *after* it — as a further content block on Anthropic and Gemini, as a further delta on OpenAI, which clients concatenate onto what they are accumulating. So the client held both, while the persisted turn held one:

| Adapter | Client receives | Was recorded |
|---|---|---|
| `anthropic.ts` | `[model text][refusal]` | `[refusal]` only (early return in `toProviderResponse`) |
| `openai.ts` | `model text` + refusal, concatenated | `this.replacedText ?? this.state.text` — the model's text swapped out |
| `gemini.ts` | thought part + text part + refusal | `[refusal]` only (early return) |

This breaks the codebase's own stated rule that the persisted interaction should "describe the turn the client saw".

## Why it costs more than a lossy log

Anything that reads the turn back — conversation history, a follow-up summarizer, a human debugging a run that died — sees a turn in which the model never spoke, and resumes from a history its own reasoning never entered. On a large turn that is thousands of billed output tokens reduced to a few hundred characters of guardrail text.

## The fix

Reconstruct what went over the wire: keep the streamed text (and Gemini's thought part), then append the refusal.

Withheld tool calls stay withheld — they never reached the client, and recording them would leave a turn owing tool results nothing will ever send. Anthropic already gated this on `toolCallsReleased`; **Gemini did not**, and appended `state.toolCalls` unconditionally, so removing its early return without that gate would have started recording calls that were never delivered. It now gates too.

`finish_reason`/`stop_reason` stays forced to the end-of-turn value on this path, matching what `formatEndSSE` already puts on the wire.

## Scope

Covers **anthropic**, **openai** and **gemini** — both wire formats behind the reported incidents, plus the many OpenAI-compatible providers built on the openai adapter.

Not yet converted, sharing the same shape: `zhipuai`, `minimax`, `cohere`, `ollama-native`, `bedrock`, `openai-responses`. Listed explicitly rather than left as a silent inconsistency; happy to sweep them in a follow-up.

## A related gap this does *not* close

`thinking` blocks are absent from reconstructed responses on **every** turn, refused or not — `StreamAccumulatorState` has no reasoning field, so outside Gemini's own `thoughtText` reasoning is never accumulated at all. Restoring it needs accumulation added per adapter and is a separate change. (Unrelated to #7385, which fixes *parsing* of Bedrock redacted reasoning deltas.)

## Tests

Three adapter-level tests pin the corrected contract, each asserting both halves — the model's output survives **and** the withheld tool call does not appear:

- `anthropic.test.ts` — the test that previously asserted `content` equalled the refusal alone now asserts `[streamed text][refusal]`. It used a helper that streams `"let me check"` before holding the tool call, so it was pinning the bug directly.
- `openai.test.ts` — content is the concatenation the client accumulates.
- `gemini.test.ts` — streamed text kept, withheld `functionCall` absent, `finishReason: "STOP"`.
- `llm-proxy-handler.test.ts` — the end-to-end streamed-refusal case now expects both text blocks the client received.

Backend `type-check`, `lint`, `knip` clean. Across `src/routes/proxy` + `src/guardrails`: 4 failing tests before and after (pre-existing and unrelated — they assert on plaintext interaction bodies, which a local `.env` encrypts).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>