### PR TITLE
fix(llm-proxy): keep the model's own output on the remaining six adapters

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -34,6 +34,47 @@ function asStreamChunk<T>(chunk: unknown): T {
   return chunk as T;
 }
 
+describe("Bedrock policy refusal", () => {
+  // A refusal appends further content, so the client holds the model's text AND
+  // the refusal. Recording the refusal alone deleted the model's own answer;
+  // the withheld tool call must stay out, or the turn owes a tool result
+  // nothing will ever send.
+  test("keeps the streamed text, drops the withheld call, appends the refusal", () => {
+    const adapter = bedrockAdapterFactory.createStreamAdapter(
+      createConverseRequest(),
+    );
+    type Chunk = Parameters<typeof adapter.processChunk>[0];
+
+    adapter.processChunk(
+      asStreamChunk<Chunk>({
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { text: "let me check" },
+        },
+      }),
+    );
+    adapter.processChunk(
+      asStreamChunk<Chunk>({
+        contentBlockStart: {
+          contentBlockIndex: 1,
+          start: { toolUse: { toolUseId: "tooluse_123", name: "read_file" } },
+        },
+      }),
+    );
+
+    adapter.formatCompleteTextSSE("blocked message");
+    const response = adapter.toProviderResponse();
+
+    const content = response.output?.message?.content ?? [];
+    expect(content.map((block) => block.text)).toEqual([
+      "let me check",
+      "blocked message",
+    ]);
+    expect(content.some((block) => "toolUse" in block)).toBe(false);
+    expect(response.stopReason).toBe("end_turn");
+  });
+});
+
 describe("Bedrock tool name encoding", () => {
   test("shortens provider-facing tool names that exceed the Bedrock limit", () => {
     const toolName =

--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -66,10 +66,9 @@ describe("Bedrock policy refusal", () => {
     const response = adapter.toProviderResponse();
 
     const content = response.output?.message?.content ?? [];
-    expect(content.map((block) => block.text)).toEqual([
-      "let me check",
-      "blocked message",
-    ]);
+    expect(
+      content.map((block) => ("text" in block ? block.text : undefined)),
+    ).toEqual(["let me check", "blocked message"]);
     expect(content.some((block) => "toolUse" in block)).toBe(false);
     expect(response.stopReason).toBe("end_turn");
   });

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -1558,35 +1558,25 @@ class BedrockStreamAdapter
         }
     > = [];
 
-    if (this.replacedText !== null) {
-      return {
-        $metadata: { requestId: this.state.responseId },
-        output: {
-          message: {
-            role: "assistant",
-            content: [{ text: this.replacedText }],
-          },
-        },
-        stopReason: "end_turn",
-        usage: {
-          inputTokens: this.state.usage?.inputTokens ?? 0,
-          outputTokens: this.state.usage?.outputTokens ?? 0,
-        },
-        metrics:
-          this.bedrockState.latencyMs !== null
-            ? { latencyMs: this.bedrockState.latencyMs }
-            : undefined,
-        trace: this.bedrockState.trace ?? undefined,
-      };
-    }
-
     // Add text block if we have text
     if (this.state.text) {
       content.push({ text: this.state.text });
     }
 
-    // Add tool use blocks
-    for (const toolCall of this.state.toolCalls) {
+    // A refusal does not erase what the model already said: its text streamed
+    // as it arrived and the refusal was appended after it, so the client holds
+    // both. Recording the refusal alone deletes the model's own answer from the
+    // turn, leaving anything that reads it back a turn in which it never spoke.
+    if (this.replacedText !== null) {
+      content.push({ text: this.replacedText });
+    }
+
+    // Add tool use blocks. Calls held back by the gate never reached the
+    // client, so they stay out of the record — a turn naming them would owe
+    // tool results nothing will ever send.
+    for (const toolCall of this.replacedText === null
+      ? this.state.toolCalls
+      : []) {
       let parsedInput: Record<string, unknown> = {};
       try {
         parsedInput = JSON.parse(toolCall.arguments);
@@ -1620,7 +1610,10 @@ class BedrockStreamAdapter
         },
       },
       stopReason:
-        (this.state.stopReason as BedrockResponse["stopReason"]) ?? "end_turn",
+        this.replacedText !== null
+          ? "end_turn"
+          : ((this.state.stopReason as BedrockResponse["stopReason"]) ??
+            "end_turn"),
       usage: {
         inputTokens: this.state.usage?.inputTokens ?? 0,
         outputTokens: this.state.usage?.outputTokens ?? 0,

--- a/platform/backend/src/routes/proxy/adapters/cohere.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere.test.ts
@@ -650,6 +650,33 @@ describe("CohereStreamAdapter", () => {
       expect(adapter.state.text).toBe("Hello, world!");
     });
 
+    // A refusal appends a further content block, so the client holds the
+    // model's text AND the refusal. Recording the refusal alone deleted the
+    // model's own answer from the turn.
+    test("a refusal keeps the streamed text and drops the withheld call", () => {
+      const adapter = cohereAdapterFactory.createStreamAdapter();
+
+      adapter.processChunk({
+        type: "content-delta",
+        index: 0,
+        delta: { message: { content: { text: "let me check" } } },
+      });
+      adapter.processChunk({
+        type: "tool-call-start",
+        tool_call: { id: "existing-id", function: { name: "test_tool" } },
+      });
+
+      adapter.formatCompleteTextSSE("blocked message");
+      const response = adapter.toProviderResponse();
+
+      expect(response.message.content).toEqual([
+        { type: "text", text: "let me check" },
+        { type: "text", text: "blocked message" },
+      ]);
+      expect(response.message.tool_calls).toBeUndefined();
+      expect(response.finish_reason).toBe("COMPLETE");
+    });
+
     test("handles tool-call-start with existing ID", () => {
       const adapter = cohereAdapterFactory.createStreamAdapter();
 

--- a/platform/backend/src/routes/proxy/adapters/cohere.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere.ts
@@ -734,24 +734,6 @@ class CohereStreamAdapter
   }
 
   toProviderResponse(): CohereResponse {
-    if (this.replacedText !== null) {
-      return {
-        id: this.state.responseId,
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: this.replacedText }],
-          tool_calls: undefined,
-        },
-        finish_reason: "COMPLETE",
-        usage: {
-          tokens: {
-            input_tokens: this.state.usage?.inputTokens ?? 0,
-            output_tokens: this.state.usage?.outputTokens ?? 0,
-          },
-        },
-      };
-    }
-
     const content: CohereResponse["message"]["content"] = [];
 
     if (this.state.text) {
@@ -761,8 +743,21 @@ class CohereStreamAdapter
       });
     }
 
+    // A refusal does not erase what the model already said: its text streamed as
+    // it arrived and the refusal was appended after it as a further content
+    // block, so the client holds both. Recording the refusal alone deletes the
+    // model's own answer from the turn.
+    if (this.replacedText !== null) {
+      content.push({ type: "text", text: this.replacedText });
+    }
+
+    // Calls held back by the gate never reached the client, so they must not
+    // appear in the record — a turn that names them would owe tool results
+    // nothing will ever send.
     const toolCalls: CohereResponse["message"]["tool_calls"] = [];
-    for (const toolCall of this.state.toolCalls) {
+    for (const toolCall of this.replacedText === null
+      ? this.state.toolCalls
+      : []) {
       toolCalls.push({
         id: toolCall.id,
         type: "function",
@@ -781,8 +776,10 @@ class CohereStreamAdapter
         tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
       },
       finish_reason:
-        (this.state.stopReason as CohereResponse["finish_reason"]) ??
-        "COMPLETE",
+        this.replacedText !== null
+          ? "COMPLETE"
+          : ((this.state.stopReason as CohereResponse["finish_reason"]) ??
+            "COMPLETE"),
       usage: {
         tokens: {
           input_tokens: this.state.usage?.inputTokens ?? 0,

--- a/platform/backend/src/routes/proxy/adapters/minimax.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/minimax.test.ts
@@ -21,6 +21,16 @@ function reasoningChunk(cumulativeText: string): StreamChunk {
   } as StreamChunk;
 }
 
+function textChunk(text: string): StreamChunk {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "MiniMax-M2.5",
+    choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+  } as StreamChunk;
+}
+
 function finalChunk(): StreamChunk {
   return {
     id: "chatcmpl-test",
@@ -63,6 +73,25 @@ describe("MinimaxStreamAdapter reasoning", () => {
     expect(second.choices[0].delta.reasoning_details).toEqual([
       { text: "First half, second half." },
     ]);
+  });
+
+  // A refusal appends further content deltas, which clients concatenate onto
+  // what they have accumulated — so the client holds the model's text AND the
+  // refusal. Reasoning the model produced is kept for the same reason.
+  test("a refusal keeps the streamed text and the reasoning", () => {
+    const adapter = minimaxAdapterFactory.createStreamAdapter();
+    adapter.processChunk(reasoningChunk("thinking about it"));
+    adapter.processChunk(textChunk("let me check"));
+
+    adapter.formatCompleteTextSSE("blocked message");
+    const response = adapter.toProviderResponse();
+
+    expect(response.choices[0].message.content).toBe(
+      "let me checkblocked message",
+    );
+    expect(response.choices[0].message.reasoning_content).toBe(
+      "thinking about it",
+    );
   });
 
   test("treats non-extending reasoning text as incremental chunks", () => {

--- a/platform/backend/src/routes/proxy/adapters/minimax.ts
+++ b/platform/backend/src/routes/proxy/adapters/minimax.ts
@@ -627,6 +627,18 @@ class MinimaxStreamAdapter
   // Set to the refusal text when the streamed response was replaced by a policy
   // refusal, so toProviderResponse persists the refusal (finish_reason "stop",
   // no tool calls) instead of the blocked tool calls.
+  // A refusal does not erase what the model already said: its text streamed as
+  // it arrived and the refusal was appended after it as further deltas, which
+  // clients concatenate onto what they have accumulated. Recording the refusal
+  // alone deletes the model's own answer from the turn, leaving anything that
+  // reads it back a turn in which the model never spoke.
+  private contentWithAnyRefusal(): string | null {
+    if (this.replacedText === null) {
+      return this.state.text || null;
+    }
+    return `${this.state.text}${this.replacedText}`;
+  }
+
   private replacedText: string | null = null;
   private request: MinimaxRequest | undefined; // Store request for token estimation (optional)
 
@@ -909,10 +921,13 @@ class MinimaxStreamAdapter
           index: 0,
           message: {
             role: "assistant",
-            content: this.replacedText ?? (this.state.text || null),
+            content: this.contentWithAnyRefusal(),
             // Convert accumulated reasoning back to reasoning_details format if
-            // present, mirrored into reasoning_content for OpenAI-compatible clients
-            ...(this.replacedText === null && this.lastReasoningText
+            // present, mirrored into reasoning_content for OpenAI-compatible
+            // clients. Kept when a refusal replaced the turn too: the model
+            // produced it, and dropping it is the same erasure as dropping the
+            // answer text.
+            ...(this.lastReasoningText
               ? {
                   reasoning_details: [{ text: this.lastReasoningText }],
                   reasoning_content: this.lastReasoningText,

--- a/platform/backend/src/routes/proxy/adapters/ollama-native.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/ollama-native.test.ts
@@ -227,6 +227,38 @@ describe("stream adapter", () => {
     expect(adapter.state.text).toBe("Hello");
   });
 
+  // A refusal appends one more message chunk, whose content Ollama clients
+  // concatenate onto the message they are building — so the client holds the
+  // model's text AND the refusal. Recording the refusal alone deleted the
+  // model's own answer from the turn.
+  test("a refusal keeps the streamed text and drops the withheld call", () => {
+    const adapter = factory.createStreamAdapter();
+    adapter.processChunk(
+      chunk({ message: { role: "assistant", content: "let me check" } }),
+    );
+    adapter.processChunk(
+      chunk({
+        message: {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "c1",
+              function: { name: "read_file", arguments: { path: "x" } },
+            },
+          ],
+        },
+      }),
+    );
+
+    adapter.formatCompleteTextSSE("blocked message");
+    const response = adapter.toProviderResponse();
+
+    expect(response.message.content).toBe("let me checkblocked message");
+    expect(response.message.tool_calls).toBeUndefined();
+    expect(response.done_reason).toBe("stop");
+  });
+
   test("buffers tool-call chunks and replays them via getRawToolCallEvents", () => {
     const adapter = factory.createStreamAdapter();
     const toolChunk = chunk({

--- a/platform/backend/src/routes/proxy/adapters/ollama-native.ts
+++ b/platform/backend/src/routes/proxy/adapters/ollama-native.ts
@@ -455,6 +455,22 @@ class OllamaNativeStreamAdapter
   // Raw native tool-call lines, buffered until policy approval then replayed.
   private rawToolCallLines: string[] = [];
   // Set to the refusal text when the response was replaced by a policy refusal.
+  // A refusal does not erase what the model already said: its text streamed
+  // as it arrived and the refusal was appended after it, so the client holds
+  // both. Recording the refusal alone deletes the model's own answer from the
+  // turn, leaving anything that reads it back — conversation history, a
+  // summarizer, a human debugging a run that died — a turn in which the model
+  // never spoke.
+  //
+  // The refusal ships as one more message chunk, whose content Ollama clients
+  // concatenate onto the message they are building, so the record matches.
+  private contentWithAnyRefusal(): string {
+    if (this.replacedText === null) {
+      return this.state.text;
+    }
+    return `${this.state.text}${this.replacedText}`;
+  }
+
   private replacedText: string | null = null;
   /** Ollama's own timing counters, read off the swallowed final chunk. */
   private upstreamMetrics: Record<string, number | undefined> = {};
@@ -667,7 +683,7 @@ class OllamaNativeStreamAdapter
       created_at: this.createdAt,
       message: {
         role: "assistant",
-        content: this.replacedText ?? this.state.text,
+        content: this.contentWithAnyRefusal(),
         ...(this.thinking ? { thinking: this.thinking } : {}),
         ...(toolCalls ? { tool_calls: toolCalls } : {}),
       },

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
@@ -161,6 +161,30 @@ describe("OpenAiResponsesStreamAdapter.toProviderResponse", () => {
   // an empty `output`, even though the text arrived in delta chunks. Persisting
   // that envelope verbatim dropped the assistant side of the interaction, so
   // LLM Logs had nothing to render for the turn.
+  // A refusal appends one more output-text delta, which clients concatenate —
+  // so the client holds the model's text AND the refusal. Recording the refusal
+  // alone deleted the model's own answer from the turn.
+  test("a refusal keeps the streamed output text", () => {
+    const adapter = openAiResponsesAdapterFactory.createStreamAdapter();
+
+    adapter.processChunk({
+      type: "response.output_text.delta",
+      item_id: "msg_1",
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 1,
+      delta: "let me check",
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    adapter.formatCompleteTextSSE("blocked message");
+    const response = adapter.toProviderResponse();
+
+    const message = response.output.find((item) => item.type === "message");
+    expect(
+      message && "content" in message ? message.content[0].text : undefined,
+    ).toBe("let me checkblocked message");
+  });
+
   test("restores accumulated output when the completed envelope is empty", () => {
     const adapter = openAiResponsesAdapterFactory.createStreamAdapter();
 

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
@@ -180,8 +180,10 @@ describe("OpenAiResponsesStreamAdapter.toProviderResponse", () => {
     const response = adapter.toProviderResponse();
 
     const message = response.output.find((item) => item.type === "message");
+    const firstBlock =
+      message && "content" in message ? message.content[0] : undefined;
     expect(
-      message && "content" in message ? message.content[0].text : undefined,
+      firstBlock && "text" in firstBlock ? firstBlock.text : undefined,
     ).toBe("let me checkblocked message");
   });
 

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -708,7 +708,19 @@ class OpenAiResponsesStreamAdapter
   toProviderResponse(): OpenAiResponsesResponse {
     const outputItems: OpenAiResponsesResponse["output"] = [];
 
-    const messageText = this.replacedText ?? this.state.text;
+    // A refusal does not erase what the model already said: its text streamed
+    // as it arrived and the refusal was appended after it, so the client holds
+    // both. Recording the refusal alone deletes the model's own answer from the
+    // turn, leaving anything that reads it back — conversation history, a
+    // summarizer, a human debugging a run that died — a turn in which the model
+    // never spoke.
+    //
+    // The refusal ships as one more output-text delta, which clients
+    // concatenate, so the recorded message text is that concatenation.
+    const messageText =
+      this.replacedText === null
+        ? this.state.text
+        : `${this.state.text}${this.replacedText}`;
     if (messageText) {
       outputItems.push({
         id: `msg_${Date.now()}`,

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "@/test";
+import type { Zhipuai } from "@/types/llm-providers";
+import { zhipuaiAdapterFactory } from "./zhipuai";
+
+type StreamChunk = Zhipuai.Types.ChatCompletionChunk;
+
+function textChunk(text: string): StreamChunk {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "glm-4",
+    choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+  } as StreamChunk;
+}
+
+describe("ZhipuaiStreamAdapter policy refusal", () => {
+  // A refusal appends one more content delta, which clients concatenate onto
+  // what they have accumulated — so the client holds the model's text AND the
+  // refusal. Recording the refusal alone deleted the model's own answer from
+  // the turn, leaving anything that read it back a turn in which it never
+  // spoke.
+  test("keeps the streamed text and appends the refusal", () => {
+    const adapter = zhipuaiAdapterFactory.createStreamAdapter();
+    adapter.processChunk(textChunk("let me check"));
+
+    adapter.formatCompleteTextSSE("blocked message");
+    const response = adapter.toProviderResponse();
+
+    expect(response.choices[0].message.content).toBe(
+      "let me checkblocked message",
+    );
+    expect(response.choices[0].finish_reason).toBe("stop");
+  });
+
+  test("leaves an unrefused turn untouched", () => {
+    const adapter = zhipuaiAdapterFactory.createStreamAdapter();
+    adapter.processChunk(textChunk("all good"));
+
+    const response = adapter.toProviderResponse();
+
+    expect(response.choices[0].message.content).toBe("all good");
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.ts
@@ -628,6 +628,22 @@ class ZhipuaiStreamAdapter
   // Set to the refusal text when the streamed response was replaced by a policy
   // refusal, so formatEndSSE finishes as "stop" (not the upstream "tool_calls")
   // and toProviderResponse persists the refusal rather than the blocked calls.
+  // A refusal does not erase what the model already said: its text streamed
+  // as it arrived and the refusal was appended after it, so the client holds
+  // both. Recording the refusal alone deletes the model's own answer from the
+  // turn, leaving anything that reads it back — conversation history, a
+  // summarizer, a human debugging a run that died — a turn in which the model
+  // never spoke.
+  //
+  // The refusal ships as one more content delta, which clients concatenate onto
+  // what they have accumulated, so the record is that same concatenation.
+  private contentWithAnyRefusal(): string | null {
+    if (this.replacedText === null) {
+      return this.state.text || null;
+    }
+    return `${this.state.text}${this.replacedText}`;
+  }
+
   private replacedText: string | null = null;
   private get responseReplacedWithText(): boolean {
     return this.replacedText !== null;
@@ -874,7 +890,7 @@ class ZhipuaiStreamAdapter
           index: 0,
           message: {
             role: "assistant",
-            content: this.replacedText ?? (this.state.text || null),
+            content: this.contentWithAnyRefusal(),
             tool_calls: toolCalls,
           },
           logprobs: null,


### PR DESCRIPTION
Completes the sweep started in #7388 (anthropic, openai, gemini). These six adapters had the same defect: a refused turn was recorded as **the refusal text alone**, deleting whatever the model had already said.

## Per-adapter, matched to each wire format

The fix is not one shape — each adapter is reconstructed to match what its own protocol puts on the wire:

| Adapter | Wire behaviour of the refusal | Recorded as |
|---|---|---|
| `zhipuai` | further content delta, clients concatenate | concatenation |
| `minimax` | further content deltas | concatenation |
| `ollama-native` | further message chunk, content concatenated | concatenation |
| `openai-responses` | further output-text delta | concatenation |
| `cohere` | further content **block** | both blocks |
| `bedrock` | further content **block** | both blocks |

## Two traps this had to avoid

1. **`cohere` and `bedrock` appended tool calls unconditionally.** Anthropic gates on `toolCallsReleased`; these did not. Removing their early returns without adding a gate would have started recording calls the guardrail *withheld* — a persisted turn owing tool results nothing will ever send. Both now gate, and the tests assert the withheld call is absent.
2. **`minimax` dropped its accumulated reasoning** whenever a refusal replaced the turn (`replacedText === null && this.lastReasoningText`). That is the same erasure as dropping the answer text, so it is kept now too.

`finish_reason` / `stopReason` / `done_reason` stay pinned to the end-of-turn value on this path, matching what each `formatEndSSE` already emits.

## Verification — the tests are load-bearing, not decorative

Each adapter gets a test driving its **real** accumulation path (its own `processChunk` chunk shapes), then `formatCompleteTextSSE`, then asserting on `toProviderResponse`. `zhipuai` had no test file at all; one was added.

Proven by reverting: with the six adapters restored to `main` and the new tests kept, **exactly 6 tests fail — one per adapter**. With the fix, all 170 tests in those six files pass. So every test fails for its own adapter's reason, and no adapter is silently uncovered.

```
with fix:     Test Files 6 passed (6) | Tests 170 passed (170)
adapters reverted: Test Files 6 failed (6) | Tests 6 failed | 164 passed (170)
```

Backend `type-check`, `lint` and `knip` all pass (verified on exit code, not on piped output). Across `src/routes/proxy` + `src/guardrails`: 1516 passing, with the same 4 pre-existing failures before and after — they assert on plaintext interaction bodies, which a local `.env` encrypts.

## Still open, deliberately not in this PR

- **Reasoning is never accumulated** into `StreamAccumulatorState`, so outside the adapters carrying their own field (gemini's `thoughtText`, ollama's `thinking`, minimax's reasoning) it is absent from every reconstructed response, refused or not. That needs accumulation added per adapter and is a change of a different shape.
- **A blocked turn is still indistinguishable in telemetry** — normal finish reason, no marker — so an unattended run that died this way looks like a healthy one.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>