### PR TITLE
security: redact provider auth headers (x-api-key, api-key, x-goog-api-key) in logs

### DIFF
--- a/platform/backend/src/logging/redaction.test.ts
+++ b/platform/backend/src/logging/redaction.test.ts
@@ -77,6 +77,33 @@ describe("log redaction", () => {
   });
 });
 
+test("censors hyphenated provider auth headers (Anthropic, Azure, Google)", () => {
+  const { logger, records } = createCapturingLogger();
+
+  logger.info(
+    {
+      request: {
+        headers: {
+          "x-api-key": "sk-ant-api03-abc123",
+          "api-key": "azure-openai-key-xyz789",
+          "x-goog-api-key": "AIzaSyABC123_google_key",
+          "content-type": "application/json",
+          "x-archestra-locked-chat-key": "lk_abc123",
+        },
+      },
+    },
+    "provider request",
+  );
+
+  const headers = (records[0].request as { headers: Record<string, unknown> })
+    .headers;
+  expect(headers["x-api-key"]).toBe("[Redacted]");
+  expect(headers["api-key"]).toBe("[Redacted]");
+  expect(headers["x-goog-api-key"]).toBe("[Redacted]");
+  expect(headers["content-type"]).toBe("application/json");
+  expect(headers["x-archestra-locked-chat-key"]).toBe("[Redacted]");
+});
+
 describe("bounded error serialization", () => {
   test("drops headers/config and truncates responseBody on logged errors", () => {
     const { logger, records } = createCapturingLogger();

--- a/platform/backend/src/logging/redaction.ts
+++ b/platform/backend/src/logging/redaction.ts
@@ -31,6 +31,18 @@ export const REDACTED_LOG_PATHS = [
     '["x-archestra-locked-chat-key"]',
     '*["x-archestra-locked-chat-key"]',
     '*.headers["x-archestra-locked-chat-key"]',
+    // Provider API keys ride hyphenated HTTP headers that the camelCase
+    // flatMap above does not catch: Anthropic (x-api-key), Azure OpenAI
+    // (api-key), and Google AI (x-goog-api-key).
+    '["x-api-key"]',
+    '*["x-api-key"]',
+    '*.headers["x-api-key"]',
+    '["api-key"]',
+    '*["api-key"]',
+    '*.headers["api-key"]',
+    '["x-goog-api-key"]',
+    '*["x-goog-api-key"]',
+    '*.headers["x-goog-api-key"]',
   ]);
 
 /**


### PR DESCRIPTION
## Problem

`REDACTED_LOG_PATHS` redacts camelCase authorization keys (`apiKey`, `token`, ...) and the hyphenated `x-archestra-locked-chat-key`, but it does **not** redact the hyphenated HTTP headers that carry provider API keys:

- `x-api-key` — Anthropic
- `api-key` — Azure OpenAI
- `x-goog-api-key` — Google AI

These headers are used across the backend (provider request paths), so a request/error log that includes them leaks the raw provider key.

## Fix

Add the three hyphenated headers to `REDACTED_LOG_PATHS` using the exact same fast-redact bracket syntax already used for `x-archestra-locked-chat-key` (three shapes each: `["key"]`, `*["key"]`, `*.headers["key"]`). No new mechanism, just extends the existing convention.

## Test

Added a discriminating test in `redaction.test.ts`: a log record with all three provider headers plus `content-type` and `x-archestra-locked-chat-key`. Asserts the three provider keys and the locked-chat key come out `[Redacted]`, while `content-type` stays visible (proves no over-redaction). Red before the fix, green after. Full backend suite passes; biome clean.