### PR TITLE
fix(deps): swap npm's bundled tar for CVE-2026-73566 in the MCP base image

### DIFF
--- a/platform/mcp_server_docker_image/Dockerfile
+++ b/platform/mcp_server_docker_image/Dockerfile
@@ -45,15 +45,15 @@ RUN uv pip sync \
 FROM ${NODE_IMAGE} AS node-builder
 
 # Upgrade npm to a version whose bundled dependencies already include the fixes for
-# tar CVE-2026-59873/CVE-2026-59874 (bundle ships tar 7.5.19), picomatch
-# CVE-2026-33671, sigstore CVE-2026-48815, and undici CVE-2026-12151 (bundle
-# ships 6.27.0, which previously required a manual bundle swap on 11.17.0).
+# picomatch CVE-2026-33671, sigstore CVE-2026-48815, and undici CVE-2026-12151
+# (bundle ships 6.27.0, which previously required a manual bundle swap on 11.17.0).
 # npm 11.18.0 was published 2026-06-29 and has cleared the 7-day release-age practice.
-# Two of npm's OWN bundled dependencies carry HIGH CVEs that no npm release fixes,
-# so both are swapped in place. 11.18.0 is the last 11.x, and 12.0.0/12.0.1 require
-# Node >=22 while this stage is node:20-alpine, so upgrading npm is not the way out.
-# Both swaps stay within the same major and satisfy the bundled consumer's range, and
-# this is also what the final stage ships — it copies this npm wholesale (see below).
+# Three of npm's OWN bundled dependencies carry HIGH CVEs that no npm release fixes,
+# so all three are swapped in place. 11.19.0 (the newest 11.x) bundles the exact same
+# versions of all three, and 12.x requires Node >=22 while this stage is node:20-alpine,
+# so upgrading npm is not the way out. Every swap stays within the same major and
+# satisfies the bundled consumers' ranges, and this is also what the final stage ships
+# — it copies this npm wholesale (see below).
 #
 #   brace-expansion  CVE-2026-14257, then CVE-2026-69152 (uncontrolled resource
 #     consumption). The bundle ships 5.0.7 via minimatch 10.2.5, which asks ^5.0.5;
@@ -63,10 +63,18 @@ FROM ${NODE_IMAGE} AS node-builder
 #     bundle ships 10.2.0 via socks 2.8.9, which asks ^10.1.1; 10.3.1 is in range and
 #     declares `node: >= 12`. The package.json override next to this file only governs
 #     the /opt/node-deps tree, so it cannot reach this copy.
+#   tar  CVE-2026-73566 (uncontrolled recursion in mapHas/filesFilter, an uncatchable
+#     stack-overflow DoS, affects <=7.5.20). The bundle ships 7.5.19, reached by npm
+#     itself plus libnpmdiff/node-gyp/pacote, whose ranges are all ^7.5.x; 7.5.22 is the
+#     newest patch (7.5.21 carries the fix), keeps 7.5.19's dependency ranges — all
+#     satisfied by the bundled chownr 3.0.0, yallist 5.0.0, minipass 7.1.3,
+#     minizlib 3.1.0 and @isaacs/fs-minipass 4.0.1 — and declares `node: >=18`.
 #
 # Each `npm pack` must run BEFORE its old copy is removed: npm reaches these packages
-# through minimatch/glob and socks respectively, so deleting first can leave npm unable
-# to run the very command that fetches the replacement.
+# through minimatch/glob, socks and pacote respectively, so deleting first can leave npm
+# unable to run the very command that fetches the replacement. tar is swapped LAST for
+# the same reason — npm cannot pack anything once its own tar is gone. The `tar -xzf`
+# calls are the shell's busybox tar, not this module, so they are unaffected.
 RUN npm install -g npm@11.18.0 && \
     cd /usr/local/lib/node_modules/npm/node_modules && \
     npm pack brace-expansion@5.0.9 && \
@@ -78,7 +86,12 @@ RUN npm install -g npm@11.18.0 && \
     rm -rf ip-address && \
     tar -xzf ip-address-10.3.1.tgz && \
     mv package ip-address && \
-    rm ip-address-10.3.1.tgz
+    rm ip-address-10.3.1.tgz && \
+    npm pack tar@7.5.22 && \
+    rm -rf tar && \
+    tar -xzf tar-7.5.22.tgz && \
+    mv package tar && \
+    rm tar-7.5.22.tgz
 
 WORKDIR /opt/node-deps
 


### PR DESCRIPTION
## What

Docker Scout is failing `Docker Image Scanning (MCP Server Base)` and blocking the merge queue:

```
✗ HIGH CVE-2026-73566 [Uncontrolled Resource Consumption]
  Fixed version : 7.5.21
1 vulnerability found in 1 package
```

`CVE-2026-73566` is uncontrolled recursion in node-tar's `mapHas`/`filesFilter` — an uncatchable stack-overflow DoS reachable via a crafted long-path tar with member selection. It affects `tar <= 7.5.20`, fixed in `7.5.21`.

## Where it comes from

The flagged copy is **npm's own bundled `tar` 7.5.19**, not an application dependency:

- `mcp_server_docker_image/package-lock.json` has no `tar` at all, so `/opt/node-deps` is clean.
- The platform image strips npm entirely (`rm -rf /usr/local/lib/node_modules/npm`), which is why only the MCP base job fails.
- The MCP base's final stage copies npm wholesale out of `node-builder`, so npm's bundled tree ships in the runtime image and gets scanned.

Bumping npm is not a way out — `11.19.0`, the newest 11.x, bundles the **identical** 7.5.19 (verified against both published tarballs), and 12.x requires Node >= 22 while this stage is `node:20-alpine`.

## Change

`tar` joins `brace-expansion` and `ip-address` as an in-place bundle swap, pinned to **7.5.22** (newest patch on the line; the fix landed in 7.5.21).

It is deliberately **last** in the chain: npm cannot `npm pack` anything once its own tar is gone. The surrounding `tar -xzf` calls are the shell's busybox tar, not this module, so they are unaffected either way.

Compatibility checked before pinning:

- Consumers in the bundle are npm itself plus `libnpmdiff` (`^7.5.1`), `node-gyp` (`^7.5.4`), `pacote` (`^7.4.3`) — 7.5.22 satisfies all.
- 7.5.22 keeps 7.5.19's dependency ranges, all satisfied by the already-bundled `chownr` 3.0.0, `yallist` 5.0.0, `minipass` 7.1.3, `minizlib` 3.1.0, `@isaacs/fs-minipass` 4.0.1.
- `engines: node >=18`, fine on `node:20-alpine`.
- Published 2026-07-24, well past the 7-day release-age practice.

The stale comment claiming npm's bundle already carried a fixed tar (and that 11.18.0 was the last 11.x) is corrected in the same block.

## Verification

Against the pinned `node:20-alpine` digest, after all three swaps:

- `tar=7.5.22`, `brace-expansion=5.0.9`, `ip-address=10.3.1`
- npm still functional on the tar-dependent paths: `npm view` OK, `npm install` (pacote → tar extract) OK, `npm pack` (tar create) OK.

Built the real Dockerfile end to end: the finished image's **only** tar module is `/usr/local/lib/node_modules/npm/node_modules/tar` at `7.5.22`. The scan gate itself runs in the merge queue.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>