### PR TITLE
fix(llm-proxy): record the reasoning openai, zhipuai and bedrock turns produced

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -34,6 +34,75 @@ function asStreamChunk<T>(chunk: unknown): T {
   return chunk as T;
 }
 
+describe("Bedrock reasoning", () => {
+  // Reasoning streams through untouched and is deliberately kept out of
+  // state.text (that holds the answer), so nothing captured it and the recorded
+  // turn looked as though the model went straight to its answer. The signature
+  // rides with the text: it is what makes a reasoning block replayable.
+  test("records the reasoning the model streamed, ahead of the answer", () => {
+    const adapter = bedrockAdapterFactory.createStreamAdapter(
+      createConverseRequest(),
+    );
+    type Chunk = Parameters<typeof adapter.processChunk>[0];
+
+    adapter.processChunk(
+      asStreamChunk<Chunk>({
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { reasoningContent: { text: "weighing it up" } },
+        },
+      }),
+    );
+    adapter.processChunk(
+      asStreamChunk<Chunk>({
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { reasoningContent: { signature: "sig-abc" } },
+        },
+      }),
+    );
+    adapter.processChunk(
+      asStreamChunk<Chunk>({
+        contentBlockDelta: {
+          contentBlockIndex: 1,
+          delta: { text: "the answer" },
+        },
+      }),
+    );
+
+    const content = adapter.toProviderResponse().output?.message?.content ?? [];
+    expect(content).toEqual([
+      {
+        reasoningContent: {
+          reasoningText: { text: "weighing it up", signature: "sig-abc" },
+        },
+      },
+      { text: "the answer" },
+    ]);
+  });
+
+  test("records a redacted reasoning block", () => {
+    const adapter = bedrockAdapterFactory.createStreamAdapter(
+      createConverseRequest(),
+    );
+    type Chunk = Parameters<typeof adapter.processChunk>[0];
+
+    adapter.processChunk(
+      asStreamChunk<Chunk>({
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { reasoningContent: { redactedContent: "encrypted-blob" } },
+        },
+      }),
+    );
+
+    const content = adapter.toProviderResponse().output?.message?.content ?? [];
+    expect(content).toEqual([
+      { reasoningContent: { redactedContent: "encrypted-blob" } },
+    ]);
+  });
+});
+
 describe("Bedrock policy refusal", () => {
   // A refusal appends further content, so the client holds the model's text AND
   // the refusal. Recording the refusal alone deleted the model's own answer;

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -1089,6 +1089,51 @@ class BedrockStreamAdapter
   // with the (discarded) tool events, so formatEndSSE must synthesize a terminal
   // messageStop (end_turn); toProviderResponse persists the refusal, not the
   // blocked tool calls.
+  /**
+   * The reasoning the model streamed, accumulated.
+   *
+   * Bedrock sends it as `reasoningContent` deltas which stream through
+   * untouched and are deliberately kept out of `state.text` (that holds the
+   * answer). Nothing else captured them, so the reconstructed turn — the one
+   * persisted as the interaction — recorded a reasoning turn as though the
+   * model had gone straight to its answer.
+   *
+   * The signature is kept with the text: it is what makes a reasoning block
+   * replayable, and a record without it describes something the API rejects.
+   */
+  private reasoningText = "";
+  private reasoningSignature = "";
+  private redactedReasoning: string | null = null;
+
+  private accumulateReasoningDelta(delta: unknown): void {
+    // Structurally narrowed rather than typed against the SDK union: the union
+    // members differ per reasoning kind (text/signature vs redacted), and this
+    // only ever reads the fields it recognises.
+    const reasoning = (
+      delta as {
+        reasoningContent?: {
+          text?: unknown;
+          signature?: unknown;
+          redactedContent?: unknown;
+          data?: unknown;
+        };
+      }
+    ).reasoningContent;
+    if (!reasoning) {
+      return;
+    }
+    if (typeof reasoning.text === "string") {
+      this.reasoningText += reasoning.text;
+    }
+    if (typeof reasoning.signature === "string") {
+      this.reasoningSignature += reasoning.signature;
+    }
+    const redacted = reasoning.redactedContent ?? reasoning.data;
+    if (typeof redacted === "string") {
+      this.redactedReasoning = (this.redactedReasoning ?? "") + redacted;
+    }
+  }
+
   private replacedText: string | null = null;
   private pendingProtocolText = "";
   private pendingProtocolContentBlockIndex: number | null = null;
@@ -1212,7 +1257,9 @@ class BedrockStreamAdapter
         // and whatever Bedrock adds next — streams through unmodified. Only
         // toolUse deltas are held back for policy evaluation. Reasoning is
         // deliberately not folded into state.text, which holds the final
-        // answer for interaction logging.
+        // answer for interaction logging — it is accumulated separately so the
+        // recorded turn still shows the reasoning the model produced.
+        this.accumulateReasoningDelta(blockDelta.delta);
         sseData =
           rawBytes ??
           encodeEventStreamMessage(
@@ -1547,16 +1594,32 @@ class BedrockStreamAdapter
   }
 
   toProviderResponse(): BedrockResponse {
-    const content: Array<
-      | { text: string }
-      | {
-          toolUse: {
-            toolUseId: string;
-            name: string;
-            input: Record<string, unknown>;
-          };
-        }
-    > = [];
+    // Typed from the response shape itself so reasoning blocks are expressible
+    // here rather than only in the wire type.
+    const content: NonNullable<
+      NonNullable<BedrockResponse["output"]>["message"]
+    >["content"] = [];
+
+    // Reasoning first, matching the order Bedrock emits it: a reasoning block
+    // precedes the answer it produced, and a record that reordered them would
+    // not describe the turn the client saw.
+    if (this.reasoningText) {
+      content.push({
+        reasoningContent: {
+          reasoningText: {
+            text: this.reasoningText,
+            ...(this.reasoningSignature
+              ? { signature: this.reasoningSignature }
+              : {}),
+          },
+        },
+      });
+    }
+    if (this.redactedReasoning !== null) {
+      content.push({
+        reasoningContent: { redactedContent: this.redactedReasoning },
+      });
+    }
 
     // Add text block if we have text
     if (this.state.text) {

--- a/platform/backend/src/routes/proxy/adapters/openai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.test.ts
@@ -851,6 +851,63 @@ describe("OpenAIStreamAdapter", () => {
     expect(response.choices[0].finish_reason).toBe("stop");
   });
 
+  // Reasoning models stream their thinking in `reasoning_content`. It reached
+  // the client but was never accumulated, so the recorded turn looked as though
+  // the model had gone straight to its answer.
+  test("toProviderResponse records the reasoning the model streamed", () => {
+    const adapter = openaiAdapterFactory.createStreamAdapter();
+    adapter.processChunk({
+      id: "chatcmpl-1",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "gpt-x",
+      choices: [
+        {
+          index: 0,
+          // Not part of the typed delta — the adapter reads it by cast for the
+          // same reason.
+          delta: {
+            reasoning_content: "weighing ",
+          } as Chunk["choices"][number]["delta"],
+          finish_reason: null,
+        },
+      ],
+    } as Chunk);
+    adapter.processChunk({
+      id: "chatcmpl-1",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "gpt-x",
+      choices: [
+        {
+          index: 0,
+          // Not part of the typed delta — the adapter reads it by cast for the
+          // same reason.
+          delta: {
+            reasoning_content: "it up",
+          } as Chunk["choices"][number]["delta"],
+          finish_reason: null,
+        },
+      ],
+    } as Chunk);
+    adapter.processChunk({
+      id: "chatcmpl-1",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "gpt-x",
+      choices: [
+        { index: 0, delta: { content: "the answer" }, finish_reason: null },
+      ],
+    } as Chunk);
+
+    const message = adapter.toProviderResponse().choices[0].message as {
+      content: string | null;
+      reasoning_content?: string;
+    };
+    expect(message.reasoning_content).toBe("weighing it up");
+    expect(message.content).toBe("the answer");
+  });
+
   test("carries the trailing usage chunk into the final SSE (net of cache)", () => {
     const adapter = openaiAdapterFactory.createStreamAdapter();
     adapter.processChunk({

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -1057,6 +1057,18 @@ export class OpenAIStreamAdapter
     return `${this.state.text}${this.replacedText}`;
   }
 
+  /**
+   * The reasoning the model streamed, accumulated.
+   *
+   * OpenAI-compatible reasoning models (qwen3, DeepSeek-R1, GLM, …) stream
+   * their thinking in `reasoning_content` (or `reasoning`). It was forwarded to
+   * the client but never accumulated, so the reconstructed turn — the one
+   * persisted as the interaction — recorded a reasoning turn as though the
+   * model had gone straight to its answer, which is what makes such a turn
+   * impossible to review afterwards.
+   */
+  private reasoningText = "";
+
   private replacedText: string | null = null;
   private get responseReplacedWithText(): boolean {
     return this.replacedText !== null;
@@ -1150,6 +1162,8 @@ export class OpenAIStreamAdapter
       (typeof reasoning === "string" && reasoning.length > 0) ||
       (typeof reasoningAlt === "string" && reasoningAlt.length > 0);
     if (hasReasoning && !delta.tool_calls) {
+      this.reasoningText +=
+        typeof reasoning === "string" ? reasoning : (reasoningAlt as string);
       sseData = `data: ${JSON.stringify(chunk)}\n\n`;
     }
 
@@ -1346,6 +1360,11 @@ export class OpenAIStreamAdapter
           message: {
             role: "assistant",
             content: this.contentWithAnyReplacement(),
+            // Non-standard, and the same field these models emit on the wire —
+            // clients that render reasoning read it back from here.
+            ...(this.reasoningText
+              ? { reasoning_content: this.reasoningText }
+              : {}),
             refusal: null,
             tool_calls: toolCalls,
           },

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.test.ts
@@ -33,6 +33,33 @@ describe("ZhipuaiStreamAdapter policy refusal", () => {
     expect(response.choices[0].finish_reason).toBe("stop");
   });
 
+  // GLM thinking mode streams its thinking in `reasoning_content`; it reached
+  // the client but was never accumulated into the recorded turn.
+  test("records the reasoning the model streamed", () => {
+    const adapter = zhipuaiAdapterFactory.createStreamAdapter();
+    adapter.processChunk({
+      id: "chatcmpl-test",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "glm-4",
+      choices: [
+        {
+          index: 0,
+          delta: { reasoning_content: "thinking" },
+          finish_reason: null,
+        },
+      ],
+    } as StreamChunk);
+    adapter.processChunk(textChunk("the answer"));
+
+    const message = adapter.toProviderResponse().choices[0].message as {
+      content: string | null;
+      reasoning_content?: string;
+    };
+    expect(message.reasoning_content).toBe("thinking");
+    expect(message.content).toBe("the answer");
+  });
+
   test("leaves an unrefused turn untouched", () => {
     const adapter = zhipuaiAdapterFactory.createStreamAdapter();
     adapter.processChunk(textChunk("all good"));

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.ts
@@ -644,6 +644,16 @@ class ZhipuaiStreamAdapter
     return `${this.state.text}${this.replacedText}`;
   }
 
+  /**
+   * The reasoning the model streamed, accumulated.
+   *
+   * GLM thinking mode streams its thinking in `reasoning_content`. It was
+   * forwarded to the client but never accumulated, so the reconstructed turn —
+   * the one persisted as the interaction — recorded a reasoning turn as though
+   * the model had gone straight to its answer.
+   */
+  private reasoningText = "";
+
   private replacedText: string | null = null;
   private get responseReplacedWithText(): boolean {
     return this.replacedText !== null;
@@ -712,6 +722,9 @@ class ZhipuaiStreamAdapter
     // `delta.tool_calls`) exposed blocked tool calls to the client before policy
     // evaluation and defeated the handler's buffering.
     const hasStreamableContent = delta.content || delta.reasoning_content;
+    if (delta.reasoning_content && !delta.tool_calls) {
+      this.reasoningText += delta.reasoning_content;
+    }
     if (hasStreamableContent && !delta.tool_calls) {
       sseData = `data: ${JSON.stringify(chunk)}\n\n`;
     }
@@ -891,6 +904,11 @@ class ZhipuaiStreamAdapter
           message: {
             role: "assistant",
             content: this.contentWithAnyRefusal(),
+            // The same field GLM emits on the wire, so clients that render
+            // reasoning read it back from here.
+            ...(this.reasoningText
+              ? { reasoning_content: this.reasoningText }
+              : {}),
             tool_calls: toolCalls,
           },
           logprobs: null,


### PR DESCRIPTION
Finishes the reasoning-accumulation sweep. These adapters receive reasoning on the wire and forwarded it to the client **without accumulating it**, so the reconstructed turn — the one persisted as the interaction — recorded a reasoning turn as though the model had gone straight to its answer.

Not a correctness bug: the client always got the reasoning, and the persisted response is never replayed as model history. It is log fidelity — a reasoning turn could not be reviewed after the fact.

## What changed

| Adapter | Source on the wire | Recorded as |
|---|---|---|
| `openai` | `reasoning_content` / `reasoning` delta | `reasoning_content` on the message |
| `zhipuai` | `reasoning_content` delta (GLM thinking mode) | `reasoning_content` on the message |
| `bedrock` | `reasoningContent` deltas (text / signature / redacted) | a `reasoningContent` content block, ahead of the answer |

`openai` and `zhipuai` hand it back under the same field the models emit, which is where a client that renders reasoning looks for it. `bedrock` emits its block **before** the answer, matching the order Bedrock sends them — a record that reordered them would not describe the turn the client saw. Signatures are kept with their block: they are what makes a reasoning block replayable, and a record without them describes something the API would reject.

## Two of the four turned out not to need it

I checked each rather than assuming the earlier list was right:

- **`openai-responses` is already covered.** Its `response.completed` envelope carries reasoning items in `output`, and the adapter returns that envelope verbatim when it carries the turn — so reasoning is already recorded.
- **`cohere` has no reasoning on its wire at all** (zero references in the adapter), so there was nothing to accumulate. It was listed in an earlier PR's follow-up note; that note was wrong and has been corrected.

`gemini`, `ollama-native` and `minimax` already carried their own reasoning field, and `anthropic` gained one in the preceding change. With this, every adapter that receives reasoning records it.

## A type fix worth noting

`bedrock`'s local `content` array was annotated more narrowly than the response type actually allows (`{text} | {toolUse}` only), so reasoning blocks were not expressible even though the wire type includes them. It is now derived from the response shape itself.

## Verification

Four new tests, all behavioral. Proven load-bearing by reverting the three adapters and re-running: **exactly those four fail**, nothing else.

- `openai` — two reasoning deltas accumulate in order, answer text stays separate
- `zhipuai` — same, GLM shape
- `bedrock` — text + signature recorded as one block, ordered ahead of the answer
- `bedrock` — redacted reasoning recorded

`type-check`, `lint`, `knip` and codegen-drift all pass, verified on exit code. Across `src/routes/proxy` + `src/guardrails`: 1524 passing with the same 4 pre-existing failures before and after (they assert on plaintext interaction bodies, which a local `.env` encrypts).
