### PR TITLE
chore(rust): declare the rust-analyzer component in rust-toolchain.toml

### DIFF
--- a/platform/rust-toolchain.toml
+++ b/platform/rust-toolchain.toml
@@ -1,6 +1,12 @@
 [toolchain]
 channel = "1.93.0"
-components = ["rustfmt"]
+# rustfmt is used by CI (`cargo fmt --check`). rust-analyzer is IDE-only, but it
+# has to be declared here: the VS Code extension resolves its server by running
+# `rustup which rust-analyzer` in the workspace folder, and falls back to its own
+# bundled server when that command fails. Recent bundled servers reject a channel
+# this old ("is using an outdated toolchain version"), so without this component
+# opening platform/ pops a modal and leaves Rust files with no IDE support.
+components = ["rustfmt", "rust-analyzer"]
 profile = "minimal"
 targets = [
   "aarch64-unknown-linux-musl",


### PR DESCRIPTION
## Problem

Opening `platform/` in VS Code pops a modal on every developer's machine:

> Your workspace uses a rust-toolchain file with a toolchain too old for the extension shipped rust-analyzer to work properly.

Dismiss it and Rust files get no IDE support at all — no completion, no go-to-definition, no diagnostics across `platform/archestra-rs`. We recommend `rust-lang.rust-analyzer` in `platform/.vscode/extensions.json`, so this hits anyone who takes that recommendation.

## Why it happens

The extension resolves its language server like this (decompiled from `out/main.js`, v0.3.3016):

1. for each workspace folder containing a `rust-toolchain.toml` / `rust-toolchain`,
2. run `rustup which rust-analyzer` with `cwd` set to that folder,
3. if it exits 0, use that binary; otherwise fall back to the server bundled with the extension.

Our pinned toolchain doesn't ship the component, so step 3 falls back. The bundled server (built 2026-08-16) then rejects our channel with `is using an outdated toolchain version`, and the extension pattern-matches that error to produce the modal.

Note that the extension never reads the `components` list — the binary just has to **exist** in the pinned toolchain. Declaring it here is simply the way to make `rustup show` put it there.

## Fix

Add `rust-analyzer` to `components`. `rustup show` (which every `Setup Rust` CI step already runs) then installs it, `rustup which` resolves, and each developer gets a server version-matched to the pinned toolchain rather than a mismatched bundled one.

## Cost, stated plainly

This adds a component CI never uses. The rust-analyzer binary is ~37MB against a ~943MB toolchain, so it's roughly a 4% increase in toolchain materialization on the three `Setup Rust` steps. The ephemeral Linux runners pay it each run; the mac mini's persistent disk pays it once. `Swatinem/rust-cache` caches the cargo registry and target dir, not the rustup toolchain, so it doesn't absorb this.

The alternative is leaving the file alone and having each developer run `rustup component add rust-analyzer` locally — zero CI cost, but it silently breaks again on every toolchain channel bump and every new hire hits the modal. Happy to go that route instead if the CI overhead isn't wanted.

## Verification

With the change applied, from `platform/`:

```
$ rustup show active-toolchain
1.93.0-aarch64-apple-darwin (overridden by '.../platform/rust-toolchain.toml')

$ rustup which rust-analyzer
/Users/.../.rustup/toolchains/1.93.0-aarch64-apple-darwin/bin/rust-analyzer   # exit 0
```

That exit-0 is the exact condition the extension tests. Confirmed locally that installing the component and reloading the window clears the modal and brings the server up.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>