### PR TITLE
fix(frontend): hide dismissed MCP alerts from server details

### DIFF
--- a/platform/frontend/src/app/mcp/registry/[id]/page.client.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/[id]/page.client.test.tsx
@@ -389,6 +389,36 @@ describe("McpCatalogItemDetailPage overview", () => {
     expect(screen.queryByRole("heading", { name: "Status" })).toBeNull();
   });
 
+  it("keeps dismissed alerts off the server details page", () => {
+    installedWithNoDeploymentEntry();
+    vi.mocked(useMcpServerIssues).mockReturnValue({
+      issuesByCatalog: new Map([
+        [
+          "cat-1",
+          [
+            {
+              kind: "needs-reauth",
+              audience: "you",
+              catalogId: "cat-1",
+              serverId: "srv-1",
+              detail: "invalid_grant",
+              since: null,
+              fingerprint: "v1:needs-reauth:test",
+              muted: true,
+              mutedReason: null,
+            },
+          ],
+        ],
+      ]),
+    } as unknown as ReturnType<typeof useMcpServerIssues>);
+    renderPage({ serverType: "remote", localConfig: null });
+
+    expect(
+      screen.queryByTestId("mcp-registry-attention-row-internal-tools"),
+    ).toBeNull();
+    expect(screen.getByText("Installed")).toBeInTheDocument();
+  });
+
   it("repairs the selected connection inline without opening a dialog", async () => {
     const user = userEvent.setup();
     const replace = vi.fn();

--- a/platform/frontend/src/app/mcp/registry/[id]/page.client.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/[id]/page.client.test.tsx
@@ -523,6 +523,54 @@ describe("McpCatalogItemDetailPage overview", () => {
     );
   });
 
+  it("keeps the OAuth reconnect form flat inside the credentials card", () => {
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("tab=credentials&server=srv-1") as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+    useMcpServers.mockReturnValue({
+      data: [
+        {
+          id: "srv-1",
+          catalogId: "cat-1",
+          name: "Linear Test",
+          serverType: "remote",
+          ownerId: "u1",
+          ownerEmail: "admin@example.com",
+          teamId: null,
+          scope: "org",
+          secretStorageType: "none",
+          createdAt: "2026-08-02T10:00:00.000Z",
+          assignedAgents: [],
+          oauthRefreshError: "refresh_failed",
+        },
+      ],
+    });
+    renderPage({
+      serverType: "remote",
+      localConfig: null,
+      oauthConfig: {
+        grantType: "authorization_code",
+        client_id: "abc123",
+        tokenEndpoint: "https://auth.example.com/token",
+        scopes: ["read"],
+      },
+    });
+
+    const form = screen.getByTestId("inline-mcp-reauthentication-form");
+    expect(form.parentElement).toHaveClass(
+      "rounded-lg",
+      "border",
+      "bg-card",
+      "p-4",
+    );
+    expect(form).not.toHaveClass("rounded-lg", "border", "bg-muted/20");
+    expect(
+      within(form).getByRole("button", { name: "Cancel" }).parentElement,
+    ).not.toHaveClass("border-t", "bg-background/60");
+  });
+
   it("reports the live fault, not the one the reader silenced", () => {
     // Issues are kind-ordered, and muting cuts across that order. Taking the
     // first issue made this page say "Failed to start" with a bell-off icon

--- a/platform/frontend/src/app/mcp/registry/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/registry/[id]/page.client.tsx
@@ -248,13 +248,13 @@ function CatalogItemDetails({
   const { statuses: deploymentStatuses, state: deploymentFeedState } =
     useMcpDeploymentStatuses();
   const { issuesByCatalog } = useMcpServerIssues(deploymentStatuses);
-  const itemIssues = issuesByCatalog.get(item.id);
-  // The worst live issue first, exactly as the registry table's Status column
-  // reads it (mcp-server-table.tsx). Issues are kind-ordered and `muted` cuts
-  // across that order, so taking issues[0] made a server carrying a silenced
-  // "Failed to start" plus a live "Needs re-authentication" report the
-  // silenced fault here and the live one in the list.
-  const statusIssue = itemIssues?.find((i) => !i.muted) ?? itemIssues?.[0];
+  // Dismissed alerts belong only to the registry's Dismissed facet. The
+  // server page reports live operational state, so muted issues neither render
+  // a notice here nor suppress the normal status.
+  const itemIssues = (issuesByCatalog.get(item.id) ?? []).filter(
+    (issue) => !issue.muted,
+  );
+  const statusIssue = itemIssues[0];
   useMcpInstallationStatusCacheSync();
 
   const { data: environmentList } = useEnvironments();
@@ -583,7 +583,7 @@ function CatalogItemDetails({
 
             <CardIssues
               item={item}
-              issues={itemIssues ?? []}
+              issues={itemIssues}
               servers={allServersForCatalog}
             />
 

--- a/platform/frontend/src/app/mcp/registry/_parts/inline-mcp-reauthentication.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/inline-mcp-reauthentication.tsx
@@ -78,10 +78,10 @@ export function InlineMcpReauthentication({
     };
     return (
       <section
-        className="rounded-lg border bg-muted/20"
+        className="space-y-4"
         data-testid="inline-mcp-reauthentication-form"
       >
-        <div className="flex items-start gap-3 p-4">
+        <div className="flex items-start gap-3">
           <KeyRound className="mt-0.5 h-4 w-4 text-muted-foreground" />
           <div className="min-w-0 flex-1">
             <h3 className="font-medium">Reconnect {server.name}</h3>
@@ -91,7 +91,7 @@ export function InlineMcpReauthentication({
             </p>
           </div>
         </div>
-        <div className="flex justify-end gap-2 border-t bg-background/60 px-4 py-3">
+        <div className="flex justify-end gap-2">
           <Button type="button" variant="outline" onClick={onClose}>
             Cancel
           </Button>


### PR DESCRIPTION
## Summary
- keep dismissed MCP alerts off server details while retaining them in the Registry Dismissed facet
- preserve normal server status when every issue is dismissed
- flatten the OAuth reconnect panel inside its credentials card

## Testing
- `NODE_ENV=test pnpm test --run src/app/mcp/registry/[id]/page.client.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm exec biome check` on the three changed files
- live verification with active and dismissed OAuth fault fixtures

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>