### PR TITLE
chore(dev): bootstrap husky from Tilt so pre-commit hooks actually run

### DIFF
--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -71,8 +71,11 @@ Load these project skills when the task matches their domain:
 
 ```bash
 # Development
-tilt up                                 # Start full development environment
+tilt up                                 # Start full development environment (also installs git hooks)
 pnpm dev                                # Start all workspaces
+pnpm run prepare                        # Install the husky pre-commit hook. `tilt up` does this for you;
+                                        # run it by hand if you skip Tilt. `pnpm install` will NOT do it,
+                                        # because ignoreScripts blocks lifecycle scripts (see below).
 pnpm lint                               # Lint and auto-fix
 pnpm type-check                         # Check TypeScript types
 pnpm test                               # Run tests

--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -82,6 +82,29 @@ local_resource(
   labels=['dev']
 )
 
+# Install the git pre-commit hook. husky's entry point is the `prepare` script,
+# but pnpm's `ignoreScripts: true` (the supply-chain guard in
+# pnpm-workspace.yaml) suppresses lifecycle scripts on install — including this
+# project's own — so `pnpm install` never runs it and a fresh clone silently
+# ends up with no core.hooksPath and no pre-commit checks. Running the script by
+# name executes only that one script; dependency install scripts stay blocked,
+# so the guard is unaffected.
+#
+# This must depend on pnpm-install: husky is a devDependency, so before that
+# resource completes the script just hits `husky: command not found` and the
+# `|| true` in it swallows the failure. The `git config` read afterwards asserts
+# the bootstrap actually took effect (it exits 1 when core.hooksPath is unset),
+# so a silent no-op shows up red in the Tilt UI instead of looking like success.
+#
+# Idempotent, and it also repairs a stale hooksPath left by husky v8, which
+# pointed at .husky/ rather than v9's .husky/_.
+local_resource(
+  'husky-hooks',
+  cmd='pnpm run prepare && git config core.hooksPath',
+  resource_deps=['pnpm-install'],
+  labels=['dev'],
+)
+
 # Rebuild the native app-runtime addon (napi) when its Rust sources change. The
 # compiled .node is gitignored and CI/Docker build it, so without this the
 # backend throws "Unable to load @archestra/app-runtime-rs" the first time an


### PR DESCRIPTION
Follow-up to #7405. Separate PR because it's an unrelated fix, found while chasing a `git commit` warning.

## The bug: nobody's pre-commit hook runs

husky is wired up through the `prepare` lifecycle script in `platform/package.json`. But `ignoreScripts: true` in `pnpm-workspace.yaml` — our supply-chain guard — suppresses lifecycle scripts on install, and **that applies to this project's own scripts, not just dependencies'**. So `pnpm install` never invokes husky, `core.hooksPath` is never set, and a fresh clone gets no pre-commit checks. Silently — there's no warning, and hooks aren't mentioned in the README or CLAUDE.md.

Verified with an isolated probe rather than assumed. Same package, only the flag differs:

| | `pnpm install` | explicit `pnpm run prepare` |
|---|---|---|
| project `prepare` | **not run** | **run** |
| dependency `postinstall` | not run | **not run** |

The right-hand column is the important one: invoking the script **by name** runs only that one script. Dependency install scripts stay blocked, so `ignoreScripts` is completely unaffected by this PR — the guard keeps doing its job.

## The fix

A `husky-hooks` local_resource next to `pnpm-install`.

**It has to depend on `pnpm-install`.** husky is a devDependency, so run any earlier and the script only reaches `husky: command not found` — which the `|| true` already inside `prepare` swallows, exit 0. I hit exactly this on the first attempt: an eval-time `local()` in the root Tiltfile looked fine and did nothing, because Tiltfile evaluation happens before any resource builds. On a fresh clone it would have no-op'd precisely when it was needed.

**The `git config core.hooksPath` read is an assertion, not decoration.** Given `|| true` can swallow a failure, the resource would otherwise go green while installing nothing. `git config` exits 1 when the key is unset, so a silent no-op shows up red in the Tilt UI instead.

## Also fixes a stale-config foot-gun

husky v8 set `core.hooksPath` to `.husky/` directly; v9 uses `.husky/_`, whose generated wrappers (mode 755, gitignored) source your hook via `sh -e`. Anyone still carrying the v8 value gets this on every commit:

```
hint: The '.../platform/.husky/pre-commit' hook was ignored because it's not set as executable.
```

Because git tries to *execute* the hook rather than letting husky's wrapper source it. This resource repairs that automatically. Worth noting the tempting fix here — `chmod +x` on the hook and committing mode 755 — is wrong: under v9 the hook is passed to `sh`, so its executable bit is never consulted.

## Verification

Not just "it parses":

- `tilt alpha tiltfile-result` evaluates the whole Tiltfile cleanly (exit 0), and the resource comes out structurally identical to `pnpm-install`, with `ResourceDependencies: ['pnpm-install']`.
- Tilt reports the working dir for these resources as `platform/dev`, so the command was written cwd-independent. Ran the exact argv Tilt will execute (`sh -c 'pnpm run prepare && git config core.hooksPath'`) from that exact directory: exit 0, prints `platform/.husky/_`.
- Confirmed the assertion behaves as claimed: `git config core.hooksPath` exits 1 unset, 0 when set.
- Confirmed the full chain fires afterwards via `git hook run pre-commit` (runs the real hook without creating a commit): git → wrapper → shim → `pnpm commit:check` → turbo.

Heads up for reviewers: once this lands and your hooks start working, `pnpm commit:check` currently fails on pre-existing lint on main — formatting in `backend/src/models/statistics.ts`, plus `useIndexOf` / `noNonNullAssertion` / `noUnusedFunctionParameters` in the dropbox and perforce connector tests and `app.routes.ts`. Those need cleaning up separately, or the first commit after this will be a surprise.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>