### PR TITLE
fix(chat): make stop cancel queued turns

### DIFF
--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -3,7 +3,7 @@ title: Chat
 category: Agents
 order: 2
 description: Built-in Chat interface for working with agents and MCP tools
-lastUpdated: 2026-08-20
+lastUpdated: 2026-08-23
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -40,7 +40,7 @@ Press Enter while a response is streaming to queue your message. Queued messages
 
 Queueing works during [context compaction](#context-compaction) too. A message you send while the conversation is being compacted waits in the queue, then sends once compaction finishes — so a long chat never drops what you typed.
 
-While a response streams, the send button becomes Stop. Clicking it (or pressing Esc) stops the response and pauses the queue; sending a new message resumes it.
+While a response streams, the send button becomes Stop. Clicking it or pressing Esc stops the response. The next queued message sends when the stream settles.
 
 ### MCP Elicitation
 

--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -40,7 +40,7 @@ Press Enter while a response is streaming to queue your message. Queued messages
 
 Queueing works during [context compaction](#context-compaction) too. A message you send while the conversation is being compacted waits in the queue, then sends once compaction finishes — so a long chat never drops what you typed.
 
-While a response streams, the send button becomes Stop. Clicking it or pressing Esc stops the response. The next queued message sends when the stream settles.
+While a response streams, the send button becomes Stop. Clicking it or pressing Esc stops the response and discards any queued messages for that conversation. Nothing else is sent until you submit a new message.
 
 ### MCP Elicitation
 

--- a/platform/backend/src/routes/chat/active-run-routes.test.ts
+++ b/platform/backend/src/routes/chat/active-run-routes.test.ts
@@ -6,6 +6,7 @@ import {
 import ActiveChatRunModel from "@/models/chat-active-run";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
+import { activeChatRunService } from "@/services/active-chat-run";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
@@ -84,22 +85,38 @@ describe("chat active-run routes", () => {
     ).resolves.toHaveLength(0);
   });
 
-  test("stop marks an accessible running active run with stopRequestedAt", async () => {
-    await ActiveChatRunModel.create({
+  test("stop waits for the accessible running run to become terminal", async () => {
+    const run = await ActiveChatRunModel.create({
       conversationId,
       userId: user.id,
       organizationId,
     });
 
-    const response = await app.inject({
-      method: "POST",
-      url: `/api/chat/conversations/${conversationId}/stop`,
+    let responseSettled = false;
+    const responsePromise = app
+      .inject({
+        method: "POST",
+        url: `/api/chat/conversations/${conversationId}/stop`,
+      })
+      .then((response) => {
+        responseSettled = true;
+        return response;
+      });
+
+    await waitForStopRequest(run?.id ?? "");
+    expect(responseSettled).toBe(false);
+
+    await activeChatRunService.markTerminal({
+      runId: run?.id ?? "",
+      status: "cancelled",
     });
 
+    const response = await responsePromise;
     expect(response.statusCode).toBe(200);
-    const run =
-      await ActiveChatRunModel.findRunningByConversation(conversationId);
-    expect(run?.stopRequestedAt).toBeInstanceOf(Date);
+    expect(response.json()).toEqual({ stopped: true });
+    expect((await ActiveChatRunModel.findById(run?.id ?? ""))?.status).toBe(
+      "cancelled",
+    );
   });
 
   test("stop returns 404 for an inaccessible conversation and does not mutate a running run", async ({
@@ -431,4 +448,16 @@ function readSsePayloads(body: string): unknown[] {
     .map((entry) => entry.slice("data: ".length))
     .filter((entry) => entry !== "[DONE]")
     .map((entry) => JSON.parse(entry));
+}
+
+async function waitForStopRequest(runId: string): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const run = await ActiveChatRunModel.findById(runId);
+    if (run?.stopRequestedAt) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error("Active chat run did not record the Stop request");
 }

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2172,19 +2172,26 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
       // connection close, even when the stream runs on a different pod.
       const activeStreamKey = `${CacheKey.ChatActiveStream}-${id}` as const;
       const streamId = await cacheManager.get<string>(activeStreamKey);
-      if (!streamId) {
-        return reply.send({ stopped: !!activeRun });
+      if (streamId) {
+        const stopKey = `${CacheKey.ChatStop}-${streamId}` as const;
+        try {
+          await cacheManager.set(stopKey, true, TimeInMs.Minute);
+        } catch (error) {
+          logger.warn(
+            { error, conversationId: id, streamId },
+            "Failed to set chat stop cache flag",
+          );
+        }
       }
-      const stopKey = `${CacheKey.ChatStop}-${streamId}` as const;
-      try {
-        await cacheManager.set(stopKey, true, TimeInMs.Minute);
-      } catch (error) {
-        logger.warn(
-          { error, conversationId: id, streamId },
-          "Failed to set chat stop cache flag",
-        );
+
+      // A successful Stop response is the submission hand-off barrier: do not
+      // let the client close its local stream and accept a new turn until the
+      // old run has durably left `running`. Otherwise the next POST can race
+      // the unique active-run guard and fail with a duplicate-run 409.
+      if (activeRun) {
+        await activeChatRunService.waitForTerminal(activeRun.id);
       }
-      return reply.send({ stopped: true });
+      return reply.send({ stopped: !!activeRun || !!streamId });
     },
   );
 

--- a/platform/backend/src/services/active-chat-run.test.ts
+++ b/platform/backend/src/services/active-chat-run.test.ts
@@ -282,7 +282,7 @@ test("createReplayStream wakes from notifier without waiting for the polling int
     organizationId: organization.id,
   });
   const notifier = new InMemoryActiveChatRunNotifier();
-  const service = new ActiveChatRunService(notifier, 10_000, 10_000);
+  const service = new ActiveChatRunService(notifier, 10, 10_000);
 
   const streamPromise = Promise.race([
     readStream(service.createReplayStream(run?.id ?? "")),

--- a/platform/backend/src/services/active-chat-run.test.ts
+++ b/platform/backend/src/services/active-chat-run.test.ts
@@ -346,6 +346,64 @@ test("startStopPolling aborts after a durable stop request notification", async 
   stopPolling();
 });
 
+test("Stop aborts a locally owned run immediately and its barrier waits for terminal state", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const notifier = new PollingActiveChatRunNotifier();
+  const service = new ActiveChatRunService(notifier, 10_000, 10_000);
+  const run = await service.createRun({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const abortController = new AbortController();
+  const stopPolling = service.startStopPolling({
+    runId: run?.id ?? "",
+    conversationId: conversation.id,
+    abortController,
+  });
+
+  await service.requestStop({
+    conversationId: conversation.id,
+    organizationId: organization.id,
+  });
+
+  // Polling-only mode cannot wake through the notifier. A run owned by this
+  // process still aborts synchronously instead of waiting for its poll timer.
+  expect(abortController.signal.aborted).toBe(true);
+
+  let barrierResolved = false;
+  const barrier = service.waitForTerminal(run?.id ?? "").then(() => {
+    barrierResolved = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  expect(barrierResolved).toBe(false);
+
+  await service.markTerminal({
+    runId: run?.id ?? "",
+    status: "cancelled",
+  });
+  await barrier;
+
+  const next = await service.createRun({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  expect(next).not.toBeNull();
+  stopPolling();
+});
+
 test("drainStreamToEvents aborts the source stream when event persistence fails", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -25,6 +25,9 @@ export class ActiveChatRunService {
   // Run ids this process created and believes may still be 'running'. Used to
   // fail only this pod's runs on graceful shutdown (no schema-level pod id).
   private readonly inFlightRunIds = new Set<string>();
+  // Lets a Stop request handled by this process abort its stream immediately.
+  // Cross-replica requests still wake the owner through the notifier below.
+  private readonly abortControllersByRunId = new Map<string, AbortController>();
   private isShuttingDown = false;
 
   constructor(
@@ -82,6 +85,7 @@ export class ActiveChatRunService {
   }): Promise<void> {
     await ActiveChatRunModel.markTerminal(params);
     this.inFlightRunIds.delete(params.runId);
+    await this.notifyEvent(params.runId);
   }
 
   // Periodic safety net for runs orphaned by a hard kill (OOM/SIGKILL) that
@@ -132,10 +136,31 @@ export class ActiveChatRunService {
   }) {
     const run = await ActiveChatRunModel.requestStop(params);
     if (run) {
+      const abortController = this.abortControllersByRunId.get(run.id);
+      if (abortController && !abortController.signal.aborted) {
+        abortController.abort();
+      }
       await this.notifyStop(run.id);
     }
 
     return run;
+  }
+
+  async waitForTerminal(runId: string): Promise<void> {
+    while (true) {
+      const run = await ActiveChatRunModel.findById(runId);
+      if (!run || run.status !== "running") {
+        return;
+      }
+
+      // Terminal transitions publish on the event channel. The timeout is a
+      // correctness fallback for a missed/cross-replica notification; every
+      // wake re-reads the durable row before Stop is allowed to return.
+      await this.notifier.waitForEvent({
+        runId,
+        timeoutMs: this.replayPollIntervalMs,
+      });
+    }
   }
 
   /**
@@ -245,7 +270,6 @@ export class ActiveChatRunService {
               status: "failed",
               error: value.errorText,
             });
-            await this.notifyEvent(params.runId);
           }
         }
 
@@ -256,7 +280,6 @@ export class ActiveChatRunService {
           status: terminal.status,
           error: terminal.error,
         });
-        await this.notifyEvent(params.runId);
       } catch (error) {
         if (!params.abortController?.signal.aborted) {
           params.abortController?.abort();
@@ -294,7 +317,6 @@ export class ActiveChatRunService {
           status: "failed",
           error: error instanceof Error ? error.message : String(error),
         });
-        await this.notifyEvent(params.runId);
       }
     })()
       .catch((error) => {
@@ -382,25 +404,10 @@ export class ActiveChatRunService {
   }): () => void {
     let stopped = false;
     const waitController = new AbortController();
+    this.abortControllersByRunId.set(params.runId, params.abortController);
 
     void (async () => {
       while (!stopped && !params.abortController.signal.aborted) {
-        // Default mode wakes this loop with Postgres LISTEN/NOTIFY. The timeout
-        // is still a safety poll so missed notifications or broken listener
-        // connections do not leave Stop requests undetected forever. In polling
-        // compatibility mode, this wait always lasts until the interval expires,
-        // so each running chat stream performs roughly one stop-check read per
-        // interval.
-        await this.notifier.waitForStop({
-          runId: params.runId,
-          timeoutMs: this.stopPollIntervalMs,
-          abortSignal: waitController.signal,
-        });
-
-        if (stopped || params.abortController.signal.aborted) {
-          return;
-        }
-
         try {
           const run = await ActiveChatRunModel.findById(params.runId);
           // The row existed when polling started, so a null read now means the
@@ -432,11 +439,28 @@ export class ActiveChatRunService {
             "Failed to poll active chat run stop flag",
           );
         }
+
+        // Default mode wakes this loop with Postgres LISTEN/NOTIFY. The timeout
+        // is still a safety poll so missed notifications or broken listener
+        // connections do not leave Stop requests undetected forever. Reading
+        // before the first wait closes the small create/register race where a
+        // Stop notification can arrive before this waiter is installed.
+        await this.notifier.waitForStop({
+          runId: params.runId,
+          timeoutMs: this.stopPollIntervalMs,
+          abortSignal: waitController.signal,
+        });
       }
     })();
 
     return () => {
       stopped = true;
+      if (
+        this.abortControllersByRunId.get(params.runId) ===
+        params.abortController
+      ) {
+        this.abortControllersByRunId.delete(params.runId);
+      }
       waitController.abort();
     };
   }

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -2155,13 +2155,15 @@ export function ChatPageContent({
     });
   }, []);
 
-  // Stop the in-flight response. Wired to the submit button's Stop face in
-  // the prompt input; any queued follow-up starts once the stream settles.
+  // Stop the in-flight response and discard its pending follow-ups. Wired to
+  // the submit button's Stop face in the prompt input.
   const handleStopStreaming = () => {
     if (conversationId) {
-      // Set the cache flag first, THEN close the connection so the
-      // connection-close handler on the backend finds the flag.
-      stopChatStreamMutation.mutateAsync(conversationId).finally(() => {
+      // Clear synchronously so no status transition can drain a queued turn
+      // while the separate Stop request is in flight. onFinish repeats this
+      // idempotently for any abort path that did not originate on this page.
+      chatMessageQueue.clear(conversationId);
+      void stopChatStreamMutation.mutateAsync(conversationId).finally(() => {
         stop?.();
       });
     } else {

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -2156,7 +2156,7 @@ export function ChatPageContent({
   }, []);
 
   // Stop the in-flight response. Wired to the submit button's Stop face in
-  // the prompt input; also pauses queue auto-drain (see ChatSessionHook).
+  // the prompt input; any queued follow-up starts once the stream settles.
   const handleStopStreaming = () => {
     if (conversationId) {
       // Set the cache flag first, THEN close the connection so the

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1685,11 +1685,10 @@ describe("stopping with queued messages", () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     chatMessageQueue.clear(conversationId);
   });
 
-  it("sends the next queued message after the active response is stopped", async () => {
+  it("discards queued messages when the active response is stopped", async () => {
     const tree = () => (
       <ChatProvider>
         <RegisterChatSession conversationId={conversationId} />
@@ -1710,57 +1709,12 @@ describe("stopping with queued messages", () => {
         isError: false,
       });
     });
-    status = "ready";
-    rerender(tree());
-
-    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
-    expect(mocks.sendMessage.mock.calls[0]?.[0]).toMatchObject({
-      role: "user",
-      parts: [{ type: "text", text: "show budget" }],
-    });
     expect(chatMessageQueue.get(conversationId)).toHaveLength(0);
-  });
 
-  it("silently retries when the stopped run is still terminalizing", async () => {
-    const tree = () => (
-      <ChatProvider>
-        <RegisterChatSession conversationId={conversationId} />
-      </ChatProvider>
-    );
-    const { rerender } = render(tree());
-    await waitFor(() => expect(chatOptions).toBeDefined());
-
-    act(() => {
-      chatMessageQueue.enqueue(conversationId, { text: "show budget" });
-    });
-    await act(async () => {
-      await chatOptions?.onFinish?.({
-        message: { id: "assistant-stopped", role: "assistant", parts: [] },
-        isAbort: true,
-        isError: false,
-      });
-    });
     status = "ready";
     rerender(tree());
-    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
-
-    vi.useFakeTimers();
-    act(() => {
-      chatOptions?.onError?.(
-        new Error(
-          "This conversation already has an active response. Stop it before sending another message.",
-        ),
-      );
-    });
-
-    expect(toast.error).not.toHaveBeenCalled();
-    expect(mocks.clearError).not.toHaveBeenCalled();
-    expect(mocks.regenerate).not.toHaveBeenCalled();
-
-    act(() => {
-      vi.advanceTimersByTime(1500);
-    });
-    expect(mocks.regenerate).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.sendMessage).not.toHaveBeenCalled());
+    expect(chatMessageQueue.get(conversationId)).toHaveLength(0);
   });
 });
 

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1654,6 +1654,73 @@ describe("ChatProvider title animation", () => {
   });
 });
 
+describe("stopping with queued messages", () => {
+  const conversationId = "conversation-stop-queue";
+  let chatOptions: Parameters<typeof mocks.useChat>[0] | undefined;
+  let status: "ready" | "streaming";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chatMessageQueue.clear(conversationId);
+    chatOptions = undefined;
+    status = "streaming";
+    mocks.resumeStream.mockResolvedValue(undefined);
+    const messages: UIMessage[] = [];
+    mocks.useChat.mockImplementation((options) => {
+      chatOptions = options;
+      return {
+        addToolApprovalResponse: mocks.addToolApprovalResponse,
+        addToolResult: mocks.addToolResult,
+        clearError: mocks.clearError,
+        error: undefined,
+        messages,
+        regenerate: mocks.regenerate,
+        resumeStream: mocks.resumeStream,
+        sendMessage: mocks.sendMessage,
+        setMessages: mocks.setMessages,
+        status,
+        stop: mocks.stop,
+      };
+    });
+  });
+
+  afterEach(() => {
+    chatMessageQueue.clear(conversationId);
+  });
+
+  it("sends the next queued message after the active response is stopped", async () => {
+    const tree = () => (
+      <ChatProvider>
+        <RegisterChatSession conversationId={conversationId} />
+      </ChatProvider>
+    );
+    const { rerender } = render(tree());
+    await waitFor(() => expect(chatOptions).toBeDefined());
+
+    act(() => {
+      chatMessageQueue.enqueue(conversationId, { text: "show budget" });
+    });
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: { id: "assistant-stopped", role: "assistant", parts: [] },
+        isAbort: true,
+        isError: false,
+      });
+    });
+    status = "ready";
+    rerender(tree());
+
+    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
+    expect(mocks.sendMessage.mock.calls[0]?.[0]).toMatchObject({
+      role: "user",
+      parts: [{ type: "text", text: "show budget" }],
+    });
+    expect(chatMessageQueue.get(conversationId)).toHaveLength(0);
+  });
+});
+
 describe("manual context compaction and the message queue", () => {
   const conversationId = "conversation-compaction-queue";
 

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1685,6 +1685,7 @@ describe("stopping with queued messages", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     chatMessageQueue.clear(conversationId);
   });
 
@@ -1718,6 +1719,48 @@ describe("stopping with queued messages", () => {
       parts: [{ type: "text", text: "show budget" }],
     });
     expect(chatMessageQueue.get(conversationId)).toHaveLength(0);
+  });
+
+  it("silently retries when the stopped run is still terminalizing", async () => {
+    const tree = () => (
+      <ChatProvider>
+        <RegisterChatSession conversationId={conversationId} />
+      </ChatProvider>
+    );
+    const { rerender } = render(tree());
+    await waitFor(() => expect(chatOptions).toBeDefined());
+
+    act(() => {
+      chatMessageQueue.enqueue(conversationId, { text: "show budget" });
+    });
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: { id: "assistant-stopped", role: "assistant", parts: [] },
+        isAbort: true,
+        isError: false,
+      });
+    });
+    status = "ready";
+    rerender(tree());
+    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
+
+    vi.useFakeTimers();
+    act(() => {
+      chatOptions?.onError?.(
+        new Error(
+          "This conversation already has an active response. Stop it before sending another message.",
+        ),
+      );
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(mocks.clearError).not.toHaveBeenCalled();
+    expect(mocks.regenerate).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(mocks.regenerate).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -495,9 +495,6 @@ function ChatSessionHook({
     useUpdateChatMessage(conversationId);
   // Track if title generation has been attempted for this conversation
   const titleGenerationAttemptedRef = useRef(false);
-  // A user-initiated Stop pauses queued-message auto-drain (stop means stop);
-  // cleared when the user sends a message again, which resumes the queue.
-  const queueDrainSuspendedRef = useRef(false);
   // Ref to hold sendMessage for use in onFinish callback
   const sendMessageRef = useRef<
     | ((
@@ -706,9 +703,6 @@ function ChatSessionHook({
       // perpetually "running" tool. Drop those dangling parts so the live view
       // matches what the backend persists (and a reload would show).
       if (isAbort) {
-        // Stop means stop: don't auto-fire the next queued message right
-        // after the user aborted a turn. Sending again resumes the queue.
-        queueDrainSuspendedRef.current = true;
         // The updater form runs against the SDK's live messages, not this
         // callback's (throttled, possibly stale) closure, so the most recently
         // streamed text is never rolled back.
@@ -1180,9 +1174,6 @@ function ChatSessionHook({
     // A new turn: any pending "clear the prior turn's persisted error on a
     // successful retry" intent no longer applies to this turn.
     recoveredPersistedErrorRef.current = false;
-    // A new user message (re)starts the turn pipeline, so queued messages
-    // paused by a Stop may flow again once this turn settles.
-    queueDrainSuspendedRef.current = false;
   }
 
   useEffect(() => {
@@ -1228,7 +1219,6 @@ function ChatSessionHook({
       queuedMessages.length === 0 ||
       !resumeSettled ||
       queueDrainInFlightRef.current ||
-      queueDrainSuspendedRef.current ||
       recoveringRef.current ||
       hasPendingApprovalRequest ||
       pendingMcpElicitation ||

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -508,6 +508,11 @@ function ChatSessionHook({
   // Auto-retry state for transient errors
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
+  // True from the moment the queue drain submits a turn until that turn
+  // finishes. A Stop can make the SDK ready before the backend marks the
+  // aborted run terminal, so the queued submit can briefly hit its 409 guard.
+  // Only that known auto-drain race is safe to retry silently.
+  const queuedTurnPendingRef = useRef(false);
   // Set while auto-retrying a *structured* (backend-persisted) error, so a
   // successful retry can wipe the now-stale persisted error card the backend
   // never clears on its own.
@@ -681,6 +686,7 @@ function ChatSessionHook({
       // either keeps a recovery in flight or clears the flag for terminal
       // errors.
       if (!isError) {
+        queuedTurnPendingRef.current = false;
         setIsRecovering(false);
         // A structured error we silently auto-retried just succeeded — clear the
         // stale persisted error card the backend leaves behind (it never clears it
@@ -808,10 +814,27 @@ function ChatSessionHook({
           queryKey: ["conversation", conversationId],
         });
       }, 500);
+      const isDuplicateRun = isDuplicateActiveRunError(chatError);
+      if (isDuplicateRun && queuedTurnPendingRef.current) {
+        if (retryCountRef.current < MAX_AUTO_RETRIES) {
+          retryCountRef.current++;
+          setIsRecovering(true);
+          retryTimerRef.current = setTimeout(() => {
+            frozenMessagesRef.current = previousMessagesRef.current;
+            previousMessagesRef.current = [];
+            regenerate();
+          }, AUTO_RETRY_DELAY_MS);
+          return;
+        }
+        queuedTurnPendingRef.current = false;
+        setIsRecovering(false);
+      }
+
       // Log the error itself, not just fields read off it: a stream failure can
       // arrive as a bare object with no name/message, and the destructured form
       // then serializes to "{}" — which is what this printed while a real
-      // failure was in flight, leaving nothing to diagnose.
+      // failure was in flight, leaving nothing to diagnose. The expected,
+      // retried queue-after-Stop race returns above and stays out of error logs.
       console.error("[ChatSession] Error occurred:", chatError, {
         conversationId,
         errorName: chatError.name,
@@ -820,7 +843,7 @@ function ChatSessionHook({
         retryCount: retryCountRef.current,
       });
 
-      if (isDuplicateActiveRunError(chatError)) {
+      if (isDuplicateRun) {
         if (!recoveringRef.current) {
           // A 409 outside auto-recovery is a genuine concurrent submit (e.g.
           // a second tab racing this conversation): reattaching would
@@ -925,6 +948,7 @@ function ChatSessionHook({
 
       // Terminal: no recovery in flight — surface the error (and keep its
       // persisted card, so drop any pending "clear on successful retry" intent).
+      queuedTurnPendingRef.current = false;
       recoveredPersistedErrorRef.current = false;
       setPendingMcpElicitation(null);
       setIsRecovering(false);
@@ -1231,6 +1255,7 @@ function ChatSessionHook({
       return;
     }
     queueDrainInFlightRef.current = true;
+    queuedTurnPendingRef.current = true;
     sendMessageRef.current?.({
       role: "user",
       // a bare skill command carries no text; keep an empty text part so the

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -508,11 +508,6 @@ function ChatSessionHook({
   // Auto-retry state for transient errors
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
-  // True from the moment the queue drain submits a turn until that turn
-  // finishes. A Stop can make the SDK ready before the backend marks the
-  // aborted run terminal, so the queued submit can briefly hit its 409 guard.
-  // Only that known auto-drain race is safe to retry silently.
-  const queuedTurnPendingRef = useRef(false);
   // Set while auto-retrying a *structured* (backend-persisted) error, so a
   // successful retry can wipe the now-stale persisted error card the backend
   // never clears on its own.
@@ -686,7 +681,6 @@ function ChatSessionHook({
       // either keeps a recovery in flight or clears the flag for terminal
       // errors.
       if (!isError) {
-        queuedTurnPendingRef.current = false;
         setIsRecovering(false);
         // A structured error we silently auto-retried just succeeded — clear the
         // stale persisted error card the backend leaves behind (it never clears it
@@ -709,6 +703,9 @@ function ChatSessionHook({
       // perpetually "running" tool. Drop those dangling parts so the live view
       // matches what the backend persists (and a reload would show).
       if (isAbort) {
+        // Stop is a hard boundary: queued follow-ups belong to the work the
+        // user just cancelled and must never auto-submit after the abort.
+        chatMessageQueue.clear(conversationId);
         // The updater form runs against the SDK's live messages, not this
         // callback's (throttled, possibly stale) closure, so the most recently
         // streamed text is never rolled back.
@@ -814,27 +811,10 @@ function ChatSessionHook({
           queryKey: ["conversation", conversationId],
         });
       }, 500);
-      const isDuplicateRun = isDuplicateActiveRunError(chatError);
-      if (isDuplicateRun && queuedTurnPendingRef.current) {
-        if (retryCountRef.current < MAX_AUTO_RETRIES) {
-          retryCountRef.current++;
-          setIsRecovering(true);
-          retryTimerRef.current = setTimeout(() => {
-            frozenMessagesRef.current = previousMessagesRef.current;
-            previousMessagesRef.current = [];
-            regenerate();
-          }, AUTO_RETRY_DELAY_MS);
-          return;
-        }
-        queuedTurnPendingRef.current = false;
-        setIsRecovering(false);
-      }
-
       // Log the error itself, not just fields read off it: a stream failure can
       // arrive as a bare object with no name/message, and the destructured form
       // then serializes to "{}" — which is what this printed while a real
-      // failure was in flight, leaving nothing to diagnose. The expected,
-      // retried queue-after-Stop race returns above and stays out of error logs.
+      // failure was in flight, leaving nothing to diagnose.
       console.error("[ChatSession] Error occurred:", chatError, {
         conversationId,
         errorName: chatError.name,
@@ -843,7 +823,7 @@ function ChatSessionHook({
         retryCount: retryCountRef.current,
       });
 
-      if (isDuplicateRun) {
+      if (isDuplicateActiveRunError(chatError)) {
         if (!recoveringRef.current) {
           // A 409 outside auto-recovery is a genuine concurrent submit (e.g.
           // a second tab racing this conversation): reattaching would
@@ -948,7 +928,6 @@ function ChatSessionHook({
 
       // Terminal: no recovery in flight — surface the error (and keep its
       // persisted card, so drop any pending "clear on successful retry" intent).
-      queuedTurnPendingRef.current = false;
       recoveredPersistedErrorRef.current = false;
       setPendingMcpElicitation(null);
       setIsRecovering(false);
@@ -1255,7 +1234,6 @@ function ChatSessionHook({
       return;
     }
     queueDrainInFlightRef.current = true;
-    queuedTurnPendingRef.current = true;
     sendMessageRef.current?.({
       role: "user",
       // a bare skill command carries no text; keep an empty text part so the


### PR DESCRIPTION
## Summary

- match Claude Code interrupt ergonomics: stopping aborts the active response and discards every queued follow-up
- make Escape and the clickable Stop control use the same stop path
- make the backend Stop response a terminal barrier so a later manual submission cannot race the old active run and produce a conflict
- abort locally owned runs immediately and retain cross-replica stop notification behavior
- document the stop-and-discard contract