### PR TITLE
fix(frontend): search pages in command palette

### DIFF
--- a/platform/frontend/src/components/conversation-search-palette.test.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.test.tsx
@@ -254,6 +254,70 @@ describe("ConversationSearchPalette", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/mcp/registry");
   });
 
+  it("searches pages by their visible labels and navigates to a match", () => {
+    mockUseConversations.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: true,
+    });
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    fireEvent.change(screen.getByTestId("command-input"), {
+      target: { value: "registry" },
+    });
+
+    expect(screen.getByText("Pages")).toBeInTheDocument();
+    expect(screen.getByText("MCP Registry")).toBeInTheDocument();
+    expect(screen.queryByText("Agents")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("MCP Registry"));
+    expect(mockRouterPush).toHaveBeenCalledWith("/mcp/registry");
+  });
+
+  it("searches pages by navigation keywords", () => {
+    mockUseConversations.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    fireEvent.change(screen.getByTestId("command-input"), {
+      target: { value: "catalog" },
+    });
+
+    expect(screen.getByText("MCP Registry")).toBeInTheDocument();
+    expect(screen.queryByText("Agents")).not.toBeInTheDocument();
+  });
+
+  it("shows page matches alongside matching chats", () => {
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    fireEvent.change(screen.getByTestId("command-input"), {
+      target: { value: "agent" },
+    });
+
+    expect(screen.getByText("Agents")).toBeInTheDocument();
+    expect(screen.getByText("First conversation")).toBeInTheDocument();
+    expect(screen.getByText("Second conversation")).toBeInTheDocument();
+    expect(screen.getByText("Chats")).toBeInTheDocument();
+  });
+
+  it("reports an empty unified search only when no chat or page matches", () => {
+    mockUseConversations.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    fireEvent.change(screen.getByTestId("command-input"), {
+      target: { value: "nothing-matches-this" },
+    });
+
+    expect(screen.getByText("No chats or pages found.")).toBeInTheDocument();
+  });
+
   it("does not show the recent chats empty state in the full search palette", () => {
     mockUseConversations.mockReturnValue({
       data: [],

--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -217,6 +217,19 @@ export function ConversationSearchPalette({
   const isTyping = searchQuery !== debouncedSearch;
   const isSearchingAndFetching = isSearching && (isTyping || isFetching);
 
+  const matchingNavigationItems = useMemo(() => {
+    if (recentChatsView) return [];
+
+    const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
+    if (!normalizedQuery) return navigationItems;
+
+    return navigationItems.filter((item) =>
+      `${item.label} ${item.value} ${item.keywords}`
+        .toLocaleLowerCase()
+        .includes(normalizedQuery),
+    );
+  }, [recentChatsView, searchQuery]);
+
   const browseConversations = useMemo(() => {
     if (debouncedSearch.trim()) {
       return null;
@@ -244,14 +257,14 @@ export function ConversationSearchPalette({
     setIsPendingDeletion(null);
   }, [selectedValue, searchQuery]);
 
-  // Search replaces the entire item set (nav items ↔ conv-<id> results). With a
-  // controlled value, cmdk only auto-selects the first item when the value is
-  // falsy — a stale selection leaves the fresh list with no selected option, so
-  // ArrowUp and Enter dead-end (WCAG 2.1.1). Clear it whenever the query flips.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reacting to debouncedSearch changes to reset the selection
+  // Search replaces and filters the item set. With a controlled value, cmdk
+  // only auto-selects the first item when the value is falsy — a stale
+  // selection leaves the fresh list with no selected option, so ArrowUp and
+  // Enter dead-end (WCAG 2.1.1). Clear it as soon as the query changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reacting to searchQuery changes to reset the selection
   useEffect(() => {
     setSelectedValue("");
-  }, [debouncedSearch]);
+  }, [searchQuery]);
 
   const handleSelectConversation = (conversationId: string) => {
     router.push(`/chat/${conversationId}`);
@@ -522,12 +535,31 @@ export function ConversationSearchPalette({
     );
   };
 
+  const renderNavigationItems = () =>
+    matchingNavigationItems.map((item) => {
+      const Icon = item.icon;
+      return (
+        <CommandItem
+          key={item.value}
+          value={`${item.value} ${item.keywords} ${item.label}`}
+          onSelect={() => {
+            router.push(item.href);
+            onOpenChange(false);
+          }}
+          className="flex items-center gap-3 px-3 py-2.5 cursor-pointer aria-selected:bg-accent rounded-sm"
+        >
+          <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="text-sm font-medium">{item.label}</span>
+        </CommandItem>
+      );
+    });
+
   return (
     <CommandDialog
       open={open}
       onOpenChange={onOpenChange}
-      title="Search conversations"
-      description="Search through your conversation history"
+      title="Search or navigate"
+      description="Search chats and navigate to pages"
       className="max-w-2xl"
       shouldFilter={false}
       value={selectedValue}
@@ -554,58 +586,68 @@ export function ConversationSearchPalette({
           <div className="py-6 text-center text-sm text-muted-foreground">
             Loading conversations...
           </div>
-        ) : isSearchingAndFetching ? (
-          <SearchSkeleton />
+        ) : isSearching ? (
+          <>
+            {matchingNavigationItems.length > 0 && (
+              <CommandGroup heading="Pages">
+                {renderNavigationItems()}
+              </CommandGroup>
+            )}
+
+            {isSearchingAndFetching ? (
+              <CommandGroup heading="Chats">
+                <SearchSkeleton />
+              </CommandGroup>
+            ) : conversations.length > 0 ? (
+              <CommandGroup heading="Chats">
+                {conversations.map((conv) => renderConversationItem(conv))}
+              </CommandGroup>
+            ) : matchingNavigationItems.length === 0 ? (
+              <CommandEmpty>
+                {recentChatsView
+                  ? "No conversations found."
+                  : "No chats or pages found."}
+              </CommandEmpty>
+            ) : null}
+          </>
         ) : (
           <>
-            {!searchQuery.trim() && (
+            <CommandGroup>
+              <CommandItem
+                value="new-chat"
+                onSelect={handleNewChat}
+                className="flex items-center gap-2 px-3 py-2.5 cursor-pointer aria-selected:bg-accent"
+              >
+                <Pencil className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="font-medium">New chat</span>
+              </CommandItem>
+              {lockedChatEnabled && (
+                <CommandItem
+                  value="new-locked-chat private locked"
+                  onSelect={handleNewLockedChat}
+                  className="flex items-center gap-2 px-3 py-2.5 cursor-pointer aria-selected:bg-accent"
+                >
+                  <LockedChatIcon className="h-4 w-4 shrink-0" />
+                  <span className="font-medium">New locked chat</span>
+                </CommandItem>
+              )}
+            </CommandGroup>
+
+            {!recentChatsView && (
               <>
-                <CommandGroup>
-                  <CommandItem
-                    value="new-chat"
-                    onSelect={handleNewChat}
-                    className="flex items-center gap-2 px-3 py-2.5 cursor-pointer aria-selected:bg-accent"
-                  >
-                    <Pencil className="h-4 w-4 shrink-0 text-muted-foreground" />
-                    <span className="font-medium">New chat</span>
-                  </CommandItem>
-                  {lockedChatEnabled && (
-                    <CommandItem
-                      value="new-locked-chat private locked"
-                      onSelect={handleNewLockedChat}
-                      className="flex items-center gap-2 px-3 py-2.5 cursor-pointer aria-selected:bg-accent"
-                    >
-                      <LockedChatIcon className="h-4 w-4 shrink-0" />
-                      <span className="font-medium">New locked chat</span>
-                    </CommandItem>
-                  )}
-                </CommandGroup>
+                <CommandSeparator className="my-2" />
 
-                {!recentChatsView && (
-                  <>
-                    <CommandSeparator className="my-2" />
-
-                    <div className="px-2 pb-1.5">
-                      <div className="flex items-center justify-between px-1">
-                        <span className="text-xs font-medium text-muted-foreground">
-                          Chats
-                        </span>
-                      </div>
-                    </div>
-                  </>
-                )}
+                <div className="px-2 pb-1.5">
+                  <div className="flex items-center justify-between px-1">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Chats
+                    </span>
+                  </div>
+                </div>
               </>
             )}
 
-            {debouncedSearch.trim() ? (
-              conversations.length === 0 ? (
-                <CommandEmpty>No conversations found.</CommandEmpty>
-              ) : (
-                <CommandGroup heading="Search Results">
-                  {conversations.map((conv) => renderConversationItem(conv))}
-                </CommandGroup>
-              )
-            ) : browseConversations ? (
+            {browseConversations ? (
               <>
                 {browseConversations.pinned.length > 0 && (
                   <CommandGroup heading="Pinned">
@@ -634,7 +676,7 @@ export function ConversationSearchPalette({
               </>
             ) : null}
 
-            {!searchQuery.trim() && !recentChatsView && (
+            {!recentChatsView && (
               <>
                 <CommandSeparator className="my-2" />
 
@@ -648,27 +690,7 @@ export function ConversationSearchPalette({
                     </span>
                   </div>
                 </div>
-                <CommandGroup>
-                  {navigationItems.map((item) => {
-                    const Icon = item.icon;
-                    return (
-                      <CommandItem
-                        key={item.value}
-                        value={`${item.value} ${item.keywords} ${item.label}`}
-                        onSelect={() => {
-                          router.push(item.href);
-                          onOpenChange(false);
-                        }}
-                        className="flex items-center gap-3 px-3 py-2.5 cursor-pointer aria-selected:bg-accent rounded-sm"
-                      >
-                        <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                        <span className="text-sm font-medium">
-                          {item.label}
-                        </span>
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
+                <CommandGroup>{renderNavigationItems()}</CommandGroup>
               </>
             )}
           </>


### PR DESCRIPTION
## Summary

- include matching page destinations in non-empty command-palette searches
- show local page matches immediately while backend chat search is loading
- group unified results as Pages and Chats, with a combined empty state
- update the accessible dialog name and description to cover navigation