### PR TITLE
fix(auth): restore built-in SSO registration and account linking

### DIFF
--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -1302,16 +1302,16 @@ describe("handleAfterHook", () => {
       await makeMember(user.id, org.id, { role: "member" });
       await makeAccount(user.id, { providerId: CREDENTIAL_PROVIDER_ID });
       await makeIdentityProvider(org.id, {
-        providerId: "google-workspace",
+        providerId: "EntraID",
         domain: "example.com",
       });
-      await makeAccount(user.id, { providerId: "google-workspace" });
+      await makeAccount(user.id, { providerId: "EntraID" });
       const session = await makeSession(user.id, {
         activeOrganizationId: org.id,
       });
 
       const ctx = createMockContext({
-        path: "/sso/callback/google-workspace",
+        path: "/sso/callback/EntraID",
         method: "GET",
         body: {},
         context: {
@@ -1333,7 +1333,7 @@ describe("handleAfterHook", () => {
       expect(
         await AccountModel.getLatestSsoAccountByUserIdAndProviderId(
           user.id,
-          "google-workspace",
+          "EntraID",
         ),
       ).toBeUndefined();
       expect(await MemberModel.getByUserId(user.id, org.id)).toBeDefined();
@@ -4238,7 +4238,7 @@ describe("SSO account linking onto existing password users", () => {
     const provider = await makeIdentityProvider(org.id, {
       providerId: "oidc-unverified-link",
       issuer: IDP_ORIGIN,
-      domain: "example.com",
+      domain: "",
       oidcConfig: {
         clientId: "test-client-id",
         clientSecret: "test-client-secret",
@@ -4334,5 +4334,110 @@ describe("SSO account linking onto existing password users", () => {
       .from(schema.usersTable)
       .where(eq(schema.usersTable.id, user.id));
     expect(userRow.emailVerified).toBe(true);
+  });
+
+  test("OIDC callback links an existing account through a matching allowed domain without an email verification claim", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeAccount,
+    makeIdentityProvider,
+  }) => {
+    const user = await makeUser({
+      email: "domain-trusted-password-user@example.com",
+      emailVerified: false,
+    });
+    const org = await makeOrganization();
+    await makeMember(user.id, org.id, { role: "member" });
+    await makeAccount(user.id, {
+      providerId: CREDENTIAL_PROVIDER_ID,
+      accountId: user.id,
+    });
+
+    const provider = await makeIdentityProvider(org.id, {
+      providerId: "EntraID",
+      issuer: IDP_ORIGIN,
+      domain: "example.com",
+      oidcConfig: {
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        authorizationEndpoint: `${IDP_ORIGIN}/authorize`,
+        tokenEndpoint: `${IDP_ORIGIN}/token`,
+        userInfoEndpoint: `${IDP_ORIGIN}/userinfo`,
+        jwksEndpoint: `${IDP_ORIGIN}/jwks`,
+        pkce: false,
+      },
+    });
+
+    const signInResponse = await auth.handler(
+      new Request("http://localhost:3000/api/auth/sign-in/sso", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          providerId: provider.providerId,
+          callbackURL: "http://localhost:3000/chat",
+        }),
+      }),
+    );
+    expect(signInResponse.status).toBe(200);
+    const { url: authorizationUrl } = (await signInResponse.json()) as {
+      url: string;
+    };
+    const state = new URL(authorizationUrl).searchParams.get("state");
+    expect(state).toBeTruthy();
+    const stateCookies = signInResponse.headers
+      .getSetCookie()
+      .map((cookie) => cookie.split(";")[0])
+      .join("; ");
+
+    mswServer.use(
+      http.post(`${IDP_ORIGIN}/token`, () =>
+        HttpResponse.json({
+          access_token: "domain-trusted-sso-access-token",
+          token_type: "Bearer",
+        }),
+      ),
+      http.get(`${IDP_ORIGIN}/userinfo`, () =>
+        HttpResponse.json({
+          sub: "domain-trusted-external-subject",
+          email: user.email,
+          name: "Domain Trusted Password User",
+        }),
+      ),
+    );
+
+    const callbackResponse = await auth.handler(
+      new Request(
+        `http://localhost:3000/api/auth/sso/callback/${provider.providerId}?code=fake-code&state=${state}`,
+        { headers: { cookie: stateCookies } },
+      ),
+    );
+
+    expect(callbackResponse.status).toBe(302);
+    const location = callbackResponse.headers.get("location") ?? "";
+    expect(location).not.toContain("error=");
+    expect(location).toContain("http://localhost:3000/chat");
+
+    const linkedAccounts = await db
+      .select()
+      .from(schema.accountsTable)
+      .where(eq(schema.accountsTable.userId, user.id));
+    expect(
+      linkedAccounts.find(
+        (account) => account.providerId === provider.providerId,
+      ),
+    ).toMatchObject({
+      accountId: "domain-trusted-external-subject",
+      userId: user.id,
+    });
+
+    const [userRow] = await db
+      .select()
+      .from(schema.usersTable)
+      .where(eq(schema.usersTable.id, user.id));
+    expect(userRow.emailVerified).toBe(false);
   });
 });

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -8,7 +8,6 @@ import {
   DEFAULT_APP_NAME,
   emailMatchesAllowedIdentityProviderDomains,
   getEmailDomain,
-  IDENTITY_TRUSTED_PROVIDER_IDS,
   OAUTH_PAGES,
   OAUTH_SCOPES,
   PredefinedRoleNameSchema,
@@ -326,15 +325,10 @@ export const auth = betterAuth({
      */
     accountLinking: {
       enabled: true,
-      /**
-       * Trust built-in SSO providers plus any identity providers configured by
-       * users. Note this list only affects better-auth's built-in social
-       * providers: the SSO plugin calls handleOAuthUserInfo with
-       * `trustProviderByName: false` and instead derives trust from the
-       * provider's `domainVerified` flag, so custom OIDC/SAML providers are
-       * NOT trusted through this list.
-       */
-      trustedProviders: getTrustedAccountLinkingProviderIds,
+      // Do not add SSO provider IDs to `trustedProviders`. Better Auth reserves
+      // every ID in that option and refuses to register an SSO provider with
+      // the same ID. SSO callbacks pass `trustProviderByName: false` and use
+      // the provider's `domainVerified` value instead.
       /**
        * Don't allow linking accounts with different emails. From the better-auth typescript
        * annotations they mention for this attribute:
@@ -1003,19 +997,6 @@ async function getTrustedOriginsForAuthRequest(request?: Request) {
       "https://*",
     ]),
   ];
-}
-
-async function getTrustedAccountLinkingProviderIds(): Promise<string[]> {
-  if (!enterpriseTier.isCoreActive()) {
-    return [...IDENTITY_TRUSTED_PROVIDER_IDS];
-  }
-
-  const { default: IdentityProviderModel } = await import(
-    // biome-ignore lint/style/noRestrictedImports: runtime-gated EE model import
-    "@/models/identity-provider.ee"
-  );
-
-  return IdentityProviderModel.getTrustedAccountLinkingProviderIds();
 }
 
 /**

--- a/platform/backend/src/auth/idp.ee.ts
+++ b/platform/backend/src/auth/idp.ee.ts
@@ -56,8 +56,8 @@ export const ssoConfig = {
   disableImplicitSignUp: false,
   providersLimit: 10,
   trustEmailVerified: true, // Trust email verification from SSO providers
-  // Enable domain verification to allow SAML account linking for non-trusted providers
-  // When enabled, providers with domainVerified: true can link accounts by email domain
+  // Enable configured-domain trust for implicit OIDC and SAML account linking.
+  // Better Auth also requires domainVerified: true, which the provider model sets.
   domainVerification: {
     enabled: true,
   },

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -198,7 +198,7 @@ describe("IdentityProviderModel", () => {
       ).toBe(OAUTH_TOKEN_TYPE.AccessToken);
     });
 
-    test("clears persisted allowed email domains for non-Google API submissions", async ({
+    test("keeps persisted allowed email domains for non-Google API submissions", async ({
       makeOrganization,
       makeUser,
     }) => {
@@ -247,14 +247,14 @@ describe("IdentityProviderModel", () => {
       expect(registerSSOProvider).toHaveBeenCalledWith(
         expect.objectContaining({
           body: expect.objectContaining({
-            domain: "sso-placeholder.example.com",
+            domain: "example.com",
           }),
         }),
       );
-      expect(created.domain).toBe("");
+      expect(created.domain).toBe("example.com");
     });
 
-    test("keeps persisted allowed email domains for Google API submissions", async ({
+    test("uses a registration placeholder without persisting it when allowed domains are empty", async ({
       makeOrganization,
       makeUser,
     }) => {
@@ -277,18 +277,18 @@ describe("IdentityProviderModel", () => {
 
       const created = await IdentityProviderModel.create(
         {
-          providerId: "Google",
-          issuer: "https://accounts.google.com",
-          domain: "example.com",
+          providerId: "Okta",
+          issuer: "https://integrator-8514409.okta.com",
+          domain: "",
           userId: user.id,
           oidcConfig: {
-            issuer: "https://accounts.google.com",
+            issuer: "https://integrator-8514409.okta.com",
             skipDiscovery: true,
             pkce: true,
-            clientId: "google-client-id",
-            clientSecret: "google-client-secret",
+            clientId: "okta-client-id",
+            clientSecret: "okta-client-secret",
             discoveryEndpoint:
-              "https://accounts.google.com/.well-known/openid-configuration",
+              "https://integrator-8514409.okta.com/.well-known/openid-configuration",
           },
         },
         org.id,
@@ -300,7 +300,14 @@ describe("IdentityProviderModel", () => {
         } as unknown as Parameters<typeof IdentityProviderModel.create>[3],
       );
 
-      expect(created.domain).toBe("example.com");
+      expect(registerSSOProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            domain: "sso-placeholder.example.com",
+          }),
+        }),
+      );
+      expect(created.domain).toBe("");
     });
 
     test("rejects registration when discovery fetch returns a non-2xx response", async ({
@@ -1042,29 +1049,8 @@ describe("IdentityProviderModel", () => {
 
       expect(updated).not.toBeNull();
       expect(updated?.issuer).toBe("https://new-issuer.com");
-      expect(updated?.domain).toBe("");
-      expect(updated?.providerId).toBe("Okta"); // Unchanged
-    });
-
-    test("keeps updated allowed email domains for Google providers", async ({
-      makeOrganization,
-      makeIdentityProvider,
-    }) => {
-      const org = await makeOrganization();
-
-      const inserted = await makeIdentityProvider(org.id, {
-        providerId: "Google",
-        issuer: "https://accounts.google.com",
-        domain: "old.example.com",
-      });
-
-      const updated = await IdentityProviderModel.update(
-        inserted.id,
-        { domain: "new.example.com" },
-        org.id,
-      );
-
       expect(updated?.domain).toBe("new.example.com");
+      expect(updated?.providerId).toBe("Okta"); // Unchanged
     });
 
     test("can update oidcConfig", async ({
@@ -1329,14 +1315,7 @@ describe("IdentityProviderModel", () => {
     });
   });
 
-  /**
-   * Test for domainVerified workaround.
-   * With `domainVerification: { enabled: true }` in Better Auth's SSO plugin,
-   * all SSO providers need `domainVerified: true` for sign-in to work.
-   * See: https://github.com/better-auth/better-auth/issues/6481
-   * TODO: Remove this test once the upstream issue is fixed.
-   */
-  describe("domainVerified workaround", () => {
+  describe("trusted-domain account linking", () => {
     test("SAML providers are created with domainVerified: true", async ({
       makeOrganization,
       makeIdentityProvider,
@@ -1386,7 +1365,6 @@ describe("IdentityProviderModel", () => {
       );
 
       expect(provider).not.toBeNull();
-      // With domainVerification enabled, OIDC providers also need domainVerified: true
       expect(provider?.domainVerified).toBe(true);
     });
 
@@ -1396,7 +1374,6 @@ describe("IdentityProviderModel", () => {
     }) => {
       const org = await makeOrganization();
 
-      // Create a provider (will have domainVerified: true from create)
       const provider = await makeIdentityProvider(org.id, {
         providerId: "Update-Test",
         oidcConfig: {
@@ -1408,28 +1385,23 @@ describe("IdentityProviderModel", () => {
         },
       });
 
-      // Manually set domainVerified to false to simulate old data
-      // (This simulates providers created before the workaround was added)
       await IdentityProviderModel.setDomainVerifiedForTesting(
         provider.id,
         false,
       );
 
-      // Verify it's now false
       const beforeUpdate = await IdentityProviderModel.findById(
         provider.id,
         org.id,
       );
       expect(beforeUpdate?.domainVerified).toBe(false);
 
-      // Update the provider (change domain)
       await IdentityProviderModel.update(
         provider.id,
         { domain: "updated.example.com" },
         org.id,
       );
 
-      // After update, domainVerified should be set back to true
       const afterUpdate = await IdentityProviderModel.findById(
         provider.id,
         org.id,

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -1,9 +1,5 @@
 import type { IdpRoleMappingConfig } from "@archestra/shared";
-import {
-  IDENTITY_TRUSTED_PROVIDER_IDS,
-  MEMBER_ROLE_NAME,
-  OAUTH_TOKEN_TYPE,
-} from "@archestra/shared";
+import { MEMBER_ROLE_NAME, OAUTH_TOKEN_TYPE } from "@archestra/shared";
 import { APIError } from "better-auth";
 import { vi } from "vitest";
 import { retrieveIdpGroups } from "@/auth/idp-team-sync-cache.ee";
@@ -797,117 +793,6 @@ describe("IdentityProviderModel", () => {
       await IdentityProviderModel.delete(provider.id, org.id);
       const fresh = await IdentityProviderModel.findAllPublic();
       expect(fresh.map((p) => p.providerId)).toEqual(["Google"]);
-    });
-  });
-
-  describe("getTrustedAccountLinkingProviderIds", () => {
-    test("returns built-in trusted providers when no custom identity providers exist", async () => {
-      await expect(
-        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
-      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
-    });
-
-    test("includes configured generic OIDC and SAML provider IDs", async ({
-      makeOrganization,
-      makeIdentityProvider,
-    }) => {
-      const org = await makeOrganization();
-
-      await makeIdentityProvider(org.id, {
-        providerId: "custom-oidc",
-        oidcConfig: { clientId: "client-id" },
-      });
-      await makeIdentityProvider(org.id, {
-        providerId: "custom-saml",
-        samlConfig: { entryPoint: "https://example.com/saml" },
-      });
-
-      await expect(
-        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
-      ).resolves.toEqual([
-        ...IDENTITY_TRUSTED_PROVIDER_IDS,
-        "custom-oidc",
-        "custom-saml",
-      ]);
-    });
-
-    test("deduplicates built-in providers that are also configured in the database", async ({
-      makeOrganization,
-      makeIdentityProvider,
-    }) => {
-      const org = await makeOrganization();
-
-      await makeIdentityProvider(org.id, { providerId: "Okta" });
-
-      await expect(
-        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
-      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
-    });
-
-    test("caches the trusted provider list until an identity provider write clears it", async ({
-      makeOrganization,
-      makeIdentityProvider,
-    }) => {
-      const org = await makeOrganization();
-
-      // Prime the cache before any custom provider exists.
-      await expect(
-        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
-      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
-
-      // A row inserted behind the model's back stays invisible while the
-      // cached list is live...
-      const provider = await makeIdentityProvider(org.id, {
-        providerId: "cached-oidc",
-        oidcConfig: { clientId: "client-id" },
-      });
-      await expect(
-        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
-      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
-
-      // ...a model write clears the cache, so the next read sees it...
-      await IdentityProviderModel.update(provider.id, {}, org.id);
-      await expect(
-        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
-      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS, "cached-oidc"]);
-
-      // ...and delete clears it again.
-      await IdentityProviderModel.delete(provider.id, org.id);
-      await expect(
-        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
-      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
-    });
-
-    test("returns the built-in trusted providers before database initialization", async () => {
-      vi.resetModules();
-      vi.doMock("@/database", async () => {
-        const actual =
-          await vi.importActual<typeof import("@/database")>("@/database");
-
-        return {
-          ...actual,
-          default: new Proxy(
-            {},
-            {
-              get() {
-                throw new Error(
-                  "Database not initialized. Call initializeDatabase() first.",
-                );
-              },
-            },
-          ),
-        };
-      });
-
-      const { default: IsolatedIdentityProviderModel } = await import(
-        "./identity-provider.ee"
-      );
-
-      await expect(
-        IsolatedIdentityProviderModel.getTrustedAccountLinkingProviderIds(),
-      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
-
-      vi.doUnmock("@/database");
     });
   });
 

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -2,11 +2,7 @@ import type {
   IdentityProviderOidcConfig,
   IdpRoleMappingConfig,
 } from "@archestra/shared";
-import {
-  IDENTITY_PROVIDER_ID,
-  MEMBER_ROLE_NAME,
-  TimeInMs,
-} from "@archestra/shared";
+import { MEMBER_ROLE_NAME, TimeInMs } from "@archestra/shared";
 import type { SSOOptions } from "@better-auth/sso";
 import { APIError } from "better-auth";
 import { and, eq } from "drizzle-orm";
@@ -610,11 +606,7 @@ class IdentityProviderModel {
     const parsedData = {
       providerId: data.providerId,
       issuer: data.issuer,
-      domain:
-        normalizePersistedAllowedEmailDomain({
-          providerId: data.providerId,
-          domain: data.domain,
-        }) || SSO_REGISTRATION_PLACEHOLDER_DOMAIN,
+      domain: data.domain || SSO_REGISTRATION_PLACEHOLDER_DOMAIN,
       ssoLoginEnabled: data.ssoLoginEnabled ?? true,
       organizationId,
       ...(data.oidcConfig && {
@@ -669,11 +661,10 @@ class IdentityProviderModel {
     }
 
     /**
-     * WORKAROUND: With `domainVerification: { enabled: true }` in Better Auth's SSO plugin,
-     * all identity providers require `domainVerified: true` for sign-in to work without DNS verification.
-     * We auto-set this for all providers to bypass the DNS verification requirement.
-     * See: https://github.com/better-auth/better-auth/issues/6481
-     * TODO: Remove this workaround once the upstream issue is fixed.
+     * Better Auth trusts an SSO provider for implicit account linking only
+     * when its configured domain is verified and matches the returned email.
+     * Archestra administrators explicitly configure these allowed domains, so
+     * mark the provider domain as verified without Better Auth's DNS flow.
      */
     // Also store roleMapping and teamSyncConfig if provided (Better Auth doesn't handle these fields)
     // Note: These are stored as JSON text but typed as objects in Drizzle schema
@@ -683,14 +674,10 @@ class IdentityProviderModel {
     const samlConfigJson = serializeConfigValue(data.samlConfig);
     const roleMappingJson = serializeConfigValue(data.roleMapping);
     const teamSyncConfigJson = serializeConfigValue(data.teamSyncConfig);
-    const persistedDomain = normalizePersistedAllowedEmailDomain({
-      providerId: data.providerId,
-      domain: data.domain,
-    });
     const [updatedProvider] = await db
       .update(schema.identityProvidersTable)
       .set({
-        domain: persistedDomain,
+        domain: data.domain,
         domainVerified: true,
         ssoLoginEnabled: data.ssoLoginEnabled ?? true,
         ...(oidcConfigJson !== undefined && {
@@ -756,15 +743,10 @@ class IdentityProviderModel {
     const samlConfigJson = serializeConfigValue(samlConfig);
     const roleMappingJson = serializeConfigValue(roleMapping);
     const teamSyncConfigJson = serializeConfigValue(teamSyncConfig);
-    const nextProviderId = restData.providerId ?? existingProvider.providerId;
-    const nextDomain = normalizePersistedAllowedEmailDomain({
-      providerId: nextProviderId,
-      domain: restData.domain ?? existingProvider.domain,
-    });
+    const nextDomain = restData.domain ?? existingProvider.domain;
 
     // Update in database
-    // WORKAROUND: Always ensure domainVerified is true to enable account linking
-    // See: https://github.com/better-auth/better-auth/issues/6481
+    // Keep administrator-configured domains trusted for implicit account linking.
     const [updatedProvider] = await db
       .update(schema.identityProvidersTable)
       .set({
@@ -866,10 +848,8 @@ class IdentityProviderModel {
 
   /**
    * Sets domainVerified flag directly (TEST ONLY)
-   * This is used to simulate legacy data that has domainVerified: false
-   * to test the workaround in update() that sets it back to true.
-   * TODO: Remove this when upstream issue is fixed:
-   * https://github.com/better-auth/better-auth/issues/6481
+   * Used to verify that updating a provider restores the trusted state for
+   * its administrator-configured allowed domains.
    */
   static async setDomainVerifiedForTesting(
     id: string,
@@ -970,17 +950,6 @@ function serializeConfigValue(
   }
 
   return JSON.stringify(value);
-}
-
-function normalizePersistedAllowedEmailDomain(params: {
-  providerId: string;
-  domain: string;
-}): string {
-  if (params.providerId === IDENTITY_PROVIDER_ID.GOOGLE) {
-    return params.domain;
-  }
-
-  return "";
 }
 
 async function hydrateOidcConfigForRegistration<

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -4,7 +4,6 @@ import type {
 } from "@archestra/shared";
 import {
   IDENTITY_PROVIDER_ID,
-  IDENTITY_TRUSTED_PROVIDER_IDS,
   MEMBER_ROLE_NAME,
   TimeInMs,
 } from "@archestra/shared";
@@ -57,27 +56,11 @@ export type IdpGetRoleData = Parameters<
 
 class IdentityProviderModel {
   /**
-   * Process-local cache for {@link getTrustedAccountLinkingProviderIds}. The
-   * lookup backs better-auth's account-linking `trustedProviders` option, which
-   * is evaluated on auth requests (including session reads), so without a cache
-   * it costs one `select distinct` per request for a list that only changes
-   * when an admin edits identity providers. Writes in this process clear the
-   * cache immediately; other pods converge within the TTL.
-   */
-  private static readonly trustedProviderIdsCache = registerProcessLocalCache(
-    new LRUCacheManager<string[]>({
-      maxSize: 1,
-      defaultTtl: TimeInMs.Minute,
-    }),
-  );
-
-  /**
    * Process-local cache for {@link findAllPublic}. Backs the unauthenticated
    * SSO-provider list the login page fetches on every render, so without a
    * cache each login-page view costs a database query for a list that only
-   * changes when an admin edits identity providers. Same invalidation story
-   * as {@link trustedProviderIdsCache}: writes in this process clear it
-   * immediately; other pods converge within the TTL.
+   * changes when an admin edits identity providers. Writes in this process
+   * clear it immediately; other pods converge within the TTL.
    */
   private static readonly publicProvidersCache = registerProcessLocalCache(
     new LRUCacheManager<PublicIdentityProvider[]>({
@@ -521,53 +504,6 @@ class IdentityProviderModel {
     return idpProviders;
   }
 
-  static async getTrustedAccountLinkingProviderIds(): Promise<string[]> {
-    const cached = IdentityProviderModel.trustedProviderIdsCache.get(
-      TRUSTED_PROVIDER_IDS_CACHE_KEY,
-    );
-    if (cached) {
-      return cached;
-    }
-
-    let configuredProviderIds: Array<{ providerId: string }> = [];
-
-    try {
-      configuredProviderIds = await db
-        .selectDistinct({
-          providerId: schema.identityProvidersTable.providerId,
-        })
-        .from(schema.identityProvidersTable);
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Database not initialized")
-      ) {
-        // Pre-initialization fallback: don't cache it, so the DB-backed list
-        // takes over on the first call after the database comes up.
-        return [...IDENTITY_TRUSTED_PROVIDER_IDS];
-      }
-
-      throw error;
-    }
-
-    const providerIds = [
-      ...new Set([
-        ...IDENTITY_TRUSTED_PROVIDER_IDS,
-        ...configuredProviderIds
-          .map(({ providerId }) => providerId)
-          .filter((providerId) => providerId.length > 0)
-          .sort((a, b) => a.localeCompare(b)),
-      ]),
-    ];
-
-    IdentityProviderModel.trustedProviderIdsCache.set(
-      TRUSTED_PROVIDER_IDS_CACHE_KEY,
-      providerIds,
-    );
-
-    return providerIds;
-  }
-
   /**
    * Find all identity providers with full configuration including secrets.
    * Use this only for authenticated admin endpoints.
@@ -778,7 +714,6 @@ class IdentityProviderModel {
       throw new Error("Failed to update identity provider after creation");
     }
 
-    IdentityProviderModel.trustedProviderIdsCache.clear();
     IdentityProviderModel.publicProvidersCache.clear();
 
     return {
@@ -860,7 +795,6 @@ class IdentityProviderModel {
 
     if (!updatedProvider) return null;
 
-    IdentityProviderModel.trustedProviderIdsCache.clear();
     IdentityProviderModel.publicProvidersCache.clear();
 
     return {
@@ -925,7 +859,6 @@ class IdentityProviderModel {
       }
     });
 
-    IdentityProviderModel.trustedProviderIdsCache.clear();
     IdentityProviderModel.publicProvidersCache.clear();
 
     return true;
@@ -1023,7 +956,6 @@ export default IdentityProviderModel;
 
 const OIDC_DISCOVERY_TIMEOUT_MS = 10_000;
 const SSO_REGISTRATION_PLACEHOLDER_DOMAIN = "sso-placeholder.example.com";
-const TRUSTED_PROVIDER_IDS_CACHE_KEY = "trusted-provider-ids";
 const PUBLIC_PROVIDERS_CACHE_KEY = "public-providers";
 
 function serializeConfigValue(

--- a/platform/backend/src/routes/identity-provider.ee.test.ts
+++ b/platform/backend/src/routes/identity-provider.ee.test.ts
@@ -1,4 +1,9 @@
+import { BUILT_IN_IDENTITY_PROVIDER_IDS } from "@archestra/shared";
+import { getCookies } from "better-auth/cookies";
+import { makeSignature } from "better-auth/crypto";
 import { vi } from "vitest";
+import { auth } from "@/auth/better-auth";
+import config from "@/config";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
@@ -375,6 +380,58 @@ describe("identity provider routes", () => {
       expect(Array.isArray(data)).toBe(true);
       expect(data.length).toBeGreaterThanOrEqual(1);
       expect(data[0]).toHaveProperty("providerId", "route-test-provider");
+    });
+  });
+
+  describe("POST /api/identity-providers", () => {
+    test("creates every built-in provider through Better Auth", async ({
+      makeMember,
+      makeSession,
+    }) => {
+      await makeMember(user.id, organizationId, { role: "admin" });
+      const session = await makeSession(user.id, {
+        activeOrganizationId: organizationId,
+      });
+      const cookie = await createSessionCookie(session.token);
+
+      for (const providerId of BUILT_IN_IDENTITY_PROVIDER_IDS) {
+        const response = await app.inject({
+          method: "POST",
+          url: "/api/identity-providers",
+          headers: { cookie },
+          payload: {
+            providerId,
+            issuer: "https://idp.example.com",
+            domain: "",
+            oidcConfig: {
+              issuer: "https://idp.example.com",
+              skipDiscovery: true,
+              pkce: true,
+              clientId: "test-client-id",
+              clientSecret: "test-client-secret",
+              discoveryEndpoint:
+                "https://idp.example.com/.well-known/openid-configuration",
+              authorizationEndpoint: "https://idp.example.com/authorize",
+              tokenEndpoint: "https://idp.example.com/token",
+              userInfoEndpoint: "https://idp.example.com/userinfo",
+              jwksEndpoint: "https://idp.example.com/jwks",
+              scopes: ["openid", "email", "profile"],
+              mapping: {
+                id: "sub",
+                email: "email",
+                name: "name",
+              },
+            },
+          },
+        });
+
+        expect(response.statusCode, `failed to create ${providerId}`).toBe(200);
+        expect(response.json()).toMatchObject({
+          providerId,
+          organizationId,
+          userId: user.id,
+        });
+      }
     });
   });
 
@@ -899,3 +956,13 @@ describe("identity provider routes", () => {
     });
   });
 });
+
+async function createSessionCookie(sessionToken: string): Promise<string> {
+  if (!config.auth.secret) {
+    throw new Error("Auth secret is not configured");
+  }
+
+  const signature = await makeSignature(sessionToken, config.auth.secret);
+  const cookieName = getCookies(auth.options).sessionToken.name;
+  return `${cookieName}=${encodeURIComponent(`${sessionToken}.${signature}`)}`;
+}

--- a/platform/backend/src/routes/identity-provider.ee.test.ts
+++ b/platform/backend/src/routes/identity-provider.ee.test.ts
@@ -395,6 +395,7 @@ describe("identity provider routes", () => {
       const cookie = await createSessionCookie(session.token);
 
       for (const providerId of BUILT_IN_IDENTITY_PROVIDER_IDS) {
+        const domain = `${providerId.toLowerCase()}.example.com`;
         const response = await app.inject({
           method: "POST",
           url: "/api/identity-providers",
@@ -402,7 +403,7 @@ describe("identity provider routes", () => {
           payload: {
             providerId,
             issuer: "https://idp.example.com",
-            domain: "",
+            domain,
             oidcConfig: {
               issuer: "https://idp.example.com",
               skipDiscovery: true,
@@ -428,6 +429,7 @@ describe("identity provider routes", () => {
         expect(response.statusCode, `failed to create ${providerId}`).toBe(200);
         expect(response.json()).toMatchObject({
           providerId,
+          domain,
           organizationId,
           userId: user.id,
         });

--- a/platform/backend/src/test/fixtures.ts
+++ b/platform/backend/src/test/fixtures.ts
@@ -1091,8 +1091,7 @@ async function makeIdentityProvider(
         ? (JSON.stringify(overrides.teamSyncConfig) as unknown as undefined)
         : undefined,
       userId: overrides.userId ?? null,
-      // WORKAROUND: With domainVerification enabled, all SSO providers need domainVerified: true
-      // See: https://github.com/better-auth/better-auth/issues/6481
+      // Model administrator-configured domains as trusted for account linking.
       domainVerified: true,
     })
     .returning();

--- a/platform/frontend/src/app/settings/identity-providers/_parts/allowed-email-domains-field.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/allowed-email-domains-field.ee.tsx
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+"use client";
+
+import type { IdentityProviderFormValues } from "@archestra/shared";
+import type { UseFormReturn } from "react-hook-form";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+interface AllowedEmailDomainsFieldProps {
+  form: UseFormReturn<IdentityProviderFormValues>;
+}
+
+export function AllowedEmailDomainsField({
+  form,
+}: AllowedEmailDomainsFieldProps) {
+  return (
+    <FormField
+      control={form.control}
+      name="domain"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>Allowed Email Domains</FormLabel>
+          <FormControl>
+            <Input placeholder="company.com, subsidiary.com" {...field} />
+          </FormControl>
+          <FormDescription>
+            Users can sign in with this provider only when their returned email
+            matches one of these domains. Separate multiple domains with commas.
+          </FormDescription>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.test.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.test.ts
@@ -29,21 +29,10 @@ function makeOidcFormValues(
 }
 
 describe("normalizeIdentityProviderFormValues", () => {
-  it("clears allowed email domains for non-Google OIDC providers", () => {
+  it("keeps allowed email domains for non-Google OIDC providers", () => {
     const normalized = normalizeIdentityProviderFormValues(
       makeOidcFormValues({
         providerId: "Okta",
-        domain: "example.com",
-      }),
-    );
-
-    expect(normalized.domain).toBe("");
-  });
-
-  it("keeps allowed email domains for Google providers", () => {
-    const normalized = normalizeIdentityProviderFormValues(
-      makeOidcFormValues({
-        providerId: "Google",
         domain: "example.com",
       }),
     );

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-provider-form.utils.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
 import {
   type archestraApiTypes,
-  IDENTITY_PROVIDER_ID,
   type IdentityProviderFormValues,
   isEntraHostname,
   isOktaHostname,
@@ -20,22 +19,21 @@ export function normalizeIdentityProviderFormValues(
   data: IdentityProviderFormValues,
 ): IdentityProviderFormValues {
   if (data.providerType !== "oidc" || !data.oidcConfig) {
-    return normalizeAllowedEmailDomains(data);
+    return data;
   }
 
-  const normalizedData = normalizeAllowedEmailDomains(data);
-  const oidcConfig = normalizeOidcIssuerFields(normalizedData);
+  const oidcConfig = normalizeOidcIssuerFields(data);
   const enterpriseManagedCredentials = oidcConfig.enterpriseManagedCredentials;
   if (!enterpriseManagedCredentials) {
     return {
-      ...normalizedData,
+      ...data,
       oidcConfig,
     };
   }
 
   const inferredExchangeType = inferEnterpriseExchangeType({
-    issuer: normalizedData.issuer,
-    providerId: normalizedData.providerId,
+    issuer: data.issuer,
+    providerId: data.providerId,
   });
 
   const hasConfiguredEnterpriseManagedFields = Object.values(
@@ -50,7 +48,7 @@ export function normalizeIdentityProviderFormValues(
 
   if (!hasConfiguredEnterpriseManagedFields) {
     return {
-      ...normalizedData,
+      ...data,
       oidcConfig,
     };
   }
@@ -59,7 +57,7 @@ export function normalizeIdentityProviderFormValues(
     enterpriseManagedCredentials.exchangeStrategy || inferredExchangeType;
 
   return {
-    ...normalizedData,
+    ...data,
     oidcConfig: normalizeOidcConfigForEnterpriseExchange({
       oidcConfig,
       exchangeStrategy,
@@ -76,19 +74,6 @@ export function normalizeIdentityProviderFormValues(
           getDefaultSubjectTokenType(inferredExchangeType),
       },
     }),
-  };
-}
-
-export function normalizeAllowedEmailDomains(
-  data: IdentityProviderFormValues,
-): IdentityProviderFormValues {
-  if (data.providerId === IDENTITY_PROVIDER_ID.GOOGLE) {
-    return data;
-  }
-
-  return {
-    ...data,
-    domain: "",
   };
 }
 

--- a/platform/frontend/src/app/settings/identity-providers/_parts/identity-providers-page.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/identity-providers-page.ee.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import {
+  BUILT_IN_IDENTITY_PROVIDER_IDS,
   E2eTestId,
   IDENTITY_PROVIDER_ID,
-  IDENTITY_TRUSTED_PROVIDER_IDS,
   type IdentityProviderId,
 } from "@archestra/shared";
 import { useSearchParams } from "next/navigation";
@@ -294,12 +294,12 @@ export function IdentityProvidersSettingsContent() {
           return p.providerId === config.providerId;
         }
 
-        // For generic providers (empty providerId), match by provider type as well
-        // Check if this is a non-trusted provider and matches the same type (OIDC vs SAML)
-        const isNonTrustedProvider = !IDENTITY_TRUSTED_PROVIDER_IDS.includes(
+        // For generic providers (empty providerId), match custom providers by
+        // provider type as well (OIDC vs SAML).
+        const isCustomProvider = !BUILT_IN_IDENTITY_PROVIDER_IDS.includes(
           p.providerId as IdentityProviderId,
         );
-        if (!isNonTrustedProvider) {
+        if (!isCustomProvider) {
           return false;
         }
 

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.test.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.test.tsx
@@ -100,16 +100,14 @@ describe("OidcConfigForm", () => {
     );
   });
 
-  it("hides allowed email domains for non-Google providers", () => {
+  it("shows allowed email domains for non-Google providers", () => {
     render(<TestWrapper />);
 
-    expect(
-      screen.queryByLabelText("Allowed Email Domains"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Allowed Email Domains")).toBeInTheDocument();
   });
 
-  it("explains that allowed email domains gate Google SSO sign-in", () => {
-    render(<TestWrapper providerId="Google" />);
+  it("explains that allowed email domains gate SSO sign-in", () => {
+    render(<TestWrapper />);
 
     expect(screen.getByLabelText("Allowed Email Domains")).toBeInTheDocument();
     expect(
@@ -150,5 +148,8 @@ describe("OidcConfigForm", () => {
     render(<TestWrapper activeSection="attribute-mapping" />);
 
     expect(screen.getByLabelText("User ID Claim")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Email Verified Claim (Optional)"),
+    ).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
@@ -32,6 +32,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
 import { useAppName } from "@/lib/hooks/use-app-name";
+import { AllowedEmailDomainsField } from "./allowed-email-domains-field.ee";
 import {
   type EnterpriseSubjectTokenType,
   getDefaultSubjectTokenType,
@@ -76,7 +77,6 @@ export function OidcConfigForm({
   const scopes = form.watch("oidcConfig.scopes") || [];
   const issuer = form.watch("issuer") || "";
   const providerId = form.watch("providerId") || "";
-  const showAllowedEmailDomains = providerId === "Google";
   const inferredEnterpriseExchangeType = inferEnterpriseExchangeType({
     issuer,
     providerId,
@@ -236,30 +236,7 @@ export function OidcConfigForm({
           />
 
           <SsoLoginEnabledField form={form} />
-
-          {showAllowedEmailDomains && (
-            <FormField
-              control={form.control}
-              name="domain"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Allowed Email Domains</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="company.com, subsidiary.com"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Users can sign in with this provider only when their
-                    returned email matches one of these domains. Separate
-                    multiple domains with commas.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          )}
+          <AllowedEmailDomainsField form={form} />
 
           <Separator />
 

--- a/platform/frontend/src/app/settings/identity-providers/_parts/saml-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/saml-config-form.ee.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
+import { AllowedEmailDomainsField } from "./allowed-email-domains-field.ee";
 import { RoleMappingForm } from "./role-mapping-form.ee";
 import { SsoLoginEnabledField } from "./sso-login-enabled-field.ee";
 import { TeamSyncConfigForm } from "./team-sync-config-form.ee";
@@ -78,6 +79,7 @@ export function SamlConfigForm({
           />
 
           <SsoLoginEnabledField form={form} />
+          <AllowedEmailDomainsField form={form} />
 
           <Separator />
 

--- a/platform/frontend/src/components/identity-provider-icons.ee.test.tsx
+++ b/platform/frontend/src/components/identity-provider-icons.ee.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { IdentityProviderIcon } from "./identity-provider-icons.ee";
+
+vi.mock("next/image", () => ({
+  default: ({
+    alt,
+    ...props
+  }: React.ComponentProps<"img"> & { alt: string }) => (
+    <img alt={alt} {...props} />
+  ),
+}));
+
+describe("IdentityProviderIcon", () => {
+  it("uses the canonical built-in ID for brand matching", () => {
+    const { rerender } = render(<IdentityProviderIcon providerId="EntraID" />);
+
+    expect(screen.getByRole("img", { name: "Microsoft" })).toBeInTheDocument();
+
+    rerender(<IdentityProviderIcon providerId="entraid" />);
+
+    expect(
+      screen.queryByRole("img", { name: "Microsoft" }),
+    ).not.toBeInTheDocument();
+    expect(document.querySelector("svg")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/identity-provider-icons.ee.tsx
+++ b/platform/frontend/src/components/identity-provider-icons.ee.tsx
@@ -19,13 +19,8 @@ export function IdentityProviderIcon({
   size = 16,
   className,
 }: IdentityProviderIconProps) {
-  const lowerProviderId = providerId.toLowerCase();
-
   // Google - use brand icon
-  if (
-    lowerProviderId === IDENTITY_PROVIDER_ID.GOOGLE.toLowerCase() ||
-    lowerProviderId.includes("google")
-  ) {
+  if (providerId === IDENTITY_PROVIDER_ID.GOOGLE) {
     return (
       <Image
         src="/icons/google.png"
@@ -38,10 +33,7 @@ export function IdentityProviderIcon({
   }
 
   // Okta - use brand icon
-  if (
-    lowerProviderId === IDENTITY_PROVIDER_ID.OKTA.toLowerCase() ||
-    lowerProviderId.includes("okta")
-  ) {
+  if (providerId === IDENTITY_PROVIDER_ID.OKTA) {
     return (
       <Image
         src="/icons/okta.png"
@@ -54,10 +46,7 @@ export function IdentityProviderIcon({
   }
 
   // GitHub - use SVG icon (better quality at small sizes)
-  if (
-    lowerProviderId === IDENTITY_PROVIDER_ID.GITHUB.toLowerCase() ||
-    lowerProviderId.includes("github")
-  ) {
+  if (providerId === IDENTITY_PROVIDER_ID.GITHUB) {
     return (
       <svg
         width={size}
@@ -73,10 +62,7 @@ export function IdentityProviderIcon({
   }
 
   // GitLab - use brand icon
-  if (
-    lowerProviderId === IDENTITY_PROVIDER_ID.GITLAB.toLowerCase() ||
-    lowerProviderId.includes("gitlab")
-  ) {
+  if (providerId === IDENTITY_PROVIDER_ID.GITLAB) {
     return (
       <Image
         src="/icons/gitlab.png"
@@ -89,12 +75,7 @@ export function IdentityProviderIcon({
   }
 
   // Microsoft Entra ID - use brand icon
-  if (
-    lowerProviderId === IDENTITY_PROVIDER_ID.ENTRA_ID.toLowerCase() ||
-    lowerProviderId.includes("microsoft") ||
-    lowerProviderId.includes("entra") ||
-    lowerProviderId.includes("azure")
-  ) {
+  if (providerId === IDENTITY_PROVIDER_ID.ENTRA_ID) {
     return (
       <Image
         src="/icons/microsoft.png"

--- a/platform/shared/identity-provider.ts
+++ b/platform/shared/identity-provider.ts
@@ -4,7 +4,6 @@ import { DOMAIN_VALIDATION_REGEX } from "./incoming-email";
 
 /**
  * Identity provider IDs - these are the canonical built-in provider identifiers used for:
- * - account linking trust configuration
  * - provider registration
  * - callback URLs (e.g. `/api/auth/sso/callback/{providerId}`)
  */
@@ -19,8 +18,8 @@ export const IDENTITY_PROVIDER_ID = {
 export type IdentityProviderId =
   (typeof IDENTITY_PROVIDER_ID)[keyof typeof IDENTITY_PROVIDER_ID];
 
-/** List of built-in identity provider IDs trusted for account linking. */
-export const IDENTITY_TRUSTED_PROVIDER_IDS =
+/** List of canonical IDs used by the built-in identity provider templates. */
+export const BUILT_IN_IDENTITY_PROVIDER_IDS =
   Object.values(IDENTITY_PROVIDER_ID);
 
 export const OAUTH_TOKEN_TYPE = {


### PR DESCRIPTION
## Summary

- allow all five built-in SSO templates to register with Better Auth 1.6.22
- remove the obsolete dynamic SSO provider trust list and its cache/database lookup
- preserve administrator-configured allowed email domains for every OIDC and SAML provider
- expose Allowed Email Domains for non-Google OIDC and SAML providers
- allow existing accounts to link through a matching trusted domain even when the IdP omits `email_verified`
- only show built-in brand icons for exact canonical provider IDs

## Root causes

### Built-in provider registration

Better Auth 1.6.22 treats every ID in `accountLinking.trustedProviders` as reserved. Archestra populated that option with the built-in template IDs and every configured SSO provider, so each template rejected its own provider ID during registration.

The list was unnecessary for SSO providers because the SSO callback disables name-based trust with `trustProviderByName: false`.

### Existing-account linking

Better Auth implicitly links an SSO identity to an existing same-email account only when the IdP marks the email verified or the provider is trusted through a verified matching domain. Archestra marked provider domains verified but then cleared the persisted domain for every provider except Google, making the trusted-domain branch impossible for Entra and other non-Google providers.

The UI and form normalizer enforced the same Google-only behavior. This also prevented the existing Archestra allowed-domain callback filter from protecting non-Google providers.

## Why tests missed it

The identity-provider model tests stubbed `registerSSOProvider`, so they never exercised dependency runtime validation. The route suite had no authenticated `POST /api/identity-providers` integration test.

The existing callback regression supplied both a matching provider domain and `email_verified: true`. Either trust mechanism could mask a failure in the other, and it used a generic provider rather than a built-in Entra configuration.

## Coverage added

- authenticated route integration creates every built-in provider through the real Better Auth plugin and verifies its domain is persisted
- callback integration proves verified-email linking works independently with no allowed domain
- callback integration proves Entra-style trusted-domain linking works with no email-verification claim
- mismatch coverage uses a non-Google provider and verifies the linked account/session cleanup path
- frontend tests pin provider-agnostic domain visibility and the email-verification claim mapping control