### PR TITLE
fix(policy-subagent): resolve LLM through shared chain

### DIFF
--- a/platform/backend/src/agents/subagents/policy-configuration.llm.test.ts
+++ b/platform/backend/src/agents/subagents/policy-configuration.llm.test.ts
@@ -1,0 +1,165 @@
+/**
+ * LLM resolution for the policy-configuration subagent, against REAL
+ * `@/utils/llm-resolution` and real database rows.
+ *
+ * The rest of this subagent's tests mock the resolution module wholesale,
+ * which is exactly what let "Configure with Subagent" ship failing on every
+ * tool: the service used to read the built-in agent's pinned selection through
+ * `resolveConfiguredAgentLlm`, an ownership-blind helper that deliberately
+ * returns a selection with NO credential when the pinned key belongs to an
+ * individual (a ChatGPT/Codex or Claude subscription, a Copilot token) and
+ * expects its caller to finish the job. A mocked resolver can't reproduce
+ * that, so these cases live here.
+ */
+import { BUILT_IN_AGENT_IDS } from "@archestra/shared";
+import { vi } from "vitest";
+import {
+  type LlmProviderApiKey,
+  LlmProviderApiKeyModelLinkModel,
+  ModelModel,
+} from "@/models";
+import AgentModel from "@/models/agent";
+import { encodeOpenAiCodexCredential } from "@/services/openai-codex-credentials";
+import { describe, expect, test } from "@/test";
+import { PolicyConfigurationService } from "./policy-configuration";
+
+// Boundary mock only: the model factory would otherwise reach a provider.
+// Resolution itself — the code under test — runs for real.
+vi.mock("@/clients/llm-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/clients/llm-client")>();
+  return { ...actual, createLLMModel: vi.fn() };
+});
+
+async function makeOpenAiModel(modelId: string) {
+  return ModelModel.upsert({
+    externalId: `openai/${modelId}`,
+    provider: "openai",
+    modelId,
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+  });
+}
+
+/** The org's policy-configuration subagent, pinned to a model and a key. */
+async function makePolicyConfigAgent(params: {
+  organizationId: string;
+  llmApiKeyId: string | null;
+  modelId: string | null;
+}) {
+  return AgentModel.create({
+    name: "Policy Configuration Subagent",
+    organizationId: params.organizationId,
+    agentType: "agent",
+    scope: "org",
+    systemPrompt: "You are a policy configuration subagent.",
+    builtInAgentConfig: {
+      name: BUILT_IN_AGENT_IDS.POLICY_CONFIG,
+      autoConfigureOnToolDiscovery: false,
+    },
+    llmApiKeyId: params.llmApiKeyId,
+    modelId: params.modelId,
+    teams: [],
+    labels: [],
+    knowledgeBaseIds: [],
+    connectorIds: [],
+  });
+}
+
+describe("PolicyConfigurationService.resolveLlm (real resolution)", () => {
+  test("resolves a subscription credential for the user who owns it", async ({
+    makeOrganization,
+    makeUser,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const credential = encodeOpenAiCodexCredential({
+      refreshToken: "refresh-token",
+      accountId: "account-id",
+    });
+    const secret = await makeSecret({ secret: { apiKey: credential } });
+    // A connected subscription is always a personal key owned by one user.
+    const key: LlmProviderApiKey = await makeLlmProviderApiKey(
+      org.id,
+      secret.id,
+      { provider: "openai", scope: "personal", userId: user.id },
+    );
+    const model = await makeOpenAiModel("gpt-5-codex");
+    await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(key.id, [
+      model.id,
+    ]);
+    await makePolicyConfigAgent({
+      organizationId: org.id,
+      llmApiKeyId: key.id,
+      modelId: model.id,
+    });
+
+    const resolved = await new PolicyConfigurationService().resolveLlm({
+      organizationId: org.id,
+      userId: user.id,
+    });
+
+    // The regression: reading the agent's pinned selection alone yielded
+    // `{ apiKey: undefined }` here — non-null, so the route's "is an LLM
+    // configured?" check passed, and then every tool failed its own call.
+    expect(resolved?.apiKey).toBe(credential);
+    expect(resolved?.modelName).toBe("gpt-5-codex");
+    // The proxy needs the row: Codex refresh tokens rotate on redemption.
+    expect(resolved?.chatApiKeyId).toBe(key.id);
+  });
+
+  test("resolves the org's usable key when the agent pins only a model", async ({
+    makeOrganization,
+    makeUser,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const secret = await makeSecret({ secret: { apiKey: "sk-org-key" } });
+    const key = await makeLlmProviderApiKey(org.id, secret.id, {
+      provider: "openai",
+      scope: "org",
+    });
+    const model = await makeOpenAiModel("gpt-4.1");
+    await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(key.id, [
+      model.id,
+    ]);
+    await makePolicyConfigAgent({
+      organizationId: org.id,
+      llmApiKeyId: null,
+      modelId: model.id,
+    });
+
+    const resolved = await new PolicyConfigurationService().resolveLlm({
+      organizationId: org.id,
+      userId: user.id,
+    });
+
+    expect(resolved?.apiKey).toBe("sk-org-key");
+    expect(resolved?.modelName).toBe("gpt-4.1");
+  });
+
+  test("returns null when nothing resolves a credential", async ({
+    makeOrganization,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makePolicyConfigAgent({
+      organizationId: org.id,
+      llmApiKeyId: null,
+      modelId: null,
+    });
+
+    const resolved = await new PolicyConfigurationService().resolveLlm({
+      organizationId: org.id,
+      userId: user.id,
+    });
+
+    // Null is what turns into the actionable "configure an LLM API key" 400,
+    // instead of N tools each failing on a missing credential.
+    expect(resolved).toBeNull();
+  });
+});

--- a/platform/backend/src/agents/subagents/policy-configuration.llm.test.ts
+++ b/platform/backend/src/agents/subagents/policy-configuration.llm.test.ts
@@ -11,8 +11,12 @@
  * expects its caller to finish the job. A mocked resolver can't reproduce
  * that, so these cases live here.
  */
-import { BUILT_IN_AGENT_IDS } from "@archestra/shared";
+import {
+  BUILT_IN_AGENT_IDS,
+  SupportedProvidersSchema,
+} from "@archestra/shared";
 import { vi } from "vitest";
+import config from "@/config";
 import { LlmProviderApiKeyModelLinkModel, ModelModel } from "@/models";
 import AgentModel from "@/models/agent";
 import { encodeOpenAiCodexCredential } from "@/services/openai-codex-credentials";
@@ -141,6 +145,17 @@ describe("PolicyConfigurationService.resolveLlm (real resolution)", () => {
     makeOrganization,
     makeUser,
   }) => {
+    for (const provider of SupportedProvidersSchema.options) {
+      const providerConfig = config.chat[provider as keyof typeof config.chat];
+      if (
+        typeof providerConfig === "object" &&
+        providerConfig !== null &&
+        "apiKey" in providerConfig
+      ) {
+        providerConfig.apiKey = "";
+      }
+    }
+
     const org = await makeOrganization();
     const user = await makeUser();
     await makePolicyConfigAgent({

--- a/platform/backend/src/agents/subagents/policy-configuration.llm.test.ts
+++ b/platform/backend/src/agents/subagents/policy-configuration.llm.test.ts
@@ -13,11 +13,7 @@
  */
 import { BUILT_IN_AGENT_IDS } from "@archestra/shared";
 import { vi } from "vitest";
-import {
-  type LlmProviderApiKey,
-  LlmProviderApiKeyModelLinkModel,
-  ModelModel,
-} from "@/models";
+import { LlmProviderApiKeyModelLinkModel, ModelModel } from "@/models";
 import AgentModel from "@/models/agent";
 import { encodeOpenAiCodexCredential } from "@/services/openai-codex-credentials";
 import { describe, expect, test } from "@/test";
@@ -80,11 +76,11 @@ describe("PolicyConfigurationService.resolveLlm (real resolution)", () => {
     });
     const secret = await makeSecret({ secret: { apiKey: credential } });
     // A connected subscription is always a personal key owned by one user.
-    const key: LlmProviderApiKey = await makeLlmProviderApiKey(
-      org.id,
-      secret.id,
-      { provider: "openai", scope: "personal", userId: user.id },
-    );
+    const key = await makeLlmProviderApiKey(org.id, secret.id, {
+      provider: "openai",
+      scope: "personal",
+      userId: user.id,
+    });
     const model = await makeOpenAiModel("gpt-5-codex");
     await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(key.id, [
       model.id,

--- a/platform/backend/src/agents/subagents/policy-configuration.test.ts
+++ b/platform/backend/src/agents/subagents/policy-configuration.test.ts
@@ -1,12 +1,13 @@
 import { eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
 import { vi } from "vitest";
+import { createLLMModel } from "@/clients/llm-client";
 import db, { schema } from "@/database";
 import AgentModel from "@/models/agent";
 import { beforeEach, describe, expect, test } from "@/test";
 import { useMswServer } from "@/test/msw";
 import type { PolicyConfig } from "@/types";
-import { resolveBestAvailableLlm } from "@/utils/llm-resolution";
+import { resolveAgentLlmOrDefault } from "@/utils/llm-resolution";
 import { PolicyConfigurationService } from "./policy-configuration";
 
 // biome-ignore lint/correctness/useHookAtTopLevel: vitest lifecycle helper (per-test MSW server), not a React hook
@@ -26,12 +27,14 @@ vi.mock("@/clients/llm-client", async () => {
   }).chat("gpt-4o-mini");
   return {
     createLLMModel: vi.fn(() => model),
+    isApiKeyRequired: vi.fn(
+      (_provider: string, apiKey: string | undefined) => !apiKey,
+    ),
   };
 });
 
 vi.mock("@/utils/llm-resolution", () => ({
-  resolveBestAvailableLlm: vi.fn(),
-  resolveConfiguredAgentLlm: vi.fn(),
+  resolveAgentLlmOrDefault: vi.fn(),
 }));
 
 // Serves the structured policy analysis as an OpenAI chat completion whose
@@ -80,42 +83,58 @@ describe("PolicyConfigurationService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     service = new PolicyConfigurationService();
-    // Default: no LLM available
-    vi.mocked(resolveBestAvailableLlm).mockResolvedValue(null);
+    // Default: resolution lands on a provider with no usable credential.
+    vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue({
+      ...MOCK_RESOLVED_LLM,
+      apiKey: undefined,
+    });
   });
 
   describe("resolveLlm", () => {
-    test("returns null when resolveBestAvailableLlm returns null", async ({
+    test("returns null when the resolved provider has no usable credential", async ({
       makeOrganization,
     }) => {
       const org = await makeOrganization();
 
       const result = await service.resolveLlm({ organizationId: org.id });
 
+      // A half-resolved selection is worse than none: it satisfies the
+      // caller's "is an LLM configured?" check and then fails every tool.
       expect(result).toBeNull();
     });
 
-    test("returns resolved config when resolveBestAvailableLlm returns a result", async ({
+    test("returns the resolved selection when a credential is available", async ({
       makeOrganization,
     }) => {
       const org = await makeOrganization();
 
-      vi.mocked(resolveBestAvailableLlm).mockResolvedValue(MOCK_RESOLVED_LLM);
+      vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue(MOCK_RESOLVED_LLM);
 
       const result = await service.resolveLlm({ organizationId: org.id });
 
       expect(result).toEqual(MOCK_RESOLVED_LLM);
     });
 
-    test("passes userId when provided", async ({ makeOrganization }) => {
+    test("resolves through the shared built-in-subagent chain", async ({
+      makeOrganization,
+    }) => {
       const org = await makeOrganization();
+      vi.spyOn(AgentModel, "getBuiltInAgent").mockResolvedValue({
+        ...MOCK_BUILT_IN_AGENT,
+        llmApiKeyId: "key-1",
+        modelId: "model-1",
+      } as never);
 
       await service.resolveLlm({
         organizationId: org.id,
         userId: "user-123",
       });
 
-      expect(resolveBestAvailableLlm).toHaveBeenCalledWith({
+      // The agent's own pinned selection is a HINT for the chain, not the
+      // final answer — the chain re-resolves the credential for the acting
+      // user, which is what makes per-user and subscription credentials work.
+      expect(resolveAgentLlmOrDefault).toHaveBeenCalledWith({
+        agent: { llmApiKeyId: "key-1", modelId: "model-1" },
         organizationId: org.id,
         userId: "user-123",
       });
@@ -140,7 +159,7 @@ describe("PolicyConfigurationService", () => {
     test("returns error when tool not found", async ({ makeOrganization }) => {
       const org = await makeOrganization();
 
-      vi.mocked(resolveBestAvailableLlm).mockResolvedValue(MOCK_RESOLVED_LLM);
+      vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue(MOCK_RESOLVED_LLM);
 
       const result = await service.configurePoliciesForTool({
         toolId: "nonexistent-tool",
@@ -158,7 +177,7 @@ describe("PolicyConfigurationService", () => {
     }) => {
       const org = await makeOrganization();
 
-      vi.mocked(resolveBestAvailableLlm).mockResolvedValue(MOCK_RESOLVED_LLM);
+      vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue(MOCK_RESOLVED_LLM);
       vi.spyOn(AgentModel, "getBuiltInAgent").mockResolvedValue(
         MOCK_BUILT_IN_AGENT as never,
       );
@@ -214,6 +233,42 @@ describe("PolicyConfigurationService", () => {
       expect(trustedDataPolicies[0].action).toBe("mark_as_trusted");
     });
 
+    test("forwards the key row the credential came from to the proxy", async ({
+      makeOrganization,
+      makeMcpServer,
+      makeTool,
+    }) => {
+      const org = await makeOrganization();
+
+      vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue({
+        ...MOCK_RESOLVED_LLM,
+        chatApiKeyId: "key-row-1",
+      });
+      vi.spyOn(AgentModel, "getBuiltInAgent").mockResolvedValue(
+        MOCK_BUILT_IN_AGENT as never,
+      );
+
+      const mcpServer = await makeMcpServer({ name: "test-server" });
+      const tool = await makeTool({ catalogId: mcpServer.catalogId });
+      servePolicyAnalysis({
+        toolInvocationAction: "allow_when_context_is_sensitive",
+        trustedDataAction: "mark_as_safe",
+        reasoning: "Safe",
+      });
+
+      await service.configurePoliciesForTool({
+        toolId: tool.id,
+        organizationId: org.id,
+      });
+
+      // Per-key configuration hangs off this row, and a Codex refresh token
+      // rotates on redemption — a loopback call without it burns the stored
+      // credential.
+      expect(vi.mocked(createLLMModel)).toHaveBeenCalledWith(
+        expect.objectContaining({ chatApiKeyId: "key-row-1" }),
+      );
+    });
+
     test("maps blocking policy config to correct actions", async ({
       makeOrganization,
       makeMcpServer,
@@ -221,7 +276,7 @@ describe("PolicyConfigurationService", () => {
     }) => {
       const org = await makeOrganization();
 
-      vi.mocked(resolveBestAvailableLlm).mockResolvedValue({
+      vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue({
         provider: "openai",
         apiKey: "sk-openai-test-key",
         modelName: "gpt-4o",
@@ -267,7 +322,7 @@ describe("PolicyConfigurationService", () => {
     }) => {
       const org = await makeOrganization();
 
-      vi.mocked(resolveBestAvailableLlm).mockResolvedValue(MOCK_RESOLVED_LLM);
+      vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue(MOCK_RESOLVED_LLM);
       vi.spyOn(AgentModel, "getBuiltInAgent").mockResolvedValue(
         MOCK_BUILT_IN_AGENT as never,
       );
@@ -300,7 +355,7 @@ describe("PolicyConfigurationService", () => {
     }) => {
       const org = await makeOrganization();
 
-      vi.mocked(resolveBestAvailableLlm).mockResolvedValue(MOCK_RESOLVED_LLM);
+      vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue(MOCK_RESOLVED_LLM);
       vi.spyOn(AgentModel, "getBuiltInAgent").mockResolvedValue(
         MOCK_BUILT_IN_AGENT as never,
       );
@@ -341,7 +396,7 @@ describe("PolicyConfigurationService", () => {
     }) => {
       const org = await makeOrganization();
 
-      vi.mocked(resolveBestAvailableLlm).mockResolvedValue(MOCK_RESOLVED_LLM);
+      vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue(MOCK_RESOLVED_LLM);
       vi.spyOn(AgentModel, "getBuiltInAgent").mockResolvedValue(
         MOCK_BUILT_IN_AGENT as never,
       );

--- a/platform/backend/src/agents/subagents/policy-configuration.ts
+++ b/platform/backend/src/agents/subagents/policy-configuration.ts
@@ -4,7 +4,7 @@ import {
   type SupportedProvider,
 } from "@archestra/shared";
 import { generateText, Output } from "ai";
-import { createLLMModel } from "@/clients/llm-client";
+import { createLLMModel, isApiKeyRequired } from "@/clients/llm-client";
 import logger from "@/logging";
 import {
   AgentModel,
@@ -23,8 +23,7 @@ import {
 } from "@/types";
 import {
   type ResolvedLlmSelection,
-  resolveBestAvailableLlm,
-  resolveConfiguredAgentLlm,
+  resolveAgentLlmOrDefault,
 } from "@/utils/llm-resolution";
 
 interface AutoPolicyResult {
@@ -48,28 +47,59 @@ interface BulkAutoPolicyResult {
  */
 export class PolicyConfigurationService {
   /**
-   * Resolve the LLM provider/key using the built-in agent's configured
-   * llmApiKeyId/llmModel, falling back to the best available LLM across the
-   * org's keys.
+   * Resolve the LLM for this subagent through the shared built-in-subagent
+   * chain: the agent's own configured model/key, then the ORGANIZATION DEFAULT
+   * model (Settings -> Agents), then the best available key, then the env
+   * fallback.
+   *
+   * Resolving through `resolveAgentLlmOrDefault` — rather than reading the
+   * agent's pinned selection directly — is what makes the returned selection
+   * usable. `resolveConfiguredAgentLlm` is ownership-blind: it deliberately
+   * returns a selection with NO apiKey when the pinned credential belongs to an
+   * individual (a Claude Pro/Max or ChatGPT subscription, a Copilot token),
+   * leaving the caller to re-resolve it for the acting user. Treating that
+   * half-resolved selection as final is what made "Configure with Subagent"
+   * fail on every tool at once: the LLM call had no credential, but a non-null
+   * selection had already satisfied the caller's "is an LLM configured?" check.
+   *
+   * Returns null when no usable credential resolves, so the caller can surface
+   * one actionable error instead of N identical provider failures.
    */
   async resolveLlm(params: {
     organizationId: string;
     userId?: string;
   }): Promise<ResolvedLlmSelection | null> {
-    const { organizationId } = params;
+    const { organizationId, userId } = params;
 
-    // Check the built-in agent's own LLM configuration first
     const builtInAgent = await AgentModel.getBuiltInAgent(
       BUILT_IN_AGENT_IDS.POLICY_CONFIG,
       organizationId,
     );
 
-    if (builtInAgent) {
-      const agentLlm = await resolveConfiguredAgentLlm(builtInAgent);
-      if (agentLlm) return agentLlm;
+    const selection = await resolveAgentLlmOrDefault({
+      agent: builtInAgent
+        ? {
+            llmApiKeyId: builtInAgent.llmApiKeyId,
+            modelId: builtInAgent.modelId,
+          }
+        : null,
+      organizationId,
+      userId,
+    });
+
+    if (isApiKeyRequired(selection.provider, selection.apiKey)) {
+      logger.warn(
+        {
+          organizationId,
+          provider: selection.provider,
+          modelName: selection.modelName,
+        },
+        "resolveLlm: resolved provider has no usable credential",
+      );
+      return null;
     }
 
-    return resolveBestAvailableLlm(params);
+    return selection;
   }
 
   /**
@@ -89,10 +119,10 @@ export class PolicyConfigurationService {
       "configurePoliciesForTool: starting",
     );
 
-    // Use pre-resolved LLM or resolve now
+    // Use pre-resolved LLM or resolve now, through the same chain the bulk
+    // flow uses — a direct single-tool call must not resolve differently.
     const resolved =
-      resolvedLlm ??
-      (await resolveBestAvailableLlm({ organizationId, userId }));
+      resolvedLlm ?? (await this.resolveLlm({ organizationId, userId }));
     if (!resolved) {
       logger.warn(
         { toolId, organizationId },
@@ -142,6 +172,7 @@ export class PolicyConfigurationService {
         apiKey: resolved.apiKey,
         modelName: resolved.modelName,
         baseUrl: resolved.baseUrl,
+        chatApiKeyId: resolved.chatApiKeyId,
         organizationId,
       });
 
@@ -367,20 +398,40 @@ export class PolicyConfigurationService {
       }),
     );
 
-    const allSuccess = results.every((r) => r.success);
-    const successCount = results.filter((r) => r.success).length;
-    const failureCount = results.filter((r) => !r.success).length;
+    const failures = results.filter((r) => !r.success);
+    const successCount = results.length - failures.length;
+    const allSuccess = failures.length === 0;
 
     logger.info(
       {
         organizationId,
         total: results.length,
         successCount,
-        failureCount,
+        failureCount: failures.length,
         allSuccess,
       },
       "configurePoliciesForTools: bulk auto-configure completed",
     );
+
+    // A bulk run that configured nothing is the shape this fails in — one
+    // cause (no usable credential, a model that won't produce the structured
+    // output) takes down every tool at once. Counts alone say nothing about
+    // which, so name the reasons here, on one line, next to the counts.
+    if (failures.length > 0) {
+      logger.warn(
+        {
+          organizationId,
+          successCount,
+          failureCount: failures.length,
+          failures: failures.map(({ toolId, error, timedOut }) => ({
+            toolId,
+            error,
+            timedOut,
+          })),
+        },
+        "configurePoliciesForTools: some tools could not be auto-configured",
+      );
+    }
 
     return {
       success: allSuccess,
@@ -398,6 +449,8 @@ export class PolicyConfigurationService {
     apiKey: string | undefined;
     modelName: string;
     baseUrl: string | null;
+    /** The key row the credential came from; see the createLLMModel call. */
+    chatApiKeyId?: string;
     organizationId: string;
   }): Promise<PolicyConfig> {
     const {
@@ -407,6 +460,7 @@ export class PolicyConfigurationService {
       apiKey,
       modelName,
       baseUrl,
+      chatApiKeyId,
       organizationId,
     } = params;
     logger.info(
@@ -436,6 +490,11 @@ export class PolicyConfigurationService {
       agentId: builtInAgent.id,
       modelName,
       baseUrl,
+      // The proxy must know which key row supplied the credential: per-key
+      // configuration (extra headers) hangs off it, and Codex refresh tokens
+      // rotate on every redemption — a loopback call without the row id
+      // discards the rotation and burns the stored credential.
+      chatApiKeyId,
     });
     const annotations = tool.meta?.annotations as
       | Record<string, unknown>

--- a/platform/backend/src/utils/llm-resolution.ts
+++ b/platform/backend/src/utils/llm-resolution.ts
@@ -207,6 +207,13 @@ export async function resolveConversationModel(
  * iterating configured providers and checking DB-managed keys.
  *
  * Returns null if no provider has both a key and a synced model.
+ *
+ * One rung of the resolution chain, not an entry point: it knows nothing about
+ * an agent's own configuration or the organization default. Callers resolving
+ * an LLM for a built-in subagent want `resolveAgentLlmOrDefault`, which walks
+ * the whole chain and ends here.
+ *
+ * @public — exercised by llm-resolution.test.ts (knip --production ignores tests)
  */
 export async function resolveBestAvailableLlm(params: {
   organizationId: string;
@@ -296,6 +303,17 @@ interface InheritedLlmSelection {
  * Resolve an agent's explicitly configured LLM (its `modelId` FK and API key),
  * including the API key secret. Returns null when the agent has no usable
  * configuration.
+ *
+ * NOT a complete resolution, and never the final answer for a caller about to
+ * make a request. This helper is ownership-blind: it returns a selection with
+ * `apiKey: undefined` whenever the credential belongs to an individual rather
+ * than the organization (a subscription connection, a per-user provider) or
+ * when the agent pins a model without a key, leaving the caller to re-resolve
+ * the credential for the acting user. Treating that half-resolved selection as
+ * final yields a selection that looks configured and fails every call.
+ * `resolveAgentLlmOrDefault` is the entry point that completes it.
+ *
+ * @public — exercised by llm-resolution.test.ts (knip --production ignores tests)
  */
 export async function resolveConfiguredAgentLlm(
   agent: PinnedLlmSelection,

--- a/platform/frontend/src/components/tool-policy-bulk-actions.test.tsx
+++ b/platform/frontend/src/components/tool-policy-bulk-actions.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolPolicyBulkActionsBar } from "./tool-policy-bulk-actions";
+
+const autoConfigureMutate = vi.hoisted(() => vi.fn());
+const toastWarning = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { warning: toastWarning, success: toastSuccess, error: vi.fn() },
+}));
+
+vi.mock("@/lib/agent-tools.query", () => ({
+  useAutoConfigurePolicies: () => ({
+    mutateAsync: autoConfigureMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/lib/policy.query", () => ({
+  useBulkCallPolicyMutation: () => ({ mutateAsync: vi.fn() }),
+  useBulkResultPolicyMutation: () => ({ mutateAsync: vi.fn() }),
+  useToolInvocationPolicies: () => ({ data: { byProfileToolId: {} } }),
+  useToolResultPolicies: () => ({ data: { byProfileToolId: {} } }),
+}));
+
+vi.mock("@/components/ui/permission-button", () => ({
+  PermissionButton: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/roles/with-permissions", () => ({
+  WithPermissions: ({
+    children,
+  }: {
+    children: (args: { hasPermission: boolean }) => React.ReactNode;
+  }) => children({ hasPermission: true }),
+}));
+
+function renderBar(selectedToolIds: string[]) {
+  return render(
+    <ToolPolicyBulkActionsBar
+      selectedToolIds={selectedToolIds}
+      onClear={vi.fn()}
+    />,
+  );
+}
+
+async function clickConfigure() {
+  await userEvent.click(
+    screen.getByRole("button", { name: /configure with subagent/i }),
+  );
+}
+
+describe("ToolPolicyBulkActionsBar — Configure with Subagent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tells the user why the tools failed, not just how many", async () => {
+    // The shape this actually fails in: one cause takes down every tool.
+    autoConfigureMutate.mockResolvedValue({
+      results: [
+        { toolId: "a", success: false, error: "LLM API key not configured" },
+        { toolId: "b", success: false, error: "LLM API key not configured" },
+      ],
+    });
+
+    renderBar(["a", "b"]);
+    await clickConfigure();
+
+    expect(toastWarning).toHaveBeenCalledWith(
+      expect.stringContaining("failed 2"),
+      expect.objectContaining({ description: "LLM API key not configured" }),
+    );
+  });
+
+  it("lists distinct reasons for a mixed batch, capped", async () => {
+    autoConfigureMutate.mockResolvedValue({
+      results: [
+        { toolId: "a", success: true },
+        { toolId: "b", success: false, error: "Tool not found" },
+        {
+          toolId: "c",
+          success: false,
+          error: "Auto-configure timed out (>20s)",
+        },
+        { toolId: "d", success: false, error: "Rate limited" },
+      ],
+    });
+
+    renderBar(["a", "b", "c", "d"]);
+    await clickConfigure();
+
+    const [message, options] = toastWarning.mock.calls.at(-1) as [
+      string,
+      { description?: string },
+    ];
+    expect(message).toContain("configured for 1 tool(s), failed 3");
+    expect(options.description).toBe(
+      "Tool not found · Auto-configure timed out (>20s) (+1 more)",
+    );
+  });
+
+  it("stays a plain success toast when nothing failed", async () => {
+    autoConfigureMutate.mockResolvedValue({
+      results: [{ toolId: "a", success: true }],
+    });
+
+    renderBar(["a"]);
+    await clickConfigure();
+
+    expect(toastSuccess).toHaveBeenCalledWith(
+      expect.stringContaining("configured for 1 tool(s)"),
+    );
+    expect(toastWarning).not.toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/components/tool-policy-bulk-actions.tsx
+++ b/platform/frontend/src/components/tool-policy-bulk-actions.tsx
@@ -131,20 +131,21 @@ export function ToolPolicyBulkActionsBar({
       ]);
       if (!result) return;
 
-      const successCount = result.results.filter(
-        (r: { success: boolean }) => r.success,
-      ).length;
-      const failureCount = result.results.filter(
-        (r: { success: boolean }) => !r.success,
-      ).length;
+      const failures = result.results.filter((r) => !r.success);
+      const successCount = result.results.length - failures.length;
 
-      if (failureCount === 0) {
+      if (failures.length === 0) {
         toast.success(
           `Default policies configured for ${successCount} tool(s). Custom policies are preserved.`,
         );
       } else {
         toast.warning(
-          `Default policies configured for ${successCount} tool(s), failed ${failureCount}. Custom policies are preserved.`,
+          `Default policies configured for ${successCount} tool(s), failed ${failures.length}. Custom policies are preserved.`,
+          {
+            description: summarizeFailureReasons(failures),
+            // A reason worth reading needs longer than the default 4s.
+            duration: 12000,
+          },
         );
       }
 
@@ -288,3 +289,36 @@ export function ToolPolicyBulkActionsBar({
     </BulkActionsBar>
   );
 }
+
+/**
+ * Why the failures failed, for the toast's description line.
+ *
+ * The API returns an error per failed tool, but the bar used to render only
+ * the count — so "failed 4" was the whole story a user got, and the actual
+ * cause (no usable LLM credential, a timeout, a model that would not produce
+ * the structured policy output) only existed in the server logs. Distinct
+ * reasons, because a bulk run overwhelmingly fails the same way for every
+ * tool, and capped so a genuinely mixed batch stays a toast rather than a wall.
+ */
+function summarizeFailureReasons(
+  failures: readonly { error?: string }[],
+): string | undefined {
+  const reasons = [
+    ...new Set(
+      failures
+        .map((failure) => failure.error?.trim())
+        .filter((error): error is string => Boolean(error)),
+    ),
+  ];
+  if (reasons.length === 0) {
+    return undefined;
+  }
+
+  const shown = reasons.slice(0, MAX_TOAST_FAILURE_REASONS);
+  const hidden = reasons.length - shown.length;
+  return hidden > 0
+    ? `${shown.join(" · ")} (+${hidden} more)`
+    : shown.join(" · ");
+}
+
+const MAX_TOAST_FAILURE_REASONS = 2;


### PR DESCRIPTION
## Summary

- resolve the Policy Configuration Subagent through the shared built-in-agent LLM chain, including acting-user and organization fallbacks
- reject credential-less selections before per-tool work and forward the resolved credential through the proxy
- surface distinct per-tool failure reasons in the bulk-action toast and aggregate them in backend logs
- add real-resolution backend coverage and UI toast coverage, with the missing-credential case isolated from developer environment keys

## Manual verification

- On current main, reproduced a stale model/no-key selection while a valid organization key was available; configuring two selected tools failed 0/2 with a missing-key provider error
- With this branch, repeated the identical action and both tools configured successfully 2/2 through the organization-key fallback
- Restored the local reproduction state after verification