### PR TITLE
fix(chatops): identify subagent inference errors

### DIFF
--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -16,7 +16,7 @@ import {
   REPEAT_CALL_TERMINATION_NOTICE,
   type ToolCallRepeatTracker,
 } from "@/clients/tool-call-repeat-tracker";
-import { ProviderError } from "@/routes/chat/errors";
+import { ProviderError, SubagentProviderError } from "@/routes/chat/errors";
 import { THINKING_ONLY_NOTICE } from "@/utils/strip-thinking-blocks";
 import { executeA2AMessage } from "./a2a-executor";
 
@@ -411,6 +411,43 @@ describe("executeA2AMessage real stream boundary", () => {
 
     expect(error).toBeInstanceOf(ProviderError);
     expect((error as ProviderError).message).toContain("Insufficient credits");
+  });
+
+  test("preserves the subagent origin on a captured provider error", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const providerError = new ProviderError({
+      code: ChatErrorCode.RateLimit,
+      message: "usage limit reached",
+      isRetryable: false,
+    });
+    const subagentError = new SubagentProviderError({
+      providerError,
+      subagentId: "00000000-0000-0000-0000-000000000099",
+      subagentName: "Research Helper",
+    });
+    primeAgent(
+      new MockLanguageModelV3({
+        doStream: async () => {
+          throw subagentError;
+        },
+      }),
+    );
+
+    const error = await executeA2AMessage({
+      agentId: agent.id,
+      message: "Handle this",
+      organizationId: org.id,
+      userId: user.id,
+      conversationId: "conv-1",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBe(subagentError);
   });
 
   test("maps an exhausted empty response to a ProviderError EmptyResponse", async ({

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -51,6 +51,7 @@ import {
   getUnavailableToolErrorDetails,
   mapProviderError,
   ProviderError,
+  SubagentProviderError,
 } from "@/routes/chat/errors";
 import { prepareMessagesForProvider } from "@/routes/chat/normalization/prepare-for-provider";
 import { buildOllamaNativeProviderOptions } from "@/routes/chat/ollama-native-params";
@@ -784,9 +785,15 @@ export async function executeA2AMessage(
         NoOutputGeneratedError.isInstance(streamError) &&
         capturedStreamError !== undefined
       ) {
+        if (capturedStreamError instanceof SubagentProviderError) {
+          throw capturedStreamError;
+        }
         throw new ProviderError(
           mapProviderError(capturedStreamError, provider),
         );
+      }
+      if (streamError instanceof SubagentProviderError) {
+        throw streamError;
       }
       throw new ProviderError(mapProviderError(streamError, provider));
     }

--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -36,7 +36,7 @@ import {
   ModelModel,
 } from "@/models";
 import { RouteCategory } from "@/observability/tracing";
-import { ProviderError } from "@/routes/chat/errors";
+import { ProviderError, SubagentProviderError } from "@/routes/chat/errors";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type {
   ChatOpsApprovalDecision,
@@ -1060,6 +1060,69 @@ describe("ChatOpsManager security validation", () => {
       expect.objectContaining({
         text: "Sorry, I encountered an error processing your request.",
         footer: `🤖 ${agent.name} · upstream exploded`,
+      }),
+    );
+  });
+
+  test("provider errors from a subagent identify the source in the reply", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const providerError = new ProviderError({
+      code: ChatErrorCode.RateLimit,
+      message: "usage limit reached",
+      isRetryable: false,
+    });
+    vi.spyOn(a2aExecutor, "executeA2AMessage").mockRejectedValue(
+      new SubagentProviderError({
+        providerError,
+        subagentId: "00000000-0000-0000-0000-000000000099",
+        subagentName: "Research Helper",
+      }),
+    );
+
+    const user = await makeUser({ email: "subagent-error@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: agent.id,
+    });
+
+    const sendReplySpy = vi.fn().mockResolvedValue("reply-id");
+    const mockProvider = createMockProvider({
+      getUserEmail: async () => "subagent-error@example.com",
+      sendReply: sendReplySpy,
+    });
+
+    const manager = new ChatOpsManager();
+    (
+      manager as unknown as { msTeamsProvider: ChatOpsProvider }
+    ).msTeamsProvider = mockProvider;
+
+    const result = await manager.processMessage({
+      message: createMockMessage(),
+      provider: mockProvider,
+    });
+
+    expect(result.success).toBe(false);
+    expect(sendReplySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Sorry, a subagent encountered an error while processing your request.",
+        footer: `🤖 ${agent.name} · Subagent Research Helper · usage limit reached`,
       }),
     );
   });

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -27,7 +27,7 @@ import {
   UserModel,
 } from "@/models";
 import { RouteCategory } from "@/observability/tracing";
-import { ProviderError } from "@/routes/chat/errors";
+import { ProviderError, SubagentProviderError } from "@/routes/chat/errors";
 import { getHiddenMessagingChannels } from "@/services/integration-overrides";
 import type {
   ChatOpsApprovalDecision,
@@ -1906,6 +1906,10 @@ export class ChatOpsManager {
     // Show truncated error details as a subtle footer (max 500 chars)
     const errorDetail =
       errMsg.length > 500 ? `${errMsg.slice(0, 500)}…` : errMsg;
+    const isSubagentError = error instanceof SubagentProviderError;
+    const sourcedErrorDetail = isSubagentError
+      ? `Subagent ${error.subagentName} · ${errorDetail}`
+      : errorDetail;
 
     // The LLM provider rejected the API key (e.g. Anthropic's "invalid
     // x-api-key"). Users rarely realize the bot resolves its model/key the
@@ -1913,7 +1917,10 @@ export class ChatOpsManager {
     // fix it instead of leaving only the provider's cryptic one-liner.
     if (isLlmProviderAuthError(errMsg)) {
       const usedLlm = llmContext
-        ? await this.describeLlmUsedForRun(llmContext)
+        ? await this.describeLlmUsedForRun({
+            ...llmContext,
+            agentId: isSubagentError ? error.subagentId : llmContext.agentId,
+          })
         : null;
       await provider.sendReply({
         originalMessage: message,
@@ -1925,7 +1932,7 @@ export class ChatOpsManager {
           "",
           `Update the key or configure a different one, then try again: ${config.frontendBaseUrl}/llm/model-providers`,
         ].join("\n"),
-        footer: footer(errorDetail),
+        footer: footer(sourcedErrorDetail),
         conversationReference: message.metadata?.conversationReference,
       });
       return;
@@ -1933,8 +1940,10 @@ export class ChatOpsManager {
 
     await provider.sendReply({
       originalMessage: message,
-      text: "Sorry, I encountered an error processing your request.",
-      footer: footer(errorDetail),
+      text: isSubagentError
+        ? "Sorry, a subagent encountered an error while processing your request."
+        : "Sorry, I encountered an error processing your request.",
+      footer: footer(sourcedErrorDetail),
       conversationReference: message.metadata?.conversationReference,
     });
   }

--- a/platform/backend/src/archestra-mcp-server/delegation.test.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.test.ts
@@ -14,7 +14,7 @@ import {
   EnvironmentModel,
   ToolModel,
 } from "@/models";
-import { ProviderError } from "@/routes/chat/errors";
+import { ProviderError, SubagentProviderError } from "@/routes/chat/errors";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import { type ArchestraContext, executeArchestraTool, getAgentTools } from ".";
@@ -278,12 +278,13 @@ describe("delegation tool execution", () => {
 describe("delegation error propagation", () => {
   let callerAgent: Agent;
   let baseContext: ArchestraContext;
+  let targetAgent: Agent;
   let toolName: string;
 
   beforeEach(async ({ makeAgent, makeAgentTool }) => {
     vi.clearAllMocks();
     callerAgent = await makeAgent({ name: "Caller Agent" });
-    const targetAgent = await makeAgent({ name: "Target Agent" });
+    targetAgent = await makeAgent({ name: "Target Agent" });
     const delegationTool = await ToolModel.findOrCreateDelegationTool(
       targetAgent.id,
     );
@@ -309,16 +310,23 @@ describe("delegation error propagation", () => {
     expect((result.content[0] as any).text).toContain("subagent exploded");
   });
 
-  test("rethrows a ProviderError so the parent stream reports the provider", async () => {
+  test("rethrows a ProviderError with the originating subagent", async () => {
     const providerError = new ProviderError({
       message: "upstream is down",
       authenticated: false,
     } as any);
     mockExecuteA2AMessage.mockRejectedValue(providerError);
 
-    await expect(
-      executeArchestraTool(toolName, { message: "hello" }, baseContext),
-    ).rejects.toBe(providerError);
+    const error = await executeArchestraTool(
+      toolName,
+      { message: "hello" },
+      baseContext,
+    ).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(SubagentProviderError);
+    expect(error.chatErrorResponse).toBe(providerError.chatErrorResponse);
+    expect(error.subagentId).toBe(targetAgent.id);
+    expect(error.subagentName).toBe(targetAgent.name);
   });
 
   test("rethrows an abort so cancellation propagates instead of becoming a tool error", async () => {

--- a/platform/backend/src/archestra-mcp-server/delegation.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.ts
@@ -17,7 +17,7 @@ import {
   AgentTeamModel,
   ToolModel,
 } from "@/models";
-import { ProviderError } from "@/routes/chat/errors";
+import { ProviderError, SubagentProviderError } from "@/routes/chat/errors";
 import type { Agent } from "@/types";
 import { errorResult, isAbortLikeError, successResult } from "./helpers";
 import type { ArchestraContext } from "./types";
@@ -258,10 +258,18 @@ export async function handleDelegation(
       { error, agentId, targetAgentId: target.id },
       "Agent delegation tool execution failed",
     );
-    // Re-throw ProviderError so it propagates to the parent stream's onError
-    // with the correct provider info (the subagent can't produce output)
+    // Re-throw provider failures so they propagate to the parent stream's
+    // onError with the correct provider info (the subagent can't produce
+    // output). Preserve the deepest origin when subagents delegate again.
     if (error instanceof ProviderError) {
-      throw error;
+      if (error instanceof SubagentProviderError) {
+        throw error;
+      }
+      throw new SubagentProviderError({
+        providerError: error,
+        subagentId: target.id,
+        subagentName: target.name,
+      });
     }
     return errorResult(
       error instanceof Error ? error.message : "Unknown error",

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -63,6 +63,27 @@ export class ProviderError extends Error {
 }
 
 /**
+ * A provider failure raised while a parent agent was waiting on a delegated
+ * agent. Keeping this as a ProviderError preserves the parent run's existing
+ * retry and provider-error handling while retaining where the failure began.
+ */
+export class SubagentProviderError extends ProviderError {
+  public readonly subagentId: string;
+  public readonly subagentName: string;
+
+  constructor(params: {
+    providerError: ProviderError;
+    subagentId: string;
+    subagentName: string;
+  }) {
+    super(params.providerError.chatErrorResponse);
+    this.name = "SubagentProviderError";
+    this.subagentId = params.subagentId;
+    this.subagentName = params.subagentName;
+  }
+}
+
+/**
  * Thrown when the provider finishes a turn cleanly (finishReason stop/length)
  * but produces no renderable content, after the empty-response auto-retries are
  * exhausted (or immediately for a non-retryable finishReason). Carries the last


### PR DESCRIPTION
## Summary

- preserve the originating subagent across delegated provider-error propagation
- clarify ChatOps error copy and footer when a failure comes from a subagent
- keep existing retry behavior and resolve key details against the failing subagent