### PR TITLE
feat(settings): compact layouts and improve table bulk selection

### DIFF
--- a/platform/frontend/src/app/account/_components/account-page-action.test.tsx
+++ b/platform/frontend/src/app/account/_components/account-page-action.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  AccountPageAction,
+  AccountPageActionSlotContext,
+} from "./account-page-action";
+
+describe("AccountPageAction", () => {
+  it("places a section action in the personal settings header", () => {
+    render(<TestAccountShell />);
+
+    const header = screen.getByTestId("personal-settings-actions");
+    expect(header).toContainElement(
+      screen.getByRole("button", { name: "Create API Key" }),
+    );
+  });
+});
+
+function TestAccountShell() {
+  const [slot, setSlot] = useState<HTMLDivElement | null>(null);
+
+  return (
+    <>
+      <div data-testid="personal-settings-actions" ref={setSlot} />
+      <AccountPageActionSlotContext.Provider value={slot}>
+        <AccountPageAction>
+          <button type="button">Create API Key</button>
+        </AccountPageAction>
+      </AccountPageActionSlotContext.Provider>
+    </>
+  );
+}

--- a/platform/frontend/src/app/account/_components/account-page-action.tsx
+++ b/platform/frontend/src/app/account/_components/account-page-action.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { createContext, useContext } from "react";
+import { createPortal } from "react-dom";
+
+export function AccountPageAction({ children }: { children: ReactNode }) {
+  const slot = useContext(AccountPageActionSlotContext);
+  return slot ? createPortal(children, slot) : null;
+}
+
+export const AccountPageActionSlotContext =
+  createContext<HTMLDivElement | null>(null);

--- a/platform/frontend/src/app/account/_components/sessions-card.tsx
+++ b/platform/frontend/src/app/account/_components/sessions-card.tsx
@@ -90,6 +90,7 @@ export function SessionsCard() {
     {
       id: "device",
       header: "Device",
+      size: 320,
       cell: ({ row }) => {
         const { deviceType, label } = describeUserAgent(row.original.userAgent);
         return (
@@ -116,6 +117,7 @@ export function SessionsCard() {
     {
       id: "signed-in",
       header: "Signed in",
+      size: 130,
       cell: ({ row }) => (
         <span className="text-sm text-muted-foreground">
           {formatRelativeTimeFromNow(row.original.createdAt)}
@@ -125,6 +127,7 @@ export function SessionsCard() {
     {
       id: "expires",
       header: "Expires",
+      size: 130,
       cell: ({ row }) => (
         <span className="text-sm text-muted-foreground">
           {formatRelativeTimeFromNow(row.original.expiresAt)}
@@ -133,7 +136,8 @@ export function SessionsCard() {
     },
     {
       id: "actions",
-      header: () => <div className="text-right">Actions</div>,
+      header: "Actions",
+      size: 90,
       cell: ({ row }) => (
         <TableRowActions
           itemName={row.original.ipAddress ?? "this session"}
@@ -240,6 +244,9 @@ export function SessionsCard() {
             hideSelectedCount
             isLoading={isPending}
             emptyMessage="No active sessions."
+            hidePaginationWhenSinglePage
+            fixedWidthColumnIds={["signed-in", "expires", "actions"]}
+            flexibleColumnIds={["device"]}
           />
         </>
       )}

--- a/platform/frontend/src/app/account/_components/sessions-card.tsx
+++ b/platform/frontend/src/app/account/_components/sessions-card.tsx
@@ -88,6 +88,7 @@ export function SessionsCard() {
       // Signing yourself out is the row's own action; doing it inside a batch
       // would kill the request revoking the rest.
       canSelect: (row) => !isCurrent(row),
+      disabledReason: () => "Use Sign out for your current session",
     }),
     {
       id: "device",

--- a/platform/frontend/src/app/account/_components/sessions-card.tsx
+++ b/platform/frontend/src/app/account/_components/sessions-card.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import type { ColumnDef, RowSelectionState } from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
 import { KeyRound, Laptop, LogOut, Smartphone, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
 import { UAParser } from "ua-parser-js";
 import { QueryLoadError } from "@/components/query-load-error";
-import { SettingsCardHeader } from "@/components/settings/settings-block";
 import { TableRowActions } from "@/components/table-row-actions";
 import { BulkActionsBar } from "@/components/ui/bulk-actions-bar";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { DataTable } from "@/components/ui/data-table";
 import {
   Empty,
@@ -165,88 +162,88 @@ export function SessionsCard() {
   ];
 
   return (
-    <Card className="w-full">
-      <SettingsCardHeader
-        title="Sessions"
-        description="Manage where your account is signed in."
-      />
-      <CardContent>
-        {isLoadingError && error instanceof StaleSessionError ? (
-          <Empty className="py-6">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <KeyRound />
-              </EmptyMedia>
-              <EmptyTitle>Sign in again to manage your sessions</EmptyTitle>
-              <EmptyDescription>
-                {/* 24 hours mirrors Better Auth's session.freshAge default,
+    <section className="w-full space-y-5">
+      <div className="space-y-1">
+        <h2 className="text-sm font-medium leading-5">Sessions</h2>
+        <p className="text-sm leading-5 text-muted-foreground">
+          Manage where your account is signed in.
+        </p>
+      </div>
+      {isLoadingError && error instanceof StaleSessionError ? (
+        <Empty className="py-6">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <KeyRound />
+            </EmptyMedia>
+            <EmptyTitle>Sign in again to manage your sessions</EmptyTitle>
+            <EmptyDescription>
+              {/* 24 hours mirrors Better Auth's session.freshAge default,
                     pinned by backend/src/auth/list-sessions-freshness.test.ts */}
-                For your security, this list is only available for the first 24
-                hours after you sign in. Sign out and back in to see where your
-                account is signed in.
-              </EmptyDescription>
-            </EmptyHeader>
-            <EmptyContent>
-              <Button
-                variant="outline"
-                onClick={() => router.push("/auth/sign-out")}
-              >
-                Sign Out
-              </Button>
-            </EmptyContent>
-          </Empty>
-        ) : isLoadingError ? (
-          <QueryLoadError
-            className="py-6"
-            title="Couldn't load your sessions"
-            onRetry={() => refetch()}
-          />
-        ) : (
-          <>
-            <BulkActionsBar
-              count={selectedSessions.length}
-              noun="session"
-              onClear={clearSelection}
-              selectAllMatching={selectAllMatching}
-              busy={bulkRevoke.isPending}
-              className="mb-3"
+              For your security, this list is only available for the first 24
+              hours after you sign in. Sign out and back in to see where your
+              account is signed in.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button
+              variant="outline"
+              onClick={() => router.push("/auth/sign-out")}
             >
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() =>
-                  bulkRevoke.mutate(selectedSessions, {
-                    onSuccess: (outcome) => {
-                      reportBulkOutcome({
-                        outcome,
-                        verb: "Revoked",
-                        failureVerb: "revoke",
-                        noun: "session",
-                      });
-                      if (outcome.failed.length === 0) clearSelection();
-                    },
-                  })
-                }
-              >
-                <span>Revoke</span>
-              </Button>
-            </BulkActionsBar>
+              Sign Out
+            </Button>
+          </EmptyContent>
+        </Empty>
+      ) : isLoadingError ? (
+        <QueryLoadError
+          className="py-6"
+          title="Couldn't load your sessions"
+          onRetry={() => refetch()}
+        />
+      ) : (
+        <>
+          <BulkActionsBar
+            count={selectedSessions.length}
+            noun="session"
+            onClear={clearSelection}
+            selectAllMatching={selectAllMatching}
+            busy={bulkRevoke.isPending}
+            className="mb-3"
+          >
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() =>
+                bulkRevoke.mutate(selectedSessions, {
+                  onSuccess: (outcome) => {
+                    reportBulkOutcome({
+                      outcome,
+                      verb: "Revoked",
+                      failureVerb: "revoke",
+                      noun: "session",
+                    });
+                    if (outcome.failed.length === 0) clearSelection();
+                  },
+                })
+              }
+            >
+              <span>Revoke</span>
+            </Button>
+          </BulkActionsBar>
 
-            <DataTable
-              columns={columns}
-              data={rows}
-              getRowId={(row) => row.id}
-              rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
-              onPageRowIdsChange={onPageRowIdsChange}
-              hideSelectedCount
-              isLoading={isPending}
-              emptyMessage="No active sessions."
-            />
-          </>
-        )}
-      </CardContent>
-    </Card>
+          <DataTable
+            columns={columns}
+            data={rows}
+            getRowId={(row) => row.id}
+            rowSelection={rowSelection}
+            onRowSelectionChange={setRowSelection}
+            onPageRowIdsChange={onPageRowIdsChange}
+            hideSelectedCount
+            isLoading={isPending}
+            emptyMessage="No active sessions."
+          />
+        </>
+      )}
+    </section>
   );
 }
 

--- a/platform/frontend/src/app/account/layout.tsx
+++ b/platform/frontend/src/app/account/layout.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
+import { AccountPageActionSlotContext } from "@/app/account/_components/account-page-action";
 import { AccountSectionNav } from "@/app/account/_components/account-section-nav";
 import { ChangePasswordDialog } from "@/app/account/_components/change-password-dialog";
 import { LoadingSpinner } from "@/components/loading";
@@ -12,8 +13,12 @@ import { usePublicConfig } from "@/lib/config/config.query";
 
 function AccountShell({ children }: { children: React.ReactNode }) {
   const searchParams = useSearchParams();
+  const pathname = usePathname();
   const highlight = searchParams.get("highlight");
   const [isChangePasswordOpen, setIsChangePasswordOpen] = useState(false);
+  const [pageActionSlot, setPageActionSlot] = useState<HTMLDivElement | null>(
+    null,
+  );
   const { data: publicConfig, isLoading: isLoadingPublicConfig } =
     usePublicConfig();
   const isBasicAuthDisabled = publicConfig?.disableBasicAuth ?? false;
@@ -29,22 +34,26 @@ function AccountShell({ children }: { children: React.ReactNode }) {
   return (
     <PageLayout
       title="Personal Settings"
-      // Page-level, not tucked inside a section: changing a password is the
-      // thing people arrive here to do, and it should stay one click away
-      // from whichever section they happen to be on. It lives in the layout so
-      // the `?highlight=change-password` deep link works on every one of them.
+      // Most account sections keep password management one click away. A page
+      // with a primary action of its own can replace it in the same header
+      // slot; API Keys uses that for Create API Key. The dialog stays mounted
+      // here so the `?highlight=change-password` deep link still works.
       actionButton={
-        showChangePasswordButton ? (
+        pathname === "/account/api-keys" ? (
+          <div ref={setPageActionSlot} />
+        ) : showChangePasswordButton ? (
           <Button type="button" onClick={() => setIsChangePasswordOpen(true)}>
             Change Password
           </Button>
         ) : null
       }
     >
-      <div className="grid items-start gap-6 lg:grid-cols-[220px_minmax(0,1fr)]">
-        <AccountSectionNav />
-        <div className="min-w-0">{children}</div>
-      </div>
+      <AccountPageActionSlotContext.Provider value={pageActionSlot}>
+        <div className="grid items-start gap-6 lg:grid-cols-[220px_minmax(0,1fr)]">
+          <AccountSectionNav />
+          <div className="min-w-0">{children}</div>
+        </div>
+      </AccountPageActionSlotContext.Provider>
       {showChangePasswordButton && (
         <ChangePasswordDialog
           open={isChangePasswordOpen}

--- a/platform/frontend/src/app/apps/_parts/apps-table.tsx
+++ b/platform/frontend/src/app/apps/_parts/apps-table.tsx
@@ -141,6 +141,8 @@ export function AppsTable({
       rowLabel: (app) => `Select ${app.name}`,
       allLabel: "Select all apps on this page",
       canSelect: (app) => app.source === "owned",
+      disabledReason: () =>
+        "Installed apps are managed through their MCP server",
     }),
     {
       id: "name",

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -218,6 +218,10 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
         // guaranteed to come back as failures.
         canSelect: (row) =>
           row.kind === "environment" && row.assignedCatalogCount === 0,
+        disabledReason: (row) =>
+          row.kind === "default"
+            ? "The default environment cannot be deleted"
+            : "Remove assigned MCP servers before deleting",
       }),
       {
         accessorKey: "name",

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
@@ -168,6 +168,7 @@ export function McpServerTable({
       rowLabel: (item) => `Select ${item.name}`,
       allLabel: "Select all MCP servers on this page",
       canSelect,
+      disabledReason: () => "Wait for installation to finish",
     }),
     {
       id: "name",

--- a/platform/frontend/src/app/settings/agents/page.tsx
+++ b/platform/frontend/src/app/settings/agents/page.tsx
@@ -252,14 +252,14 @@ export default function AgentSettingsPage() {
               isLoadError ? (
                 <QueryLoadError
                   title="Couldn't load your LLM providers"
-                  className="w-80"
+                  className="w-full sm:w-80"
                   onRetry={() => {
                     refetchApiKeys();
                     refetchModels();
                   }}
                 />
               ) : (
-                <div className="flex flex-col gap-2 w-80">
+                <div className="flex w-full flex-col gap-2 sm:w-80">
                   <LlmProviderApiKeyDropdown
                     availableKeys={availableKeys}
                     selectedApiKeyId={selectedApiKeyId || null}
@@ -272,7 +272,7 @@ export default function AgentSettingsPage() {
                       setApiKeySelectorOpen(false);
                     }}
                     triggerVariant="select"
-                    triggerClassName="w-80"
+                    triggerClassName="w-full"
                     popoverClassName="w-80"
                     emptyTriggerLabel="Select provider key..."
                   />
@@ -288,7 +288,7 @@ export default function AgentSettingsPage() {
                           ? "Loading models..."
                           : "Select model..."
                     }
-                    className="w-80"
+                    className="w-full"
                     disabled={
                       isSaving ||
                       !hasPermission ||
@@ -340,7 +340,7 @@ export default function AgentSettingsPage() {
                 agents={orgAgents ?? []}
                 placeholder="Select agent..."
                 searchPlaceholder="Search agents..."
-                className="w-80"
+                className="w-full sm:w-80"
                 disabled={isSaving || !hasPermission}
                 hint="Only org-wide agents are shown"
                 sentinelOption={{

--- a/platform/frontend/src/app/settings/appearance/_components/chat-links-editor.tsx
+++ b/platform/frontend/src/app/settings/appearance/_components/chat-links-editor.tsx
@@ -68,12 +68,26 @@ export function ChatLinksEditor({
 
   return (
     <div className="space-y-3">
-      <div className="space-y-1">
-        <Label>Chat Links</Label>
-        <p className="text-xs text-muted-foreground">
-          Add up to 3 optional buttons shown on the new chat page. Labels are
-          required and limited to 25 characters.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <Label>Chat Links</Label>
+          <p className="text-xs text-muted-foreground">
+            Add up to 3 optional buttons shown on the new chat page. Labels are
+            required and limited to 25 characters.
+          </p>
+        </div>
+        {links.length < 3 && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={handleAdd}
+          >
+            <Plus className="h-4 w-4" />
+            Add Link
+          </Button>
+        )}
       </div>
       <div className="space-y-3">
         {links.map((link, index) => {
@@ -156,12 +170,6 @@ export function ChatLinksEditor({
           );
         })}
       </div>
-      {links.length < 3 && (
-        <Button type="button" variant="outline" size="sm" onClick={handleAdd}>
-          <Plus className="h-4 w-4" />
-          Add Link
-        </Button>
-      )}
     </div>
   );
 }

--- a/platform/frontend/src/app/settings/appearance/_components/chat-placeholders-editor.tsx
+++ b/platform/frontend/src/app/settings/appearance/_components/chat-placeholders-editor.tsx
@@ -53,12 +53,28 @@ export function ChatPlaceholdersEditor({
   );
 
   return (
-    <div className="space-y-2">
-      <Label>Chat Placeholders</Label>
-      <p className="text-xs text-muted-foreground">
-        Custom placeholder texts for the chat input. Max 20 entries, 80 chars
-        each.
-      </p>
+    <div className="space-y-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <Label>Chat Placeholders</Label>
+          <p className="text-xs text-muted-foreground">
+            Custom placeholder texts for the chat input. Max 20 entries, 80
+            chars each.
+          </p>
+        </div>
+        {placeholders.length < 20 && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={handleAdd}
+          >
+            <Plus className="h-4 w-4" />
+            Add Placeholder
+          </Button>
+        )}
+      </div>
       <div className="space-y-2">
         {placeholders.map((placeholder, index) => (
           <div key={keysRef.current[index]} className="flex items-center gap-2">
@@ -82,12 +98,6 @@ export function ChatPlaceholdersEditor({
           </div>
         ))}
       </div>
-      {placeholders.length < 20 && (
-        <Button type="button" variant="outline" size="sm" onClick={handleAdd}>
-          <Plus className="h-4 w-4" />
-          Add Placeholder
-        </Button>
-      )}
     </div>
   );
 }

--- a/platform/frontend/src/app/settings/appearance/_components/image-upload.tsx
+++ b/platform/frontend/src/app/settings/appearance/_components/image-upload.tsx
@@ -4,8 +4,7 @@ import { Upload, X } from "lucide-react";
 import Image from "next/image";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
-import { SettingsCardHeader } from "@/components/settings/settings-block";
-import { Card, CardContent } from "@/components/ui/card";
+import { SettingsBlock } from "@/components/settings/settings-block";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { useUpdateAppearanceSettings } from "@/lib/organization.query";
 
@@ -86,9 +85,10 @@ export function ImageUpload({
   const hasPreview = preview || currentImage;
 
   return (
-    <Card>
-      <SettingsCardHeader title={title} description={description} />
-      <CardContent className="space-y-4">
+    <SettingsBlock
+      title={title}
+      description={description}
+      control={
         <div className="flex items-center gap-4">
           <div className="relative h-10 w-10 rounded-md border border-border bg-muted flex items-center justify-center overflow-hidden shrink-0">
             {hasPreview ? (
@@ -127,15 +127,16 @@ export function ImageUpload({
             )}
           </div>
         </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          aria-label="Upload image"
-          accept="image/png"
-          className="hidden"
-          onChange={handleFileSelect}
-        />
-      </CardContent>
-    </Card>
+      }
+    >
+      <input
+        ref={fileInputRef}
+        type="file"
+        aria-label="Upload image"
+        accept="image/png"
+        className="hidden"
+        onChange={handleFileSelect}
+      />
+    </SettingsBlock>
   );
 }

--- a/platform/frontend/src/app/settings/appearance/_components/logos-section.tsx
+++ b/platform/frontend/src/app/settings/appearance/_components/logos-section.tsx
@@ -3,8 +3,7 @@
 import { Upload, X } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
-import { SettingsCardHeader } from "@/components/settings/settings-block";
-import { Card, CardContent } from "@/components/ui/card";
+import { SettingsBlock } from "@/components/settings/settings-block";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { useUpdateAppearanceSettings } from "@/lib/organization.query";
 
@@ -62,23 +61,20 @@ export function LogosSection({
   };
 
   return (
-    <Card>
-      <SettingsCardHeader title="Logos" description="PNG or SVG, max 2 MB." />
-      <CardContent>
-        <div className="divide-y divide-border border-t border-border">
-          {ROWS.map(({ label, description, field }) => (
-            <LogoRow
-              key={field}
-              label={label}
-              description={description}
-              field={field}
-              current={values[field]}
-              onChange={onChange}
-            />
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+    <SettingsBlock title="Logos" description="PNG or SVG, max 2 MB.">
+      <div className="divide-y divide-border border-y border-border">
+        {ROWS.map(({ label, description, field }) => (
+          <LogoRow
+            key={field}
+            label={label}
+            description={description}
+            field={field}
+            current={values[field]}
+            onChange={onChange}
+          />
+        ))}
+      </div>
+    </SettingsBlock>
   );
 }
 

--- a/platform/frontend/src/app/settings/appearance/_components/onboarding-wizards-editor.tsx
+++ b/platform/frontend/src/app/settings/appearance/_components/onboarding-wizards-editor.tsx
@@ -107,7 +107,7 @@ export function OnboardingWizardEditor({
 
   if (!wizard) {
     return (
-      <div className="space-y-3">
+      <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
           <Label>Onboarding</Label>
           <p className="text-xs text-muted-foreground">
@@ -120,6 +120,7 @@ export function OnboardingWizardEditor({
           type="button"
           variant="outline"
           size="sm"
+          className="shrink-0"
           onClick={handleAddWizard}
         >
           <Plus className="h-4 w-4" />

--- a/platform/frontend/src/app/settings/appearance/_components/site-notifications-section.test.tsx
+++ b/platform/frontend/src/app/settings/appearance/_components/site-notifications-section.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SiteNotificationsSection } from "./site-notifications-section";
+
+vi.mock("@/components/editor");
+vi.mock("@/lib/auth/auth.query", () => ({
+  useHasPermissions: () => ({ data: true }),
+}));
+vi.mock("@/lib/site-notification.query", () => ({
+  useSiteNotification: () => ({ data: null, isLoading: false }),
+  useDeleteSiteNotification: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+describe("SiteNotificationsSection", () => {
+  it("shows a markdown editor and live preview together", () => {
+    const onContentChange = vi.fn();
+
+    render(
+      <SiteNotificationsSection
+        content="# Planned maintenance"
+        expiresAt={null}
+        onContentChange={onContentChange}
+        onExpiresAtChange={() => {}}
+        onDeleted={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Markdown")).toBeVisible();
+    expect(screen.getByText("Preview")).toBeVisible();
+    expect(
+      screen.getByRole("heading", { name: "Planned maintenance" }),
+    ).toBeVisible();
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Notification content" }),
+      { target: { value: "Updated notice" } },
+    );
+    expect(onContentChange).toHaveBeenCalledWith("Updated notice");
+  });
+});

--- a/platform/frontend/src/app/settings/appearance/_components/site-notifications-section.tsx
+++ b/platform/frontend/src/app/settings/appearance/_components/site-notifications-section.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import { Trash2 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { Editor } from "@/components/editor";
 import { ExpirationDateTimeField } from "@/components/expiration-date-time-field";
-import { SettingsCardHeader } from "@/components/settings/settings-block";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { SettingsBlock } from "@/components/settings/settings-block";
 import { PermissionButton } from "@/components/ui/permission-button";
-import { Textarea } from "@/components/ui/textarea";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import {
   useDeleteSiteNotification,
@@ -73,7 +71,6 @@ export function SiteNotificationsSection({
   });
   const deleteMutation = useDeleteSiteNotification();
 
-  const [tab, setTab] = useState<"markdown" | "preview">("markdown");
   const trimmedContent = content.trim();
 
   const handleDelete = useCallback(async () => {
@@ -87,12 +84,11 @@ export function SiteNotificationsSection({
   }
 
   return (
-    <Card>
-      <SettingsCardHeader
-        title="Site Notifications"
-        description="Manage a site-wide announcement banner displayed across the app."
-      />
-      <CardContent className="space-y-4">
+    <SettingsBlock
+      title="Site Notifications"
+      description="Manage a site-wide announcement banner displayed across the app."
+    >
+      <div className="space-y-4">
         {isLoading ? (
           <p className="text-sm text-muted-foreground">
             Loading notification settings...
@@ -110,35 +106,38 @@ export function SiteNotificationsSection({
               }
             />
 
-            <div className="rounded-lg border">
-              <div className="flex items-center gap-1 border-b p-1">
-                <Button
-                  type="button"
-                  variant={tab === "markdown" ? "secondary" : "ghost"}
-                  size="sm"
-                  onClick={() => setTab("markdown")}
-                >
+            <div className="grid overflow-hidden rounded-lg border lg:grid-cols-2">
+              <div className="min-w-0 border-b lg:border-b-0 lg:border-r">
+                <div className="border-b bg-muted/30 px-3 py-2 text-xs font-medium text-muted-foreground">
                   Markdown
-                </Button>
-                <Button
-                  type="button"
-                  variant={tab === "preview" ? "secondary" : "ghost"}
-                  size="sm"
-                  onClick={() => setTab("preview")}
-                >
-                  Preview
-                </Button>
-              </div>
-              {tab === "markdown" ? (
-                <Textarea
-                  aria-label="Notification content"
+                </div>
+                <Editor
+                  height="240px"
+                  defaultLanguage="markdown"
                   value={content}
-                  onChange={(event) => onContentChange(event.target.value)}
-                  placeholder="Write your notification content using markdown."
-                  className="border-0 rounded-none font-mono text-sm min-h-[160px] resize-none focus-visible:ring-0"
+                  onChange={(value) => onContentChange(value ?? "")}
+                  options={{
+                    ariaLabel: "Notification content",
+                    minimap: { enabled: false },
+                    lineNumbers: "off",
+                    folding: false,
+                    glyphMargin: false,
+                    lineDecorationsWidth: 8,
+                    lineNumbersMinChars: 0,
+                    scrollBeyondLastLine: false,
+                    wordWrap: "on",
+                    fontSize: 13,
+                    padding: { top: 10, bottom: 10 },
+                    placeholder:
+                      "Write your notification content using markdown.",
+                  }}
                 />
-              ) : (
-                <div className="p-4 min-h-[160px] [&_p]:my-1 [&_h1]:text-base [&_h1]:font-semibold [&_h2]:text-sm [&_h2]:font-semibold [&_a]:text-primary [&_a]:underline [&_strong]:font-semibold [&_em]:italic">
+              </div>
+              <div className="min-w-0">
+                <div className="border-b bg-muted/30 px-3 py-2 text-xs font-medium text-muted-foreground">
+                  Preview
+                </div>
+                <div className="h-[240px] overflow-y-auto p-4 [&_p]:my-1 [&_h1]:text-base [&_h1]:font-semibold [&_h2]:text-sm [&_h2]:font-semibold [&_a]:text-primary [&_a]:underline [&_strong]:font-semibold [&_em]:italic">
                   {trimmedContent.length > 0 ? (
                     <ReactMarkdown
                       remarkPlugins={[remarkGfm]}
@@ -152,7 +151,7 @@ export function SiteNotificationsSection({
                     </p>
                   )}
                 </div>
-              )}
+              </div>
             </div>
 
             {notification && (
@@ -172,7 +171,7 @@ export function SiteNotificationsSection({
             )}
           </>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </SettingsBlock>
   );
 }

--- a/platform/frontend/src/app/settings/appearance/_components/theme-selector.tsx
+++ b/platform/frontend/src/app/settings/appearance/_components/theme-selector.tsx
@@ -2,9 +2,8 @@
 
 import type { OrganizationTheme } from "@archestra/shared";
 import { WithPermissions } from "@/components/roles/with-permissions";
-import { SettingsCardHeader } from "@/components/settings/settings-block";
+import { SettingsBlock } from "@/components/settings/settings-block";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { type ThemeMetadata, themes } from "@/themes";
 
 interface ThemeSelectorProps {
@@ -17,34 +16,31 @@ export function ThemeSelector({
   onThemeSelect,
 }: ThemeSelectorProps) {
   return (
-    <Card>
-      <SettingsCardHeader
-        title="Color Theme"
-        description="Choose a color theme for your organization. Changes are previewed in real-time."
-      />
-      <CardContent>
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
-          {themes.map((theme) => (
-            <div key={theme.id} className="flex-1">
-              <WithPermissions
-                permissions={{ organizationSettings: ["update"] }}
-                noPermissionHandle="tooltip"
-                key={theme.id}
-              >
-                {({ hasPermission }) => (
-                  <ThemeOption
-                    theme={theme}
-                    isSelected={selectedTheme === theme.id}
-                    onClick={() => onThemeSelect(theme.id)}
-                    disabled={!hasPermission}
-                  />
-                )}
-              </WithPermissions>
-            </div>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+    <SettingsBlock
+      title="Color Theme"
+      description="Choose a color theme for your organization. Changes are previewed in real-time."
+    >
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4">
+        {themes.map((theme) => (
+          <div key={theme.id} className="flex-1">
+            <WithPermissions
+              permissions={{ organizationSettings: ["update"] }}
+              noPermissionHandle="tooltip"
+              key={theme.id}
+            >
+              {({ hasPermission }) => (
+                <ThemeOption
+                  theme={theme}
+                  isSelected={selectedTheme === theme.id}
+                  onClick={() => onThemeSelect(theme.id)}
+                  disabled={!hasPermission}
+                />
+              )}
+            </WithPermissions>
+          </div>
+        ))}
+      </div>
+    </SettingsBlock>
   );
 }
 

--- a/platform/frontend/src/app/settings/appearance/page.tsx
+++ b/platform/frontend/src/app/settings/appearance/page.tsx
@@ -2,14 +2,14 @@
 
 import { DEFAULT_APP_DESCRIPTION, DEFAULT_APP_NAME } from "@archestra/shared";
 import { useQueryClient } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { useCallback, useState } from "react";
 import {
-  SettingsCardHeader,
+  SettingsBlock,
   SettingsSaveBar,
   SettingsSectionStack,
 } from "@/components/settings/settings-block";
 import { SmallTeamTierBanner } from "@/components/small-team-tier-banner";
-import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -316,14 +316,16 @@ export default function AppearanceSettingsPage() {
         }}
       />
 
-      <Card>
-        <SettingsCardHeader
-          title="Branding"
-          description="Customize your organization's browser tab title, OpenGraph description, footer text, chat links, and chat placeholders."
-        />
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="appName">App Name</Label>
+      <SettingsBlock
+        title="Branding"
+        description="Customize your organization's browser tab title, OpenGraph description, footer text, chat links, and chat placeholders."
+      >
+        <div className="space-y-5">
+          <AppearanceControlRow
+            id="appName"
+            label="App Name"
+            description="Shown in the browser tab title. This also brands the built-in MCP server name and built-in MCP tool names and prefix."
+          >
             <Input
               id="appName"
               placeholder={DEFAULT_APP_NAME}
@@ -331,13 +333,12 @@ export default function AppearanceSettingsPage() {
               onChange={(e) => setAppName(e.target.value)}
               maxLength={100}
             />
-            <p className="text-xs text-muted-foreground">
-              Shown in the browser tab title. This also brands the built-in MCP
-              server name and built-in MCP tool names and prefix.
-            </p>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="ogDescription">OpenGraph Description</Label>
+          </AppearanceControlRow>
+          <AppearanceControlRow
+            id="ogDescription"
+            label="OpenGraph Description"
+            description="Used when sharing links to your platform."
+          >
             <Textarea
               id="ogDescription"
               placeholder={DEFAULT_APP_DESCRIPTION}
@@ -346,12 +347,12 @@ export default function AppearanceSettingsPage() {
               maxLength={500}
               rows={2}
             />
-            <p className="text-xs text-muted-foreground">
-              Used when sharing links to your platform.
-            </p>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="footerText">Footer Text</Label>
+          </AppearanceControlRow>
+          <AppearanceControlRow
+            id="footerText"
+            label="Footer Text"
+            description="Custom text shown in the footer alongside the version number."
+          >
             <Textarea
               id="footerText"
               placeholder="Leave empty to show version number"
@@ -360,10 +361,7 @@ export default function AppearanceSettingsPage() {
               maxLength={500}
               rows={2}
             />
-            <p className="text-xs text-muted-foreground">
-              Custom text shown in the footer alongside the version number.
-            </p>
-          </div>
+          </AppearanceControlRow>
           <ChatLinksEditor
             links={effectiveChatLinks}
             validationErrors={displayedChatLinkValidationErrors}
@@ -385,10 +383,11 @@ export default function AppearanceSettingsPage() {
               return true;
             }}
           />
-          <div className="space-y-2">
-            <Label htmlFor="chatErrorSupportMessage">
-              Support Contact Message
-            </Label>
+          <AppearanceControlRow
+            id="chatErrorSupportMessage"
+            label="Support Contact Message"
+            description="Shown alongside errors in chat. Use this to direct users to your support team."
+          >
             <Input
               id="chatErrorSupportMessage"
               placeholder="e.g. Contact support@company.com for assistance and send us the information below"
@@ -396,52 +395,37 @@ export default function AppearanceSettingsPage() {
               onChange={(e) => setChatErrorSupportMessage(e.target.value)}
               maxLength={500}
             />
-            <p className="text-xs text-muted-foreground">
-              Shown alongside errors in chat. Use this to direct users to your
-              support team.
-            </p>
-          </div>
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="slimChatErrorUi">
-                Simplified Chat Error Cards
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                Hide provider, model, stack trace, and raw error details in
-                chat. Users will only see the support message or default error
-                text plus correlation IDs.
-              </p>
-            </div>
+          </AppearanceControlRow>
+          <AppearanceControlRow
+            id="slimChatErrorUi"
+            label="Simplified Chat Error Cards"
+            description="Hide provider, model, stack trace, and raw error details in chat. Users will only see the support message or default error text plus correlation IDs."
+          >
             <Switch
               id="slimChatErrorUi"
-              className="mt-0.5"
+              className="ml-auto"
               checked={effectiveSlimChatErrorUi}
               onCheckedChange={(checked) => setSlimChatErrorUi(checked)}
             />
-          </div>
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="animateChatPlaceholders">
-                Animate Chat Placeholders
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                Show the chat placeholder text with a typing animation. Single
-                placeholder entries always stay static.
-              </p>
-            </div>
+          </AppearanceControlRow>
+          <AppearanceControlRow
+            id="animateChatPlaceholders"
+            label="Animate Chat Placeholders"
+            description="Show the chat placeholder text with a typing animation. Single placeholder entries always stay static."
+          >
             <Switch
               id="animateChatPlaceholders"
-              className="mt-0.5"
+              className="ml-auto"
               checked={effectiveAnimateChatPlaceholders}
               onCheckedChange={(checked) => setAnimateChatPlaceholders(checked)}
             />
-          </div>
+          </AppearanceControlRow>
           <ChatPlaceholdersEditor
             placeholders={effectiveChatPlaceholders}
             onChange={setChatPlaceholders}
           />
-        </CardContent>
-      </Card>
+        </div>
+      </SettingsBlock>
 
       <SiteNotificationsSection
         content={effectiveNotificationContent}
@@ -508,5 +492,27 @@ export default function AppearanceSettingsPage() {
         }
       />
     </SettingsSectionStack>
+  );
+}
+
+function AppearanceControlRow({
+  id,
+  label,
+  description,
+  children,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_20rem] sm:items-start sm:gap-8">
+      <div className="space-y-1">
+        <Label htmlFor={id}>{label}</Label>
+        <p className="text-xs leading-5 text-muted-foreground">{description}</p>
+      </div>
+      <div className="flex min-w-0 items-start">{children}</div>
+    </div>
   );
 }

--- a/platform/frontend/src/app/settings/auth/page.tsx
+++ b/platform/frontend/src/app/settings/auth/page.tsx
@@ -4,12 +4,11 @@ import type { archestraApiTypes } from "@archestra/shared";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import {
-  SettingsCardHeader,
+  SettingsBlock,
   SettingsSaveBar,
   SettingsSectionStack,
 } from "@/components/settings/settings-block";
 import { SmallTeamTierBanner } from "@/components/small-team-tier-banner";
-import { Card } from "@/components/ui/card";
 import { Form, FormField } from "@/components/ui/form";
 import { RoleSelect } from "@/components/ui/role-select";
 import { Switch } from "@/components/ui/switch";
@@ -164,56 +163,52 @@ export default function AuthSettingsPage() {
               without a license; the API refuses the writes regardless. */}
           {enterpriseCoreActive && (
             <>
-              <Card>
-                <SettingsCardHeader
-                  title="Require Two-Factor Authentication"
-                  description={
-                    isBasicAuthDisabled
-                      ? "Unavailable while email/password sign-in is disabled: enrolling in 2FA requires confirming a password, so requiring it would lock every member out. Enforce multi-factor authentication at your identity provider instead."
-                      : "Every member must enroll in 2FA. Turning this on signs out members who haven't enrolled; their next sign-in requires setup before anything else."
-                  }
-                  action={
-                    <FormField
-                      control={form.control}
-                      name="requireTwoFactor"
-                      render={({ field }) => (
-                        <Switch
-                          id="requireTwoFactor"
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                          disabled={isBasicAuthDisabled}
-                        />
-                      )}
-                    />
-                  }
-                />
-              </Card>
+              <SettingsBlock
+                title="Require Two-Factor Authentication"
+                description={
+                  isBasicAuthDisabled
+                    ? "Unavailable while email/password sign-in is disabled: enrolling in 2FA requires confirming a password, so requiring it would lock every member out. Enforce multi-factor authentication at your identity provider instead."
+                    : "Every member must enroll in 2FA. Turning this on signs out members who haven't enrolled; their next sign-in requires setup before anything else."
+                }
+                control={
+                  <FormField
+                    control={form.control}
+                    name="requireTwoFactor"
+                    render={({ field }) => (
+                      <Switch
+                        id="requireTwoFactor"
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isBasicAuthDisabled}
+                      />
+                    )}
+                  />
+                }
+              />
 
               <SessionLifetimeSection form={form} />
             </>
           )}
 
-          <Card>
-            <SettingsCardHeader
-              title="Default Role for New Users"
-              description="Role assigned to users who join via email/password self-signup or ChatOps auto-provisioning. SSO users are governed by their identity provider's role mapping."
-              action={
-                <FormField
-                  control={form.control}
-                  name="defaultMemberRole"
-                  render={({ field }) => (
-                    <RoleSelect
-                      id="defaultMemberRole"
-                      value={field.value}
-                      onValueChange={field.onChange}
-                      data-testid="default-member-role-select"
-                      className="w-40"
-                    />
-                  )}
-                />
-              }
-            />
-          </Card>
+          <SettingsBlock
+            title="Default Role for New Users"
+            description="Role assigned to users who join via email/password self-signup or ChatOps auto-provisioning. SSO users are governed by their identity provider's role mapping."
+            control={
+              <FormField
+                control={form.control}
+                name="defaultMemberRole"
+                render={({ field }) => (
+                  <RoleSelect
+                    id="defaultMemberRole"
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    data-testid="default-member-role-select"
+                    className="w-40"
+                  />
+                )}
+              />
+            }
+          />
 
           <OrganizationTokenSection />
 

--- a/platform/frontend/src/app/settings/connection/_parts/connection-settings-form.tsx
+++ b/platform/frontend/src/app/settings/connection/_parts/connection-settings-form.tsx
@@ -476,9 +476,7 @@ export function ConnectionSettingsForm() {
 // ===================================================================
 
 /**
- * One setting whose control sits beside its label. Thin wrappers over
- * {@link SettingsBlock} so this page reads as the same kind of card as every
- * other settings page, rather than the dialog it was lifted out of.
+ * One compact setting whose control sits beside its label.
  */
 function SettingRow({
   title,
@@ -494,7 +492,7 @@ function SettingRow({
   );
 }
 
-/** One setting whose control needs the full width, below the header. */
+/** One compact setting whose control needs the full width below its header. */
 function SettingSection({
   title,
   description,

--- a/platform/frontend/src/app/settings/knowledge/page.test.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.test.tsx
@@ -1040,12 +1040,12 @@ describe("KnowledgeSettingsPage", () => {
       ];
       renderPage();
 
-      const rerankingCard = screen
+      const rerankingSection = screen
         .getByText("Search Ranking Configuration")
-        .closest('[data-slot="card"]');
-      expect(rerankingCard).not.toBeNull();
+        .closest("section");
+      expect(rerankingSection).not.toBeNull();
       await user.click(
-        within(rerankingCard as HTMLElement).getByRole("button", {
+        within(rerankingSection as HTMLElement).getByRole("button", {
           name: /OpenAI Key/i,
         }),
       );
@@ -1080,12 +1080,12 @@ describe("KnowledgeSettingsPage", () => {
       ];
       renderPage();
 
-      const rerankingCard = screen
+      const rerankingSection = screen
         .getByText("Search Ranking Configuration")
-        .closest('[data-slot="card"]');
-      expect(rerankingCard).not.toBeNull();
+        .closest("section");
+      expect(rerankingSection).not.toBeNull();
       await user.click(
-        within(rerankingCard as HTMLElement).getByRole("button", {
+        within(rerankingSection as HTMLElement).getByRole("button", {
           name: /xAI Console Key/i,
         }),
       );

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -54,19 +54,12 @@ import { QueryLoadError } from "@/components/query-load-error";
 import { WithPermissions } from "@/components/roles/with-permissions";
 import { IntegrationAvailabilitySection } from "@/components/settings/integration-availability-section";
 import {
+  SettingsBlock,
   SettingsSaveBar,
   SettingsSectionStack,
 } from "@/components/settings/settings-block";
 import { SmallTeamTierBanner } from "@/components/small-team-tier-banner";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import {
   DialogBody,
   DialogForm,
@@ -1166,132 +1159,132 @@ function KnowledgeSettingsContent() {
       loadingFallback={<LoadingSpinner />}
     >
       <SettingsSectionStack>
-        <Card id="embedding-configuration">
-          <CardHeader>
-            <CardTitle>Embedding Configuration</CardTitle>
-            <CardDescription className="leading-relaxed">
+        <SettingsBlock
+          id="embedding-configuration"
+          title="Embedding Configuration"
+          description={
+            <>
               The model that turns your documents into searchable meaning. It
               decides how well a search finds passages that say what was asked
               in different words. Pick it once — changing it later means
               re-indexing everything. A key appears here once its embedding
               models are synced with dimensions set (384, 768, 1024, 1536 or
               3072).
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <WithPermissions
-              permissions={{ knowledgeSettings: ["update"] }}
-              noPermissionHandle="tooltip"
-            >
-              {({ hasPermission }) => (
-                <div className="flex flex-col gap-4">
-                  <CardRow label="Key">
-                    <ApiKeySelector
-                      value={embeddingChatApiKeyId}
-                      onChange={setEmbeddingChatApiKeyId}
-                      disabled={!hasPermission || isEmbeddingModelLocked}
-                      forEmbedding
-                      label="embedding API key"
-                      allowedKeyIds={embeddingCapableKeyIds}
-                      pulse={
-                        embeddingSetupStep === "add-key" ||
-                        embeddingSetupStep === "select-key"
-                      }
-                    />
-                  </CardRow>
-                  <CardRow label="Model">
-                    <LlmModelSearchableSelect
-                      value={embeddingModel ?? ""}
-                      onValueChange={(v) => setEmbeddingModel(v || null)}
-                      options={(embeddingModels ?? []).map((model) => ({
-                        value: model.id,
-                        model: model.displayName ?? model.id,
-                        modelId: model.id,
-                        provider: model.provider,
-                        description:
-                          model.displayName === model.id ? undefined : model.id,
-                        capabilities: model.capabilities,
-                        isFree: model.isFree,
-                        isBest: model.isBest,
-                        badge: model.embeddingDimensions
-                          ? `${model.embeddingDimensions} dims`
-                          : undefined,
-                      }))}
-                      placeholder="Select embedding model..."
-                      searchPlaceholder="Search embedding models..."
-                      emptyMessage={embeddingEmptyMessage}
-                      className={cn(
-                        "w-full",
-                        embeddingSetupStep === "select-model" &&
-                          SETUP_HIGHLIGHT_CLASS,
-                      )}
-                      popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
-                      popoverListClassName={KNOWLEDGE_MODEL_POPOVER_LIST_CLASS}
-                      popoverSide="bottom"
-                      popoverAlign="end"
-                      truncateOptionLabels={false}
-                      disabled={
-                        !hasPermission ||
-                        isEmbeddingModelLocked ||
-                        !embeddingChatApiKeyId
-                      }
-                    />
-                  </CardRow>
-                  <p className="text-sm text-muted-foreground sm:ml-auto sm:w-80">
-                    Don't see your model?{" "}
-                    <Link
-                      href="/llm/models"
-                      className="inline-flex items-center gap-0.5 text-primary underline-offset-2 hover:underline"
-                    >
-                      Sync models and configure embedding dimensions
-                      <ArrowUpRight className="h-3.5 w-3.5" />
-                    </Link>
-                  </p>
-                  {embeddingModel &&
-                    selectedEmbeddingProvider &&
-                    noticeDismissalScope && (
-                      <EmbeddingModelImageSupportNotice
-                        modelId={embeddingModel}
-                        provider={selectedEmbeddingProvider}
-                        dismissalScope={noticeDismissalScope}
-                        supportsImages={
-                          selectedEmbeddingCatalogModel
-                            ? embeddingModelSupportsImages(
-                                selectedEmbeddingCatalogModel,
-                              )
-                            : null
-                        }
-                        showSettingsLink={false}
-                        className="sm:ml-auto sm:w-80"
-                      />
-                    )}
-                  {selectedEmbeddingProvider === "gemini" &&
-                    selectedEmbeddingModel?.embeddingDimensions === 1536 && (
-                      <p className="flex items-start gap-2 text-xs text-muted-foreground sm:ml-auto sm:w-80">
-                        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                        <span>
-                          Gemini will truncate from its native 3072 dimensions
-                          via outputDimensionality.
-                        </span>
-                      </p>
-                    )}
-                  {embeddingStatus.status === "failed" &&
-                    embeddingStatus.error && (
-                      <p className="flex items-start gap-2 text-sm text-destructive sm:ml-auto sm:w-80">
-                        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                        <span>{embeddingStatus.error}</span>
-                      </p>
-                    )}
-                  <DropEmbeddingConfigDialog
-                    open={showDropDialog}
-                    onOpenChange={setShowDropDialog}
+            </>
+          }
+        >
+          <WithPermissions
+            permissions={{ knowledgeSettings: ["update"] }}
+            noPermissionHandle="tooltip"
+          >
+            {({ hasPermission }) => (
+              <div className="flex flex-col gap-4">
+                <CardRow label="Key">
+                  <ApiKeySelector
+                    value={embeddingChatApiKeyId}
+                    onChange={setEmbeddingChatApiKeyId}
+                    disabled={!hasPermission || isEmbeddingModelLocked}
+                    forEmbedding
+                    label="embedding API key"
+                    allowedKeyIds={embeddingCapableKeyIds}
+                    pulse={
+                      embeddingSetupStep === "add-key" ||
+                      embeddingSetupStep === "select-key"
+                    }
                   />
-                </div>
-              )}
-            </WithPermissions>
-          </CardContent>
+                </CardRow>
+                <CardRow label="Model">
+                  <LlmModelSearchableSelect
+                    value={embeddingModel ?? ""}
+                    onValueChange={(v) => setEmbeddingModel(v || null)}
+                    options={(embeddingModels ?? []).map((model) => ({
+                      value: model.id,
+                      model: model.displayName ?? model.id,
+                      modelId: model.id,
+                      provider: model.provider,
+                      description:
+                        model.displayName === model.id ? undefined : model.id,
+                      capabilities: model.capabilities,
+                      isFree: model.isFree,
+                      isBest: model.isBest,
+                      badge: model.embeddingDimensions
+                        ? `${model.embeddingDimensions} dims`
+                        : undefined,
+                    }))}
+                    placeholder="Select embedding model..."
+                    searchPlaceholder="Search embedding models..."
+                    emptyMessage={embeddingEmptyMessage}
+                    className={cn(
+                      "w-full",
+                      embeddingSetupStep === "select-model" &&
+                        SETUP_HIGHLIGHT_CLASS,
+                    )}
+                    popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
+                    popoverListClassName={KNOWLEDGE_MODEL_POPOVER_LIST_CLASS}
+                    popoverSide="bottom"
+                    popoverAlign="end"
+                    truncateOptionLabels={false}
+                    disabled={
+                      !hasPermission ||
+                      isEmbeddingModelLocked ||
+                      !embeddingChatApiKeyId
+                    }
+                  />
+                </CardRow>
+                <p className="text-sm text-muted-foreground sm:ml-auto sm:w-80">
+                  Don't see your model?{" "}
+                  <Link
+                    href="/llm/models"
+                    className="inline-flex items-center gap-0.5 text-primary underline-offset-2 hover:underline"
+                  >
+                    Sync models and configure embedding dimensions
+                    <ArrowUpRight className="h-3.5 w-3.5" />
+                  </Link>
+                </p>
+                {embeddingModel &&
+                  selectedEmbeddingProvider &&
+                  noticeDismissalScope && (
+                    <EmbeddingModelImageSupportNotice
+                      modelId={embeddingModel}
+                      provider={selectedEmbeddingProvider}
+                      dismissalScope={noticeDismissalScope}
+                      supportsImages={
+                        selectedEmbeddingCatalogModel
+                          ? embeddingModelSupportsImages(
+                              selectedEmbeddingCatalogModel,
+                            )
+                          : null
+                      }
+                      showSettingsLink={false}
+                      className="sm:ml-auto sm:w-80"
+                    />
+                  )}
+                {selectedEmbeddingProvider === "gemini" &&
+                  selectedEmbeddingModel?.embeddingDimensions === 1536 && (
+                    <p className="flex items-start gap-2 text-xs text-muted-foreground sm:ml-auto sm:w-80">
+                      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <span>
+                        Gemini will truncate from its native 3072 dimensions via
+                        outputDimensionality.
+                      </span>
+                    </p>
+                  )}
+                {embeddingStatus.status === "failed" &&
+                  embeddingStatus.error && (
+                    <p className="flex items-start gap-2 text-sm text-destructive sm:ml-auto sm:w-80">
+                      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                      <span>{embeddingStatus.error}</span>
+                    </p>
+                  )}
+                <DropEmbeddingConfigDialog
+                  open={showDropDialog}
+                  onOpenChange={setShowDropDialog}
+                />
+              </div>
+            )}
+          </WithPermissions>
           {showEmbeddingFooter && (
-            <CardFooter className="-mb-6 mt-2 flex flex-col gap-3 rounded-b-xl border-t bg-muted/30 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="mt-5 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
               {isEmbeddingModelLocked ? (
                 <p className="flex items-start gap-2 text-sm text-muted-foreground">
                   <Lock className="mt-0.5 h-4 w-4 shrink-0" />
@@ -1338,22 +1331,24 @@ function KnowledgeSettingsContent() {
                   </div>
                 )}
               </WithPermissions>
-            </CardFooter>
+            </div>
           )}
-        </Card>
+        </SettingsBlock>
 
-        <Card id="search-ranking-configuration">
-          <CardHeader>
-            <CardTitle>Search Ranking Configuration</CardTitle>
-            <CardDescription>
+        <SettingsBlock
+          id="search-ranking-configuration"
+          title="Search Ranking Configuration"
+          description={
+            <>
               Orders the passages a search has found. Keyword ranking scores
               them by the words they share with the question and builds the
               shortlist; reranking reads that shortlist and puts the passages
               that answer the question first. Changes apply to the next search —
               nothing is re-indexed.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-6">
+            </>
+          }
+        >
+          <div className="flex flex-col gap-6">
             <section id="keyword-ranking" className="flex flex-col gap-3">
               <div className="space-y-1">
                 <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
@@ -1579,9 +1574,9 @@ function KnowledgeSettingsContent() {
                   </p>
                 )}
             </section>
-          </CardContent>
+          </div>
           {(rerankerChatApiKeyId || rerankerModel) && (
-            <CardFooter className="-mb-6 mt-2 flex flex-col gap-3 rounded-b-xl border-t bg-muted/30 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="mt-5 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
               <span />
               <WithPermissions
                 permissions={{ knowledgeSettings: ["update"] }}
@@ -1619,78 +1614,77 @@ function KnowledgeSettingsContent() {
                   </div>
                 )}
               </WithPermissions>
-            </CardFooter>
+            </div>
           )}
-        </Card>
+        </SettingsBlock>
 
-        <Card id="document-ocr">
-          <CardHeader>
-            <CardTitle>Document OCR</CardTitle>
-            <CardDescription>
+        <SettingsBlock
+          id="document-ocr"
+          title="Document OCR"
+          description={
+            <>
               Reads the text in scanned or image-only PDF pages — a signed
               contract that was scanned, for example — so those documents show
               up in search like any other. Without it, such pages are skipped.
               Each transcribed page is one metered model call, visible in LLM
               cost statistics. Optional.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <WithPermissions
-              permissions={{ knowledgeSettings: ["update"] }}
-              noPermissionHandle="tooltip"
-            >
-              {({ hasPermission }) => (
-                <div className="flex flex-col gap-4">
-                  <CardRow label="Key">
-                    <ApiKeySelector
-                      value={ocrChatApiKeyId}
-                      onChange={handleOcrKeyChange}
-                      disabled={!hasPermission}
-                      label="OCR API key"
-                      allowedKeyIds={ocrCapableKeyIds}
-                      autoSelectFirstKey={false}
-                    />
-                  </CardRow>
-                  <CardRow label="Model">
-                    <OcrModelSelector
-                      value={ocrModel}
-                      onChange={setOcrModel}
-                      disabled={!hasPermission}
-                      selectedKeyId={ocrChatApiKeyId}
-                    />
-                  </CardRow>
-                  <p className="text-sm text-muted-foreground sm:ml-auto sm:w-80">
-                    Don't see your model?{" "}
-                    <Link
-                      href="/llm/models"
-                      className="inline-flex items-center gap-0.5 text-primary underline-offset-2 hover:underline"
-                    >
-                      Mark its image or PDF input modality
-                      <ArrowUpRight className="h-3.5 w-3.5" />
-                    </Link>
+            </>
+          }
+        >
+          <WithPermissions
+            permissions={{ knowledgeSettings: ["update"] }}
+            noPermissionHandle="tooltip"
+          >
+            {({ hasPermission }) => (
+              <div className="flex flex-col gap-4">
+                <CardRow label="Key">
+                  <ApiKeySelector
+                    value={ocrChatApiKeyId}
+                    onChange={handleOcrKeyChange}
+                    disabled={!hasPermission}
+                    label="OCR API key"
+                    allowedKeyIds={ocrCapableKeyIds}
+                    autoSelectFirstKey={false}
+                  />
+                </CardRow>
+                <CardRow label="Model">
+                  <OcrModelSelector
+                    value={ocrModel}
+                    onChange={setOcrModel}
+                    disabled={!hasPermission}
+                    selectedKeyId={ocrChatApiKeyId}
+                  />
+                </CardRow>
+                <p className="text-sm text-muted-foreground sm:ml-auto sm:w-80">
+                  Don't see your model?{" "}
+                  <Link
+                    href="/llm/models"
+                    className="inline-flex items-center gap-0.5 text-primary underline-offset-2 hover:underline"
+                  >
+                    Mark its image or PDF input modality
+                    <ArrowUpRight className="h-3.5 w-3.5" />
+                  </Link>
+                </p>
+                {ocrConfigured && !ocrWasEnabled && (
+                  <p className="flex items-start gap-2 text-xs text-muted-foreground sm:ml-auto sm:w-80">
+                    <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span>
+                      Saving triggers a full re-sync of every connector so
+                      documents previously skipped as unreadable are picked up.
+                    </span>
                   </p>
-                  {ocrConfigured && !ocrWasEnabled && (
-                    <p className="flex items-start gap-2 text-xs text-muted-foreground sm:ml-auto sm:w-80">
-                      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                      <span>
-                        Saving triggers a full re-sync of every connector so
-                        documents previously skipped as unreadable are picked
-                        up.
-                      </span>
-                    </p>
-                  )}
-                  {ocrStatus.status === "failed" && ocrStatus.error && (
-                    <p className="flex items-start gap-2 text-sm text-destructive sm:ml-auto sm:w-80">
-                      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                      <span>{ocrStatus.error}</span>
-                    </p>
-                  )}
-                </div>
-              )}
-            </WithPermissions>
-          </CardContent>
+                )}
+                {ocrStatus.status === "failed" && ocrStatus.error && (
+                  <p className="flex items-start gap-2 text-sm text-destructive sm:ml-auto sm:w-80">
+                    <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>{ocrStatus.error}</span>
+                  </p>
+                )}
+              </div>
+            )}
+          </WithPermissions>
           {(ocrChatApiKeyId || ocrModel) && (
-            <CardFooter className="-mb-6 mt-2 flex flex-col gap-3 rounded-b-xl border-t bg-muted/30 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="mt-5 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
               <span />
               <WithPermissions
                 permissions={{ knowledgeSettings: ["update"] }}
@@ -1728,9 +1722,9 @@ function KnowledgeSettingsContent() {
                   </div>
                 )}
               </WithPermissions>
-            </CardFooter>
+            </div>
           )}
-        </Card>
+        </SettingsBlock>
 
         <SettingsSaveBar
           hasChanges={hasChanges}

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -1340,15 +1340,78 @@ function KnowledgeSettingsContent() {
           title="Search Ranking Configuration"
           description={
             <>
-              Orders the passages a search has found. Keyword ranking scores
-              them by the words they share with the question and builds the
-              shortlist; reranking reads that shortlist and puts the passages
-              that answer the question first. Changes apply to the next search —
-              nothing is re-indexed.
+              Orders the passages a search has found. Reranking reads the
+              shortlist and puts the passages that answer the question first;
+              keyword ranking scores them by the words they share with the
+              question. Changes apply to the next search — nothing is
+              re-indexed.
             </>
           }
         >
           <div className="flex flex-col gap-6">
+            <section
+              id="reranking-configuration"
+              className="flex flex-col gap-3"
+            >
+              <div className="space-y-1">
+                <h4 className="text-sm font-medium">Reranking</h4>
+                <p className="text-sm text-muted-foreground">
+                  Reads the shortlisted passages with a model and puts the ones
+                  that answer the question first. Works with any chat model, or
+                  a Cohere Rerank model on Cohere and Azure AI Foundry keys.
+                  Optional.{" "}
+                  <ExternalDocsLink
+                    href={getDocsUrl(DocsPage.PlatformKnowledge, "reranking")}
+                    className="text-primary hover:underline"
+                    showIcon={false}
+                  >
+                    Learn more.
+                  </ExternalDocsLink>
+                </p>
+              </div>
+              <WithPermissions
+                permissions={{ knowledgeSettings: ["update"] }}
+                noPermissionHandle="tooltip"
+              >
+                {({ hasPermission }) => (
+                  <div className="flex flex-col gap-4">
+                    <CardRow label="Key">
+                      <ApiKeySelector
+                        value={rerankerChatApiKeyId}
+                        onChange={handleRerankerKeyChange}
+                        disabled={!hasPermission}
+                        label="reranker API key"
+                        pulse={
+                          !embeddingSetupStep &&
+                          (rerankerSetupStep === "add-key" ||
+                            rerankerSetupStep === "select-key")
+                        }
+                      />
+                    </CardRow>
+                    <CardRow label="Model">
+                      <RerankerModelSelector
+                        value={rerankerModel}
+                        onChange={setRerankerModel}
+                        disabled={!hasPermission}
+                        selectedKeyId={rerankerChatApiKeyId}
+                        pulse={
+                          !embeddingSetupStep &&
+                          rerankerSetupStep === "select-model"
+                        }
+                      />
+                    </CardRow>
+                    {rerankerStatus.status === "failed" &&
+                      rerankerStatus.error && (
+                        <p className="flex items-start gap-2 text-sm text-destructive sm:ml-auto sm:w-80">
+                          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                          <span>{rerankerStatus.error}</span>
+                        </p>
+                      )}
+                  </div>
+                )}
+              </WithPermissions>
+            </section>
+            <Separator />
             <section id="keyword-ranking" className="flex flex-col gap-3">
               <div className="space-y-1">
                 <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
@@ -1440,69 +1503,6 @@ function KnowledgeSettingsContent() {
                         </p>
                       )}
                     </CardRow>
-                  </div>
-                )}
-              </WithPermissions>
-            </section>
-            <Separator />
-            <section
-              id="reranking-configuration"
-              className="flex flex-col gap-3"
-            >
-              <div className="space-y-1">
-                <h4 className="text-sm font-medium">Reranking</h4>
-                <p className="text-sm text-muted-foreground">
-                  Reads the shortlisted passages with a model and puts the ones
-                  that answer the question first. Works with any chat model, or
-                  a Cohere Rerank model on Cohere and Azure AI Foundry keys.
-                  Optional.{" "}
-                  <ExternalDocsLink
-                    href={getDocsUrl(DocsPage.PlatformKnowledge, "reranking")}
-                    className="text-primary hover:underline"
-                    showIcon={false}
-                  >
-                    Learn more.
-                  </ExternalDocsLink>
-                </p>
-              </div>
-              <WithPermissions
-                permissions={{ knowledgeSettings: ["update"] }}
-                noPermissionHandle="tooltip"
-              >
-                {({ hasPermission }) => (
-                  <div className="flex flex-col gap-4">
-                    <CardRow label="Key">
-                      <ApiKeySelector
-                        value={rerankerChatApiKeyId}
-                        onChange={handleRerankerKeyChange}
-                        disabled={!hasPermission}
-                        label="reranker API key"
-                        pulse={
-                          !embeddingSetupStep &&
-                          (rerankerSetupStep === "add-key" ||
-                            rerankerSetupStep === "select-key")
-                        }
-                      />
-                    </CardRow>
-                    <CardRow label="Model">
-                      <RerankerModelSelector
-                        value={rerankerModel}
-                        onChange={setRerankerModel}
-                        disabled={!hasPermission}
-                        selectedKeyId={rerankerChatApiKeyId}
-                        pulse={
-                          !embeddingSetupStep &&
-                          rerankerSetupStep === "select-model"
-                        }
-                      />
-                    </CardRow>
-                    {rerankerStatus.status === "failed" &&
-                      rerankerStatus.error && (
-                        <p className="flex items-start gap-2 text-sm text-destructive sm:ml-auto sm:w-80">
-                          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                          <span>{rerankerStatus.error}</span>
-                        </p>
-                      )}
                   </div>
                 )}
               </WithPermissions>

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -154,11 +154,9 @@ function CardRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-      <Label className="shrink-0 text-sm text-muted-foreground sm:w-40">
-        {label}
-      </Label>
-      <div className="min-w-0 flex-1">{children}</div>
+    <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_20rem] sm:items-center sm:gap-8">
+      <Label className="text-sm text-muted-foreground">{label}</Label>
+      <div className="min-w-0">{children}</div>
     </div>
   );
 }
@@ -1239,7 +1237,7 @@ function KnowledgeSettingsContent() {
                       }
                     />
                   </CardRow>
-                  <p className="text-sm text-muted-foreground sm:pl-44">
+                  <p className="text-sm text-muted-foreground sm:ml-auto sm:w-80">
                     Don't see your model?{" "}
                     <Link
                       href="/llm/models"
@@ -1264,12 +1262,12 @@ function KnowledgeSettingsContent() {
                             : null
                         }
                         showSettingsLink={false}
-                        className="sm:ml-44"
+                        className="sm:ml-auto sm:w-80"
                       />
                     )}
                   {selectedEmbeddingProvider === "gemini" &&
                     selectedEmbeddingModel?.embeddingDimensions === 1536 && (
-                      <p className="flex items-start gap-2 text-xs text-muted-foreground sm:pl-44">
+                      <p className="flex items-start gap-2 text-xs text-muted-foreground sm:ml-auto sm:w-80">
                         <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>
                           Gemini will truncate from its native 3072 dimensions
@@ -1279,7 +1277,7 @@ function KnowledgeSettingsContent() {
                     )}
                   {embeddingStatus.status === "failed" &&
                     embeddingStatus.error && (
-                      <p className="flex items-start gap-2 text-sm text-destructive sm:pl-44">
+                      <p className="flex items-start gap-2 text-sm text-destructive sm:ml-auto sm:w-80">
                         <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
                         <span>{embeddingStatus.error}</span>
                       </p>
@@ -1348,77 +1346,14 @@ function KnowledgeSettingsContent() {
           <CardHeader>
             <CardTitle>Search Ranking Configuration</CardTitle>
             <CardDescription>
-              Orders the passages a search has found. Reranking reads the
-              shortlist and puts the passages that answer the question first;
-              keyword ranking scores them by the words they share with the
-              question. Changes apply to the next search — nothing is
-              re-indexed.
+              Orders the passages a search has found. Keyword ranking scores
+              them by the words they share with the question and builds the
+              shortlist; reranking reads that shortlist and puts the passages
+              that answer the question first. Changes apply to the next search —
+              nothing is re-indexed.
             </CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col gap-6">
-            <section
-              id="reranking-configuration"
-              className="flex flex-col gap-3"
-            >
-              <div className="space-y-1">
-                <h4 className="text-sm font-medium">Reranking</h4>
-                <p className="text-sm text-muted-foreground">
-                  Reads the shortlisted passages with a model and puts the ones
-                  that answer the question first. Works with any chat model, or
-                  a Cohere Rerank model on Cohere and Azure AI Foundry keys.
-                  Optional.{" "}
-                  <ExternalDocsLink
-                    href={getDocsUrl(DocsPage.PlatformKnowledge, "reranking")}
-                    className="text-primary hover:underline"
-                    showIcon={false}
-                  >
-                    Learn more.
-                  </ExternalDocsLink>
-                </p>
-              </div>
-              <WithPermissions
-                permissions={{ knowledgeSettings: ["update"] }}
-                noPermissionHandle="tooltip"
-              >
-                {({ hasPermission }) => (
-                  <div className="flex flex-col gap-4">
-                    <CardRow label="Key">
-                      <ApiKeySelector
-                        value={rerankerChatApiKeyId}
-                        onChange={handleRerankerKeyChange}
-                        disabled={!hasPermission}
-                        label="reranker API key"
-                        pulse={
-                          !embeddingSetupStep &&
-                          (rerankerSetupStep === "add-key" ||
-                            rerankerSetupStep === "select-key")
-                        }
-                      />
-                    </CardRow>
-                    <CardRow label="Model">
-                      <RerankerModelSelector
-                        value={rerankerModel}
-                        onChange={setRerankerModel}
-                        disabled={!hasPermission}
-                        selectedKeyId={rerankerChatApiKeyId}
-                        pulse={
-                          !embeddingSetupStep &&
-                          rerankerSetupStep === "select-model"
-                        }
-                      />
-                    </CardRow>
-                    {rerankerStatus.status === "failed" &&
-                      rerankerStatus.error && (
-                        <p className="flex items-start gap-2 text-sm text-destructive sm:pl-44">
-                          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                          <span>{rerankerStatus.error}</span>
-                        </p>
-                      )}
-                  </div>
-                )}
-              </WithPermissions>
-            </section>
-            <Separator />
             <section id="keyword-ranking" className="flex flex-col gap-3">
               <div className="space-y-1">
                 <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
@@ -1510,6 +1445,69 @@ function KnowledgeSettingsContent() {
                         </p>
                       )}
                     </CardRow>
+                  </div>
+                )}
+              </WithPermissions>
+            </section>
+            <Separator />
+            <section
+              id="reranking-configuration"
+              className="flex flex-col gap-3"
+            >
+              <div className="space-y-1">
+                <h4 className="text-sm font-medium">Reranking</h4>
+                <p className="text-sm text-muted-foreground">
+                  Reads the shortlisted passages with a model and puts the ones
+                  that answer the question first. Works with any chat model, or
+                  a Cohere Rerank model on Cohere and Azure AI Foundry keys.
+                  Optional.{" "}
+                  <ExternalDocsLink
+                    href={getDocsUrl(DocsPage.PlatformKnowledge, "reranking")}
+                    className="text-primary hover:underline"
+                    showIcon={false}
+                  >
+                    Learn more.
+                  </ExternalDocsLink>
+                </p>
+              </div>
+              <WithPermissions
+                permissions={{ knowledgeSettings: ["update"] }}
+                noPermissionHandle="tooltip"
+              >
+                {({ hasPermission }) => (
+                  <div className="flex flex-col gap-4">
+                    <CardRow label="Key">
+                      <ApiKeySelector
+                        value={rerankerChatApiKeyId}
+                        onChange={handleRerankerKeyChange}
+                        disabled={!hasPermission}
+                        label="reranker API key"
+                        pulse={
+                          !embeddingSetupStep &&
+                          (rerankerSetupStep === "add-key" ||
+                            rerankerSetupStep === "select-key")
+                        }
+                      />
+                    </CardRow>
+                    <CardRow label="Model">
+                      <RerankerModelSelector
+                        value={rerankerModel}
+                        onChange={setRerankerModel}
+                        disabled={!hasPermission}
+                        selectedKeyId={rerankerChatApiKeyId}
+                        pulse={
+                          !embeddingSetupStep &&
+                          rerankerSetupStep === "select-model"
+                        }
+                      />
+                    </CardRow>
+                    {rerankerStatus.status === "failed" &&
+                      rerankerStatus.error && (
+                        <p className="flex items-start gap-2 text-sm text-destructive sm:ml-auto sm:w-80">
+                          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                          <span>{rerankerStatus.error}</span>
+                        </p>
+                      )}
                   </div>
                 )}
               </WithPermissions>
@@ -1661,7 +1659,7 @@ function KnowledgeSettingsContent() {
                       selectedKeyId={ocrChatApiKeyId}
                     />
                   </CardRow>
-                  <p className="text-sm text-muted-foreground sm:pl-44">
+                  <p className="text-sm text-muted-foreground sm:ml-auto sm:w-80">
                     Don't see your model?{" "}
                     <Link
                       href="/llm/models"
@@ -1672,7 +1670,7 @@ function KnowledgeSettingsContent() {
                     </Link>
                   </p>
                   {ocrConfigured && !ocrWasEnabled && (
-                    <p className="flex items-start gap-2 text-xs text-muted-foreground sm:pl-44">
+                    <p className="flex items-start gap-2 text-xs text-muted-foreground sm:ml-auto sm:w-80">
                       <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                       <span>
                         Saving triggers a full re-sync of every connector so
@@ -1682,7 +1680,7 @@ function KnowledgeSettingsContent() {
                     </p>
                   )}
                   {ocrStatus.status === "failed" && ocrStatus.error && (
-                    <p className="flex items-start gap-2 text-sm text-destructive sm:pl-44">
+                    <p className="flex items-start gap-2 text-sm text-destructive sm:ml-auto sm:w-80">
                       <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
                       <span>{ocrStatus.error}</span>
                     </p>

--- a/platform/frontend/src/app/settings/mcp/page.test.tsx
+++ b/platform/frontend/src/app/settings/mcp/page.test.tsx
@@ -106,9 +106,11 @@ function renderPage() {
 
 /** The select belonging to one settings block, scoped by the block's title. */
 function blockSelect(title: string) {
-  const card = screen.getByText(title).closest('[data-slot="card"]');
-  if (!card) throw new Error(`No settings block titled "${title}"`);
-  return within(card as HTMLElement).getByRole("combobox");
+  const section = screen
+    .getByRole("heading", { name: title })
+    .closest("section");
+  if (!section) throw new Error(`No settings block titled "${title}"`);
+  return within(section).getByRole("combobox");
 }
 
 describe("McpSettingsPage", () => {

--- a/platform/frontend/src/app/settings/secrets/page.tsx
+++ b/platform/frontend/src/app/settings/secrets/page.tsx
@@ -4,11 +4,10 @@ import { RefreshCw, Server } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { useSetSettingsAction } from "@/app/settings/layout";
 import {
-  SettingsCardHeader,
+  SettingsBlock,
   SettingsSectionStack,
 } from "@/components/settings/settings-block";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Card, CardContent } from "@/components/ui/card";
 import { PermissionButton } from "@/components/ui/permission-button";
 import {
   useCheckSecretsConnectivity,
@@ -66,16 +65,15 @@ export default function SecretsSettingsPage() {
 
   return (
     <SettingsSectionStack>
-      <Card>
-        <SettingsCardHeader
-          title={
-            <span className="flex items-center gap-2">
-              <Server className="h-5 w-5" />
-              Secrets Storage
-            </span>
-          }
-        />
-        <CardContent className="space-y-4">
+      <SettingsBlock
+        title={
+          <span className="flex items-center gap-2">
+            <Server className="h-4 w-4" />
+            Secrets Storage
+          </span>
+        }
+      >
+        <div className="space-y-4">
           <div className="text-sm font-mono bg-muted p-3 rounded space-y-1">
             {Object.entries(secretsType.meta).map(([key, value]) => (
               <p key={key}>
@@ -107,8 +105,8 @@ export default function SecretsSettingsPage() {
                 </AlertDescription>
               </Alert>
             )}
-        </CardContent>
-      </Card>
+        </div>
+      </SettingsBlock>
     </SettingsSectionStack>
   );
 }

--- a/platform/frontend/src/app/settings/service-accounts/page.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/page.tsx
@@ -134,10 +134,12 @@ export default function ServiceAccountsSettingsPage() {
       {
         accessorKey: "name",
         header: "Account",
+        size: 240,
         cell: ({ row }) => (
           <Link
-            className="font-medium hover:underline"
+            className="block truncate font-medium hover:underline"
             href={`/settings/service-accounts/${row.original.id}`}
+            title={row.original.name}
           >
             {row.original.name}
           </Link>
@@ -146,6 +148,7 @@ export default function ServiceAccountsSettingsPage() {
       {
         accessorKey: "role",
         header: "Role",
+        size: 120,
         cell: ({ row }) => (
           <Badge variant="secondary">{formatRoleName(row.original.role)}</Badge>
         ),
@@ -153,11 +156,13 @@ export default function ServiceAccountsSettingsPage() {
       {
         accessorKey: "tokenCount",
         header: "API keys",
+        size: 90,
         cell: ({ row }) => row.original.tokenCount,
       },
       {
         accessorKey: "disabled",
         header: "Status",
+        size: 100,
         cell: ({ row }) =>
           row.original.disabled ? (
             <Badge variant="outline">Disabled</Badge>
@@ -168,6 +173,7 @@ export default function ServiceAccountsSettingsPage() {
       {
         accessorKey: "createdAt",
         header: "Created",
+        size: 130,
         cell: ({ row }) => formatRelativeTimeFromNow(row.original.createdAt),
       },
     ];
@@ -181,6 +187,7 @@ export default function ServiceAccountsSettingsPage() {
       {
         id: "actions",
         header: "Actions",
+        size: 130,
         cell: ({ row }) => (
           <TableRowActions
             itemName={row.original.name}
@@ -250,9 +257,8 @@ export default function ServiceAccountsSettingsPage() {
           isPending={isPending}
           loadingFallback={<LoadingSpinner />}
         >
-          <div className="space-y-4">
+          <div>
             <FilterBar
-              className="mb-0"
               onClearFilters={
                 search
                   ? () => updateQueryParams({ search: null, page: "1" })
@@ -309,6 +315,15 @@ export default function ServiceAccountsSettingsPage() {
                   onClearFilters={() =>
                     updateQueryParams({ search: null, page: "1" })
                   }
+                  hidePaginationWhenSinglePage
+                  fixedWidthColumnIds={[
+                    "role",
+                    "tokenCount",
+                    "disabled",
+                    "createdAt",
+                    "actions",
+                  ]}
+                  flexibleColumnIds={["name"]}
                 />
               </>
             )}

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -380,6 +380,7 @@ function MembersTab({
       rowLabel: (row) => `Select ${row.email}`,
       allLabel: "Select all users on this page",
       canSelect: (row) => !isSelf(row),
+      disabledReason: () => "You cannot remove your own account",
     }),
     {
       id: "avatar",

--- a/platform/frontend/src/components/roles/roles-list.ee.tsx
+++ b/platform/frontend/src/components/roles/roles-list.ee.tsx
@@ -308,6 +308,7 @@ export function RolesList({ headerAction }: { headerAction?: ReactNode }) {
       // Predefined roles are immutable — there is nothing a bulk action could
       // do to them.
       canSelect: (role) => !role.predefined,
+      disabledReason: () => "Predefined roles cannot be deleted",
     }),
     {
       id: "icon",

--- a/platform/frontend/src/components/settings/api-keys-card.tsx
+++ b/platform/frontend/src/components/settings/api-keys-card.tsx
@@ -137,22 +137,37 @@ function ApiKeysCardContent() {
       {
         accessorKey: "name",
         header: "Name",
-        cell: ({ row }) => row.original.name || "Untitled key",
+        size: 160,
+        cell: ({ row }) => {
+          const name = row.original.name || "Untitled key";
+          return (
+            <span className="block truncate" title={name}>
+              {name}
+            </span>
+          );
+        },
       },
       {
         accessorKey: "start",
         header: "Key",
-        cell: ({ row }) => (
-          <code className="text-xs font-mono">
-            {row.original.start || row.original.prefix
-              ? `${row.original.start || row.original.prefix}...`
-              : "Hidden"}
-          </code>
-        ),
+        size: 130,
+        cell: ({ row }) => {
+          const keyPrefix = row.original.start || row.original.prefix;
+          const displayValue = keyPrefix ? `${keyPrefix}...` : "Hidden";
+          return (
+            <code
+              className="block truncate font-mono text-xs"
+              title={displayValue}
+            >
+              {displayValue}
+            </code>
+          );
+        },
       },
       {
         accessorKey: "enabled",
         header: "Status",
+        size: 90,
         cell: ({ row }) =>
           row.original.enabled ? (
             <Badge variant="secondary">Active</Badge>
@@ -163,16 +178,19 @@ function ApiKeysCardContent() {
       {
         accessorKey: "createdAt",
         header: "Created",
+        size: 130,
         cell: ({ row }) => formatRelativeTimeFromNow(row.original.createdAt),
       },
       {
         accessorKey: "lastRequest",
         header: "Last used",
+        size: 110,
         cell: ({ row }) => formatRelativeTimeFromNow(row.original.lastRequest),
       },
       {
         accessorKey: "expiresAt",
         header: "Expires",
+        size: 100,
         cell: ({ row }) => formatRelativeTime(row.original.expiresAt),
       },
     ];
@@ -186,6 +204,7 @@ function ApiKeysCardContent() {
       {
         id: "actions",
         header: "Actions",
+        size: 80,
         cell: ({ row }) => (
           <TableRowActions
             actions={[
@@ -299,9 +318,8 @@ function ApiKeysCardContent() {
           isPending={isPending}
           loadingFallback={<LoadingSpinner />}
         >
-          <div className="space-y-4">
+          <div>
             <FilterBar
-              className="mb-0"
               onClearFilters={
                 search
                   ? () => updateQueryParams({ search: null, page: "1" })
@@ -366,6 +384,16 @@ function ApiKeysCardContent() {
                   onClearFilters={() =>
                     updateQueryParams({ search: null, page: "1" })
                   }
+                  hidePaginationWhenSinglePage
+                  fixedWidthColumnIds={[
+                    "start",
+                    "enabled",
+                    "createdAt",
+                    "lastRequest",
+                    "expiresAt",
+                    "actions",
+                  ]}
+                  flexibleColumnIds={["name"]}
                 />
               </>
             )}

--- a/platform/frontend/src/components/settings/api-keys-card.tsx
+++ b/platform/frontend/src/components/settings/api-keys-card.tsx
@@ -6,6 +6,7 @@ import { KeyRound, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
+import { AccountPageAction } from "@/app/account/_components/account-page-action";
 import { CopyButton } from "@/components/copy-button";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { ExpirationDateTimeField } from "@/components/expiration-date-time-field";
@@ -16,13 +17,11 @@ import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { QueryLoadError } from "@/components/query-load-error";
 import { WithPermissions } from "@/components/roles/with-permissions";
 import { SearchInput } from "@/components/search-input";
-import { SettingsCardHeader } from "@/components/settings/settings-block";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Badge } from "@/components/ui/badge";
 import { BulkActionsBar } from "@/components/ui/bulk-actions-bar";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { DataTable } from "@/components/ui/data-table";
 import { DialogForm, DialogStickyFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -253,129 +252,126 @@ function ApiKeysCardContent() {
 
   return (
     <>
-      <Card>
-        <SettingsCardHeader
-          title="API Keys"
-          description={
-            <>
-              Keys that let scripts and integrations call the{" "}
-              {apiDocsUrl ? (
-                <ExternalDocsLink
-                  href={apiDocsUrl}
-                  className="text-inherit underline underline-offset-4"
-                  showIcon={false}
-                >
-                  platform API
-                </ExternalDocsLink>
-              ) : (
-                "platform API"
-              )}{" "}
-              as you.
-              <WithPermissions
-                permissions={{ serviceAccount: ["read"] }}
-                noPermissionHandle="hide"
-              >
-                {" "}
-                For automation not tied to your user, use{" "}
-                <Link
-                  href="/settings/service-accounts"
-                  className="underline underline-offset-4"
-                >
-                  Service Accounts
-                </Link>
-                .
-              </WithPermissions>
-            </>
-          }
-          action={
-            <PermissionButton
-              permissions={{ apiKey: ["create"] }}
-              onClick={() => setIsCreateDialogOpen(true)}
-            >
-              <Plus className="h-4 w-4" />
-              Create API Key
-            </PermissionButton>
-          }
-        />
-        <CardContent>
-          <LoadingWrapper
-            isPending={isPending}
-            loadingFallback={<LoadingSpinner />}
-          >
-            <div className="space-y-4">
-              <FilterBar
-                className="mb-0"
-                onClearFilters={
-                  search
-                    ? () => updateQueryParams({ search: null, page: "1" })
-                    : undefined
-                }
-              >
-                <SearchInput
-                  objectNamePlural="API keys"
-                  searchFields={["key name"]}
-                  className={filterSearchClass}
-                />
-              </FilterBar>
-              {isApiKeysLoadError ? (
-                <QueryLoadError
-                  title="Couldn't load your API keys"
-                  onRetry={() => refetchApiKeys()}
-                />
-              ) : (
-                <>
-                  <BulkActionsBar
-                    count={selectedApiKeys.length}
-                    noun="API key"
-                    onClear={clearSelection}
-                    busy={bulkDelete.isPending}
-                    selectAllMatching={selectAllMatching}
-                    className="mb-3"
-                  >
-                    <PermissionButton
-                      permissions={{ apiKey: ["delete"] }}
-                      variant="destructive"
-                      size="sm"
-                      onClick={() =>
-                        bulkDelete.mutate(selectedApiKeys, {
-                          onSuccess: (outcome) => {
-                            reportBulkOutcome({
-                              outcome,
-                              verb: "Deleted",
-                              failureVerb: "delete",
-                              noun: "API key",
-                            });
-                            if (outcome.failed.length === 0) clearSelection();
-                          },
-                        })
-                      }
-                    >
-                      <Trash2 className="h-4 w-4" />
-                      <span>Delete</span>
-                    </PermissionButton>
-                  </BulkActionsBar>
+      <AccountPageAction>
+        <PermissionButton
+          permissions={{ apiKey: ["create"] }}
+          onClick={() => setIsCreateDialogOpen(true)}
+        >
+          <Plus className="h-4 w-4" />
+          Create API Key
+        </PermissionButton>
+      </AccountPageAction>
 
-                  <DataTable
-                    columns={columns}
-                    data={filteredApiKeys}
-                    getRowId={(row) => row.id}
-                    rowSelection={rowSelection}
-                    onRowSelectionChange={setRowSelection}
-                    onPageRowIdsChange={onPageRowIdsChange}
-                    hideSelectedCount
-                    emptyMessage="No API keys yet"
-                    hasActiveFilters={search.trim().length > 0}
-                    filteredEmptyMessage="No API keys match your search. Try adjusting your search."
-                    onClearFilters={() =>
-                      updateQueryParams({ search: null, page: "1" })
+      <section className="space-y-5">
+        <div className="space-y-1">
+          <h2 className="text-sm font-medium leading-5">API Keys</h2>
+          <p className="text-sm leading-5 text-muted-foreground">
+            Keys that let scripts and integrations call the{" "}
+            {apiDocsUrl ? (
+              <ExternalDocsLink
+                href={apiDocsUrl}
+                className="text-inherit underline underline-offset-4"
+                showIcon={false}
+              >
+                platform API
+              </ExternalDocsLink>
+            ) : (
+              <span>platform API</span>
+            )}{" "}
+            as you.
+            <WithPermissions
+              permissions={{ serviceAccount: ["read"] }}
+              noPermissionHandle="hide"
+            >
+              {" "}
+              For automation not tied to your user, use{" "}
+              <Link
+                href="/settings/service-accounts"
+                className="underline underline-offset-4"
+              >
+                Service Accounts
+              </Link>
+              .
+            </WithPermissions>
+          </p>
+        </div>
+        <LoadingWrapper
+          isPending={isPending}
+          loadingFallback={<LoadingSpinner />}
+        >
+          <div className="space-y-4">
+            <FilterBar
+              className="mb-0"
+              onClearFilters={
+                search
+                  ? () => updateQueryParams({ search: null, page: "1" })
+                  : undefined
+              }
+            >
+              <SearchInput
+                objectNamePlural="API keys"
+                searchFields={["key name"]}
+                className={filterSearchClass}
+              />
+            </FilterBar>
+            {isApiKeysLoadError ? (
+              <QueryLoadError
+                title="Couldn't load your API keys"
+                onRetry={() => refetchApiKeys()}
+              />
+            ) : (
+              <>
+                <BulkActionsBar
+                  count={selectedApiKeys.length}
+                  noun="API key"
+                  onClear={clearSelection}
+                  busy={bulkDelete.isPending}
+                  selectAllMatching={selectAllMatching}
+                  className="mb-3"
+                >
+                  <PermissionButton
+                    permissions={{ apiKey: ["delete"] }}
+                    variant="destructive"
+                    size="sm"
+                    onClick={() =>
+                      bulkDelete.mutate(selectedApiKeys, {
+                        onSuccess: (outcome) => {
+                          reportBulkOutcome({
+                            outcome,
+                            verb: "Deleted",
+                            failureVerb: "delete",
+                            noun: "API key",
+                          });
+                          if (outcome.failed.length === 0) clearSelection();
+                        },
+                      })
                     }
-                  />
-                </>
-              )}
-            </div>
-          </LoadingWrapper>
-        </CardContent>
-      </Card>
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    <span>Delete</span>
+                  </PermissionButton>
+                </BulkActionsBar>
+
+                <DataTable
+                  columns={columns}
+                  data={filteredApiKeys}
+                  getRowId={(row) => row.id}
+                  rowSelection={rowSelection}
+                  onRowSelectionChange={setRowSelection}
+                  onPageRowIdsChange={onPageRowIdsChange}
+                  hideSelectedCount
+                  emptyMessage="No API keys yet"
+                  hasActiveFilters={search.trim().length > 0}
+                  filteredEmptyMessage="No API keys match your search. Try adjusting your search."
+                  onClearFilters={() =>
+                    updateQueryParams({ search: null, page: "1" })
+                  }
+                />
+              </>
+            )}
+          </div>
+        </LoadingWrapper>
+      </section>
 
       <FormDialog
         open={isCreateDialogOpen}

--- a/platform/frontend/src/components/settings/permissions-card.tsx
+++ b/platform/frontend/src/components/settings/permissions-card.tsx
@@ -10,10 +10,9 @@ import {
 } from "@archestra/shared";
 import { ChevronDown, ChevronRight, Search } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
-import { SettingsCardHeader } from "@/components/settings/settings-block";
+import { SettingsBlock } from "@/components/settings/settings-block";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   Collapsible,
   CollapsibleContent,
@@ -55,12 +54,10 @@ export function PermissionsCard() {
 
   if (isLoading) {
     return (
-      <Card>
-        <CardContent className="space-y-4">
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-40 w-full" />
-        </CardContent>
-      </Card>
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
     );
   }
 
@@ -73,55 +70,54 @@ export function PermissionsCard() {
     granted.length > 0 && expandedCategories.size === granted.length;
 
   return (
-    <Card>
-      <SettingsCardHeader
-        title="Your Permissions"
-        description={
-          totalResources > 0 ? (
-            <>
-              What your{" "}
-              {role ? (
-                <span className="font-medium capitalize text-foreground">
-                  {role}
-                </span>
-              ) : (
-                "current"
-              )}{" "}
-              role grants you — {totalResources} resource
-              {totalResources === 1 ? "" : "s"} across {granted.length} categor
-              {granted.length === 1 ? "y" : "ies"}.
-            </>
-          ) : (
-            "What your role grants you across the platform."
-          )
-        }
-        action={
-          granted.length > 0 ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                setExpandedCategories(
-                  allExpanded
-                    ? new Set()
-                    : new Set(granted.map((group) => group.category)),
-                )
-              }
-            >
-              <span>{allExpanded ? "Collapse all" : "Expand all"}</span>
-            </Button>
-          ) : null
-        }
-      />
-      <CardContent className="space-y-4 border-t pt-6">
+    <SettingsBlock
+      title="Your Permissions"
+      description={
+        totalResources > 0 ? (
+          <>
+            What your{" "}
+            {role ? (
+              <span className="font-medium capitalize text-foreground">
+                {role}
+              </span>
+            ) : (
+              "current"
+            )}{" "}
+            role grants you — {totalResources} resource
+            {totalResources === 1 ? "" : "s"} across {granted.length} categor
+            {granted.length === 1 ? "y" : "ies"}.
+          </>
+        ) : (
+          "What your role grants you across the platform."
+        )
+      }
+      control={
+        granted.length > 0 ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              setExpandedCategories(
+                allExpanded
+                  ? new Set()
+                  : new Set(granted.map((group) => group.category)),
+              )
+            }
+          >
+            <span>{allExpanded ? "Collapse all" : "Expand all"}</span>
+          </Button>
+        ) : null
+      }
+    >
+      <div className="space-y-4">
         {totalResources === 0 ? (
           <p className="text-sm text-muted-foreground">
             Your role grants no resource permissions.
           </p>
         ) : (
           <>
-            <div className="relative">
+            <div className="relative sm:max-w-md">
               <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={filter}
@@ -136,7 +132,7 @@ export function PermissionsCard() {
                 No permissions match that filter.
               </p>
             ) : (
-              <div className="space-y-2">
+              <div className="divide-y border-y">
                 {matches.map(({ category, resources }) => (
                   <CategorySection
                     key={category}
@@ -154,8 +150,8 @@ export function PermissionsCard() {
             )}
           </>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </SettingsBlock>
   );
 }
 
@@ -174,26 +170,26 @@ function CategorySection({
 }) {
   return (
     <Collapsible open={isExpanded} onOpenChange={() => onToggle(category)}>
-      <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-md border bg-card p-3 hover:bg-accent/50 transition-colors">
+      <CollapsibleTrigger className="flex w-full items-center gap-2 py-3 text-left text-muted-foreground transition-colors hover:text-foreground">
         {isExpanded ? (
           <ChevronDown className="h-4 w-4 shrink-0" />
         ) : (
           <ChevronRight className="h-4 w-4 shrink-0" />
         )}
-        <span className="font-semibold text-sm">{category}</span>
+        <span className="text-sm font-medium text-foreground">{category}</span>
         <span className="ml-auto text-xs text-muted-foreground">
           {resources.length} resource
           {resources.length !== 1 ? <span>s</span> : null}
         </span>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="mt-1 space-y-1 pl-6">
+        <div className="divide-y pb-2 pl-6">
           {resources.map((resource) => {
             const actions = permissions[resource] || [];
             return (
               <div
                 key={resource}
-                className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-md border bg-card px-3 py-2.5"
+                className="grid gap-2 py-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-4"
               >
                 <div className="min-w-0">
                   <p className="text-sm font-medium leading-tight">
@@ -205,7 +201,7 @@ function CategorySection({
                     </p>
                   )}
                 </div>
-                <div className="flex flex-wrap gap-1 shrink-0">
+                <div className="flex shrink-0 flex-wrap gap-1 sm:justify-end">
                   {actions.map((action) => (
                     <Badge key={action} variant="outline" className="text-xs">
                       {actionLabels[action] || action}

--- a/platform/frontend/src/components/settings/profile-card.tsx
+++ b/platform/frontend/src/components/settings/profile-card.tsx
@@ -4,9 +4,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { SettingsBlock } from "@/components/settings/settings-block";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   Form,
   FormControl,
@@ -46,21 +46,19 @@ export function ProfileCard() {
   const image = session?.user?.image ?? null;
 
   return (
-    <Card>
-      <CardContent>
-        {/* A settings form is read at a fixed measure: fields stretched to a
-            1400px card are hard to scan and imply far more input than a
-            name. */}
-        <div className="max-w-xl">
-          <ProfileForm
-            name={name}
-            email={email}
-            image={image}
-            role={role ?? ""}
-          />
-        </div>
-      </CardContent>
-    </Card>
+    <SettingsBlock
+      title="Profile"
+      description="Your personal details and organization role."
+    >
+      <div className="max-w-xl">
+        <ProfileForm
+          name={name}
+          email={email}
+          image={image}
+          role={role ?? ""}
+        />
+      </div>
+    </SettingsBlock>
   );
 }
 
@@ -191,29 +189,28 @@ function ReadOnlyField({
 
 function ProfileSkeleton() {
   return (
-    <Card>
-      <CardContent>
-        {/* Shaped like the form it replaces, so the section does not jump
-            when the session lands. */}
-        <div className="max-w-xl space-y-6">
-          <div className="flex items-start gap-4">
-            <Skeleton className="size-16 shrink-0 rounded-full" />
-            <div className="grid min-w-0 flex-1 gap-2">
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-9 w-full" />
-              <Skeleton className="h-4 w-2/3" />
-            </div>
+    <SettingsBlock
+      title="Profile"
+      description="Your personal details and organization role."
+    >
+      <div className="max-w-xl space-y-6">
+        <div className="flex items-start gap-4">
+          <Skeleton className="size-16 shrink-0 rounded-full" />
+          <div className="grid min-w-0 flex-1 gap-2">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-4 w-2/3" />
           </div>
-          {["email", "role"].map((field) => (
-            <div key={field} className="grid gap-2">
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-9 w-full" />
-              <Skeleton className="h-4 w-2/3" />
-            </div>
-          ))}
-          <Skeleton className="h-9 w-32" />
         </div>
-      </CardContent>
-    </Card>
+        {["email", "role"].map((field) => (
+          <div key={field} className="grid gap-2">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        ))}
+        <Skeleton className="h-9 w-32" />
+      </div>
+    </SettingsBlock>
   );
 }

--- a/platform/frontend/src/components/settings/settings-block.test.tsx
+++ b/platform/frontend/src/components/settings/settings-block.test.tsx
@@ -3,37 +3,41 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import {
-  SettingsCardHeader,
+  SettingsBlock,
   SettingsSaveBar,
   SettingsSectionStack,
 } from "./settings-block";
 
 vi.mock("@/lib/auth/auth.query");
 
-describe("SettingsCardHeader", () => {
-  it("adds spacing between the title and description", () => {
-    const { container } = render(
-      <SettingsCardHeader
+describe("SettingsBlock", () => {
+  it("renders a semantic section with an accessible heading", () => {
+    render(
+      <SettingsBlock
         title="Default model"
         description="Pick the model used by default."
       />,
     );
 
-    expect(container.querySelector(".space-y-1\\.5")).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Default model" }),
+    ).toBeVisible();
     expect(screen.getByText("Pick the model used by default.")).toBeVisible();
   });
 
-  it("vertically centers the action area", () => {
-    const { container } = render(
-      <SettingsCardHeader
+  it("supports an aligned control and full-width content", () => {
+    render(
+      <SettingsBlock
         title="Default model"
         description="Pick the model used by default."
-        action={<button type="button">Reset</button>}
-      />,
+        control={<button type="button">Reset</button>}
+      >
+        <div>Advanced controls</div>
+      </SettingsBlock>,
     );
 
-    expect(container.querySelector(".items-center")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Reset" })).toBeVisible();
+    expect(screen.getByText("Advanced controls")).toBeVisible();
   });
 });
 

--- a/platform/frontend/src/components/settings/settings-block.tsx
+++ b/platform/frontend/src/components/settings/settings-block.tsx
@@ -26,9 +26,17 @@ export function SettingsBlock({
   children,
   id,
 }: SettingsBlockProps) {
+  const hasControl = control != null;
+
   return (
     <section id={id} className="scroll-mt-24">
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,20rem)] lg:gap-8">
+      <div
+        className={cn(
+          "grid gap-4",
+          hasControl &&
+            "lg:grid-cols-[minmax(0,1fr)_minmax(16rem,20rem)] lg:gap-8",
+        )}
+      >
         <div className="min-w-0 space-y-1">
           <h2 className="text-sm font-medium leading-5">{title}</h2>
           {description && (
@@ -38,7 +46,7 @@ export function SettingsBlock({
           )}
           {notice && <div className="pt-2 text-sm leading-5">{notice}</div>}
         </div>
-        {control && (
+        {hasControl && (
           <div className="flex min-w-0 items-start lg:justify-end">
             {control}
           </div>

--- a/platform/frontend/src/components/settings/settings-block.tsx
+++ b/platform/frontend/src/components/settings/settings-block.tsx
@@ -5,45 +5,17 @@ import type { ReactNode } from "react";
 import { createContext, useContext, useState } from "react";
 import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/button";
-import { CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { cn } from "@/lib/utils";
 
 interface SettingsBlockProps {
   title: ReactNode;
   description?: ReactNode;
-  control: ReactNode;
+  control?: ReactNode;
   notice?: ReactNode;
   children?: ReactNode;
   /** Anchor for a link that points at this specific setting. */
   id?: string;
-}
-
-interface SettingsCardHeaderProps {
-  title: ReactNode;
-  description?: ReactNode;
-  action?: ReactNode;
-  notice?: ReactNode;
-}
-
-export function SettingsCardHeader({
-  title,
-  description,
-  action,
-  notice,
-}: SettingsCardHeaderProps) {
-  return (
-    <CardHeader>
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="min-w-0 flex-1 space-y-1.5">
-          <CardTitle>{title}</CardTitle>
-          {description && <CardDescription>{description}</CardDescription>}
-        </div>
-        {action && <div className="flex shrink-0 items-center">{action}</div>}
-      </div>
-      {notice && <div className="text-sm mt-2">{notice}</div>}
-    </CardHeader>
-  );
 }
 
 export function SettingsBlock({

--- a/platform/frontend/src/components/settings/settings-block.tsx
+++ b/platform/frontend/src/components/settings/settings-block.tsx
@@ -5,13 +5,7 @@ import type { ReactNode } from "react";
 import { createContext, useContext, useState } from "react";
 import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { cn } from "@/lib/utils";
 
@@ -61,17 +55,25 @@ export function SettingsBlock({
   id,
 }: SettingsBlockProps) {
   return (
-    <Card id={id} className="scroll-mt-24">
-      <SettingsCardHeader
-        title={title}
-        description={description}
-        action={control}
-        notice={notice}
-      />
-      {children && (
-        <CardContent className="pt-6 border-t">{children}</CardContent>
-      )}
-    </Card>
+    <section id={id} className="scroll-mt-24">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,20rem)] lg:gap-8">
+        <div className="min-w-0 space-y-1">
+          <h2 className="text-sm font-medium leading-5">{title}</h2>
+          {description && (
+            <div className="text-sm leading-5 text-muted-foreground">
+              {description}
+            </div>
+          )}
+          {notice && <div className="pt-2 text-sm leading-5">{notice}</div>}
+        </div>
+        {control && (
+          <div className="flex min-w-0 items-start lg:justify-end">
+            {control}
+          </div>
+        )}
+      </div>
+      {children && <div className="mt-4">{children}</div>}
+    </section>
   );
 }
 
@@ -133,7 +135,7 @@ export function SettingsSectionStack({
   const [slot, setSlot] = useState<HTMLDivElement | null>(null);
 
   return (
-    <div className={cn("space-y-5", className)}>
+    <div className={cn("space-y-8", className)}>
       <SaveBarSlotContext.Provider value={slot}>
         {children}
       </SaveBarSlotContext.Provider>

--- a/platform/frontend/src/components/tokens/platform-token-card.tsx
+++ b/platform/frontend/src/components/tokens/platform-token-card.tsx
@@ -2,9 +2,8 @@
 
 import { Key } from "lucide-react";
 import type { ReactNode } from "react";
-import { SettingsCardHeader } from "@/components/settings/settings-block";
+import { SettingsBlock } from "@/components/settings/settings-block";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface PlatformTokenCardProps {
@@ -29,14 +28,13 @@ export function PlatformTokenCard({
   const showAction = !isLoading && !error && tokenExists;
 
   return (
-    <Card>
-      <SettingsCardHeader
-        title={title}
-        description={description}
-        action={showAction ? action : undefined}
-      />
+    <SettingsBlock
+      title={title}
+      description={description}
+      control={showAction ? action : undefined}
+    >
       {!showAction && (
-        <CardContent>
+        <div>
           {isLoading ? (
             <Skeleton className="h-10 w-full max-w-sm" />
           ) : error ? (
@@ -53,8 +51,8 @@ export function PlatformTokenCard({
               </p>
             </div>
           )}
-        </CardContent>
+        </div>
       )}
-    </Card>
+    </SettingsBlock>
   );
 }

--- a/platform/frontend/src/components/ui/bulk-select-column.test.tsx
+++ b/platform/frontend/src/components/ui/bulk-select-column.test.tsx
@@ -37,7 +37,10 @@ describe("createSelectColumn", () => {
     await user.click(screen.getByRole("checkbox", { name: "Select all rows" }));
 
     expect(
-      screen.getByRole("checkbox", { name: "Select Custom" }),
+      screen.getByRole("checkbox", { name: "Select Custom one" }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Select Custom two" }),
     ).toBeChecked();
     expect(
       screen.getByRole("checkbox", { name: "Select Predefined" }),
@@ -49,7 +52,8 @@ function TestTable() {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const data: TestRow[] = [
     { id: "fixed", name: "Predefined", fixed: true },
-    { id: "custom", name: "Custom", fixed: false },
+    { id: "custom-one", name: "Custom one", fixed: false },
+    { id: "custom-two", name: "Custom two", fixed: false },
   ];
 
   return (

--- a/platform/frontend/src/components/ui/bulk-select-column.test.tsx
+++ b/platform/frontend/src/components/ui/bulk-select-column.test.tsx
@@ -1,0 +1,72 @@
+import type { RowSelectionState } from "@tanstack/react-table";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { createSelectColumn } from "./bulk-select-column";
+import { DataTable } from "./data-table";
+
+type TestRow = {
+  id: string;
+  name: string;
+  fixed: boolean;
+};
+
+describe("createSelectColumn", () => {
+  it("shows disabled rows and explains why they cannot be selected", async () => {
+    const user = userEvent.setup();
+    render(<TestTable />);
+
+    const disabledCheckbox = screen.getByRole("checkbox", {
+      name: "Select Predefined",
+    });
+    expect(disabledCheckbox).toBeDisabled();
+
+    await user.hover(screen.getByTitle("Predefined rows cannot be deleted"));
+    expect(
+      await screen.findByRole("tooltip", {
+        name: "Predefined rows cannot be deleted",
+      }),
+    ).toBeVisible();
+  });
+
+  it("selects only rows that the bulk action can change", async () => {
+    const user = userEvent.setup();
+    render(<TestTable />);
+
+    await user.click(screen.getByRole("checkbox", { name: "Select all rows" }));
+
+    expect(
+      screen.getByRole("checkbox", { name: "Select Custom" }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Select Predefined" }),
+    ).not.toBeChecked();
+  });
+});
+
+function TestTable() {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const data: TestRow[] = [
+    { id: "fixed", name: "Predefined", fixed: true },
+    { id: "custom", name: "Custom", fixed: false },
+  ];
+
+  return (
+    <DataTable
+      columns={[
+        createSelectColumn<TestRow>({
+          rowLabel: (row) => `Select ${row.name}`,
+          allLabel: "Select all rows",
+          canSelect: (row) => !row.fixed,
+          disabledReason: () => "Predefined rows cannot be deleted",
+        }),
+        { accessorKey: "name", header: "Name" },
+      ]}
+      data={data}
+      getRowId={(row) => row.id}
+      rowSelection={rowSelection}
+      onRowSelectionChange={setRowSelection}
+    />
+  );
+}

--- a/platform/frontend/src/components/ui/bulk-select-column.tsx
+++ b/platform/frontend/src/components/ui/bulk-select-column.tsx
@@ -3,6 +3,11 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { Checkbox } from "@/components/ui/checkbox";
 import { DATA_TABLE_SELECT_COLUMN_SIZE } from "@/components/ui/data-table.constants";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 /**
  * The multiselect checkbox column, so every table that grows a bulk affordance
@@ -15,21 +20,18 @@ export function createSelectColumn<T>({
   rowLabel,
   allLabel = "Select all on this page",
   canSelect,
+  disabledReason,
 }: {
   /** Names the row for screen readers, e.g. `(agent) => `Select ${agent.name}``. */
   rowLabel: (row: T) => string;
   allLabel?: string;
   /**
-   * Rows the bulk actions cannot apply to — the synthetic Default environment,
-   * your own membership. They render no checkbox at all rather than a disabled
-   * one: there is nothing the user could do to make it tick.
-   *
-   * This hides the control; it does not fence the selection. "Select all on
-   * this page" is a table-level toggle and will still mark these rows, so the
-   * caller must filter them out of the set it acts on — which it has to do
-   * anyway for ids left behind by another page.
+   * Rows the bulk actions cannot apply to. They keep a disabled checkbox in the
+   * column so the table stays visually consistent and explain why on hover.
    */
   canSelect?: (row: T) => boolean;
+  /** Concise explanation shown for a row that cannot be selected. */
+  disabledReason?: (row: T) => string;
 }): ColumnDef<T> {
   return {
     id: "select",
@@ -37,25 +39,58 @@ export function createSelectColumn<T>({
     minSize: DATA_TABLE_SELECT_COLUMN_SIZE,
     maxSize: DATA_TABLE_SELECT_COLUMN_SIZE,
     enableSorting: false,
-    header: ({ table }) => (
-      <Checkbox
-        checked={
-          table.getIsAllPageRowsSelected() ||
-          (table.getIsSomePageRowsSelected() && "indeterminate")
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        onClick={(event) => event.stopPropagation()}
-        aria-label={allLabel}
-      />
-    ),
-    cell: ({ row }) =>
-      canSelect && !canSelect(row.original) ? null : (
+    header: ({ table }) => {
+      const selectableRows = table
+        .getRowModel()
+        .rows.filter((row) => canSelect?.(row.original) ?? true);
+      const selectedCount = selectableRows.filter((row) =>
+        row.getIsSelected(),
+      ).length;
+      const allSelected =
+        selectableRows.length > 0 && selectedCount === selectableRows.length;
+      const someSelected = selectedCount > 0 && !allSelected;
+
+      return (
         <Checkbox
-          checked={row.getIsSelected()}
+          checked={allSelected || (someSelected && "indeterminate")}
+          onCheckedChange={(value) => {
+            for (const row of selectableRows) {
+              row.toggleSelected(!!value);
+            }
+          }}
+          onClick={(event) => event.stopPropagation()}
+          aria-label={allLabel}
+          disabled={selectableRows.length === 0}
+        />
+      );
+    },
+    cell: ({ row }) => {
+      const selectable = canSelect?.(row.original) ?? true;
+      const checkbox = (
+        <Checkbox
+          className={!selectable ? "pointer-events-none" : undefined}
+          checked={selectable && row.getIsSelected()}
           onCheckedChange={(value) => row.toggleSelected(!!value)}
           onClick={(event) => event.stopPropagation()}
           aria-label={rowLabel(row.original)}
+          disabled={!selectable}
         />
-      ),
+      );
+
+      if (selectable) return checkbox;
+      const reason =
+        disabledReason?.(row.original) ?? "Unavailable for bulk actions";
+
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex cursor-not-allowed" title={reason}>
+              {checkbox}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{reason}</TooltipContent>
+        </Tooltip>
+      );
+    },
   };
 }

--- a/platform/frontend/src/components/ui/bulk-select-column.tsx
+++ b/platform/frontend/src/components/ui/bulk-select-column.tsx
@@ -54,9 +54,14 @@ export function createSelectColumn<T>({
         <Checkbox
           checked={allSelected || (someSelected && "indeterminate")}
           onCheckedChange={(value) => {
-            for (const row of selectableRows) {
-              row.toggleSelected(!!value);
-            }
+            table.setRowSelection((current) => {
+              const next = { ...current };
+              for (const row of selectableRows) {
+                if (value) next[row.id] = true;
+                else delete next[row.id];
+              }
+              return next;
+            });
           }}
           onClick={(event) => event.stopPropagation()}
           aria-label={allLabel}


### PR DESCRIPTION
## Summary

- Replace bulky organization settings cards with compact, consistent settings sections across Appearance, Agents, Connection, Knowledge, Auth, Secrets, and related pages
- Let descriptions use the full content width whenever a settings header has no right-side control
- Align provider-key and model selectors in slim control columns, and compact organization/personal token settings
- Simplify personal settings with direct API key and session tables, a page-header Create API Key action, compact gateway token/profile sections, and a divided permissions list
- Tighten API key, service account, and session tables with the shared filter, DataTable, pagination, bulk-selection, and TableRowActions patterns
- Keep bulk-selection checkboxes visible but disabled when rows cannot be selected, with concise hover explanations
- Fix header select-all so it atomically selects every eligible visible row while leaving ineligible rows disabled
- Use the shared Monaco editor for site-notification Markdown with a live rendered preview