### PR TITLE
chore: redesign OAuth callback experience

### DIFF
--- a/platform/frontend/src/app/oauth-callback/oauth-callback-status.test.tsx
+++ b/platform/frontend/src/app/oauth-callback/oauth-callback-status.test.tsx
@@ -5,14 +5,12 @@ describe("OAuthCallbackStatus", () => {
   it("explains the secure handoff while the connection is completing", () => {
     render(<OAuthCallbackStatus status="processing" phase="completing" />);
 
+    expect(screen.getByText("Finishing OAuth Connection")).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Finishing the connection" }),
+      screen.getByText("Completing OAuth authentication"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Authorization received")).toBeInTheDocument();
-    expect(screen.getByText("Securing credentials")).toBeInTheDocument();
-    expect(screen.getByText("Connecting MCP server")).toBeInTheDocument();
     expect(
-      screen.getByRole("status", { name: "OAuth connection in progress" }),
+      screen.getByText("Securing credentials and connecting the MCP server"),
     ).toBeInTheDocument();
   });
 
@@ -29,13 +27,7 @@ describe("OAuthCallbackStatus", () => {
       />,
     );
 
-    expect(
-      screen.getByRole("heading", {
-        name: "We couldn't finish the connection",
-      }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Authorization not completed")).toBeInTheDocument();
-    expect(screen.getByText("Credentials unchanged")).toBeInTheDocument();
+    expect(screen.getByText("Connection Not Completed")).toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent(
       "The authorization request was declined.",
     );

--- a/platform/frontend/src/app/oauth-callback/oauth-callback-status.test.tsx
+++ b/platform/frontend/src/app/oauth-callback/oauth-callback-status.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { OAuthCallbackStatus } from "./oauth-callback-status";
+
+describe("OAuthCallbackStatus", () => {
+  it("explains the secure handoff while the connection is completing", () => {
+    render(<OAuthCallbackStatus status="processing" phase="completing" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Finishing the connection" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Authorization received")).toBeInTheDocument();
+    expect(screen.getByText("Securing credentials")).toBeInTheDocument();
+    expect(screen.getByText("Connecting MCP server")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: "OAuth connection in progress" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the provider error and returns through the supplied action", () => {
+    const onAction = vi.fn();
+
+    render(
+      <OAuthCallbackStatus
+        status="error"
+        errorTitle="OAuth authentication failed"
+        errorDescription="The authorization request was declined."
+        actionLabel="Go Back"
+        onAction={onAction}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "We couldn't finish the connection",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Authorization not completed")).toBeInTheDocument();
+    expect(screen.getByText("Credentials unchanged")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "The authorization request was declined.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Go Back" }));
+    expect(onAction).toHaveBeenCalledOnce();
+  });
+});

--- a/platform/frontend/src/app/oauth-callback/oauth-callback-status.tsx
+++ b/platform/frontend/src/app/oauth-callback/oauth-callback-status.tsx
@@ -1,0 +1,238 @@
+import {
+  AlertTriangle,
+  ArrowRight,
+  Check,
+  KeyRound,
+  LockKeyhole,
+  Server,
+  ShieldCheck,
+} from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type OAuthCallbackStatusProps =
+  | {
+      status: "processing";
+      phase: "initializing" | "completing";
+    }
+  | {
+      status: "error";
+      errorTitle: string;
+      errorDescription: string;
+      actionLabel: string;
+      onAction: () => void;
+    };
+
+export function OAuthCallbackStatus(props: OAuthCallbackStatusProps) {
+  const isError = props.status === "error";
+  const copy = isError
+    ? {
+        eyebrow: "Connection interrupted",
+        title: "We couldn't finish the connection",
+        description:
+          "Your existing setup is unchanged. Review the details below, then return and try again.",
+      }
+    : getProcessingCopy(props.phase);
+
+  return (
+    <Card
+      className="grid w-full overflow-hidden rounded-2xl border-border/70 bg-card/95 py-0 shadow-[0_28px_80px_-38px_color-mix(in_oklab,var(--foreground)_28%,transparent)] backdrop-blur-sm md:grid-cols-[minmax(19rem,0.82fr)_minmax(24rem,1.18fr)]"
+      aria-live="polite"
+    >
+      <ConnectionDiagram status={props.status} />
+
+      <section className="flex min-h-[25rem] flex-col justify-between p-7 sm:p-10 md:min-h-[30rem] md:p-12">
+        <div>
+          <div className="mb-8 flex size-11 items-center justify-center rounded-xl border border-primary/15 bg-primary/8 text-primary shadow-[inset_0_1px_0_color-mix(in_oklab,var(--background)_70%,transparent)]">
+            {isError ? (
+              <AlertTriangle className="size-5" aria-hidden="true" />
+            ) : (
+              <ShieldCheck className="size-5" aria-hidden="true" />
+            )}
+          </div>
+
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            {copy.eyebrow}
+          </p>
+          <h1 className="max-w-xl text-3xl font-semibold tracking-[-0.035em] text-foreground sm:text-4xl">
+            {copy.title}
+          </h1>
+          <p className="mt-4 max-w-lg text-base leading-7 text-muted-foreground">
+            {copy.description}
+          </p>
+
+          {isError && (
+            <Alert variant="destructive" className="mt-8 rounded-xl">
+              <AlertTriangle aria-hidden="true" />
+              <AlertTitle>{props.errorTitle}</AlertTitle>
+              <AlertDescription>{props.errorDescription}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <div className="mt-10 border-t border-border/70 pt-6">
+          {isError ? (
+            <Button onClick={props.onAction} size="lg" className="group">
+              <span>{props.actionLabel}</span>
+              <ArrowRight
+                className="transition-transform group-hover:translate-x-0.5"
+                aria-hidden="true"
+              />
+            </Button>
+          ) : (
+            <div className="flex items-start gap-3 text-sm text-muted-foreground">
+              <LockKeyhole
+                className="mt-0.5 size-4 shrink-0 text-foreground/70"
+                aria-hidden="true"
+              />
+              <p className="max-w-sm leading-6">
+                Keep this page open. You'll return automatically when the secure
+                handoff is complete.
+              </p>
+            </div>
+          )}
+        </div>
+      </section>
+    </Card>
+  );
+}
+
+function ConnectionDiagram({
+  status,
+}: {
+  status: OAuthCallbackStatusProps["status"];
+}) {
+  const isError = status === "error";
+
+  return (
+    <aside className="relative flex min-h-[20rem] overflow-hidden border-b border-border/70 bg-muted/35 p-7 sm:p-10 md:min-h-[30rem] md:border-r md:border-b-0">
+      <div className="absolute -top-24 -left-24 size-64 rounded-full bg-primary/8 blur-3xl" />
+      <div className="relative flex w-full flex-col justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex size-9 items-center justify-center rounded-xl border border-border/80 bg-background/80 shadow-sm">
+            <LockKeyhole
+              className="size-4 text-foreground/75"
+              aria-hidden="true"
+            />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-foreground">
+              Secure handoff
+            </p>
+            <p className="text-xs text-muted-foreground">
+              OAuth credentials stay protected
+            </p>
+          </div>
+        </div>
+
+        <output
+          className="my-10 flex flex-col"
+          aria-label={
+            isError
+              ? "OAuth connection interrupted"
+              : "OAuth connection in progress"
+          }
+        >
+          <ConnectionNode
+            icon={
+              isError ? (
+                <AlertTriangle className="size-4" aria-hidden="true" />
+              ) : (
+                <Check className="size-4" aria-hidden="true" />
+              )
+            }
+            label={
+              isError ? "Authorization not completed" : "Authorization received"
+            }
+            state={isError ? "error" : "complete"}
+          />
+          <ConnectionLine active={!isError} />
+          <ConnectionNode
+            icon={<KeyRound className="size-4" aria-hidden="true" />}
+            label={isError ? "Credentials unchanged" : "Securing credentials"}
+            state={isError ? "pending" : "active"}
+          />
+          <ConnectionLine active={false} />
+          <ConnectionNode
+            icon={<Server className="size-4" aria-hidden="true" />}
+            label={isError ? "MCP server unchanged" : "Connecting MCP server"}
+            state="pending"
+          />
+        </output>
+
+        <p className="max-w-xs text-xs leading-5 text-muted-foreground">
+          OAuth access is exchanged directly with the provider and stored using
+          your configured secret management.
+        </p>
+      </div>
+    </aside>
+  );
+}
+
+function ConnectionNode({
+  icon,
+  label,
+  state,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  state: "active" | "complete" | "error" | "pending";
+}) {
+  return (
+    <div className="flex items-center gap-4">
+      <div
+        className={cn(
+          "relative flex size-10 shrink-0 items-center justify-center rounded-xl border bg-background shadow-sm",
+          state === "complete" && "border-primary/20 text-primary",
+          state === "active" && "border-primary/30 text-primary",
+          state === "error" &&
+            "border-destructive/30 bg-destructive/5 text-destructive",
+          state === "pending" && "border-border/70 text-muted-foreground/60",
+        )}
+      >
+        {state === "active" && (
+          <span className="absolute inset-1 animate-pulse rounded-lg border border-primary/25 motion-reduce:animate-none" />
+        )}
+        <span className="relative">{icon}</span>
+      </div>
+      <span
+        className={cn(
+          "text-sm font-medium",
+          state === "pending" ? "text-muted-foreground/65" : "text-foreground",
+        )}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function ConnectionLine({ active }: { active: boolean }) {
+  return (
+    <div className="ml-[1.2rem] h-11 w-px overflow-hidden bg-border">
+      {active && (
+        <div className="h-full w-px animate-pulse bg-linear-to-b from-transparent via-primary to-transparent motion-reduce:animate-none" />
+      )}
+    </div>
+  );
+}
+
+function getProcessingCopy(phase: "initializing" | "completing") {
+  if (phase === "initializing") {
+    return {
+      eyebrow: "Secure OAuth connection",
+      title: "Preparing your connection",
+      description:
+        "We're reading the authorization response and preparing the secure handoff.",
+    };
+  }
+
+  return {
+    eyebrow: "Secure OAuth connection",
+    title: "Finishing the connection",
+    description:
+      "Your authorization is confirmed. We're securing the credentials and connecting the MCP server.",
+  };
+}

--- a/platform/frontend/src/app/oauth-callback/oauth-callback-status.tsx
+++ b/platform/frontend/src/app/oauth-callback/oauth-callback-status.tsx
@@ -1,16 +1,20 @@
 import {
   AlertTriangle,
   ArrowRight,
-  Check,
-  KeyRound,
   LockKeyhole,
-  Server,
   ShieldCheck,
 } from "lucide-react";
+import { LoadingSpinner } from "@/components/loading";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { cn } from "@/lib/utils";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 type OAuthCallbackStatusProps =
   | {
@@ -26,213 +30,93 @@ type OAuthCallbackStatusProps =
     };
 
 export function OAuthCallbackStatus(props: OAuthCallbackStatusProps) {
-  const isError = props.status === "error";
-  const copy = isError
-    ? {
-        eyebrow: "Connection interrupted",
-        title: "We couldn't finish the connection",
-        description:
-          "Your existing setup is unchanged. Review the details below, then return and try again.",
-      }
-    : getProcessingCopy(props.phase);
+  if (props.status === "error") {
+    return (
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+            <AlertTriangle className="size-6" aria-hidden="true" />
+          </div>
+          <CardTitle>Connection Not Completed</CardTitle>
+          <CardDescription>
+            Your existing MCP server setup was not changed.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent>
+          <Alert variant="destructive">
+            <AlertTriangle aria-hidden="true" />
+            <AlertTitle>{props.errorTitle}</AlertTitle>
+            <AlertDescription>{props.errorDescription}</AlertDescription>
+          </Alert>
+        </CardContent>
+
+        <CardFooter>
+          <Button className="w-full" onClick={props.onAction}>
+            <span>{props.actionLabel}</span>
+            <ArrowRight aria-hidden="true" />
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  const copy = getProcessingCopy(props.phase);
 
   return (
-    <Card
-      className="grid w-full overflow-hidden rounded-2xl border-border/70 bg-card/95 py-0 shadow-[0_28px_80px_-38px_color-mix(in_oklab,var(--foreground)_28%,transparent)] backdrop-blur-sm md:grid-cols-[minmax(19rem,0.82fr)_minmax(24rem,1.18fr)]"
-      aria-live="polite"
-    >
-      <ConnectionDiagram status={props.status} />
-
-      <section className="flex min-h-[25rem] flex-col justify-between p-7 sm:p-10 md:min-h-[30rem] md:p-12">
-        <div>
-          <div className="mb-8 flex size-11 items-center justify-center rounded-xl border border-primary/15 bg-primary/8 text-primary shadow-[inset_0_1px_0_color-mix(in_oklab,var(--background)_70%,transparent)]">
-            {isError ? (
-              <AlertTriangle className="size-5" aria-hidden="true" />
-            ) : (
-              <ShieldCheck className="size-5" aria-hidden="true" />
-            )}
-          </div>
-
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-            {copy.eyebrow}
-          </p>
-          <h1 className="max-w-xl text-3xl font-semibold tracking-[-0.035em] text-foreground sm:text-4xl">
-            {copy.title}
-          </h1>
-          <p className="mt-4 max-w-lg text-base leading-7 text-muted-foreground">
-            {copy.description}
-          </p>
-
-          {isError && (
-            <Alert variant="destructive" className="mt-8 rounded-xl">
-              <AlertTriangle aria-hidden="true" />
-              <AlertTitle>{props.errorTitle}</AlertTitle>
-              <AlertDescription>{props.errorDescription}</AlertDescription>
-            </Alert>
-          )}
+    <Card className="w-full max-w-md">
+      <CardHeader className="text-center">
+        <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <ShieldCheck className="size-6" aria-hidden="true" />
         </div>
+        <CardTitle>{copy.title}</CardTitle>
+        <CardDescription>{copy.description}</CardDescription>
+      </CardHeader>
 
-        <div className="mt-10 border-t border-border/70 pt-6">
-          {isError ? (
-            <Button onClick={props.onAction} size="lg" className="group">
-              <span>{props.actionLabel}</span>
-              <ArrowRight
-                className="transition-transform group-hover:translate-x-0.5"
-                aria-hidden="true"
-              />
-            </Button>
-          ) : (
-            <div className="flex items-start gap-3 text-sm text-muted-foreground">
-              <LockKeyhole
-                className="mt-0.5 size-4 shrink-0 text-foreground/70"
-                aria-hidden="true"
-              />
-              <p className="max-w-sm leading-6">
-                Keep this page open. You'll return automatically when the secure
-                handoff is complete.
-              </p>
-            </div>
-          )}
-        </div>
-      </section>
-    </Card>
-  );
-}
-
-function ConnectionDiagram({
-  status,
-}: {
-  status: OAuthCallbackStatusProps["status"];
-}) {
-  const isError = status === "error";
-
-  return (
-    <aside className="relative flex min-h-[20rem] overflow-hidden border-b border-border/70 bg-muted/35 p-7 sm:p-10 md:min-h-[30rem] md:border-r md:border-b-0">
-      <div className="absolute -top-24 -left-24 size-64 rounded-full bg-primary/8 blur-3xl" />
-      <div className="relative flex w-full flex-col justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex size-9 items-center justify-center rounded-xl border border-border/80 bg-background/80 shadow-sm">
-            <LockKeyhole
-              className="size-4 text-foreground/75"
-              aria-hidden="true"
-            />
-          </div>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-3 rounded-md border bg-muted/50 p-4">
+          <LoadingSpinner
+            className="mx-0 size-5 shrink-0"
+            label={copy.loadingLabel}
+          />
           <div>
             <p className="text-sm font-medium text-foreground">
-              Secure handoff
+              {copy.statusTitle}
             </p>
-            <p className="text-xs text-muted-foreground">
-              OAuth credentials stay protected
+            <p className="mt-1 text-sm text-muted-foreground">
+              This usually takes only a few seconds.
             </p>
           </div>
         </div>
 
-        <output
-          className="my-10 flex flex-col"
-          aria-label={
-            isError
-              ? "OAuth connection interrupted"
-              : "OAuth connection in progress"
-          }
-        >
-          <ConnectionNode
-            icon={
-              isError ? (
-                <AlertTriangle className="size-4" aria-hidden="true" />
-              ) : (
-                <Check className="size-4" aria-hidden="true" />
-              )
-            }
-            label={
-              isError ? "Authorization not completed" : "Authorization received"
-            }
-            state={isError ? "error" : "complete"}
+        <div className="flex items-start justify-center gap-2 text-xs text-muted-foreground">
+          <LockKeyhole
+            className="mt-0.5 size-3.5 shrink-0"
+            aria-hidden="true"
           />
-          <ConnectionLine active={!isError} />
-          <ConnectionNode
-            icon={<KeyRound className="size-4" aria-hidden="true" />}
-            label={isError ? "Credentials unchanged" : "Securing credentials"}
-            state={isError ? "pending" : "active"}
-          />
-          <ConnectionLine active={false} />
-          <ConnectionNode
-            icon={<Server className="size-4" aria-hidden="true" />}
-            label={isError ? "MCP server unchanged" : "Connecting MCP server"}
-            state="pending"
-          />
-        </output>
-
-        <p className="max-w-xs text-xs leading-5 text-muted-foreground">
-          OAuth access is exchanged directly with the provider and stored using
-          your configured secret management.
-        </p>
-      </div>
-    </aside>
-  );
-}
-
-function ConnectionNode({
-  icon,
-  label,
-  state,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  state: "active" | "complete" | "error" | "pending";
-}) {
-  return (
-    <div className="flex items-center gap-4">
-      <div
-        className={cn(
-          "relative flex size-10 shrink-0 items-center justify-center rounded-xl border bg-background shadow-sm",
-          state === "complete" && "border-primary/20 text-primary",
-          state === "active" && "border-primary/30 text-primary",
-          state === "error" &&
-            "border-destructive/30 bg-destructive/5 text-destructive",
-          state === "pending" && "border-border/70 text-muted-foreground/60",
-        )}
-      >
-        {state === "active" && (
-          <span className="absolute inset-1 animate-pulse rounded-lg border border-primary/25 motion-reduce:animate-none" />
-        )}
-        <span className="relative">{icon}</span>
-      </div>
-      <span
-        className={cn(
-          "text-sm font-medium",
-          state === "pending" ? "text-muted-foreground/65" : "text-foreground",
-        )}
-      >
-        {label}
-      </span>
-    </div>
-  );
-}
-
-function ConnectionLine({ active }: { active: boolean }) {
-  return (
-    <div className="ml-[1.2rem] h-11 w-px overflow-hidden bg-border">
-      {active && (
-        <div className="h-full w-px animate-pulse bg-linear-to-b from-transparent via-primary to-transparent motion-reduce:animate-none" />
-      )}
-    </div>
+          <p>
+            Keep this page open. You'll return automatically when it's ready.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
 function getProcessingCopy(phase: "initializing" | "completing") {
   if (phase === "initializing") {
     return {
-      eyebrow: "Secure OAuth connection",
-      title: "Preparing your connection",
-      description:
-        "We're reading the authorization response and preparing the secure handoff.",
+      title: "Preparing OAuth Connection",
+      description: "Getting the secure authorization handoff ready.",
+      loadingLabel: "Preparing OAuth authentication",
+      statusTitle: "Reading authorization response",
     };
   }
 
   return {
-    eyebrow: "Secure OAuth connection",
-    title: "Finishing the connection",
-    description:
-      "Your authorization is confirmed. We're securing the credentials and connecting the MCP server.",
+    title: "Finishing OAuth Connection",
+    description: "Your authorization is confirmed.",
+    loadingLabel: "Completing OAuth authentication",
+    statusTitle: "Securing credentials and connecting the MCP server",
   };
 }

--- a/platform/frontend/src/app/oauth-callback/page.tsx
+++ b/platform/frontend/src/app/oauth-callback/page.tsx
@@ -1,17 +1,7 @@
 "use client";
 
-import { AlertCircle, Loader2 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { trackEvent } from "@/lib/analytics";
 import { useHandleOAuthCallback } from "@/lib/auth/oauth.query";
 import {
@@ -46,6 +36,7 @@ import {
   type OAuthCallbackErrorState,
   toInternalReturnPath,
 } from "./oauth-callback.utils";
+import { OAuthCallbackStatus } from "./oauth-callback-status";
 
 function OAuthCallbackContent() {
   const searchParams = useSearchParams();
@@ -222,49 +213,23 @@ function OAuthCallbackContent() {
   if (callbackError) {
     return (
       <OAuthCallbackLayout>
-        <Card>
-          <CardHeader>
-            <CardTitle>OAuth Authentication</CardTitle>
-            <CardDescription>
-              Authentication could not be completed.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>{callbackError.title}</AlertTitle>
-              <AlertDescription>{callbackError.description}</AlertDescription>
-            </Alert>
-            <Button
-              onClick={() => {
-                clearOAuthReturnUrl();
-                router.push(errorReturnPath ?? "/mcp/registry");
-              }}
-            >
-              {errorReturnPath ? "Go Back" : "Return to MCP Registry"}
-            </Button>
-          </CardContent>
-        </Card>
+        <OAuthCallbackStatus
+          status="error"
+          errorTitle={callbackError.title}
+          errorDescription={callbackError.description}
+          actionLabel={errorReturnPath ? "Go Back" : "Return to MCP Registry"}
+          onAction={() => {
+            clearOAuthReturnUrl();
+            router.push(errorReturnPath ?? "/mcp/registry");
+          }}
+        />
       </OAuthCallbackLayout>
     );
   }
 
   return (
     <OAuthCallbackLayout>
-      <Card>
-        <CardHeader>
-          <CardTitle>OAuth Authentication</CardTitle>
-          <CardDescription>Processing authentication...</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-col items-center space-y-4">
-            <Loader2 className="h-12 w-12 animate-spin text-blue-600" />
-            <p className="text-center text-muted-foreground">
-              Completing OAuth authentication and installing MCP server...
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      <OAuthCallbackStatus status="processing" phase="completing" />
     </OAuthCallbackLayout>
   );
 }
@@ -272,28 +237,17 @@ function OAuthCallbackContent() {
 function LoadingFallback() {
   return (
     <OAuthCallbackLayout>
-      <Card>
-        <CardHeader>
-          <CardTitle>OAuth Authentication</CardTitle>
-          <CardDescription>Initializing OAuth flow...</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-col items-center space-y-4">
-            <Loader2 className="h-12 w-12 animate-spin text-blue-600" />
-            <p className="text-center text-muted-foreground">
-              Preparing to complete authentication...
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      <OAuthCallbackStatus status="processing" phase="initializing" />
     </OAuthCallbackLayout>
   );
 }
 
 function OAuthCallbackLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="mx-auto flex min-h-[calc(100dvh-8rem)] w-full max-w-2xl items-center justify-center p-6">
-      <div className="w-full">{children}</div>
+    <div className="relative isolate mx-auto flex min-h-[calc(100dvh-8rem)] w-full max-w-6xl items-center justify-center overflow-hidden px-4 py-10 sm:px-6 lg:px-10">
+      <div className="absolute top-[12%] left-[8%] -z-10 size-48 rounded-full bg-primary/5 blur-3xl" />
+      <div className="absolute right-[4%] bottom-[8%] -z-10 size-64 rounded-full bg-muted blur-3xl" />
+      {children}
     </div>
   );
 }

--- a/platform/frontend/src/app/oauth-callback/page.tsx
+++ b/platform/frontend/src/app/oauth-callback/page.tsx
@@ -244,9 +244,7 @@ function LoadingFallback() {
 
 function OAuthCallbackLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="relative isolate mx-auto flex min-h-[calc(100dvh-8rem)] w-full max-w-6xl items-center justify-center overflow-hidden px-4 py-10 sm:px-6 lg:px-10">
-      <div className="absolute top-[12%] left-[8%] -z-10 size-48 rounded-full bg-primary/5 blur-3xl" />
-      <div className="absolute right-[4%] bottom-[8%] -z-10 size-64 rounded-full bg-muted blur-3xl" />
+    <div className="mx-auto flex min-h-[calc(100dvh-8rem)] w-full items-center justify-center p-4">
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

- replace the boilerplate OAuth callback loader with clear preparing, completing, and error states
- reuse the existing Card, Alert, Button, and LoadingSpinner patterns used across the frontend
- extract the status presentation into a focused component with behavior-oriented coverage
- keep the callback flow and redirect behavior unchanged