### PR TITLE
fix(agents): render system prompts around malformed expressions

### DIFF
--- a/docs/pages/platform-agents.md
+++ b/docs/pages/platform-agents.md
@@ -3,7 +3,7 @@ title: Overview
 category: Agents
 order: 1
 description: Agent overview, invocation paths, knowledge sources, and prompt templating
-lastUpdated: 2026-08-22
+lastUpdated: 2026-08-23
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -208,11 +208,12 @@ Agent system prompts support [Handlebars](https://handlebarsjs.com/) templating.
 
 ### Variables
 
-| Variable         | Type     | Description                          |
-| ---------------- | -------- | ------------------------------------ |
-| `{{user.name}}`  | string   | Name of the user invoking the agent  |
-| `{{user.email}}` | string   | Email of the user invoking the agent |
-| `{{user.teams}}` | string[] | Team names the user belongs to       |
+| Variable         | Type     | Description                                      |
+| ---------------- | -------- | ------------------------------------------------ |
+| `{{user.name}}`  | string   | Name of the user invoking the agent              |
+| `{{user.email}}` | string   | Email of the user invoking the agent             |
+| `{{user.role}}`  | string   | Organization role of the user invoking the agent |
+| `{{user.teams}}` | string[] | Team names the user belongs to                   |
 
 ### Helpers
 
@@ -239,3 +240,9 @@ You are a helpful assistant for
   {{#each user.teams}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}.
 {{/if}}
 ```
+
+### Literal Braces
+
+Prefix an expression with a backslash to keep it as text: `\{{user.name}}` renders as `{{user.name}}`. This is useful when a prompt documents its own variables.
+
+An expression Handlebars cannot read is left as written, and the rest of the prompt still renders. The agent editor flags those expressions as you type, so you can see which ones reach the model as literal text.

--- a/platform/backend/src/agents/agent-system-prompt.test.ts
+++ b/platform/backend/src/agents/agent-system-prompt.test.ts
@@ -150,6 +150,57 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Teams: Platform.");
   });
 
+  test("renders the invoking user's organization role", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const agent = await makeAgent({
+      systemPrompt: "Role: {{user.role}}.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser({ email: "admin@test.com" });
+    await makeMember(user.id, agent.organizationId, { role: ADMIN_ROLE_NAME });
+
+    const prompt = await buildAgentSystemPrompt({
+      agent,
+      mcpTools: {},
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    });
+
+    expect(prompt).toContain(`Role: ${ADMIN_ROLE_NAME}.`);
+  });
+
+  test("substitutes the valid variables when the prompt also holds an unparseable expression", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    // A prompt that documents its own variables cannot be compiled, and used to
+    // send every expression in it to the model as literal text.
+    const agent = await makeAgent({
+      systemPrompt: "Hi {{user.name}}. Available: {{user.*}}.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser({ name: "Alice", email: "alice@test.com" });
+    await makeMember(user.id, agent.organizationId);
+
+    const prompt = await buildAgentSystemPrompt({
+      agent,
+      mcpTools: {},
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    });
+
+    expect(prompt).toContain("Hi Alice.");
+    expect(prompt).not.toContain("{{user.name}}");
+    // Only the expression Handlebars cannot read stays as the author wrote it.
+    expect(prompt).toContain("Available: {{user.*}}.");
+  });
+
   test("includes the skill catalog only when the load-skill tool is present", async ({
     makeAgent,
     makeUser,

--- a/platform/backend/src/agents/agent-system-prompt.ts
+++ b/platform/backend/src/agents/agent-system-prompt.ts
@@ -19,7 +19,7 @@ import {
 } from "@archestra/shared";
 import type { Tool } from "ai";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
-import { TeamModel, UserModel } from "@/models";
+import { MemberModel, TeamModel, UserModel } from "@/models";
 import type { OpenedApp } from "@/services/apps/opened-app-context";
 import { buildSkillCatalogPrompt } from "@/skills/skill-catalog-prompt";
 import {
@@ -508,13 +508,15 @@ async function renderAgentPrompt(params: {
   // Build template context only when prompts use Handlebars syntax.
   let promptContext: UserSystemPromptContext | null = null;
   if (promptNeedsRendering(systemPrompt)) {
-    const [resolvedUser, userTeams] = await Promise.all([
+    const [resolvedUser, userTeams, member] = await Promise.all([
       user ?? UserModel.getById(userId),
       TeamModel.getUserTeamsForOrganization({ userId, organizationId }),
+      MemberModel.getByUserId(userId, organizationId),
     ]);
     promptContext = buildUserSystemPromptContext({
       userName: resolvedUser?.name ?? "",
       userEmail: resolvedUser?.email ?? "",
+      userRole: member?.role,
       userTeams: userTeams.map((t) => t.name),
     });
   }

--- a/platform/backend/src/skills/skill-activation.test.ts
+++ b/platform/backend/src/skills/skill-activation.test.ts
@@ -1,4 +1,5 @@
 import {
+  ADMIN_ROLE_NAME,
   buildUserSystemPromptContext,
   getArchestraToolFullName,
   TOOL_DOWNLOAD_FILE_SHORT_NAME,
@@ -436,6 +437,37 @@ describe("buildSkillActivationPromptContext", () => {
 
     expect(result).toContain("Skill-Org-Finance");
     expect(result).not.toContain("Other-Org-Secret");
+  });
+
+  test("renders the activating user's organization role", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+  }) => {
+    const user = await makeUser();
+    const organization = await makeOrganization();
+    await makeMember(user.id, organization.id, { role: ADMIN_ROLE_NAME });
+
+    const promptContext = await buildSkillActivationPromptContext({
+      userId: user.id,
+      organizationId: organization.id,
+    });
+
+    const result = formatSkillActivation({
+      skill: {
+        name: "Role",
+        content: "Role: {{user.role}}",
+        compatibility: null,
+        allowedTools: null,
+        templated: true,
+      },
+      version: 1,
+      files: [],
+      canRunSandbox: false,
+      promptContext,
+    });
+
+    expect(result).toContain(`Role: ${ADMIN_ROLE_NAME}`);
   });
 
   test("returns null when no organization is resolved", async ({

--- a/platform/backend/src/skills/skill-activation.ts
+++ b/platform/backend/src/skills/skill-activation.ts
@@ -7,7 +7,7 @@ import {
   type UserSystemPromptContext,
 } from "@archestra/shared";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
-import { TeamModel, UserModel } from "@/models";
+import { MemberModel, TeamModel, UserModel } from "@/models";
 import { renderSystemPrompt } from "@/templating";
 import type { Skill, SkillFile } from "@/types";
 
@@ -127,7 +127,7 @@ export function formatSkillActivation({
 
 /**
  * Build the user context for rendering a `templated` skill body, mirroring the
- * agent system-prompt path (name, email, team names). Team names are scoped to
+ * agent system-prompt path (name, email, org role, team names). Team names are scoped to
  * the activating organization so a skill never sees the user's teams from other
  * orgs. Returns `null` when there is no user/org to resolve, so callers skip the
  * lookups for non-templated skills.
@@ -138,13 +138,15 @@ export async function buildSkillActivationPromptContext(params: {
 }): Promise<UserSystemPromptContext | null> {
   const { userId, organizationId } = params;
   if (!userId || !organizationId) return null;
-  const [user, teams] = await Promise.all([
+  const [user, teams, member] = await Promise.all([
     UserModel.getById(userId),
     TeamModel.getUserTeamsForOrganization({ userId, organizationId }),
+    MemberModel.getByUserId(userId, organizationId),
   ]);
   return buildUserSystemPromptContext({
     userName: user?.name ?? "",
     userEmail: user?.email ?? "",
+    userRole: member?.role,
     userTeams: teams.map((team) => team.name),
   });
 }

--- a/platform/backend/src/templating.test.ts
+++ b/platform/backend/src/templating.test.ts
@@ -299,6 +299,7 @@ describe("renderSystemPrompt", () => {
     user: {
       name: "Alice Smith",
       email: "alice@example.com",
+      role: "member",
       teams: ["Engineering", "Platform"],
     },
   };
@@ -351,6 +352,85 @@ describe("renderSystemPrompt", () => {
     );
   });
 
+  test("renders user.role variable", () => {
+    const template = "Role: {{user.role}}";
+    expect(renderSystemPrompt(template, baseContext)).toBe("Role: member");
+  });
+
+  test("renders user.role in a conditional", () => {
+    const template =
+      '{{#equals user.role "admin"}}admin tools{{else}}standard tools{{/equals}}';
+    expect(renderSystemPrompt(template, baseContext)).toBe("standard tools");
+  });
+
+  test("keeps rendering the valid variables around an unparseable expression", () => {
+    // `*` is not a legal Handlebars identifier, so this aborts compilation of
+    // the whole template — which used to ship every other variable to the model
+    // as literal text.
+    const template =
+      "Hi {{user.name}} ({{user.email}}). Variables: {{user.*}} are available.";
+    expect(renderSystemPrompt(template, baseContext)).toBe(
+      "Hi Alice Smith (alice@example.com). Variables: {{user.*}} are available.",
+    );
+  });
+
+  test("preserves multi-line block helpers alongside an unparseable expression", () => {
+    const template = [
+      "Operating for {{user.name}} ({{user.email}}).",
+      "Docs: {{user.*}}, {{currentDate}}.",
+      '{{#includes user.teams "Engineering"}}',
+      "  Engineering scope applies.",
+      "{{/includes}}",
+    ].join("\n");
+
+    const result = renderSystemPrompt(template, baseContext);
+
+    expect(result).toContain("Operating for Alice Smith (alice@example.com).");
+    // The block still evaluates rather than degrading to literal text.
+    expect(result).toContain("Engineering scope applies.");
+    expect(result).not.toContain("{{#includes");
+    // Only the expression Handlebars cannot parse stays as written.
+    expect(result).toContain("{{user.*}}");
+    expect(result).not.toContain("{{user.name}}");
+    expect(result).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+
+  test("renders variables when the prompt calls a block helper that does not exist", () => {
+    const template =
+      "Hi {{user.name}}. {{#notAHelper user.teams}}scoped{{/notAHelper}}";
+    const result = renderSystemPrompt(template, baseContext);
+
+    expect(result).toContain("Hi Alice Smith.");
+    expect(result).toContain("scoped");
+  });
+
+  test("renders variables when a block is left unclosed", () => {
+    const template = "Hi {{user.name}}. {{#if user.teams}}scoped";
+    expect(renderSystemPrompt(template, baseContext)).toBe(
+      "Hi Alice Smith. {{#if user.teams}}scoped",
+    );
+  });
+
+  test("leaves author-escaped expressions literal without adding a backslash", () => {
+    const template = "Literal \\{{user.name}} vs rendered {{user.name}}";
+    expect(renderSystemPrompt(template, baseContext)).toBe(
+      "Literal {{user.name}} vs rendered Alice Smith",
+    );
+  });
+
+  test("keeps an unparseable triple-stache literal", () => {
+    const template = "{{{user.*}}} then {{user.name}}";
+    expect(renderSystemPrompt(template, baseContext)).toBe(
+      "{{{user.*}}} then Alice Smith",
+    );
+  });
+
+  test("does not substitute expressions inside a quoted helper argument", () => {
+    const template =
+      '{{#includes user.teams "}}"}}odd{{else}}normal{{/includes}}';
+    expect(renderSystemPrompt(template, baseContext)).toBe("normal");
+  });
+
   test("renders empty string for missing variables", () => {
     const template = "Hello {{user.nonexistent}}!";
     expect(renderSystemPrompt(template, baseContext)).toBe("Hello !");
@@ -369,7 +449,7 @@ Current date: {{currentDate}}.`;
 
   test("handles empty teams array", () => {
     const context = {
-      user: { name: "Bob", email: "bob@test.com", teams: [] },
+      user: { name: "Bob", email: "bob@test.com", role: "member", teams: [] },
     };
     const template =
       "{{#if user.teams}}Teams: {{#each user.teams}}{{this}}{{/each}}{{else}}No teams{{/if}}";
@@ -400,7 +480,12 @@ Current date: {{currentDate}}.`;
 
   test("does not HTML-escape apostrophes in variable values", () => {
     const context = {
-      user: { name: "O'Brien", email: "obrien@test.com", teams: [] },
+      user: {
+        name: "O'Brien",
+        email: "obrien@test.com",
+        role: "member",
+        teams: [],
+      },
     };
     const template = "Hello {{user.name}}";
     expect(renderSystemPrompt(template, context)).toBe("Hello O'Brien");
@@ -408,7 +493,12 @@ Current date: {{currentDate}}.`;
 
   test("does not HTML-escape ampersands in variable values", () => {
     const context = {
-      user: { name: "Alice", email: "alice@test.com", teams: ["R&D"] },
+      user: {
+        name: "Alice",
+        email: "alice@test.com",
+        role: "member",
+        teams: ["R&D"],
+      },
     };
     const template = "Teams: {{#each user.teams}}{{this}}{{/each}}";
     expect(renderSystemPrompt(template, context)).toBe("Teams: R&D");
@@ -419,6 +509,7 @@ Current date: {{currentDate}}.`;
       user: {
         name: "use `tool` here",
         email: "test@test.com",
+        role: "member",
         teams: [],
       },
     };
@@ -430,7 +521,12 @@ Current date: {{currentDate}}.`;
 
   test("does not HTML-escape angle brackets in variable values", () => {
     const context = {
-      user: { name: "<admin>", email: "admin@test.com", teams: [] },
+      user: {
+        name: "<admin>",
+        email: "admin@test.com",
+        role: "member",
+        teams: [],
+      },
     };
     const template = "User: {{user.name}}";
     expect(renderSystemPrompt(template, context)).toBe("User: <admin>");
@@ -441,6 +537,7 @@ Current date: {{currentDate}}.`;
       user: {
         name: "O'Brien",
         email: "obrien@test.com",
+        role: "member",
         teams: ["R&D"],
       },
     };
@@ -492,6 +589,7 @@ describe("renderSystemPrompt with null handling", () => {
     user: {
       name: "Alice",
       email: "alice@test.com",
+      role: "member",
       teams: ["Engineering"],
     },
   };

--- a/platform/backend/src/templating.ts
+++ b/platform/backend/src/templating.ts
@@ -1,8 +1,12 @@
 import {
+  escapeTemplateExpressions,
   extractSsoGroupsFromRenderedTemplate,
+  isBlockExpression,
   isTruthyTemplateOutput,
+  isUnparseableExpression,
   registerSsoTemplateHelpers,
   SYSTEM_PROMPT_HELPER_NAMES,
+  type TemplateExpression,
   type UserSystemPromptContext,
 } from "@archestra/shared";
 import Handlebars from "handlebars";
@@ -56,7 +60,15 @@ export function promptNeedsRendering(
 /**
  * Render an agent's system prompt, applying Handlebars template variables
  * (e.g. {{user.name}}) when present. Returns null if no system prompt is set.
- * If the template fails to compile or render, returns the original string unchanged.
+ *
+ * Rendering is deliberately resilient. A Handlebars template is compiled as a
+ * single unit, so one malformed expression anywhere in the prompt aborts the
+ * whole render — and a prompt that renders raw ships every *valid* expression
+ * to the model as literal `{{user.name}}` text. Authors write prose, not
+ * programs: prompts routinely document their own variables (`{{user.*}}`) or
+ * quote another engine's syntax, and neither should cost them the substitutions
+ * that do work. So an expression Handlebars cannot parse is escaped to the
+ * literal text the author typed, and everything around it still renders.
  *
  * @param additionalContext - Optional extra context merged alongside user context.
  *   Used by specific subagents (e.g. policy configuration) to inject agent-specific
@@ -73,16 +85,46 @@ export function renderSystemPrompt(
     return systemPrompt;
   }
 
-  try {
-    const template = Handlebars.compile(systemPrompt, { noEscape: true });
-    return template({ ...context, ...additionalContext });
-  } catch (error) {
-    logger.warn(
-      { err: error },
-      "Failed to render system prompt template, using raw template string",
-    );
-    return systemPrompt;
+  const data = { ...context, ...additionalContext };
+
+  const direct = tryRender(systemPrompt, data);
+  if (direct.ok) {
+    return direct.output;
   }
+
+  // Escape the individual expressions that cannot parse on their own — the
+  // common case, and the one that leaves every other variable substitutable.
+  const { template: repaired, escaped } = escapeTemplateExpressions(
+    systemPrompt,
+    cannotParse,
+  );
+  if (escaped.length > 0) {
+    const partial = tryRender(repaired, data);
+    if (partial.ok) {
+      logUnrenderable(escaped, direct.error);
+      return partial.output;
+    }
+  }
+
+  // Still failing: the damage is structural (an unclosed block, or a block
+  // helper that does not exist) rather than a single bad expression. Escaping
+  // every block token leaves the block syntax visible as written while the
+  // plain variables around it — the ones users actually notice leaking — render.
+  const { template: blocksEscaped, escaped: escapedBlocks } =
+    escapeTemplateExpressions(repaired, isBlockExpression);
+  if (escapedBlocks.length > 0) {
+    const withoutBlocks = tryRender(blocksEscaped, data);
+    if (withoutBlocks.ok) {
+      logUnrenderable([...escaped, ...escapedBlocks], direct.error);
+      return withoutBlocks.output;
+    }
+  }
+
+  logger.warn(
+    { err: direct.error },
+    "Failed to render system prompt template, using raw template string",
+  );
+  return systemPrompt;
 }
 
 /**
@@ -132,3 +174,50 @@ export function extractGroupsWithTemplate(
 }
 
 export type { UserSystemPromptContext };
+
+// ===== Internal helpers =====
+
+/** Most unrenderable expressions to name in a log line. */
+const LOGGED_EXPRESSION_LIMIT = 10;
+
+type RenderAttempt =
+  | { ok: true; output: string }
+  | { ok: false; error: unknown };
+
+function tryRender(
+  template: string,
+  data: Record<string, unknown>,
+): RenderAttempt {
+  try {
+    // Compilation is lazy: parse errors surface on first invocation, so both
+    // steps have to sit inside the same try.
+    return {
+      ok: true,
+      output: Handlebars.compile(template, { noEscape: true })(data),
+    };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+/** Bind the shared syntax check to this module's Handlebars runtime. */
+function cannotParse(expression: TemplateExpression): boolean {
+  return isUnparseableExpression(expression, (template) =>
+    Handlebars.parse(template),
+  );
+}
+
+/**
+ * Surface what was left literal. Admins otherwise only learn about it when a
+ * model quotes `{{user.name}}` back at a user.
+ */
+function logUnrenderable(expressions: string[], error: unknown): void {
+  logger.warn(
+    {
+      err: error,
+      unrenderableExpressions: expressions.slice(0, LOGGED_EXPRESSION_LIMIT),
+      unrenderableExpressionCount: expressions.length,
+    },
+    "System prompt contains template expressions Handlebars cannot render; they were left as literal text and the rest of the prompt was rendered",
+  );
+}

--- a/platform/frontend/src/components/system-prompt-editor.test.tsx
+++ b/platform/frontend/src/components/system-prompt-editor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -104,6 +104,44 @@ describe("SystemPromptEditor", () => {
     );
     expect(screen.queryByRole("dialog")).toBeNull();
     expect(screen.getAllByTestId("editor")).toHaveLength(1);
+  });
+
+  it("warns about expressions Handlebars cannot parse", async () => {
+    mockGetFrontendDocsUrl.mockReturnValue(null);
+
+    render(
+      <SystemPromptEditor
+        value="Hi {{user.name}}, see {{user.*}} for the rest."
+        onChange={vi.fn()}
+      />,
+    );
+
+    // The parser is loaded lazily, so the warning arrives after a tick.
+    await waitFor(() =>
+      expect(screen.getByText("{{user.*}}")).toBeInTheDocument(),
+    );
+    // The valid expression is not flagged.
+    expect(screen.queryByText("{{user.name}}")).toBeNull();
+  });
+
+  it("clears the warning once the expression parses", async () => {
+    mockGetFrontendDocsUrl.mockReturnValue(null);
+
+    const { rerender } = render(
+      <SystemPromptEditor value="Hi {{user.*}}" onChange={vi.fn()} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("{{user.*}}")).toBeInTheDocument(),
+    );
+
+    // A valid template — block helpers included — leaves nothing flagged.
+    rerender(
+      <SystemPromptEditor
+        value={'Hi {{user.name}}. {{#includes user.teams "A"}}a{{/includes}}'}
+        onChange={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.queryByText("{{user.*}}")).toBeNull());
   });
 
   it("leaves the full-screen editor read-only when the form is", async () => {

--- a/platform/frontend/src/components/system-prompt-editor.tsx
+++ b/platform/frontend/src/components/system-prompt-editor.tsx
@@ -5,7 +5,7 @@ import {
   getSystemPromptTemplateExpressions,
 } from "@archestra/shared";
 import type { EditorProps } from "@monaco-editor/react";
-import { Maximize2, Minimize2 } from "lucide-react";
+import { Maximize2, Minimize2, TriangleAlert } from "lucide-react";
 import { type ReactNode, useState } from "react";
 
 import { Editor } from "@/components/editor";
@@ -23,6 +23,7 @@ import {
   computeHandlebarsReplaceOffsets,
   shouldShowHandlebarsCompletions,
 } from "@/lib/utils/handlebars-completion";
+import { useUnparseableExpressions } from "@/lib/utils/handlebars-validation";
 
 export function SystemPromptEditor({
   value,
@@ -49,6 +50,7 @@ export function SystemPromptEditor({
     "system-prompt-templating",
   );
   const [isFullScreen, setIsFullScreen] = useState(false);
+  const unparseableExpressions = useUnparseableExpressions(value);
   const templateExpressions = getSystemPromptTemplateExpressions({
     builtInAgentId,
   });
@@ -118,6 +120,7 @@ export function SystemPromptEditor({
           options={{ ...SHARED_EDITOR_OPTIONS, readOnly }}
         />
       </div>
+      <UnparseableExpressionsWarning expressions={unparseableExpressions} />
       <SystemPromptFullScreenDialog
         open={isFullScreen}
         onOpenChange={setIsFullScreen}
@@ -127,6 +130,7 @@ export function SystemPromptEditor({
         description={description}
         headerExtra={headerExtra}
         templateExpressions={templateExpressions}
+        unparseableExpressions={unparseableExpressions}
       />
     </div>
   );
@@ -135,6 +139,42 @@ export function SystemPromptEditor({
 // ===
 // Internal helpers
 // ===
+
+/**
+ * Names the expressions Handlebars cannot parse. They are rendered as the
+ * literal text the author typed rather than dropped, so this is a warning and
+ * not an error — but an author who meant to interpolate a value has no other
+ * way to find out before a model reads the braces back to a user.
+ */
+function UnparseableExpressionsWarning({
+  expressions,
+}: {
+  expressions: string[];
+}) {
+  if (expressions.length === 0) return null;
+
+  const shown = [...new Set(expressions)].slice(0, UNPARSEABLE_SHOWN_MAX);
+
+  return (
+    <p className="text-xs text-amber-600 dark:text-amber-500">
+      <TriangleAlert className="mr-1 inline size-3.5 align-[-2px]" />
+      {shown.length === 1
+        ? "This expression isn't valid Handlebars and will appear literally in the prompt: "
+        : "These expressions aren't valid Handlebars and will appear literally in the prompt: "}
+      {shown.map((expression, index) => (
+        <span key={expression}>
+          {index > 0 && <span>, </span>}
+          <code className="font-mono">{expression}</code>
+        </span>
+      ))}
+      {expressions.length > shown.length && <span>, …</span>}
+      {". Prefix one with a backslash to keep it as literal text on purpose."}
+    </p>
+  );
+}
+
+/** Enough to act on without turning the warning into a second prompt. */
+const UNPARSEABLE_SHOWN_MAX = 5;
 
 /**
  * The same instruction, the whole viewport wide and tall: a second editor on
@@ -152,6 +192,7 @@ function SystemPromptFullScreenDialog({
   description,
   headerExtra,
   templateExpressions,
+  unparseableExpressions,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -161,6 +202,7 @@ function SystemPromptFullScreenDialog({
   description: ReactNode;
   headerExtra?: ReactNode;
   templateExpressions: TemplateExpressions;
+  unparseableExpressions: string[];
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -217,6 +259,13 @@ function SystemPromptFullScreenDialog({
             }}
           />
         </div>
+        {unparseableExpressions.length > 0 && (
+          <div className="border-t px-4 py-3">
+            <UnparseableExpressionsWarning
+              expressions={unparseableExpressions}
+            />
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/platform/frontend/src/lib/utils/handlebars-validation.ts
+++ b/platform/frontend/src/lib/utils/handlebars-validation.ts
@@ -1,0 +1,56 @@
+import { findUnparseableExpressions } from "@archestra/shared";
+import { useEffect, useState } from "react";
+
+/**
+ * The template expressions in a prompt that Handlebars cannot parse.
+ *
+ * These are not rejected — a prompt is prose, and an expression the engine
+ * cannot read is rendered as the literal text the author typed. But that is
+ * almost never what someone typing `{{user.name}}` intends, and until the
+ * prompt is run against a model there is nothing to notice it by, so the editor
+ * says so up front.
+ *
+ * Handlebars is loaded lazily: only prompt authors need the parser, and it is
+ * far too large to sit in the initial bundle.
+ */
+export function useUnparseableExpressions(template: string): string[] {
+  const [expressions, setExpressions] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!template.includes("{{")) {
+      setExpressions([]);
+      return;
+    }
+
+    let active = true;
+    void (async () => {
+      try {
+        const parse = await loadHandlebarsParser();
+        if (!active) return;
+        setExpressions(findUnparseableExpressions(template, parse));
+      } catch {
+        // Validation is advisory; a parser that will not load must not take
+        // the editor with it.
+        if (active) setExpressions([]);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [template]);
+
+  return expressions;
+}
+
+// ===
+// Internal helpers
+// ===
+
+type HandlebarsRuntime = typeof import("handlebars");
+
+async function loadHandlebarsParser(): Promise<(template: string) => unknown> {
+  const module = await import("handlebars/dist/handlebars");
+  const handlebars = (module.default ?? module) as HandlebarsRuntime;
+  return (template: string) => handlebars.parse(template);
+}

--- a/platform/shared/handlebars-expressions.ts
+++ b/platform/shared/handlebars-expressions.ts
@@ -27,51 +27,7 @@ export interface TemplateExpression {
 }
 
 /** Parses a Handlebars template, throwing when it is syntactically invalid. */
-export type HandlebarsParser = (template: string) => unknown;
-
-/**
- * Locate the Handlebars expressions in a template.
- *
- * Deliberately conservative: an expression this misses is simply not reported,
- * which degrades to the caller's existing fallback rather than to wrong output.
- */
-export function findTemplateExpressions(
-  template: string,
-): TemplateExpression[] {
-  const expressions: TemplateExpression[] = [];
-
-  for (let i = 0; i < template.length - 1; i++) {
-    if (template[i] !== "{" || template[i + 1] !== "{") continue;
-
-    // An expression the author already escaped is literal text, not a template
-    // expression, and must not be escaped a second time.
-    if (template[i - 1] === "\\") continue;
-
-    // `{{{value}}}` needs three closing braces, `{{value}}` two. Raw blocks
-    // (`{{{{`) are left alone — skip the whole run so their inner braces are
-    // not mistaken for a triple-stache.
-    let braces = 0;
-    while (template[i + braces] === "{") braces++;
-    if (braces > 3) {
-      i += braces - 1;
-      continue;
-    }
-
-    const end = findExpressionEnd(template, i + braces, braces);
-    if (end === -1) break; // Unterminated: nothing after it is parseable either.
-
-    const source = template.slice(i, end);
-    expressions.push({
-      start: i,
-      end,
-      source,
-      body: source.slice(braces, source.length - braces).trim(),
-    });
-    i = end - 1;
-  }
-
-  return expressions;
-}
+type HandlebarsParser = (template: string) => unknown;
 
 /**
  * Whether Handlebars rejects this expression on its own.
@@ -147,6 +103,48 @@ export function findUnparseableExpressions(
 }
 
 // ===== Internal helpers =====
+
+/**
+ * Locate the Handlebars expressions in a template.
+ *
+ * Deliberately conservative: an expression this misses is simply not reported,
+ * which degrades to the caller's existing fallback rather than to wrong output.
+ */
+function findTemplateExpressions(template: string): TemplateExpression[] {
+  const expressions: TemplateExpression[] = [];
+
+  for (let i = 0; i < template.length - 1; i++) {
+    if (template[i] !== "{" || template[i + 1] !== "{") continue;
+
+    // An expression the author already escaped is literal text, not a template
+    // expression, and must not be escaped a second time.
+    if (template[i - 1] === "\\") continue;
+
+    // `{{{value}}}` needs three closing braces, `{{value}}` two. Raw blocks
+    // (`{{{{`) are left alone — skip the whole run so their inner braces are
+    // not mistaken for a triple-stache.
+    let braces = 0;
+    while (template[i + braces] === "{") braces++;
+    if (braces > 3) {
+      i += braces - 1;
+      continue;
+    }
+
+    const end = findExpressionEnd(template, i + braces, braces);
+    if (end === -1) break; // Unterminated: nothing after it is parseable either.
+
+    const source = template.slice(i, end);
+    expressions.push({
+      start: i,
+      end,
+      source,
+      body: source.slice(braces, source.length - braces).trim(),
+    });
+    i = end - 1;
+  }
+
+  return expressions;
+}
 
 /**
  * Index just past the closing braces of an expression, or -1 when unterminated.

--- a/platform/shared/handlebars-expressions.ts
+++ b/platform/shared/handlebars-expressions.ts
@@ -1,0 +1,191 @@
+/**
+ * Locating and neutralizing the individual expressions inside a Handlebars
+ * template.
+ *
+ * Handlebars compiles a template as a single unit, so one malformed expression
+ * anywhere aborts the whole render. For prompts — prose that happens to carry
+ * template syntax — that is the wrong trade: it costs the author every
+ * substitution that *would* have worked and ships raw `{{user.name}}` text to
+ * the model. These helpers let a caller find the offending expressions so it
+ * can render around them (backend) or warn about them before they are saved
+ * (frontend).
+ *
+ * The Handlebars parser is injected rather than imported so this module stays
+ * dependency-free and browser-safe; callers pass their own runtime.
+ */
+
+/** A single `{{...}}` occurrence and where it sits in the template. */
+export interface TemplateExpression {
+  /** Index of the first `{`. */
+  start: number;
+  /** Index just past the final `}`. */
+  end: number;
+  /** The full expression as written, braces included. */
+  source: string;
+  /** The text between the braces, trimmed. */
+  body: string;
+}
+
+/** Parses a Handlebars template, throwing when it is syntactically invalid. */
+export type HandlebarsParser = (template: string) => unknown;
+
+/**
+ * Locate the Handlebars expressions in a template.
+ *
+ * Deliberately conservative: an expression this misses is simply not reported,
+ * which degrades to the caller's existing fallback rather than to wrong output.
+ */
+export function findTemplateExpressions(
+  template: string,
+): TemplateExpression[] {
+  const expressions: TemplateExpression[] = [];
+
+  for (let i = 0; i < template.length - 1; i++) {
+    if (template[i] !== "{" || template[i + 1] !== "{") continue;
+
+    // An expression the author already escaped is literal text, not a template
+    // expression, and must not be escaped a second time.
+    if (template[i - 1] === "\\") continue;
+
+    // `{{{value}}}` needs three closing braces, `{{value}}` two. Raw blocks
+    // (`{{{{`) are left alone — skip the whole run so their inner braces are
+    // not mistaken for a triple-stache.
+    let braces = 0;
+    while (template[i + braces] === "{") braces++;
+    if (braces > 3) {
+      i += braces - 1;
+      continue;
+    }
+
+    const end = findExpressionEnd(template, i + braces, braces);
+    if (end === -1) break; // Unterminated: nothing after it is parseable either.
+
+    const source = template.slice(i, end);
+    expressions.push({
+      start: i,
+      end,
+      source,
+      body: source.slice(braces, source.length - braces).trim(),
+    });
+    i = end - 1;
+  }
+
+  return expressions;
+}
+
+/**
+ * Whether Handlebars rejects this expression on its own.
+ *
+ * Only syntax is considered: a helper that does not exist parses fine and fails
+ * at render time, which is a different (and separately recoverable) problem.
+ */
+export function isUnparseableExpression(
+  expression: TemplateExpression,
+  parse: HandlebarsParser,
+): boolean {
+  const { body, source } = expression;
+
+  // Comments never fail, and partials and block closers are only ever invalid
+  // because of the tag that opened them.
+  if (body.startsWith("!") || body.startsWith(">") || body.startsWith("/")) {
+    return false;
+  }
+
+  // A block opener cannot parse alone; give it the closing tag it is missing.
+  if (body.startsWith("#") || body.startsWith("^")) {
+    const name = body.slice(1).trim().split(/[\s}]/)[0];
+    if (!name) return false;
+    return !canParse(`${source}{{/${name}}}`, parse);
+  }
+
+  return !canParse(source, parse);
+}
+
+/** Whether this expression opens, closes, or branches a block. */
+export function isBlockExpression({ body }: TemplateExpression): boolean {
+  return (
+    body.startsWith("#") ||
+    body.startsWith("^") ||
+    body.startsWith("/") ||
+    body === "else"
+  );
+}
+
+/**
+ * Prefix each expression the predicate selects with `\`, which Handlebars
+ * renders as the literal expression text (the backslash itself is consumed).
+ */
+export function escapeTemplateExpressions(
+  template: string,
+  shouldEscape: (expression: TemplateExpression) => boolean,
+): { template: string; escaped: string[] } {
+  const escaped: string[] = [];
+  let result = "";
+  let copiedTo = 0;
+
+  for (const expression of findTemplateExpressions(template)) {
+    if (!shouldEscape(expression)) continue;
+    escaped.push(expression.source);
+    result += `${template.slice(copiedTo, expression.start)}\\`;
+    copiedTo = expression.start;
+  }
+
+  return { template: result + template.slice(copiedTo), escaped };
+}
+
+/**
+ * The expressions in a template that Handlebars cannot parse, as written.
+ * These render as literal text rather than as values.
+ */
+export function findUnparseableExpressions(
+  template: string,
+  parse: HandlebarsParser,
+): string[] {
+  return findTemplateExpressions(template)
+    .filter((expression) => isUnparseableExpression(expression, parse))
+    .map((expression) => expression.source);
+}
+
+// ===== Internal helpers =====
+
+/**
+ * Index just past the closing braces of an expression, or -1 when unterminated.
+ * Quoted parameters may themselves contain braces (`{{helper "}}"}}`), so
+ * string literals are skipped rather than scanned.
+ */
+function findExpressionEnd(
+  template: string,
+  from: number,
+  braces: number,
+): number {
+  const closing = "}".repeat(braces);
+  let quote: string | null = null;
+
+  for (let i = from; i < template.length; i++) {
+    const char = template[i];
+
+    if (quote) {
+      if (char === "\\") i++;
+      else if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (template.startsWith(closing, i)) return i + braces;
+  }
+
+  return -1;
+}
+
+function canParse(template: string, parse: HandlebarsParser): boolean {
+  try {
+    parse(template);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/platform/shared/index.ts
+++ b/platform/shared/index.ts
@@ -16,6 +16,7 @@ export * from "./docs";
 export * from "./e2e-test-ids";
 export * from "./environment-defaults";
 export * from "./gemini-models";
+export * from "./handlebars-expressions";
 export { client as archestraApiClient } from "./hey-api/clients/api/client.gen";
 export * as archestraApiSdk from "./hey-api/clients/api/sdk.gen";
 export * as archestraApiTypes from "./hey-api/clients/api/types.gen";

--- a/platform/shared/system-prompt-template.ts
+++ b/platform/shared/system-prompt-template.ts
@@ -7,12 +7,14 @@ const toTemplateExpression = (path: string) => `{{${path}}}`;
 export const SYSTEM_PROMPT_VARIABLE_PATHS = {
   userName: `${USER_SYSTEM_PROMPT_CONTEXT_KEY}.name`,
   userEmail: `${USER_SYSTEM_PROMPT_CONTEXT_KEY}.email`,
+  userRole: `${USER_SYSTEM_PROMPT_CONTEXT_KEY}.role`,
   userTeams: `${USER_SYSTEM_PROMPT_CONTEXT_KEY}.teams`,
 } as const;
 
 export const SYSTEM_PROMPT_VARIABLE_EXPRESSIONS = {
   userName: toTemplateExpression(SYSTEM_PROMPT_VARIABLE_PATHS.userName),
   userEmail: toTemplateExpression(SYSTEM_PROMPT_VARIABLE_PATHS.userEmail),
+  userRole: toTemplateExpression(SYSTEM_PROMPT_VARIABLE_PATHS.userRole),
   userTeams: toTemplateExpression(SYSTEM_PROMPT_VARIABLE_PATHS.userTeams),
 } as const;
 
@@ -29,6 +31,10 @@ export const SYSTEM_PROMPT_VARIABLES = [
   {
     expression: SYSTEM_PROMPT_VARIABLE_EXPRESSIONS.userEmail,
     description: "Email of the user invoking the agent",
+  },
+  {
+    expression: SYSTEM_PROMPT_VARIABLE_EXPRESSIONS.userRole,
+    description: "Organization role of the user invoking the agent",
   },
   {
     expression: SYSTEM_PROMPT_VARIABLE_EXPRESSIONS.userTeams,
@@ -136,6 +142,12 @@ export interface UserSystemPromptContext {
   user: {
     name: string;
     email: string;
+    /**
+     * The user's organization role. Empty when the caller has no membership to
+     * resolve it from (e.g. an autonomous run acting outside a member context),
+     * so a prompt branching on it degrades to "no role" rather than to a leak.
+     */
+    role: string;
     teams: string[];
   };
 }
@@ -143,12 +155,14 @@ export interface UserSystemPromptContext {
 export function buildUserSystemPromptContext(params: {
   userName: string;
   userEmail: string;
+  userRole?: string | null;
   userTeams: string[];
 }): UserSystemPromptContext {
   return {
     [USER_SYSTEM_PROMPT_CONTEXT_KEY]: {
       name: params.userName,
       email: params.userEmail,
+      role: params.userRole ?? "",
       teams: params.userTeams,
     },
   };


### PR DESCRIPTION
## Summary

- render valid system-prompt variables even when another Handlebars expression cannot be parsed
- preserve malformed expressions as literal text and warn prompt authors in the editor
- add `{{user.role}}` to agent and templated-skill context
- document literal expressions and the new role variable

## Reproduction and validation

The supplied session export contains five Bedrock interactions. Every response completed with `end_turn`. In the four requests whose prompt contained `{{user.*}}`, valid name, email, and role expressions remained unrendered and the model repeated them literally. The short request without the malformed wildcard rendered normally.

On clean `main`, both a minimal prompt and the supplied 49 KB prompt reproduce the same mechanism: Handlebars rejects `{{user.*}}`, then `renderSystemPrompt` returns the entire raw prompt.

Validated live against the reported `us.anthropic.claude-sonnet-5` Bedrock inference profile:

- before the fix, the model reported that `{{user.name}}` and `{{user.email}}` were unfilled template placeholders
- after rendering through this branch, the same model returned the neutral rendered name and email
- both inference calls completed with `end_turn`

The visible errored-turn cards in the supplied screenshot occur after successful model responses and are not explained by Handlebars rendering. This PR intentionally does not claim to fix that separate symptom.