### PR TITLE
ci: stabilize hibernation e2e and Docker scans

### DIFF
--- a/.github/actions/scan-docker-image/action.yml
+++ b/.github/actions/scan-docker-image/action.yml
@@ -29,33 +29,54 @@ inputs:
 runs:
   using: composite
   steps:
-    # First attempt is allowed to fail so a transient infrastructure error
-    # (e.g. a 403 downloading the Scout binary release asset, which has kicked
-    # PRs out of the merge queue) gets one retry. A genuine CVE finding fails
-    # the retry identically, so real findings still fail the job.
-    - name: Docker Scout CVE Check
-      id: scout-first-attempt
-      continue-on-error: true
-      uses: docker/scout-action@7520205ff60037fdc436b40b6a1d1e55a839ec2d # v1.22.0
-      with:
-        command: cves
-        image: ${{ inputs.image }}
-        dockerhub-user: ${{ inputs.dockerhub-user }}
-        dockerhub-password: ${{ inputs.dockerhub-password }}
-        only-severities: ${{ inputs.only-severities }}
-        only-fixed: ${{ inputs.only-fixed }}
-        write-comment: false
-        exit-code: ${{ inputs.exit-code }}
+    # scout-action downloads its 174 MB helper from GitHub's release-asset API
+    # without forwarding github-token, so hosted-runner IP rate limits surface
+    # as a 403 before the scan starts. Download the official CLI through `gh`
+    # instead: the workflow token authenticates the asset request, and the
+    # pinned checksum protects the extracted executable.
+    - name: Install Docker Scout CLI
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        SCOUT_VERSION: "1.24.0"
+        SCOUT_ARCHIVE_SHA256: "f4e2814bd61040365153d5b964b144cb2dc6ee536a68b5bac4cadf00fc0ec34b"
+      run: |
+        set -euo pipefail
 
-    - name: Docker Scout CVE Check (retry)
-      if: steps.scout-first-attempt.outcome == 'failure'
-      uses: docker/scout-action@7520205ff60037fdc436b40b6a1d1e55a839ec2d # v1.22.0
-      with:
-        command: cves
-        image: ${{ inputs.image }}
-        dockerhub-user: ${{ inputs.dockerhub-user }}
-        dockerhub-password: ${{ inputs.dockerhub-password }}
-        only-severities: ${{ inputs.only-severities }}
-        only-fixed: ${{ inputs.only-fixed }}
-        write-comment: false
-        exit-code: ${{ inputs.exit-code }}
+        scout_dir="${RUNNER_TEMP}/docker-scout-${SCOUT_VERSION}"
+        scout_archive="${scout_dir}/docker-scout_${SCOUT_VERSION}_linux_amd64.tar.gz"
+        mkdir -p "${scout_dir}"
+
+        gh release download "v${SCOUT_VERSION}" \
+          --repo docker/scout-cli \
+          --pattern "docker-scout_${SCOUT_VERSION}_linux_amd64.tar.gz" \
+          --output "${scout_archive}" \
+          --clobber
+        echo "${SCOUT_ARCHIVE_SHA256}  ${scout_archive}" | sha256sum --check
+        tar -xzf "${scout_archive}" -C "${scout_dir}" docker-scout
+
+    - name: Docker Scout CVE Check
+      shell: bash
+      env:
+        DOCKER_SCOUT_HUB_USER: ${{ inputs.dockerhub-user }}
+        DOCKER_SCOUT_HUB_PASSWORD: ${{ inputs.dockerhub-password }}
+        SCOUT_IMAGE: ${{ inputs.image }}
+        SCOUT_ONLY_SEVERITIES: ${{ inputs.only-severities }}
+        SCOUT_ONLY_FIXED: ${{ inputs.only-fixed }}
+        SCOUT_EXIT_CODE: ${{ inputs.exit-code }}
+      run: |
+        set -euo pipefail
+
+        scout_args=(
+          cves
+          "${SCOUT_IMAGE}"
+          --only-severity "${SCOUT_ONLY_SEVERITIES}"
+        )
+        if [[ "${SCOUT_ONLY_FIXED}" == "true" ]]; then
+          scout_args+=(--only-fixed)
+        fi
+        if [[ "${SCOUT_EXIT_CODE}" == "true" ]]; then
+          scout_args+=(--exit-code)
+        fi
+
+        "${RUNNER_TEMP}/docker-scout-1.24.0/docker-scout" "${scout_args[@]}"

--- a/platform/e2e-tests/tests/mcp-hibernation-topology.spec.ts
+++ b/platform/e2e-tests/tests/mcp-hibernation-topology.spec.ts
@@ -8,9 +8,6 @@ import {
   DEFAULT_TEAM_NAME,
   ENGINEERING_TEAM_NAME,
   MCP_SERVER_NAMESPACE,
-  METRICS_BASE_URL,
-  METRICS_BEARER_TOKEN,
-  METRICS_ENDPOINT,
 } from "../consts";
 // `apiRequest` is the plain helper, not the same-named test fixture: the
 // describe-scoped readers below cannot take fixtures.
@@ -91,16 +88,6 @@ const INSTALL_WAIT_ATTEMPTS = 120;
  * should wait longer than this for a hibernation that is going to happen.
  */
 const HIBERNATION_DEADLINE_MS = 240_000;
-
-/**
- * Per-(server_name, state) gauge the runtime manager publishes for every
- * deployment it has loaded (observability/metrics/mcp.ts). It is the only
- * transport-independent surface carrying PER-INSTALL deployment state — the
- * REST API exposes the install row, not its live K8s state — which is what
- * makes it the observable for "no install advertises a stale state" on a
- * deployment two installs share.
- */
-const DEPLOYMENT_STATUS_METRIC = "mcp_server_deployment_status";
 
 interface InstallFixture {
   id: string;
@@ -389,24 +376,6 @@ test.describe("MCP idle hibernation - deployment topologies", () => {
       installB.name,
       "the two installs must report under different identifiers, or no metric assertion below can tell them apart",
     ).not.toBe(installA.name);
-  };
-
-  /** What each install currently reports as its live deployment state. */
-  const readReportedStates = async (
-    request: APIRequestContext,
-  ): Promise<Map<string, string>> => {
-    const response = await request.get(
-      `${METRICS_BASE_URL}${METRICS_ENDPOINT}`,
-      {
-        headers: { Authorization: `Bearer ${METRICS_BEARER_TOKEN}` },
-      },
-    );
-    if (!response.ok()) {
-      throw new Error(
-        `Metrics endpoint returned ${response.status()} ${await response.text()}`,
-      );
-    }
-    return parseReportedDeploymentStates(await response.text());
   };
 
   test.beforeAll(
@@ -747,7 +716,7 @@ test.describe("MCP idle hibernation - deployment topologies", () => {
     },
   );
 
-  test("two installs of a multitenant catalog share one Deployment, and sleeping it is visible on both", async ({
+  test("two installs of a multitenant catalog share one Deployment, and sleeping stops their shared pod", async ({
     request,
   }) => {
     // Two cold tool calls, a scale-to-zero the kubelet has to act on, and the
@@ -804,29 +773,16 @@ test.describe("MCP idle hibernation - deployment topologies", () => {
       })
       .toBe(0);
 
-    // Both installs must converge on "hibernated". They are separate
-    // deployment objects in the runtime manager pointing at one Kubernetes
-    // Deployment — a transition is applied to the object it was called on and
-    // mirrored onto the siblings — so an install whose state is derived from
-    // anything but that shared object keeps advertising a server that is not
-    // running. Two series, one per install's own row name (distinct, and
-    // checked at the top of this test), so the mirroring onto B is what the
-    // second entry can fail on.
-    await expect
-      .poll(
-        async () => {
-          const states = await readReportedStates(request);
-          return {
-            [installA.name]: states.get(installA.name),
-            [installB.name]: states.get(installB.name),
-          };
-        },
-        { timeout: 120_000, intervals: [2_000, 5_000] },
-      )
-      .toEqual({
-        [installA.name]: "hibernated",
-        [installB.name]: "hibernated",
-      });
+    // Assert cluster truth directly. The metrics NodePort is load-balanced
+    // across two web replicas in CI, while each replica reports only the
+    // runtime objects it has loaded; a single scrape is therefore not a
+    // cluster-wide per-install observable. The independent gateway calls in
+    // this and the next test pin the user-visible behavior for both installs.
+    expect(await readHibernationShape(sharedDeploymentName)).toEqual({
+      replicas: 0,
+      hibernated: "true",
+      preHibernationReplicas: String(sharedReplicas),
+    });
   });
 
   test("demand on one install wakes the shared pod for every install on it", async ({
@@ -877,24 +833,6 @@ test.describe("MCP idle hibernation - deployment topologies", () => {
     // assignment are all pinned to A's install id, so being answered here is
     // A's own observation and not a second reading of B's.
     expect(await callTool(request, installA)).toBe(multitenantToolText);
-
-    // And the wake is mirrored back onto both installs' reported state, the
-    // same way the sleep was — one series per install's own row name.
-    await expect
-      .poll(
-        async () => {
-          const states = await readReportedStates(request);
-          return {
-            [installA.name]: states.get(installA.name),
-            [installB.name]: states.get(installB.name),
-          };
-        },
-        { timeout: 120_000, intervals: [2_000, 5_000] },
-      )
-      .toEqual({
-        [installA.name]: "running",
-        [installB.name]: "running",
-      });
   });
 
   /**
@@ -1221,33 +1159,3 @@ test.describe("MCP idle hibernation - deployment topologies", () => {
     }
   });
 });
-
-// === Internal ===
-
-/**
- * The state each MCP install reports, parsed out of the Prometheus exposition
- * text. The gauge carries one series per (server_name, state) pair with the
- * active one set to 1, so the answer is the state whose sample is 1.
- */
-function parseReportedDeploymentStates(body: string): Map<string, string> {
-  const states = new Map<string, string>();
-  const samplePattern = new RegExp(
-    `^${DEPLOYMENT_STATUS_METRIC}\\{([^}]*)\\}\\s+(\\S+)`,
-    "gm",
-  );
-  for (const sample of body.matchAll(samplePattern)) {
-    if (Number(sample[2]) !== 1) continue;
-    const labels = new Map(
-      Array.from(sample[1].matchAll(/(\w+)="([^"]*)"/g), (label) => [
-        label[1],
-        label[2],
-      ]),
-    );
-    const serverName = labels.get("server_name");
-    const state = labels.get("state");
-    if (serverName && state) {
-      states.set(serverName, state);
-    }
-  }
-  return states;
-}


### PR DESCRIPTION
## Why

Recent CI data shows two distinct flakes:

- The same multitenant hibernation assertion failed in eight Kubernetes jobs across August 22–23, including the [referenced E2E job](https://github.com/archestra-ai/archestra/actions/runs/32655578304/job/97233623183), while neighboring runs passed. CI runs two web replicas, but the test scraped one load-balanced, process-local metrics endpoint and treated missing series on that replica as cluster-wide state.
- The [referenced Docker scan job](https://github.com/archestra-ai/archestra/actions/runs/32657293245/job/97237948855) failed before CVE analysis while the Scout action downloaded its helper: both immediate attempts returned HTTP 403. The next queued run succeeded unchanged. The action retrieves release metadata with a GitHub token but downloads the release asset without forwarding authentication; the immediate retry repeats the same shared-runner request.

## What

- Assert multitenant hibernation using Kubernetes Deployment state and independent install-pinned gateway calls, removing invalid single-replica metric assertions.
- Download the official Docker Scout CLI v1.24.0 through authenticated GitHub CLI, verify its pinned SHA-256 checksum, and invoke it directly with the same severity, fixed-vulnerability, and exit-code behavior.

## Validation

- `pnpm --filter @e2e-tests check:ci`
- Playwright `api-k8s-hibernation` test discovery
- `zizmor` reports no findings for the composite action
- Docker Scout archive checksum and Linux CLI execution verified locally
- [Labeled Docker scan run](https://github.com/archestra-ai/archestra/actions/runs/32658157789): all three image variants completed their real CVE scans successfully
- Documentation audited; no user-facing behavior changed