### PR TITLE
chore: clean up log tables

### DIFF
--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -3,7 +3,7 @@ title: "Authentication"
 category: MCP
 order: 4
 description: "How authentication works for MCP clients and upstream MCP servers"
-lastUpdated: 2026-08-04
+lastUpdated: 2026-08-23
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -254,7 +254,7 @@ flowchart TD
 
 #### Called As
 
-Every tool call records the identity whose credential served it. Chat shows it on the tool call card. The MCP Gateway logs show it in the **Called as** column, next to the user who made the call. A call through a shared service account reads as that account, on behalf of the caller.
+Every tool call records the identity whose credential served it. Chat shows it on the tool call card. The MCP Gateway logs show the caller and serving credential together in the **Identity** column. A call through a shared service account reads as that account, on behalf of the caller.
 
 The identity is a person, a team, or the organization. Calls that use a token minted for the caller — Identity Provider Token Exchange, or a forwarded JWKS token — run as that caller. A call made with a gateway token runs as the team or the organization that issued the token.
 

--- a/platform/e2e-tests/tests/audit-log.spec.ts
+++ b/platform/e2e-tests/tests/audit-log.spec.ts
@@ -42,7 +42,7 @@ test.describe("Audit log UI", {
     ).toBeVisible({ timeout: 15_000 });
 
     // Column headers are stable and part of the visual contract.
-    for (const column of ["When", "Actor", "Action", "Resource", "Where"]) {
+    for (const column of ["Activity", "Actor", "Resource", "Time"]) {
       await expect(
         adminPage.getByRole("columnheader", { name: column }),
       ).toBeVisible();
@@ -63,7 +63,9 @@ test.describe("Audit log UI", {
       /* empty state is acceptable; the next assertion handles it */
     });
 
-    const resourceCells = adminPage.locator("tbody tr td:nth-child(4)");
+    const resourceCells = adminPage.locator(
+      'tbody tr td[data-column-id="resource"]',
+    );
     const count = await resourceCells.count();
     if (count === 0) return; // empty state, nothing to assert
 

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.test.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.test.tsx
@@ -9,7 +9,8 @@ import { ALL_ACTOR_TYPES, ALL_OUTCOMES } from "./audit-log-action-labels";
 import { AuditLogTable } from "./audit-log-table";
 
 /**
- * Contract: AuditLogTable — columns (When / Actor / Action / Outcome / Resource / Where),
+ * Contract: AuditLogTable — compact columns (Activity / Actor / Resource / Time),
+ * with network metadata reserved for the detail dialog,
  * resource NAME shown in grid (denormalized, snapshot fallback) for the
  * high-signal picker types only, while the raw resource id stays hidden,
  * detail dialog on row click, URL-driven filters (incl. the entity picker →
@@ -203,8 +204,12 @@ describe("AuditLogTable", () => {
     expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
     expect(screen.getByText("Agent updated")).toBeInTheDocument();
     expect(screen.getByText("Success")).toBeInTheDocument();
-    // The resource chip reads "Agent: <name>"; the bold prefix is the type alone.
     expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Activity" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Where" })).toBeNull();
+    expect(screen.queryByText("10.0.0.1")).toBeNull();
   });
 
   it("action column renders the human label, not the raw dotted name", () => {
@@ -229,7 +234,7 @@ describe("AuditLogTable", () => {
     expect(screen.queryByText("Unknown create")).not.toBeInTheDocument();
   });
 
-  it("outcome column renders the correct badge text for each outcome", () => {
+  it("activity shows the correct result for each outcome", () => {
     mockUseAuditLogs.mockReturnValue(
       withRows([makeEvent({ outcome: "denied" })]),
     );
@@ -268,9 +273,10 @@ describe("AuditLogTable", () => {
       await screen.findByRole("heading", { name: /Event details/i }),
     ).toBeInTheDocument();
     expect(screen.getByText("/api/agents/agent-123")).toBeInTheDocument();
+    expect(screen.getByText("10.0.0.1")).toBeInTheDocument();
   });
 
-  it("does not render the resource_id in the table — only the resource-type badge", () => {
+  it("does not render the resource_id in the table — only the resource type", () => {
     mockUseAuditLogs.mockReturnValue(
       withRows([
         makeEvent({
@@ -536,7 +542,7 @@ describe("AuditLogTable", () => {
     expect(refetch).toHaveBeenCalledTimes(1);
   });
 
-  it("renders When / Where headers and surfaces the client IP in the grid", () => {
+  it("keeps client network metadata out of the overview", () => {
     mockUseAuditLogs.mockReturnValue(
       withRows([
         makeEvent({
@@ -548,9 +554,9 @@ describe("AuditLogTable", () => {
 
     renderTable();
 
-    expect(screen.getByText("When")).toBeInTheDocument();
-    expect(screen.getByText("Where")).toBeInTheDocument();
-    expect(screen.getByText("172.16.0.5")).toBeInTheDocument();
+    expect(screen.getByText("Time")).toBeInTheDocument();
+    expect(screen.queryByText("Where")).toBeNull();
+    expect(screen.queryByText("172.16.0.5")).toBeNull();
   });
 
   it("Clear filters resets URL search params via router.push", async () => {

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
@@ -12,16 +12,10 @@ import {
 } from "@/components/filter-bar";
 import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
-import { TruncatedText } from "@/components/truncated-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { DateTimeRangePicker } from "@/components/ui/date-time-range-picker";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useProfilesPaginated } from "@/lib/agent.query";
 import { useApps } from "@/lib/app.query";
@@ -42,9 +36,8 @@ import { useMemberSearch } from "@/lib/member.query";
 import { useRolesPaginated } from "@/lib/role.query";
 import { useSkillsPaginated } from "@/lib/skills/skill.query";
 import { useTeams } from "@/lib/teams/team.query";
-import { formatDate } from "@/lib/utils";
+import { formatDate, formatRelativeTimeFromNow } from "@/lib/utils";
 import {
-  ACTION_BADGE_VARIANT,
   ACTOR_TYPE_LABEL,
   ALL_ACTIONS,
   ALL_ACTOR_TYPES,
@@ -65,7 +58,7 @@ const ALL_VALUE = "all";
 
 // The high-signal types whose names render in the Resource column and whose
 // entities populate the "Filter by resource" picker. Every other type keeps a
-// bare type chip in the list; its full identity lives in the detail dialog.
+// bare type label in the list; its full identity lives in the detail dialog.
 const LIST_NAME_RESOURCE_TYPES: ReadonlySet<string> = new Set([
   "agent",
   "app",
@@ -416,6 +409,91 @@ export function AuditLogTable() {
   const columns = useMemo<ColumnDef<AuditLogRow>[]>(
     () => [
       {
+        id: "activity",
+        header: "Activity",
+        size: 300,
+        minSize: 240,
+        cell: ({ row }) => (
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="min-w-0 truncate text-sm font-medium">
+              {formatAction(row.original.action)}
+            </span>
+            <Badge
+              variant={OUTCOME_BADGE_VARIANT[row.original.outcome]}
+              className="px-1.5 py-0 text-[10px]"
+            >
+              {OUTCOME_LABEL[row.original.outcome]}
+            </Badge>
+          </div>
+        ),
+      },
+      {
+        id: "actor",
+        header: "Actor",
+        size: 240,
+        minSize: 190,
+        cell: ({ row }) => {
+          const {
+            actorName,
+            actorEmail,
+            actorType,
+            impersonatedBy,
+            impersonatedByEmail,
+          } = row.original;
+          const label = actorName ?? actorEmail ?? "Deleted user";
+          return (
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                <User className="size-3.5" />
+              </span>
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{label}</div>
+                <div className="truncate text-xs text-muted-foreground">
+                  {impersonatedBy
+                    ? `via ${impersonatedByEmail ?? "deleted user"}`
+                    : ACTOR_TYPE_LABEL[actorType]}
+                </div>
+              </div>
+            </div>
+          );
+        },
+      },
+      {
+        id: "resource",
+        header: "Resource",
+        size: 280,
+        minSize: 220,
+        cell: ({ row }) => {
+          const { resourceType } = row.original;
+          const name =
+            resourceType && LIST_NAME_RESOURCE_TYPES.has(resourceType)
+              ? resourceDisplayName(row.original)
+              : null;
+          if (!resourceType && !name) {
+            return <span className="text-xs text-muted-foreground">—</span>;
+          }
+          const displayName =
+            name && name.length > RESOURCE_NAME_TRUNCATE_LENGTH
+              ? `${name.slice(0, RESOURCE_NAME_TRUNCATE_LENGTH)}…`
+              : name;
+          return (
+            <div className="min-w-0">
+              <div
+                className="truncate text-sm font-medium"
+                title={name ?? undefined}
+              >
+                {displayName ?? formatResourceType(resourceType ?? "")}
+              </div>
+              {name && resourceType ? (
+                <div className="truncate text-xs text-muted-foreground">
+                  {formatResourceType(resourceType)}
+                </div>
+              ) : null}
+            </div>
+          );
+        },
+      },
+      {
         id: "createdAt",
         header: ({ column }) => (
           <Button
@@ -423,133 +501,25 @@ export function AuditLogTable() {
             className="h-auto !p-0 font-medium hover:bg-transparent"
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
-            When
+            Time
             <SortIcon isSorted={column.getIsSorted()} />
           </Button>
         ),
+        size: 190,
+        minSize: 175,
         cell: ({ row }) => (
-          <div className="font-mono text-xs">
-            {formatDate({ date: row.original.createdAt })}
+          <div className="min-w-0">
+            <div className="text-sm">
+              {formatRelativeTimeFromNow(row.original.createdAt)}
+            </div>
+            <div className="truncate font-mono text-[11px] text-muted-foreground">
+              {formatDate({
+                date: row.original.createdAt,
+                dateFormat: "MMM d, yyyy · HH:mm:ss",
+              })}
+            </div>
           </div>
         ),
-      },
-      {
-        id: "actor",
-        header: "Actor",
-        cell: ({ row }) => {
-          const { actorName, actorEmail, impersonatedBy, impersonatedByEmail } =
-            row.original;
-          const label = actorName ?? actorEmail ?? "Deleted user";
-          return (
-            <div className="flex flex-col items-start gap-0.5">
-              <Badge variant="outline" className="text-xs">
-                <User className="mr-1 h-3 w-3 shrink-0" />
-                <TruncatedText message={label} maxLength={24} />
-              </Badge>
-              {impersonatedBy && (
-                <span
-                  className="text-[10px] text-amber-600 dark:text-amber-500"
-                  title="This action ran in an impersonated session; the named actor was being impersonated by this admin."
-                >
-                  via {impersonatedByEmail ?? "deleted user"}
-                </span>
-              )}
-            </div>
-          );
-        },
-      },
-      {
-        id: "action",
-        header: "Action",
-        cell: ({ row }) => (
-          <Badge
-            variant={
-              ACTION_BADGE_VARIANT[row.original.action as AuditEventName]
-            }
-            className="text-xs whitespace-nowrap"
-          >
-            {formatAction(row.original.action)}
-          </Badge>
-        ),
-      },
-      {
-        id: "outcome",
-        header: "Outcome",
-        cell: ({ row }) => (
-          <Badge
-            variant={OUTCOME_BADGE_VARIANT[row.original.outcome]}
-            className="text-xs"
-          >
-            {OUTCOME_LABEL[row.original.outcome]}
-          </Badge>
-        ),
-      },
-      {
-        id: "resource",
-        header: "Resource",
-        cell: ({ row }) => {
-          const { resourceType: rt } = row.original;
-          const name =
-            rt && LIST_NAME_RESOURCE_TYPES.has(rt)
-              ? resourceDisplayName(row.original)
-              : null;
-          if (!rt && !name) {
-            return <span className="text-xs text-muted-foreground">—</span>;
-          }
-          const displayName =
-            name && name.length > RESOURCE_NAME_TRUNCATE_LENGTH
-              ? `${name.slice(0, RESOURCE_NAME_TRUNCATE_LENGTH)}…`
-              : name;
-          // One chip holding "Type: name" as a single text flow (not flex
-          // columns). break-all splits machine names mid-word (the Model
-          // providers convention) so every line fills the cell width instead
-          // of breaking ragged at each hyphen; rounded-md instead of the
-          // badge's pill rounding keeps multiline corners off the text.
-          return (
-            <Badge
-              variant="secondary"
-              className="max-w-full rounded-md whitespace-normal text-xs"
-            >
-              <span className="break-all font-normal">
-                {rt && (
-                  <span className="font-semibold">
-                    {formatResourceType(rt)}
-                  </span>
-                )}
-                {rt && name ? <span>: </span> : null}
-                {name && <span title={name}>{displayName}</span>}
-              </span>
-            </Badge>
-          );
-        },
-      },
-      {
-        id: "where",
-        header: "Where",
-        cell: ({ row }) => {
-          const { sourceIp, userAgent } = row.original;
-          if (!sourceIp && !userAgent) {
-            return <span className="text-xs text-muted-foreground">—</span>;
-          }
-          const ipDisplay = sourceIp ?? "—";
-          if (!userAgent) {
-            return (
-              <code className="text-xs text-muted-foreground">{ipDisplay}</code>
-            );
-          }
-          return (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <code className="text-xs text-muted-foreground">
-                  {ipDisplay}
-                </code>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-sm break-all">
-                {userAgent}
-              </TooltipContent>
-            </Tooltip>
-          );
-        },
       },
     ],
     [],

--- a/platform/frontend/src/app/llm/logs/page.client.test.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.test.tsx
@@ -1,3 +1,4 @@
+import type { archestraApiTypes } from "@archestra/shared";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -24,6 +25,7 @@ globalThis.ResizeObserver = class {
 
 vi.mock("next/navigation");
 vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/hooks/use-app-name");
 
 vi.mock("@/lib/agent.query", () => ({ useProfiles: vi.fn() }));
 vi.mock("@/lib/interactions/interaction.query", async (importOriginal) => ({
@@ -52,6 +54,55 @@ const orgProxy = {
 };
 
 const push = vi.fn();
+
+type SessionSummary =
+  archestraApiTypes.GetInteractionSessionsResponses["200"]["data"][number];
+
+function makeSessionSummary(
+  overrides: Partial<SessionSummary> = {},
+): SessionSummary {
+  return {
+    sessionId: "demo-session",
+    sessionSource: null,
+    source: "api",
+    sources: ["api"],
+    interactionId: null,
+    requestCount: 1,
+    totalInputTokens: 100,
+    totalOutputTokens: 50,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    totalCost: "0.01",
+    totalBilledCost: "0.01",
+    totalSubscriptionCost: null,
+    totalBaselineCost: "0.01",
+    totalToonCostSavings: null,
+    totalCacheSavings: null,
+    toonSkipReasonCounts: {
+      applied: 0,
+      notEnabled: 0,
+      notEffective: 0,
+      noToolResults: 0,
+    },
+    firstRequestTime: "2026-08-23T16:20:00.000Z",
+    lastRequestTime: "2026-08-23T16:30:00.000Z",
+    models: ["gpt-5.4"],
+    profileId: orgProxy.id,
+    profileName: orgProxy.name,
+    externalAgentIds: [],
+    externalAgentIdLabels: [],
+    authMethods: [],
+    authenticatedAppNames: [],
+    userNames: [],
+    userIds: [],
+    unattributedReason: null,
+    lastUserMessagePreview: null,
+    lastInteractionType: null,
+    conversationTitle: null,
+    claudeCodeTitle: null,
+    ...overrides,
+  };
+}
 
 // role="combobox" takes no accessible name from its contents, so the trigger is
 // addressed by the label it renders.
@@ -122,5 +173,49 @@ describe("LlmProxyLogsPage proxy filter", () => {
       expect.stringContaining("page=1"),
       expect.anything(),
     );
+  });
+
+  it("presents session context and usage without separate source and details columns", () => {
+    vi.mocked(useInteractionSessions).mockReturnValue({
+      data: {
+        data: [
+          makeSessionSummary({
+            sessionId: "demo-session",
+            profileId: orgProxy.id,
+            profileName: orgProxy.name,
+            lastUserMessagePreview: "Summarize the quarterly report",
+            requestCount: 3,
+            totalInputTokens: 100,
+            totalCacheReadTokens: 50,
+            totalCacheWriteTokens: 50,
+            models: ["gpt-5.4", "gpt-5.4-mini"],
+            userNames: ["Demo Admin"],
+          }),
+        ],
+        pagination: { total: 1 },
+      },
+      isFetching: false,
+    } as unknown as ReturnType<typeof useInteractionSessions>);
+
+    render(<LlmProxyLogsPage />);
+
+    for (const header of [
+      "Session",
+      "Agent",
+      "Model",
+      "Usage",
+      "Spend",
+      "Last request",
+    ]) {
+      expect(
+        screen.getByRole("columnheader", { name: header }),
+      ).toBeInTheDocument();
+    }
+    expect(screen.getByText("Summarize the quarterly report")).toBeVisible();
+    expect(screen.getByText("3 requests")).toBeVisible();
+    expect(screen.getByText("25% cache read")).toBeVisible();
+    expect(screen.getByText("+1 more")).toBeVisible();
+    expect(screen.queryByRole("columnheader", { name: "Source" })).toBeNull();
+    expect(screen.queryByRole("columnheader", { name: "Details" })).toBeNull();
   });
 });

--- a/platform/frontend/src/app/llm/logs/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.tsx
@@ -8,7 +8,7 @@ import {
   type InteractionSource,
 } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Database, Layers, MessageSquare, User } from "lucide-react";
+import { Database, Layers, MessageSquare } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useMemo } from "react";
@@ -28,12 +28,7 @@ import { SourceBadge } from "@/components/source-badge";
 import { Badge } from "@/components/ui/badge";
 import { DataTable } from "@/components/ui/data-table";
 import { DateTimeRangePicker } from "@/components/ui/date-time-range-picker";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { UnattributedUserBadge } from "@/components/unattributed-user-badge";
 import {
   ClientFilterSelect,
@@ -48,7 +43,7 @@ import {
   useInteractionSessions,
   useUniqueUserIds,
 } from "@/lib/interactions/interaction.query";
-import { formatDate } from "@/lib/utils";
+import { formatDate, formatRelativeTimeFromNow } from "@/lib/utils";
 import { ErrorBoundary } from "../../_parts/error-boundary";
 
 function formatDuration(start: Date | string, end: Date | string): string {
@@ -111,7 +106,6 @@ function getSessionDisplayData(session: SessionData) {
     conversationTitle,
     isArchestraChat,
     clientSource,
-    lastUserMessage,
     displayText,
   };
 }
@@ -272,8 +266,8 @@ function SessionsTable() {
       {
         id: "session",
         header: "Session",
-        size: 300,
-        minSize: 220,
+        size: 285,
+        minSize: 230,
         cell: ({ row }) => {
           const session = row.original;
           const {
@@ -281,18 +275,26 @@ function SessionsTable() {
             displayText,
             isArchestraChat,
             clientSource,
-            lastUserMessage,
           } = getSessionDisplayData(session);
 
+          const primaryText = isArchestraChat
+            ? conversationTitle
+            : displayText ||
+              (session.source?.startsWith("knowledge:")
+                ? (INTERACTION_SOURCE_DISPLAY[
+                    session.source as keyof typeof INTERACTION_SOURCE_DISPLAY
+                  ]?.label ?? session.source)
+                : "No message");
+
           return (
-            <div className="flex max-w-full min-w-0 items-center gap-2 overflow-hidden text-xs">
-              {isArchestraChat ? (
-                <>
-                  <span className="min-w-0 flex-1 truncate">
-                    {(conversationTitle ?? "").length > 60
-                      ? `${(conversationTitle ?? "").slice(0, 60)}...`
-                      : conversationTitle}
-                  </span>
+            <div className="flex min-w-0 flex-col gap-1.5 py-0.5">
+              <div
+                className={`truncate text-sm font-medium ${primaryText === "No message" ? "text-muted-foreground" : ""}`}
+              >
+                {primaryText}
+              </div>
+              <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+                {isArchestraChat ? (
                   <Link
                     href={`/chat/${session.sessionId}`}
                     onClick={(e) => e.stopPropagation()}
@@ -300,112 +302,122 @@ function SessionsTable() {
                   >
                     <Badge
                       variant="outline"
-                      className="text-xs hover:bg-accent cursor-pointer"
+                      className="cursor-pointer px-1.5 py-0 text-[10px] hover:bg-accent"
                     >
-                      <MessageSquare className="h-3 w-3 mr-1" />
+                      <MessageSquare className="size-3" />
                       Chat
                     </Badge>
                   </Link>
-                </>
-              ) : clientSource ? (
-                <>
-                  {displayText ? (
-                    <span className="min-w-0 flex-1 truncate">
-                      {displayText.length > 80
-                        ? `${displayText.slice(0, 80)}...`
-                        : displayText}
-                    </span>
-                  ) : (
-                    <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                      No message
-                    </span>
-                  )}
+                ) : null}
+                {clientSource ? (
                   <ClientSourceBadge
                     client={clientSource}
-                    className="shrink-0"
+                    className="shrink-0 px-1.5 py-0 text-[10px]"
                   />
-                </>
-              ) : lastUserMessage ? (
-                <span className="min-w-0 max-w-full truncate">
-                  {lastUserMessage.length > 80
-                    ? `${lastUserMessage.slice(0, 80)}...`
-                    : lastUserMessage}
-                </span>
-              ) : session.source?.startsWith("knowledge:") ? (
-                <span className="min-w-0 max-w-full truncate text-muted-foreground">
-                  {INTERACTION_SOURCE_DISPLAY[
-                    session.source as keyof typeof INTERACTION_SOURCE_DISPLAY
-                  ]?.label ?? session.source}
-                </span>
-              ) : (
-                <span className="min-w-0 max-w-full truncate text-muted-foreground">
-                  No message
-                </span>
-              )}
+                ) : null}
+                {isArchestraChat ? null : (
+                  <SessionSourceBadge session={session} compact />
+                )}
+              </div>
             </div>
           );
         },
       },
       {
-        id: "requests",
-        header: "Requests",
-        size: 96,
-        minSize: 88,
-        cell: ({ row }) => (
-          <span className="font-mono text-xs">
-            {row.original.requestCount.toLocaleString()}
-          </span>
-        ),
-      },
-      {
-        id: "cache",
-        header: "Cache read",
-        size: 120,
-        minSize: 96,
+        id: "agent",
+        header: "Agent",
+        size: 190,
+        minSize: 155,
         cell: ({ row }) => {
-          const read = row.original.totalCacheReadTokens;
-          const write = row.original.totalCacheWriteTokens;
-          if (read === 0 && write === 0) {
-            return <span className="text-muted-foreground text-xs">—</span>;
-          }
-          const totalInput = row.original.totalInputTokens + read + write;
-          const hitRate =
-            totalInput > 0 ? Math.round((read / totalInput) * 100) : 0;
+          const session = row.original;
+          const agent = agents?.find((a) => a.id === session.profileId);
+          const isKnowledge = session.source?.startsWith("knowledge:");
+          const agentName =
+            agent?.name ??
+            session.profileName ??
+            (isKnowledge
+              ? "Knowledge Base"
+              : session.profileId === null
+                ? "Deleted LLM Proxy"
+                : "Unknown");
           return (
-            <span className="font-mono text-xs">
-              {hitRate}% · {read.toLocaleString()}
-            </span>
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                {isKnowledge ? (
+                  <Database className="size-3.5" />
+                ) : (
+                  <Layers className="size-3.5" />
+                )}
+              </span>
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{agentName}</div>
+                {session.userNames.length > 0 ? (
+                  <div className="truncate text-xs text-muted-foreground">
+                    {session.userNames.join(", ")}
+                  </div>
+                ) : (
+                  <UnattributedUserBadge reason={session.unattributedReason} />
+                )}
+              </div>
+            </div>
           );
         },
       },
       {
         id: "models",
-        header: "Models",
-        cell: ({ row }) => (
-          <TooltipProvider>
-            <div className="flex flex-wrap gap-1 min-w-0 max-w-full overflow-hidden">
-              {row.original.models.map((model) => (
-                <Tooltip key={model}>
-                  <TooltipTrigger asChild>
-                    <Badge
-                      variant="secondary"
-                      className="text-xs max-w-full cursor-default inline-block truncate"
-                    >
-                      {model}
-                    </Badge>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="font-mono text-xs">{model}</p>
-                  </TooltipContent>
-                </Tooltip>
-              ))}
+        header: "Model",
+        size: 155,
+        minSize: 120,
+        cell: ({ row }) => {
+          const [model, ...additionalModels] = row.original.models;
+          return model ? (
+            <div className="min-w-0">
+              <div className="truncate font-mono text-xs" title={model}>
+                {model}
+              </div>
+              {additionalModels.length > 0 ? (
+                <div className="text-xs text-muted-foreground">
+                  +{additionalModels.length} more
+                </div>
+              ) : null}
             </div>
-          </TooltipProvider>
-        ),
+          ) : (
+            <span className="text-xs text-muted-foreground">—</span>
+          );
+        },
+      },
+      {
+        id: "usage",
+        header: "Usage",
+        size: 125,
+        minSize: 110,
+        cell: ({ row }) => {
+          const session = row.original;
+          const read = session.totalCacheReadTokens;
+          const totalInput =
+            session.totalInputTokens +
+            session.totalCacheReadTokens +
+            session.totalCacheWriteTokens;
+          const hitRate =
+            totalInput > 0 ? Math.round((read / totalInput) * 100) : 0;
+          return (
+            <div>
+              <div className="text-sm tabular-nums">
+                {session.requestCount.toLocaleString()}{" "}
+                {session.requestCount === 1 ? "request" : "requests"}
+              </div>
+              <div className="text-xs text-muted-foreground tabular-nums">
+                {read > 0 ? `${hitRate}% cache read` : "No cache read"}
+              </div>
+            </div>
+          );
+        },
       },
       {
         id: "cost",
-        header: "Cost",
+        header: "Spend",
+        size: 115,
+        minSize: 100,
         cell: ({ row }) =>
           row.original.totalCost ? (
             <TooltipProvider>
@@ -420,82 +432,38 @@ function SessionsTable() {
                 format="percent"
                 tooltip="hover"
                 variant="session"
+                subscriptionBadge="compact"
               />
             </TooltipProvider>
           ) : null,
       },
       {
-        id: "source",
-        header: "Source",
-        size: 220,
-        minSize: 170,
-        cell: ({ row }) => (
-          <div className="max-w-full min-w-0 overflow-hidden">
-            <SessionSourceBadge session={row.original} />
-          </div>
-        ),
-      },
-      {
         id: "time",
-        header: "Time",
-        size: 160,
-        minSize: 145,
-        cell: ({ row }) => (
-          <div className="flex min-w-0 flex-col gap-0.5 font-mono text-xs">
-            {row.original.lastRequestTime && (
-              <span>
-                {formatDate({ date: String(row.original.lastRequestTime) })}
-              </span>
-            )}
-            {row.original.requestCount > 1 &&
-              row.original.firstRequestTime &&
-              row.original.lastRequestTime && (
-                <span className="text-muted-foreground">
-                  {formatDuration(
-                    row.original.firstRequestTime,
-                    row.original.lastRequestTime,
-                  )}
-                </span>
-              )}
-          </div>
-        ),
-      },
-      {
-        id: "details",
-        header: "Details",
-        size: 280,
-        minSize: 220,
+        header: "Last request",
+        size: 165,
+        minSize: 150,
         cell: ({ row }) => {
-          const agent = agents?.find((a) => a.id === row.original.profileId);
+          const { firstRequestTime, lastRequestTime, requestCount } =
+            row.original;
+          if (!lastRequestTime) {
+            return <span className="text-xs text-muted-foreground">—</span>;
+          }
+          const duration =
+            requestCount > 1 && firstRequestTime
+              ? formatDuration(firstRequestTime, lastRequestTime)
+              : null;
           return (
-            <div className="flex max-w-full min-w-0 flex-wrap gap-1 overflow-hidden">
-              <Badge variant="secondary" className="min-w-0 max-w-full text-xs">
-                {row.original.source?.startsWith("knowledge:") ? (
-                  <Database className="h-3 w-3 mr-1 shrink-0" />
-                ) : (
-                  <Layers className="h-3 w-3 mr-1 shrink-0" />
-                )}
-                <span className="min-w-0 truncate">
-                  {agent?.name ??
-                    row.original.profileName ??
-                    (row.original.source?.startsWith("knowledge:")
-                      ? "Knowledge Base"
-                      : row.original.profileId === null
-                        ? "Deleted LLM Proxy"
-                        : "Unknown")}
-                </span>
-              </Badge>
-              {row.original.userNames.map((userName) => (
-                <Badge
-                  key={userName}
-                  variant="outline"
-                  className="min-w-0 max-w-full text-xs"
-                >
-                  <User className="h-3 w-3 mr-1 shrink-0" />
-                  <span className="min-w-0 truncate">{userName}</span>
-                </Badge>
-              ))}
-              <UnattributedUserBadge reason={row.original.unattributedReason} />
+            <div className="min-w-0">
+              <div className="text-sm">
+                {formatRelativeTimeFromNow(lastRequestTime)}
+              </div>
+              <div className="truncate font-mono text-[11px] text-muted-foreground">
+                {formatDate({
+                  date: String(lastRequestTime),
+                  dateFormat: "MMM d, yyyy · HH:mm",
+                })}
+                {duration ? ` · ${duration}` : ""}
+              </div>
             </div>
           );
         },
@@ -644,7 +612,13 @@ function SessionsTable() {
   );
 }
 
-function SessionSourceBadge({ session }: { session: SessionData }) {
+function SessionSourceBadge({
+  session,
+  compact = false,
+}: {
+  session: SessionData;
+  compact?: boolean;
+}) {
   const sources = Array.from(
     new Set(
       session.sources?.filter((source): source is InteractionSource =>
@@ -657,7 +631,11 @@ function SessionSourceBadge({ session }: { session: SessionData }) {
     return (
       <SourceBadge
         source={session.source ?? sources[0]}
-        className="max-w-[11rem] min-w-0 overflow-hidden"
+        className={
+          compact
+            ? "max-w-[11rem] min-w-0 overflow-hidden px-1.5 py-0 text-[10px]"
+            : "max-w-[11rem] min-w-0 overflow-hidden"
+        }
         labelClassName="min-w-0"
       />
     );
@@ -666,7 +644,11 @@ function SessionSourceBadge({ session }: { session: SessionData }) {
   return (
     <Badge
       variant="outline"
-      className="max-w-[11rem] min-w-0 overflow-hidden text-xs"
+      className={
+        compact
+          ? "max-w-[11rem] min-w-0 overflow-hidden px-1.5 py-0 text-[10px]"
+          : "max-w-[11rem] min-w-0 overflow-hidden text-xs"
+      }
     >
       <span className="flex min-w-0 items-center gap-1.5">
         <Layers className="h-3 w-3 shrink-0" />

--- a/platform/frontend/src/app/mcp/logs/page.client.test.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.test.tsx
@@ -3,6 +3,8 @@ import userEvent from "@testing-library/user-event";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useProfiles } from "@/lib/agent.query";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import { useMcpToolCalls } from "@/lib/mcp/mcp-tool-call.query";
 import McpGatewayLogsPage from "./page.client";
@@ -20,8 +22,13 @@ globalThis.ResizeObserver = class {
 };
 
 vi.mock("next/navigation");
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/hooks/use-app-name");
 
 vi.mock("@/lib/agent.query", () => ({ useProfiles: vi.fn() }));
+vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
+  useInternalMcpCatalog: vi.fn(),
+}));
 vi.mock("@/lib/mcp/mcp-server.query", () => ({ useMcpServers: vi.fn() }));
 vi.mock("@/lib/mcp/mcp-tool-call.query", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/mcp/mcp-tool-call.query")>()),
@@ -69,6 +76,12 @@ describe("McpGatewayLogsPage gateway filter", () => {
     vi.mocked(useMcpServers).mockReturnValue({
       data: [],
     } as unknown as ReturnType<typeof useMcpServers>);
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useInternalMcpCatalog).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useInternalMcpCatalog>);
     vi.mocked(useMcpToolCalls).mockReturnValue({
       data: { data: [], pagination: { total: 0 } },
       isFetching: false,
@@ -126,5 +139,71 @@ describe("McpGatewayLogsPage gateway filter", () => {
     expect(vi.mocked(useMcpToolCalls)).toHaveBeenLastCalledWith(
       expect.objectContaining({ agentId: "g1" }),
     );
+  });
+
+  it("presents the call context without separate method, server, and arguments columns", () => {
+    vi.mocked(useMcpServers).mockReturnValue({
+      data: [
+        {
+          name: "document-search-deployment",
+          catalogName: "Document Search",
+          catalogId: "document-search-catalog",
+        },
+      ],
+    } as unknown as ReturnType<typeof useMcpServers>);
+    vi.mocked(useInternalMcpCatalog).mockReturnValue({
+      data: [
+        {
+          id: "document-search-catalog",
+          name: "Document Search",
+          icon: "📚",
+        },
+      ],
+    } as unknown as ReturnType<typeof useInternalMcpCatalog>);
+    vi.mocked(useMcpToolCalls).mockReturnValue({
+      data: {
+        data: [
+          {
+            id: "call-1",
+            ownerType: "agent",
+            agentId: orgGateway.id,
+            appId: null,
+            mcpServerName: "document-search-deployment",
+            method: "tools/call",
+            toolCall: {
+              id: "tool-call-1",
+              name: "documents__search_documents",
+              arguments: { query: "raw argument only belongs in details" },
+            },
+            toolResult: { isError: false, content: [] },
+            userId: "user-1",
+            authMethod: "session",
+            createdAt: "2026-08-23T16:30:00.000Z",
+            userName: "Demo Admin",
+            appName: null,
+          },
+        ],
+        pagination: { total: 1 },
+      },
+      isFetching: false,
+    } as unknown as ReturnType<typeof useMcpToolCalls>);
+
+    render(<McpGatewayLogsPage />);
+
+    for (const header of ["Call", "Gateway", "Identity", "Result", "Time"]) {
+      expect(
+        screen.getByRole("columnheader", { name: header }),
+      ).toBeInTheDocument();
+    }
+    expect(screen.getByText("search_documents")).toBeVisible();
+    expect(screen.getByText("Document Search")).toBeVisible();
+    expect(screen.getByText("📚")).toBeInTheDocument();
+    expect(screen.getByText("Demo Admin")).toBeVisible();
+    expect(screen.getByText("Success")).toBeVisible();
+    expect(screen.queryByRole("columnheader", { name: "Method" })).toBeNull();
+    expect(
+      screen.queryByRole("columnheader", { name: "Arguments" }),
+    ).toBeNull();
+    expect(screen.queryByText(/raw argument only belongs/)).toBeNull();
   });
 });

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -7,7 +7,7 @@ import {
   parseFullToolName,
 } from "@archestra/shared";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
-import { ChevronDown, ChevronUp, User } from "lucide-react";
+import { Boxes, ChevronDown, ChevronUp, User } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AgentSelector } from "@/components/agent-selector";
@@ -18,21 +18,18 @@ import {
   filterSearchClass,
 } from "@/components/filter-bar";
 import { LockedChatContentUnavailableLabel } from "@/components/locked-chat-content-unavailable";
+import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
-import { TruncatedText } from "@/components/truncated-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { DateTimeRangePicker } from "@/components/ui/date-time-range-picker";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useProfiles } from "@/lib/agent.query";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useDateTimeRangePicker } from "@/lib/hooks/use-date-time-range-picker";
+import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import {
   formatAuthMethod,
@@ -40,7 +37,7 @@ import {
   useMcpToolCalls,
 } from "@/lib/mcp/mcp-tool-call.query";
 import { resolveMcpToolCallStatus } from "@/lib/mcp-logs/tool-call-status";
-import { formatDate } from "@/lib/utils";
+import { formatDate, formatRelativeTimeFromNow } from "@/lib/utils";
 import { ErrorBoundary } from "../../_parts/error-boundary";
 
 type McpToolCallData =
@@ -198,203 +195,165 @@ function McpToolCallsTable({
   });
 
   const { data: mcpServers } = useMcpServers();
+  const { data: canReadMcpRegistry } = useHasPermissions({
+    mcpRegistry: ["read"],
+  });
+  const { data: catalogItems } = useInternalMcpCatalog({
+    enabled: canReadMcpRegistry === true,
+  });
 
-  // Map deployment names (e.g. "outlook-2w7avkls6j") to human-readable catalog names (e.g. "Outlook")
-  const serverNameToCatalogName = useMemo(() => {
-    const map = new Map<string, string>();
+  // Tool-call rows store the installed server's deployment name. Join it to
+  // the catalog metadata already used by the registry so the log can show the
+  // human-readable name and its icon without changing the logs API.
+  const serverDisplayByName = useMemo(() => {
+    const catalogById = new Map(
+      catalogItems?.map((item) => [item.id, item]) ?? [],
+    );
+    const map = new Map<
+      string,
+      { name: string; icon: string | null; catalogId: string }
+    >();
     if (mcpServers) {
       for (const server of mcpServers) {
-        if (server.catalogName) {
-          map.set(server.name, server.catalogName);
-        }
+        const catalog = catalogById.get(server.catalogId);
+        map.set(server.name, {
+          name: server.catalogName ?? catalog?.name ?? server.name,
+          icon: catalog?.icon ?? null,
+          catalogId: server.catalogId,
+        });
       }
     }
     return map;
-  }, [mcpServers]);
+  }, [catalogItems, mcpServers]);
 
   const mcpToolCalls = mcpToolCallsResponse?.data ?? [];
   const paginationMeta = mcpToolCallsResponse?.pagination;
 
   const columns: ColumnDef<McpToolCallData>[] = [
     {
-      id: "createdAt",
-      header: ({ column }) => {
-        return (
-          <Button
-            variant="ghost"
-            className="h-auto !p-0 font-medium hover:bg-transparent"
-            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          >
-            Date
-            <SortIcon isSorted={column.getIsSorted()} />
-          </Button>
-        );
-      },
-      cell: ({ row }) => (
-        <div className="font-mono text-xs">
-          {formatDate({
-            date: row.original.createdAt,
-          })}
-        </div>
-      ),
-    },
-    {
-      id: "method",
-      header: "Method",
+      id: "call",
+      header: "Call",
+      size: 290,
+      minSize: 245,
       cell: ({ row }) => {
+        const call = row.original.toolCall;
         const method = row.original.method || "tools/call";
-        const variant =
-          method === "initialize"
-            ? "outline"
-            : method === "tools/list"
-              ? "secondary"
-              : "default";
+        const fullName = isLockedChatUnavailableContent(call)
+          ? undefined
+          : call?.name;
+        const toolName = fullName
+          ? parseFullToolName(fullName).toolName || fullName
+          : null;
+        const rawServerName = row.original.mcpServerName;
+        const serverDisplay = serverDisplayByName.get(rawServerName);
+        const serverName = serverDisplay?.name ?? rawServerName;
         return (
-          <Badge variant={variant} className="text-xs whitespace-nowrap">
-            {method}
-          </Badge>
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+              <McpCatalogIcon
+                icon={serverDisplay?.icon}
+                catalogId={serverDisplay?.catalogId}
+                size={14}
+              />
+            </span>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium">
+                {isLockedChatUnavailableContent(call) ? (
+                  <LockedChatContentUnavailableLabel value={call} />
+                ) : toolName ? (
+                  <code className="font-mono text-xs">{toolName}</code>
+                ) : (
+                  formatMcpMethod(method)
+                )}
+              </div>
+              <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+                <span className="truncate" title={rawServerName}>
+                  {serverName || "Platform"}
+                </span>
+                {method === "tools/call" ? null : (
+                  <Badge
+                    variant="outline"
+                    className="shrink-0 px-1.5 py-0 text-[10px] font-normal"
+                  >
+                    {method}
+                  </Badge>
+                )}
+              </div>
+            </div>
+          </div>
         );
       },
     },
     {
       id: "agent",
       accessorFn: (row) => getGatewayDisplayName(row, agents),
-      header: "MCP Gateway",
+      header: "Gateway",
+      size: 205,
+      minSize: 160,
       cell: ({ row }) => (
-        <div className="flex items-center gap-1.5">
-          <TruncatedText
-            message={getGatewayDisplayName(row.original, agents)}
-            maxLength={30}
-          />
-          {row.original.ownerType === "app" && (
-            <Badge variant="outline" className="text-xs whitespace-nowrap">
-              App
-            </Badge>
-          )}
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+            <Boxes className="size-3.5" />
+          </span>
+          <div className="min-w-0">
+            <div className="truncate text-sm font-medium">
+              {getGatewayDisplayName(row.original, agents)}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {row.original.ownerType === "app" ? "App" : "MCP gateway"}
+            </div>
+          </div>
         </div>
       ),
     },
     {
-      id: "user",
-      header: "User",
+      id: "identity",
+      header: "Identity",
+      size: 245,
+      minSize: 215,
       cell: ({ row }) => {
         const { userName, authMethod } = row.original;
-        if (!userName && !authMethod) {
-          return <div className="text-xs text-muted-foreground">—</div>;
-        }
-        return (
-          <div className="flex flex-wrap gap-1">
-            {userName && (
-              <Badge variant="outline" className="text-xs max-w-[150px]">
-                <User className="h-3 w-3 mr-1 shrink-0" />
-                <span className="truncate">{userName}</span>
-              </Badge>
-            )}
-            {authMethod && (
-              <Badge variant="secondary" className="text-xs whitespace-nowrap">
-                {formatAuthMethod(authMethod)}
-              </Badge>
-            )}
-          </div>
-        );
-      },
-    },
-    {
-      id: "executedAs",
-      header: "Called as",
-      cell: ({ row }) => {
-        // Whose credential served the call upstream. The User column above is
-        // who asked for it, so the two together read "ran as X on behalf of Y".
-        // Blank for calls the platform served in process and for rows recorded
-        // before the identity was captured.
         const executedAs = extractMcpExecutedAs(row.original.toolResult);
-        if (!executedAs) {
+        if (!userName && !authMethod && !executedAs) {
           return <div className="text-xs text-muted-foreground">—</div>;
         }
-        // An auditor needs the person, never "Me" — the reader is rarely the
-        // caller here, so no identity is ever written from their perspective.
         return (
-          <ExecutedAsBadge
-            executedAs={executedAs}
-            caller={formatCallerIdentity(row.original)}
-          />
-        );
-      },
-    },
-    {
-      id: "mcpServerName",
-      header: "MCP Server",
-      cell: ({ row }) => {
-        const rawName = row.original.mcpServerName;
-        if (!rawName) {
-          return <div className="text-xs text-muted-foreground">—</div>;
-        }
-        const displayName = serverNameToCatalogName.get(rawName) ?? rawName;
-        return (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="max-w-[160px]">
-                <Badge
-                  variant="secondary"
-                  className="text-xs max-w-full inline-flex"
-                >
-                  <span className="truncate">{displayName}</span>
-                </Badge>
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+              <User className="size-3.5" />
+            </span>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium">
+                {userName ?? "Unattributed"}
               </div>
-            </TooltipTrigger>
-            <TooltipContent>{rawName}</TooltipContent>
-          </Tooltip>
-        );
-      },
-    },
-    {
-      id: "toolName",
-      header: "Tool Name",
-      cell: ({ row }) => {
-        // A locked row carries the sentinel in place of the call, so there is
-        // no name to parse — the em dash the column already uses for a missing
-        // name says the same thing without a second marker per row.
-        const call = row.original.toolCall;
-        const fullName = isLockedChatUnavailableContent(call)
-          ? undefined
-          : call?.name;
-        if (!fullName) {
-          return <div className="text-xs text-muted-foreground">—</div>;
-        }
-        const { toolName } = parseFullToolName(fullName);
-        return <code className="text-xs">{toolName || fullName}</code>;
-      },
-    },
-    {
-      id: "arguments",
-      header: "Arguments",
-      cell: ({ row }) => {
-        // LockedChat rows carry a sentinel in place of the recorded call, so
-        // there are no arguments to preview — say why instead of showing "—".
-        const call = row.original.toolCall;
-        if (isLockedChatUnavailableContent(call)) {
-          return <LockedChatContentUnavailableLabel value={call} />;
-        }
-        // Redaction replaces only the arguments, keeping the call's id and
-        // name, so the marker arrives nested rather than in the call's place.
-        const args = call?.arguments;
-        if (isLockedChatUnavailableContent(args)) {
-          return <LockedChatContentUnavailableLabel value={args} />;
-        }
-        if (!args) {
-          return <div className="text-xs text-muted-foreground">—</div>;
-        }
-        const argsString = JSON.stringify(args);
-        return (
-          <div className="text-xs font-mono">
-            <TruncatedText message={argsString} maxLength={60} />
+              <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+                {authMethod ? (
+                  <span className="shrink-0">
+                    {formatAuthMethod(authMethod)}
+                  </span>
+                ) : null}
+                {authMethod && executedAs ? (
+                  <span aria-hidden="true">·</span>
+                ) : null}
+                {executedAs ? (
+                  <span className="min-w-0 overflow-hidden">
+                    <ExecutedAsBadge
+                      executedAs={executedAs}
+                      caller={formatCallerIdentity(row.original)}
+                    />
+                  </span>
+                ) : null}
+              </div>
+            </div>
           </div>
         );
       },
     },
     {
       id: "status",
-      header: "Status",
+      header: "Result",
+      size: 105,
+      minSize: 95,
       cell: ({ row }) => {
         const result = row.original.toolResult;
         const method = row.original.method || "tools/call";
@@ -442,6 +401,36 @@ function McpToolCallsTable({
           </Badge>
         );
       },
+    },
+    {
+      id: "createdAt",
+      header: ({ column }) => {
+        return (
+          <Button
+            variant="ghost"
+            className="h-auto !p-0 font-medium hover:bg-transparent"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Time
+            <SortIcon isSorted={column.getIsSorted()} />
+          </Button>
+        );
+      },
+      size: 175,
+      minSize: 160,
+      cell: ({ row }) => (
+        <div className="min-w-0">
+          <div className="text-sm">
+            {formatRelativeTimeFromNow(row.original.createdAt)}
+          </div>
+          <div className="truncate font-mono text-[11px] text-muted-foreground">
+            {formatDate({
+              date: row.original.createdAt,
+              dateFormat: "MMM d, yyyy · HH:mm:ss",
+            })}
+          </div>
+        </div>
+      ),
     },
   ];
 
@@ -580,4 +569,11 @@ function getGatewayDisplayName(
   return (
     agent?.name ?? (row.agentId === null ? "Deleted MCP Gateway" : "Unknown")
   );
+}
+
+function formatMcpMethod(method: string) {
+  if (method === "initialize") return "Initialize";
+  if (method === "tools/list") return "List tools";
+  if (method === "tools/call") return "Tool call";
+  return method;
 }


### PR DESCRIPTION
## Summary

- simplify the audit log overview into Activity, Actor, Resource, and Time while keeping request and source metadata in event details
- consolidate LLM session context, usage, spend, and timing into a more compact six-column layout
- consolidate MCP call, gateway, identity, result, and time context, including catalog icons with a generic fallback
- update the MCP authentication documentation for the combined Identity column