### PR TITLE
fix(knowledge): surface silent ingestion loss

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -275,6 +275,8 @@ Connectors pull data from external tools into Knowledge Bases. A connector can b
 
 Open a connector to review its document sync runs and progress. You can cancel a running document sync from its **Actions** column. Cancellation stops new source batches and keeps documents already ingested by the run. A later sync continues from the saved connector checkpoint.
 
+Open a run's details to review warnings and connector errors. The logs name documents whose content exceeded an indexing limit. Unsupported file types are counted as skipped. A document that produces no chunks finishes with an error.
+
 ## Visibility
 
 Each connector has a visibility setting that determines which users can retrieve its data when an agent calls `query_knowledge_sources`. Connectors and Knowledge Bases are filtered by visibility throughout the UI: users only see sources they have access to, and only those can be assigned to agents and MCP Gateways.

--- a/platform/backend/src/knowledge-base/chunk-and-store.ts
+++ b/platform/backend/src/knowledge-base/chunk-and-store.ts
@@ -11,9 +11,9 @@ import { buildContextualHeaders } from "./contextual-retrieval";
  *
  * Every ingestion path has to go through here: chunks — not the document row —
  * are what retrieval searches, and the embedding pass only ever READS chunks
- * (a document with none is marked `completed` with `chunkCount: 0`). So a path
- * that stores a document without chunking it produces a document that looks
- * fully indexed and can never be retrieved.
+ * (a document with none is marked `failed` and surfaced on its connector run).
+ * So a path that stores a document without chunking it cannot silently look
+ * indexed while remaining impossible to retrieve.
  *
  * Callers replacing a document's content must delete its existing chunks first;
  * this appends.

--- a/platform/backend/src/knowledge-base/connector-sync.test.ts
+++ b/platform/backend/src/knowledge-base/connector-sync.test.ts
@@ -72,6 +72,11 @@ function makeMockConnector(
     sourceUrl?: string;
     metadata?: Record<string, unknown>;
     operationalMetadataKeys?: string[];
+    contentTruncation?: {
+      originalCharacterCount: number;
+      indexedCharacterCount: number;
+      originalContentHash: string;
+    };
   }>,
   options?: { hasMore?: boolean },
 ) {
@@ -132,6 +137,90 @@ describe("ConnectorSyncService", () => {
     // Connector stays "running" — the last batch_embedding task sets "success"
     const updated = await KnowledgeBaseConnectorModel.findById(connector.id);
     expect(updated?.lastSyncStatus).toBe("running");
+  });
+
+  test("persists and logs a connector content-truncation marker", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const secretId = await createSecret();
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    await KnowledgeBaseConnectorModel.update(connector.id, { secretId });
+
+    setupSecret();
+    const contentTruncation = {
+      originalCharacterCount: 600_000,
+      indexedCharacterCount: 500_000,
+      originalContentHash: "full-source-hash",
+    };
+    mockGetConnector.mockReturnValue(
+      makeMockConnector([
+        {
+          id: "long-doc",
+          title: "Long handbook",
+          content: "retained prefix",
+          contentTruncation,
+        },
+      ]),
+    );
+
+    const warn = vi.fn();
+    const stubLogger = {
+      info: vi.fn(),
+      warn,
+      debug: vi.fn(),
+      error: vi.fn(),
+      child: () => stubLogger,
+    };
+    const firstRun = await connectorSyncService.executeSync(connector.id, {
+      logger: stubLogger as never,
+    });
+
+    const firstStored = await KbDocumentModel.findBySourceId({
+      connectorId: connector.id,
+      sourceId: "long-doc",
+    });
+    expect(firstStored?.metadata).toMatchObject({ contentTruncation });
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: "long-doc",
+        name: "Long handbook",
+        ...contentTruncation,
+      }),
+      "Document content exceeded the indexing limit and was truncated",
+    );
+
+    // A tail-only source change retains the exact same indexed prefix. The
+    // full-source fingerprint must still invalidate the stored content hash.
+    await ConnectorRunModel.update(firstRun.runId, {
+      status: "success",
+      completedAt: new Date(),
+    });
+    mockGetConnector.mockReturnValue(
+      makeMockConnector([
+        {
+          id: "long-doc",
+          title: "Long handbook",
+          content: "retained prefix",
+          contentTruncation: {
+            ...contentTruncation,
+            originalContentHash: "changed-tail-hash",
+          },
+        },
+      ]),
+    );
+    await connectorSyncService.executeSync(connector.id, {
+      logger: stubLogger as never,
+    });
+    const secondStored = await KbDocumentModel.findBySourceId({
+      connectorId: connector.id,
+      sourceId: "long-doc",
+    });
+    expect(secondStored?.id).toBe(firstStored?.id);
+    expect(secondStored?.contentHash).not.toBe(firstStored?.contentHash);
   });
 
   test("an unresolvable OCR configuration degrades to syncing without OCR", async ({

--- a/platform/backend/src/knowledge-base/connector-sync.ts
+++ b/platform/backend/src/knowledge-base/connector-sync.ts
@@ -935,13 +935,30 @@ class ConnectorSyncService {
     // text (and the hash stays stable, so a later clean re-sync still dedupes).
     const content = stripNullBytes(doc.content);
     const title = stripNullBytes(doc.title);
+    const metadata = doc.contentTruncation
+      ? {
+          ...doc.metadata,
+          contentTruncation: doc.contentTruncation,
+        }
+      : doc.metadata;
+
+    if (doc.contentTruncation) {
+      log.warn(
+        {
+          documentId: doc.id,
+          name: title,
+          ...doc.contentTruncation,
+        },
+        "Document content exceeded the indexing limit and was truncated",
+      );
+    }
 
     // Include media data in hash so unchanged images are properly skipped.
     const hashMetadata = metadataForContentHash(
-      doc.metadata,
+      metadata,
       doc.operationalMetadataKeys,
     );
-    const hashInput = doc.mediaContent
+    const indexedHashInput = doc.mediaContent
       ? `${doc.mediaContent.mimeType}:${doc.mediaContent.data}` +
         (hashMetadata
           ? "\n" +
@@ -952,6 +969,12 @@ class ConnectorSyncService {
           "\n" +
           JSON.stringify(hashMetadata, Object.keys(hashMetadata).sort())
         : content;
+    // A connector retains only the indexed prefix, so include the fingerprint
+    // of the complete source text explicitly. Changes confined to the omitted
+    // tail must still invalidate the document and re-run indexing.
+    const hashInput = doc.contentTruncation
+      ? `${indexedHashInput}\ntruncated-source:${doc.contentTruncation.originalContentHash}`
+      : indexedHashInput;
     const contentHash = createHash("sha256").update(hashInput).digest("hex");
 
     // Lookup existing document by connector + source ID
@@ -977,7 +1000,7 @@ class ConnectorSyncService {
             title,
             content,
             mediaContent: doc.mediaContent,
-            metadata: doc.metadata,
+            metadata,
             connectorType,
             connectorId,
             organizationId,
@@ -1008,7 +1031,7 @@ class ConnectorSyncService {
           await KbDocumentModel.update(existing.id, {
             title,
             sourceUrl: doc.sourceUrl ?? null,
-            metadata: doc.metadata,
+            metadata,
             embeddingStatus: "pending",
           });
 
@@ -1026,14 +1049,14 @@ class ConnectorSyncService {
         // not content. Keep them current without re-chunking unchanged text.
         if (
           JSON.stringify(existing.metadata ?? {}) !==
-            JSON.stringify(doc.metadata ?? {}) ||
+            JSON.stringify(metadata ?? {}) ||
           existing.title !== title ||
           existing.sourceUrl !== (doc.sourceUrl ?? null)
         ) {
           await KbDocumentModel.update(existing.id, {
             title,
             sourceUrl: doc.sourceUrl ?? null,
-            metadata: doc.metadata,
+            metadata,
           });
         }
 
@@ -1059,7 +1082,7 @@ class ConnectorSyncService {
         // for its older M-Files revision. Lock first; the permission pass
         // unlocks only after evaluating cached+latest source revisions.
         acl: isAutoSync ? [] : acl,
-        metadata: doc.metadata,
+        metadata,
         embeddingStatus: "pending",
       });
       const chunkAcl = isAutoSync ? [] : acl;
@@ -1071,7 +1094,7 @@ class ConnectorSyncService {
         title,
         content,
         mediaContent: doc.mediaContent,
-        metadata: doc.metadata,
+        metadata,
         connectorType,
         connectorId,
         organizationId,
@@ -1100,7 +1123,7 @@ class ConnectorSyncService {
       contentHash,
       sourceUrl: doc.sourceUrl,
       acl,
-      metadata: doc.metadata,
+      metadata,
     });
 
     await this.chunkAndStore({
@@ -1108,7 +1131,7 @@ class ConnectorSyncService {
       title,
       content,
       mediaContent: doc.mediaContent,
-      metadata: doc.metadata,
+      metadata,
       connectorType,
       connectorId,
       organizationId,

--- a/platform/backend/src/knowledge-base/connectors/base-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/base-connector.test.ts
@@ -5,6 +5,7 @@ import {
   buildCheckpoint,
   extractErrorMessage,
   resolveIngestibleImageMimeTypes,
+  truncateConnectorContent,
 } from "./base-connector";
 
 /**
@@ -63,6 +64,35 @@ class TestableConnector extends BaseConnector {
 }
 
 describe("BaseConnector", () => {
+  describe("truncateConnectorContent", () => {
+    test("returns short content without a truncation marker", () => {
+      expect(
+        truncateConnectorContent({ content: "short", maxLength: 10 }),
+      ).toEqual({ content: "short" });
+    });
+
+    test("retains a prefix and fingerprints the complete source text", () => {
+      const first = truncateConnectorContent({
+        content: "shared-prefix-first-tail",
+        maxLength: 13,
+      });
+      const second = truncateConnectorContent({
+        content: "shared-prefix-second-tail",
+        maxLength: 13,
+      });
+
+      expect(first.content).toBe("shared-prefix");
+      expect(first.truncation).toMatchObject({
+        originalCharacterCount: 24,
+        indexedCharacterCount: 13,
+      });
+      expect(first.truncation?.originalContentHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(first.truncation?.originalContentHash).not.toBe(
+        second.truncation?.originalContentHash,
+      );
+    });
+  });
+
   describe("joinUrl", () => {
     const connector = new TestableConnector();
 

--- a/platform/backend/src/knowledge-base/connectors/base-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/base-connector.ts
@@ -1,15 +1,37 @@
+import { createHash } from "node:crypto";
 import type { ModelInputModality } from "@archestra/shared";
 import type pino from "pino";
 import type { OcrRunContext } from "@/knowledge-base/pdf-ocr";
 import defaultLogger from "@/logging";
 import type {
   Connector,
+  ConnectorContentTruncation,
   ConnectorCredentials,
   ConnectorItemFailure,
   ConnectorItemSkipped,
   ConnectorSyncBatch,
   ConnectorType,
 } from "@/types";
+
+export function truncateConnectorContent(params: {
+  content: string;
+  maxLength: number;
+}): { content: string; truncation?: ConnectorContentTruncation } {
+  if (params.content.length <= params.maxLength) {
+    return { content: params.content };
+  }
+
+  return {
+    content: params.content.slice(0, params.maxLength),
+    truncation: {
+      originalCharacterCount: params.content.length,
+      indexedCharacterCount: params.maxLength,
+      originalContentHash: createHash("sha256")
+        .update(params.content)
+        .digest("hex"),
+    },
+  };
+}
 
 /**
  * The image MIME types a connector should ingest: empty unless the configured

--- a/platform/backend/src/knowledge-base/connectors/dropbox/dropbox-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/dropbox/dropbox-connector.test.ts
@@ -742,6 +742,28 @@ describe("DropboxConnector", () => {
       expect(batches[0].documents[0].content).toContain("Spend");
     });
 
+    it("marks text that exceeds the connector indexing limit", async () => {
+      stubFlatListing([makeFile("id:long", "long.txt")]);
+      mockFilesDownload.mockResolvedValueOnce(
+        makeDownloadResult("x".repeat(500_001)),
+      );
+
+      const connector = new DropboxConnector();
+      const batches: ConnectorSyncBatch[] = [];
+      for await (const batch of connector.sync({
+        config: {},
+        credentials,
+        checkpoint: null,
+      })) {
+        batches.push(batch);
+      }
+
+      expect(batches[0].documents[0].contentTruncation).toMatchObject({
+        originalCharacterCount: 500_001,
+        indexedCharacterCount: 500_000,
+      });
+    });
+
     it("records an unsupported-type skip instead of silently dropping unknown binaries", async () => {
       stubFlatListing([
         makeFile("id:v1", "video.mp4"),

--- a/platform/backend/src/knowledge-base/connectors/dropbox/dropbox-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/dropbox/dropbox-connector.ts
@@ -4,6 +4,7 @@ import { Dropbox } from "dropbox";
 import { extractPdfText, type OcrRunContext } from "@/knowledge-base/pdf-ocr";
 import * as metrics from "@/observability/metrics";
 import type {
+  ConnectorContentTruncation,
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorSyncBatch,
@@ -24,6 +25,7 @@ import {
   buildCheckpoint,
   extractErrorMessage,
   resolveIngestibleImageMimeTypes,
+  truncateConnectorContent,
 } from "../base-connector";
 import { extractTextFromDocx } from "../docx-text-extractor";
 import {
@@ -932,7 +934,7 @@ export class DropboxConnector extends BaseConnector {
             });
             return null;
           }
-          return fileToDocument(file, extracted.text, extracted.mediaContent);
+          return fileToDocument({ file, ...extracted });
         },
         fallback: null,
         itemId: file.id,
@@ -990,6 +992,7 @@ export class DropboxConnector extends BaseConnector {
     text: string;
     mediaContent?: { mimeType: string; data: string };
     emptyReason?: string;
+    contentTruncation?: ConnectorContentTruncation;
   }> {
     const ext = getExtension(file.name);
 
@@ -1006,8 +1009,13 @@ export class DropboxConnector extends BaseConnector {
           "Dropbox: PDF page extraction warning",
         );
       }
+      const limited = truncateConnectorContent({
+        content: extracted.text,
+        maxLength: MAX_CONTENT_LENGTH,
+      });
       return {
-        text: extracted.text.slice(0, MAX_CONTENT_LENGTH),
+        text: limited.content,
+        contentTruncation: limited.truncation,
         emptyReason: extracted.emptyReason,
       };
     }
@@ -1026,7 +1034,14 @@ export class DropboxConnector extends BaseConnector {
       };
     }
 
-    return { text: buffer.toString("utf-8").slice(0, MAX_CONTENT_LENGTH) };
+    const limited = truncateConnectorContent({
+      content: buffer.toString("utf-8"),
+      maxLength: MAX_CONTENT_LENGTH,
+    });
+    return {
+      text: limited.content,
+      contentTruncation: limited.truncation,
+    };
   }
 
   /**
@@ -1599,11 +1614,13 @@ function laterOf(a: string, b: string): string {
   return a >= b ? a : b;
 }
 
-function fileToDocument(
-  file: DropboxFileMetadata,
-  content: string,
-  mediaContent?: { mimeType: string; data: string },
-): ConnectorDocument {
+function fileToDocument(params: {
+  file: DropboxFileMetadata;
+  text: string;
+  mediaContent?: { mimeType: string; data: string };
+  contentTruncation?: ConnectorContentTruncation;
+}): ConnectorDocument {
+  const { file, text: content, mediaContent, contentTruncation } = params;
   return {
     id: file.id,
     title: file.name,
@@ -1621,5 +1638,6 @@ function fileToDocument(
     },
     updatedAt: new Date(file.server_modified),
     ...(mediaContent ? { mediaContent } : {}),
+    contentTruncation,
   };
 }

--- a/platform/backend/src/knowledge-base/connectors/gdrive/gdrive-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/gdrive/gdrive-connector.test.ts
@@ -349,6 +349,42 @@ describe("GoogleDriveConnector", () => {
       expect(batches[0].documents[1].title).toBe("notes.txt");
     });
 
+    it("marks text that exceeds the connector indexing limit", async () => {
+      resetMocks();
+      const connector = new GoogleDriveConnector();
+      const source = Buffer.from("x".repeat(500_001));
+
+      mockFilesList.mockResolvedValueOnce({
+        data: {
+          files: [makeDriveFile("long-1", "long.txt")],
+          nextPageToken: undefined,
+        },
+      });
+      mockFilesGet.mockResolvedValueOnce({
+        data: source.buffer.slice(
+          source.byteOffset,
+          source.byteOffset + source.byteLength,
+        ),
+      });
+
+      const batches: ConnectorSyncBatch[] = [];
+      for await (const batch of connector.sync({
+        config: {},
+        credentials,
+        checkpoint: null,
+      })) {
+        batches.push(batch);
+      }
+
+      expect(batches[0].documents[0].contentTruncation).toMatchObject({
+        originalCharacterCount: 500_001,
+        indexedCharacterCount: 500_000,
+      });
+      expect(batches[0].documents[0].content).not.toContain(
+        "x".repeat(500_001),
+      );
+    });
+
     it("syncs Google Docs via export", async () => {
       resetMocks();
       const connector = new GoogleDriveConnector();

--- a/platform/backend/src/knowledge-base/connectors/gdrive/gdrive-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/gdrive/gdrive-connector.ts
@@ -3,6 +3,7 @@ import type { ModelInputModality } from "@archestra/shared";
 import type { admin_directory_v1, drive_v3 } from "googleapis";
 import { extractPdfText, type OcrRunContext } from "@/knowledge-base/pdf-ocr";
 import type {
+  ConnectorContentTruncation,
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorSyncBatch,
@@ -19,6 +20,7 @@ import {
   buildCheckpoint,
   extractErrorMessage,
   resolveIngestibleImageMimeTypes,
+  truncateConnectorContent,
 } from "../base-connector";
 import { extractTextFromDocx } from "../docx-text-extractor";
 import {
@@ -1161,7 +1163,7 @@ export class GoogleDriveConnector extends BaseConnector {
               });
               return null;
             }
-            return fileToDocument(file, result.text, result.mediaContent);
+            return fileToDocument({ file, ...result });
           },
           fallback: null,
           itemId: file.id ?? "unknown",
@@ -1381,7 +1383,7 @@ export class GoogleDriveConnector extends BaseConnector {
               });
               return null;
             }
-            return fileToDocument(file, result.text, result.mediaContent);
+            return fileToDocument({ file, ...result });
           },
           fallback: null,
           itemId: file.id ?? "unknown",
@@ -1509,6 +1511,7 @@ export class GoogleDriveConnector extends BaseConnector {
   ): Promise<{
     text: string;
     mediaContent?: { mimeType: string; data: string };
+    contentTruncation?: ConnectorContentTruncation;
     /** Why the text came back empty, for skip reporting on the run. */
     emptyReason?: string;
   }> {
@@ -1525,11 +1528,15 @@ export class GoogleDriveConnector extends BaseConnector {
           { fileId, mimeType: resolved.exportMimeType },
           { responseType: "text" },
         );
-        const text =
-          typeof res.data === "string"
-            ? res.data.slice(0, MAX_CONTENT_LENGTH)
-            : "";
-        return { text };
+        if (typeof res.data !== "string") return { text: "" };
+        const limited = truncateConnectorContent({
+          content: res.data,
+          maxLength: MAX_CONTENT_LENGTH,
+        });
+        return {
+          text: limited.content,
+          contentTruncation: limited.truncation,
+        };
       } catch (error) {
         const message = extractErrorMessage(error);
         this.log.debug(
@@ -1566,8 +1573,13 @@ export class GoogleDriveConnector extends BaseConnector {
             "Google Drive: PDF page extraction warning",
           );
         }
+        const limited = truncateConnectorContent({
+          content: extracted.text,
+          maxLength: MAX_CONTENT_LENGTH,
+        });
         return {
-          text: extracted.text.slice(0, MAX_CONTENT_LENGTH),
+          text: limited.content,
+          contentTruncation: limited.truncation,
           emptyReason: extracted.emptyReason,
         };
       } catch (error) {
@@ -1583,8 +1595,13 @@ export class GoogleDriveConnector extends BaseConnector {
     // Plain text files: download and read as text
     if (resolved?.kind === "text") {
       const buffer = await this.downloadFileBuffer(drive, fileId);
+      const limited = truncateConnectorContent({
+        content: buffer.toString("utf-8"),
+        maxLength: MAX_CONTENT_LENGTH,
+      });
       return {
-        text: buffer.toString("utf-8").slice(0, MAX_CONTENT_LENGTH),
+        text: limited.content,
+        contentTruncation: limited.truncation,
       };
     }
 
@@ -1603,8 +1620,13 @@ export class GoogleDriveConnector extends BaseConnector {
           "Google Drive: PDF page extraction warning",
         );
       }
+      const limited = truncateConnectorContent({
+        content: extracted.text,
+        maxLength: MAX_CONTENT_LENGTH,
+      });
       return {
-        text: extracted.text.slice(0, MAX_CONTENT_LENGTH),
+        text: limited.content,
+        contentTruncation: limited.truncation,
         emptyReason: extracted.emptyReason,
       };
     }
@@ -1912,11 +1934,13 @@ function willEnumerateDomain(config: GoogleDriveConfig): boolean {
   );
 }
 
-function fileToDocument(
-  file: DriveFile,
-  content: string,
-  mediaContent?: { mimeType: string; data: string },
-): ConnectorDocument {
+function fileToDocument(params: {
+  file: DriveFile;
+  text: string;
+  mediaContent?: { mimeType: string; data: string };
+  contentTruncation?: ConnectorContentTruncation;
+}): ConnectorDocument {
+  const { file, text: content, mediaContent, contentTruncation } = params;
   const title = file.name ?? "Untitled";
   const fullContent = content ? `# ${title}\n\n${content}` : `# ${title}`;
 
@@ -1937,6 +1961,7 @@ function fileToDocument(
     },
     updatedAt: file.modifiedTime ? new Date(file.modifiedTime) : undefined,
     mediaContent,
+    contentTruncation,
   };
 }
 

--- a/platform/backend/src/knowledge-base/connectors/mfiles/mfiles-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/mfiles/mfiles-connector.test.ts
@@ -325,6 +325,35 @@ describe("MFilesConnector content sync", () => {
     });
   });
 
+  test("marks text that exceeds the connector indexing limit", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse("token"))
+      .mockResolvedValueOnce(extensionResponse(capabilities("12")))
+      .mockResolvedValueOnce(
+        extensionResponse(objectPage([{ objectTypeId: 0, objectId: 123 }])),
+      )
+      .mockResolvedValueOnce(jsonResponse(objectVersion()))
+      .mockResolvedValueOnce(
+        new Response("x".repeat(500_001), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const [batch] = await collect(
+      new MFilesConnector().sync({
+        config: CONFIG,
+        credentials: CREDENTIALS,
+        checkpoint: null,
+      }),
+    );
+
+    expect(batch.documents[0].content).toHaveLength(500_000);
+    expect(batch.documents[0].contentTruncation).toMatchObject({
+      originalCharacterCount: 500_001,
+      indexedCharacterCount: 500_000,
+    });
+  });
+
   test("commits and sweeps an empty authoritative baseline", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()

--- a/platform/backend/src/knowledge-base/connectors/mfiles/mfiles-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/mfiles/mfiles-connector.ts
@@ -20,6 +20,7 @@ import {
   BaseConnector,
   extractErrorMessage,
   resolveIngestibleImageMimeTypes,
+  truncateConnectorContent,
 } from "../base-connector";
 import { extractTextFromDocx } from "../docx-text-extractor";
 import {
@@ -1046,10 +1047,15 @@ export class MFilesConnector extends BaseConnector {
       });
       if (!extracted) continue;
       const modifiedAt = file.ChangeTimeUtc ?? params.object.LastModifiedUtc;
+      const limited = truncateConnectorContent({
+        content: extracted.text,
+        maxLength: MAX_CONTENT_LENGTH,
+      });
       documents.push({
         id: buildSourceId(params.object, file),
         title: buildDocumentTitle(params.object, file),
-        content: extracted.text.slice(0, MAX_CONTENT_LENGTH),
+        content: limited.content,
+        contentTruncation: limited.truncation,
         sourceUrl: params.client.objectUrl(params.object),
         metadata: {
           source: "mfiles",

--- a/platform/backend/src/knowledge-base/connectors/onedrive/onedrive-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/onedrive/onedrive-connector.test.ts
@@ -243,6 +243,37 @@ describe("OneDriveConnector", () => {
       expect(batches[0].documents[0].content).toContain("Hello OneDrive");
     });
 
+    it("marks text that exceeds the connector indexing limit", async () => {
+      const connector = new OneDriveConnector();
+      const { mockGet } = setupMockClient(connector);
+      const source = Buffer.from("x".repeat(500_001));
+
+      mockGet.mockResolvedValueOnce({ value: [] });
+      mockGet.mockResolvedValueOnce({
+        value: [makeDriveItem("file-1", "long.txt")],
+      });
+      mockGet.mockResolvedValueOnce(
+        source.buffer.slice(
+          source.byteOffset,
+          source.byteOffset + source.byteLength,
+        ),
+      );
+
+      const batches: ConnectorSyncBatch[] = [];
+      for await (const batch of connector.sync({
+        config: baseConfig,
+        credentials,
+        checkpoint: null,
+      })) {
+        batches.push(batch);
+      }
+
+      expect(batches[0].documents[0].contentTruncation).toMatchObject({
+        originalCharacterCount: 500_001,
+        indexedCharacterCount: 500_000,
+      });
+    });
+
     it("skips unsupported file types", async () => {
       const connector = new OneDriveConnector();
       const { mockGet } = setupMockClient(connector);

--- a/platform/backend/src/knowledge-base/connectors/onedrive/onedrive-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/onedrive/onedrive-connector.ts
@@ -6,6 +6,7 @@ import type { DriveItem as GraphDriveItem } from "@microsoft/microsoft-graph-typ
 import { extractPdfText, type OcrRunContext } from "@/knowledge-base/pdf-ocr";
 import * as metrics from "@/observability/metrics";
 import type {
+  ConnectorContentTruncation,
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorSyncBatch,
@@ -26,6 +27,7 @@ import {
   buildCheckpoint,
   extractErrorMessage,
   resolveIngestibleImageMimeTypes,
+  truncateConnectorContent,
 } from "../base-connector";
 import { extractTextFromDocx } from "../docx-text-extractor";
 import {
@@ -715,12 +717,7 @@ export class OneDriveConnector extends BaseConnector {
               });
               return null;
             }
-            return driveItemToDocument(
-              item,
-              userId,
-              result.text,
-              result.mediaContent,
-            );
+            return driveItemToDocument({ item, userId, ...result });
           },
           fallback: null,
           itemId: item.id,
@@ -809,6 +806,7 @@ export class OneDriveConnector extends BaseConnector {
   ): Promise<{
     text: string;
     mediaContent?: { mimeType: string; data: string };
+    contentTruncation?: ConnectorContentTruncation;
     /** Why the text came back empty, for skip reporting on the run. */
     emptyReason?: string;
     /**
@@ -825,10 +823,13 @@ export class OneDriveConnector extends BaseConnector {
         .api(contentPath)
         .responseType(ResponseType.ARRAYBUFFER)
         .get()) as ArrayBuffer;
+      const limited = truncateConnectorContent({
+        content: Buffer.from(arrayBuffer).toString("utf-8"),
+        maxLength: MAX_CONTENT_LENGTH,
+      });
       return {
-        text: Buffer.from(arrayBuffer)
-          .toString("utf-8")
-          .slice(0, MAX_CONTENT_LENGTH),
+        text: limited.content,
+        contentTruncation: limited.truncation,
       };
     }
 
@@ -849,8 +850,13 @@ export class OneDriveConnector extends BaseConnector {
           "OneDrive: PDF page extraction warning",
         );
       }
+      const limited = truncateConnectorContent({
+        content: extracted.text,
+        maxLength: MAX_CONTENT_LENGTH,
+      });
       return {
-        text: extracted.text.slice(0, MAX_CONTENT_LENGTH),
+        text: limited.content,
+        contentTruncation: limited.truncation,
         emptyReason: extracted.emptyReason,
       };
     }
@@ -1956,12 +1962,20 @@ async function extractTextFromBinary(params: {
   }
 }
 
-function driveItemToDocument(
-  item: DriveItem,
-  userId: string,
-  content: string,
-  mediaContent?: { mimeType: string; data: string },
-): ConnectorDocument {
+function driveItemToDocument(params: {
+  item: DriveItem;
+  userId: string;
+  text: string;
+  mediaContent?: { mimeType: string; data: string };
+  contentTruncation?: ConnectorContentTruncation;
+}): ConnectorDocument {
+  const {
+    item,
+    userId,
+    text: content,
+    mediaContent,
+    contentTruncation,
+  } = params;
   const title = item.name;
   const fullContent = content ? `# ${title}\n\n${content}` : `# ${title}`;
 
@@ -1982,5 +1996,6 @@ function driveItemToDocument(
     },
     updatedAt: new Date(item.lastModifiedDateTime),
     mediaContent,
+    contentTruncation,
   };
 }

--- a/platform/backend/src/knowledge-base/connectors/salesforce/salesforce-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/salesforce/salesforce-connector.test.ts
@@ -366,6 +366,40 @@ describe("SalesforceConnector", () => {
       expect(doc.content).not.toContain("**CaseComments:**");
     });
 
+    test("marks records that exceed the connector indexing limit", async () => {
+      const c = new SalesforceConnector();
+      mockLogin.mockResolvedValueOnce({});
+      mockQuery.mockResolvedValueOnce({
+        done: true,
+        totalSize: 1,
+        records: [
+          {
+            attributes: { type: "Account" },
+            Id: "001LONG",
+            Name: "Long Account",
+            Description: "x".repeat(500_001),
+            LastModifiedDate: "2026-04-20T09:00:00.000Z",
+          },
+        ],
+      });
+
+      const batches = await collectBatches(
+        c.sync({
+          config: { objects: ["Account"] },
+          credentials: CREDS,
+          checkpoint: null,
+        }),
+      );
+
+      expect(batches[0].documents[0].content).toHaveLength(500_000);
+      expect(batches[0].documents[0].contentTruncation).toMatchObject({
+        indexedCharacterCount: 500_000,
+      });
+      expect(
+        batches[0].documents[0].contentTruncation?.originalCharacterCount,
+      ).toBeGreaterThan(500_000);
+    });
+
     test("uses advanced object config fields and associations", async () => {
       const c = new SalesforceConnector();
       mockLogin.mockResolvedValueOnce({});

--- a/platform/backend/src/knowledge-base/connectors/salesforce/salesforce-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/salesforce/salesforce-connector.ts
@@ -22,6 +22,7 @@ import {
   buildCheckpoint,
   extractErrorMessage,
   isoCursorWithSkewBuffer,
+  truncateConnectorContent,
 } from "../base-connector";
 
 const DEFAULT_BATCH_SIZE = 200;
@@ -1573,8 +1574,10 @@ function salesforceRecordToDocument(params: {
     }
   }
 
-  // Truncate content to MAX_CONTENT_LENGTH (matching GDrive pattern)
-  const content = contentParts.join("\n").slice(0, MAX_CONTENT_LENGTH);
+  const limited = truncateConnectorContent({
+    content: contentParts.join("\n"),
+    maxLength: MAX_CONTENT_LENGTH,
+  });
   const sourceUrl = params.instanceUrl
     ? `${params.instanceUrl}/${recordId}`
     : undefined;
@@ -1583,7 +1586,8 @@ function salesforceRecordToDocument(params: {
   return {
     id: `salesforce:${params.objectName}:${recordId}`,
     title,
-    content,
+    content: limited.content,
+    contentTruncation: limited.truncation,
     sourceUrl,
     metadata: {
       objectName: params.objectName,

--- a/platform/backend/src/knowledge-base/connectors/sharepoint/sharepoint-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/sharepoint/sharepoint-connector.test.ts
@@ -622,6 +622,43 @@ describe("SharePointConnector", () => {
         "Drive items query failed",
       );
     });
+
+    it("reports unsupported drive files with the unsupported-type category", async () => {
+      const connector = new SharePointConnector();
+      const { mockGet } = setupMockClient(connector);
+
+      mockGet
+        .mockResolvedValueOnce({ id: "site-123" })
+        .mockResolvedValueOnce({ value: [{ id: "drive-1" }] })
+        .mockResolvedValueOnce({ value: [] }) // listDirectSubfolders("root")
+        .mockResolvedValueOnce({
+          value: [makeDriveItem("item-1", "archive.exe")],
+        })
+        .mockResolvedValueOnce({ value: [] }); // sitePages
+
+      const batches: ConnectorSyncBatch[] = [];
+      for await (const batch of connector.sync({
+        config: {
+          tenantId: "test-tenant-id",
+          siteUrl: "https://tenant.sharepoint.com/sites/test",
+        },
+        credentials,
+        checkpoint: null,
+      })) {
+        batches.push(batch);
+      }
+
+      expect(batches[0].documents).toEqual([]);
+      expect(batches[0].skipped).toEqual([
+        {
+          itemId: "item-1",
+          name: "archive.exe",
+          reason: "unsupported_file_type",
+          category: "unsupported_type",
+          sourceScope: { metadataField: "driveId", value: "drive-1" },
+        },
+      ]);
+    });
   });
 
   describe("sync — site pages", () => {
@@ -660,6 +697,39 @@ describe("SharePointConnector", () => {
       expect(pageBatch.documents[0].content).toContain("Hello world");
       expect(pageBatch.documents[0].content).toContain("More content");
       expect(pageBatch.documents[0].id).toBe("page-page-1");
+    });
+
+    it("marks site-page text that exceeds the connector indexing limit", async () => {
+      const connector = new SharePointConnector();
+      const { mockGet } = setupMockClient(connector);
+
+      mockGet
+        .mockResolvedValueOnce({ id: "site-123" })
+        .mockResolvedValueOnce({ value: [] })
+        .mockResolvedValueOnce({
+          value: [makeSitePage("page-1", "Long Page")],
+        })
+        .mockResolvedValueOnce({
+          value: [{ innerHtml: `<p>${"x".repeat(500_001)}</p>` }],
+        });
+
+      const batches: ConnectorSyncBatch[] = [];
+      for await (const batch of connector.sync({
+        config: {
+          tenantId: "test-tenant-id",
+          siteUrl: "https://tenant.sharepoint.com/sites/test",
+        },
+        credentials,
+        checkpoint: null,
+      })) {
+        batches.push(batch);
+      }
+
+      const page = batches.at(-1)?.documents[0];
+      expect(page?.contentTruncation).toMatchObject({
+        originalCharacterCount: 500_001,
+        indexedCharacterCount: 500_000,
+      });
     });
 
     it("reports a page with no extractable content as a categorized skip naming the page", async () => {

--- a/platform/backend/src/knowledge-base/connectors/sharepoint/sharepoint-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/sharepoint/sharepoint-connector.ts
@@ -9,6 +9,7 @@ import type {
 import { extractPdfText, type OcrRunContext } from "@/knowledge-base/pdf-ocr";
 import * as metrics from "@/observability/metrics";
 import type {
+  ConnectorContentTruncation,
   ConnectorCredentials,
   ConnectorDocument,
   ConnectorSyncBatch,
@@ -30,6 +31,7 @@ import {
   buildCheckpoint,
   extractErrorMessage,
   resolveIngestibleImageMimeTypes,
+  truncateConnectorContent,
 } from "../base-connector";
 import { extractTextFromDocx } from "../docx-text-extractor";
 import {
@@ -928,7 +930,6 @@ export class SharePointConnector extends BaseConnector {
         (item) =>
           item.file &&
           !item.folder &&
-          isSupportedFile(item.name, imageMimeTypes) &&
           // Client-side incremental filter: Graph API does not support
           // $filter on lastModifiedDateTime for drive item children.
           isModifiedSince(item.lastModifiedDateTime, syncFrom),
@@ -937,6 +938,16 @@ export class SharePointConnector extends BaseConnector {
       const documents: ConnectorDocument[] = [];
 
       for (const item of items) {
+        if (!isSupportedFile(item.name, imageMimeTypes)) {
+          this.trackSkipped({
+            itemId: item.id,
+            name: item.name,
+            reason: "unsupported_file_type",
+            category: "unsupported_type",
+            sourceScope: { metadataField: "driveId", value: driveId },
+          });
+          continue;
+        }
         const doc = await this.safeItemFetch({
           fetch: async () => {
             const result = await this.downloadFileData(
@@ -959,12 +970,7 @@ export class SharePointConnector extends BaseConnector {
               });
               return null;
             }
-            return driveItemToDocument(
-              item,
-              driveId,
-              result.text,
-              result.mediaContent,
-            );
+            return driveItemToDocument({ item, driveId, ...result });
           },
           fallback: null,
           itemId: item.id,
@@ -1067,6 +1073,7 @@ export class SharePointConnector extends BaseConnector {
   ): Promise<{
     text: string;
     mediaContent?: { mimeType: string; data: string };
+    contentTruncation?: ConnectorContentTruncation;
     /** Why the text came back empty, for skip reporting on the run. */
     emptyReason?: string;
   }> {
@@ -1079,10 +1086,13 @@ export class SharePointConnector extends BaseConnector {
         .api(contentPath)
         .responseType(ResponseType.ARRAYBUFFER)
         .get()) as ArrayBuffer;
+      const limited = truncateConnectorContent({
+        content: Buffer.from(arrayBuffer).toString("utf-8"),
+        maxLength: MAX_CONTENT_LENGTH,
+      });
       return {
-        text: Buffer.from(arrayBuffer)
-          .toString("utf-8")
-          .slice(0, MAX_CONTENT_LENGTH),
+        text: limited.content,
+        contentTruncation: limited.truncation,
       };
     }
 
@@ -1104,8 +1114,13 @@ export class SharePointConnector extends BaseConnector {
           "SharePoint: PDF page extraction warning",
         );
       }
+      const limited = truncateConnectorContent({
+        content: extracted.text,
+        maxLength: MAX_CONTENT_LENGTH,
+      });
       return {
-        text: extracted.text.slice(0, MAX_CONTENT_LENGTH),
+        text: limited.content,
+        contentTruncation: limited.truncation,
         emptyReason: extracted.emptyReason,
       };
     }
@@ -1196,7 +1211,7 @@ export class SharePointConnector extends BaseConnector {
               });
               return null;
             }
-            return sitePageToDocument(page, siteId, content);
+            return sitePageToDocument({ page, siteId, content });
           },
           fallback: null,
           itemId: page.id,
@@ -1280,7 +1295,7 @@ export class SharePointConnector extends BaseConnector {
       }
     }
 
-    return parts.join("\n\n").slice(0, MAX_CONTENT_LENGTH);
+    return parts.join("\n\n");
   }
 
   private async countDriveItems(params: {
@@ -2601,12 +2616,20 @@ async function extractTextFromBinary(params: {
   }
 }
 
-function driveItemToDocument(
-  item: DriveItem,
-  driveId: string,
-  content: string,
-  mediaContent?: { mimeType: string; data: string },
-): ConnectorDocument {
+function driveItemToDocument(params: {
+  item: DriveItem;
+  driveId: string;
+  text: string;
+  mediaContent?: { mimeType: string; data: string };
+  contentTruncation?: ConnectorContentTruncation;
+}): ConnectorDocument {
+  const {
+    item,
+    driveId,
+    text: content,
+    mediaContent,
+    contentTruncation,
+  } = params;
   const title = item.name;
   const fullContent = content ? `# ${title}\n\n${content}` : `# ${title}`;
 
@@ -2629,16 +2652,24 @@ function driveItemToDocument(
     },
     updatedAt: new Date(item.lastModifiedDateTime),
     mediaContent,
+    contentTruncation,
   };
 }
 
-function sitePageToDocument(
-  page: SitePage,
-  siteId: string,
-  content: string,
-): ConnectorDocument {
+function sitePageToDocument(params: {
+  page: SitePage;
+  siteId: string;
+  content: string;
+}): ConnectorDocument {
+  const { page, siteId, content } = params;
   const title = page.title || page.name;
-  const fullContent = content ? `# ${title}\n\n${content}` : `# ${title}`;
+  const limited = truncateConnectorContent({
+    content,
+    maxLength: MAX_CONTENT_LENGTH,
+  });
+  const fullContent = limited.content
+    ? `# ${title}\n\n${limited.content}`
+    : `# ${title}`;
 
   return {
     id: `page-${page.id}`,
@@ -2654,5 +2685,6 @@ function sitePageToDocument(
       createdDateTime: page.createdDateTime,
     },
     updatedAt: new Date(page.lastModifiedDateTime),
+    contentTruncation: limited.truncation,
   };
 }

--- a/platform/backend/src/knowledge-base/embedder.test.ts
+++ b/platform/backend/src/knowledge-base/embedder.test.ts
@@ -349,7 +349,7 @@ describe("EmbeddingService", () => {
     expect(updated?.embeddingStatus).toBe("failed");
   });
 
-  test("no chunks marks document as completed with chunkCount 0", async ({
+  test("no chunks marks document as failed with chunkCount 0", async ({
     makeOrganization,
     makeKnowledgeBase,
     makeKnowledgeBaseConnector,
@@ -370,8 +370,36 @@ describe("EmbeddingService", () => {
     await embeddingService.processDocument(doc.id, makeEmbeddingContext());
 
     const updated = await KbDocumentModel.findById(doc.id);
-    expect(updated?.embeddingStatus).toBe("completed");
+    expect(updated?.embeddingStatus).toBe("failed");
     expect(updated?.chunkCount).toBe(0);
+    expect(embeddingRequests).toHaveLength(0);
+  });
+
+  test("a zero-chunk batch is counted and names the document", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    const doc = await KbDocumentModel.create({
+      connectorId: connector.id,
+      organizationId: org.id,
+      title: "Unchunkable Guide",
+      content: "Content but no chunks",
+      contentHash: "hash-zero-chunk-batch",
+      embeddingStatus: "pending",
+    });
+
+    const outcome = await embeddingService.processDocuments([doc.id]);
+
+    expect(outcome).toMatchObject({
+      failedDocumentCount: 1,
+      skippedImageChunkCount: 0,
+    });
+    expect(outcome.errorMessage).toContain("Unchunkable Guide");
+    expect(outcome.errorMessage).toContain(doc.id);
     expect(embeddingRequests).toHaveLength(0);
   });
 
@@ -621,19 +649,22 @@ describe("EmbeddingService", () => {
     await KbChunkModel.insertMany([
       { documentId: doc1.id, content: "Chunk", chunkIndex: 0 },
     ]);
-    // doc2 has no chunks → should complete with chunkCount 0
+    // doc2 has no chunks → should fail visibly with chunkCount 0
 
     responseQueue.push({ kind: "error", status: 400 });
 
-    await embeddingService.processDocuments([doc1.id, doc2.id]);
+    const outcome = await embeddingService.processDocuments([doc1.id, doc2.id]);
 
     const updated1 = await KbDocumentModel.findById(doc1.id);
     expect(updated1?.embeddingStatus).toBe("failed");
 
-    // doc2 had no chunks, so it completes regardless
+    // doc2 had no chunks, so it is part of the surfaced batch failure.
     const updated2 = await KbDocumentModel.findById(doc2.id);
-    expect(updated2?.embeddingStatus).toBe("completed");
+    expect(updated2?.embeddingStatus).toBe("failed");
     expect(updated2?.chunkCount).toBe(0);
+    expect(outcome.failedDocumentCount).toBe(2);
+    expect(outcome.errorMessage).toContain("No Chunks Doc");
+    expect(outcome.errorMessage).toContain("could not be reached");
   });
 
   test("attributes a single-document embed to that document's connector", async ({

--- a/platform/backend/src/knowledge-base/embedder.ts
+++ b/platform/backend/src/knowledge-base/embedder.ts
@@ -63,9 +63,13 @@ class EmbeddingService {
 
       if (chunks.length === 0) {
         await KbDocumentModel.update(documentId, {
-          embeddingStatus: "completed",
+          embeddingStatus: "failed",
           chunkCount: 0,
         });
+        logger.warn(
+          { documentId, title: document.title },
+          "[Embedder] Document produced no chunks and cannot be retrieved",
+        );
         return;
       }
 
@@ -162,6 +166,7 @@ class EmbeddingService {
       chunkIds: string[];
       chunkCount: number;
     }> = [];
+    const zeroChunkDocuments: Array<{ documentId: string; title: string }> = [];
     // Store raw chunk data; inputs are built after the embedding config is resolved.
     const allChunks: Array<{
       chunkId: string;
@@ -200,9 +205,17 @@ class EmbeddingService {
 
       if (chunks.length === 0) {
         await KbDocumentModel.update(documentId, {
-          embeddingStatus: "completed",
+          embeddingStatus: "failed",
           chunkCount: 0,
         });
+        zeroChunkDocuments.push({
+          documentId,
+          title: document.title,
+        });
+        logger.warn(
+          { documentId, runId: connectorRunId, title: document.title },
+          "[Embedder] Document produced no chunks and cannot be retrieved",
+        );
         continue;
       }
 
@@ -220,10 +233,12 @@ class EmbeddingService {
       }
     }
 
+    const zeroChunkError = describeZeroChunkDocuments(zeroChunkDocuments);
+
     if (allChunks.length === 0) {
       return {
-        failedDocumentCount: 0,
-        errorMessage: null,
+        failedDocumentCount: zeroChunkDocuments.length,
+        errorMessage: zeroChunkError,
         skippedImageChunkCount: 0,
       };
     }
@@ -245,8 +260,8 @@ class EmbeddingService {
         await KbDocumentModel.update(documentId, { embeddingStatus: "failed" });
       }
       return {
-        failedDocumentCount: docChunkMap.length,
-        errorMessage: message,
+        failedDocumentCount: docChunkMap.length + zeroChunkDocuments.length,
+        errorMessage: combineEmbeddingErrors(zeroChunkError, message),
         skippedImageChunkCount: 0,
       };
     }
@@ -263,8 +278,8 @@ class EmbeddingService {
         });
       }
       return {
-        failedDocumentCount: 0,
-        errorMessage: null,
+        failedDocumentCount: zeroChunkDocuments.length,
+        errorMessage: zeroChunkError,
         skippedImageChunkCount: 0,
       };
     }
@@ -406,8 +421,11 @@ class EmbeddingService {
     }
 
     return {
-      failedDocumentCount,
-      errorMessage: failedDocumentCount > 0 ? firstErrorMessage : null,
+      failedDocumentCount: failedDocumentCount + zeroChunkDocuments.length,
+      errorMessage: combineEmbeddingErrors(
+        zeroChunkError,
+        failedDocumentCount > 0 ? firstErrorMessage : null,
+      ),
       skippedImageChunkCount,
     };
   }
@@ -600,6 +618,25 @@ class EmbeddingService {
 export const embeddingService = new EmbeddingService();
 
 // ===== Internal helpers =====
+
+function describeZeroChunkDocuments(
+  documents: Array<{ documentId: string; title: string }>,
+): string | null {
+  if (documents.length === 0) return null;
+
+  const names = documents
+    .map((document) => `"${document.title}" (${document.documentId})`)
+    .join(", ");
+  return `${documents.length} document${documents.length === 1 ? "" : "s"} produced no chunks and cannot be retrieved: ${names}`;
+}
+
+function combineEmbeddingErrors(
+  first: string | null,
+  second: string | null,
+): string | null {
+  if (first && second) return `${first}; ${second}`;
+  return first ?? second;
+}
 
 function embeddingInputLogValue(input: EmbeddingInput): string {
   return typeof input === "string" ? input : `[image:${input.mimeType}]`;

--- a/platform/backend/src/knowledge-base/file-upload/index-file.ts
+++ b/platform/backend/src/knowledge-base/file-upload/index-file.ts
@@ -251,10 +251,9 @@ export async function indexFilesIntoKnowledgeBase(params: {
       }
 
       // Chunks — not the document row — are what retrieval searches, and the
-      // embedding pass only reads them. Without this the document is marked
-      // `completed` with zero chunks: indexed by every appearance, retrievable
-      // by nothing. Re-indexing replaces the previous chunks rather than
-      // appending to them.
+      // embedding pass only reads them. Without this the document fails with
+      // zero chunks and cannot be retrieved. Re-indexing replaces the previous
+      // chunks rather than appending to them.
       if (existing) {
         await KbChunkModel.deleteByDocument(document.id);
       }

--- a/platform/backend/src/types/knowledge-connector.ts
+++ b/platform/backend/src/types/knowledge-connector.ts
@@ -806,12 +806,27 @@ export interface DocumentPermissions {
   isPublic?: boolean;
 }
 
+export interface ConnectorContentTruncation {
+  /** Character count before the connector applied its indexing limit. */
+  originalCharacterCount: number;
+  /** Character count retained for indexing. */
+  indexedCharacterCount: number;
+  /** Hash of the complete source text, including the omitted tail. */
+  originalContentHash: string;
+}
+
 export interface ConnectorDocument {
   id: string;
   title: string;
   content: string;
   sourceUrl?: string;
   metadata: Record<string, unknown>;
+  /**
+   * Set when a connector intentionally retains only a prefix of the source
+   * text. The sync persists this marker in document metadata and names the
+   * affected document in the run log.
+   */
+  contentTruncation?: ConnectorContentTruncation;
   /**
    * Metadata keys used only for sync bookkeeping. They are persisted but do
    * not change the content hash or force re-chunking when their values rotate.


### PR DESCRIPTION
## Summary

- persist and log explicit metadata whenever a connector truncates source text, including a full-source fingerprint so tail-only edits trigger reindexing
- mark zero-chunk documents failed and count/name them in embedding batch outcomes
- categorize unsupported SharePoint file types as skipped, matching the other drive connectors
- document the visible sync-run diagnostics

Closes #7319