### PR TITLE
feat(knowledge): add pluggable retrieval backend

### DIFF
--- a/docs/pages/platform-adding-knowledge-retrieval-backends.md
+++ b/docs/pages/platform-adding-knowledge-retrieval-backends.md
@@ -56,7 +56,18 @@ Ingestion and query code call this interface. A new implementation must not add 
 
 ## Implementation
 
-Create a backend module under `backend/src/knowledge-base/retrieval-backends/`. Use a class when the client owns connections or cached state.
+Create `backend/src/knowledge-base/retrieval-backends/opensearch/opensearch-retrieval-backend.ts`. Use one subdirectory per backend, as knowledge connectors do.
+
+```text
+retrieval-backends/
+├── registry.ts
+├── postgres/
+│   └── postgres-retrieval-backend.ts
+└── opensearch/
+    └── opensearch-retrieval-backend.ts
+```
+
+Use a class when the client owns connections or cached state.
 
 ```typescript
 import type { Client as OpenSearchClient } from "@opensearch-project/opensearch";
@@ -67,7 +78,7 @@ import type {
   KeywordSearchParams,
   KnowledgeRetrievalBackend,
   VectorSearchParams,
-} from "../retrieval-backend";
+} from "../../retrieval-backend";
 
 export class OpenSearchRetrievalBackend
   implements KnowledgeRetrievalBackend
@@ -206,7 +217,7 @@ Do not expose the selector through the frontend. Retrieval storage is deployment
 
 ## Registration
 
-Construct one backend singleton from the selector. Keep the PostgreSQL object as the default.
+Register the implementation in `retrieval-backends/registry.ts`. Construct one singleton from the selector. Keep the PostgreSQL object as the default.
 
 ```typescript
 export const knowledgeRetrievalBackend = createKnowledgeRetrievalBackend();

--- a/docs/pages/platform-adding-knowledge-retrieval-backends.md
+++ b/docs/pages/platform-adding-knowledge-retrieval-backends.md
@@ -1,0 +1,265 @@
+---
+title: Adding Knowledge Retrieval Backends
+category: Development
+order: 4
+description: Developer guide for implementing a knowledge retrieval backend in Archestra Platform
+lastUpdated: 2026-08-23
+---
+
+<!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
+
+<!--
+This is a development guide for adding knowledge retrieval backends to Archestra.
+-->
+
+## Overview
+
+A retrieval backend stores and searches knowledge chunks. PostgreSQL with pgvector is the built-in implementation. It is the only runtime option shipped by Archestra.
+
+The `KnowledgeRetrievalBackend` contract covers ingestion, embedding, search, context expansion, and deletion. PostgreSQL remains the source of truth for documents, access rules, and citations.
+
+Adding a production backend requires four changes:
+
+1. Implement `KnowledgeRetrievalBackend`.
+2. Add one backend selector and its connection settings.
+3. Register the implementation when the application starts.
+4. Test indexing, retrieval, access control, and deletion.
+
+Do not add configuration for a backend that does not exist. A selector with one valid value adds no capability.
+
+## Use Case
+
+Suppose a deployment already operates an OpenSearch cluster for a large document corpus. A retrieval implementation can mirror Archestra chunks into that cluster. Queries use OpenSearch ranking while PostgreSQL continues to enforce access and supply citations.
+
+This guide uses `opensearch` as a fictional backend name. The repository does not include that implementation.
+
+## Backend Boundary
+
+The contract lives in `backend/src/knowledge-base/retrieval-backend.ts`.
+
+| Method | Responsibility |
+| --- | --- |
+| `insertChunks` | Store canonical chunks and mirror searchable fields. |
+| `getDocumentChunks` | Load chunks before embedding. |
+| `countDocumentChunks` | Detect documents that require indexing. |
+| `deleteDocumentChunks` | Remove old chunks before reindexing a document. |
+| `indexEmbeddings` | Store vectors for one embedding dimension. |
+| `vectorSearch` | Rank semantic matches. |
+| `keywordSearch` | Rank keyword matches. |
+| `findNeighbors` | Load adjacent chunks for context expansion. |
+| `getTextSearchLanguages` | Resolve analyzers for keyword queries. |
+| `hasKeywordStatistics` | Report whether BM25 statistics are ready. |
+| `getPopulatedEmbeddingDimensions` | Report indexed embedding dimensions. |
+| `isSearchTimeout` | Identify a backend timeout. |
+
+Ingestion and query code call this interface. A new implementation must not add backend-specific branches to those callers.
+
+## Implementation
+
+Create a backend module under `backend/src/knowledge-base/retrieval-backends/`. Use a class when the client owns connections or cached state.
+
+```typescript
+import type { Client as OpenSearchClient } from "@opensearch-project/opensearch";
+import { KbChunkModel } from "@/models";
+import type { InsertKbChunk, KbChunk } from "@/types";
+import type {
+  FindNeighborsParams,
+  KeywordSearchParams,
+  KnowledgeRetrievalBackend,
+  VectorSearchParams,
+} from "../retrieval-backend";
+
+export class OpenSearchRetrievalBackend
+  implements KnowledgeRetrievalBackend
+{
+  readonly requiresResultVerification = true;
+
+  constructor(private readonly client: OpenSearchClient) {}
+
+  async insertChunks(chunks: InsertKbChunk[]): Promise<KbChunk[]> {
+    const stored = await KbChunkModel.insertMany(chunks);
+    await this.indexChunkFields(stored);
+    return stored;
+  }
+
+  async vectorSearch(params: VectorSearchParams) {
+    return this.searchVectorIndex(params);
+  }
+
+  async keywordSearch(params: KeywordSearchParams) {
+    return this.searchKeywordIndex(params);
+  }
+
+  async findNeighbors(params: FindNeighborsParams) {
+    return this.loadNeighbors(params);
+  }
+
+  // Implement the remaining contract methods.
+
+  private async indexChunkFields(chunks: KbChunk[]) {
+    // Write stable Archestra IDs and searchable fields to the external index.
+  }
+
+  private async searchVectorIndex(params: VectorSearchParams) {
+    // Apply every scope in params before ranking candidates.
+  }
+
+  private async searchKeywordIndex(params: KeywordSearchParams) {
+    // Apply the same scopes as vector search.
+  }
+
+  private async loadNeighbors(params: FindNeighborsParams) {
+    // Return chunks next to each anchor within the requested radius.
+  }
+}
+```
+
+The example omits client-specific code. Keep network retries, authentication, and index mappings inside the backend module.
+
+## Access Control
+
+Every search request includes these scopes:
+
+- connector IDs;
+- user ACL entries, or an explicit ACL bypass;
+- an environment ID when the caller supplies one.
+
+Apply those filters inside both search methods. This keeps inaccessible rows out of the candidate window.
+
+Set `requiresResultVerification` to `true` for an external index. Archestra then reloads each candidate from PostgreSQL. It reapplies connector, ACL, environment, and soft-delete filters.
+
+External results contribute only the stable chunk ID and score. PostgreSQL supplies content, metadata, and citation fields. A forged or stale external record cannot replace canonical data.
+
+PostgreSQL uses `requiresResultVerification: false`. Its queries already apply the canonical filters.
+
+ACL and environment changes must also reach the external index. Add synchronization hooks to those update paths before enabling the backend. Canonical verification prevents unauthorized results, but stale external filters can still hide results that a user should see.
+
+## Identity and Citations
+
+Store these Archestra values in the external index:
+
+- chunk ID;
+- document ID;
+- chunk index;
+- connector ID;
+- ACL entries;
+- environment identity;
+- soft-delete state, when the index retains deleted records.
+
+The chunk ID joins an external match to its PostgreSQL row. The document ID and chunk index form the model-visible citation reference.
+
+Do not replace these values with backend-generated identities. Backend document IDs may be stored as additional fields.
+
+## Context Expansion
+
+`findNeighbors` receives document and chunk-index anchors. It returns adjacent chunks within the requested radius.
+
+Neighbors must belong to the same document as their anchor. Stop at missing or inaccessible chunks. Do not stitch media chunks into text passages.
+
+External neighbor candidates pass through PostgreSQL verification. Their content is not trusted.
+
+## Writes and Deletes
+
+PostgreSQL remains the canonical store. `insertChunks` must write there before or alongside the external index.
+
+`indexEmbeddings` stores vectors in the selected search backend. Preserve the embedding dimension because one deployment can contain chunks indexed with different models.
+
+`deleteDocumentChunks` must be idempotent. Content replacement calls it before inserting new chunks.
+
+Whole-document deletion currently relies on PostgreSQL foreign-key cascades. Before selecting an external backend in production, add external deletion to every document lifecycle path:
+
+- delete one document;
+- delete documents removed during connector sync;
+- delete every document for a connector;
+- force a full connector resync.
+
+Test partial failures between PostgreSQL and the external service. Retrying the operation must converge on the same state.
+
+## Ranking and Timeouts
+
+Return search results in rank order. Archestra preserves the backend score during canonical verification.
+
+Vector and keyword search run as separate lanes. `isSearchTimeout` must recognize the client library's timeout error. A timed-out lane is dropped while other lanes continue. Other errors fail the query.
+
+`getTextSearchLanguages` and `hasKeywordStatistics` support hybrid keyword search. Map these methods to backend analyzers and statistics. Do not silently disable the keyword lane.
+
+## Configuration
+
+Add runtime configuration only when the second implementation is usable. Keep selection deployment-wide.
+
+Use one selector:
+
+```dotenv
+ARCHESTRA_KNOWLEDGE_BASE_RETRIEVAL_BACKEND=opensearch
+```
+
+The default remains `postgres`. Add backend connection settings only when the client requires them.
+
+Follow the standard environment-variable path:
+
+1. Parse and validate values under `config.kb` in `backend/src/config.ts`.
+2. Add each variable to `platform/.env.example`.
+3. Document each variable in [Deployment](/docs/platform-deployment).
+4. Add parser tests to `backend/src/config.test.ts` when validation is not trivial.
+
+Do not expose the selector through the frontend. Retrieval storage is deployment infrastructure, not a per-connector choice.
+
+## Registration
+
+Construct one backend singleton from the selector. Keep the PostgreSQL object as the default.
+
+```typescript
+export const knowledgeRetrievalBackend = createKnowledgeRetrievalBackend();
+
+function createKnowledgeRetrievalBackend(): KnowledgeRetrievalBackend {
+  switch (config.kb.retrievalBackend) {
+    case "opensearch":
+      return new OpenSearchRetrievalBackend(createOpenSearchClient());
+    case "postgres":
+      return postgresKnowledgeRetrievalBackend;
+  }
+}
+```
+
+Keep the factory in the retrieval module. Callers continue to import the singleton or receive a backend through constructor injection.
+
+## Testing
+
+Run the existing query behavior suite against the new implementation. Add backend-specific tests for its client boundary.
+
+At minimum, cover:
+
+- chunk insertion and embedding updates;
+- vector and keyword ranking;
+- connector, ACL, environment, and soft-delete filters;
+- canonical rehydration of content and citations;
+- inaccessible and forged candidates;
+- adjacent chunk lookup;
+- every deletion path;
+- retries after partial writes;
+- timeout classification;
+- mixed embedding dimensions.
+
+Mock only the external client in unit tests. Use the real PostgreSQL test setup for canonical rows and access rules.
+
+Run these checks from `platform/`:
+
+```bash
+pnpm --dir backend test
+pnpm --dir backend type-check
+pnpm --dir backend knip
+(cd .. && python3 .github/scripts/check-docs-links.py)
+```
+
+## Completion Checklist
+
+- The implementation satisfies every contract method.
+- PostgreSQL retains canonical documents, ACLs, and citations.
+- Search filters are pushed into the external backend.
+- ACL and environment changes update the external index.
+- External candidates and neighbors enable canonical verification.
+- Whole-document deletion updates both stores.
+- One deployment-level selector chooses the backend.
+- Backend-specific variables appear in `.env.example` and deployment docs.
+- Existing PostgreSQL behavior tests still pass.
+- The new backend has indexing, retrieval, access, timeout, and deletion tests.

--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -1044,3 +1044,7 @@ A connector can be assigned a deployment environment. Only agents and gateways i
 ## Adding New Connector Types
 
 See [Adding Knowledge Connectors](/docs/platform-adding-knowledge-connectors) for a developer guide on implementing new connector types.
+
+## Adding Retrieval Backends
+
+See [Adding Knowledge Retrieval Backends](/docs/platform-adding-knowledge-retrieval-backends) for a developer guide on implementing a new search index.

--- a/platform/backend/src/knowledge-base/RETRIEVAL_BACKENDS.md
+++ b/platform/backend/src/knowledge-base/RETRIEVAL_BACKENDS.md
@@ -1,0 +1,111 @@
+# Knowledge Retrieval Backends
+
+The retrieval backend separates the knowledge query pipeline from its search
+index. PostgreSQL with pgvector is the built-in implementation and the only
+runtime option shipped by Archestra.
+
+There is no retrieval-backend environment variable yet. A selector with one
+valid value adds configuration without adding a capability. When another
+production implementation ships, add one enum setting under `config.kb`, one
+matching `ARCHESTRA_KNOWLEDGE_BASE_*` variable, and one factory switch where the
+singleton is constructed.
+
+## Contract
+
+`KnowledgeRetrievalBackend` in `retrieval-backend.ts` covers the operations used
+outside the PostgreSQL model:
+
+| Operation | Purpose |
+| --- | --- |
+| `insertChunks` | Store chunk text, position, keyword metadata, and ACLs. |
+| `getDocumentChunks` | Load chunks for embedding. |
+| `countDocumentChunks` | Detect documents that need re-embedding. |
+| `deleteDocumentChunks` | Remove an old index before replacing document content. |
+| `indexEmbeddings` | Write vectors for one supported dimension. |
+| `vectorSearch` | Rank semantic matches. |
+| `keywordSearch` | Rank keyword matches. |
+| `findNeighbors` | Fetch adjacent chunks for context expansion. |
+| `getTextSearchLanguages` | Resolve the keyword analyzers used by a query. |
+| `hasKeywordStatistics` | Decide whether BM25 statistics are ready. |
+| `getPopulatedEmbeddingDimensions` | Diagnose an embedding-dimension mismatch. |
+| `isSearchTimeout` | Classify a backend timeout for lane-level degradation. |
+
+Ingestion, embedding, querying, and context expansion call this contract. The
+PostgreSQL object delegates to `KbChunkModel`, which keeps the current behavior.
+`QueryService` accepts a backend in its constructor. The application singleton
+uses the PostgreSQL object.
+
+## Required Guarantees
+
+### Access Control
+
+Every search and neighbor request includes these scopes:
+
+- connector IDs;
+- the user's ACL tokens, or an explicit ACL bypass;
+- the environment ID when the caller supplies one.
+
+An external backend must push these filters into its query. This preserves the
+requested result count and avoids filling the candidate window with inaccessible
+rows.
+
+External filtering is not trusted. Set `requiresResultVerification` to `true`.
+Archestra then reloads each candidate from PostgreSQL and reapplies the ACL,
+connector, environment, and soft-delete predicates. It keeps only the external
+score and stable chunk ID. Content, document metadata, and citation fields come
+from PostgreSQL. Neighbor candidates go through the same canonical check.
+
+PostgreSQL sets `requiresResultVerification` to `false` because its search
+statements already apply those predicates directly.
+
+### Identity and Citations
+
+Each result must preserve its chunk ID, document ID, and chunk index. The chunk
+ID is the join key for external-result verification. The document ID and chunk
+index form the model-visible citation reference.
+
+Do not use a backend-generated document identity. Store Archestra's IDs in the
+external index.
+
+### Context Expansion
+
+`findNeighbors` returns chunks from the same document around an anchor index.
+It must stop at missing or inaccessible chunks. External neighbor content is
+reloaded from PostgreSQL before passages are stitched together.
+
+Media chunks are never stitched into text passages.
+
+### Ranking and Timeouts
+
+Search methods return rows in rank order. Verification preserves that order and
+the backend score. Vector and keyword lanes run independently. A backend timeout
+must be recognized by `isSearchTimeout`; the query service drops that lane and
+uses the other one. Other errors fail the query.
+
+### Writes and Deletes
+
+PostgreSQL remains the canonical document and ACL store. An external
+implementation can mirror chunks into its index during `insertChunks` and add
+vectors during `indexEmbeddings`.
+
+`deleteDocumentChunks` must be idempotent. It runs before changed content is
+re-chunked. Deleting a whole document removes its PostgreSQL chunks by foreign-key
+cascade. An external implementation also needs a deletion hook for those
+document lifecycle paths before it can be selected in production.
+
+## Adding an Implementation
+
+1. Implement every `KnowledgeRetrievalBackend` method.
+2. Keep PostgreSQL as the canonical document, ACL, and citation store.
+3. Set `requiresResultVerification` to `true`.
+4. Push connector, ACL, and environment filters into both search methods.
+5. Store Archestra chunk and document identities in the external index.
+6. Normalize timeout detection through `isSearchTimeout`.
+7. Add the document-deletion lifecycle hook described above.
+8. Run the query behavior suite against the implementation.
+9. Add backend-specific tests for indexing, deletion, filtering, and timeout
+   behavior.
+
+`query.test.ts` includes an alternate backend that returns forged fields and an
+inaccessible row. The test proves that ACL verification, canonical citations,
+and context expansion do not depend on PostgreSQL ranking.

--- a/platform/backend/src/knowledge-base/RETRIEVAL_BACKENDS.md
+++ b/platform/backend/src/knowledge-base/RETRIEVAL_BACKENDS.md
@@ -32,8 +32,9 @@ outside the PostgreSQL model:
 
 Ingestion, embedding, querying, and context expansion call this contract. The
 PostgreSQL object delegates to `KbChunkModel`, which keeps the current behavior.
-`QueryService` accepts a backend in its constructor. The application singleton
-uses the PostgreSQL object.
+Implementations live under `retrieval-backends/<name>/`. The registry at
+`retrieval-backends/registry.ts` constructs the application singleton.
+`QueryService` accepts a backend in its constructor.
 
 ## Required Guarantees
 
@@ -95,15 +96,17 @@ document lifecycle paths before it can be selected in production.
 
 ## Adding an Implementation
 
-1. Implement every `KnowledgeRetrievalBackend` method.
-2. Keep PostgreSQL as the canonical document, ACL, and citation store.
-3. Set `requiresResultVerification` to `true`.
-4. Push connector, ACL, and environment filters into both search methods.
-5. Store Archestra chunk and document identities in the external index.
-6. Normalize timeout detection through `isSearchTimeout`.
-7. Add the document-deletion lifecycle hook described above.
-8. Run the query behavior suite against the implementation.
-9. Add backend-specific tests for indexing, deletion, filtering, and timeout
+1. Create `retrieval-backends/<name>/<name>-retrieval-backend.ts`.
+2. Implement every `KnowledgeRetrievalBackend` method.
+3. Keep PostgreSQL as the canonical document, ACL, and citation store.
+4. Set `requiresResultVerification` to `true`.
+5. Push connector, ACL, and environment filters into both search methods.
+6. Store Archestra chunk and document identities in the external index.
+7. Normalize timeout detection through `isSearchTimeout`.
+8. Add the document-deletion lifecycle hook described above.
+9. Register the implementation in `retrieval-backends/registry.ts`.
+10. Run the query behavior suite against the implementation.
+11. Add backend-specific tests for indexing, deletion, filtering, and timeout
    behavior.
 
 `query.test.ts` includes an alternate backend that returns forged fields and an

--- a/platform/backend/src/knowledge-base/chunk-and-store.ts
+++ b/platform/backend/src/knowledge-base/chunk-and-store.ts
@@ -1,10 +1,10 @@
 import type { TextSearchLanguage } from "@archestra/shared";
 import type pino from "pino";
-import { KbChunkModel } from "@/models";
 import * as metrics from "@/observability/metrics";
 import type { AclEntry } from "@/types";
 import { chunkDocument } from "./chunker";
 import { buildContextualHeaders } from "./contextual-retrieval";
+import { knowledgeRetrievalBackend } from "./retrieval-backend";
 
 /**
  * Split a stored document into chunks and persist them.
@@ -50,7 +50,7 @@ export async function chunkAndStoreDocument(params: {
   // multimodal embedding API instead of text embedding.
   if (mediaContent) {
     const dataUrl = `data:${mediaContent.mimeType};base64,${mediaContent.data}`;
-    await KbChunkModel.insertMany([
+    await knowledgeRetrievalBackend.insertChunks([
       {
         documentId,
         content: dataUrl,
@@ -86,7 +86,7 @@ export async function chunkAndStoreDocument(params: {
     connectorId,
   });
 
-  await KbChunkModel.insertMany(
+  await knowledgeRetrievalBackend.insertChunks(
     chunks.map((chunk, index) => ({
       documentId,
       content: chunk.content,

--- a/platform/backend/src/knowledge-base/chunk-and-store.ts
+++ b/platform/backend/src/knowledge-base/chunk-and-store.ts
@@ -4,7 +4,7 @@ import * as metrics from "@/observability/metrics";
 import type { AclEntry } from "@/types";
 import { chunkDocument } from "./chunker";
 import { buildContextualHeaders } from "./contextual-retrieval";
-import { knowledgeRetrievalBackend } from "./retrieval-backend";
+import { knowledgeRetrievalBackend } from "./retrieval-backends/registry";
 
 /**
  * Split a stored document into chunks and persist them.

--- a/platform/backend/src/knowledge-base/connector-sync.ts
+++ b/platform/backend/src/knowledge-base/connector-sync.ts
@@ -30,7 +30,7 @@ import { toKnowledgeBaseUserMessage } from "./errors";
 import { resolveEmbeddingConfig, resolveOcrConfig } from "./kb-llm-client";
 import { OCR_RUN_PAGE_BUDGET } from "./pdf-ocr";
 import { enqueuePermissionSyncAfterContentSync } from "./permission-sync-trigger";
-import { knowledgeRetrievalBackend } from "./retrieval-backend";
+import { knowledgeRetrievalBackend } from "./retrieval-backends/registry";
 import { knowledgeSourceAccessControlService } from "./source-access-control";
 
 /**

--- a/platform/backend/src/knowledge-base/connector-sync.ts
+++ b/platform/backend/src/knowledge-base/connector-sync.ts
@@ -7,7 +7,6 @@ import config from "@/config";
 import defaultLogger from "@/logging";
 import {
   ConnectorRunModel,
-  KbChunkModel,
   KbDocumentModel,
   KnowledgeBaseConnectorModel,
 } from "@/models";
@@ -31,6 +30,7 @@ import { toKnowledgeBaseUserMessage } from "./errors";
 import { resolveEmbeddingConfig, resolveOcrConfig } from "./kb-llm-client";
 import { OCR_RUN_PAGE_BUDGET } from "./pdf-ocr";
 import { enqueuePermissionSyncAfterContentSync } from "./permission-sync-trigger";
+import { knowledgeRetrievalBackend } from "./retrieval-backend";
 import { knowledgeSourceAccessControlService } from "./source-access-control";
 
 /**
@@ -967,9 +967,8 @@ class ConnectorSyncService {
 
       // Same content hash → skip (unchanged)
       if (existing.contentHash === contentHash) {
-        const existingChunkCount = await KbChunkModel.countByDocument(
-          existing.id,
-        );
+        const existingChunkCount =
+          await knowledgeRetrievalBackend.countDocumentChunks(existing.id);
 
         if (existingChunkCount === 0) {
           await this.chunkAndStore({
@@ -1065,7 +1064,7 @@ class ConnectorSyncService {
       const chunkAcl = isAutoSync ? [] : acl;
 
       // Re-chunk: content changed, so replace stale chunks
-      await KbChunkModel.deleteByDocument(existing.id);
+      await knowledgeRetrievalBackend.deleteDocumentChunks(existing.id);
       await this.chunkAndStore({
         documentId: existing.id,
         title,

--- a/platform/backend/src/knowledge-base/context-expansion.ts
+++ b/platform/backend/src/knowledge-base/context-expansion.ts
@@ -1,10 +1,8 @@
 import logger from "@/logging";
 import type { VectorSearchResult } from "@/models/kb-chunk";
 import type { AclEntry } from "@/types";
-import {
-  type KnowledgeRetrievalBackend,
-  knowledgeRetrievalBackend,
-} from "./retrieval-backend";
+import type { KnowledgeRetrievalBackend } from "./retrieval-backend";
+import { knowledgeRetrievalBackend } from "./retrieval-backends/registry";
 import { verifyExternalNeighborChunks } from "./retrieval-result-verifier";
 
 // ===== Exports =====

--- a/platform/backend/src/knowledge-base/context-expansion.ts
+++ b/platform/backend/src/knowledge-base/context-expansion.ts
@@ -1,7 +1,11 @@
 import logger from "@/logging";
-import { KbChunkModel } from "@/models";
 import type { VectorSearchResult } from "@/models/kb-chunk";
 import type { AclEntry } from "@/types";
+import {
+  type KnowledgeRetrievalBackend,
+  knowledgeRetrievalBackend,
+} from "./retrieval-backend";
+import { verifyExternalNeighborChunks } from "./retrieval-result-verifier";
 
 // ===== Exports =====
 
@@ -31,8 +35,16 @@ export async function expandChunkContext(params: {
   userAcl: AclEntry[];
   bypassAcl?: boolean;
   environmentId?: string | null;
+  retrievalBackend?: KnowledgeRetrievalBackend;
 }): Promise<VectorSearchResult[]> {
-  const { results, radius, userAcl, bypassAcl = false, environmentId } = params;
+  const {
+    results,
+    radius,
+    userAcl,
+    bypassAcl = false,
+    environmentId,
+    retrievalBackend = knowledgeRetrievalBackend,
+  } = params;
 
   if (radius <= 0 || results.length === 0) return results;
 
@@ -40,7 +52,7 @@ export async function expandChunkContext(params: {
   const expandable = results.filter((r) => !isMediaChunk(r.content));
   if (expandable.length === 0) return results;
 
-  const neighbors = await KbChunkModel.findNeighbors({
+  const neighborParams = {
     anchors: expandable.map((r) => ({
       documentId: r.documentId,
       chunkIndex: r.chunkIndex,
@@ -49,7 +61,11 @@ export async function expandChunkContext(params: {
     userAcl,
     bypassAcl,
     environmentId,
-  });
+  };
+  const candidates = await retrievalBackend.findNeighbors(neighborParams);
+  const neighbors = retrievalBackend.requiresResultVerification
+    ? await verifyExternalNeighborChunks({ ...neighborParams, candidates })
+    : candidates;
 
   if (neighbors.length === 0) return results;
 

--- a/platform/backend/src/knowledge-base/embedder.ts
+++ b/platform/backend/src/knowledge-base/embedder.ts
@@ -1,6 +1,6 @@
 import { addNomicTaskPrefix, EMBEDDING_BATCH_SIZE } from "@archestra/shared";
 import logger from "@/logging";
-import { KbChunkModel, KbDocumentModel } from "@/models";
+import { KbDocumentModel } from "@/models";
 import {
   callEmbedding,
   type EmbeddingApiResponse,
@@ -20,6 +20,7 @@ import {
   getDefaultOrgEmbeddingConfig,
 } from "./kb-llm-client";
 import { parseImageDataUrl } from "./media-chunk";
+import { knowledgeRetrievalBackend } from "./retrieval-backend";
 
 const RETRY_MAX_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 1000;
@@ -59,7 +60,8 @@ class EmbeddingService {
     await KbDocumentModel.update(documentId, { embeddingStatus: "processing" });
 
     try {
-      const chunks = await KbChunkModel.findByDocument(documentId);
+      const chunks =
+        await knowledgeRetrievalBackend.getDocumentChunks(documentId);
 
       if (chunks.length === 0) {
         await KbDocumentModel.update(documentId, {
@@ -118,7 +120,10 @@ class EmbeddingService {
         }
       }
 
-      await KbChunkModel.updateEmbeddings(allUpdates, ctx.dimensions);
+      await knowledgeRetrievalBackend.indexEmbeddings({
+        updates: allUpdates,
+        dimensions: ctx.dimensions,
+      });
 
       await KbDocumentModel.update(documentId, {
         embeddingStatus: "completed",
@@ -196,7 +201,8 @@ class EmbeddingService {
         embeddingStatus: "processing",
       });
 
-      const chunks = await KbChunkModel.findByDocument(documentId);
+      const chunks =
+        await knowledgeRetrievalBackend.getDocumentChunks(documentId);
 
       if (chunks.length === 0) {
         await KbDocumentModel.update(documentId, {
@@ -363,7 +369,10 @@ class EmbeddingService {
     );
     if (successfulUpdates.length > 0) {
       try {
-        await KbChunkModel.updateEmbeddings(successfulUpdates, ctx.dimensions);
+        await knowledgeRetrievalBackend.indexEmbeddings({
+          updates: successfulUpdates,
+          dimensions: ctx.dimensions,
+        });
       } catch (error) {
         // Persistence failed (e.g. a pgvector dimension error on write). Fail the
         // affected documents and surface the cause rather than crashing.

--- a/platform/backend/src/knowledge-base/embedder.ts
+++ b/platform/backend/src/knowledge-base/embedder.ts
@@ -20,7 +20,7 @@ import {
   getDefaultOrgEmbeddingConfig,
 } from "./kb-llm-client";
 import { parseImageDataUrl } from "./media-chunk";
-import { knowledgeRetrievalBackend } from "./retrieval-backend";
+import { knowledgeRetrievalBackend } from "./retrieval-backends/registry";
 
 const RETRY_MAX_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 1000;

--- a/platform/backend/src/knowledge-base/file-upload/index-file.ts
+++ b/platform/backend/src/knowledge-base/file-upload/index-file.ts
@@ -8,8 +8,9 @@ import {
   OCR_RUN_PAGE_BUDGET,
   type OcrRunContext,
 } from "@/knowledge-base/pdf-ocr";
+import { knowledgeRetrievalBackend } from "@/knowledge-base/retrieval-backend";
 import logger from "@/logging";
-import { KbChunkModel, KbDocumentModel, KbFileModel } from "@/models";
+import { KbDocumentModel, KbFileModel } from "@/models";
 import { readRowBytes } from "@/skills-sandbox/file-storage";
 import { taskQueueService } from "@/task-queue";
 import { type AclEntry, ApiError } from "@/types";
@@ -256,7 +257,7 @@ export async function indexFilesIntoKnowledgeBase(params: {
       // by nothing. Re-indexing replaces the previous chunks rather than
       // appending to them.
       if (existing) {
-        await KbChunkModel.deleteByDocument(document.id);
+        await knowledgeRetrievalBackend.deleteDocumentChunks(document.id);
       }
       await chunkAndStoreDocument({
         documentId: document.id,

--- a/platform/backend/src/knowledge-base/file-upload/index-file.ts
+++ b/platform/backend/src/knowledge-base/file-upload/index-file.ts
@@ -8,7 +8,7 @@ import {
   OCR_RUN_PAGE_BUDGET,
   type OcrRunContext,
 } from "@/knowledge-base/pdf-ocr";
-import { knowledgeRetrievalBackend } from "@/knowledge-base/retrieval-backend";
+import { knowledgeRetrievalBackend } from "@/knowledge-base/retrieval-backends/registry";
 import logger from "@/logging";
 import { KbDocumentModel, KbFileModel } from "@/models";
 import { readRowBytes } from "@/skills-sandbox/file-storage";

--- a/platform/backend/src/knowledge-base/query.test.ts
+++ b/platform/backend/src/knowledge-base/query.test.ts
@@ -86,7 +86,15 @@ import type { VectorSearchResult } from "@/models/kb-chunk";
 import { describe, expect, test } from "@/test";
 
 import { KnowledgeBaseSearchTimeoutError } from "./errors";
-import { findEmbeddingDimensionMismatch, queryService } from "./query";
+import {
+  findEmbeddingDimensionMismatch,
+  QueryService,
+  queryService,
+} from "./query";
+import {
+  type KnowledgeRetrievalBackend,
+  knowledgeRetrievalBackend,
+} from "./retrieval-backend";
 
 function makeFakeEmbedding(seed: number): number[] {
   return Array.from({ length: 1536 }, (_, i) => Math.cos(seed + i * 0.01));
@@ -210,6 +218,138 @@ describe("QueryService", () => {
       input: ["TypeScript"],
       dimensions: 1536,
     });
+  });
+
+  test("an alternate backend preserves ACL scope, citations, and context expansion", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    setupEmbeddingConfig();
+    setupSingleQueryExpansion();
+
+    const visibleDocument = await KbDocumentModel.create({
+      connectorId: connector.id,
+      organizationId: org.id,
+      sourceId: "runbook-42",
+      title: "Certificate rotation runbook",
+      content: "Certificate inventory and rotation steps",
+      contentHash: "alternate-backend-visible",
+      sourceUrl: "https://docs.example.test/runbook-42",
+      metadata: { section: "rotation" },
+      embeddingStatus: "completed",
+    });
+    const restrictedDocument = await KbDocumentModel.create({
+      connectorId: connector.id,
+      organizationId: org.id,
+      sourceId: "restricted-42",
+      title: "Restricted runbook",
+      content: "Restricted result",
+      contentHash: "alternate-backend-restricted",
+      embeddingStatus: "completed",
+    });
+    const [visibleNeighbor, visibleChunk, restrictedChunk] =
+      await KbChunkModel.insertMany([
+        {
+          documentId: visibleDocument.id,
+          content: "Use the current certificate inventory.",
+          chunkIndex: 0,
+          acl: ["org:*"],
+        },
+        {
+          documentId: visibleDocument.id,
+          content: "The rotation starts after approval.",
+          chunkIndex: 1,
+          acl: ["org:*"],
+        },
+        {
+          documentId: restrictedDocument.id,
+          content: "Restricted result",
+          chunkIndex: 0,
+          acl: ["team:restricted"],
+        },
+      ]);
+
+    const visibleHit: VectorSearchResult = {
+      id: visibleChunk.id,
+      content: "Forged external content",
+      chunkIndex: 1,
+      documentId: visibleDocument.id,
+      sourceId: "forged-source",
+      title: "Forged external title",
+      sourceUrl: null,
+      metadata: null,
+      connectorType: null,
+      score: 0.95,
+    };
+    const indexedRows: VectorSearchResult[] = [
+      visibleHit,
+      {
+        ...visibleHit,
+        id: restrictedChunk.id,
+        documentId: restrictedDocument.id,
+        content: "Restricted result",
+        score: 0.9,
+      },
+    ];
+
+    const alternateBackend: KnowledgeRetrievalBackend = {
+      ...knowledgeRetrievalBackend,
+      requiresResultVerification: true,
+      // Deliberately return restricted and forged data. Archestra must treat
+      // these as ranked ids only, then apply its own canonical access state.
+      vectorSearch: async () => indexedRows,
+      keywordSearch: async () => indexedRows,
+      getTextSearchLanguages: async () => [],
+      hasKeywordStatistics: async () => false,
+      getPopulatedEmbeddingDimensions: async () => new Set([1536]),
+      findNeighbors: async () => [
+        {
+          id: visibleNeighbor.id,
+          documentId: visibleDocument.id,
+          chunkIndex: 0,
+          content: "Forged external neighbour content",
+        },
+        {
+          id: restrictedChunk.id,
+          documentId: restrictedDocument.id,
+          chunkIndex: 0,
+          content: "Restricted result",
+        },
+      ],
+      isSearchTimeout: () => false,
+    };
+    const alternateQueryService = new QueryService(alternateBackend);
+
+    embeddingQueue.push(makeFakeEmbedding(1));
+    const results = await alternateQueryService.query({
+      connectorIds: [connector.id],
+      organizationId: org.id,
+      queryText: "How do certificates rotate?",
+      userAcl: ["org:*"],
+      environmentId: null,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      content:
+        "Use the current certificate inventory.\n\nThe rotation starts after approval.",
+      chunkIndex: 1,
+      metadata: { section: "rotation" },
+      ref: `${visibleDocument.id}#1`,
+      citation: {
+        title: "Certificate rotation runbook",
+        sourceUrl: "https://docs.example.test/runbook-42",
+        documentId: visibleDocument.id,
+        sourceId: "runbook-42",
+        connectorType: "jira",
+      },
+    });
+    expect(results[0].content).not.toContain("Forged external");
+    expect(results[0].content).not.toContain("Restricted result");
   });
 
   test("returns a media chunk as a descriptor plus an out-of-band payload", async ({

--- a/platform/backend/src/knowledge-base/query.test.ts
+++ b/platform/backend/src/knowledge-base/query.test.ts
@@ -91,10 +91,8 @@ import {
   QueryService,
   queryService,
 } from "./query";
-import {
-  type KnowledgeRetrievalBackend,
-  knowledgeRetrievalBackend,
-} from "./retrieval-backend";
+import type { KnowledgeRetrievalBackend } from "./retrieval-backend";
+import { knowledgeRetrievalBackend } from "./retrieval-backends/registry";
 
 function makeFakeEmbedding(seed: number): number[] {
   return Array.from({ length: 1536 }, (_, i) => Math.cos(seed + i * 0.01));

--- a/platform/backend/src/knowledge-base/query.ts
+++ b/platform/backend/src/knowledge-base/query.ts
@@ -27,10 +27,8 @@ import {
   KEYWORD_QUERY_HYBRID_ALPHA_WEIGHT,
 } from "./query-expansion";
 import rerank from "./reranker";
-import {
-  type KnowledgeRetrievalBackend,
-  knowledgeRetrievalBackend,
-} from "./retrieval-backend";
+import type { KnowledgeRetrievalBackend } from "./retrieval-backend";
+import { knowledgeRetrievalBackend } from "./retrieval-backends/registry";
 import { verifyExternalRetrievalResults } from "./retrieval-result-verifier";
 import reciprocalRankFusion from "./rrf";
 

--- a/platform/backend/src/knowledge-base/query.ts
+++ b/platform/backend/src/knowledge-base/query.ts
@@ -4,9 +4,8 @@ import {
   type TextSearchLanguage,
 } from "@archestra/shared";
 import config from "@/config";
-import { isDbStatementTimeoutError } from "@/database/retry";
 import logger from "@/logging";
-import { KbChunkModel, OrganizationModel } from "@/models";
+import { OrganizationModel } from "@/models";
 import type { Bm25Tuning, VectorSearchResult } from "@/models/kb-chunk";
 import * as metrics from "@/observability/metrics";
 import type { AclEntry } from "@/types";
@@ -28,6 +27,11 @@ import {
   KEYWORD_QUERY_HYBRID_ALPHA_WEIGHT,
 } from "./query-expansion";
 import rerank from "./reranker";
+import {
+  type KnowledgeRetrievalBackend,
+  knowledgeRetrievalBackend,
+} from "./retrieval-backend";
+import { verifyExternalRetrievalResults } from "./retrieval-result-verifier";
 import reciprocalRankFusion from "./rrf";
 
 interface ChunkResult {
@@ -62,7 +66,12 @@ interface ChunkResult {
   };
 }
 
-class QueryService {
+/** @public — extension point for alternate knowledge retrieval backends. */
+export class QueryService {
+  constructor(
+    private readonly retrievalBackend: KnowledgeRetrievalBackend = knowledgeRetrievalBackend,
+  ) {}
+
   async query(params: {
     connectorIds: string[];
     organizationId: string;
@@ -110,7 +119,7 @@ class QueryService {
     const [expandedQueries, searchLanguages] = await Promise.all([
       expandQuery({ queryText, organizationId, connectorId }),
       hybridEnabled
-        ? KbChunkModel.getTextSearchLanguages(connectorIds)
+        ? this.retrievalBackend.getTextSearchLanguages(connectorIds)
         : Promise.resolve([]),
     ]);
 
@@ -173,7 +182,9 @@ class QueryService {
     // actionable error instead of a puzzling empty result.
     if (merged.length === 0) {
       const populated =
-        await KbChunkModel.getPopulatedEmbeddingDimensions(connectorIds);
+        await this.retrievalBackend.getPopulatedEmbeddingDimensions(
+          connectorIds,
+        );
       const mismatch = findEmbeddingDimensionMismatch(
         populated,
         embeddingConfig.dimensions,
@@ -213,6 +224,7 @@ class QueryService {
         userAcl: params.userAcl,
         bypassAcl,
         environmentId,
+        retrievalBackend: this.retrievalBackend,
       });
     } catch (error) {
       logger.warn(
@@ -347,9 +359,9 @@ class QueryService {
     // Each lane is cut individually by the search statement timeout (`null` =
     // timed out): dropping one lane degrades the merge instead of failing the
     // whole query, and the caller escalates only when every lane is gone.
-    const [vectorRows, fullTextRows] = await Promise.all([
-      runSearchLane("vector", () =>
-        KbChunkModel.vectorSearch({
+    const [unverifiedVectorRows, unverifiedFullTextRows] = await Promise.all([
+      runSearchLane("vector", this.retrievalBackend, () =>
+        this.retrievalBackend.vectorSearch({
           connectorIds,
           queryEmbedding,
           dimensions: embeddingConfig.dimensions,
@@ -360,8 +372,8 @@ class QueryService {
         }),
       ),
       hybridEnabled
-        ? runSearchLane("keyword", () =>
-            KbChunkModel.fullTextSearch({
+        ? runSearchLane("keyword", this.retrievalBackend, () =>
+            this.retrievalBackend.keywordSearch({
               connectorIds,
               queryText,
               languages: searchLanguages,
@@ -373,6 +385,23 @@ class QueryService {
             }),
           )
         : Promise.resolve<VectorSearchResult[] | null>([]),
+    ]);
+
+    const [vectorRows, fullTextRows] = await Promise.all([
+      this.verifyResults({
+        candidates: unverifiedVectorRows,
+        connectorIds,
+        userAcl,
+        bypassAcl,
+        environmentId,
+      }),
+      this.verifyResults({
+        candidates: unverifiedFullTextRows,
+        connectorIds,
+        userAcl,
+        bypassAcl,
+        environmentId,
+      }),
     ]);
 
     const lanesAttempted = hybridEnabled ? 2 : 1;
@@ -424,7 +453,7 @@ class QueryService {
    * can be missing right after the upgrade that introduced them, or for a
    * language first indexed since the last rebuild. Until they exist, `ts_rank`
    * ranks instead. A language with nothing indexed never triggers this (see
-   * {@link KbChunkModel.hasBm25Stats}).
+   * the retrieval backend's keyword-statistics check).
    *
    * The constants are an organization's Knowledge-settings override where set,
    * else the deployment default — resolved per query so a change saved in the
@@ -437,7 +466,7 @@ class QueryService {
     connectorIds: string[],
   ): Promise<Bm25Tuning | undefined> {
     const [statsReady, org] = await Promise.all([
-      KbChunkModel.hasBm25Stats(searchLanguages, connectorIds),
+      this.retrievalBackend.hasKeywordStatistics(searchLanguages, connectorIds),
       OrganizationModel.getById(organizationId),
     ]);
     if (!statsReady) {
@@ -451,6 +480,25 @@ class QueryService {
       k1: org?.kbBm25K1 ?? config.kb.bm25K1,
       b: org?.kbBm25B ?? config.kb.bm25B,
     };
+  }
+
+  private async verifyResults(params: {
+    candidates: VectorSearchResult[] | null;
+    connectorIds: string[];
+    userAcl: AclEntry[];
+    bypassAcl: boolean;
+    environmentId?: string | null;
+  }): Promise<VectorSearchResult[] | null> {
+    if (
+      params.candidates === null ||
+      !this.retrievalBackend.requiresResultVerification
+    ) {
+      return params.candidates;
+    }
+    return verifyExternalRetrievalResults({
+      ...params,
+      candidates: params.candidates,
+    });
   }
 
   private mapResults(rows: VectorSearchResult[]): ChunkResult[] {
@@ -488,12 +536,13 @@ interface SingleQuerySearchResult {
  */
 async function runSearchLane(
   lane: "vector" | "keyword",
+  retrievalBackend: KnowledgeRetrievalBackend,
   run: () => Promise<VectorSearchResult[]>,
 ): Promise<VectorSearchResult[] | null> {
   try {
     return await run();
   } catch (error) {
-    if (!isDbStatementTimeoutError(error)) throw error;
+    if (!retrievalBackend.isSearchTimeout(error)) throw error;
     metrics.rag.reportSearchLaneTimeout(lane);
     logger.warn(
       { lane },

--- a/platform/backend/src/knowledge-base/retrieval-backend.ts
+++ b/platform/backend/src/knowledge-base/retrieval-backend.ts
@@ -1,0 +1,106 @@
+import type { TextSearchLanguage } from "@archestra/shared";
+import { isDbStatementTimeoutError } from "@/database/retry";
+import { KbChunkModel } from "@/models";
+import type { Bm25Tuning, VectorSearchResult } from "@/models/kb-chunk";
+import type { AclEntry, InsertKbChunk, KbChunk } from "@/types";
+
+// ===== Public contract =====
+
+/**
+ * Storage and search operations required by the knowledge retrieval pipeline.
+ *
+ * Implementations own chunk indexing, vector and keyword search, adjacency,
+ * and deletion. Every read method receives the caller's ACL and environment
+ * scope. An implementation must apply both before returning any content.
+ * Search results must retain document and chunk identity because citations and
+ * context expansion depend on those fields after ranking.
+ *
+ * PostgreSQL is the only implementation shipped by Archestra. Keeping callers
+ * behind this contract lets another implementation be added at construction
+ * time without changing ingestion, query, or context-expansion code.
+ */
+export interface KnowledgeRetrievalBackend {
+  /**
+   * External indexes set this to true. Their candidates are then re-hydrated
+   * from PostgreSQL and checked against Archestra's ACL and environment scope.
+   * The built-in PostgreSQL queries already apply those predicates directly.
+   */
+  requiresResultVerification: boolean;
+  insertChunks(chunks: InsertKbChunk[]): Promise<KbChunk[]>;
+  getDocumentChunks(documentId: string): Promise<KbChunk[]>;
+  countDocumentChunks(documentId: string): Promise<number>;
+  deleteDocumentChunks(documentId: string): Promise<number>;
+  indexEmbeddings(params: {
+    updates: Array<{ chunkId: string; embedding: number[] }>;
+    dimensions: number;
+  }): Promise<void>;
+  vectorSearch(params: VectorSearchParams): Promise<VectorSearchResult[]>;
+  keywordSearch(params: KeywordSearchParams): Promise<VectorSearchResult[]>;
+  findNeighbors(params: FindNeighborsParams): Promise<NeighborChunk[]>;
+  getTextSearchLanguages(connectorIds: string[]): Promise<TextSearchLanguage[]>;
+  getPopulatedEmbeddingDimensions(connectorIds: string[]): Promise<Set<number>>;
+  hasKeywordStatistics(
+    languages: TextSearchLanguage[],
+    connectorIds: string[],
+  ): Promise<boolean>;
+  isSearchTimeout(error: unknown): boolean;
+}
+
+export interface VectorSearchParams extends SearchScope {
+  queryEmbedding: number[];
+  dimensions: number;
+  limit?: number;
+}
+
+export interface KeywordSearchParams extends SearchScope {
+  queryText: string;
+  languages?: TextSearchLanguage[];
+  bm25?: Bm25Tuning;
+  limit?: number;
+}
+
+export interface FindNeighborsParams extends AccessScope {
+  anchors: Array<{ documentId: string; chunkIndex: number }>;
+  radius: number;
+}
+
+export interface NeighborChunk {
+  id: string;
+  documentId: string;
+  chunkIndex: number;
+  content: string;
+}
+
+/** The built-in backend. No retrieval-specific configuration is required. */
+export const knowledgeRetrievalBackend: KnowledgeRetrievalBackend = {
+  requiresResultVerification: false,
+  insertChunks: (chunks) => KbChunkModel.insertMany(chunks),
+  getDocumentChunks: (documentId) => KbChunkModel.findByDocument(documentId),
+  countDocumentChunks: (documentId) => KbChunkModel.countByDocument(documentId),
+  deleteDocumentChunks: (documentId) =>
+    KbChunkModel.deleteByDocument(documentId),
+  indexEmbeddings: ({ updates, dimensions }) =>
+    KbChunkModel.updateEmbeddings(updates, dimensions),
+  vectorSearch: (params) => KbChunkModel.vectorSearch(params),
+  keywordSearch: (params) => KbChunkModel.fullTextSearch(params),
+  findNeighbors: (params) => KbChunkModel.findNeighbors(params),
+  getTextSearchLanguages: (connectorIds) =>
+    KbChunkModel.getTextSearchLanguages(connectorIds),
+  getPopulatedEmbeddingDimensions: (connectorIds) =>
+    KbChunkModel.getPopulatedEmbeddingDimensions(connectorIds),
+  hasKeywordStatistics: (languages, connectorIds) =>
+    KbChunkModel.hasBm25Stats(languages, connectorIds),
+  isSearchTimeout: (error) => isDbStatementTimeoutError(error),
+};
+
+// ===== Internal types =====
+
+interface AccessScope {
+  userAcl: AclEntry[];
+  bypassAcl?: boolean;
+  environmentId?: string | null;
+}
+
+interface SearchScope extends AccessScope {
+  connectorIds: string[];
+}

--- a/platform/backend/src/knowledge-base/retrieval-backend.ts
+++ b/platform/backend/src/knowledge-base/retrieval-backend.ts
@@ -1,6 +1,4 @@
 import type { TextSearchLanguage } from "@archestra/shared";
-import { isDbStatementTimeoutError } from "@/database/retry";
-import { KbChunkModel } from "@/models";
 import type { Bm25Tuning, VectorSearchResult } from "@/models/kb-chunk";
 import type { AclEntry, InsertKbChunk, KbChunk } from "@/types";
 
@@ -70,28 +68,6 @@ export interface NeighborChunk {
   chunkIndex: number;
   content: string;
 }
-
-/** The built-in backend. No retrieval-specific configuration is required. */
-export const knowledgeRetrievalBackend: KnowledgeRetrievalBackend = {
-  requiresResultVerification: false,
-  insertChunks: (chunks) => KbChunkModel.insertMany(chunks),
-  getDocumentChunks: (documentId) => KbChunkModel.findByDocument(documentId),
-  countDocumentChunks: (documentId) => KbChunkModel.countByDocument(documentId),
-  deleteDocumentChunks: (documentId) =>
-    KbChunkModel.deleteByDocument(documentId),
-  indexEmbeddings: ({ updates, dimensions }) =>
-    KbChunkModel.updateEmbeddings(updates, dimensions),
-  vectorSearch: (params) => KbChunkModel.vectorSearch(params),
-  keywordSearch: (params) => KbChunkModel.fullTextSearch(params),
-  findNeighbors: (params) => KbChunkModel.findNeighbors(params),
-  getTextSearchLanguages: (connectorIds) =>
-    KbChunkModel.getTextSearchLanguages(connectorIds),
-  getPopulatedEmbeddingDimensions: (connectorIds) =>
-    KbChunkModel.getPopulatedEmbeddingDimensions(connectorIds),
-  hasKeywordStatistics: (languages, connectorIds) =>
-    KbChunkModel.hasBm25Stats(languages, connectorIds),
-  isSearchTimeout: (error) => isDbStatementTimeoutError(error),
-};
 
 // ===== Internal types =====
 

--- a/platform/backend/src/knowledge-base/retrieval-backends/postgres/postgres-retrieval-backend.ts
+++ b/platform/backend/src/knowledge-base/retrieval-backends/postgres/postgres-retrieval-backend.ts
@@ -1,0 +1,25 @@
+import { isDbStatementTimeoutError } from "@/database/retry";
+import { KbChunkModel } from "@/models";
+import type { KnowledgeRetrievalBackend } from "../../retrieval-backend";
+
+/** The built-in retrieval backend. It requires no backend-specific settings. */
+export const postgresRetrievalBackend: KnowledgeRetrievalBackend = {
+  requiresResultVerification: false,
+  insertChunks: (chunks) => KbChunkModel.insertMany(chunks),
+  getDocumentChunks: (documentId) => KbChunkModel.findByDocument(documentId),
+  countDocumentChunks: (documentId) => KbChunkModel.countByDocument(documentId),
+  deleteDocumentChunks: (documentId) =>
+    KbChunkModel.deleteByDocument(documentId),
+  indexEmbeddings: ({ updates, dimensions }) =>
+    KbChunkModel.updateEmbeddings(updates, dimensions),
+  vectorSearch: (params) => KbChunkModel.vectorSearch(params),
+  keywordSearch: (params) => KbChunkModel.fullTextSearch(params),
+  findNeighbors: (params) => KbChunkModel.findNeighbors(params),
+  getTextSearchLanguages: (connectorIds) =>
+    KbChunkModel.getTextSearchLanguages(connectorIds),
+  getPopulatedEmbeddingDimensions: (connectorIds) =>
+    KbChunkModel.getPopulatedEmbeddingDimensions(connectorIds),
+  hasKeywordStatistics: (languages, connectorIds) =>
+    KbChunkModel.hasBm25Stats(languages, connectorIds),
+  isSearchTimeout: (error) => isDbStatementTimeoutError(error),
+};

--- a/platform/backend/src/knowledge-base/retrieval-backends/registry.ts
+++ b/platform/backend/src/knowledge-base/retrieval-backends/registry.ts
@@ -1,0 +1,11 @@
+import type { KnowledgeRetrievalBackend } from "../retrieval-backend";
+import { postgresRetrievalBackend } from "./postgres/postgres-retrieval-backend";
+
+/**
+ * The retrieval backend used by ingestion and queries.
+ *
+ * Keep backend construction here. Add runtime selection only when a second
+ * production implementation exists.
+ */
+export const knowledgeRetrievalBackend: KnowledgeRetrievalBackend =
+  postgresRetrievalBackend;

--- a/platform/backend/src/knowledge-base/retrieval-result-verifier.ts
+++ b/platform/backend/src/knowledge-base/retrieval-result-verifier.ts
@@ -1,0 +1,34 @@
+import { KbChunkModel } from "@/models";
+import type { VectorSearchResult } from "@/models/kb-chunk";
+import type { AclEntry } from "@/types";
+import type { FindNeighborsParams, NeighborChunk } from "./retrieval-backend";
+
+/**
+ * Verify candidates returned by an external retrieval backend against
+ * Archestra's canonical PostgreSQL access-control state.
+ */
+export async function verifyExternalRetrievalResults(params: {
+  candidates: VectorSearchResult[];
+  connectorIds: string[];
+  userAcl: AclEntry[];
+  bypassAcl?: boolean;
+  environmentId?: string | null;
+}): Promise<VectorSearchResult[]> {
+  return KbChunkModel.verifyExternalSearchResults(params);
+}
+
+/**
+ * Re-read external neighbour candidates through the canonical PostgreSQL
+ * adjacency and access filters. Content returned by the external index is not
+ * trusted.
+ */
+export async function verifyExternalNeighborChunks(
+  params: FindNeighborsParams & { candidates: NeighborChunk[] },
+): Promise<NeighborChunk[]> {
+  if (params.candidates.length === 0) return [];
+  const verified = await KbChunkModel.findNeighbors(params);
+  const candidateIds = new Set(
+    params.candidates.map((candidate) => candidate.id),
+  );
+  return verified.filter((neighbor) => candidateIds.has(neighbor.id));
+}

--- a/platform/backend/src/models/kb-chunk.ts
+++ b/platform/backend/src/models/kb-chunk.ts
@@ -175,6 +175,79 @@ class KbChunkModel {
   }
 
   /**
+   * Re-hydrate candidates from an external retrieval backend and apply every
+   * security predicate in PostgreSQL. Candidate content and citation fields
+   * are deliberately ignored: only the backend's rank and stable chunk id are
+   * trusted. This keeps ACL, environment isolation, and soft-delete filtering
+   * under Archestra's control even when ranking runs outside PostgreSQL.
+   */
+  static async verifyExternalSearchResults(params: {
+    candidates: VectorSearchResult[];
+    connectorIds: string[];
+    userAcl: AclEntry[];
+    bypassAcl?: boolean;
+    environmentId?: string | null;
+  }): Promise<VectorSearchResult[]> {
+    const {
+      candidates,
+      connectorIds,
+      userAcl,
+      bypassAcl = false,
+      environmentId,
+    } = params;
+    if (candidates.length === 0 || connectorIds.length === 0) return [];
+    if (!bypassAcl && userAcl.length === 0) return [];
+
+    const candidateIds = sql.join(
+      [...new Set(candidates.map((candidate) => candidate.id))].map(
+        (id) => sql`${id}::uuid`,
+      ),
+      sql`, `,
+    );
+    const scopedConnectorIds = sql.join(
+      connectorIds.map((id) => sql`${id}`),
+      sql`, `,
+    );
+    const aclEntries = bypassAcl
+      ? null
+      : sql.join(
+          userAcl.map((entry) => sql`${entry}`),
+          sql`, `,
+        );
+    const environmentFilter =
+      environmentId !== undefined
+        ? sql`AND kbc.environment_id IS NOT DISTINCT FROM ${environmentId}`
+        : sql``;
+
+    const rows = await db.execute(sql`
+      SELECT
+        c.id, c.content, c.chunk_index AS "chunkIndex",
+        c.document_id AS "documentId", d.source_id AS "sourceId", d.title,
+        d.source_url AS "sourceUrl", d.metadata,
+        kbc.connector_type AS "connectorType"
+      FROM kb_chunks c
+      JOIN kb_documents d ON d.id = c.document_id
+      LEFT JOIN knowledge_base_connectors kbc ON kbc.id = d.connector_id
+      WHERE c.id IN (${candidateIds})
+        AND d.connector_id IN (${scopedConnectorIds})
+        AND kbc.deleted_at IS NULL
+        ${environmentFilter}
+        ${bypassAcl ? sql`` : sql`AND c.acl ?| ARRAY[${aclEntries}]`}
+    `);
+
+    const verifiedById = new Map(
+      (rows.rows as Array<Omit<VectorSearchResult, "score">>).map((row) => [
+        row.id,
+        row,
+      ]),
+    );
+    return candidates.flatMap((candidate) => {
+      const verified = verifiedById.get(candidate.id);
+      return verified ? [{ ...verified, score: candidate.score }] : [];
+    });
+  }
+
+  /**
    * Return the set of embedding dimensions that actually have stored vectors for
    * the given connectors (one entry per non-empty per-dimension column). Used to
    * diagnose a dimension mismatch when a search returns nothing: if documents


### PR DESCRIPTION
## Summary

- define a retrieval backend contract for indexing, vector and keyword search, neighbor expansion, and chunk deletion
- keep PostgreSQL as the only built-in backend and avoid adding a one-value configuration selector
- rehydrate external candidates from canonical PostgreSQL state so ACLs, environments, soft deletion, content, and citations remain platform-controlled
- document the extension contract, invariants, and steps for adding a production backend