### PR TITLE
chore: polish guardrails, registry, and skills tables

### DIFF
--- a/platform/e2e-tests/tests/tool-guardrails.spec.ts
+++ b/platform/e2e-tests/tests/tool-guardrails.spec.ts
@@ -32,12 +32,12 @@ test("labels an app's launch tool with its app, not as observed traffic", async 
       page,
       `/mcp/tool-guardrails?origin=app&search=${encodeURIComponent(name)}`,
     );
-    const appRow = page.locator("table tbody tr").filter({ hasText: name });
+    const appRow = page.getByRole("row").filter({ hasText: name });
     await expect(appRow).toHaveCount(1);
     await expect(appRow).not.toContainText("Observed tools");
 
     // Its details dialog agrees: origin App, never "Intercepted".
-    await appRow.getByRole("button", { name: /edit policies/i }).click();
+    await appRow.click();
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText("App", { exact: true })).toBeVisible();

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.test.tsx
@@ -153,6 +153,30 @@ describe("McpServerTable uninstall permission", () => {
     expect(await screen.findByText("Uninstall MCP Server")).toBeInTheDocument();
   });
 
+  it("keeps compact registry columns fixed while the server name fills the remaining width", () => {
+    const { container } = renderTable(table);
+
+    expect(container.querySelector("table")).toHaveStyle({
+      minWidth: "1108px",
+    });
+    expect(
+      (container.querySelector('th[data-column-id="name"]') as HTMLElement)
+        .style.width,
+    ).toBe("");
+    expect(container.querySelector('th[data-column-id="tools"]')).toHaveStyle({
+      width: "90px",
+    });
+    expect(container.querySelector('th[data-column-id="author"]')).toHaveStyle({
+      width: "212px",
+    });
+    expect(container.querySelector('th[data-column-id="status"]')).toHaveStyle({
+      width: "190px",
+    });
+    expect(container.querySelector('th[data-column-id="actions"]')).toHaveStyle(
+      { width: "260px" },
+    );
+  });
+
   it("refuses the uninstall for a user without the delete permission", async () => {
     const user = userEvent.setup();
     grantAllExcept({ mcpServerInstallation: ["delete"] });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
@@ -174,7 +174,7 @@ export function McpServerTable({
       id: "name",
       accessorKey: "name",
       header: "MCP Server",
-      size: 540,
+      size: 300,
       cell: ({ row }) => {
         const item = row.original;
         return (
@@ -197,7 +197,9 @@ export function McpServerTable({
     },
     {
       id: "author",
-      size: 140,
+      // Visibility badges cap their label at 180px. Include the cell padding
+      // so the full badge fits without donating extra space to this column.
+      size: 212,
       header: "Accessible to",
       cell: ({ row }) => (
         <ResourceVisibilityBadge
@@ -470,9 +472,9 @@ export function McpServerTable({
         fixedWidthColumnIds={
           attention
             ? ["select", "issue", "owner", "dismissReason", "actions"]
-            : undefined
+            : ["tools", "author", "status", "actions"]
         }
-        flexibleColumnIds={attention ? ["name"] : undefined}
+        flexibleColumnIds={["name"]}
       />
     </>
   );

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.test.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AssignedToolsTable } from "./assigned-tools-table";
+
+const mocks = vi.hoisted(() => ({
+  callPolicyMutation: vi.fn(),
+  resultPolicyMutation: vi.fn(),
+}));
+
+vi.mock("@/components/filter-bar", () => ({
+  FilterBar: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  FilterSelect: () => <button type="button">All Sources</button>,
+  filterSearchClass: "",
+}));
+
+vi.mock("@/components/search-input", () => ({
+  SearchInput: () => <input aria-label="Search tools" />,
+}));
+
+vi.mock("@/components/tool-policy-bulk-actions", () => ({
+  ToolPolicyBulkActionsBar: () => null,
+}));
+
+vi.mock("@/components/mcp-catalog-icon", () => ({
+  McpCatalogIcon: () => <span aria-hidden>source icon</span>,
+}));
+
+vi.mock("@/components/roles/with-permissions", () => ({
+  WithPermissions: ({
+    children,
+  }: {
+    children: (params: { hasPermission: boolean }) => ReactNode;
+  }) => children({ hasPermission: true }),
+}));
+
+vi.mock("@/lib/hooks/use-data-table-query-params", () => ({
+  useDataTableQueryParams: () => ({
+    searchParams: new URLSearchParams(),
+    pageIndex: 0,
+    pageSize: 10,
+    updateQueryParams: vi.fn(),
+    setPagination: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
+  useInternalMcpCatalog: () => ({
+    data: [
+      {
+        id: "catalog-1",
+        name: "Document Search",
+        icon: "📚",
+        serverType: "remote",
+      },
+    ],
+  }),
+}));
+
+vi.mock("@/lib/policy.query", () => ({
+  useCallPolicyMutation: () => ({ mutateAsync: mocks.callPolicyMutation }),
+  useResultPolicyMutation: () => ({ mutateAsync: mocks.resultPolicyMutation }),
+  useToolInvocationPolicies: () => ({
+    data: {
+      byProfileToolId: {
+        "tool-1": [
+          {
+            id: "call-policy-1",
+            toolId: "tool-1",
+            action: "allow_when_context_is_untrusted",
+            conditions: [],
+          },
+        ],
+      },
+    },
+  }),
+  useToolResultPolicies: () => ({
+    data: {
+      byProfileToolId: {
+        "tool-1": [
+          {
+            id: "result-policy-1",
+            toolId: "tool-1",
+            action: "mark_as_trusted",
+            conditions: [],
+          },
+        ],
+      },
+    },
+  }),
+}));
+
+vi.mock("@/lib/tools/tool.query", () => ({
+  useToolsWithAssignments: () => ({
+    isLoading: false,
+    data: {
+      data: [
+        {
+          id: "tool-1",
+          name: "document_search__search_documents",
+          description: "Search indexed documents",
+          parameters: {},
+          annotations: null,
+          catalogId: "catalog-1",
+          assignmentCount: 4,
+          assignments: [],
+          delegateToAgent: null,
+          createdAt: "2026-08-23T12:00:00.000Z",
+          updatedAt: "2026-08-23T12:00:00.000Z",
+        },
+      ],
+      pagination: { total: 1, limit: 10, offset: 0 },
+    },
+  }),
+  useAllMatchingTools: () => ({
+    data: undefined,
+    isFetching: false,
+  }),
+  useToolObservers: () => ({
+    data: { users: [], clients: [] },
+  }),
+}));
+
+describe("AssignedToolsTable", () => {
+  beforeEach(() => {
+    mocks.callPolicyMutation.mockReset();
+    mocks.resultPolicyMutation.mockReset();
+  });
+
+  it("presents source and assignment context as part of the tool identity", () => {
+    render(<AssignedToolsTable onToolClick={vi.fn()} />);
+
+    const toolCell = screen.getByText("search_documents").closest("td");
+    if (!toolCell) throw new Error("Expected the tool identity table cell");
+    expect(within(toolCell).getByText("Document Search")).toBeVisible();
+    expect(within(toolCell).getByText("4 assignments")).toBeVisible();
+
+    expect(
+      screen.queryByRole("columnheader", { name: "Source" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Assignments" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Actions" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses readable policy labels and opens details from the row", () => {
+    const onToolClick = vi.fn();
+    render(<AssignedToolsTable onToolClick={onToolClick} />);
+
+    expect(screen.getByText("Allow always")).toBeVisible();
+    expect(screen.getByText("Safe")).toBeVisible();
+
+    const row = screen.getByText("search_documents").closest("tr");
+    if (!row) throw new Error("Expected the tool row");
+    fireEvent.click(row);
+    expect(onToolClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps inline policy controls from opening row details", () => {
+    const onToolClick = vi.fn();
+    render(<AssignedToolsTable onToolClick={onToolClick} />);
+
+    fireEvent.click(screen.getByText("Allow always"));
+    expect(onToolClick).not.toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
@@ -16,10 +16,10 @@ import {
   ChevronDown,
   ChevronUp,
   Network,
-  Pencil,
   Server,
 } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { RowClickShield } from "@/components/agent-pages/row-click-shield";
 import { CallPolicyToggle } from "@/components/call-policy-toggle";
 import {
   FilterBar,
@@ -31,10 +31,8 @@ import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { ResultPolicyToggle } from "@/components/result-policy-toggle";
 import { WithPermissions } from "@/components/roles/with-permissions";
 import { SearchInput } from "@/components/search-input";
-import { TableRowActions } from "@/components/table-row-actions";
 import { ToolPolicyBulkActionsBar } from "@/components/tool-policy-bulk-actions";
 import { TruncatedText } from "@/components/truncated-text";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { DataTable } from "@/components/ui/data-table";
@@ -96,6 +94,8 @@ type ToolsSortByValues = NonNullable<
 type ToolsSortDirectionValues = NonNullable<
   GetToolsWithAssignmentsQueryParams["sortDirection"]
 > | null;
+type InternalMcpCatalogItem =
+  archestraApiTypes.GetInternalMcpCatalogResponses["200"][number];
 
 interface AssignedToolsTableProps {
   onToolClick: (tool: ToolWithAssignmentsData) => void;
@@ -465,187 +465,29 @@ export function AssignedToolsTable({
             className="-ml-4 h-auto px-4 py-2 font-medium hover:bg-transparent"
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
-            Tool Name
+            Tool
             <SortIcon isSorted={column.getIsSorted()} />
           </Button>
         ),
-        cell: ({ row }) => {
-          // Only trim prefix for MCP tools (which have catalogId set and were slugified with server name)
-          // LLM proxy discovered tools (no catalogId) should show the full name as-is.
-          // It's needed to show the full name in the table to distinguish them from catalog tools. (After prefix-stripping they might look the same)
-          const displayName = row.original.catalogId
-            ? parseFullToolName(row.original.name).toolName || row.original.name
-            : row.original.name;
-          // A delegation tool is named after its target agent, so the personal
-          // agents seeded one per member all mint an `agent__my_assistant`.
-          // The owner is the only thing separating those rows.
-          const source = getToolSource(row.original, internalMcpCatalogItems);
-          const owner = source.kind === "agent" ? source.ownerEmail : null;
-          return (
-            <div className="max-w-[260px] md:max-w-none truncate">
-              <TruncatedText
-                message={displayName}
-                className="break-all"
-                maxLength={60}
-              />
-              {owner && (
-                <div className="truncate text-xs text-muted-foreground">
-                  {owner}
-                </div>
-              )}
-            </div>
-          );
-        },
-        size: 200,
-      },
-      {
-        id: "origin",
-        // Mirrors the backend's origin ordering (catalog-backed first, then
-        // delegation, then observed); app launch tools are catalog-backed.
-        accessorFn: (row) => {
-          const kind = getToolSource(row, internalMcpCatalogItems).kind;
-          if (kind === "app" || kind === "mcp") return "1-mcp";
-          return kind === "agent" ? "2-agent" : "3-intercepted";
-        },
-        size: 180,
-        header: ({ column }) => (
-          <Button
-            variant="ghost"
-            className="-ml-4 h-auto px-4 py-2 font-medium hover:bg-transparent"
-            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          >
-            Source
-            <SortIcon isSorted={column.getIsSorted()} />
-          </Button>
+        cell: ({ row }) => (
+          <ToolIdentityCell
+            tool={row.original}
+            catalogItems={internalMcpCatalogItems}
+            onOpen={() => onToolClick(row.original)}
+          />
         ),
-        cell: ({ row }) => {
-          const source = getToolSource(row.original, internalMcpCatalogItems);
-
-          if (source.kind === "app") {
-            return (
-              <div className="min-w-0 max-w-full">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Badge
-                        variant="default"
-                        className="bg-sky-600 text-white inline-flex max-w-full gap-1.5 overflow-hidden align-middle"
-                      >
-                        <AppWindow className="h-3.5 w-3.5 shrink-0" />
-                        <span className="min-w-0 truncate">
-                          {source.appName || APP_TOOL_SOURCE_LABEL}
-                        </span>
-                      </Badge>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{APP_TOOL_SOURCE_DESCRIPTION}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
-            );
-          }
-
-          if (source.kind === "mcp") {
-            const { catalogItem } = source;
-            return (
-              <div className="min-w-0 max-w-full">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Badge
-                        variant="default"
-                        className="bg-indigo-500 text-white inline-flex max-w-full gap-1.5 overflow-hidden align-middle"
-                      >
-                        {catalogItem ? (
-                          <McpCatalogIcon
-                            icon={catalogItem.icon}
-                            catalogId={catalogItem.id}
-                            size={14}
-                          />
-                        ) : (
-                          <Server className="h-3.5 w-3.5 shrink-0" />
-                        )}
-                        <span className="min-w-0 truncate">
-                          {catalogItem?.name ?? MCP_TOOL_SOURCE_LABEL}
-                        </span>
-                      </Badge>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{catalogItem?.name ?? MCP_TOOL_SOURCE_LABEL}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
-            );
-          }
-
-          if (source.kind === "agent") {
-            return (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Badge
-                      variant="secondary"
-                      className="bg-violet-600 text-white gap-1.5"
-                    >
-                      <Bot className="h-3.5 w-3.5 shrink-0" />
-                      Agent
-                    </Badge>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>
-                      Delegates to {source.agentName} agent
-                      {source.ownerEmail ? ` (${source.ownerEmail})` : ""}
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            );
-          }
-
-          return (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    variant="secondary"
-                    className="bg-amber-700 text-white gap-1.5"
-                  >
-                    <Network className="h-3.5 w-3.5 shrink-0" />
-                    {OBSERVED_TOOL_SOURCE_LABEL}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>{OBSERVED_TOOL_SOURCE_DESCRIPTION}</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          );
-        },
-      },
-      {
-        id: "assignmentCount",
-        header: "Assignments",
-        size: 140,
-        cell: ({ row }) => {
-          const count = row.original.assignmentCount;
-          return (
-            <Badge variant="outline" className="text-xs">
-              {count} {count === 1 ? "assignment" : "assignments"}
-            </Badge>
-          );
-        },
+        size: 360,
       },
       {
         id: "callPolicy",
+        size: 230,
         header: ({ column }) => (
           <Button
             variant="ghost"
             className="-ml-4 h-auto px-4 py-2 font-medium hover:bg-transparent"
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
-            Call Policy
+            Calls
             <SortIcon isSorted={column.getIsSorted()} />
           </Button>
         ),
@@ -660,12 +502,15 @@ export function AssignedToolsTable({
           if (hasCustomPolicy) {
             return (
               <Button
-                variant="outline"
+                variant="ghost"
                 size="sm"
-                className="w-[90px] text-xs"
-                onClick={() => onToolClick(row.original)}
+                className="h-8 w-[200px] justify-start bg-muted px-3 text-xs"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onToolClick(row.original);
+                }}
               >
-                Custom
+                Custom rules
               </Button>
             );
           }
@@ -683,7 +528,7 @@ export function AssignedToolsTable({
               noPermissionHandle="tooltip"
             >
               {({ hasPermission }) => (
-                <div className="flex items-center gap-2">
+                <RowClickShield className="flex items-center gap-2">
                   <CallPolicyToggle
                     value={currentAction}
                     onChange={(action) =>
@@ -694,12 +539,12 @@ export function AssignedToolsTable({
                       )
                     }
                     disabled={isUpdating || !hasPermission}
-                    size="sm"
+                    size="table"
                   />
                   {isUpdating && (
                     <LoadingSpinner className="ml-1 h-3 w-3 text-muted-foreground" />
                   )}
-                </div>
+                </RowClickShield>
               )}
             </WithPermissions>
           );
@@ -707,7 +552,8 @@ export function AssignedToolsTable({
       },
       {
         id: "toolResultTreatment",
-        header: "Results are",
+        size: 180,
+        header: "Results",
         cell: ({ row }) => {
           const policies =
             resultPolicies?.byProfileToolId[row.original.id] || [];
@@ -719,12 +565,15 @@ export function AssignedToolsTable({
           if (hasCustomPolicy) {
             return (
               <Button
-                variant="outline"
+                variant="ghost"
                 size="sm"
-                className="w-[90px] text-xs"
-                onClick={() => onToolClick(row.original)}
+                className="h-8 w-[150px] justify-start bg-muted px-3 text-xs"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onToolClick(row.original);
+                }}
               >
-                Custom
+                Custom rules
               </Button>
             );
           }
@@ -745,7 +594,7 @@ export function AssignedToolsTable({
               noPermissionHandle="tooltip"
             >
               {({ hasPermission }) => (
-                <div className="flex items-center gap-2">
+                <RowClickShield className="flex items-center gap-2">
                   <ResultPolicyToggle
                     size="sm"
                     value={resultAction}
@@ -762,28 +611,11 @@ export function AssignedToolsTable({
                   {isUpdating && (
                     <LoadingSpinner className="h-3 w-3 text-muted-foreground" />
                   )}
-                </div>
+                </RowClickShield>
               )}
             </WithPermissions>
           );
         },
-      },
-      {
-        id: "actions",
-        header: "Actions",
-        cell: ({ row }) => (
-          <TableRowActions
-            itemName={row.original.name}
-            actions={[
-              {
-                icon: <Pencil className="h-4 w-4" />,
-                label: "Edit policies",
-                permissions: { toolPolicy: ["update"] },
-                onClick: () => onToolClick(row.original),
-              },
-            ]}
-          />
-        ),
       },
     ],
     [
@@ -951,6 +783,7 @@ export function AssignedToolsTable({
         data={tools}
         sorting={sorting}
         onSortingChange={handleSortingChange}
+        onRowClick={onToolClick}
         manualSorting
         manualPagination
         pagination={{
@@ -974,7 +807,102 @@ export function AssignedToolsTable({
         emptyMessage="No tools have been assigned yet."
         filteredEmptyMessage="No tools match your filters. Try adjusting your search."
         onClearFilters={clearFilters}
+        flexibleColumnIds={["name"]}
+        fixedWidthColumnIds={["callPolicy", "toolResultTreatment"]}
       />
+    </div>
+  );
+}
+
+function ToolIdentityCell({
+  tool,
+  catalogItems,
+  onOpen,
+}: {
+  tool: ToolWithAssignmentsData;
+  catalogItems?: InternalMcpCatalogItem[];
+  onOpen: () => void;
+}) {
+  // Catalog-backed names include a source prefix. Observed names do not, and
+  // keeping those intact prevents unrelated tools from looking identical.
+  const displayName = tool.catalogId
+    ? parseFullToolName(tool.name).toolName || tool.name
+    : tool.name;
+  const source = getToolSource(tool, catalogItems);
+  const assignmentLabel =
+    tool.assignmentCount === 0
+      ? "Not assigned"
+      : `${tool.assignmentCount} ${tool.assignmentCount === 1 ? "assignment" : "assignments"}`;
+
+  let sourceLabel: string;
+  let sourceDescription: string;
+  let sourceIcon: ReactNode;
+
+  if (source.kind === "app") {
+    sourceLabel = source.appName || APP_TOOL_SOURCE_LABEL;
+    sourceDescription = APP_TOOL_SOURCE_DESCRIPTION;
+    sourceIcon = <AppWindow className="size-4" />;
+  } else if (source.kind === "mcp") {
+    sourceLabel = source.catalogItem?.name ?? MCP_TOOL_SOURCE_LABEL;
+    sourceDescription = `Provided by ${sourceLabel}`;
+    sourceIcon = source.catalogItem ? (
+      <McpCatalogIcon
+        icon={source.catalogItem.icon}
+        catalogId={source.catalogItem.id}
+        size={16}
+      />
+    ) : (
+      <Server className="size-4" />
+    );
+  } else if (source.kind === "agent") {
+    sourceLabel = `Agent · ${source.agentName}`;
+    sourceDescription = source.ownerEmail
+      ? `Delegates to ${source.agentName} (${source.ownerEmail})`
+      : `Delegates to ${source.agentName}`;
+    sourceIcon = <Bot className="size-4" />;
+  } else {
+    sourceLabel = OBSERVED_TOOL_SOURCE_LABEL;
+    sourceDescription = OBSERVED_TOOL_SOURCE_DESCRIPTION;
+    sourceIcon = <Network className="size-4" />;
+  }
+
+  return (
+    <div className="flex min-w-0 items-center gap-3 py-1">
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border bg-muted/50 text-muted-foreground">
+              {sourceIcon}
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>{sourceDescription}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      <div className="min-w-0">
+        <button
+          type="button"
+          className="block max-w-full text-left text-sm font-medium hover:underline"
+          aria-label={`View policies for ${displayName}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpen();
+          }}
+        >
+          <TruncatedText
+            message={displayName}
+            className="block truncate"
+            maxLength={60}
+          />
+        </button>
+        <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="truncate">{sourceLabel}</span>
+          <span aria-hidden className="shrink-0 text-border">
+            ·
+          </span>
+          <span className="shrink-0">{assignmentLabel}</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.test.tsx
+++ b/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.test.tsx
@@ -76,7 +76,7 @@ describe("ExternalMcpSkillsSection", () => {
     ).toBeNull();
     expect(screen.getByText("2 files")).toBeInTheDocument();
     expect(screen.getByText("7")).toBeInTheDocument();
-    expect(screen.getByText("by 2 users")).toBeInTheDocument();
+    expect(screen.getByText("2 users")).toBeInTheDocument();
     expect(screen.getAllByText("Rows per page").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Page 1 of 1").length).toBeGreaterThan(0);
     const chatParams = new URLSearchParams({

--- a/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.test.tsx
+++ b/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.test.tsx
@@ -76,7 +76,8 @@ describe("ExternalMcpSkillsSection", () => {
     ).toBeNull();
     expect(screen.getByText("2 files")).toBeInTheDocument();
     expect(screen.getByText("7")).toBeInTheDocument();
-    expect(screen.getByText("2 users")).toBeInTheDocument();
+    expect(screen.getByText(/7 uses, 2 users,/)).toBeInTheDocument();
+    expect(screen.queryByText("2 users")).not.toBeInTheDocument();
     expect(screen.getAllByText("Rows per page").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Page 1 of 1").length).toBeGreaterThan(0);
     const chatParams = new URLSearchParams({

--- a/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.tsx
+++ b/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.tsx
@@ -27,8 +27,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { useSession } from "@/lib/auth/auth.query";
-import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { SkillUsageDialog } from "./skill-usage-dialog";
+import { SkillUsageSummary } from "./skill-usage-summary";
 
 type ExternalSkill =
   archestraApiTypes.GetExternalMcpSkillsResponses["200"][number];
@@ -188,7 +188,7 @@ export function ExternalMcpSkillsSection({
     {
       id: "usageCount",
       accessorKey: "usageCount",
-      size: 120,
+      size: 280,
       header: ({ column }) => (
         <div className="flex justify-end pr-4">
           <Button
@@ -203,23 +203,11 @@ export function ExternalMcpSkillsSection({
       ),
       cell: ({ row }) => (
         <div className="flex justify-end pr-4">
-          <div className="w-full px-1.5 py-0.5 text-right text-sm">
-            <div>
-              {row.original.usageCount}
-              {row.original.usageUserCount > 0 && (
-                <span className="text-muted-foreground">
-                  {" "}
-                  by {row.original.usageUserCount}{" "}
-                  {row.original.usageUserCount === 1 ? "user" : "users"}
-                </span>
-              )}
-            </div>
-            <div className="text-xs text-muted-foreground">
-              {formatRelativeTimeFromNow(row.original.lastUsedAt, {
-                neverLabel: "Never used",
-              })}
-            </div>
-          </div>
+          <SkillUsageSummary
+            usageCount={row.original.usageCount}
+            usageUserCount={row.original.usageUserCount}
+            lastUsedAt={row.original.lastUsedAt}
+          />
         </div>
       ),
     },
@@ -310,6 +298,14 @@ export function ExternalMcpSkillsSection({
             sorting={sorting}
             onSortingChange={setSorting}
             onRowClick={(row) => router.push(externalSkillHref(row))}
+            tableClassName="[&_td]:py-1.5"
+            fixedWidthColumnIds={[
+              "serverName",
+              "visibility",
+              "files",
+              "usageCount",
+            ]}
+            flexibleColumnIds={["name"]}
           />
         }
       />

--- a/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.tsx
+++ b/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.tsx
@@ -188,7 +188,7 @@ export function ExternalMcpSkillsSection({
     {
       id: "usageCount",
       accessorKey: "usageCount",
-      size: 280,
+      size: 100,
       header: ({ column }) => (
         <div className="flex justify-end pr-4">
           <Button

--- a/platform/frontend/src/app/skills/_parts/skill-usage-summary.test.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-usage-summary.test.tsx
@@ -16,10 +16,15 @@ it("presents skill usage as one compact, interactive summary", async () => {
   );
 
   const summary = screen.getByRole("button", {
-    name: "View usage for document-tools",
+    name: "View usage for document-tools: 12 uses, 3 users, Never used",
   });
-  expect(summary).toHaveClass("py-1");
-  expect(summary).toHaveTextContent("12·3 users·Never used");
+  expect(summary).toHaveTextContent("12");
+  expect(summary).not.toHaveTextContent("3 users");
+
+  await userEvent.hover(summary);
+  const tooltip = await screen.findByRole("tooltip");
+  expect(tooltip).toHaveTextContent("12 uses");
+  expect(tooltip).toHaveTextContent("3 users · Never used");
 
   await userEvent.click(summary);
   expect(onClick).toHaveBeenCalledOnce();

--- a/platform/frontend/src/app/skills/_parts/skill-usage-summary.test.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-usage-summary.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, it, vi } from "vitest";
+import { SkillUsageSummary } from "./skill-usage-summary";
+
+it("presents skill usage as one compact, interactive summary", async () => {
+  const onClick = vi.fn();
+  render(
+    <SkillUsageSummary
+      usageCount={12}
+      usageUserCount={3}
+      lastUsedAt={null}
+      label="View usage for document-tools"
+      onClick={onClick}
+    />,
+  );
+
+  const summary = screen.getByRole("button", {
+    name: "View usage for document-tools",
+  });
+  expect(summary).toHaveClass("py-1");
+  expect(summary).toHaveTextContent("12·3 users·Never used");
+
+  await userEvent.click(summary);
+  expect(onClick).toHaveBeenCalledOnce();
+});

--- a/platform/frontend/src/app/skills/_parts/skill-usage-summary.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-usage-summary.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
@@ -21,46 +22,49 @@ export function SkillUsageSummary({
   const lastUsed = formatRelativeTimeFromNow(lastUsedAt, {
     neverLabel: "Never used",
   });
-  const summary = (
-    <span className="inline-flex max-w-full items-center justify-end gap-1.5 whitespace-nowrap tabular-nums">
-      <span className="font-medium text-foreground">{usageCount}</span>
-      {usageUserCount > 0 && (
-        <>
-          <span aria-hidden className="text-muted-foreground/60">
-            ·
-          </span>
-          <span className="text-muted-foreground">
-            {usageUserCount} {usageUserCount === 1 ? "user" : "users"}
-          </span>
-        </>
-      )}
-      <span aria-hidden className="text-muted-foreground/60">
-        ·
-      </span>
-      <span className="truncate text-xs text-muted-foreground" title={lastUsed}>
-        {lastUsed}
-      </span>
+  const usesLabel = `${usageCount} ${usageCount === 1 ? "use" : "uses"}`;
+  const usersLabel =
+    usageUserCount > 0
+      ? `${usageUserCount} ${usageUserCount === 1 ? "user" : "users"}`
+      : null;
+  const activityLabel = usersLabel
+    ? `${usesLabel}, ${usersLabel}, ${lastUsed}`
+    : `${usesLabel}, ${lastUsed}`;
+  const count = (
+    <span className="font-medium tabular-nums text-foreground">
+      {usageCount}
     </span>
   );
-
-  if (!onClick) return summary;
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <button
-          type="button"
-          className="flex w-full justify-end rounded px-1.5 py-1 text-sm hover:bg-muted"
-          aria-label={label}
-          onClick={(event) => {
-            event.stopPropagation();
-            onClick();
-          }}
-        >
-          {summary}
-        </button>
+        {onClick ? (
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-7 w-full justify-end px-1.5"
+            aria-label={label ? `${label}: ${activityLabel}` : activityLabel}
+            onClick={(event) => {
+              event.stopPropagation();
+              onClick();
+            }}
+          >
+            {count}
+          </Button>
+        ) : (
+          <span className="flex h-7 w-full items-center justify-end px-1.5">
+            <span className="sr-only">{activityLabel}</span>
+            <span aria-hidden>{count}</span>
+          </span>
+        )}
       </TooltipTrigger>
-      <TooltipContent>View usage over the last month</TooltipContent>
+      <TooltipContent className="space-y-0.5">
+        <p className="font-medium">{usesLabel}</p>
+        <p className="text-xs text-muted-foreground">
+          {usersLabel ? `${usersLabel} · ${lastUsed}` : lastUsed}
+        </p>
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/platform/frontend/src/app/skills/_parts/skill-usage-summary.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-usage-summary.tsx
@@ -1,0 +1,66 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
+
+export function SkillUsageSummary({
+  usageCount,
+  usageUserCount,
+  lastUsedAt,
+  onClick,
+  label,
+}: {
+  usageCount: number;
+  usageUserCount: number;
+  lastUsedAt: string | null;
+  onClick?: () => void;
+  label?: string;
+}) {
+  const lastUsed = formatRelativeTimeFromNow(lastUsedAt, {
+    neverLabel: "Never used",
+  });
+  const summary = (
+    <span className="inline-flex max-w-full items-center justify-end gap-1.5 whitespace-nowrap tabular-nums">
+      <span className="font-medium text-foreground">{usageCount}</span>
+      {usageUserCount > 0 && (
+        <>
+          <span aria-hidden className="text-muted-foreground/60">
+            ·
+          </span>
+          <span className="text-muted-foreground">
+            {usageUserCount} {usageUserCount === 1 ? "user" : "users"}
+          </span>
+        </>
+      )}
+      <span aria-hidden className="text-muted-foreground/60">
+        ·
+      </span>
+      <span className="truncate text-xs text-muted-foreground" title={lastUsed}>
+        {lastUsed}
+      </span>
+    </span>
+  );
+
+  if (!onClick) return summary;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full justify-end rounded px-1.5 py-1 text-sm hover:bg-muted"
+          aria-label={label}
+          onClick={(event) => {
+            event.stopPropagation();
+            onClick();
+          }}
+        >
+          {summary}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>View usage over the last month</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/platform/frontend/src/app/skills/page.client.test.tsx
+++ b/platform/frontend/src/app/skills/page.client.test.tsx
@@ -177,6 +177,7 @@ describe("SkillsPage rows", () => {
   it("shows Chat and Edit in the row and folds the rest into the row menu", async () => {
     render(<SkillsPage />);
 
+    expect(screen.queryByText("Standalone skills")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Chat pdf-tools")).toBeInTheDocument();
     expect(screen.getByLabelText("Edit pdf-tools")).toBeInTheDocument();
     // Delete is one click away from Edit no longer.

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -378,6 +378,7 @@ function SkillsList() {
       (kind === "all" && noVisibleFilterResults));
   const showMcpSection =
     showMcpSkills && (visibleExternalSkills.length > 0 || kind === "mcp");
+  const showStandaloneHeading = isDeletedView || mcpSkillsEnabled;
 
   const clearFilters = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString());
@@ -628,7 +629,7 @@ function SkillsList() {
     {
       id: "usageCount",
       accessorKey: "usageCount",
-      size: 280,
+      size: 100,
       header: ({ column }) => (
         // Right padding keeps the right-aligned value from sitting flush
         // against the Actions buttons in the next cell.
@@ -802,14 +803,21 @@ function SkillsList() {
                 {showStandaloneSection && (
                   <section
                     className="space-y-3"
-                    aria-labelledby="standalone-skills-title"
+                    aria-label={showStandaloneHeading ? undefined : "Skills"}
+                    aria-labelledby={
+                      showStandaloneHeading
+                        ? "standalone-skills-title"
+                        : undefined
+                    }
                   >
-                    <h2
-                      id="standalone-skills-title"
-                      className="text-sm font-medium uppercase tracking-wide text-muted-foreground"
-                    >
-                      {isDeletedView ? "Deleted skills" : "Standalone skills"}
-                    </h2>
+                    {showStandaloneHeading && (
+                      <h2
+                        id="standalone-skills-title"
+                        className="text-sm font-medium uppercase tracking-wide text-muted-foreground"
+                      >
+                        {isDeletedView ? "Deleted skills" : "Standalone skills"}
+                      </h2>
+                    )}
 
                     <BulkActionsBar
                       count={selectedSkills.length}

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -114,6 +114,7 @@ import {
 } from "./_parts/skill-actions-model";
 import { skillEditHref } from "./_parts/skill-page-config";
 import { SkillUsageDialog } from "./_parts/skill-usage-dialog";
+import { SkillUsageSummary } from "./_parts/skill-usage-summary";
 import { SkillVersionHistoryDialog } from "./_parts/skill-version-history-dialog";
 
 type SkillItem = archestraApiTypes.GetSkillsResponses["200"]["data"][number];
@@ -627,7 +628,7 @@ function SkillsList() {
     {
       id: "usageCount",
       accessorKey: "usageCount",
-      size: 120,
+      size: 280,
       header: ({ column }) => (
         // Right padding keeps the right-aligned value from sitting flush
         // against the Actions buttons in the next cell.
@@ -644,37 +645,13 @@ function SkillsList() {
       ),
       cell: ({ row }) => (
         <div className="flex justify-end pr-6">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="w-full rounded px-1.5 py-0.5 text-right text-sm hover:bg-muted"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setUsageSkill(row.original);
-                }}
-              >
-                <div>
-                  {row.original.usageCount}
-                  {row.original.usageUserCount > 0 && (
-                    <span className="text-muted-foreground">
-                      {" "}
-                      by {row.original.usageUserCount}{" "}
-                      {row.original.usageUserCount === 1 ? "user" : "users"}
-                    </span>
-                  )}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {formatRelativeTimeFromNow(row.original.lastUsedAt, {
-                    neverLabel: "Never used",
-                  })}
-                </div>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>
-              Who used this skill over the last month
-            </TooltipContent>
-          </Tooltip>
+          <SkillUsageSummary
+            usageCount={row.original.usageCount}
+            usageUserCount={row.original.usageUserCount}
+            lastUsedAt={row.original.lastUsedAt}
+            label={`View usage for ${row.original.name}`}
+            onClick={() => setUsageSkill(row.original)}
+          />
         </div>
       ),
     },
@@ -985,6 +962,7 @@ function SkillsList() {
                           rowSelection={rowSelection}
                           onRowSelectionChange={setRowSelection}
                           isLoading={isFetching}
+                          tableClassName="[&_td]:py-1.5"
                           fixedWidthColumnIds={[
                             "visibility",
                             "files",

--- a/platform/frontend/src/components/call-policy-toggle.tsx
+++ b/platform/frontend/src/components/call-policy-toggle.tsx
@@ -23,7 +23,7 @@ interface CallPolicyToggleProps {
   value: CallPolicyAction;
   onChange: (action: CallPolicyAction) => void;
   disabled?: boolean;
-  size?: "sm" | "lg";
+  size?: "sm" | "table" | "lg";
 }
 
 export function CallPolicyToggle({
@@ -32,14 +32,19 @@ export function CallPolicyToggle({
   disabled,
   size = "sm",
 }: CallPolicyToggleProps) {
-  if (size === "lg") {
+  if (size === "lg" || size === "table") {
+    const isTable = size === "table";
     return (
       <Select
         value={value}
         onValueChange={(val: CallPolicyAction) => onChange(val)}
         disabled={disabled}
       >
-        <SelectTrigger className="w-[220px]">
+        <SelectTrigger
+          className={isTable ? "h-8 w-[200px] text-xs" : "w-[220px]"}
+          size={isTable ? "sm" : "default"}
+          onClick={isTable ? (event) => event.stopPropagation() : undefined}
+        >
           <SelectValue placeholder="Select policy" />
         </SelectTrigger>
         <SelectContent>


### PR DESCRIPTION
## Summary

- consolidate guardrail source, icon, assignment context, and call policy into a cleaner scanning surface
- make guardrail rows open policy details and remove the repetitive actions column
- tighten MCP Registry column sizing so the server name uses remaining space and Actions stays visible without horizontal scrolling
- keep Skills rows compact, reduce the Uses column to the primary count, and move user/recency detail into a tooltip
- hide the redundant Standalone skills heading when standalone skills are the only available kind; retain grouping when MCP-provided skills are enabled

## Validation

- frontend type-check, knip, and Biome checks
- focused Skills tests: 9 passing
- full frontend test suite before the final focused refinement: 499 files, 4,734 passing, 3 skipped
- Chrome verification with isolated mock data at 1,400px: registry Actions visible with no horizontal overflow; Skills rows render at 49px

## Documentation

- audited the existing Guardrails, MCP Registry, and Skills documentation; no updates are needed for these presentation-only changes