### PR TITLE
fix(logging): apply redaction to captured task logs

### DIFF
--- a/platform/backend/src/entrypoints/_shared/log-capture.test.ts
+++ b/platform/backend/src/entrypoints/_shared/log-capture.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@/test";
+import { createCapturingLogger } from "./log-capture";
+
+test("redacts credential fields in captured logs", () => {
+  const { logger, getLogOutput } = createCapturingLogger();
+  logger.level = "info";
+  const credential = "credential-that-must-not-be-captured";
+  const error = new Error("upstream request failed") as Error & {
+    headers: Record<string, string>;
+    config: Record<string, string>;
+  };
+  error.headers = { authorization: credential };
+  error.config = { apiKey: credential };
+
+  logger.error({ authorization: credential, error }, "connector sync failed");
+
+  const output = getLogOutput();
+  expect(output).toContain("[Redacted]");
+  expect(output).toContain("upstream request failed");
+  expect(output).not.toContain(credential);
+});

--- a/platform/backend/src/entrypoints/_shared/log-capture.ts
+++ b/platform/backend/src/entrypoints/_shared/log-capture.ts
@@ -1,7 +1,7 @@
 import { Writable } from "node:stream";
-import pino from "pino";
+import type pino from "pino";
 import pretty from "pino-pretty";
-import { LOG_LEVEL } from "@/logging/log-level";
+import { createLogger } from "@/logging/create-logger";
 
 const MAX_LOG_SIZE = 1024 * 1024; // 1 MB
 
@@ -59,13 +59,12 @@ export function createCapturingLogger(): {
   // Forward pretty output to captureStream
   prettyStream.pipe(captureStream);
 
-  const logger = pino(
-    { level: LOG_LEVEL },
-    pino.multistream([
+  const logger = createLogger({
+    streams: [
       { level: "trace", stream: prettyStdout },
       { level: "trace", stream: prettyCaptureStream },
-    ]),
-  );
+    ],
+  });
 
   return {
     logger,

--- a/platform/backend/src/logging/create-logger.ts
+++ b/platform/backend/src/logging/create-logger.ts
@@ -1,0 +1,34 @@
+import pino from "pino";
+import { LOG_LEVEL } from "@/logging/log-level";
+import { REDACTED_LOG_PATHS, serializeErrorBounded } from "@/logging/redaction";
+
+/**
+ * Creates a production logger with the safety settings every output stream
+ * must share. Callers choose destinations and may add record context, but
+ * cannot bypass redaction or bounded error serialization.
+ */
+export function createLogger({
+  streams,
+  mixin,
+  level = LOG_LEVEL,
+}: {
+  streams: pino.StreamEntry[];
+  mixin?: pino.LoggerOptions["mixin"];
+  level?: pino.LoggerOptions["level"];
+}): pino.Logger {
+  return pino(
+    {
+      level,
+      mixin,
+      // Pod metadata already identifies the host in containerized runtimes.
+      base: undefined,
+      // Apply before fan-out so no destination sees credential-shaped fields.
+      redact: { paths: REDACTED_LOG_PATHS, censor: "[Redacted]" },
+      serializers: {
+        err: serializeErrorBounded,
+        error: serializeErrorBounded,
+      },
+    },
+    pino.multistream(streams),
+  );
+}

--- a/platform/backend/src/logging/index.ts
+++ b/platform/backend/src/logging/index.ts
@@ -11,10 +11,9 @@ import {
 } from "@opentelemetry/api-logs";
 import pino from "pino";
 import pretty from "pino-pretty";
+import { createLogger } from "@/logging/create-logger";
 import { LOG_FORMAT } from "@/logging/log-format";
-import { LOG_LEVEL } from "@/logging/log-level";
 import { logRingBuffer } from "@/logging/log-ring-buffer";
-import { REDACTED_LOG_PATHS, serializeErrorBounded } from "@/logging/redaction";
 import { getActiveSessionId } from "@/observability/request-context";
 
 /**
@@ -45,46 +44,31 @@ import { getActiveSessionId } from "@/observability/request-context";
 
 let _instance: pino.Logger | null = null;
 
-function createLogger(): pino.Logger {
+function createDefaultLogger(): pino.Logger {
   // Write raw JSON to stdout via an async, buffered destination so log writes
   // don't block the event loop when the container log pipe is backpressured.
-  return pino(
-    {
-      level: LOG_LEVEL,
-      // Keep `time` as epoch ms (pino default) so OTEL and log shippers can
-      // read it without parsing. Add a sibling `timeIso` for human readers
-      // looking at raw stdout.
-      mixin: () => ({
-        ...injectTraceContext(),
-        timeIso: new Date().toISOString(),
-      }),
-      // Drop `pid` and `hostname` — they're noise in a containerized
-      // environment where pod metadata already identifies the host.
-      base: undefined,
-      // Defense-in-depth: censor credential-shaped keys in every record
-      // before any stream (stdout, OTLP, ring buffer) sees it. Call sites
-      // must still avoid logging payloads — this only catches the common
-      // credential key names at the top and second level of a merge object.
-      redact: { paths: REDACTED_LOG_PATHS, censor: "[Redacted]" },
-      serializers: {
-        err: serializeErrorBounded,
-        error: serializeErrorBounded,
-      },
-    },
-    pino.multistream([
+  return createLogger({
+    // Keep `time` as epoch ms (pino default) so OTEL and log shippers can
+    // read it without parsing. Add a sibling `timeIso` for human readers
+    // looking at raw stdout.
+    mixin: () => ({
+      ...injectTraceContext(),
+      timeIso: new Date().toISOString(),
+    }),
+    streams: [
       { level: "trace", stream: createStdoutStream() },
       { level: "trace", stream: createOtelLogStream() },
       // Retain a rolling window of recent records so captured backend
       // exceptions can carry the log lines that preceded them (see
       // `log-ring-buffer.ts` and the PostHog error-tracking service).
       { level: "trace", stream: logRingBuffer.createStream() },
-    ]),
-  );
+    ],
+  });
 }
 
 const logger: pino.Logger = new Proxy({} as pino.Logger, {
   get(_, prop) {
-    if (!_instance) _instance = createLogger();
+    if (!_instance) _instance = createDefaultLogger();
     const value = (_instance as unknown as Record<string | symbol, unknown>)[
       prop
     ];

--- a/platform/backend/src/logging/redaction.test.ts
+++ b/platform/backend/src/logging/redaction.test.ts
@@ -1,12 +1,10 @@
 import { Writable } from "node:stream";
-import pino from "pino";
 import { describe, expect, test } from "@/test";
-import { REDACTED_LOG_PATHS, serializeErrorBounded } from "./redaction";
+import { createLogger } from "./create-logger";
 
 /**
- * Builds a pino logger with the same redact/serializer options the real
- * logger uses (see ./index.ts), writing into an in-memory sink so tests can
- * assert on the exact records that would reach stdout/OTLP.
+ * Builds a production-configured logger writing into an in-memory sink so
+ * tests can assert on the exact records that would reach any logger stream.
  */
 function createCapturingLogger() {
   const records: Record<string, unknown>[] = [];
@@ -16,17 +14,10 @@ function createCapturingLogger() {
       callback();
     },
   });
-  const logger = pino(
-    {
-      redact: { paths: REDACTED_LOG_PATHS, censor: "[Redacted]" },
-      serializers: {
-        err: serializeErrorBounded,
-        error: serializeErrorBounded,
-      },
-      base: undefined,
-    },
-    sink,
-  );
+  const logger = createLogger({
+    streams: [{ stream: sink }],
+    level: "info",
+  });
   return { logger, records };
 }
 


### PR DESCRIPTION
## Problem

The task-queue capture logger instantiated Pino directly instead of using the backend logging safety configuration. Connector and permission sync output could therefore retain credential-shaped fields from log records or error metadata in its 1 MB capture buffer.

## Fix

- add a shared logger factory that owns log level, base fields, credential redaction, and bounded error serialization
- construct both the default backend logger and task capture logger through that factory
- make the existing redaction tests exercise the shared production configuration
- add a regression test at the captured-log boundary

This addresses the concrete production gap identified while reviewing #7391. The speculative provider-header additions from that PR are intentionally not included.