### PR TITLE
feat(chat): move conversations between projects

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -108261,7 +108261,7 @@
         "tags": [
           "Chat"
         ],
-        "description": "Update conversation title, model, agent, or API key\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`chat:update`: Edit chat messages and conversation settings",
+        "description": "Update conversation title, model, agent, API key, or project\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`chat:update`: Edit chat messages and conversation settings",
         "requestBody": {
           "required": true,
           "content": {
@@ -108293,6 +108293,12 @@
                   "artifact": {
                     "nullable": true,
                     "type": "string"
+                  },
+                  "projectId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   },
                   "pinnedAt": {
                     "nullable": true,

--- a/docs/pages/platform-projects.md
+++ b/docs/pages/platform-projects.md
@@ -3,7 +3,7 @@ title: Projects
 category: Projects
 order: 1
 description: A shared workspace to organize your work
-lastUpdated: 2026-08-17
+lastUpdated: 2026-08-23
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -15,6 +15,8 @@ A project is a shared workspace for your chats, files, instructions, and schedul
 ## Creating a Project
 
 Start a project from the Projects page, or turn an existing chat into one with **Create project** in the chat's menu — the chat and its files move right in.
+
+Use **Change project** to move a chat into an existing project. Use **Remove from project** to make it a regular chat again.
 
 ![Chat sidebar menu with the Create project action](/docs/automated_screenshots/platform-projects_create-from-chat.webp)
 

--- a/platform/backend/src/database/schemas/conversation.ts
+++ b/platform/backend/src/database/schemas/conversation.ts
@@ -77,8 +77,8 @@ const conversationsTable = softDeletablePgTable(
       >(),
     artifact: text("artifact"),
     /**
-     * Project this chat was started in (forever — no moves in v1). SET NULL on
-     * project delete: the chat survives as an ordinary conversation.
+     * Project this chat belongs to. SET NULL on project delete: the chat
+     * survives as an ordinary conversation.
      */
     projectId: uuid("project_id").references(() => projectsTable.id, {
       onDelete: "set null",

--- a/platform/backend/src/routes/chat/conversation-routes.test.ts
+++ b/platform/backend/src/routes/chat/conversation-routes.test.ts
@@ -163,6 +163,95 @@ describe("chat conversation and message routes", () => {
     expect(unpinResponse.json().pinnedAt).toBeNull();
   });
 
+  test("moves a conversation into a project and removes it again", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({
+      organizationId,
+      authorId: currentUser.id,
+      scope: "personal",
+    });
+    const conversation = await ConversationModel.create({
+      userId: currentUser.id,
+      organizationId,
+      agentId: agent.id,
+    });
+    const project = await projectService.create({
+      organizationId,
+      userId: currentUser.id,
+      name: "Research workspace",
+      description: null,
+    });
+
+    const moveResponse = await app.inject({
+      method: "PATCH",
+      url: `/api/chat/conversations/${conversation.id}`,
+      payload: { projectId: project.id },
+    });
+
+    expect(moveResponse.statusCode).toBe(200);
+    expect(moveResponse.json().projectId).toBe(project.id);
+    expect(
+      (
+        await ConversationModel.findById({
+          id: conversation.id,
+          userId: currentUser.id,
+          organizationId,
+        })
+      )?.projectId,
+    ).toBe(project.id);
+
+    const removeResponse = await app.inject({
+      method: "PATCH",
+      url: `/api/chat/conversations/${conversation.id}`,
+      payload: { projectId: null },
+    });
+
+    expect(removeResponse.statusCode).toBe(200);
+    expect(removeResponse.json().projectId).toBeNull();
+  });
+
+  test("does not move a conversation into an inaccessible project", async ({
+    makeAgent,
+    makeUser,
+  }) => {
+    const agent = await makeAgent({
+      organizationId,
+      authorId: currentUser.id,
+      scope: "personal",
+    });
+    const conversation = await ConversationModel.create({
+      userId: currentUser.id,
+      organizationId,
+      agentId: agent.id,
+    });
+    const otherUser = await makeUser();
+    const otherProject = await projectService.create({
+      organizationId,
+      userId: otherUser.id,
+      name: "Private workspace",
+      description: null,
+    });
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/chat/conversations/${conversation.id}`,
+      payload: { projectId: otherProject.id },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error.message).toBe("Project not found");
+    expect(
+      (
+        await ConversationModel.findById({
+          id: conversation.id,
+          userId: currentUser.id,
+          organizationId,
+        })
+      )?.projectId,
+    ).toBeNull();
+  });
+
   test("persists a thinking effort and rejects an unknown one", async ({
     makeAgent,
   }) => {

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2847,7 +2847,8 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
     {
       schema: {
         operationId: RouteId.UpdateChatConversation,
-        description: "Update conversation title, model, agent, or API key",
+        description:
+          "Update conversation title, model, agent, API key, or project",
         tags: ["Chat"],
         params: z.object({ id: UuidIdSchema }),
         body: UpdateConversationSchema,
@@ -2855,6 +2856,29 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ params: { id }, body, user, organizationId }, reply) => {
+      if (body.projectId) {
+        const project = await ProjectModel.findById(body.projectId);
+        if (
+          !project ||
+          !(await ProjectShareModel.userCanAccessProject({
+            project,
+            userId: user.id,
+            organizationId,
+          }))
+        ) {
+          throw new ApiError(404, "Project not found");
+        }
+
+        const currentConversation = await ConversationModel.findById({
+          id,
+          userId: user.id,
+          organizationId,
+        });
+        if (currentConversation?.lockedChat) {
+          throw new ApiError(400, "Locked chats cannot be moved to a project");
+        }
+      }
+
       // Validate chatApiKeyId if provided
       // Skip validation if it matches the agent's configured key (permission flows through agent access)
       if (body.chatApiKeyId) {

--- a/platform/backend/src/types/conversation.ts
+++ b/platform/backend/src/types/conversation.ts
@@ -160,6 +160,7 @@ export const UpdateConversationSchema = createUpdateSchema(
     chatApiKeyId: true,
     agentId: true,
     artifact: true,
+    projectId: true,
     pinnedAt: true,
     thinkingEffort: true,
   })

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -20,6 +20,7 @@ import {
 import { usePathname, useRouter } from "next/navigation";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { ChatListSkeleton } from "@/app/_parts/chat-list-skeleton";
+import { ConversationProjectActions } from "@/app/_parts/conversation-project-actions";
 import { CreateProjectFromChatDialog } from "@/app/_parts/create-project-from-chat-dialog";
 import { isScheduledRunConversation } from "@/app/_parts/scheduled-run-sidebar.utils";
 import { AgentIcon } from "@/components/agent-icon";
@@ -270,6 +271,21 @@ export function ChatSidebarSection({
     pinConversationMutation.mutate({ id, pinned: !isPinned });
   };
 
+  const handleChangeProject = async (
+    conversationId: string,
+    projectId: string | null,
+  ) => {
+    try {
+      await updateConversationMutation.mutateAsync({
+        id: conversationId,
+        projectId,
+      });
+      setOpenMenuId(null);
+    } catch {
+      // Error is handled by the mutation's onError callback
+    }
+  };
+
   const handleSelectProject = (id: string) => {
     if (isMobile) {
       setOpenMobile(false);
@@ -345,6 +361,10 @@ export function ChatSidebarSection({
         hasCreatePermission: canCreateProject === true,
         conversation: conv,
       });
+    const showProjectActions =
+      canUpdateConversation === true &&
+      canReadProjects === true &&
+      isActionAvailableForConversation(conv, "changeProject");
     // AI title generation is rejected for locked chats (the server would
     // have to read encrypted messages), so hide both regenerate affordances.
     const canRegenerateTitle = isActionAvailableForConversation(
@@ -565,6 +585,16 @@ export function ChatSidebarSection({
                           <Sparkles className="h-4 w-4 mr-2" />
                           Regenerate title
                         </DropdownMenuItem>
+                      )}
+                      {showProjectActions && (
+                        <ConversationProjectActions
+                          projectId={conv.projectId}
+                          projects={projectsData ?? []}
+                          isPending={updateConversationMutation.isPending}
+                          onProjectChange={(projectId) =>
+                            handleChangeProject(conv.id, projectId)
+                          }
+                        />
                       )}
                     </>
                   )}

--- a/platform/frontend/src/app/_parts/conversation-project-actions.test.tsx
+++ b/platform/frontend/src/app/_parts/conversation-project-actions.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConversationProjectActions } from "./conversation-project-actions";
+
+vi.mock("@/components/agent-icon", () => ({
+  AgentIcon: ({ icon }: { icon: string }) => <span>{icon}</span>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenuSub: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuSubTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <button type="button" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/command", () => ({
+  Command: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CommandInput: ({ placeholder }: { placeholder: string }) => (
+    <input placeholder={placeholder} />
+  ),
+  CommandList: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CommandEmpty: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CommandGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CommandItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <button type="button" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+}));
+
+const projects = [
+  { id: "project-1", name: "Research", icon: null },
+  { id: "project-2", name: "Planning", icon: "P" },
+];
+
+describe("ConversationProjectActions", () => {
+  it("moves a chat without a project into a selected project", () => {
+    const onProjectChange = vi.fn();
+    render(
+      <ConversationProjectActions
+        projectId={null}
+        projects={projects}
+        isPending={false}
+        onProjectChange={onProjectChange}
+      />,
+    );
+
+    expect(screen.getByText("Change project")).toBeInTheDocument();
+    expect(screen.queryByText("Remove from project")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Research" }));
+    expect(onProjectChange).toHaveBeenCalledWith("project-1");
+  });
+
+  it("changes or removes a chat that already belongs to a project", () => {
+    const onProjectChange = vi.fn();
+    render(
+      <ConversationProjectActions
+        projectId="project-1"
+        projects={projects}
+        isPending={false}
+        onProjectChange={onProjectChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "PPlanning" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove from project" }),
+    );
+
+    expect(onProjectChange).toHaveBeenNthCalledWith(1, "project-2");
+    expect(onProjectChange).toHaveBeenNthCalledWith(2, null);
+  });
+});

--- a/platform/frontend/src/app/_parts/conversation-project-actions.tsx
+++ b/platform/frontend/src/app/_parts/conversation-project-actions.tsx
@@ -33,7 +33,7 @@ export function ConversationProjectActions({
     <Fragment>
       <DropdownMenuSub>
         <DropdownMenuSubTrigger disabled={isPending}>
-          <FolderInput />
+          <FolderInput className="h-4 w-4 mr-2" />
           <span>Change project</span>
         </DropdownMenuSubTrigger>
         <DropdownMenuSubContent className="w-64 p-0">
@@ -77,7 +77,7 @@ export function ConversationProjectActions({
           disabled={isPending}
           onSelect={() => onProjectChange(null)}
         >
-          <FolderX />
+          <FolderX className="h-4 w-4 mr-2" />
           <span>Remove from project</span>
         </DropdownMenuItem>
       )}

--- a/platform/frontend/src/app/_parts/conversation-project-actions.tsx
+++ b/platform/frontend/src/app/_parts/conversation-project-actions.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Check, Folder, FolderInput, FolderX } from "lucide-react";
+import { Fragment } from "react";
+import { AgentIcon } from "@/components/agent-icon";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ConversationProjectActions({
+  projectId,
+  projects,
+  isPending,
+  onProjectChange,
+}: {
+  projectId: string | null;
+  projects: Array<{ id: string; name: string; icon: string | null }>;
+  isPending: boolean;
+  onProjectChange: (projectId: string | null) => void;
+}) {
+  return (
+    <Fragment>
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger disabled={isPending}>
+          <FolderInput />
+          <span>Change project</span>
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent className="w-64 p-0">
+          <Command onKeyDown={(event) => event.stopPropagation()}>
+            <CommandInput placeholder="Search projects..." />
+            <CommandList>
+              <CommandEmpty>No projects found.</CommandEmpty>
+              <CommandGroup>
+                {projects.map((project) => {
+                  const isCurrent = project.id === projectId;
+                  return (
+                    <CommandItem
+                      key={project.id}
+                      value={project.name}
+                      disabled={isPending}
+                      onSelect={() => {
+                        if (!isCurrent) onProjectChange(project.id);
+                      }}
+                    >
+                      {project.icon ? (
+                        <AgentIcon
+                          icon={project.icon}
+                          fallbackType="project"
+                          size={16}
+                        />
+                      ) : (
+                        <Folder />
+                      )}
+                      <span className="truncate">{project.name}</span>
+                      {isCurrent && <Check className="ml-auto" />}
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+      {projectId && (
+        <DropdownMenuItem
+          disabled={isPending}
+          onSelect={() => onProjectChange(null)}
+        >
+          <FolderX />
+          <span>Remove from project</span>
+        </DropdownMenuItem>
+      )}
+    </Fragment>
+  );
+}

--- a/platform/frontend/src/lib/chat/chat.query.test.tsx
+++ b/platform/frontend/src/lib/chat/chat.query.test.tsx
@@ -370,6 +370,22 @@ describe("mergeUpdatedConversationIntoCache", () => {
 
     expect(merged.titleIsPlaceholder).toBe(true);
   });
+
+  test("applies a project change to the cached conversation", () => {
+    const oldConversation = makeConversation();
+    const updatedConversation = {
+      ...oldConversation,
+      projectId: "project-1",
+    } satisfies archestraApiTypes.UpdateChatConversationResponses["200"];
+
+    const merged = mergeUpdatedConversationIntoCache(
+      oldConversation,
+      updatedConversation,
+      { id: "conversation-1", projectId: "project-1" },
+    );
+
+    expect(merged.projectId).toBe("project-1");
+  });
 });
 
 describe("invalidateConversationFileQueries", () => {
@@ -695,7 +711,7 @@ describe("useClearChatErrors", () => {
   });
 });
 
-describe("thinking effort reaches the wire", () => {
+describe("conversation settings reach the wire", () => {
   // Both mutations rebuild the request body from an explicit field list, so a
   // new field is dropped silently unless it is added there. Type-checking does
   // not catch it: the extra property is accepted by the argument type.
@@ -723,6 +739,30 @@ describe("thinking effort reaches the wire", () => {
     expect(archestraApiSdk.updateChatConversation).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({ thinkingEffort: "high" }),
+      }),
+    );
+  });
+
+  it("sends a project assignment when updating a conversation", async () => {
+    vi.mocked(archestraApiSdk.updateChatConversation).mockResolvedValue({
+      data: { ...makeConversation(), projectId: "project-1" },
+      error: undefined,
+    } as Awaited<ReturnType<typeof archestraApiSdk.updateChatConversation>>);
+
+    const { result } = renderHook(() => useUpdateConversation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: "c1",
+        projectId: "project-1",
+      });
+    });
+
+    expect(archestraApiSdk.updateChatConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ projectId: "project-1" }),
       }),
     );
   });

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -130,6 +130,9 @@ export function mergeUpdatedConversationIntoCache(
   if (variables.pinnedAt !== undefined) {
     merged.pinnedAt = updatedConversation.pinnedAt;
   }
+  if (variables.projectId !== undefined) {
+    merged.projectId = updatedConversation.projectId;
+  }
 
   return merged;
 }
@@ -439,6 +442,7 @@ export function useUpdateConversation() {
       modelId,
       chatApiKeyId,
       agentId,
+      projectId,
       pinnedAt,
       thinkingEffort,
     }: { id: string } & WithThinkingEffortSetting<
@@ -453,6 +457,7 @@ export function useUpdateConversation() {
               modelId,
               chatApiKeyId,
               agentId,
+              projectId,
               pinnedAt,
               // The generated body type drops `nullable: true` from enum
               // schemas, so null (auto) has to be re-asserted here.
@@ -463,6 +468,16 @@ export function useUpdateConversation() {
       ),
     onSuccess: (data, variables) => {
       if (!data) return;
+      const previousProjectId =
+        queryClient.getQueryData<
+          archestraApiTypes.GetChatConversationResponses["200"]
+        >(["conversation", variables.id])?.projectId ??
+        queryClient
+          .getQueriesData<
+            archestraApiTypes.GetChatConversationsResponses["200"]
+          >({ queryKey: ["conversations"] })
+          .flatMap(([, conversations]) => conversations ?? [])
+          .find((conversation) => conversation.id === variables.id)?.projectId;
       // `mergeUpdatedConversationIntoCache` deliberately has no branch for the
       // reasoning depth: the composer owns what it displays, including the
       // clicks its write queue coalesces away. Echoing a response back would
@@ -486,8 +501,33 @@ export function useUpdateConversation() {
       // Only invalidate the conversations list for sidebar-relevant changes
       // (pin status, agent). Model/key updates don't affect the sidebar
       // and unnecessary invalidation causes cascading re-renders.
-      if (variables.pinnedAt !== undefined || variables.agentId) {
+      if (
+        variables.pinnedAt !== undefined ||
+        variables.agentId ||
+        variables.projectId !== undefined
+      ) {
         queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      }
+      if (variables.projectId !== undefined) {
+        toast.success(
+          variables.projectId
+            ? "Chat moved to project"
+            : "Chat removed from project",
+        );
+        queryClient.invalidateQueries({ queryKey: ["projects", "list"] });
+        queryClient.invalidateQueries({
+          queryKey: ["conversation-files", variables.id],
+        });
+        if (previousProjectId) {
+          queryClient.invalidateQueries({
+            queryKey: ["projects", previousProjectId, "conversations"],
+          });
+        }
+        if (variables.projectId) {
+          queryClient.invalidateQueries({
+            queryKey: ["projects", variables.projectId, "conversations"],
+          });
+        }
       }
       if (variables.agentId) {
         // Agent changed — invalidate tools-related queries

--- a/platform/frontend/src/lib/chat/locked-chat.ts
+++ b/platform/frontend/src/lib/chat/locked-chat.ts
@@ -104,6 +104,7 @@ export type LockedChatBlockedAction =
   | "share"
   | "fork"
   | "createProject"
+  | "changeProject"
   | "generateTitle"
   | "compaction";
 

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -2303,7 +2303,7 @@ export const deleteChatConversation = <ThrowOnError extends boolean = false>(opt
 export const getChatConversation = <ThrowOnError extends boolean = false>(options: Options<GetChatConversationData, ThrowOnError>) => (options.client ?? client).get<GetChatConversationResponses, GetChatConversationErrors, ThrowOnError>({ url: '/api/chat/conversations/{id}', ...options });
 
 /**
- * Update conversation title, model, agent, or API key
+ * Update conversation title, model, agent, API key, or project
  *
  * Authentication:
  *

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -30189,6 +30189,7 @@ export type UpdateChatConversationData = {
         chatApiKeyId?: string | null;
         agentId?: string;
         artifact?: string | null;
+        projectId?: string | null;
         pinnedAt?: string | null;
         thinkingEffort?: 'low' | 'medium' | 'high';
     };


### PR DESCRIPTION
## Summary

- add a searchable **Change project** submenu to sidebar chat actions
- add **Remove from project** for chats already assigned to a project
- extend conversation updates with access-checked project assignment and refresh affected chat/project caches
- update the generated API contract and Projects documentation