### PR TITLE
fix(frontend): polish embedding settings layout

### DIFF
--- a/platform/frontend/src/app/knowledge/_parts/embedding-model-image-support-notice.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/embedding-model-image-support-notice.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+
 "use client";
 
 import {
@@ -93,23 +95,25 @@ export function EmbeddingModelImageSupportNotice({
     >
       <div className="flex min-w-0 flex-1 items-start gap-2">
         <Info className="mt-0.5 size-4 shrink-0" />
-        <p className="leading-relaxed">
-          <span className="font-medium text-foreground">
-            <code>{modelKey}</code>
-          </span>{" "}
-          handles text only. Choose a multimodal embedding model to sync
-          supported image files.{" "}
-          <a
-            href={getDocsUrl(DocsPage.PlatformKnowledge, "image-embedding")}
-            target="_blank"
-            rel="noreferrer"
-            className="text-foreground underline decoration-dotted underline-offset-4 hover:decoration-solid"
-          >
-            Learn more
-          </a>
-        </p>
+        <div className="min-w-0 space-y-1">
+          <p className="font-medium text-foreground">
+            <code className="break-all">{modelKey}</code>
+          </p>
+          <p className="leading-relaxed">
+            Handles text only. Choose a multimodal embedding model to sync
+            supported image files.{" "}
+            <a
+              href={getDocsUrl(DocsPage.PlatformKnowledge, "image-embedding")}
+              target="_blank"
+              rel="noreferrer"
+              className="text-foreground underline decoration-dotted underline-offset-4 hover:decoration-solid"
+            >
+              Learn more
+            </a>
+          </p>
+        </div>
       </div>
-      <div className="flex shrink-0 items-center gap-1 self-end sm:self-auto">
+      <div className="flex shrink-0 items-center justify-end gap-1 self-end sm:self-auto">
         {showSettingsLink && (
           <Button variant="outline" size="sm" asChild>
             <Link href="/settings/knowledge#embedding-configuration">

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-embedding-model-notice.test.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-embedding-model-notice.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+
 import { DocsPage, getDocsUrl } from "@archestra/shared";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -55,9 +57,9 @@ describe("ConnectorEmbeddingModelNotice", () => {
 
     expect(await screen.findByRole("note")).toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    expect(screen.getByRole("note")).toHaveTextContent(
-      "openai/text-embedding-model handles text only",
-    );
+    const note = screen.getByRole("note");
+    expect(note).toHaveTextContent("openai/text-embedding-model");
+    expect(note).toHaveTextContent("Handles text only");
     expect(
       screen.getByText(/choose a multimodal embedding model/i),
     ).toBeInTheDocument();

--- a/platform/frontend/src/app/settings/knowledge/page.test.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -645,10 +647,12 @@ describe("KnowledgeSettingsPage", () => {
       ];
       renderPage();
 
+      expect(screen.getByText("Embedding index locked")).toBeInTheDocument();
       expect(
-        screen.getByText(
-          /To change the embedding model, drop the existing index/,
-        ),
+        screen.getByText(/Drop the index to change models/),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Drop index" }),
       ).toBeInTheDocument();
     });
 
@@ -669,11 +673,7 @@ describe("KnowledgeSettingsPage", () => {
       ];
       renderPage();
 
-      expect(
-        screen.getByText(
-          /To change the embedding model, drop the existing index/,
-        ),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Embedding index locked")).toBeInTheDocument();
     });
 
     it("does not show lock message when key or model is missing", () => {
@@ -686,9 +686,7 @@ describe("KnowledgeSettingsPage", () => {
       renderPage();
 
       expect(
-        screen.queryByText(
-          /To change the embedding model, drop the existing index/,
-        ),
+        screen.queryByText("Embedding index locked"),
       ).not.toBeInTheDocument();
     });
 

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+
 "use client";
 
 import {
@@ -1256,7 +1258,7 @@ function KnowledgeSettingsContent() {
                           : null
                       }
                       showSettingsLink={false}
-                      className="sm:ml-auto sm:w-80"
+                      className="sm:ml-auto sm:w-80 sm:flex-col sm:items-stretch sm:gap-2.5"
                     />
                   )}
                 {selectedEmbeddingProvider === "gemini" &&
@@ -1284,15 +1286,29 @@ function KnowledgeSettingsContent() {
             )}
           </WithPermissions>
           {showEmbeddingFooter && (
-            <div className="mt-5 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <div
+              className={cn(
+                "mt-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between",
+                isEmbeddingModelLocked
+                  ? "rounded-lg border border-border/60 bg-muted/30 px-4 py-3"
+                  : "border-t pt-4",
+              )}
+            >
               {isEmbeddingModelLocked ? (
-                <p className="flex items-start gap-2 text-sm text-muted-foreground">
-                  <Lock className="mt-0.5 h-4 w-4 shrink-0" />
-                  <span>
-                    To change the embedding model, drop the existing index — all
-                    documents will need to be re-embedded.
-                  </span>
-                </p>
+                <div className="flex min-w-0 items-start gap-3 sm:max-w-md">
+                  <div className="rounded-md border bg-background p-2 text-muted-foreground shadow-xs">
+                    <Lock className="size-4" />
+                  </div>
+                  <div className="min-w-0 space-y-0.5">
+                    <p className="text-sm font-medium">
+                      Embedding index locked
+                    </p>
+                    <p className="text-sm leading-relaxed text-muted-foreground">
+                      Drop the index to change models. All documents will need
+                      to be re-embedded afterward.
+                    </p>
+                  </div>
+                </div>
               ) : (
                 <span />
               )}
@@ -1301,7 +1317,7 @@ function KnowledgeSettingsContent() {
                 noPermissionHandle="tooltip"
               >
                 {({ hasPermission }) => (
-                  <div className="flex flex-wrap justify-end gap-2">
+                  <div className="flex shrink-0 items-center justify-end gap-2 self-end sm:self-auto">
                     {embeddingConfigured && (
                       <Button
                         type="button"
@@ -1325,7 +1341,7 @@ function KnowledgeSettingsContent() {
                         onClick={() => setShowDropDialog(true)}
                       >
                         <Trash2 className="mr-1 h-3.5 w-3.5" />
-                        Drop
+                        Drop index
                       </Button>
                     )}
                   </div>


### PR DESCRIPTION
## Summary

- give the text-only embedding notice a stacked, more readable layout
- present the locked embedding index as a compact callout with a constrained explanation
- keep Test connection and Drop index side by side and update behavior coverage
- mark the touched knowledge files under the Enterprise license