### PR TITLE
chore: polish registry and plugin tables

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -85,7 +85,6 @@ import {
 } from "./local-server-install-dialog";
 import { ManageUsersDialog } from "./manage-users-dialog";
 import { McpServerAttentionList } from "./mcp-server-attention-list";
-import { waitingActionFacetLabel } from "./mcp-server-attention-owner";
 import {
   type CatalogItem,
   type InstalledServer,
@@ -101,7 +100,6 @@ import {
   ISSUE_OPTIONS,
   NOT_INSTALLED_STATUS_VALUE,
   REGISTRY_STATUS_PARAM,
-  RegistryAttentionFacets,
   RegistryFilterChips,
   RegistryFilterDropdown,
   type RegistryFilters,
@@ -891,19 +889,10 @@ export function InternalMCPCatalog({
   }, [catalogItems]);
   // Outstanding issues per catalog item, from the same signals every registry
   // surface renders. This feeds the audience facets, Issue filter and table.
-  const { issuesByCatalog, facetCounts } =
-    useMcpServerIssues(deploymentStatuses);
+  const { issuesByCatalog } = useMcpServerIssues(deploymentStatuses);
   const selectedFacet = alertingEnabled
     ? selectedAttentionFacet(filters.status)
     : null;
-  const othersFacetLabel = useMemo(
-    () =>
-      waitingActionFacetLabel({
-        issuesByCatalog,
-        servers: installedServers ?? [],
-      }),
-    [issuesByCatalog, installedServers],
-  );
   useEffect(() => {
     const requestedFacet = selectedAttentionFacet(filters.status);
     if (alertingFeature === false && requestedFacet) {
@@ -1112,9 +1101,6 @@ export function InternalMCPCatalog({
     ? clearFiltersKeepingFacet
     : handleClearAllFilters;
 
-  const registryItems = (catalogItems ?? []).filter(
-    (item) => item.id !== ARCHESTRA_MCP_CATALOG_ID,
-  );
   // The healthy-fleet line counts servers somebody actually installed. Over
   // the catalog it read "All 40 MCP servers are healthy" on a deployment with
   // three connections and thirty-seven entries nobody had ever touched.
@@ -1128,18 +1114,6 @@ export function InternalMCPCatalog({
     <TableCardView storageKey="archestra-mcp-registry-view" defaultMode="table">
       <div className="space-y-4">
         <div className="space-y-3">
-          {alertingEnabled && (
-            <div className="min-w-0 overflow-x-auto">
-              <RegistryAttentionFacets
-                counts={facetCounts}
-                totalCount={registryItems.length}
-                othersLabel={othersFacetLabel}
-                showOthers={!userIsMcpServerAdmin}
-                selected={selectedFacet}
-                onSelect={selectFacet}
-              />
-            </div>
-          )}
           <FilterBar
             className="mb-0"
             onClearFilters={

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-attention-list.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-attention-list.test.tsx
@@ -156,9 +156,10 @@ describe("McpServerAttentionList", () => {
       />,
     );
 
-    for (const name of ["MCP Server", "Issue", "Owner", "Actions"]) {
+    for (const name of ["MCP Server", "Issue", "Actions"]) {
       expect(screen.getByRole("columnheader", { name })).toBeInTheDocument();
     }
+    expect(screen.queryByRole("columnheader", { name: "Owner" })).toBeNull();
     expect(
       screen.queryByRole("columnheader", { name: "Issue types" }),
     ).toBeNull();
@@ -190,7 +191,7 @@ describe("McpServerAttentionList", () => {
     await user.click(
       screen.getByRole("checkbox", { name: "Select First server" }),
     );
-    expect(screen.getByText("MCP server selected")).toBeInTheDocument();
+    expect(screen.getAllByText("1 MCP server selected")).toHaveLength(2);
 
     await user.click(screen.getByRole("button", { name: "Dismiss selected" }));
     expect(
@@ -208,9 +209,7 @@ describe("McpServerAttentionList", () => {
         reason: "Owner is away",
       }),
     );
-    expect(
-      screen.getByText("Select MCP servers to apply bulk actions"),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("1 MCP server selected")).toBeNull();
   });
 
   it("renders the same server metadata as the All-facet name column", () => {
@@ -265,8 +264,8 @@ describe("McpServerAttentionList", () => {
       />,
     );
 
-    const owner = screen.getByText("admin@example.com");
-    expect(owner).toHaveClass("break-words");
+    const owner = screen.getByText(/admin@example.com/);
+    expect(owner.closest("p")).toHaveClass("break-words");
     expect(owner).not.toHaveClass("truncate");
   });
 
@@ -292,13 +291,15 @@ describe("McpServerAttentionList", () => {
       />,
     );
 
-    const removeSelected = screen.getByRole("button", {
-      name: "Remove connections",
-    });
-    expect(removeSelected).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Remove connections" }),
+    ).toBeNull();
     await user.click(
       screen.getByRole("checkbox", { name: "Select all alerts" }),
     );
+    const removeSelected = screen.getByRole("button", {
+      name: "Remove connections",
+    });
     expect(removeSelected).toBeEnabled();
     await user.click(removeSelected);
 
@@ -444,7 +445,7 @@ describe("McpServerAttentionList", () => {
     await user.click(
       screen.getByRole("checkbox", { name: "Select all alerts" }),
     );
-    expect(screen.getByText("MCP servers selected")).toBeInTheDocument();
+    expect(screen.getAllByText("2 MCP servers selected")).toHaveLength(2);
     expect(
       screen.getByRole("checkbox", { name: "Select First server" }),
     ).toBeChecked();
@@ -524,7 +525,7 @@ describe("McpServerAttentionList", () => {
     );
 
     const row = screen.getByRole("row", { name: /Shared provider/ });
-    expect(within(row).getByText("Multiple actors")).toBeInTheDocument();
+    expect(within(row).getByText(/Multiple actors/)).toBeInTheDocument();
     expect(within(row).queryByText("first@example.com")).toBeNull();
   });
 
@@ -638,7 +639,7 @@ describe("McpServerAttentionList", () => {
     expect(
       screen.getByRole("checkbox", { name: "Select Second server" }),
     ).toBeChecked();
-    expect(screen.getByText("MCP server selected")).toBeInTheDocument();
+    expect(screen.getAllByText("1 MCP server selected")).toHaveLength(2);
   });
 
   it("does not retarget a selected row to a newly failing connection", async () => {
@@ -691,8 +692,8 @@ describe("McpServerAttentionList", () => {
       screen.getByRole("checkbox", { name: "Select First server" }),
     ).not.toBeChecked();
     expect(
-      screen.getByRole("button", { name: "Dismiss selected" }),
-    ).toBeDisabled();
+      screen.queryByRole("button", { name: "Dismiss selected" }),
+    ).toBeNull();
   });
 
   it("does not revive selection after leaving and returning to a filter", async () => {
@@ -770,7 +771,7 @@ describe("McpServerAttentionList", () => {
     );
   });
 
-  it("shows supplied and empty dismissal reasons in the Dismissed table", () => {
+  it("shows dismissal context inside the compact Issue column", () => {
     const first = item("cat-1", "First server");
     const second = item("cat-2", "Second server");
     const withReason = reauthIssue({
@@ -806,27 +807,19 @@ describe("McpServerAttentionList", () => {
     );
 
     expect(
-      screen.getByRole("columnheader", { name: "Dismiss reason" }),
-    ).toBeInTheDocument();
-    expect(
       screen
         .getAllByRole("columnheader")
         .map((header) => header.textContent?.trim()),
-    ).toEqual([
-      "",
-      "MCP Server",
-      "Dismiss reason",
-      "Issue",
-      "Owner",
-      "Actions",
-    ]);
+    ).toEqual(["", "MCP Server", "Issue", "Actions"]);
     expect(
       within(screen.getByRole("row", { name: /First server/ })).getByText(
-        "Deferred",
+        /Reason: Deferred/,
       ),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByRole("row", { name: /Second server/ })).getByText("—"),
+      within(screen.getByRole("row", { name: /Second server/ })).getByText(
+        /No dismissal reason/,
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-attention-list.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-attention-list.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import type { RowSelectionState } from "@tanstack/react-table";
-import { Bell, BellOff, Loader2, Trash2 } from "lucide-react";
+import { Bell, BellOff, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
+import { BulkActionsBar } from "@/components/ui/bulk-actions-bar";
 import { Button } from "@/components/ui/button";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useRestoreMcpServerAlerts } from "@/lib/mcp/mcp-server.query";
@@ -93,9 +94,6 @@ export function McpServerAttentionList({
     return map;
   }, [items, issuesByCatalog, facet]);
 
-  const selectableItemIds = items
-    .filter((item) => (selectableIssuesByItem.get(item.id)?.length ?? 0) > 0)
-    .map((item) => item.id);
   const selectableIssues = items.flatMap(
     (item) => selectableIssuesByItem.get(item.id) ?? [],
   );
@@ -217,86 +215,57 @@ export function McpServerAttentionList({
 
   return (
     <div className="space-y-3" data-testid="mcp-registry-attention-list">
-      <div className="flex flex-col gap-3 rounded-lg border bg-muted/50 p-3 sm:flex-row sm:items-center">
-        <div className="flex items-center gap-2">
-          {selectedItems.length > 0 ? (
-            <>
-              <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
-                {selectedItems.length}
-              </span>
-              <span className="text-sm font-medium">
-                {selectedItems.length === 1
-                  ? "MCP server selected"
-                  : "MCP servers selected"}
-              </span>
-            </>
-          ) : (
-            <span className="text-sm text-muted-foreground">
-              {selectableItemIds.length > 0
-                ? "Select MCP servers to apply bulk actions"
-                : restoringDismissed
-                  ? "No restorable alerts in this view"
-                  : "No actionable alerts in this view"}
-            </span>
-          )}
-          {restoring && (
-            <Loader2
-              aria-label="Restoring selected alerts"
-              className="h-4 w-4 animate-spin text-muted-foreground"
-            />
-          )}
-        </div>
-        <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
-          {restoringDismissed ? (
+      <BulkActionsBar
+        count={selectedItems.length}
+        noun="MCP server"
+        plural="MCP servers"
+        onClear={clearSelection}
+        busy={restoring}
+      >
+        {restoringDismissed ? (
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label="Restore selected"
+            disabled={selectedDismissTargets.length === 0 || restoring}
+            onClick={() => void restoreSelected()}
+          >
+            <Bell className="h-4 w-4" />
+            <span>Restore</span>
+          </Button>
+        ) : (
+          <>
             <Button
               variant="outline"
               size="sm"
-              disabled={selectedDismissTargets.length === 0 || restoring}
-              onClick={() => void restoreSelected()}
+              aria-label="Dismiss selected"
+              disabled={selectedDismissTargets.length === 0}
+              onClick={() => setDismissOpen(true)}
             >
-              <Bell className="h-4 w-4" />
-              Restore selected
+              <BellOff className="h-4 w-4" />
+              <span>Dismiss</span>
             </Button>
-          ) : (
-            <>
+            {facet === "you" ? (
               <Button
-                variant="outline"
+                variant="destructive"
                 size="sm"
-                disabled={selectedDismissTargets.length === 0}
-                onClick={() => setDismissOpen(true)}
+                disabled={!canRemoveSelected}
+                title={
+                  !canDeleteInstalls
+                    ? "You do not have permission to remove MCP connections"
+                    : !everySelectedItemIsRemovable
+                      ? "Every selected row must identify connections you can remove"
+                      : undefined
+                }
+                onClick={() => setUninstallOpen(true)}
               >
-                <BellOff className="h-4 w-4" />
-                Dismiss selected
+                <Trash2 className="h-4 w-4" />
+                <span>Remove connections</span>
               </Button>
-              {facet === "you" && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={!canRemoveSelected}
-                  title={
-                    !canDeleteInstalls
-                      ? "You do not have permission to remove MCP connections"
-                      : selectedItems.length === 0
-                        ? "Select MCP servers to remove their connections"
-                        : !everySelectedItemIsRemovable
-                          ? "Every selected row must identify connections you can remove"
-                          : undefined
-                  }
-                  onClick={() => setUninstallOpen(true)}
-                >
-                  <Trash2 className="h-4 w-4 text-destructive" />
-                  Remove connections
-                </Button>
-              )}
-            </>
-          )}
-          {selectedItems.length > 0 && (
-            <Button variant="ghost" size="sm" onClick={clearSelection}>
-              Clear selection
-            </Button>
-          )}
-        </div>
-      </div>
+            ) : null}
+          </>
+        )}
+      </BulkActionsBar>
 
       <McpServerTable
         items={items}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.test.tsx
@@ -166,7 +166,7 @@ describe("McpServerTable uninstall permission", () => {
     expect(screen.queryByText("Uninstall MCP Server")).not.toBeInTheDocument();
   });
 
-  it("renders Dismiss as a visible row action, never an overflow item", async () => {
+  it("keeps queue actions inline and moves lower-priority actions into overflow", async () => {
     const user = userEvent.setup();
     const issue = {
       kind: "needs-reauth",
@@ -215,14 +215,18 @@ describe("McpServerTable uninstall permission", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("link", {
+      screen.queryByRole("link", {
         name: "Credentials some-remote-server",
       }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", {
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
         name: "More actions some-remote-server",
       }),
-    ).toBeNull();
+    );
+    expect(
+      screen.getByRole("menuitem", { name: "Credentials" }),
+    ).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
@@ -174,7 +174,7 @@ export function McpServerTable({
       id: "name",
       accessorKey: "name",
       header: "MCP Server",
-      size: 540,
+      size: 460,
       cell: ({ row }) => {
         const item = row.original;
         return (
@@ -187,7 +187,7 @@ export function McpServerTable({
     },
     {
       id: "tools",
-      size: 90,
+      size: 72,
       header: () => <div className="text-right">Tools</div>,
       cell: ({ row }) => (
         <div className="text-right text-sm text-muted-foreground">
@@ -197,7 +197,7 @@ export function McpServerTable({
     },
     {
       id: "author",
-      size: 140,
+      size: 160,
       header: "Accessible to",
       cell: ({ row }) => (
         <ResourceVisibilityBadge
@@ -214,7 +214,7 @@ export function McpServerTable({
       id: "status",
       // The table is a scanning surface: the status label is enough here.
       // Diagnosis and remediation live on the server page and attention facet.
-      size: 190,
+      size: 180,
       header: "Status",
       cell: ({ row }) => {
         const item = row.original;
@@ -263,7 +263,7 @@ export function McpServerTable({
     },
     {
       id: "actions",
-      size: 260,
+      size: 180,
       header: () => <div className="text-right">Actions</div>,
       cell: ({ row }) => {
         const item = row.original;
@@ -321,7 +321,7 @@ export function McpServerTable({
           id: "name",
           accessorKey: "name",
           header: "MCP Server",
-          size: 540,
+          size: 420,
           cell: ({ row }) => {
             const item = row.original;
             return (
@@ -335,7 +335,7 @@ export function McpServerTable({
         {
           id: "issue",
           header: "Issue",
-          size: 440,
+          size: 360,
           cell: ({ row }) => {
             const item = row.original;
             const issues = attentionRawIssues(item);
@@ -381,7 +381,7 @@ export function McpServerTable({
         {
           id: "actions",
           header: () => <div className="text-right">Actions</div>,
-          size: 160,
+          size: 112,
           cell: ({ row }) => {
             const item = row.original;
             return (

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
@@ -332,51 +332,10 @@ export function McpServerTable({
             );
           },
         },
-        ...(attention.facet === "muted"
-          ? [
-              {
-                id: "dismissReason",
-                header: "Dismiss reason",
-                size: 280,
-                cell: ({ row }) => {
-                  const reasons = Array.from(
-                    new Set(
-                      attentionRawIssues(row.original)
-                        .map((issue) => issue.mutedReason?.trim())
-                        .filter((reason): reason is string => !!reason),
-                    ),
-                  );
-                  return reasons.length > 0 ? (
-                    <span className="block break-words">
-                      {reasons.join("; ")}
-                    </span>
-                  ) : (
-                    <span className="text-muted-foreground">—</span>
-                  );
-                },
-              } satisfies ColumnDef<CatalogItem>,
-            ]
-          : []),
         {
           id: "issue",
           header: "Issue",
-          size: 220,
-          cell: ({ row }) => (
-            <div className="flex min-w-0 flex-wrap gap-1.5">
-              {attentionIssues(row.original).map((issue) => (
-                <McpServerIssueBadge
-                  key={issue.kind}
-                  issue={issue}
-                  showDetail={false}
-                />
-              ))}
-            </div>
-          ),
-        },
-        {
-          id: "owner",
-          header: "Owner",
-          size: 220,
+          size: 440,
           cell: ({ row }) => {
             const item = row.original;
             const issues = attentionRawIssues(item);
@@ -386,10 +345,36 @@ export function McpServerTable({
                   servers: attentionServers(item),
                 }).label
               : "—";
+            const reasons = Array.from(
+              new Set(
+                issues
+                  .map((issue) => issue.mutedReason?.trim())
+                  .filter((reason): reason is string => !!reason),
+              ),
+            );
             return (
-              <span className="block break-words" title={owner}>
-                {owner}
-              </span>
+              <div className="min-w-0 space-y-1.5">
+                <div className="flex min-w-0 flex-wrap gap-1.5">
+                  {attentionIssues(item).map((issue) => (
+                    <McpServerIssueBadge
+                      key={issue.kind}
+                      issue={issue}
+                      showDetail={false}
+                    />
+                  ))}
+                </div>
+                <p className="break-words text-xs text-muted-foreground">
+                  {attention.facet === "muted" ? (
+                    <>
+                      {reasons.length > 0
+                        ? `Reason: ${reasons.join("; ")}`
+                        : "No dismissal reason"}
+                      <span aria-hidden> · </span>
+                    </>
+                  ) : null}
+                  <span title={owner}>Owner: {owner}</span>
+                </p>
+              </div>
             );
           },
         },
@@ -467,12 +452,7 @@ export function McpServerTable({
         }
         emptyMessage="No MCP servers found."
         hidePaginationWhenSinglePage
-        fixedWidthColumnIds={
-          attention
-            ? ["select", "issue", "owner", "dismissReason", "actions"]
-            : undefined
-        }
-        flexibleColumnIds={attention ? ["name"] : undefined}
+        fixedWidthColumnIds={attention ? ["select", "actions"] : undefined}
       />
     </>
   );

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
@@ -174,7 +174,7 @@ export function McpServerTable({
       id: "name",
       accessorKey: "name",
       header: "MCP Server",
-      size: 460,
+      size: 320,
       cell: ({ row }) => {
         const item = row.original;
         return (
@@ -187,7 +187,7 @@ export function McpServerTable({
     },
     {
       id: "tools",
-      size: 72,
+      size: 64,
       header: () => <div className="text-right">Tools</div>,
       cell: ({ row }) => (
         <div className="text-right text-sm text-muted-foreground">
@@ -197,7 +197,7 @@ export function McpServerTable({
     },
     {
       id: "author",
-      size: 160,
+      size: 120,
       header: "Accessible to",
       cell: ({ row }) => (
         <ResourceVisibilityBadge
@@ -214,7 +214,7 @@ export function McpServerTable({
       id: "status",
       // The table is a scanning surface: the status label is enough here.
       // Diagnosis and remediation live on the server page and attention facet.
-      size: 180,
+      size: 260,
       header: "Status",
       cell: ({ row }) => {
         const item = row.original;
@@ -263,7 +263,7 @@ export function McpServerTable({
     },
     {
       id: "actions",
-      size: 180,
+      size: 160,
       header: () => <div className="text-right">Actions</div>,
       cell: ({ row }) => {
         const item = row.original;
@@ -321,7 +321,7 @@ export function McpServerTable({
           id: "name",
           accessorKey: "name",
           header: "MCP Server",
-          size: 420,
+          size: 280,
           cell: ({ row }) => {
             const item = row.original;
             return (
@@ -335,7 +335,7 @@ export function McpServerTable({
         {
           id: "issue",
           header: "Issue",
-          size: 360,
+          size: 420,
           cell: ({ row }) => {
             const item = row.original;
             const issues = attentionRawIssues(item);
@@ -717,6 +717,7 @@ function McpServerRowActions({
     (issue) => issue.kind === "failed-to-start" || issue.kind === "not-running",
   );
   const actions: TableRowAction[] = [];
+  const alertActions: TableRowAction[] = [];
   if (reauthIssue) {
     actions.push({
       icon: <KeyRound className="h-4 w-4" />,
@@ -792,17 +793,17 @@ function McpServerRowActions({
       });
     }
   }
-  // Dismiss/Restore is queue management, not an overflow action. Keep it
-  // visible beside the row's other first-class actions.
+  // Dismiss/Restore is queue management, so reserve inline space for it even
+  // when the row has enough capabilities to overflow its action cluster.
   if (dismissTargets.length > 0) {
-    actions.push({
+    alertActions.push({
       icon: <BellOff className="h-4 w-4" />,
       label: dismissTargets.length === 1 ? "Dismiss alert" : "Dismiss alerts",
       onClick: () => setDismissOpen(true),
     });
   }
   if (restoreTargets.length > 0) {
-    actions.push({
+    alertActions.push({
       icon: <Bell className="h-4 w-4" />,
       label: restoreTargets.length === 1 ? "Restore alert" : "Restore alerts",
       disabled: restoreMutation.isPending,
@@ -833,12 +834,23 @@ function McpServerRowActions({
       href: logsAction.href,
     });
   }
-  if (actions.length === 0) return null;
+  if (actions.length === 0 && alertActions.length === 0) return null;
+
+  const inlineActionCount = Math.max(0, 3 - alertActions.length);
+  const inlineActions = [
+    ...actions.slice(0, inlineActionCount),
+    ...alertActions,
+  ];
+  const dropdownActions = actions.slice(inlineActionCount);
 
   return (
     <>
       <div className="flex justify-end">
-        <TableRowActions itemName={item.name} actions={actions} />
+        <TableRowActions
+          itemName={item.name}
+          actions={inlineActions}
+          dropdownActions={dropdownActions}
+        />
       </div>
 
       <UninstallServerDialog

--- a/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.test.tsx
@@ -2,55 +2,8 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
   emptyRegistryFilters,
-  RegistryAttentionFacets,
   RegistryFilterChips,
 } from "./registry-list-controls";
-
-const counts = { you: 2, others: 1, muted: 0 };
-
-describe("RegistryAttentionFacets", () => {
-  it("names the visible actor for non-admin viewers", () => {
-    render(
-      <RegistryAttentionFacets
-        counts={counts}
-        totalCount={6}
-        othersLabel="Waiting action by owner@example.com"
-        showOthers
-        selected={null}
-        onSelect={vi.fn()}
-      />,
-    );
-
-    expect(
-      screen.getByRole("button", {
-        name: "Waiting action by owner@example.com (1)",
-      }),
-    ).toBeInTheDocument();
-    const facets = screen.getByTestId("mcp-registry-attention-facets");
-    const beta = screen.getByText("Beta");
-    expect(beta.previousElementSibling).toBe(facets);
-  });
-
-  it("omits the waiting facet for an installation admin", () => {
-    render(
-      <RegistryAttentionFacets
-        counts={{ ...counts, others: 0 }}
-        totalCount={6}
-        othersLabel="Waiting action by other user"
-        showOthers={false}
-        selected={null}
-        onSelect={vi.fn()}
-      />,
-    );
-
-    expect(screen.getAllByRole("button")).toHaveLength(2);
-    expect(screen.getByRole("button", { name: "All (6)" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Action required (2)" }),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/Waiting action by/)).toBeNull();
-  });
-});
 
 describe("RegistryFilterChips", () => {
   it("uses the issue label instead of exposing its URL slug", () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
@@ -18,12 +18,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { typeRole } from "@/lib/design/type-scale";
 import {
   MCP_SERVER_ISSUE_KINDS,
   type McpServerAttentionFacet,
 } from "@/lib/mcp/mcp-server-issues";
-import type { McpServerFacetCounts } from "@/lib/mcp/use-mcp-server-issues";
 import { cn } from "@/lib/utils";
 
 export type SortKey =
@@ -199,85 +197,6 @@ export function RegistrySortMenu({
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
-  );
-}
-
-/**
- * The list's audience facets, always visible rather than folded into the
- * Status popover. Installation admins omit the others facet because every
- * visible issue is actionable for them.
- *
- * Each count comes from `attentionCatalogIds`, so the numbers here and the
- * rows the list renders are the same computation.
- */
-export function RegistryAttentionFacets({
-  counts,
-  totalCount,
-  othersLabel,
-  showOthers,
-  selected,
-  onSelect,
-}: {
-  counts: McpServerFacetCounts;
-  /** Catalog items the list would show with no facet applied. */
-  totalCount: number;
-  othersLabel: string;
-  /** Installation admins can act on every visible issue. */
-  showOthers: boolean;
-  selected: McpServerAttentionFacet | null;
-  onSelect: (facet: McpServerAttentionFacet | null) => void;
-}) {
-  const facets: {
-    facet: McpServerAttentionFacet | null;
-    label: string;
-    count: number;
-  }[] = [
-    { facet: null, label: "All", count: totalCount },
-    { facet: "you", label: "Action required", count: counts.you },
-  ];
-  if (showOthers) {
-    facets.push({ facet: "others", label: othersLabel, count: counts.others });
-  }
-  // Dismissed is a facet the viewer created; nobody else needs a button for an
-  // empty box they have never used.
-  if (counts.muted > 0) {
-    facets.push({ facet: "muted", label: "Dismissed", count: counts.muted });
-  }
-
-  return (
-    <div className="flex w-max items-center gap-2">
-      <fieldset
-        className="flex w-max items-stretch rounded-md border p-0.5"
-        data-testid="mcp-registry-attention-facets"
-      >
-        <legend className="sr-only">
-          Filter MCP servers by who has to act
-        </legend>
-        {facets.map(({ facet, label, count }) => (
-          <button
-            key={facet ?? "all"}
-            type="button"
-            aria-label={`${label} (${count})`}
-            aria-pressed={selected === facet}
-            onClick={() => onSelect(facet)}
-            data-testid={`mcp-registry-facet-${facet ?? "all"}`}
-            className={cn(
-              typeRole({ role: "body" }),
-              "inline-flex flex-none items-center justify-center gap-1 whitespace-nowrap rounded-[5px] px-2.5 py-1 transition-colors hover:bg-accent",
-              selected === facet && "bg-secondary font-medium",
-            )}
-          >
-            <span>{label}</span>
-            <span className="tabular-nums text-muted-foreground">
-              ({count})
-            </span>
-          </button>
-        ))}
-      </fieldset>
-      <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
-        Beta
-      </Badge>
-    </div>
   );
 }
 

--- a/platform/frontend/src/app/mcp/registry/layout.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/layout.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
+import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
+import {
+  useMcpDeploymentStatuses,
+  useMcpServers,
+} from "@/lib/mcp/mcp-server.query";
+import { useMcpServerIssues } from "@/lib/mcp/use-mcp-server-issues";
+import McpCatalogLayout from "./layout";
+
+vi.mock("next/navigation");
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/config/config.query");
+vi.mock("@/lib/hooks/use-app-name");
+vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
+  useInternalMcpCatalog: vi.fn(),
+}));
+vi.mock("@/lib/mcp/mcp-server.query", () => ({
+  useMcpDeploymentStatuses: vi.fn(),
+  useMcpServers: vi.fn(),
+}));
+vi.mock("@/lib/mcp/use-mcp-server-issues", () => ({
+  useMcpServerIssues: vi.fn(),
+}));
+
+describe("McpCatalogLayout", () => {
+  beforeEach(() => {
+    vi.mocked(usePathname).mockReturnValue("/mcp/registry");
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("status=needs-my-action") as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+      replace: vi.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(useFeature).mockImplementation(
+      (feature) => feature === "mcpServerAlertingEnabled",
+    );
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useInternalMcpCatalog).mockReturnValue({
+      data: [{ id: "first" }, { id: "second" }, { id: "third" }],
+    } as ReturnType<typeof useInternalMcpCatalog>);
+    vi.mocked(useMcpServers).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useMcpServers>);
+    vi.mocked(useMcpDeploymentStatuses).mockReturnValue({
+      statuses: {},
+      state: "disabled",
+    });
+    vi.mocked(useMcpServerIssues).mockReturnValue({
+      issuesByCatalog: new Map(),
+      facetCounts: { you: 1, others: 1, muted: 0 },
+    });
+  });
+
+  it("renders registry audience views as header tabs", () => {
+    render(
+      <McpCatalogLayout>
+        <div>Registry content</div>
+      </McpCatalogLayout>,
+    );
+
+    expect(screen.getAllByRole("link", { name: /All.*3/ })).toHaveLength(2);
+    const actionRequired = screen.getByTestId(
+      "mcp-registry-action-required-tab",
+    );
+    expect(actionRequired).toHaveTextContent("Action required");
+    expect(actionRequired).toHaveTextContent("(1)");
+    expect(actionRequired).toHaveTextContent("Beta");
+    expect(actionRequired).toHaveAttribute("aria-current", "page");
+    expect(
+      screen.queryByTestId("mcp-registry-attention-facets"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/layout.tsx
+++ b/platform/frontend/src/app/mcp/registry/layout.tsx
@@ -1,13 +1,26 @@
 "use client";
 
+import { ARCHESTRA_MCP_CATALOG_ID } from "@archestra/shared";
 import { Plus } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { PageLayout } from "@/components/page-layout";
+import { Badge } from "@/components/ui/badge";
 import { PermissionButton } from "@/components/ui/permission-button";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
+import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
+import {
+  useMcpDeploymentStatuses,
+  useMcpServers,
+} from "@/lib/mcp/mcp-server.query";
+import { useMcpServerIssues } from "@/lib/mcp/use-mcp-server-issues";
+import { waitingActionFacetLabel } from "./_parts/mcp-server-attention-owner";
 import {
   ATTENTION_FACET_STATUS_VALUES,
+  mcpRegistryFacetHref,
   REGISTRY_STATUS_PARAM,
+  selectedAttentionFacet,
 } from "./_parts/registry-list-controls";
 
 /**
@@ -67,18 +80,11 @@ export default function McpCatalogLayout({
     return <div className="mx-auto w-full px-6 py-6 md:px-6">{children}</div>;
   }
 
-  // The main list navigates to the routed setup wizard.
-  const registryActionButton = isMainRegistry ? (
-    <PermissionButton
-      permissions={{ mcpRegistry: ["create"] }}
-      onClick={() => router.push("/mcp/registry/new")}
-    >
-      <Plus className="h-4 w-4" />
-      Add MCP Server
-    </PermissionButton>
-  ) : undefined;
-
-  return (
+  return isMainRegistry ? (
+    <McpRegistryListLayout onAdd={() => router.push("/mcp/registry/new")}>
+      {children}
+    </McpRegistryListLayout>
+  ) : (
     <PageLayout
       title="MCP Registry"
       description={
@@ -86,10 +92,127 @@ export default function McpCatalogLayout({
           Manage your own list of MCP servers and make them available to agents.
         </>
       }
-      actionButton={registryActionButton}
     >
       {children}
     </PageLayout>
+  );
+}
+
+function McpRegistryListLayout({
+  children,
+  onAdd,
+}: {
+  children: React.ReactNode;
+  onAdd: () => void;
+}) {
+  const searchParams = useSearchParams();
+  const alertingEnabled = useFeature("mcpServerAlertingEnabled") === true;
+  const { data: catalogItems } = useInternalMcpCatalog();
+  const { data: servers } = useMcpServers();
+  const { statuses } = useMcpDeploymentStatuses();
+  const { issuesByCatalog, facetCounts } = useMcpServerIssues(statuses);
+  const { data: userIsMcpServerAdmin } = useHasPermissions({
+    mcpServerInstallation: ["admin"],
+  });
+  const selectedFacet = selectedAttentionFacet(
+    new Set(searchParams.getAll(REGISTRY_STATUS_PARAM)),
+  );
+  const totalCount = (catalogItems ?? []).filter(
+    (item) => item.id !== ARCHESTRA_MCP_CATALOG_ID,
+  ).length;
+  const othersLabel = waitingActionFacetLabel({
+    issuesByCatalog,
+    servers: servers ?? [],
+  });
+  const tabs = alertingEnabled
+    ? [
+        {
+          label: <RegistryTabLabel label="All" count={totalCount} />,
+          href: "/mcp/registry",
+          active: selectedFacet === null,
+        },
+        {
+          label: (
+            <RegistryTabLabel
+              label="Action required"
+              count={facetCounts.you}
+              beta
+            />
+          ),
+          href: mcpRegistryFacetHref("you"),
+          active: selectedFacet === "you",
+          testId: "mcp-registry-action-required-tab",
+        },
+        ...(!userIsMcpServerAdmin && facetCounts.others > 0
+          ? [
+              {
+                label: (
+                  <RegistryTabLabel
+                    label={othersLabel}
+                    count={facetCounts.others}
+                  />
+                ),
+                href: mcpRegistryFacetHref("others"),
+                active: selectedFacet === "others",
+              },
+            ]
+          : []),
+        ...(facetCounts.muted > 0
+          ? [
+              {
+                label: (
+                  <RegistryTabLabel
+                    label="Dismissed"
+                    count={facetCounts.muted}
+                  />
+                ),
+                href: mcpRegistryFacetHref("muted"),
+                active: selectedFacet === "muted",
+              },
+            ]
+          : []),
+      ]
+    : [];
+
+  return (
+    <PageLayout
+      title="MCP Registry"
+      description="Manage your own list of MCP servers and make them available to agents."
+      tabs={tabs}
+      actionButton={
+        <PermissionButton
+          permissions={{ mcpRegistry: ["create"] }}
+          onClick={onAdd}
+        >
+          <Plus className="h-4 w-4" />
+          <span>Add MCP Server</span>
+        </PermissionButton>
+      }
+    >
+      {children}
+    </PageLayout>
+  );
+}
+
+function RegistryTabLabel({
+  label,
+  count,
+  beta = false,
+}: {
+  label: string;
+  count: number;
+  beta?: boolean;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span>{label}</span>
+      <span className="tabular-nums text-muted-foreground">({count})</span>
+      {beta ? (
+        <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+          Beta
+        </Badge>
+      ) : null}
+    </span>
   );
 }
 

--- a/platform/frontend/src/app/plugins/[id]/page.client.tsx
+++ b/platform/frontend/src/app/plugins/[id]/page.client.tsx
@@ -55,7 +55,6 @@ import {
 import { PluginGithubUpdatesDialog } from "../_parts/plugin-github-updates-dialog";
 import { PluginInstallDialog } from "../_parts/plugin-install-dialog";
 import {
-  ARCHESTRA_PLUGIN_PROVENANCE_LABEL,
   CLIENT_LABELS,
   isArchestraPlugin,
   PLUGIN_DESCRIPTION_FALLBACK,
@@ -144,6 +143,7 @@ function PluginDetailView({
   const { data: canUpdate } = useHasPermissions({
     plugin: ["update", "admin"],
   });
+  const appName = useAppName();
 
   const isGithubPlugin = plugin.sourceKind === "github";
   const isArchestra = isArchestraPlugin(plugin);
@@ -191,7 +191,7 @@ function PluginDetailView({
           )}
           {isArchestra && (
             <Badge variant="secondary" className="font-normal">
-              {ARCHESTRA_PLUGIN_PROVENANCE_LABEL}
+              {appName}
             </Badge>
           )}
           {!plugin.enabled && (

--- a/platform/frontend/src/app/plugins/[id]/page.test.tsx
+++ b/platform/frontend/src/app/plugins/[id]/page.test.tsx
@@ -233,8 +233,11 @@ describe("PluginDetailPage", () => {
     ).toHaveAttribute("data-language", "powershell");
   });
 
-  it("marks OpenAPPA as Archestra while retaining regular GitHub actions", async () => {
+  it("uses the configured app name for the featured plugin", async () => {
     const user = userEvent.setup();
+    vi.mocked(useAppearanceSettings).mockReturnValue({
+      data: { appName: "Northstar" },
+    } as unknown as ReturnType<typeof useAppearanceSettings>);
     renderPage({
       ...BASE_PLUGIN,
       sourceKind: "github",
@@ -244,7 +247,7 @@ describe("PluginDetailPage", () => {
       sourceMarketplacePluginName: "appa-runtime",
     });
 
-    expect(screen.getByText("Archestra")).toBeVisible();
+    expect(screen.getByText("Northstar")).toBeVisible();
     expect(screen.queryByText("Imported from GitHub")).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "More actions" }));
     expect(screen.getByRole("menuitem", { name: "Updates" })).toBeVisible();

--- a/platform/frontend/src/app/plugins/_parts/plugin-page-config.ts
+++ b/platform/frontend/src/app/plugins/_parts/plugin-page-config.ts
@@ -1,8 +1,5 @@
 export const PLUGIN_DESCRIPTION_FALLBACK = "No description.";
 
-// white-label-ok: OpenAPPA provenance names the upstream vendor, not this deployment.
-export const ARCHESTRA_PLUGIN_PROVENANCE_LABEL = "Archestra";
-
 export const CLIENT_LABELS: Record<string, string> = {
   "claude-code": "Claude Code",
   "copilot-cli": "Copilot CLI",

--- a/platform/frontend/src/app/plugins/page.client.test.tsx
+++ b/platform/frontend/src/app/plugins/page.client.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation");
+vi.mock("@/lib/config/config.query", () => ({ useFeature: () => true }));
+vi.mock("@/lib/hooks/use-app-name", () => ({
+  useAppName: () => "Northstar",
+}));
+vi.mock("@/lib/auth/auth.query", () => ({
+  useSession: () => ({ data: { user: { id: "user-1" } } }),
+  useHasPermissions: () => ({ data: true }),
+}));
+vi.mock("@/components/resource-scope-filter", () => ({
+  ActiveFilterBadges: () => null,
+  ResourceScopeFilter: () => <button type="button">Visibility filter</button>,
+  useScopeFilterParams: () => ({
+    scope: undefined,
+    teamIds: undefined,
+    authorIds: undefined,
+    excludeAuthorIds: undefined,
+    excludeOtherPersonal: false,
+    hasActiveScopeFilters: false,
+  }),
+}));
+vi.mock("@/components/search-input", () => ({
+  SearchInput: () => <input aria-label="Search plugins" />,
+}));
+vi.mock("./_parts/plugin-install-dialog", () => ({
+  PluginInstallDialog: () => null,
+}));
+vi.mock("@/lib/plugins/plugin.query", () => ({
+  usePlugins: () => ({
+    data: [PLUGIN],
+    isPending: false,
+    isFetching: false,
+    isLoadingError: false,
+    refetch: vi.fn(),
+  }),
+  useBulkDeletePlugins: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useBulkUpdatePluginVisibility: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useDeletePlugin: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import PluginsPage from "./page.client";
+
+const PLUGIN = vi.hoisted(() => ({
+  id: "plugin-1",
+  organizationId: "org-1",
+  authorId: "user-1",
+  scope: "org",
+  clientType: "claude-code",
+  supportedPlatforms: ["posix", "windows"],
+  pluginSlug: "policy-runtime",
+  displayName: "Policy Runtime",
+  description: "Applies approved policy hooks.",
+  contentHash: "hash-1",
+  sourceKind: "github",
+  sourceRepo: "archestra-ai/OpenAPPA",
+  sourceRef: "main",
+  sourceSha: "abc123",
+  sourceSubdir: null,
+  sourceExclude: [],
+  sourceMarketplaceRepo: "archestra-ai/OpenAPPA",
+  sourceMarketplacePath: ".claude-plugin/marketplace.json",
+  sourceMarketplacePluginName: "appa-runtime",
+  githubSyncInterval: "1h",
+  githubSyncRef: "main",
+  lastSyncedAt: "2026-08-23T18:00:00.000Z",
+  pendingSourceSha: null,
+  pendingContentHash: null,
+  pendingDetectedAt: null,
+  sourceId: "default-policy-runtime",
+  approvedContentHash: "hash-1",
+  approvedAt: null,
+  approvedBy: null,
+  enabled: true,
+  createdAt: "2026-08-01T12:00:00.000Z",
+  updatedAt: "2026-08-23T18:00:00.000Z",
+  deletedAt: null,
+  teams: [],
+  users: [],
+  fileCount: 13,
+}));
+
+describe("PluginsPage", () => {
+  beforeEach(() => {
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(usePathname).mockReturnValue("/plugins");
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as ReturnType<typeof useSearchParams>,
+    );
+  });
+
+  it("groups related facts into a compact, white-labelled table", () => {
+    render(<PluginsPage />);
+
+    for (const name of [
+      "Plugin",
+      "Compatibility",
+      "Visibility",
+      "Source",
+      "Activity",
+      "Actions",
+    ]) {
+      expect(screen.getByRole("columnheader", { name })).toBeInTheDocument();
+    }
+    for (const removed of ["Client", "Platforms", "Files", "Updated"]) {
+      expect(
+        screen.queryByRole("columnheader", { name: removed }),
+      ).not.toBeInTheDocument();
+    }
+    expect(screen.getByText("Northstar")).toBeVisible();
+    expect(screen.getByText("13 files")).toBeVisible();
+  });
+
+  it("keeps secondary filters behind More filters until applied", async () => {
+    const user = userEvent.setup();
+    render(<PluginsPage />);
+
+    expect(
+      screen.queryByRole("combobox", { name: "Filter by platform" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "More filters" }));
+
+    expect(
+      screen.getByRole("combobox", { name: "Filter by platform" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("combobox", { name: "Filter by source" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("combobox", { name: "Filter by repository" }),
+    ).toBeVisible();
+  });
+});

--- a/platform/frontend/src/app/plugins/page.client.tsx
+++ b/platform/frontend/src/app/plugins/page.client.tsx
@@ -65,6 +65,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { useBulkSelection } from "@/lib/hooks/use-bulk-selection";
 import {
   type PluginListItem,
@@ -83,7 +84,6 @@ import { PluginClientIcon } from "./_parts/plugin-client-icon";
 import { PluginGithubSyncBadge } from "./_parts/plugin-github-sync-badge";
 import { PluginInstallDialog } from "./_parts/plugin-install-dialog";
 import {
-  ARCHESTRA_PLUGIN_PROVENANCE_LABEL,
   CLIENT_LABELS,
   comparePinnedPluginTableOrder,
   comparePluginCatalogOrder,
@@ -151,6 +151,7 @@ function PluginsList() {
   } = usePlugins();
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
+  const appName = useAppName();
 
   const setFilter = useCallback(
     (name: string, value: string) => {
@@ -387,7 +388,6 @@ function PluginsList() {
       size: 420,
       cell: ({ row }) => {
         const plugin = row.original;
-        const repo = plugin.sourceMarketplaceRepo ?? plugin.sourceRepo;
         return (
           <div className="flex min-w-0 items-center gap-3">
             <PluginSourceIcon plugin={plugin} />
@@ -398,31 +398,8 @@ function PluginsList() {
                 </span>
                 {isArchestraPlugin(plugin) && (
                   <Badge variant="secondary" className="shrink-0">
-                    {ARCHESTRA_PLUGIN_PROVENANCE_LABEL}
+                    {appName}
                   </Badge>
-                )}
-                {repo && (
-                  <span className="truncate font-mono text-xs text-muted-foreground">
-                    {repo}
-                  </span>
-                )}
-                <PluginGithubSyncBadge plugin={plugin} />
-                {plugin.pendingSourceSha && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Badge
-                        variant="outline"
-                        className="shrink-0 gap-1 border-amber-500/40 text-amber-600 dark:text-amber-400"
-                      >
-                        <Github className="h-3 w-3" />
-                        update
-                      </Badge>
-                    </TooltipTrigger>
-                    <TooltipContent className="max-w-xs">
-                      A new source commit is waiting for review on the plugin
-                      page.
-                    </TooltipContent>
-                  </Tooltip>
                 )}
                 {!plugin.enabled && (
                   <Badge variant="outline" className="shrink-0">
@@ -441,18 +418,41 @@ function PluginsList() {
       },
     },
     {
-      id: "client",
-      size: 120,
-      header: "Client",
-      cell: ({ row }) => (
-        <Badge
-          variant="secondary"
-          className="gap-1.5 font-normal [&_img]:size-3.5"
-        >
-          {clientFilterIcon(row.original.clientType)}
-          {CLIENT_LABELS[row.original.clientType] ?? row.original.clientType}
-        </Badge>
-      ),
+      id: "compatibility",
+      size: 190,
+      header: "Compatibility",
+      cell: ({ row }) => {
+        const plugin = row.original;
+        const platforms = plugin.supportedPlatforms;
+        const platformLabel = [
+          platforms.includes("posix") ? "macOS and Linux" : null,
+          platforms.includes("windows") ? "Windows" : null,
+        ]
+          .filter(Boolean)
+          .join(", ");
+        return (
+          <div className="flex min-w-0 items-center gap-2">
+            <Badge
+              variant="secondary"
+              className="min-w-0 gap-1.5 font-normal [&_img]:size-3.5"
+            >
+              {clientFilterIcon(plugin.clientType)}
+              <span className="truncate">
+                {CLIENT_LABELS[plugin.clientType] ?? plugin.clientType}
+              </span>
+            </Badge>
+            <span
+              className="flex shrink-0 items-center gap-1.5"
+              role="img"
+              aria-label={`Supported platforms: ${platformLabel}`}
+              title={platformLabel}
+            >
+              {platforms.includes("posix") && <OsLogos platform="macos" />}
+              {platforms.includes("windows") && <OsLogos platform="windows" />}
+            </span>
+          </div>
+        );
+      },
     },
     {
       id: "visibility",
@@ -471,40 +471,50 @@ function PluginsList() {
       ),
     },
     {
-      id: "platforms",
-      size: 100,
-      header: "Platforms",
+      id: "source",
+      size: 250,
+      header: "Source",
       cell: ({ row }) => {
-        const platforms = row.original.supportedPlatforms;
-        const label = [
-          platforms.includes("posix") ? "macOS and Linux" : null,
-          platforms.includes("windows") ? "Windows" : null,
-        ]
-          .filter(Boolean)
-          .join(", ");
+        const plugin = row.original;
+        const repo = plugin.sourceMarketplaceRepo ?? plugin.sourceRepo;
+        if (plugin.sourceKind !== "github") {
+          return (
+            <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
+              <Pencil className="size-3.5" />
+              Manual
+            </span>
+          );
+        }
         return (
-          <div
-            className="flex items-center gap-2"
-            role="img"
-            aria-label={`Supported platforms: ${label}`}
-            title={label}
-          >
-            {platforms.includes("posix") && <OsLogos platform="macos" />}
-            {platforms.includes("windows") && <OsLogos platform="windows" />}
+          <div className="min-w-0 space-y-1">
+            <div className="flex items-center gap-1.5">
+              <PluginGithubSyncBadge plugin={plugin} />
+              {plugin.pendingSourceSha && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge
+                      variant="outline"
+                      className="shrink-0 gap-1 border-amber-500/40 text-amber-600 dark:text-amber-400"
+                    >
+                      <Github className="h-3 w-3" />
+                      Update
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    A new source commit is waiting for review on the plugin
+                    page.
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+            {repo ? (
+              <div className="truncate font-mono text-xs text-muted-foreground">
+                {repo}
+              </div>
+            ) : null}
           </div>
         );
       },
-    },
-    {
-      id: "files",
-      size: 90,
-      header: () => <div className="text-right">Files</div>,
-      cell: ({ row }) => (
-        <div className="text-right text-sm text-muted-foreground">
-          {row.original.fileCount}{" "}
-          {row.original.fileCount === 1 ? "file" : "files"}
-        </div>
-      ),
     },
     {
       id: "updatedAt",
@@ -519,7 +529,7 @@ function PluginsList() {
             new Date(left.original.updatedAt).getTime() -
             new Date(right.original.updatedAt).getTime(),
         }),
-      size: 130,
+      size: 160,
       header: ({ column }) => (
         <div className="flex justify-end pr-4">
           <Button
@@ -527,14 +537,20 @@ function PluginsList() {
             className="h-auto !p-0 font-medium hover:bg-transparent"
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
-            Updated
+            Activity
             <SortIcon isSorted={column.getIsSorted()} />
           </Button>
         </div>
       ),
       cell: ({ row }) => (
-        <div className="pr-4 text-right text-sm text-muted-foreground">
-          {formatRelativeTimeFromNow(row.original.updatedAt)}
+        <div className="space-y-0.5 pr-4 text-right text-sm">
+          <div>
+            {row.original.fileCount}{" "}
+            {row.original.fileCount === 1 ? "file" : "files"}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Updated {formatRelativeTimeFromNow(row.original.updatedAt)}
+          </div>
         </div>
       ),
     },
@@ -601,15 +617,115 @@ function PluginsList() {
                 <FilterBar
                   className="mb-0"
                   onClearFilters={hasActiveFilters ? clearFilters : undefined}
+                  moreFilters={[
+                    {
+                      key: "visibility",
+                      label: "Visibility",
+                      active: scopeFilter.hasActiveScopeFilters,
+                      control: (
+                        <ResourceScopeFilter
+                          ownerLabelPlural="plugins"
+                          adminPermission={{ plugin: ["admin"] }}
+                        />
+                      ),
+                    },
+                    {
+                      key: "platform",
+                      label: "Platform",
+                      active: platform !== "all",
+                      control: (
+                        <FacetSelect
+                          label="Filter by platform"
+                          value={platform}
+                          onChange={(value) => setFilter("platform", value)}
+                          options={[
+                            ["all", "All platforms"],
+                            [
+                              "posix",
+                              "macOS / Linux",
+                              <OsLogos key="posix" platform="macos" />,
+                            ],
+                            [
+                              "windows",
+                              "Windows",
+                              <OsLogos key="windows" platform="windows" />,
+                            ],
+                          ]}
+                        />
+                      ),
+                    },
+                    {
+                      key: "source",
+                      label: "Source",
+                      active: source !== "all",
+                      control: (
+                        <FacetSelect
+                          label="Filter by source"
+                          value={source}
+                          onChange={(value) => setFilter("source", value)}
+                          options={[
+                            ["all", "All sources"],
+                            [
+                              "github",
+                              "GitHub",
+                              <Github key="github" className="size-4" />,
+                            ],
+                            [
+                              "manual",
+                              "Manual",
+                              <Pencil key="manual" className="size-4" />,
+                            ],
+                          ]}
+                        />
+                      ),
+                    },
+                    ...(sourceRepos.length > 0
+                      ? [
+                          {
+                            key: "repository",
+                            label: "Repository",
+                            active: !!sourceRepo,
+                            control: (
+                              <FacetSelect
+                                label="Filter by repository"
+                                value={sourceRepo || "all"}
+                                onChange={(value) =>
+                                  setFilter(
+                                    "sourceRepo",
+                                    value === "all" ? "" : value,
+                                  )
+                                }
+                                options={[
+                                  ["all", "All repositories"],
+                                  ...[...sourceRepos]
+                                    .sort(comparePluginRepositoryOrder)
+                                    .map(
+                                      (repo) =>
+                                        [
+                                          repo,
+                                          repo,
+                                          <RepositoryOwnerIcon
+                                            key={repo}
+                                            repo={repo}
+                                          />,
+                                          repo.toLowerCase() ===
+                                          "archestra-ai/openappa"
+                                            ? "plugin-featured-repository-option"
+                                            : undefined,
+                                        ] as const,
+                                    ),
+                                ]}
+                              />
+                            ),
+                          },
+                        ]
+                      : []),
+                  ]}
                   actions={<TableCardViewToggle />}
                 >
                   <SearchInput
                     paramName="search"
                     className={filterSearchClass}
-                  />
-                  <ResourceScopeFilter
-                    ownerLabelPlural="plugins"
-                    adminPermission={{ plugin: ["admin"] }}
                   />
                   <FacetSelect
                     label="Filter by client"
@@ -631,67 +747,6 @@ function PluginsList() {
                       ["cursor", "Cursor", clientFilterIcon("cursor")],
                     ]}
                   />
-                  <FacetSelect
-                    label="Filter by platform"
-                    value={platform}
-                    onChange={(value) => setFilter("platform", value)}
-                    options={[
-                      ["all", "All platforms"],
-                      [
-                        "posix",
-                        "macOS / Linux",
-                        <OsLogos key="posix" platform="macos" />,
-                      ],
-                      [
-                        "windows",
-                        "Windows",
-                        <OsLogos key="windows" platform="windows" />,
-                      ],
-                    ]}
-                  />
-                  <FacetSelect
-                    label="Filter by source"
-                    value={source}
-                    onChange={(value) => setFilter("source", value)}
-                    options={[
-                      ["all", "All sources"],
-                      [
-                        "github",
-                        "GitHub",
-                        <Github key="github" className="size-4" />,
-                      ],
-                      [
-                        "manual",
-                        "Manual",
-                        <Pencil key="manual" className="size-4" />,
-                      ],
-                    ]}
-                  />
-                  {sourceRepos.length > 0 && (
-                    <FacetSelect
-                      label="Filter by repository"
-                      value={sourceRepo || "all"}
-                      onChange={(value) =>
-                        setFilter("sourceRepo", value === "all" ? "" : value)
-                      }
-                      options={[
-                        ["all", "All repositories"],
-                        ...[...sourceRepos]
-                          .sort(comparePluginRepositoryOrder)
-                          .map(
-                            (repo) =>
-                              [
-                                repo,
-                                repo,
-                                <RepositoryOwnerIcon key={repo} repo={repo} />,
-                                repo.toLowerCase() === "archestra-ai/openappa"
-                                  ? "plugin-featured-repository-option"
-                                  : undefined,
-                              ] as const,
-                          ),
-                      ]}
-                    />
-                  )}
                 </FilterBar>
                 <ActiveFilterBadges adminPermission={{ plugin: ["admin"] }} />
               </div>
@@ -833,10 +888,8 @@ function PluginsList() {
                     onPageRowIdsChange={bulkSelection.onPageRowIdsChange}
                     isLoading={isFetching}
                     fixedWidthColumnIds={[
-                      "client",
+                      "compatibility",
                       "visibility",
-                      "platforms",
-                      "files",
                       "updatedAt",
                     ]}
                     flexibleColumnIds={["displayName"]}

--- a/platform/frontend/src/components/page-layout.test.tsx
+++ b/platform/frontend/src/components/page-layout.test.tsx
@@ -90,6 +90,40 @@ describe("PageLayout tabs", () => {
     ).toHaveLength(0);
   });
 
+  it("accepts an explicit active tab for query-owned views", () => {
+    vi.mocked(usePathname).mockReturnValue("/mcp/registry");
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("status=needs-my-action") as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+
+    render(
+      <PageLayout
+        title="MCP Registry"
+        tabs={[
+          { label: "All", href: "/mcp/registry", active: false },
+          {
+            label: "Action required",
+            href: "/mcp/registry?status=needs-my-action",
+            active: true,
+            testId: "action-required-tab",
+          },
+        ]}
+      >
+        <div />
+      </PageLayout>,
+    );
+
+    expect(screen.getByTestId("action-required-tab")).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getAllByRole("link", { name: "All" })[0]).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
   /**
    * Below `md` the tab row shows the first `mobileVisibleCount` tabs and folds
    * the rest into a popover. Both rows are in the DOM at once, so a tab past

--- a/platform/frontend/src/components/page-layout.tsx
+++ b/platform/frontend/src/components/page-layout.tsx
@@ -55,7 +55,13 @@ export function PageLayout({
    * the desktop link only, which is the copy visible at the desktop viewports
    * the e2e suite runs at, so it resolves to exactly one element.
    */
-  tabs?: { label: React.ReactNode; href: string; testId?: string }[];
+  tabs?: {
+    label: React.ReactNode;
+    href: string;
+    testId?: string;
+    /** Override URL matching for tabs that represent query-owned views. */
+    active?: boolean;
+  }[];
   title: React.ReactNode;
   /**
    * Browser tab title, for pages whose visible `title` is composed markup (an
@@ -114,8 +120,8 @@ export function PageLayout({
   const mobileOverflowTabs = tabs.slice(mobileVisibleCount);
 
   // Check if the active tab is in the overflow
-  const activeOverflowTab = mobileOverflowTabs.find((tab) =>
-    isTabActive(pathname, tab.href, tabs),
+  const activeOverflowTab = mobileOverflowTabs.find(
+    (tab) => tab.active ?? isTabActive(currentUrl, tab.href, tabs),
   );
 
   return (
@@ -160,7 +166,8 @@ export function PageLayout({
               {/* Desktop: Show all tabs */}
               <div className="hidden md:flex gap-4 mb-0 overflow-x-auto whitespace-nowrap">
                 {tabs.map((tab) => {
-                  const isActive = isTabActive(currentUrl, tab.href, tabs);
+                  const isActive =
+                    tab.active ?? isTabActive(currentUrl, tab.href, tabs);
                   return (
                     <Link
                       key={tab.href}
@@ -185,7 +192,8 @@ export function PageLayout({
               {/* Mobile: Show first N tabs + overflow dropdown */}
               <div className="flex md:hidden gap-3 mb-0 items-center whitespace-nowrap overflow-x-auto">
                 {mobileVisibleTabs.map((tab) => {
-                  const isActive = isTabActive(currentUrl, tab.href, tabs);
+                  const isActive =
+                    tab.active ?? isTabActive(currentUrl, tab.href, tabs);
                   return (
                     <Link
                       key={tab.href}
@@ -242,11 +250,9 @@ export function PageLayout({
                         align="end"
                       >
                         {mobileOverflowTabs.map((tab) => {
-                          const isActive = isTabActive(
-                            currentUrl,
-                            tab.href,
-                            tabs,
-                          );
+                          const isActive =
+                            tab.active ??
+                            isTabActive(currentUrl, tab.href, tabs);
                           return (
                             <Link
                               key={tab.href}


### PR DESCRIPTION
## Summary

- move MCP Registry attention views into the page header tabs and use the canonical selection bar
- compact registry tables by consolidating issue context and tightening column width budgets
- simplify the Plugins table and secondary filters while respecting the configured application name