### PR TITLE
ci: put resource-starved jobs back on Blacksmith; move hibernation e2e to nightly

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -267,10 +267,8 @@ jobs:
     # check tasks and @frontend:check:ci itself runs tsc/vitest/knip/biome
     # concurrently — so it scales with cores: the same all-cache-miss
     # check:ci measured 1m51s on 16 vcpu vs 10m16s on 4-vcpu ubuntu-latest
-    # (whole job 3 min avg vs 15.2 min avg). CI_RUNNER_XL is the kill
-    # switch, same repo-variable pattern as MAC_MINI_CI below: set it to
-    # another label (e.g. ubuntu-latest) to reroute with no workflow change.
-    runs-on: ${{ vars.CI_RUNNER_XL || 'blacksmith-16vcpu-ubuntu-2404' }}
+    # (whole job 3 min avg vs 15.2 min avg).
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     # Backstop: on a turbo remote-cache hit every check here finishes well
     # under 10m, but leaked test-runner processes (vitest fork workers /
     # esbuild) occasionally orphan and hold the step's log pipe open, leaving

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -273,16 +273,13 @@ jobs:
     # under 10m, but leaked test-runner processes (vitest fork workers /
     # esbuild) occasionally orphan and hold the step's log pipe open, leaving
     # a *finished* job hanging until GitHub's 6h default. Fail fast instead.
-    # 30 was sized for fork PRs, which run without cache secrets and pay a
-    # full cold build on a 4vcpu runner. That is too tight for the private
-    # mirror, where task-env sessions open their PRs: ubuntu-latest is
-    # 4-vCPU/16-GB for public repos but 2-vCPU/7-GB for private ones, and the
-    # job that finishes in ~5 min here needed 22m28s on its one clean mirror
-    # run while 9 of the other 11 burned the whole budget (30m19s-30m42s,
-    # including one run started after remote caching was configured there).
-    # So those cancellations were the ceiling, not a hang. Sized for the
-    # slowest hardware this runs on, as backend-unit-tests below already is.
-    timeout-minutes: 45
+    # Sized for the slowest path this runs on: fork PRs, which run without
+    # cache secrets and pay a full cold build. On these 16-vcpu Blacksmith
+    # runners the job ran with this same 20-minute budget for months before
+    # the runner migration, and the private mirror's task-env PRs now use
+    # the same Blacksmith installation — so the 45-minute sizing for its
+    # 2-vCPU private ubuntu-latest runners no longer applies.
+    timeout-minutes: 20
     permissions:
       contents: write # Required to push generated code updates back to release-please PRs.
     defaults:
@@ -478,8 +475,8 @@ jobs:
   # the merge queue in minutes instead of blocking it for hours.
   #
   # The backend unit test shards deliberately stay off the mac mini: the
-  # merge queue runs several stacked groups concurrently, and 16 shards per
-  # group oversubscribe the machine's 3 runner slots — queued-behind-saturation
+  # merge queue runs several stacked groups concurrently, and even 4 shards
+  # per group oversubscribe the machine's 3 runner slots — queued-behind-saturation
   # is indistinguishable from dead for the jobs involved and adds minutes of
   # merge latency per group.
   #
@@ -593,23 +590,25 @@ jobs:
 
   # Backend unit tests, sharded across parallel runners. Vitest's --shard
   # slices the file list deterministically (SHA1 of each path), so the
-  # sixteen jobs partition the suite exactly once. Splitting this out of the
-  # lint job takes the suite off the workflow's critical path. Standard
-  # GitHub-hosted runners are free on public repos, so the wide shard count
-  # trades (free) per-shard setup for wall-clock.
+  # four jobs partition the suite exactly once. Splitting this out of the
+  # lint job takes the suite off the workflow's critical path. Four shards
+  # on 16-vcpu Blacksmith runners are the measured sweet spot (the July
+  # shape, ~3-3.5 min per shard): the wide 16-shard fan-out on free 4-vcpu
+  # runners paid the per-shard module-import overhead sixteen times (vitest
+  # measured import 365s of a 402s shard wall) and still ran 6-9 min per
+  # shard.
   backend-unit-tests:
-    name: Backend Unit Tests (shard ${{ matrix.shard }}/16)
+    name: Backend Unit Tests (shard ${{ matrix.shard }}/4)
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     # A full local suite run is ~4 min on comparable hardware; a shard is a
-    # sixteenth of that plus setup. Sized for the slowest hardware this runs
-    # on rather than this repo's: ubuntu-latest is 4-vCPU/16-GB for public
-    # repos but 2-vCPU/7-GB for private ones, and on the private mirror where
-    # task-env sessions open their PRs the same shard takes ~2x as long (9-14
-    # min observed, against the 15 the public runners never came close to).
-    # Beyond this, something is hung.
-    timeout-minutes: 25
+    # quarter of that plus setup and the cargo build (~3-3.5 min/shard in
+    # the pre-migration July runs on these same runners). The private
+    # mirror's task-env PRs run on the same Blacksmith installation now, so
+    # the old 2-vCPU private ubuntu-latest sizing no longer applies. Beyond
+    # this, something is hung.
+    timeout-minutes: 15
     permissions:
       contents: read
     defaults:
@@ -623,7 +622,7 @@ jobs:
       # failure picture in one pass.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -641,7 +640,7 @@ jobs:
       # platform-specific and the remote cache is shared with dev machines),
       # so every shard really compiles the three Rust crates: measured at
       # 2m30s-3m22s per shard on a cold 4vcpu runner. A warm cargo target
-      # dir turns that into an incremental no-op. All sixteen shards restore
+      # dir turns that into an incremental no-op. All four shards restore
       # the same entry (shared-key); only shard 1 saves. Fresh PR branches
       # restore the entry maintained by the warm-backend-build-cache job on
       # main pushes (Actions caches only flow down from the default branch).
@@ -667,11 +666,11 @@ jobs:
             pnpm exec turbo build --filter="@backend^..."
           }
 
-      - name: Run backend unit tests (shard ${{ matrix.shard }} of 16)
+      - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
         working-directory: ./platform/backend
         env:
           SHARD: ${{ matrix.shard }}
-        run: pnpm exec vitest run --shard="${SHARD}/16"
+        run: pnpm exec vitest run --shard="${SHARD}/4"
 
   # Stable-named gate over the shard matrix so branch protection / merge queue
   # can require a single check ("Backend Unit Tests") regardless of shard count.

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -262,17 +262,15 @@ jobs:
     # bot-pr-guard (see above): contributor bot only — release-please PRs
     # need this job's codegen auto-commit.
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'
-    # Runner-size knob, same repo-variable pattern as MAC_MINI_CI below: when
-    # CI_RUNNER_XL names a runner label (a 16-vcpu-class GitHub larger runner,
-    # or e.g. blacksmith-16vcpu-ubuntu-2404), this job runs there; unset/empty
-    # falls back to the free standard runner, so the knob is inert until the
-    # label exists. This job is the PR workflow's wall-clock and its work is
-    # embarrassingly parallel — turbo fans out six check tasks and
-    # @frontend:check:ci itself runs tsc/vitest/knip/biome concurrently — so
-    # it scales with cores: the same all-cache-miss check:ci measured 1m51s on
-    # a 16-vcpu runner vs 10m16s on 4-vcpu ubuntu-latest (whole job 3 min avg
-    # before the runner migration vs 15.2 min avg after).
-    runs-on: ${{ vars.CI_RUNNER_XL || 'ubuntu-latest' }}
+    # Back on a 16-vcpu Blacksmith runner: this job is the PR workflow's
+    # wall-clock and its work is embarrassingly parallel — turbo fans out six
+    # check tasks and @frontend:check:ci itself runs tsc/vitest/knip/biome
+    # concurrently — so it scales with cores: the same all-cache-miss
+    # check:ci measured 1m51s on 16 vcpu vs 10m16s on 4-vcpu ubuntu-latest
+    # (whole job 3 min avg vs 15.2 min avg). CI_RUNNER_XL is the kill
+    # switch, same repo-variable pattern as MAC_MINI_CI below: set it to
+    # another label (e.g. ubuntu-latest) to reroute with no workflow change.
+    runs-on: ${{ vars.CI_RUNNER_XL || 'blacksmith-16vcpu-ubuntu-2404' }}
     # Backstop: on a turbo remote-cache hit every check here finishes well
     # under 10m, but leaked test-runner processes (vitest fork workers /
     # esbuild) occasionally orphan and hold the step's log pipe open, leaving

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -262,7 +262,17 @@ jobs:
     # bot-pr-guard (see above): contributor bot only — release-please PRs
     # need this job's codegen auto-commit.
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'
-    runs-on: ubuntu-latest
+    # Runner-size knob, same repo-variable pattern as MAC_MINI_CI below: when
+    # CI_RUNNER_XL names a runner label (a 16-vcpu-class GitHub larger runner,
+    # or e.g. blacksmith-16vcpu-ubuntu-2404), this job runs there; unset/empty
+    # falls back to the free standard runner, so the knob is inert until the
+    # label exists. This job is the PR workflow's wall-clock and its work is
+    # embarrassingly parallel — turbo fans out six check tasks and
+    # @frontend:check:ci itself runs tsc/vitest/knip/biome concurrently — so
+    # it scales with cores: the same all-cache-miss check:ci measured 1m51s on
+    # a 16-vcpu runner vs 10m16s on 4-vcpu ubuntu-latest (whole job 3 min avg
+    # before the runner migration vs 15.2 min avg after).
+    runs-on: ${{ vars.CI_RUNNER_XL || 'ubuntu-latest' }}
     # Backstop: on a turbo remote-cache hit every check here finishes well
     # under 10m, but leaked test-runner processes (vitest fork workers /
     # esbuild) occasionally orphan and hold the step's log pipe open, leaving

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -4,9 +4,11 @@ name: Platform E2E Tests
 # For PRs, add the "run-e2e" label to trigger the full E2E suite on demand.
 # Remove and re-add the label to re-trigger after new commits.
 #
-# MCP idle-hibernation smoke coverage runs in the merge queue with real idle
-# windows excluded. Nightly, workflow_dispatch, and the separate
-# "run-e2e-hibernation" label run the complete serial project.
+# MCP idle-hibernation coverage stays OFF the merge queue: the leg is ~10
+# minutes of mostly serial waiting, which every queued merge was paying.
+# The nightly schedule and workflow_dispatch run the complete serial
+# project; the separate "run-e2e-hibernation" label runs it on a PR on
+# demand.
 #
 # Three test environments:
 #   - Lite: the platform as one quickstart-mode container plus WireMock and
@@ -95,15 +97,15 @@ jobs:
       matrix:
         include:
           - name: Platform
-            # CI_RUNNER_XL knob (see the lint job in on-pull-requests.yml).
-            # The platform image build is compile-bound (pnpm install + turbo
-            # build + Rust NAPI inside docker build): measured 12-13 min on
-            # 4-vcpu ubuntu-latest vs ~30s on a 16-vcpu runner with a warm
-            # local layer cache. A bigger runner cannot bring the warm-cache
-            # number back, but it claws back the compile-heavy layers that
-            # the registry cache-from misses on every source change. This is
-            # merge-queue critical path: the lite legs serialize behind it.
-            runner: ${{ vars.CI_RUNNER_XL || 'ubuntu-latest' }}
+            # 16-vcpu Blacksmith (CI_RUNNER_XL overrides — see the lint job
+            # in on-pull-requests.yml). The platform image build is
+            # compile-bound (pnpm install + turbo build + Rust NAPI inside
+            # docker build) and is merge-queue critical path — the lite legs
+            # serialize behind it. Measured 12-13 min on 4-vcpu ubuntu-latest
+            # vs ~30s on a 16-vcpu Blacksmith runner whose sticky disk keeps
+            # the local layer cache warm; the registry cache-from misses the
+            # compile-heavy layers on every source change.
+            runner: ${{ vars.CI_RUNNER_XL || 'blacksmith-16vcpu-ubuntu-2404' }}
             context: ./platform
             dockerfile: ""
             artifact-name: platform-docker-image
@@ -396,7 +398,7 @@ jobs:
   # is NOT purely wait-bound in practice: Setup Archestra Platform (Kind
   # cluster + helm install + image load) measured 2.4 min on an 8-vcpu
   # runner vs 13.7 min on 4-vcpu ubuntu-latest, so runner size dominates
-  # its wall-clock — hence the CI_RUNNER_L knob below.
+  # its wall-clock — hence the 8-vcpu runner below.
   # The required check is "Merge E2E Test Reports", not this job.
   platform-e2e-k8s-tests:
     name: Platform E2E Tests (K8s)
@@ -410,17 +412,16 @@ jobs:
     # instead of being skipped — the merge is still blocked either way by the
     # required "Build ... Image" checks.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' || github.event.label.name == 'run-e2e-hibernation' }}
-    # CI_RUNNER_L knob (see the lint job in on-pull-requests.yml): an
-    # 8-vcpu-class label, falling back to the free standard runner when the
-    # repo variable is unset. See the setup-time measurements in the job
-    # comment above.
-    runs-on: ${{ vars.CI_RUNNER_L || 'ubuntu-latest' }}
-    # Three budgets, matched to which legs run. The ordinary K8s leg fits inside
-    # 60 minutes. Merge queue adds a 90-minute hibernation leg after the 25-minute
-    # image-poll ceiling and 20-minute K8s leg, so it needs 150. Nightly,
-    # dispatch, and the explicit hibernation label allow that leg 120 minutes
-    # and need 175. Each budget leaves room for setup and artifact uploads.
-    timeout-minutes: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-e2e-hibernation') && 175 || github.event_name == 'merge_group' && 150 || 60 }}
+    # 8-vcpu Blacksmith, as before the runner migration (CI_RUNNER_L
+    # overrides — see the lint job in on-pull-requests.yml). See the
+    # setup-time measurements in the job comment above.
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
+    # Two budgets, matched to which legs run. The ordinary K8s leg (merge
+    # queue and run-e2e PRs) fits inside 60 minutes. Nightly, dispatch, and
+    # the explicit hibernation label add a hibernation leg allowed 120
+    # minutes after the 25-minute image-poll ceiling and 20-minute K8s leg,
+    # so they need 175. Each budget leaves room for setup and uploads.
+    timeout-minutes: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-e2e-hibernation') && 175 || 60 }}
     permissions:
       contents: read # Required to checkout the repository and read test assets.
       id-token: write # Required for Workload Identity Federation in setup actions.
@@ -514,25 +515,27 @@ jobs:
           retention-days: 1
 
       # Serial because these specs share the organization toggle and cluster.
-      # Merge queue excludes @slow-window tests but still gates real-cluster
-      # wake/reset/topology behavior. Scheduled and explicit runs include all
-      # idle-window coverage.
+      # Deliberately NOT run in the merge queue: the leg is ~10 min of mostly
+      # serial waiting that every queued merge paid. Nightly (schedule),
+      # dispatch, and the explicit run-e2e-hibernation label run the full
+      # project; a regression surfaces in the next nightly instead of
+      # blocking every merge.
       - name: Run hibernation E2E tests
         id: e2e-hibernation
-        if: ${{ github.event_name == 'merge_group' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-e2e-hibernation' }}
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-e2e-hibernation' }}
         continue-on-error: true
         uses: ./.github/actions/run-e2e-tests
         with:
           projects: api-k8s-hibernation
-          extra_args: ${{ github.event_name == 'merge_group' && '--workers=1 --grep-invert=@slow-window' || '--workers=1' }}
-          timeout: ${{ github.event_name == 'merge_group' && '90' || '120' }}
+          extra_args: "--workers=1"
+          timeout: "120"
           # Its own directory, so this leg neither overwrites the run above nor
           # depends on the host runner deleting the root-owned files the
           # container leaves behind.
           blob_report_dir: blob-report-hibernation
 
       - name: Upload hibernation blob report
-        if: ${{ !cancelled() && (github.event_name == 'merge_group' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-e2e-hibernation') }}
+        if: ${{ !cancelled() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-e2e-hibernation') }}
         uses: ./.github/actions/github-upload-artifact
         with:
           name: blob-report-k8s-hibernation
@@ -635,12 +638,12 @@ jobs:
     name: Platform E2E Tests (Lite ${{ matrix.name }})
     needs: [platform-e2e-build]
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' || github.event.label.name == 'run-e2e-hibernation' }}
-    # CI_RUNNER_L knob (see the lint job in on-pull-requests.yml). Each leg
-    # boots the full lite stack and then runs Playwright next to it; the
-    # matrix comment below caps chromium at 2 workers precisely because a
-    # standard runner starves — on an 8-vcpu-class runner the pre-migration
-    # single lite job ran 6.9 min where today's legs run 8-9 min each.
-    runs-on: ${{ vars.CI_RUNNER_L || 'ubuntu-latest' }}
+    # 8-vcpu Blacksmith, as before the runner migration (CI_RUNNER_L
+    # overrides — see the lint job in on-pull-requests.yml). Each leg boots
+    # the full lite stack and then runs Playwright next to it: the
+    # pre-migration single lite job ran 6.9 min on 8 vcpu where the 4-vcpu
+    # legs ran 8-9 min each.
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     strategy:
       # A failing leg must not cancel its siblings; we want the full failure

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -648,15 +648,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Each leg boots its own full lite stack — on free runners that
-          # duplicated ~4 min setup buys test wall-clock. The nightly
+          # Each leg boots its own full lite stack — the duplicated setup
+          # buys test wall-clock. The nightly
           # cross-browser projects ride the api leg: they only carry the
           # small @firefox/@webkit-tagged subset.
-          # The chromium legs cap Playwright at 2 workers: the config's CI
-          # default (90% of cores ≈ 3) oversubscribes a standard runner that
-          # is also hosting the whole lite stack, and the resulting CPU
-          # starvation is what makes the heavy dialog-interaction specs
-          # (static-credentials, chat) miss their interaction windows. The
+          # The chromium legs cap Playwright at 2 workers: sized on 4-vcpu
+          # standard runners, where the CI default (90% of cores) oversubscribed
+          # a runner that was also hosting the whole lite stack, and the
+          # resulting CPU starvation made the heavy dialog-interaction specs
+          # (static-credentials, chat) miss their interaction windows.
+          # Conservative on the 8-vcpu runners; raising it is a follow-up. The
           # api leg keeps the default — API-bound specs gain from parallelism
           # and don't fight for paint time.
           - name: api

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -97,15 +97,14 @@ jobs:
       matrix:
         include:
           - name: Platform
-            # 16-vcpu Blacksmith (CI_RUNNER_XL overrides — see the lint job
-            # in on-pull-requests.yml). The platform image build is
-            # compile-bound (pnpm install + turbo build + Rust NAPI inside
-            # docker build) and is merge-queue critical path — the lite legs
-            # serialize behind it. Measured 12-13 min on 4-vcpu ubuntu-latest
-            # vs ~30s on a 16-vcpu Blacksmith runner whose sticky disk keeps
-            # the local layer cache warm; the registry cache-from misses the
+            # 16-vcpu Blacksmith: the platform image build is compile-bound
+            # (pnpm install + turbo build + Rust NAPI inside docker build)
+            # and is merge-queue critical path — the lite legs serialize
+            # behind it. Measured 12-13 min on 4-vcpu ubuntu-latest vs ~30s
+            # on a 16-vcpu Blacksmith runner whose sticky disk keeps the
+            # local layer cache warm; the registry cache-from misses the
             # compile-heavy layers on every source change.
-            runner: ${{ vars.CI_RUNNER_XL || 'blacksmith-16vcpu-ubuntu-2404' }}
+            runner: blacksmith-16vcpu-ubuntu-2404
             context: ./platform
             dockerfile: ""
             artifact-name: platform-docker-image
@@ -412,10 +411,9 @@ jobs:
     # instead of being skipped — the merge is still blocked either way by the
     # required "Build ... Image" checks.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' || github.event.label.name == 'run-e2e-hibernation' }}
-    # 8-vcpu Blacksmith, as before the runner migration (CI_RUNNER_L
-    # overrides — see the lint job in on-pull-requests.yml). See the
-    # setup-time measurements in the job comment above.
-    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
+    # 8-vcpu Blacksmith, as before the runner migration. See the setup-time
+    # measurements in the job comment above.
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     # Two budgets, matched to which legs run. The ordinary K8s leg (merge
     # queue and run-e2e PRs) fits inside 60 minutes. Nightly, dispatch, and
     # the explicit hibernation label add a hibernation leg allowed 120
@@ -638,12 +636,11 @@ jobs:
     name: Platform E2E Tests (Lite ${{ matrix.name }})
     needs: [platform-e2e-build]
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' || github.event.label.name == 'run-e2e-hibernation' }}
-    # 8-vcpu Blacksmith, as before the runner migration (CI_RUNNER_L
-    # overrides — see the lint job in on-pull-requests.yml). Each leg boots
-    # the full lite stack and then runs Playwright next to it: the
-    # pre-migration single lite job ran 6.9 min on 8 vcpu where the 4-vcpu
-    # legs ran 8-9 min each.
-    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
+    # 8-vcpu Blacksmith, as before the runner migration. Each leg boots the
+    # full lite stack and then runs Playwright next to it: the pre-migration
+    # single lite job ran 6.9 min on 8 vcpu where the 4-vcpu legs ran 8-9
+    # min each.
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
       # A failing leg must not cancel its siblings; we want the full failure

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -95,7 +95,15 @@ jobs:
       matrix:
         include:
           - name: Platform
-            runner: ubuntu-latest
+            # CI_RUNNER_XL knob (see the lint job in on-pull-requests.yml).
+            # The platform image build is compile-bound (pnpm install + turbo
+            # build + Rust NAPI inside docker build): measured 12-13 min on
+            # 4-vcpu ubuntu-latest vs ~30s on a 16-vcpu runner with a warm
+            # local layer cache. A bigger runner cannot bring the warm-cache
+            # number back, but it claws back the compile-heavy layers that
+            # the registry cache-from misses on every source change. This is
+            # merge-queue critical path: the lite legs serialize behind it.
+            runner: ${{ vars.CI_RUNNER_XL || 'ubuntu-latest' }}
             context: ./platform
             dockerfile: ""
             artifact-name: platform-docker-image
@@ -383,11 +391,12 @@ jobs:
   # servers, and the Vault K8s-auth boot. Everything else runs in the lite
   # job below against the container harness.
   #
-  # One environment, no sharding: the whole job runs ~4-5 min, so every extra
-  # shard would pay the full environment setup again to split a couple of
-  # minutes of tests. A standard runner suffices because the job is
-  # wait-bound, not compute-bound: setup blocks on image pulls and pod
-  # readiness probes, and the tests are API-bound Playwright specs.
+  # One environment, no sharding: every extra shard would pay the full
+  # environment setup again to split a couple of minutes of tests. The job
+  # is NOT purely wait-bound in practice: Setup Archestra Platform (Kind
+  # cluster + helm install + image load) measured 2.4 min on an 8-vcpu
+  # runner vs 13.7 min on 4-vcpu ubuntu-latest, so runner size dominates
+  # its wall-clock — hence the CI_RUNNER_L knob below.
   # The required check is "Merge E2E Test Reports", not this job.
   platform-e2e-k8s-tests:
     name: Platform E2E Tests (K8s)
@@ -401,7 +410,11 @@ jobs:
     # instead of being skipped — the merge is still blocked either way by the
     # required "Build ... Image" checks.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' || github.event.label.name == 'run-e2e-hibernation' }}
-    runs-on: ubuntu-latest
+    # CI_RUNNER_L knob (see the lint job in on-pull-requests.yml): an
+    # 8-vcpu-class label, falling back to the free standard runner when the
+    # repo variable is unset. See the setup-time measurements in the job
+    # comment above.
+    runs-on: ${{ vars.CI_RUNNER_L || 'ubuntu-latest' }}
     # Three budgets, matched to which legs run. The ordinary K8s leg fits inside
     # 60 minutes. Merge queue adds a 90-minute hibernation leg after the 25-minute
     # image-poll ceiling and 20-minute K8s leg, so it needs 150. Nightly,
@@ -622,7 +635,12 @@ jobs:
     name: Platform E2E Tests (Lite ${{ matrix.name }})
     needs: [platform-e2e-build]
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' || github.event.label.name == 'run-e2e-hibernation' }}
-    runs-on: ubuntu-latest
+    # CI_RUNNER_L knob (see the lint job in on-pull-requests.yml). Each leg
+    # boots the full lite stack and then runs Playwright next to it; the
+    # matrix comment below caps chromium at 2 workers precisely because a
+    # standard runner starves — on an 8-vcpu-class runner the pre-migration
+    # single lite job ran 6.9 min where today's legs run 8-9 min each.
+    runs-on: ${{ vars.CI_RUNNER_L || 'ubuntu-latest' }}
     timeout-minutes: 30
     strategy:
       # A failing leg must not cancel its siblings; we want the full failure


### PR DESCRIPTION
## Before → after (measured on this PR's own runs)

| | Before (last week avg) | After |
|---|---|---|
| Platform Lint and Unit Tests | 15.2 min | **2.3 min** ✅ measured |
| Backend unit tests | 16 shards × 6–9 min | 4 shards × 5.1–6.3 min ✅ measured (July shape; suite has grown since July's ~3.5) |
| **PR workflow wall** | **~16 min** | **7.3 min** ✅ measured with the final config |
| Build Platform Image | 12–13 min | **0.6 min** ✅ measured |
| e2e K8s job | 27 min (incl. 10.4 min hibernation) | **5.9 min** ✅ measured, hibernation skipped |
| e2e Lite legs | 8.2–8.9 min | 5.1–5.6 min ✅ measured |
| **e2e workflow wall (= merge-queue latency)** | **26–29 min** | **12 min** ✅ measured |

## Why CI got slow

Empirical comparison of successful runs this week vs 2026-07-25 (job/step timings from the Actions API, matched cache-miss profiles). Two causes:

1. **The runner migration** (#7049 / #7052 / #7058, Aug 1) moved the CPU-bound jobs to free 4-vcpu `ubuntu-latest`. The regressed jobs are exactly the parallel/compile-bound ones: the lint job fans out six turbo tasks and `@frontend:check:ci` itself runs tsc/vitest/knip/biome concurrently (same all-cache-miss `check:ci`: 1m51s on 16 vcpu vs 10m16s on 4 vcpu); the image build compiles pnpm + turbo + Rust NAPI inside `docker build`; the K8s/lite jobs boot the whole platform next to Playwright. #7052 anticipated this: *"If wall-clock regresses badly, revert just this commit."*
2. **The hibernation e2e leg** (#7135, Aug 20) added ~10.4 min of mostly serial waiting inside the K8s job on **every merge group**.

## What this PR does

**1. The starved jobs go back to their pre-migration Blacksmith labels** (~half GH larger-runner pricing; the sticky-disk layer cache is what makes the image build 0.6 min):

- `blacksmith-16vcpu-ubuntu-2404`: Platform Lint and Unit Tests, Build Platform Image, Backend Unit Tests
- `blacksmith-8vcpu-ubuntu-2404`: Platform E2E Tests (K8s), Platform E2E Tests (Lite *)

The backend shards also drop 16 → 4: the wide fan-out existed to compensate for 4-vcpu runners and paid the vitest module-import overhead (`import 365s` of a 402s shard wall) sixteen times. The `backend-unit-tests-gate` job keeps the stable required-check name, so branch protection is unchanged.

**2. The hibernation e2e leg leaves the merge queue.** It now runs on the nightly schedule (`0 3 * * *`), `workflow_dispatch`, and the on-demand `run-e2e-hibernation` PR label — regressions surface in the next nightly instead of taxing every queued merge. Verified on this PR's `run-e2e` run: hibernation steps skipped.

**3. Stale sizing comments/timeouts refreshed**: lint timeout 45 → 20 and shard timeout 25 → 15 were sized for the private mirror's 2-vCPU `ubuntu-latest`; the mirror (`archestra-private`) is now covered by the same Blacksmith installation.

## Operational notes

- The blacksmith.sh GitHub App had been **suspended**; unsuspended 2026-08-24 and the installation now covers `archestra`, `archestra-private`, and `OpenAPPA`. Gotcha: jobs queued *before* an unsuspend are never delivered to Blacksmith — re-run them.
- The mirror's nightly e2e schedule runs were already being cancelled nightly (missing WIF/AR secrets → build fails → cancel-on-build-failure); unchanged by this PR, but now worth disabling there to avoid burning Blacksmith minutes on doomed runs.
- Volume context: 418 `pull_request` + 247 `merge_group` runs last week.

## Follow-up candidates (out of scope)

- **Lite chromium `--workers=2` cap** was sized on 4-vcpu standard runners; conservative on 8 vcpu (comment updated, behavior unchanged).
- Quickstart (5.5 min) and Frontend Integration (4.7 min) also run slower than July but are off the critical paths.
