### PR TITLE
feat(frontend): agent card parity with gateway cards, and chip Skills as New

### DIFF
--- a/platform/backend/src/models/agent.test.ts
+++ b/platform/backend/src/models/agent.test.ts
@@ -13,6 +13,7 @@ import {
 import { eq } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { describe, expect, test } from "@/test";
+import type { InteractionRequest, InteractionResponse } from "@/types";
 import AgentModel from "./agent";
 import AgentExcludedToolModel from "./agent-excluded-tool";
 import AgentToolModel from "./agent-tool";
@@ -3645,6 +3646,133 @@ describe("AgentModel", () => {
       expect(await AgentExcludedToolModel.findToolIdsByAgent(clone.id)).toEqual(
         [keptId],
       );
+    });
+  });
+
+  describe("lastUsedAt", () => {
+    const at = (isoDay: string) => new Date(`2026-08-${isoDay}T00:00:00.000Z`);
+
+    const seedMcpCall = (agentId: string, createdAt: Date) =>
+      db.insert(schema.mcpToolCallsTable).values({
+        agentId,
+        mcpServerName: "test-server",
+        method: "tools/call",
+        createdAt,
+      });
+
+    const seedInteraction = (profileId: string, createdAt: Date) =>
+      db.insert(schema.interactionsTable).values({
+        profileId,
+        request: {
+          model: "claude-sonnet-5",
+          messages: [{ role: "user", content: "hello" }],
+        } as unknown as InteractionRequest,
+        response: {
+          id: "resp",
+          content: [{ type: "text", text: "hi" }],
+        } as unknown as InteractionResponse,
+        type: "anthropic:messages",
+        createdAt,
+      });
+
+    const lastUsedOf = async (name: string) => {
+      const result = await AgentModel.findAllPaginated({
+        limit: 50,
+        offset: 0,
+      });
+      return result.data.find((agent) => agent.name === name)?.lastUsedAt;
+    };
+
+    test("is null for an agent that was never used", async () => {
+      await AgentModel.create({ name: "Unused", teams: [], scope: "org" });
+
+      expect(await lastUsedOf("Unused")).toBeNull();
+    });
+
+    test("reports an MCP request routed through the agent", async () => {
+      const agent = await AgentModel.create({
+        name: "Gateway-ish",
+        teams: [],
+        scope: "org",
+      });
+      await seedMcpCall(agent.id, at("10"));
+
+      expect(await lastUsedOf("Gateway-ish")).toEqual(at("10"));
+    });
+
+    /**
+     * The reason this signal is not the MCP log alone: an agent driven from
+     * chat can answer for months without ever routing a tool call, and used to
+     * report itself as never used.
+     */
+    test("reports an LLM call made on the agent's behalf", async () => {
+      const agent = await AgentModel.create({
+        name: "Chat only",
+        teams: [],
+        scope: "org",
+      });
+      await seedInteraction(agent.id, at("11"));
+
+      expect(await lastUsedOf("Chat only")).toEqual(at("11"));
+    });
+
+    test("reports the later of the two signals, whichever it is", async () => {
+      const mcpLater = await AgentModel.create({
+        name: "MCP later",
+        teams: [],
+        scope: "org",
+      });
+      await seedInteraction(mcpLater.id, at("10"));
+      await seedMcpCall(mcpLater.id, at("20"));
+
+      const interactionLater = await AgentModel.create({
+        name: "Interaction later",
+        teams: [],
+        scope: "org",
+      });
+      await seedMcpCall(interactionLater.id, at("10"));
+      await seedInteraction(interactionLater.id, at("20"));
+
+      expect(await lastUsedOf("MCP later")).toEqual(at("20"));
+      expect(await lastUsedOf("Interaction later")).toEqual(at("20"));
+    });
+
+    test("sorts by the same value the rows report", async () => {
+      const oldest = await AgentModel.create({
+        name: "Oldest",
+        teams: [],
+        scope: "org",
+      });
+      const middle = await AgentModel.create({
+        name: "Middle",
+        teams: [],
+        scope: "org",
+      });
+      const newest = await AgentModel.create({
+        name: "Newest",
+        teams: [],
+        scope: "org",
+      });
+      await AgentModel.create({ name: "Never", teams: [], scope: "org" });
+
+      // Each agent's later signal is the one that must order it, so the two
+      // kinds are deliberately crossed over here.
+      await seedMcpCall(oldest.id, at("01"));
+      await seedInteraction(middle.id, at("02"));
+      await seedMcpCall(middle.id, at("01"));
+      await seedInteraction(newest.id, at("03"));
+
+      const result = await AgentModel.findAllPaginated(
+        { limit: 50, offset: 0 },
+        { sortBy: "lastUsedAt", sortDirection: "desc" },
+      );
+
+      expect(result.data.map((agent) => agent.name)).toEqual([
+        "Newest",
+        "Middle",
+        "Oldest",
+        "Never",
+      ]);
     });
   });
 });

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -401,18 +401,65 @@ class AgentModel {
   }
 
   /**
-   * Populate lastUsedAt on agents from the MCP tool-call log: the most recent
-   * request (any JSON-RPC method) routed through each agent's MCP gateway
-   * endpoint. Null when nothing was ever routed through the agent.
+   * Populate lastUsedAt on agents: the most recent moment anything ran through
+   * the agent, whichever came last of
+   *
+   * - an MCP request (any JSON-RPC method) routed through its gateway endpoint,
+   * - an LLM call made on its behalf.
+   *
+   * Null when neither ever happened. Both halves are needed because the two
+   * kinds of agent are used differently: an MCP gateway is all requests and no
+   * LLM calls, while an agent driven from chat may answer for months without
+   * ever routing a tool call. Reading only the MCP log would report such an
+   * agent as never used.
    */
   private static async populateLastUsedAt(agents: Agent[]): Promise<void> {
     const agentIds = agents.map((a) => a.id);
     if (agentIds.length === 0) return;
 
-    const lastCallMap = await McpToolCallModel.getLastCallAtForAgents(agentIds);
+    const [lastCallMap, lastInteractionMap] = await Promise.all([
+      McpToolCallModel.getLastCallAtForAgents(agentIds),
+      AgentModel.getLastInteractionAtForAgents(agentIds),
+    ]);
+
     for (const agent of agents) {
-      agent.lastUsedAt = lastCallMap.get(agent.id) ?? null;
+      const lastCallAt = lastCallMap.get(agent.id) ?? null;
+      const lastInteractionAt = lastInteractionMap.get(agent.id) ?? null;
+      agent.lastUsedAt = mostRecent(lastCallAt, lastInteractionAt);
     }
+  }
+
+  /**
+   * When each agent last had an LLM call made on its behalf, absent for agents
+   * with none. Read straight off `interactions` rather than through
+   * `InteractionModel`, which imports this module — the same reason the
+   * `lastUsedAt` sort below reads `mcpToolCallsTable` directly.
+   *
+   * The `IN` list is one page of agents, so the
+   * `(profile_id, created_at DESC)` index answers each agent's max with a
+   * backward scan instead of walking a very large table.
+   */
+  private static async getLastInteractionAtForAgents(
+    agentIds: string[],
+  ): Promise<Map<string, Date>> {
+    if (agentIds.length === 0) return new Map();
+
+    const rows = await db
+      .select({
+        profileId: schema.interactionsTable.profileId,
+        lastInteractionAt: max(schema.interactionsTable.createdAt),
+      })
+      .from(schema.interactionsTable)
+      .where(inArray(schema.interactionsTable.profileId, agentIds))
+      .groupBy(schema.interactionsTable.profileId);
+
+    const lastInteractionMap = new Map<string, Date>();
+    for (const row of rows) {
+      if (row.profileId && row.lastInteractionAt) {
+        lastInteractionMap.set(row.profileId, row.lastInteractionAt);
+      }
+    }
+    return lastInteractionMap;
   }
 
   /**
@@ -1476,6 +1523,20 @@ class AgentModel {
         .groupBy(schema.mcpToolCallsTable.agentId)
         .as("lastUsedAts");
 
+      /**
+       * The LLM-call half of "last used", correlated rather than aggregated:
+       * an unfiltered `GROUP BY profile_id` here would aggregate the whole of
+       * `interactions` — the platform's largest table — on every sorted list
+       * request. Correlating it instead costs one backward scan of
+       * `(profile_id, created_at DESC)` per candidate agent, and agents number
+       * in the hundreds.
+       */
+      const lastInteractionAt = sql`(
+        SELECT max(${schema.interactionsTable.createdAt})
+        FROM ${schema.interactionsTable}
+        WHERE ${schema.interactionsTable.profileId} = ${schema.agentsTable.id}
+      )`;
+
       query = query
         .leftJoin(
           lastUsedAtSubquery,
@@ -1483,9 +1544,13 @@ class AgentModel {
         )
         .orderBy(
           ...personalAgentPriorityOrderClauses,
-          // Never-used agents sort as oldest (asc first / desc last).
+          // Ordered by the same value the row displays: the later of the two
+          // signals. Never-used agents sort as oldest (asc first / desc last).
           direction(
-            sql`COALESCE(${lastUsedAtSubquery.lastUsedAt}, '-infinity'::timestamp)`,
+            sql`GREATEST(
+              COALESCE(${lastUsedAtSubquery.lastUsedAt}, '-infinity'::timestamp),
+              COALESCE(${lastInteractionAt}, '-infinity'::timestamp)
+            )`,
           ),
         );
     } else if (sorting?.sortBy === "team") {
@@ -4061,5 +4126,15 @@ const agentToolRefColumns = {
   rawName: schema.toolsTable.rawName,
   description: schema.toolsTable.description,
 };
+
+/**
+ * The later of two nullable timestamps, or null when both are absent. Used to
+ * fold the two halves of "last used" into the single moment a row reports.
+ */
+function mostRecent(a: Date | null, b: Date | null): Date | null {
+  if (!a) return b;
+  if (!b) return a;
+  return a > b ? a : b;
+}
 
 export default AgentModel;

--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -293,8 +293,9 @@ const contentNavGroups: NavGroup[] = [
         icon: Sparkles,
         customIsActive: (pathname: string) =>
           SKILLS_SECTION_PREFIXES.some((prefix) => pathname.startsWith(prefix)),
+        // "New", the default: the row is named for Skills, which is new. The
+        // Plugins tab keeps its own Beta chip in the tab bar.
         beta: true,
-        badgeLabel: "Beta",
       },
       {
         title: "Messaging Channels",

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -19,6 +19,10 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
+import {
+  AgentAccessBadges,
+  AgentLastUsedFooter,
+} from "@/components/agent-card-meta";
 import { AgentIcon } from "@/components/agent-icon";
 import { AgentNameCell } from "@/components/agent-name-cell";
 import {
@@ -704,6 +708,11 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
                             setRowSelection(next);
                           }}
                           selectionLabel={`Select ${agent.name}`}
+                          footer={
+                            <AgentLastUsedFooter
+                              lastUsedAt={agent.lastUsedAt}
+                            />
+                          }
                         >
                           <div className="flex flex-wrap items-center gap-2">
                             <ResourceVisibilityBadge
@@ -720,6 +729,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
                                 source={effectiveDefault.source}
                               />
                             ) : null}
+                            <AgentAccessBadges agent={agent} />
                           </div>
                         </TableCard>
                       ))}

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -12,6 +12,10 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
+import {
+  AgentAccessBadges,
+  AgentLastUsedFooter,
+} from "@/components/agent-card-meta";
 import { AgentIcon } from "@/components/agent-icon";
 import { AgentNameCell } from "@/components/agent-name-cell";
 import {
@@ -793,12 +797,9 @@ function McpGateways({
                           }}
                           selectionLabel={`Select ${agent.name}`}
                           footer={
-                            <span>
-                              Last used{" "}
-                              {formatRelativeTimeFromNow(
-                                agent.lastUsedAt ?? null,
-                              )}
-                            </span>
+                            <AgentLastUsedFooter
+                              lastUsedAt={agent.lastUsedAt}
+                            />
                           }
                         >
                           <div className="flex flex-wrap items-center gap-2">
@@ -811,16 +812,7 @@ function McpGateways({
                               currentUserId={currentUserId}
                               showSelfAsMe
                             />
-                            <Badge variant="outline">
-                              {agent.accessAllTools
-                                ? "All tools"
-                                : `${agent.tools.filter((tool) => !tool.delegateToAgentId).length} tools`}
-                            </Badge>
-                            <Badge variant="outline">
-                              {agent.accessAllSubagents
-                                ? "All subagents"
-                                : `${agent.tools.filter((tool) => tool.delegateToAgentId).length} subagents`}
-                            </Badge>
+                            <AgentAccessBadges agent={agent} />
                           </div>
                         </TableCard>
                       ))}

--- a/platform/frontend/src/components/agent-card-meta.test.tsx
+++ b/platform/frontend/src/components/agent-card-meta.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentAccessBadges, AgentLastUsedFooter } from "./agent-card-meta";
+
+const tool = () => ({ delegateToAgentId: null });
+const subagent = (id: string) => ({ delegateToAgentId: id });
+
+function renderBadges(
+  agent: React.ComponentProps<typeof AgentAccessBadges>["agent"],
+) {
+  return render(<AgentAccessBadges agent={agent} />);
+}
+
+describe("AgentAccessBadges", () => {
+  it("names the Auto-mode set instead of counting rows that aren't there", () => {
+    // An Auto-mode agent reaches its whole catalogue while storing no per-tool
+    // rows, so counting them would advertise "0 tools" for the agent with the
+    // most access.
+    renderBadges({
+      accessAllTools: true,
+      accessAllSubagents: true,
+      tools: [],
+    });
+
+    expect(screen.getByText("All tools")).toBeInTheDocument();
+    expect(screen.getByText("All subagents")).toBeInTheDocument();
+  });
+
+  it("splits delegation rows out of the tool count", () => {
+    // Both live in `tools`; only the ones carrying a delegate target are
+    // subagents, and counting the array twice would double-count them.
+    renderBadges({
+      accessAllTools: false,
+      accessAllSubagents: false,
+      tools: [tool(), tool(), tool(), subagent("a"), subagent("b")],
+    });
+
+    expect(screen.getByText("3 tools")).toBeInTheDocument();
+    expect(screen.getByText("2 subagents")).toBeInTheDocument();
+  });
+
+  it("counts an empty set as zero rather than hiding the badge", () => {
+    renderBadges({
+      accessAllTools: false,
+      accessAllSubagents: false,
+      tools: [],
+    });
+
+    expect(screen.getByText("0 tools")).toBeInTheDocument();
+    expect(screen.getByText("0 subagents")).toBeInTheDocument();
+  });
+
+  it("says one tool, not 1 tools", () => {
+    renderBadges({
+      accessAllTools: false,
+      accessAllSubagents: false,
+      tools: [tool(), subagent("a")],
+    });
+
+    expect(screen.getByText("1 tool")).toBeInTheDocument();
+    expect(screen.getByText("1 subagent")).toBeInTheDocument();
+  });
+
+  it("can name one set and count the other", () => {
+    // The two modes are independent settings; a gateway commonly exposes every
+    // tool while delegating to a hand-picked few agents.
+    renderBadges({
+      accessAllTools: true,
+      accessAllSubagents: false,
+      tools: [subagent("a")],
+    });
+
+    expect(screen.getByText("All tools")).toBeInTheDocument();
+    expect(screen.getByText("1 subagent")).toBeInTheDocument();
+  });
+});
+
+describe("AgentLastUsedFooter", () => {
+  it("reads as a sentence when the agent was never used", () => {
+    // The shared date helper capitalises its default, which reads as "Last
+    // used Never" mid-sentence.
+    render(<AgentLastUsedFooter lastUsedAt={null} />);
+
+    expect(screen.getByText(/Last used never/)).toBeInTheDocument();
+  });
+
+  it("reports how long ago the agent was last used", () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    render(<AgentLastUsedFooter lastUsedAt={twoHoursAgo.toISOString()} />);
+
+    expect(screen.getByText(/Last used about 2 hours ago/)).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/agent-card-meta.tsx
+++ b/platform/frontend/src/components/agent-card-meta.tsx
@@ -1,0 +1,69 @@
+import { Badge } from "@/components/ui/badge";
+import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
+
+/**
+ * The at-a-glance facts an agent card carries under its title, shared by the
+ * Agents and MCP Gateways lists so the two grids stay legible as one thing.
+ *
+ * Both lists are fed by `GET /api/agents`, so these read straight off the row
+ * with no extra request. The shape is structural rather than the generated
+ * response type because the two pages narrow that type differently.
+ */
+type AgentCardAccess = {
+  accessAllTools: boolean;
+  accessAllSubagents: boolean;
+  tools: Array<{ delegateToAgentId?: string | null }>;
+};
+
+/**
+ * Counts, not names: the card has room for a number, and the detail page is
+ * one click away for the list. "All" is its own answer — an Auto-mode agent
+ * has no per-tool rows at all, so counting them would read "0" while the agent
+ * reaches the whole catalogue.
+ *
+ * Delegation tools are unique per target agent (a unique index on
+ * `tools.delegate_to_agent_id`), so counting the rows counts the subagents.
+ */
+export function AgentAccessBadges({ agent }: { agent: AgentCardAccess }) {
+  const toolCount = agent.tools.filter(
+    (tool) => !tool.delegateToAgentId,
+  ).length;
+  const subagentCount = agent.tools.filter(
+    (tool) => tool.delegateToAgentId,
+  ).length;
+
+  return (
+    <>
+      <Badge variant="outline">
+        {agent.accessAllTools ? "All tools" : countLabel(toolCount, "tool")}
+      </Badge>
+      <Badge variant="outline">
+        {agent.accessAllSubagents
+          ? "All subagents"
+          : countLabel(subagentCount, "subagent")}
+      </Badge>
+    </>
+  );
+}
+
+/**
+ * When the agent last did anything — an MCP request routed through it or an
+ * LLM call made on its behalf. "Never" is a real answer here, and a useful
+ * one: it is how an abandoned agent shows up in a long list.
+ */
+export function AgentLastUsedFooter({
+  lastUsedAt,
+}: {
+  lastUsedAt?: string | Date | null;
+}) {
+  return (
+    <span>
+      Last used{" "}
+      {formatRelativeTimeFromNow(lastUsedAt ?? null, { neverLabel: "never" })}
+    </span>
+  );
+}
+
+function countLabel(count: number, noun: string) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}

--- a/platform/frontend/src/components/skills-plugins-nav-tabs.test.tsx
+++ b/platform/frontend/src/components/skills-plugins-nav-tabs.test.tsx
@@ -49,7 +49,7 @@ describe("useSkillsPluginsNavTabs", () => {
     expect(screen.getByTestId("tabs")).toBeEmptyDOMElement();
   });
 
-  it("marks both pages beta, as the sidebar rows did", () => {
+  it("chips each page at its own stage: Skills new, Plugins beta", () => {
     setPageAccess({ "/skills": true, "/plugins": true });
 
     function TabLabels() {
@@ -66,7 +66,8 @@ describe("useSkillsPluginsNavTabs", () => {
     }
     render(<TabLabels />);
 
-    expect(screen.getByTestId("/skills")).toHaveTextContent("SkillsBeta");
+    // Different chips on purpose: Skills has shipped, Plugins has not.
+    expect(screen.getByTestId("/skills")).toHaveTextContent("SkillsNew");
     expect(screen.getByTestId("/plugins")).toHaveTextContent("PluginsBeta");
   });
 });

--- a/platform/frontend/src/components/skills-plugins-nav-tabs.tsx
+++ b/platform/frontend/src/components/skills-plugins-nav-tabs.tsx
@@ -35,23 +35,28 @@ export function useSkillsPluginsNavTabs() {
   if (reachable.length < 2) {
     return [];
   }
-  return reachable.map(({ href, title }) => ({
+  return reachable.map(({ href, title, badge }) => ({
     href,
-    label: <BetaTabLabel title={title} />,
+    label: <NavTabLabel title={title} badge={badge} />,
   }));
 }
 
+/**
+ * The two tabs carry different chips because they are at different stages:
+ * Skills is newly released, Plugins is still in beta. The sidebar row is
+ * named for Skills and so carries the matching "New".
+ */
 const NAV_TABS = [
-  { title: "Skills", href: "/skills" },
-  { title: "Plugins", href: "/plugins" },
+  { title: "Skills", href: "/skills", badge: "New" },
+  { title: "Plugins", href: "/plugins", badge: "Beta" },
 ];
 
-function BetaTabLabel({ title }: { title: string }) {
+function NavTabLabel({ title, badge }: { title: string; badge: string }) {
   return (
     <span className="flex items-center gap-1.5">
       {title}
       <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-        Beta
+        {badge}
       </Badge>
     </span>
   );


### PR DESCRIPTION
Two frontend consistency fixes in the Studio nav surfaces.

---

# 1. Agent cards get the gateway card's tools, subagents, and last-used

The MCP Gateways grid carries three small facts the Agents grid was missing, despite both being built on the same card shell and fed by the same `GET /api/agents` payload: how many tools it reaches, how many subagents, and when it was last used.

| Before | After |
| --- | --- |
| Agent cards showed a visibility badge and nothing else | Same three facts as a gateway card, in the same places |

Both grids now render one shared `AgentAccessBadges` / `AgentLastUsedFooter` pair, so the two views cannot drift apart again.

### Two fixes that came with the extraction

- **`1 tools`** — the gateway card interpolated a bare count. Pluralised in the shared component, so both grids get it.
- **`Last used Never`** — the shared date helper capitalises its default label, which reads wrong mid-sentence. The footer now passes `neverLabel: "never"`.

### Why `lastUsedAt` needed a second half

`lastUsedAt` was the max of the MCP tool-call log alone. That is exactly right for a gateway, whose entire job is routing MCP requests — but an agent driven from chat can answer for months without ever routing a tool call, and would report itself as never used.

This is not hypothetical. On the local dev database, of the three agents with any usage at all, **two had interactions but no MCP calls** — they would have rendered "Last used never" on a card whose whole purpose is to tell you otherwise.

So the signal is now the later of:
- an MCP request routed through the agent's gateway endpoint, and
- an LLM call made on the agent's behalf.

### Performance

`interactions` is the platform's largest, write-hot table, so both read paths are deliberate:

- **List display** — one `GROUP BY profile_id` over a `WHERE profile_id IN (...)` list of a *single page* of agents. Served by the existing `interactions_profile_created_at_idx` on `(profile_id, created_at DESC)`, so each agent's max is a backward index scan.
- **`sortBy=lastUsedAt`** — a **correlated** scalar subquery, not an aggregate. An unfiltered `GROUP BY profile_id` here would aggregate the whole table on every sorted list request; correlating costs one index lookup per candidate agent instead, and agents number in the hundreds.

No new index, no migration.

---

# 2. Skills is chipped New; Beta belongs to Plugins

Skills has shipped, Plugins has not, but both carried the same **Beta** chip — underselling the released half and making one chip stand for two different stages.

- **Sidebar row** — drops its explicit `badgeLabel` to take the default **New**. The row is named for Skills, its landing page.
- **Tab bar** — gains a per-tab chip: Skills reads **New**, Plugins keeps **Beta**.

---

## Tests

- `models/agent.test.ts` — 6 new cases: never-used, MCP-only, interaction-only, later-of-the-two in both directions, and that `sortBy=lastUsedAt` orders by the same value the row displays. The three asserting new behaviour fail on `main` and pass here; the other two pin behaviour that must not change.
- `components/agent-card-meta.test.tsx` — 7 new cases covering the Auto-mode "All tools" naming (counting rows would advertise "0 tools" for the agent with the most access), the delegation/tool split, zero, and singular.
- `components/skills-plugins-nav-tabs.test.tsx` — updated to assert the two chips are now different.
- Full `agent.test.ts` (132), `routes/agent` (317), and the frontend `_parts` + component suites (103) green.

## Verified

Rendered both grids from this branch against the MSW fixture frontend and compared them side by side — the layouts now match. Confirmed the sidebar chip renders **New**. The tab bar itself stays collapsed under the fixture (its user has no `/plugins` page permission, so there is nowhere to switch to); the unit test covers that path by asserting the rendered tab text directly.

## Not in scope

The Agents **table** view still lacks the gateway table's `toolsCount` / `subagentsCount` / `lastUsedAt` columns. That is a column-density decision rather than a consistency fix, so it is left alone here; the backend already accepts all three sort keys for any agent type if we want them later.

## Note on CI

`pnpm lint` is currently failing on `main` in three files this branch does not touch (`connection-flow.utils.ts`, `llm/model-providers/page.tsx`, `mcp/registry/_parts/environments-section.tsx`) — unused imports/variables. Every file in this diff is lint-clean.
