### PR TITLE
chore(bench): refresh benchmark lanes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -175,7 +175,7 @@ jobs:
           # Scheduled runs carry no inputs and an empty dispatch field is falsy, so these fallbacks
           # are the single source of the daily selection.
           BENCH_ENVS: ${{ inputs.envs || 'basic' }}
-          BENCH_LANES: ${{ inputs.lanes || 'glm,deepseek-flash-0731,qwen37-plus,gemma-4-31b,gpt-56-luna,mimo-25,qwen36-35b-a3b,mimo-25-adv-deepseek-flash' }}
+          BENCH_LANES: ${{ inputs.lanes || 'glm,deepseek-flash-0731,qwen38-flash,gemma-4-31b,spark,gpt-56-luna,mimo-25,qwen36-35b-a3b,mimo-25-adv-deepseek-flash' }}
         run: |
           set -euo pipefail
           # Dispatch inputs are the only caller-controlled values on the envsubst allowlist, and they

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -175,7 +175,7 @@ jobs:
           # Scheduled runs carry no inputs and an empty dispatch field is falsy, so these fallbacks
           # are the single source of the daily selection.
           BENCH_ENVS: ${{ inputs.envs || 'basic' }}
-          BENCH_LANES: ${{ inputs.lanes || 'glm,deepseek-flash-0731,qwen38-flash,gemma-4-31b,spark,gpt-56-luna,mimo-25,qwen36-35b-a3b,mimo-25-adv-deepseek-flash' }}
+          BENCH_LANES: ${{ inputs.lanes || 'glm,glm-flash,deepseek-flash-0731,qwen38-flash,gemma-4-31b,spark,gpt-56-luna,mimo-25,qwen36-35b-a3b,mimo-25-adv-deepseek-flash' }}
         run: |
           set -euo pipefail
           # Dispatch inputs are the only caller-controlled values on the envsubst allowlist, and they

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -175,7 +175,7 @@ jobs:
           # Scheduled runs carry no inputs and an empty dispatch field is falsy, so these fallbacks
           # are the single source of the daily selection.
           BENCH_ENVS: ${{ inputs.envs || 'basic' }}
-          BENCH_LANES: ${{ inputs.lanes || 'glm,deepseek-flash-0731,qwen37-plus,gemma-4-31b,gpt-56-luna,mimo-25,qwen36-35b-a3b,qwen36-27b,mimo-25-adv-deepseek-flash' }}
+          BENCH_LANES: ${{ inputs.lanes || 'glm,deepseek-flash-0731,qwen37-plus,gemma-4-31b,gpt-56-luna,mimo-25,qwen36-35b-a3b,mimo-25-adv-deepseek-flash' }}
         run: |
           set -euo pipefail
           # Dispatch inputs are the only caller-controlled values on the envsubst allowlist, and they

--- a/ai-labs/lanes.toml
+++ b/ai-labs/lanes.toml
@@ -33,9 +33,9 @@ provider = "openrouter"
 model = "deepseek/deepseek-v4-flash-0731"
 
 [[lane]]
-name = "qwen37-plus"
+name = "qwen38-flash"
 provider = "openrouter"
-model = "qwen/qwen3.7-plus"
+model = "qwen/qwen3.8-flash"
 
 [[lane]]
 name = "gemma-4-31b"
@@ -83,6 +83,11 @@ provider = "openrouter"
 model = "openai/gpt-oss-120b"
 
 [[lane]]
+name = "spark"
+provider = "openrouter"
+model = "meta/muse-spark-1.2-contributor"
+
+[[lane]]
 name = "kimi"
 provider = "anthropic"
 model = "kimi-for-coding"
@@ -93,10 +98,10 @@ openrouter_model = "moonshotai/kimi-k2.7-code"
 [[lane]]
 name = "glm"
 provider = "anthropic"
-model = "glm-5.3"
+model = "glm-5.3-flash"
 base_url = "https://api.z.ai/api/anthropic"
 api_key_env = "ZAI_API_KEY"
-openrouter_model = "z-ai/glm-5.2"
+openrouter_model = "z-ai/glm-5.3-flash"
 
 [[lane]]
 name = "mimo-25-adv-deepseek-flash"

--- a/ai-labs/lanes.toml
+++ b/ai-labs/lanes.toml
@@ -78,11 +78,6 @@ provider = "openrouter"
 model = "qwen/qwen3.6-35b-a3b"
 
 [[lane]]
-name = "qwen36-27b"
-provider = "openrouter"
-model = "qwen/qwen3.6-27b"
-
-[[lane]]
 name = "gpt-oss-120b"
 provider = "openrouter"
 model = "openai/gpt-oss-120b"

--- a/ai-labs/lanes.toml
+++ b/ai-labs/lanes.toml
@@ -98,6 +98,14 @@ openrouter_model = "moonshotai/kimi-k2.7-code"
 [[lane]]
 name = "glm"
 provider = "anthropic"
+model = "glm-5.3"
+base_url = "https://api.z.ai/api/anthropic"
+api_key_env = "ZAI_API_KEY"
+openrouter_model = "z-ai/glm-5.3"
+
+[[lane]]
+name = "glm-flash"
+provider = "anthropic"
 model = "glm-5.3-flash"
 base_url = "https://api.z.ai/api/anthropic"
 api_key_env = "ZAI_API_KEY"


### PR DESCRIPTION
## Summary

- remove the retired Qwen 3.6 27B lane from the registry and scheduled benchmark roster
- replace Qwen 3.7 Plus with Qwen 3.8 Flash through OpenRouter
- keep the direct Z.ai `glm` lane on GLM 5.3 and add `glm-flash` on GLM 5.3 Flash for a base-vs-flash comparison
- add the `spark` lane for Meta Muse Spark 1.2 Contributor through OpenRouter
- use exact current OpenRouter pricing slugs for both GLM arms

## Validation

- `cargo test -p archestra_bench --test integration test_load_real_lanes`
- `git diff --check`

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
