### PR TITLE
ci: stop auto-requesting reviewers on release-please PRs

### DIFF
--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -24,8 +24,10 @@ env:
   ASSIGNEE_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","piercypixel"]'
   CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk","piercypixel","arsenyinfo"]'
   # PRs opened by these bot accounts already have an owner shepherding them
-  # (e.g. the task-env pipeline's requester), so skip reviewer auto-assignment.
-  REVIEW_REQUEST_EXEMPT_LOGINS: '["archestra-task-envs[bot]"]'
+  # (e.g. the task-env pipeline's requester), or are merged as part of a deliberate
+  # process rather than reviewed (release-please PRs, opened by archestra-ci[bot], are
+  # merged by whoever cuts the release), so skip reviewer auto-assignment.
+  REVIEW_REQUEST_EXEMPT_LOGINS: '["archestra-task-envs[bot]", "archestra-ci[bot]"]'
 
 concurrency:
   group: random-issue-pr-assignee-${{ github.event.issue.number || github.ref }}


### PR DESCRIPTION
## What

Adds `archestra-ci[bot]` to `REVIEW_REQUEST_EXEMPT_LOGINS` in `.github/workflows/random-issue-pr-assignee.yml`.

## Why

Release-please PRs are opened by `archestra-ci[bot]`. That login isn't on `CORE_TEAM_LOGINS` and wasn't exempt, so the scheduled `request-recent-pr-reviewers` job assigned a random core-team member as reviewer on every release PR. Release PRs aren't reviewed — they're merged by whoever cuts the release — so the request is pure noise.

Example: #7454 (`chore(main): release platform 1.3.44`), author `archestra-ci[bot]`, requested reviewer `joeyorlando`.