### PR TITLE
fix(plugins): edit GitHub source and authentication

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -316641,7 +316641,7 @@
         "tags": [
           "Plugins"
         ],
-        "description": "Update plugin metadata or replace its files\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`plugin:admin`: Publish executable plugins through connection marketplaces\n`plugin:update`: Modify plugin metadata and files",
+        "description": "Update plugin metadata, visibility, GitHub source settings, or files\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`plugin:admin`: Publish executable plugins through connection marketplaces\n`plugin:update`: Modify plugin metadata and files",
         "requestBody": {
           "required": true,
           "content": {
@@ -316695,6 +316695,77 @@
                       "type": "string",
                       "minLength": 1
                     }
+                  },
+                  "githubSource": {
+                    "type": "object",
+                    "properties": {
+                      "repoUrl": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 2048
+                      },
+                      "ref": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 1024
+                          },
+                          {
+                            "type": "string",
+                            "nullable": true,
+                            "enum": [
+                              null
+                            ]
+                          }
+                        ]
+                      },
+                      "syncInterval": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "15m",
+                              "1h",
+                              "1d"
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "nullable": true,
+                            "enum": [
+                              null
+                            ]
+                          }
+                        ]
+                      },
+                      "authentication": {
+                        "type": "object",
+                        "properties": {
+                          "githubAppConfigId": {
+                            "nullable": true,
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
+                          "githubPatId": {
+                            "nullable": true,
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          }
+                        },
+                        "required": [
+                          "githubAppConfigId",
+                          "githubPatId"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "repoUrl",
+                      "ref",
+                      "syncInterval"
+                    ]
                   },
                   "files": {
                     "minItems": 1,

--- a/docs/pages/platform-agent-plugins.md
+++ b/docs/pages/platform-agent-plugins.md
@@ -3,7 +3,7 @@ title: Plugins
 category: Agents
 order: 4
 description: Client-native extensions delivered to Claude Code, Codex, Copilot CLI, and Cursor
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-26
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -52,6 +52,8 @@ GitHub-owned files stay read-only in Archestra. Edit them in their repository.
 GitHub checks can run manually, every 15 minutes, every hour, or once a day. A changed commit becomes an update candidate.
 
 An update never replaces approved files automatically. Open **Updates**, review the candidate, then approve and apply it.
+
+Open a GitHub plugin's edit page to change its repository, tracked ref, check schedule, or visibility. Leave the token field empty to keep its current credential. If a token expires, enter a replacement token or select a GitHub App.
 
 OpenAPPA is imported once for each organization when Plugins are enabled. It behaves like any other GitHub plugin after import. You can update or delete it.
 

--- a/platform/backend/src/models/plugin.ts
+++ b/platform/backend/src/models/plugin.ts
@@ -438,6 +438,49 @@ class PluginModel {
             sourceMarketplacePluginName: params.source.marketplacePluginName,
           }
         : { sourceSha: params.sourceSha, sourceRef: params.sourceRef };
+      const githubSource = params.input.githubSource;
+      const githubRepoChanged = githubSource
+        ? githubSource.repoUrl.toLowerCase() !==
+          existing.sourceRepo?.toLowerCase()
+        : false;
+      const githubRefChanged = githubSource
+        ? githubSource.ref !== existing.githubSyncRef
+        : false;
+      const githubTrackingChanged = githubRepoChanged || githubRefChanged;
+      const githubAuthentication = githubSource?.authentication;
+      const githubAuthenticationChanged = githubAuthentication
+        ? githubAuthentication.githubAppConfigId !==
+            existing.githubAppConfigId ||
+          githubAuthentication.githubPatId !== existing.githubPatId
+        : false;
+      const clearGithubCandidate =
+        githubTrackingChanged || githubSource?.syncInterval === null;
+      const githubSourceUpdate = githubSource
+        ? {
+            sourceRepo: githubSource.repoUrl,
+            sourceRef: githubSource.ref,
+            githubSyncRef: githubSource.ref,
+            githubSyncInterval: githubSource.syncInterval,
+            ...(githubAuthentication
+              ? {
+                  githubAppConfigId: githubAuthentication.githubAppConfigId,
+                  githubPatId: githubAuthentication.githubPatId,
+                }
+              : {}),
+            ...(githubTrackingChanged || githubAuthenticationChanged
+              ? { lastSyncedAt: null }
+              : {}),
+            ...(githubAuthenticationChanged ? { lastSyncError: null } : {}),
+            ...(clearGithubCandidate
+              ? {
+                  pendingSourceSha: null,
+                  pendingContentHash: null,
+                  pendingDetectedAt: null,
+                  lastSyncError: null,
+                }
+              : {}),
+          }
+        : {};
       const [plugin] = await tx
         .update(schema.pluginsTable)
         .set({
@@ -448,6 +491,7 @@ class PluginModel {
           scope,
           syncGeneration: sql`${schema.pluginsTable.syncGeneration} + 1`,
           ...sourceUpdate,
+          ...githubSourceUpdate,
           ...(params.sourceSha || params.source
             ? {
                 pendingSourceSha: null,

--- a/platform/backend/src/plugins/github-import.ts
+++ b/platform/backend/src/plugins/github-import.ts
@@ -28,6 +28,12 @@ export class PluginImportError extends Error {
   }
 }
 
+/** Normalize any accepted GitHub repository URL to the stored owner/repo form. */
+export function normalizeGithubPluginRepoUrl(repoUrl: string): string {
+  const { owner, repo } = parseSource({ repoUrl });
+  return `${owner}/${repo}`;
+}
+
 /**
  * Resolve one GitHub tree to immutable, by-value plugin bytes. This service
  * never executes or interprets hook configuration and always strips transport

--- a/platform/backend/src/routes/plugin/plugin.routes.test.ts
+++ b/platform/backend/src/routes/plugin/plugin.routes.test.ts
@@ -5,6 +5,7 @@ import { registerAuditLogHook } from "@/middleware/audit-log-hook";
 import { AuditLogModel, PluginModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
+import { createGithubPat } from "@/services/github-pat";
 import {
   afterEach,
   beforeEach,
@@ -155,6 +156,249 @@ describe("plugin routes", () => {
     expect(updated.json().approvedContentHash).toBe(updated.json().contentHash);
     expect(updated.json().files).toHaveLength(1);
     expect(updated.json().files[0].content).toBe(replacement);
+  });
+
+  test("atomically updates a GitHub plugin source, ref, cadence, and visibility", async () => {
+    const plugin = await PluginModel.create({
+      organizationId: ctx.organizationId,
+      userId: ctx.user.id,
+      input: createPayload(),
+      source: {
+        repo: "old-owner/plugin",
+        ref: "main",
+        sha: "old-commit",
+        subdir: "",
+        exclude: [],
+        syncInterval: "1d",
+        syncRef: "main",
+      },
+    });
+    if (!plugin) throw new Error("failed to seed GitHub plugin");
+    const observed = await PluginModel.findByIdForSync(plugin.id);
+    if (!observed) throw new Error("failed to load GitHub sync state");
+    await PluginModel.markGithubSyncResult({
+      id: plugin.id,
+      expectedSyncGeneration: observed.syncGeneration,
+      expectedPendingSourceSha: observed.pendingSourceSha,
+      sourceSha: STUB_COMMIT_SHA,
+      files: plugin.files,
+      error: null,
+    });
+
+    const updated = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/plugins/${plugin.id}`,
+      payload: {
+        githubSource: {
+          repoUrl: "https://github.com/new-owner/plugin.git",
+          ref: "release",
+          syncInterval: "1h",
+        },
+        scope: "org",
+        teamIds: [],
+        userIds: [],
+      },
+    });
+
+    expect(updated.statusCode).toBe(200);
+    expect(updated.json()).toMatchObject({
+      sourceRepo: "new-owner/plugin",
+      sourceRef: "release",
+      githubSyncRef: "release",
+      githubSyncInterval: "1h",
+      scope: "org",
+      sourceSha: "old-commit",
+      pendingSourceSha: null,
+      pendingContentHash: null,
+      pendingDetectedAt: null,
+      lastSyncedAt: null,
+    });
+    expect(updated.json().files).toEqual(plugin.files);
+
+    const fetchMock = stubGithub([
+      {
+        owner: "new-owner",
+        repo: "plugin",
+        files: { "hooks/hooks.json": "updated bytes\n" },
+      },
+    ]);
+    const preview = await ctx.app.inject({
+      method: "POST",
+      url: `/api/plugins/${plugin.id}/github/preview-update`,
+      payload: {},
+    });
+    expect(preview.statusCode).toBe(200);
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        String(input).includes("/repos/new-owner/plugin/commits/release"),
+      ),
+    ).toBe(true);
+  });
+
+  test("replaces an expired GitHub token without changing approved plugin bytes", async () => {
+    const expiredPat = await createGithubPat({
+      organizationId: ctx.organizationId,
+      data: { name: "Expired token", token: "ghp_expired" },
+    });
+    const replacementPat = await createGithubPat({
+      organizationId: ctx.organizationId,
+      data: { name: "Replacement token", token: "ghp_replacement" },
+    });
+    const plugin = await PluginModel.create({
+      organizationId: ctx.organizationId,
+      userId: ctx.user.id,
+      input: createPayload(),
+      source: {
+        repo: "private-owner/plugin",
+        ref: "main",
+        sha: "approved-commit",
+        subdir: "",
+        exclude: [],
+        syncInterval: "1d",
+        syncRef: "main",
+        githubPatId: expiredPat.id,
+      },
+    });
+    if (!plugin) throw new Error("failed to seed GitHub plugin");
+    const observed = await PluginModel.findByIdForSync(plugin.id);
+    if (!observed) throw new Error("failed to load GitHub sync state");
+    await PluginModel.markGithubSyncResult({
+      id: plugin.id,
+      expectedSyncGeneration: observed.syncGeneration,
+      expectedPendingSourceSha: observed.pendingSourceSha,
+      error: "Bad credentials",
+    });
+
+    const updated = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/plugins/${plugin.id}`,
+      payload: {
+        githubSource: {
+          repoUrl: "private-owner/plugin",
+          ref: "main",
+          syncInterval: "1d",
+          authentication: {
+            githubAppConfigId: null,
+            githubPatId: replacementPat.id,
+          },
+        },
+      },
+    });
+
+    expect(updated.statusCode).toBe(200);
+    expect(updated.json()).toMatchObject({
+      sourceSha: "approved-commit",
+      githubPatId: replacementPat.id,
+      githubAppConfigId: null,
+      lastSyncedAt: null,
+      lastSyncError: null,
+    });
+    expect(updated.json().files).toEqual(plugin.files);
+
+    const preserved = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/plugins/${plugin.id}`,
+      payload: {
+        githubSource: {
+          repoUrl: "private-owner/plugin",
+          ref: "main",
+          syncInterval: "1d",
+        },
+      },
+    });
+    expect(preserved.statusCode).toBe(200);
+    expect(preserved.json()).toMatchObject({
+      githubPatId: replacementPat.id,
+      githubAppConfigId: null,
+    });
+
+    const fetchMock = stubGithub([
+      {
+        owner: "private-owner",
+        repo: "plugin",
+        files: { "hooks/hooks.json": "replacement-auth bytes\n" },
+      },
+    ]);
+    const preview = await ctx.app.inject({
+      method: "POST",
+      url: `/api/plugins/${plugin.id}/github/preview-update`,
+      payload: {},
+    });
+    expect(preview.statusCode).toBe(200);
+    expect(
+      fetchMock.mock.calls.some(([, init]) =>
+        JSON.stringify(
+          (init as { headers?: unknown } | undefined)?.headers ?? {},
+        ).includes("ghp_replacement"),
+      ),
+    ).toBe(true);
+
+    const cleared = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/plugins/${plugin.id}`,
+      payload: {
+        githubSource: {
+          repoUrl: "private-owner/plugin",
+          ref: "main",
+          syncInterval: "1d",
+          authentication: {
+            githubAppConfigId: null,
+            githubPatId: null,
+          },
+        },
+      },
+    });
+    expect(cleared.statusCode).toBe(200);
+    expect(cleared.json()).toMatchObject({
+      githubPatId: null,
+      githubAppConfigId: null,
+    });
+  });
+
+  test("rejects GitHub source settings for manual plugins and non-GitHub URLs", async () => {
+    const manual = await ctx.app.inject({
+      method: "POST",
+      url: "/api/plugins",
+      payload: createPayload(),
+    });
+    const manualUpdate = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/plugins/${manual.json().id}`,
+      payload: {
+        githubSource: {
+          repoUrl: "owner/plugin",
+          ref: null,
+          syncInterval: null,
+        },
+      },
+    });
+    expect(manualUpdate.statusCode).toBe(409);
+
+    const github = await PluginModel.create({
+      organizationId: ctx.organizationId,
+      userId: ctx.user.id,
+      input: createPayload(),
+      source: {
+        repo: "owner/plugin",
+        ref: "main",
+        sha: "old-commit",
+        subdir: "",
+        exclude: [],
+      },
+    });
+    if (!github) throw new Error("failed to seed GitHub plugin");
+    const invalidUrl = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/plugins/${github.id}`,
+      payload: {
+        githubSource: {
+          repoUrl: "https://gitlab.com/owner/plugin",
+          ref: "main",
+          syncInterval: "1d",
+        },
+      },
+    });
+    expect(invalidUrl.statusCode).toBe(400);
   });
 
   test("rejects unsafe, duplicate, and malformed file sets", async () => {

--- a/platform/backend/src/routes/plugin/plugin.routes.ts
+++ b/platform/backend/src/routes/plugin/plugin.routes.ts
@@ -16,6 +16,7 @@ import {
 } from "@/models";
 import {
   importPluginFromGithub,
+  normalizeGithubPluginRepoUrl,
   PluginImportError,
 } from "@/plugins/github-import";
 import {
@@ -701,7 +702,8 @@ const pluginRoutes: FastifyPluginAsyncZod = async (fastify) => {
     {
       schema: {
         operationId: RouteId.UpdatePlugin,
-        description: "Update plugin metadata or replace its files",
+        description:
+          "Update plugin metadata, visibility, GitHub source settings, or files",
         tags: ["Plugins"],
         params: PluginParamsSchema,
         body: UpdatePluginSchema,
@@ -721,6 +723,33 @@ const pluginRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "GitHub-sourced plugin files are read-only; preview and approve a source update instead",
         );
       }
+      if (body.githubSource && existing.sourceKind !== "github") {
+        throw new ApiError(
+          409,
+          "Only GitHub-sourced plugins have GitHub source settings",
+        );
+      }
+      const githubSource = body.githubSource;
+      if (githubSource?.authentication) {
+        await resolveGithubToken({
+          githubAppConfigId:
+            githubSource.authentication.githubAppConfigId ?? undefined,
+          githubPatId: githubSource.authentication.githubPatId ?? undefined,
+          organizationId,
+          userId: user.id,
+        });
+      }
+      const input = githubSource
+        ? {
+            ...body,
+            githubSource: {
+              ...githubSource,
+              repoUrl: await runGithubImport(async () =>
+                normalizeGithubPluginRepoUrl(githubSource.repoUrl),
+              ),
+            },
+          }
+        : body;
       await validatePluginVisibility({
         organizationId,
         scope: body.scope ?? existing.scope,
@@ -731,7 +760,7 @@ const pluginRoutes: FastifyPluginAsyncZod = async (fastify) => {
         id: params.id,
         organizationId,
         userId: user.id,
-        input: body,
+        input,
       });
       if (!plugin) throw new ApiError(404, "Plugin not found");
       return reply.send(plugin);
@@ -927,7 +956,10 @@ async function importExistingGithubPlugin(params: {
     importPluginFromGithub({
       repoUrl: plugin.sourceRepo as string,
       ref:
-        params.approvedCommitSha ?? plugin.pendingSourceSha ?? plugin.sourceRef,
+        params.approvedCommitSha ??
+        plugin.pendingSourceSha ??
+        syncState.githubSyncRef ??
+        plugin.sourceRef,
       subdir: plugin.sourceSubdir ?? "",
       exclude: plugin.sourceExclude,
       githubToken,

--- a/platform/backend/src/types/plugin.ts
+++ b/platform/backend/src/types/plugin.ts
@@ -83,6 +83,25 @@ export const UpdatePluginSchema = z
     scope: ResourceVisibilityScopeSchema.optional(),
     teamIds: z.array(z.string().min(1)).max(100).optional(),
     userIds: z.array(z.string().min(1)).max(100).optional(),
+    githubSource: z
+      .object({
+        repoUrl: z.string().trim().min(1).max(2_048),
+        ref: z.union([z.string().trim().min(1).max(1_024), z.null()]),
+        syncInterval: z.union([PluginGithubSyncIntervalSchema, z.null()]),
+        authentication: z
+          .object({
+            githubAppConfigId: z.string().uuid().nullable(),
+            githubPatId: z.string().uuid().nullable(),
+          })
+          .refine(
+            (value) =>
+              [value.githubAppConfigId, value.githubPatId].filter(Boolean)
+                .length <= 1,
+            { message: "Choose only one GitHub authentication method" },
+          )
+          .optional(),
+      })
+      .optional(),
     files: z
       .array(PluginFileInputSchema)
       .min(1)

--- a/platform/frontend/src/app/plugins/[id]/edit/page.client.tsx
+++ b/platform/frontend/src/app/plugins/[id]/edit/page.client.tsx
@@ -4,11 +4,25 @@ import type { ResourceVisibilityScope } from "@archestra/shared";
 import { ArrowLeft, ArrowRight, Info } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  GithubAuthConfigFields,
+  type GithubAuthMethod,
+} from "@/components/github-auth-config-fields";
 import { PageLayout } from "@/components/page-layout";
 import { QueryLoadError } from "@/components/query-load-error";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { PermissionButton } from "@/components/ui/permission-button";
+import { SecretInput } from "@/components/ui/secret-input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   UnsavedChangesDialog,
   useBeforeUnloadWhileDirty,
@@ -18,6 +32,8 @@ import { WizardFooter } from "@/components/wizard-footer";
 import { WizardStepper } from "@/components/wizard-stepper";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
+import { useGithubAppConfigs } from "@/lib/github-app-config.query";
+import { useCreateGithubPat } from "@/lib/github-pat.query";
 import {
   type PluginDetail,
   usePlugin,
@@ -48,6 +64,13 @@ const STEP_DESCRIPTIONS: Record<PluginEditStepId, string> = {
   access: "Choose who can discover and install the plugin.",
 };
 
+const GITHUB_SYNC_OPTIONS = [
+  { value: "off", label: "Manual checks" },
+  { value: "15m", label: "Every 15 minutes" },
+  { value: "1h", label: "Every hour" },
+  { value: "1d", label: "Once a day" },
+] as const;
+
 interface PluginDraft {
   displayName: string;
   description: string;
@@ -57,6 +80,12 @@ interface PluginDraft {
   scope: ResourceVisibilityScope;
   teamIds: string[];
   userIds: string[];
+  githubRepoUrl: string;
+  githubSyncRef: string;
+  githubSyncInterval: "15m" | "1h" | "1d" | null;
+  githubAuthMethod: GithubAuthMethod;
+  githubAppConfigId: string;
+  githubToken: string;
 }
 
 /**
@@ -109,6 +138,8 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
     plugin: ["update", "admin"],
   });
   const updatePlugin = useUpdatePlugin(plugin.id);
+  const { data: githubAppConfigs = [] } = useGithubAppConfigs();
+  const createGithubPat = useCreateGithubPat();
 
   const isGithubPlugin = plugin.sourceKind === "github";
   const editSteps = isGithubPlugin
@@ -144,6 +175,12 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
       scope: plugin.scope,
       teamIds: plugin.teams.map((team) => team.id),
       userIds: plugin.users.map((member) => member.id),
+      githubRepoUrl: plugin.sourceRepo ?? "",
+      githubSyncRef: plugin.githubSyncRef ?? plugin.sourceRef ?? "",
+      githubSyncInterval: plugin.githubSyncInterval,
+      githubAuthMethod: plugin.githubAppConfigId ? "github_app" : "pat",
+      githubAppConfigId: plugin.githubAppConfigId ?? "",
+      githubToken: "",
     }),
     [plugin],
   );
@@ -169,6 +206,14 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
 
   const contentComplete =
     draft.displayName.trim().length > 0 && draft.files.length > 0;
+  const githubAuthenticationComplete =
+    draft.githubAuthMethod === "github_app"
+      ? draft.githubAppConfigId.length > 0
+      : base.githubAuthMethod !== "github_app" ||
+        draft.githubToken.trim().length > 0;
+  const sourceComplete =
+    !isGithubPlugin ||
+    (draft.githubRepoUrl.trim().length > 0 && githubAuthenticationComplete);
   // Which save is in flight: Save finishes on the plugin's page, Save &
   // Continue moves to the next step.
   const [savingWith, setSavingWith] = useState<"finish" | "continue" | null>(
@@ -177,12 +222,63 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
   const isSaving = savingWith !== null;
 
   const handleSave = async (intent: "finish" | "continue") => {
-    const submitted = draft;
+    let submitted = draft;
     setSavingWith(intent);
+    let githubPatId =
+      submitted.githubAuthMethod === "pat" ? plugin.githubPatId : null;
+    if (
+      isGithubPlugin &&
+      submitted.githubAuthMethod === "pat" &&
+      submitted.githubToken.trim()
+    ) {
+      const created = await createGithubPat
+        .mutateAsync({
+          name: `${plugin.displayName} token`,
+          token: submitted.githubToken.trim(),
+        })
+        .catch(() => null);
+      if (!created) {
+        setSavingWith(null);
+        return;
+      }
+      githubPatId = created.id;
+      submitted = {
+        ...submitted,
+        githubToken: "",
+      };
+      setDraft(submitted);
+    }
+    const githubAppConfigId =
+      submitted.githubAuthMethod === "github_app"
+        ? submitted.githubAppConfigId || null
+        : null;
+    const baseGithubPatId =
+      base.githubAuthMethod === "pat" ? plugin.githubPatId : null;
+    const baseGithubAppConfigId =
+      base.githubAuthMethod === "github_app"
+        ? base.githubAppConfigId || null
+        : null;
+    const githubAuthenticationChanged =
+      githubPatId !== baseGithubPatId ||
+      githubAppConfigId !== baseGithubAppConfigId;
     const saved = await updatePlugin
       .mutateAsync({
         ...(isGithubPlugin
-          ? {}
+          ? {
+              githubSource: {
+                repoUrl: submitted.githubRepoUrl.trim(),
+                ref: submitted.githubSyncRef.trim() || null,
+                syncInterval: submitted.githubSyncInterval,
+                ...(githubAuthenticationChanged
+                  ? {
+                      authentication: {
+                        githubAppConfigId,
+                        githubPatId,
+                      },
+                    }
+                  : {}),
+              },
+            }
           : {
               displayName: submitted.displayName.trim(),
               description: submitted.description,
@@ -223,12 +319,27 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
     },
     [guard],
   );
+  const githubAppConfigOptions =
+    plugin.githubAppConfigId &&
+    !githubAppConfigs.some((config) => config.id === plugin.githubAppConfigId)
+      ? [
+          {
+            id: plugin.githubAppConfigId,
+            name: "Current GitHub App configuration",
+          },
+          ...githubAppConfigs,
+        ]
+      : githubAppConfigs;
 
   return (
     <PageLayout
       title={`Edit ${plugin.displayName}`}
       documentTitle={`Edit ${plugin.displayName}`}
-      description={STEP_DESCRIPTIONS[step]}
+      description={
+        isGithubPlugin
+          ? "Edit the tracked GitHub source, authentication, update schedule, and discoverability."
+          : STEP_DESCRIPTIONS[step]
+      }
       backLink={
         <PluginBackLink
           href={detailHref}
@@ -296,6 +407,128 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
             )}
             {step === "access" && (
               <fieldset disabled={canUpdate === false} className="contents">
+                {isGithubPlugin && (
+                  <div className="space-y-5 border-b pb-6">
+                    <div className="space-y-2">
+                      <Label htmlFor="plugin-github-repo-url">
+                        Repository URL
+                      </Label>
+                      <Input
+                        id="plugin-github-repo-url"
+                        value={draft.githubRepoUrl}
+                        onChange={(event) =>
+                          patchDraft({ githubRepoUrl: event.target.value })
+                        }
+                        placeholder="github.com/owner/repo"
+                        autoComplete="off"
+                        data-1p-ignore
+                        data-lpignore="true"
+                      />
+                      <p className="text-sm text-muted-foreground">
+                        The GitHub repository checked for plugin updates.
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="plugin-github-sync-interval">
+                        Keep in sync
+                      </Label>
+                      <Select
+                        value={draft.githubSyncInterval ?? "off"}
+                        onValueChange={(value) =>
+                          patchDraft({
+                            githubSyncInterval:
+                              value === "off"
+                                ? null
+                                : (value as "15m" | "1h" | "1d"),
+                          })
+                        }
+                      >
+                        <SelectTrigger
+                          id="plugin-github-sync-interval"
+                          className="w-full"
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {GITHUB_SYNC_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <p className="text-sm text-muted-foreground">
+                        New commits become review candidates and never replace
+                        approved plugin bytes automatically.
+                      </p>
+                    </div>
+                    <GithubAuthConfigFields
+                      authMethod={draft.githubAuthMethod}
+                      onAuthMethodChange={(githubAuthMethod) =>
+                        patchDraft({
+                          githubAuthMethod,
+                          ...(githubAuthMethod === "pat"
+                            ? { githubAppConfigId: "" }
+                            : {}),
+                        })
+                      }
+                      githubAppConfigId={draft.githubAppConfigId}
+                      onGithubAppConfigIdChange={(githubAppConfigId) =>
+                        patchDraft({ githubAppConfigId })
+                      }
+                      githubAppConfigs={githubAppConfigOptions}
+                      patFields={
+                        <div className="space-y-2">
+                          <Label htmlFor="plugin-github-token">
+                            Personal Access Token
+                          </Label>
+                          <SecretInput
+                            id="plugin-github-token"
+                            value={draft.githubToken}
+                            onChange={(event) =>
+                              patchDraft({ githubToken: event.target.value })
+                            }
+                            placeholder="Leave empty to keep existing token"
+                          />
+                          <p className="text-sm text-muted-foreground">
+                            <span>
+                              Leave empty to keep existing credentials
+                              unchanged.
+                            </span>{" "}
+                            <span>
+                              Fine-grained or classic — see{" "}
+                              <a
+                                href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="font-medium text-primary underline-offset-4 hover:underline"
+                              >
+                                managing your personal access tokens
+                              </a>
+                              .
+                            </span>
+                          </p>
+                        </div>
+                      }
+                    />
+                    <div className="space-y-2">
+                      <Label htmlFor="plugin-github-sync-ref">Ref</Label>
+                      <Input
+                        id="plugin-github-sync-ref"
+                        value={draft.githubSyncRef}
+                        onChange={(event) =>
+                          patchDraft({ githubSyncRef: event.target.value })
+                        }
+                        placeholder="Default branch"
+                        autoComplete="off"
+                      />
+                      <p className="text-sm text-muted-foreground">
+                        Leave empty to track the repository&apos;s default
+                        branch.
+                      </p>
+                    </div>
+                  </div>
+                )}
                 <PluginScopeSelector
                   scope={draft.scope}
                   onScopeChange={(scope) => patchDraft({ scope })}
@@ -344,7 +577,7 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
                 <PermissionButton
                   permissions={{ plugin: ["update", "admin"] }}
                   variant={nextStep ? "outline" : "default"}
-                  disabled={!contentComplete || isSaving}
+                  disabled={!contentComplete || !sourceComplete || isSaving}
                   onClick={() => handleSave("finish")}
                 >
                   {savingWith === "finish" ? "Saving..." : "Save"}
@@ -362,7 +595,7 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
                 (isDirty || isSaving ? (
                   <PermissionButton
                     permissions={{ plugin: ["update", "admin"] }}
-                    disabled={!contentComplete || isSaving}
+                    disabled={!contentComplete || !sourceComplete || isSaving}
                     onClick={() => handleSave("continue")}
                   >
                     <span>
@@ -375,7 +608,7 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
                 ) : (
                   <Button
                     type="button"
-                    disabled={!contentComplete}
+                    disabled={!contentComplete || !sourceComplete}
                     onClick={() => goToStep(nextStep.id)}
                   >
                     <span>{nextStep.title}</span>

--- a/platform/frontend/src/app/plugins/[id]/edit/page.test.tsx
+++ b/platform/frontend/src/app/plugins/[id]/edit/page.test.tsx
@@ -2,9 +2,17 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// Radix Select uses APIs that jsdom does not implement.
+Element.prototype.scrollIntoView = vi.fn();
+Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+Element.prototype.setPointerCapture = vi.fn();
+Element.prototype.releasePointerCapture = vi.fn();
+
 vi.mock("next/navigation");
 vi.mock("@/lib/auth/auth.query");
 vi.mock("@/lib/config/config.query");
+vi.mock("@/lib/github-app-config.query");
+vi.mock("@/lib/github-pat.query");
 vi.mock("@/lib/organization.query");
 vi.mock("@/lib/plugins/plugin.query");
 vi.mock("@/lib/teams/team.query");
@@ -12,6 +20,8 @@ vi.mock("@/lib/teams/team.query");
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
+import { useGithubAppConfigs } from "@/lib/github-app-config.query";
+import { useCreateGithubPat } from "@/lib/github-pat.query";
 import {
   useAppearanceSettings,
   useOrganizationMembers,
@@ -24,12 +34,20 @@ import {
 import { useAssignableTeams } from "@/lib/teams/team.query";
 import { PluginEditPage } from "./page.client";
 
+const EXPIRED_PAT_ID = "11111111-1111-4111-8111-111111111111";
+const REPLACEMENT_PAT_ID = "22222222-2222-4222-8222-222222222222";
+
 const IMPORTED_PLUGIN = {
   id: "plugin-1",
   displayName: "Imported plugin",
   description: "Owned by its source repository",
   pluginSlug: "imported-plugin",
   sourceKind: "github",
+  sourceRepo: "archestra-ai/OpenAPPA",
+  githubSyncRef: "main",
+  githubSyncInterval: "1d",
+  githubPatId: EXPIRED_PAT_ID,
+  githubAppConfigId: null,
   enabled: true,
   supportedPlatforms: ["posix"],
   scope: "org",
@@ -62,9 +80,11 @@ const MANUAL_PLUGIN = {
 } as unknown as PluginDetail;
 
 const updateMock = vi.fn();
+const createPatMock = vi.fn();
 
 beforeEach(() => {
   updateMock.mockReset();
+  createPatMock.mockReset();
   vi.mocked(useFeature).mockReturnValue(true);
   vi.mocked(usePathname).mockReturnValue(`/plugins/${IMPORTED_PLUGIN.id}/edit`);
   vi.mocked(useSearchParams).mockReturnValue(
@@ -82,6 +102,17 @@ beforeEach(() => {
   vi.mocked(useUpdatePlugin).mockReturnValue({
     mutateAsync: updateMock,
   } as unknown as ReturnType<typeof useUpdatePlugin>);
+  vi.mocked(useCreateGithubPat).mockReturnValue({
+    mutateAsync: createPatMock,
+  } as unknown as ReturnType<typeof useCreateGithubPat>);
+  vi.mocked(useGithubAppConfigs).mockReturnValue({
+    data: [
+      {
+        id: "33333333-3333-4333-8333-333333333333",
+        name: "Archestra GitHub App",
+      },
+    ],
+  } as unknown as ReturnType<typeof useGithubAppConfigs>);
   vi.mocked(useHasPermissions).mockReturnValue({
     data: true,
   } as unknown as ReturnType<typeof useHasPermissions>);
@@ -100,17 +131,127 @@ beforeEach(() => {
 });
 
 describe("PluginEditPage", () => {
-  it("only edits access for an imported plugin", () => {
+  it("leaves empty authentication unchanged while editing GitHub source settings", async () => {
+    const user = userEvent.setup();
+    updateMock.mockResolvedValue(IMPORTED_PLUGIN);
     render(<PluginEditPage id={IMPORTED_PLUGIN.id} />);
 
     expect(
-      screen.getByText("Choose who can discover and install the plugin."),
+      screen.getByText(
+        "Edit the tracked GitHub source, authentication, update schedule, and discoverability.",
+      ),
+    ).toBeVisible();
+    expect(screen.getByLabelText("Repository URL")).toHaveValue(
+      "archestra-ai/OpenAPPA",
+    );
+    expect(screen.getByLabelText("Keep in sync")).toHaveTextContent(
+      "Once a day",
+    );
+    expect(screen.getByLabelText("Ref")).toHaveValue("main");
+    expect(screen.getByLabelText("Authentication Method")).toHaveTextContent(
+      "Personal Access Token",
+    );
+    expect(screen.getByLabelText("Personal Access Token")).toHaveValue("");
+    expect(screen.getByLabelText("Personal Access Token")).toHaveAttribute(
+      "placeholder",
+      "Leave empty to keep existing token",
+    );
+    expect(
+      screen.getByText(/Leave empty to keep existing credentials unchanged/),
     ).toBeVisible();
     expect(screen.queryByLabelText("Display name")).not.toBeInTheDocument();
     expect(screen.queryByText("Content")).not.toBeInTheDocument();
     expect(
       screen.queryByText(/Payload bytes are owned by the GitHub source/),
     ).not.toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText("Repository URL"));
+    await user.type(
+      screen.getByLabelText("Repository URL"),
+      "github.com/acme/plugin",
+    );
+    await user.clear(screen.getByLabelText("Ref"));
+    await user.type(screen.getByLabelText("Ref"), "release");
+    await user.click(screen.getByLabelText("Keep in sync"));
+    await user.click(screen.getByRole("option", { name: "Every hour" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubSource: {
+          repoUrl: "github.com/acme/plugin",
+          ref: "release",
+          syncInterval: "1h",
+        },
+        scope: "org",
+      }),
+    );
+  });
+
+  it("replaces an expired token with a newly saved credential", async () => {
+    const user = userEvent.setup();
+    createPatMock.mockResolvedValue({
+      id: REPLACEMENT_PAT_ID,
+      name: "Replacement token",
+    });
+    updateMock.mockResolvedValue({
+      ...IMPORTED_PLUGIN,
+      githubPatId: REPLACEMENT_PAT_ID,
+    });
+    render(<PluginEditPage id={IMPORTED_PLUGIN.id} />);
+
+    await user.type(
+      screen.getByLabelText("Personal Access Token"),
+      "ghp_fresh",
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(createPatMock).toHaveBeenCalledWith({
+      name: "Imported plugin token",
+      token: "ghp_fresh",
+    });
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubSource: expect.objectContaining({
+          authentication: {
+            githubAppConfigId: null,
+            githubPatId: REPLACEMENT_PAT_ID,
+          },
+        }),
+      }),
+    );
+  });
+
+  it("switches from the configured token to a GitHub App", async () => {
+    const user = userEvent.setup();
+    updateMock.mockResolvedValue({
+      ...IMPORTED_PLUGIN,
+      githubPatId: null,
+      githubAppConfigId: "33333333-3333-4333-8333-333333333333",
+    });
+    render(<PluginEditPage id={IMPORTED_PLUGIN.id} />);
+
+    await user.click(screen.getByLabelText("Authentication Method"));
+    await user.click(screen.getByRole("option", { name: "GitHub App" }));
+    expect(
+      screen.queryByLabelText("Personal Access Token"),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText("GitHub App Configuration"));
+    await user.click(
+      screen.getByRole("option", { name: "Archestra GitHub App" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubSource: expect.objectContaining({
+          authentication: {
+            githubAppConfigId: "33333333-3333-4333-8333-333333333333",
+            githubPatId: null,
+          },
+        }),
+      }),
+    );
   });
 
   it("uses the shared footer outside the card and preserves file metadata", async () => {

--- a/platform/frontend/src/app/settings/github/page.tsx
+++ b/platform/frontend/src/app/settings/github/page.tsx
@@ -257,8 +257,9 @@ export default function GithubSettingsPage() {
         <Info className="mt-0.5 size-4 shrink-0" />
         <p>
           GitHub credentials — App configurations and personal access tokens —
-          used by Knowledge Base (RAG) connectors, skill imports, and recurring
-          skill sync. For an agentic integration, use the{" "}
+          used by Knowledge Base (RAG) connectors, skill and plugin imports,
+          recurring skill sync, and scheduled plugin checks. For an agentic
+          integration, use the{" "}
           <Link
             href="/mcp/registry"
             className="font-medium text-foreground underline-offset-4 hover:underline"
@@ -401,7 +402,7 @@ function GithubAppDialog({
                 <FormItem>
                   <FormLabel>Name</FormLabel>
                   <FormControl>
-                    <Input placeholder="Platform skills app" {...field} />
+                    <Input placeholder="Repository access app" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -570,7 +571,7 @@ function GithubPatDialog({
                 <FormItem>
                   <FormLabel>Name</FormLabel>
                   <FormControl>
-                    <Input placeholder="Skills repo token" {...field} />
+                    <Input placeholder="Repository access token" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -594,8 +595,8 @@ function GithubPatDialog({
                     />
                   </FormControl>
                   <FormDescription>
-                    A fine-grained token with read access to the repositories
-                    you import skills from.
+                    A fine-grained token with read access to repositories used
+                    for skill and plugin imports.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -657,14 +658,15 @@ function DeleteCredentialDialog({
           <>
             This permanently deletes{" "}
             <span className="font-medium">{row?.name}</span> and its stored
-            private key. Connectors and synced skills still using it must be
-            reconfigured first.
+            private key. Connectors, synced skills, and GitHub-linked plugins
+            still using it must be reconfigured first.
           </>
         ) : (
           <>
             This permanently deletes{" "}
-            <span className="font-medium">{row?.name}</span>. Synced skills
-            still authenticating with it must be disconnected first.
+            <span className="font-medium">{row?.name}</span>. Synced skills and
+            GitHub-linked plugins still authenticating with it must be
+            reconfigured first.
           </>
         )
       }

--- a/platform/frontend/src/app/settings/layout.tsx
+++ b/platform/frontend/src/app/settings/layout.tsx
@@ -31,7 +31,7 @@ const PAGE_CONFIG: Record<string, { title: string; description: ReactNode }> = {
   "/settings/github": {
     title: "GitHub",
     description:
-      "Manage organization GitHub credentials for connectors and skill sync.",
+      "Manage organization GitHub credentials for connectors, skill and plugin imports, recurring skill sync, and scheduled plugin checks.",
   },
   "/settings/environments": {
     title: "Environments",

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -7438,7 +7438,7 @@ export const deletePlugin = <ThrowOnError extends boolean = false>(options: Opti
 export const getPlugin = <ThrowOnError extends boolean = false>(options: Options<GetPluginData, ThrowOnError>) => (options.client ?? client).get<GetPluginResponses, GetPluginErrors, ThrowOnError>({ url: '/api/plugins/{id}', ...options });
 
 /**
- * Update plugin metadata or replace its files
+ * Update plugin metadata, visibility, GitHub source settings, or files
  *
  * Authentication:
  *

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -81163,6 +81163,15 @@ export type UpdatePluginData = {
         scope?: 'personal' | 'team' | 'org';
         teamIds?: Array<string>;
         userIds?: Array<string>;
+        githubSource?: {
+            repoUrl: string;
+            ref: string | null;
+            syncInterval: '15m' | '1h' | '1d' | null;
+            authentication?: {
+                githubAppConfigId: string | null;
+                githubPatId: string | null;
+            };
+        };
         files?: Array<{
             path: string;
             content: string;


### PR DESCRIPTION
## Summary

- let administrators reconfigure a GitHub plugin's repository, tracked ref, check schedule, and visibility after import
- let an expired personal access token be replaced or switched to a GitHub App without changing approved plugin bytes
- document plugin credential use in GitHub settings and the Plugins guide

## Validation

- pnpm codegen
- pnpm lint
- pnpm type-check
- pnpm --dir backend knip
- backend plugin route tests: 18 passed
- frontend plugin edit and settings tests: 22 passed

Origin: [T-1158](https://slack.com/archives/C0B2AGC0AFQ/p1787653506802069?thread_ts=1787653455.142879&cid=C0B2AGC0AFQ)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>