### PR TITLE
fix(agents): streamline Advisor setup

### DIFF
--- a/docs/pages/platform-built-in-subagents.md
+++ b/docs/pages/platform-built-in-subagents.md
@@ -3,12 +3,12 @@ title: Built-in Subagents
 category: Agents
 order: 11
 description: The system subagents Archestra seeds into every organization, and what each one does
-lastUpdated: 2026-08-20
+lastUpdated: 2026-08-26
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
 
-Archestra seeds a set of built-in subagents into every organization. Each one handles a specific internal job — proposing tool policies, quarantining untrusted output, summarizing long chats, and so on. Most run automatically; you rarely invoke them directly. The Advisor is the exception: you turn it on per agent.
+Archestra seeds a set of built-in subagents into every organization. Each one handles a specific internal job — proposing tool policies, quarantining untrusted output, summarizing long chats, and so on. Most run automatically; you rarely invoke them directly. The Advisor is the exception: an administrator configures it once for the organization, and it can then be enabled on individual agents.
 
 An admin can open a built-in subagent in its settings and change its **system prompt** and **model** (requires `agent:admin`), and reset either back to the shipped default. Built-in subagents cannot be deleted or exported.
 
@@ -16,17 +16,28 @@ When a subagent has no model set, it runs on the model of the work it serves. A 
 
 ## Advisor
 
-The Advisor is in beta.
+> **Beta:** The Advisor is still under active development.
 
-The Advisor is a stronger model an agent consults at the decisions that shape a task: which approach to take, an error that keeps coming back, whether the work is really done. Everything else stays on the agent's own model.
+The Advisor is a shared reviewer that gives agents a second opinion. It is useful when an agent is choosing between approaches that would be expensive to reverse, is stuck, or wants its result reviewed before submitting it.
 
-Turn it on per agent with the **Advisor Subagent** switch, under **Subagents**. It works the same in Auto and Custom mode. **Advisor settings** on that row opens **Settings → LLM**, where the Advisor's model is picked — a stronger model than the callers use is the point.
+### Set up the Advisor
 
-Enabling the Advisor also instructs the agent to consult it before delivering a final answer, sharing the raw evidence behind the answer — samples of skipped input, for example — so the advice reviews the work, not a summary of it. When the Advisor's recommendation differs from the agent's own answer, the agent follows the Advisor.
+1. Open an agent and find **Advisor Subagent** under **Subagents**.
+2. Select **Open Advisor**. The organization's shared Advisor opens in a new tab.
+3. Choose the Advisor's model and save it. For a useful second opinion, choose a stronger model than the agents that consult it.
+4. Return to the original agent and turn on **Advisor Subagent**.
 
-The Advisor cannot see the conversation, the files, or the tools. It reads only the message the calling model writes, then returns advice. It changes nothing.
+The switch works the same in Auto and Custom subagent mode. Without an explicitly configured model, the Advisor follows the normal built-in-subagent fallback described above.
 
-There is one Advisor per organization, reachable from every environment. Consultations count against the consulting agent's environment [cost limits](/docs/platform-costs-and-limits). Each consultation is a separate interaction, billed at the Advisor's model rates. The agent consults at decision points rather than on every turn, so a cheap agent model paired with a strong Advisor usually costs less than running the strong model throughout.
+### What happens during a consultation
+
+An enabled agent is instructed to consult the Advisor before every final answer, verdict, or deliverable. It can also consult earlier when it needs help with an important decision.
+
+The agent sends one message containing its proposed answer, relevant constraints, and the evidence the Advisor needs to review. The Advisor cannot inspect the conversation, files, or tools, cannot ask a follow-up question, and cannot take action. It returns a recommendation and its reasoning to the calling agent. The calling agent follows a different recommendation unless the Advisor lacked relevant evidence or its advice conflicts with the task's instructions.
+
+### Scope and cost
+
+Each organization has one Advisor, available to agents in every environment. A consultation is a separate model interaction billed at the Advisor's model rates, and its spend counts against the consulting agent's environment [cost limits](/docs/platform-costs-and-limits).
 
 ## Policy Configuration Subagent
 

--- a/platform/frontend/src/app/settings/llm/page.test.tsx
+++ b/platform/frontend/src/app/settings/llm/page.test.tsx
@@ -127,6 +127,16 @@ describe("LlmSettingsPage", () => {
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
+  it("does not duplicate Advisor setup in LLM settings", async () => {
+    renderPage();
+
+    await screen.findByText("Apply compression to tool results");
+    expect(screen.queryByText("Advisor")).toBeNull();
+    expect(
+      screen.queryByRole("link", { name: /configure advisor/i }),
+    ).toBeNull();
+  });
+
   // The org-wide default user limit is no longer edited from the LLM settings
   // save bar (the old "Unset" button). It now lives in the unified
   // "Default user limits" list (a NULL-environment row with its own delete

--- a/platform/frontend/src/app/settings/llm/page.tsx
+++ b/platform/frontend/src/app/settings/llm/page.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import {
-  ADVISOR_AGENT_NAME,
-  archestraApiSdk,
-  type archestraApiTypes,
-} from "@archestra/shared";
+import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQueryClient } from "@tanstack/react-query";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { DefaultUserLimitsSection } from "@/app/settings/llm/_parts/default-user-limits-section";
@@ -19,8 +14,6 @@ import {
   SettingsSaveBar,
   SettingsSectionStack,
 } from "@/components/settings/settings-block";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { CardTitle } from "@/components/ui/card";
 import { MultiSelect } from "@/components/ui/multi-select";
 import {
@@ -272,41 +265,6 @@ export default function LlmSettingsPage() {
           </div>
         )}
       </SettingsBlock>
-      <SettingsBlock
-        // Linked from every agent's Advisor Subagent row, on the detail page
-        // and in the setup wizard.
-        id="advisor"
-        title={
-          <span className="flex items-center gap-2">
-            Advisor
-            <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-              Beta
-            </Badge>
-          </span>
-        }
-        description={
-          <>
-            Pair a cheaper model with a stronger advisor model consulted at key
-            moments in a task. The advisor is called at decision points rather
-            than on every turn, so this usually costs less than running the
-            stronger model throughout, though each call is billed at the advisor
-            model&apos;s rates. Pick the advisor&apos;s model on the Advisor
-            agent, then turn on the &quot;Advisor Subagent&quot; switch on the
-            agents and MCP Gateways that should reach it.
-          </>
-        }
-        control={
-          <Button asChild variant="outline">
-            <Link
-              // The agents list hides built-ins under its default scope, so
-              // the name filter alone lands on an empty table.
-              href={`/agents?name=${encodeURIComponent(ADVISOR_AGENT_NAME)}&scope=built_in`}
-            >
-              Configure advisor
-            </Link>
-          </Button>
-        }
-      />
       <SettingsSaveBar
         hasChanges={hasChanges}
         isSaving={updateLlmSettingsMutation.isPending}

--- a/platform/frontend/src/components/agent-form.test.tsx
+++ b/platform/frontend/src/components/agent-form.test.tsx
@@ -740,12 +740,23 @@ describe("AgentForm delegation state", () => {
 
     const toggle = await screen.findByTestId(E2eTestId.ConsultAdvisorSwitch);
     expect(toggle).not.toBeChecked();
+    expect(
+      screen.getByText("Answers without consulting the Advisor."),
+    ).toBeInTheDocument();
+    const openAdvisor = screen.getByRole("link", { name: /open advisor/i });
+    expect(openAdvisor).toHaveAttribute("href", `/agents/${advisorAgent.id}`);
+    expect(openAdvisor).toHaveAttribute("target", "_blank");
 
     await user.click(toggle);
 
     await waitFor(() => {
       expect(screen.getByTestId(E2eTestId.ConsultAdvisorSwitch)).toBeChecked();
     });
+    expect(
+      screen.getByText(
+        "Gets a second opinion from the Advisor before answering.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("renders no environment selector for the advisor", async () => {

--- a/platform/frontend/src/components/agent-form.tsx
+++ b/platform/frontend/src/components/agent-form.tsx
@@ -993,11 +993,6 @@ export function AgentForm({
   const { data: canReadIdentityProviders } = useHasPermissions({
     identityProvider: ["read"],
   });
-  // The Advisor's own model is one org-wide setting; the row links it for
-  // readers who may open it.
-  const { data: canReadLlmSettings } = useHasPermissions({
-    llmSettings: ["read"],
-  });
   const advisorDocsUrl = getDocsUrl(
     DocsPage.PlatformBuiltInSubagents,
     "advisor",
@@ -3557,8 +3552,9 @@ export function AgentForm({
                               </Badge>
                             </div>
                             <p className="text-xs text-muted-foreground">
-                              This {agentTypeDisplayName[agentType] || "agent"}{" "}
-                              consults a stronger model when making decisions.{" "}
+                              {advisorEnabled
+                                ? "Gets a second opinion from the Advisor before answering."
+                                : "Answers without consulting the Advisor."}{" "}
                               <ExternalDocsLink
                                 href={advisorDocsUrl}
                                 className="underline"
@@ -3568,38 +3564,38 @@ export function AgentForm({
                               </ExternalDocsLink>
                             </p>
                           </div>
-                          {canReadLlmSettings && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  size="sm"
-                                  className="shrink-0"
-                                  asChild
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="shrink-0"
+                                asChild
+                              >
+                                {/* New tab: this form holds unsaved edits
+                                  that navigating away would discard. */}
+                                <Link
+                                  href={agentDetailHref(
+                                    "agent",
+                                    advisorAgentId,
+                                  )}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
                                 >
-                                  {/* New tab: this form holds unsaved edits
-                                    that navigating away would discard. */}
-                                  <Link
-                                    href="/settings/llm#advisor"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                  >
-                                    <Settings2 className="size-4" />
-                                    <span>Advisor settings</span>
-                                    <span className="sr-only">
-                                      (opens in new tab)
-                                    </span>
-                                  </Link>
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent className="max-w-xs">
-                                Choose the model the Advisor answers with, in
-                                LLM settings. One Advisor is shared across the
-                                organization.
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
+                                  <Settings2 className="size-4" />
+                                  <span>Open Advisor</span>
+                                  <span className="sr-only">
+                                    (opens in new tab)
+                                  </span>
+                                </Link>
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-64">
+                              Open the organization&apos;s shared Advisor to see
+                              or change the model it uses.
+                            </TooltipContent>
+                          </Tooltip>
                           <Switch
                             id="consult-advisor"
                             checked={advisorEnabled}


### PR DESCRIPTION
## Summary

- remove the duplicate Advisor setup card from LLM settings
- link each agent's Advisor row directly to the shared Advisor and clarify its enabled state
- tighten the Advisor tooltip and rewrite the public setup, behavior, scope, and cost documentation

## Validation

- 50 focused frontend tests
- frontend Biome lint
- frontend TypeScript check
- documentation link and frontmatter check
- live platform and documentation previews

Origin: [T-1122](https://slack.com/archives/C0B2AGC0AFQ/p1787182471123609?thread_ts=1787182448.532819&cid=C0B2AGC0AFQ)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>