### PR TITLE
fix(plugins): make GitHub imports reliable and surface failures

### DIFF
--- a/platform/backend/src/plugins/github-import.test.ts
+++ b/platform/backend/src/plugins/github-import.test.ts
@@ -147,7 +147,10 @@ describe("importPluginFromGithub", () => {
       "hooks/hooks.json": "{}\n",
     };
     const treeSizes: Record<string, number> = { "hooks/hooks.json": 0 };
-    for (let index = 0; index < 8; index += 1) {
+    // More candidates than the worker pool can claim before the aggregate
+    // budget fills: unattempted entries must become skipped files, not holes
+    // that crash the assembly pass.
+    for (let index = 0; index < 20; index += 1) {
       const path = `zz-assets/${index}.txt`;
       files[path] = "x".repeat(700 * 1024);
       treeSizes[path] = 0;
@@ -174,6 +177,53 @@ describe("importPluginFromGithub", () => {
     );
     expect(totalBytes).toBeLessThanOrEqual(PLUGIN_MAX_TOTAL_BYTES);
     expect(imported.skippedFiles.length).toBeGreaterThan(0);
+  });
+
+  test("imports the approved commit even when the tracking branch moved", async () => {
+    const reviewedSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const movedSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const fetchMock = stubGithub([
+      {
+        owner: "plugin-moved",
+        repo: "plugin",
+        commitSha: reviewedSha,
+        files: { "hooks/hooks.json": "{}\n" },
+      },
+    ]);
+    const githubStub = fetchMock.getMockImplementation() as
+      | ((input: string | URL | Request) => Promise<Response>)
+      | undefined;
+    fetchMock.mockImplementation(async (input) => {
+      const url = new URL(
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url,
+      );
+      // The branch advanced after the review: resolving "main" now yields a
+      // commit whose raw files the stub does not serve.
+      if (
+        url.hostname === "api.github.com" &&
+        url.pathname.endsWith("/commits/main")
+      ) {
+        return Response.json({ sha: movedSha });
+      }
+      if (!githubStub) throw new Error("GitHub stub is not configured");
+      return githubStub(input);
+    });
+
+    const imported = await importPluginFromGithub({
+      repoUrl: "plugin-moved/plugin",
+      ref: reviewedSha,
+      trackingRef: "main",
+    });
+
+    expect(imported.commitSha).toBe(reviewedSha);
+    expect(imported.requestedRef).toBe("main");
+    expect(imported.files.map((file) => file.path)).toEqual([
+      "hooks/hooks.json",
+    ]);
   });
 
   test("imports through public Git when the anonymous REST quota is exhausted", async () => {

--- a/platform/backend/src/plugins/github-import.ts
+++ b/platform/backend/src/plugins/github-import.ts
@@ -55,7 +55,10 @@ export async function importPluginFromGithub(params: {
     params.trackingRef !== undefined
       ? params.trackingRef
       : (source.ref ?? params.ref ?? null);
-  const ref = requestedRef ?? "HEAD";
+  // A pinned commit always wins over the tracking branch at resolution time:
+  // the branch may have moved since the review the caller approved, and
+  // resolving the branch would race the approval check that follows.
+  const ref = params.ref ?? requestedRef ?? "HEAD";
 
   const commitSha = await resolveCommit({
     octokit,
@@ -92,28 +95,19 @@ export async function importPluginFromGithub(params: {
   const { candidates, skippedFiles } = collected;
 
   candidates.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  const downloaded = await downloadCandidates({
+    candidates,
+    source,
+    commitSha,
+    githubToken: params.githubToken,
+    deadlineAt: params.deadlineAt,
+    signal: deadlineSignal,
+  });
   const files: PluginFileInput[] = [];
   let downloadedBytes = 0;
-  for (const candidate of candidates) {
-    assertWithinDeadline(params.deadlineAt);
-    const remainingBytes = Math.min(
-      PLUGIN_MAX_FILE_BYTES,
-      PLUGIN_MAX_TOTAL_BYTES - downloadedBytes,
-    );
-    if (remainingBytes <= 0) {
-      skippedFiles.push(candidate.relativePath);
-      continue;
-    }
-    const bytes = await fetchRawFile({
-      owner: source.owner,
-      repo: source.repo,
-      commitSha,
-      path: candidate.repoPath,
-      githubToken: params.githubToken,
-      maxBytes: remainingBytes,
-      deadlineAt: params.deadlineAt,
-      signal: deadlineSignal,
-    });
+  for (let index = 0; index < candidates.length; index += 1) {
+    const candidate = candidates[index];
+    const bytes = downloaded[index];
     if (
       bytes === null ||
       bytes.length > PLUGIN_MAX_FILE_BYTES ||
@@ -155,6 +149,8 @@ export async function importPluginFromGithub(params: {
 }
 
 // === Internal helpers ===
+
+const FILE_DOWNLOAD_CONCURRENCY = 6;
 
 async function resolveCommit(params: {
   octokit: Octokit;
@@ -265,15 +261,64 @@ async function fetchRawFile(params: {
     );
   } catch (error) {
     throw new PluginImportError(
-      `Could not fetch ${params.path}: ${errorMessage(error)}`,
+      `Could not fetch ${params.path} from GitHub (${errorMessage(error)}); retry the import`,
     );
   }
   if (!response.ok) {
     throw new PluginImportError(
-      `Could not fetch ${params.path}: GitHub returned ${response.status}`,
+      `Could not fetch ${params.path} from GitHub (HTTP ${response.status}); retry the import`,
     );
   }
   return readResponseBodyWithLimit(response, params.maxBytes);
+}
+
+/**
+ * Downloads every candidate with bounded concurrency. Serial fetches let one
+ * slow network eat the batch deadline a file at a time; a small worker pool
+ * keeps the per-file timeout the failure unit instead. The pool stops once
+ * enough bytes are in flight to fill the aggregate budget — the assembly pass
+ * then applies the per-file and total limits in sorted path order, exactly as
+ * a serial loop would.
+ */
+async function downloadCandidates(params: {
+  candidates: ReturnType<typeof collectPluginTreeFiles>["candidates"];
+  source: { owner: string; repo: string };
+  commitSha: string;
+  githubToken?: string;
+  deadlineAt?: number;
+  signal?: AbortSignal;
+}): Promise<Array<Buffer | null>> {
+  const { candidates } = params;
+  const downloaded: Array<Buffer | null> = new Array(candidates.length).fill(
+    null,
+  );
+  let nextCandidate = 0;
+  let budgetedBytes = 0;
+  const workerCount = Math.min(FILE_DOWNLOAD_CONCURRENCY, candidates.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextCandidate < candidates.length) {
+        if (budgetedBytes >= PLUGIN_MAX_TOTAL_BYTES) return;
+        assertWithinDeadline(params.deadlineAt);
+        const index = nextCandidate;
+        nextCandidate += 1;
+        const candidate = candidates[index];
+        const bytes = await fetchRawFile({
+          owner: params.source.owner,
+          repo: params.source.repo,
+          commitSha: params.commitSha,
+          path: candidate.repoPath,
+          githubToken: params.githubToken,
+          maxBytes: PLUGIN_MAX_FILE_BYTES,
+          deadlineAt: params.deadlineAt,
+          signal: params.signal,
+        });
+        downloaded[index] = bytes;
+        budgetedBytes += bytes?.length ?? 0;
+      }
+    }),
+  );
+  return downloaded;
 }
 
 function decodeContent(bytes: Buffer): {

--- a/platform/backend/src/plugins/github-marketplace-import.ts
+++ b/platform/backend/src/plugins/github-marketplace-import.ts
@@ -95,7 +95,8 @@ export async function prepareGithubMarketplaceImports(params: {
   let exhaustedReason: string | null = null;
   for (const selection of params.selections) {
     if (!exhaustedReason && Date.now() >= deadlineAt) {
-      exhaustedReason = "Marketplace import time budget was exhausted";
+      exhaustedReason =
+        "Marketplace import time budget was exhausted; retry with fewer plugins selected";
     }
     if (exhaustedReason) {
       failed.push({ name: selection.name, error: exhaustedReason });

--- a/platform/frontend/src/app/globals.css
+++ b/platform/frontend/src/app/globals.css
@@ -506,125 +506,138 @@ div:has(> [data-testid="emoji-picker-list-header"]) {
   }
 }
 
-/* OpenAPPA is the first-party Plugin. A restrained accent hairline and one
-   smooth glint every 12 seconds distinguish it without persistent motion. */
-@keyframes plugin-featured-glint {
-  0%,
-  72%,
-  100% {
-    opacity: 0;
-    transform: translate3d(-120%, 0, 0) skewX(-16deg);
-  }
-  79% {
-    opacity: 0.12;
-  }
-  87% {
-    opacity: 0.28;
-    transform: translate3d(280%, 0, 0) skewX(-16deg);
-  }
-  91% {
-    opacity: 0;
-    transform: translate3d(280%, 0, 0) skewX(-16deg);
-  }
-}
-
-.plugin-featured-action,
-.plugin-featured-repository-option {
+/* OpenAPPA stays an ordinary pinned row; only its install action is featured. */
+button.plugin-featured-action {
+  --plugin-featured-spark: color-mix(
+    in oklab,
+    white 40%,
+    var(--primary) 60%
+  );
   position: relative;
   overflow: hidden;
-  isolation: isolate;
+  border-color: color-mix(in oklab, var(--primary) 45%, transparent);
+  background-color: color-mix(in oklab, var(--primary) 5%, transparent);
+  /* Position the strips from the real border rather than the inset padding
+     box, so their orbit follows the control's outline. */
+  background-origin: border-box;
+  background-image:
+    linear-gradient(
+      90deg,
+      transparent,
+      var(--plugin-featured-spark) 50%,
+      transparent
+    ),
+    linear-gradient(
+      180deg,
+      transparent,
+      var(--plugin-featured-spark) 50%,
+      transparent
+    ),
+    linear-gradient(
+      90deg,
+      transparent,
+      var(--plugin-featured-spark) 50%,
+      transparent
+    ),
+    linear-gradient(
+      180deg,
+      transparent,
+      var(--plugin-featured-spark) 50%,
+      transparent
+    );
+  background-size:
+    8px 2px,
+    2px 8px,
+    8px 2px,
+    2px 8px;
+  background-repeat: no-repeat;
+  background-position:
+    -8px 0,
+    100% -8px,
+    calc(100% + 8px) 100%,
+    0 calc(100% + 8px);
+  animation: plugin-featured-action-border-spark 6s linear infinite;
 }
 
-.plugin-featured-row > td::after,
-.plugin-featured-action::after,
-.plugin-featured-repository-option::after {
+button.plugin-featured-action:hover {
+  background-color: color-mix(in oklab, var(--primary) 9%, transparent);
+}
+
+/* One perimeter tour, then rest. The shorter cycle keeps the small action
+   noticeable without turning it into constant motion. */
+@keyframes plugin-featured-action-border-spark {
+  0%,
+  20% {
+    background-position:
+      -8px 0,
+      100% -8px,
+      calc(100% + 8px) 100%,
+      0 calc(100% + 8px);
+  }
+  35% {
+    background-position:
+      calc(100% + 8px) 0,
+      100% -8px,
+      calc(100% + 8px) 100%,
+      0 calc(100% + 8px);
+  }
+  50% {
+    background-position:
+      calc(100% + 8px) 0,
+      100% calc(100% + 8px),
+      calc(100% + 8px) 100%,
+      0 calc(100% + 8px);
+  }
+  65% {
+    background-position:
+      calc(100% + 8px) 0,
+      100% calc(100% + 8px),
+      -8px 100%,
+      0 calc(100% + 8px);
+  }
+  80%,
+  100% {
+    background-position:
+      calc(100% + 8px) 0,
+      100% calc(100% + 8px),
+      -8px 100%,
+      0 -8px;
+  }
+}
+
+button.plugin-featured-action::after {
   content: "";
   position: absolute;
-  inset: 0 auto 0 -30%;
-  width: 26%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 60%;
   pointer-events: none;
   background: linear-gradient(
-    90deg,
+    100deg,
     transparent 0%,
-    color-mix(in oklab, white 16%, transparent) 28%,
-    color-mix(in oklab, white 55%, var(--primary)) 47%,
-    color-mix(in oklab, white 82%, var(--primary)) 50%,
-    color-mix(in oklab, white 34%, var(--primary)) 54%,
-    color-mix(in oklab, white 10%, transparent) 72%,
+    color-mix(in oklab, var(--primary) 20%, transparent) 35%,
+    color-mix(in oklab, white 12%, var(--primary) 30%) 50%,
+    color-mix(in oklab, var(--primary) 20%, transparent) 65%,
     transparent 100%
   );
-  mix-blend-mode: soft-light;
-  opacity: 0;
-  transform: translate3d(-120%, 0, 0) skewX(-16deg);
-  animation: plugin-featured-glint 12s cubic-bezier(0.16, 1, 0.3, 1) infinite;
-  animation-delay: var(--plugin-featured-delay, 0s);
+  transform: translate3d(-150%, 0, 0) skewX(-16deg);
+  animation: plugin-featured-action-glint 5s ease-in-out infinite;
 }
 
-.plugin-featured-row {
-  outline: 1px solid color-mix(in oklab, var(--primary) 30%, transparent);
-  outline-offset: -1px;
-}
-
-.plugin-featured-row > td {
-  position: relative;
-  overflow: hidden;
-  isolation: isolate;
-  background-color: color-mix(in oklab, var(--primary) 3%, transparent);
-  background-image: linear-gradient(
-    180deg,
-    color-mix(in oklab, white 4%, transparent),
-    transparent 55%
-  );
-}
-
-.plugin-featured-row > td:nth-child(2) {
-  --plugin-featured-delay: 40ms;
-}
-
-.plugin-featured-row > td:nth-child(3) {
-  --plugin-featured-delay: 80ms;
-}
-
-.plugin-featured-row > td:nth-child(4) {
-  --plugin-featured-delay: 120ms;
-}
-
-.plugin-featured-row > td:nth-child(5) {
-  --plugin-featured-delay: 160ms;
-}
-
-.plugin-featured-row > td:nth-child(6) {
-  --plugin-featured-delay: 200ms;
-}
-
-.plugin-featured-row > td:nth-child(7) {
-  --plugin-featured-delay: 240ms;
-}
-
-.plugin-featured-row > td:nth-child(8) {
-  --plugin-featured-delay: 280ms;
-}
-
-.plugin-featured-row > td:nth-child(9) {
-  --plugin-featured-delay: 320ms;
-}
-
-.plugin-featured-action {
-  border-color: color-mix(in oklab, var(--primary) 38%, var(--border));
-  color: color-mix(in oklab, var(--primary) 68%, var(--foreground));
-  background-color: color-mix(in oklab, var(--primary) 4%, transparent);
-  box-shadow: inset 0 1px 0 color-mix(in oklab, white 16%, transparent);
-}
-
-.plugin-featured-repository-option {
-  color: color-mix(in oklab, var(--primary) 42%, var(--foreground));
-  background-color: color-mix(in oklab, var(--primary) 2%, transparent);
+@keyframes plugin-featured-action-glint {
+  0% {
+    transform: translate3d(-150%, 0, 0) skewX(-16deg);
+  }
+  18%,
+  100% {
+    transform: translate3d(260%, 0, 0) skewX(-16deg);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .plugin-featured-row > td::after,
-  .plugin-featured-action::after,
-  .plugin-featured-repository-option::after {
+  button.plugin-featured-action,
+  button.plugin-featured-action::after {
     animation: none;
   }
 }

--- a/platform/frontend/src/app/plugins/page.client.tsx
+++ b/platform/frontend/src/app/plugins/page.client.tsx
@@ -706,10 +706,6 @@ function PluginsList() {
                                             key={repo}
                                             repo={repo}
                                           />,
-                                          repo.toLowerCase() ===
-                                          "archestra-ai/openappa"
-                                            ? "plugin-featured-repository-option"
-                                            : undefined,
                                         ] as const,
                                     ),
                                 ]}
@@ -879,9 +875,6 @@ function PluginsList() {
                       canViewPluginDetails
                         ? (row) => router.push(pluginDetailHref(row.id))
                         : undefined
-                    }
-                    getRowClassName={(row) =>
-                      isArchestraPlugin(row) ? "plugin-featured-row" : undefined
                     }
                     rowSelection={bulkSelection.rowSelection}
                     onRowSelectionChange={bulkSelection.setRowSelection}

--- a/platform/frontend/src/lib/plugins/plugin.query.test.tsx
+++ b/platform/frontend/src/lib/plugins/plugin.query.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const sdk = vi.hoisted(() => ({
   updatePlugin: vi.fn(),
   deletePlugin: vi.fn(),
+  importGithubPluginMarketplace: vi.fn(),
 }));
 
 vi.mock("@archestra/shared", () => ({ archestraApiSdk: sdk }));
@@ -13,9 +14,12 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
 }));
 
+import { toast } from "sonner";
 import {
+  type ImportGithubPluginMarketplaceBody,
   useBulkDeletePlugins,
   useBulkUpdatePluginVisibility,
+  useImportGithubPluginMarketplace,
 } from "./plugin.query";
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -73,5 +77,35 @@ describe("Plugin bulk mutations", () => {
 
     expect(outcome.succeeded).toEqual([{ id: "p1", name: "One" }]);
     expect(outcome.failed).toHaveLength(1);
+  });
+
+  it("names the failed plugins and their reasons in the import toast", async () => {
+    sdk.importGithubPluginMarketplace.mockResolvedValue({
+      data: {
+        created: [{ id: "p0" }],
+        failed: [
+          { name: "one", error: "first reason" },
+          { name: "two", error: "second reason" },
+        ],
+      },
+      error: undefined,
+    });
+    const { result } = renderHook(() => useImportGithubPluginMarketplace(), {
+      wrapper,
+    });
+
+    await act(() =>
+      result.current.mutateAsync({} as ImportGithubPluginMarketplaceBody),
+    );
+
+    expect(toast.success).toHaveBeenCalledWith("1 plugin imported");
+    expect(toast.warning).toHaveBeenCalledWith(
+      "2 plugin imports failed",
+      expect.objectContaining({
+        description: expect.stringContaining(
+          "one: first reason · two: second reason",
+        ),
+      }),
+    );
   });
 });

--- a/platform/frontend/src/lib/plugins/plugin.query.ts
+++ b/platform/frontend/src/lib/plugins/plugin.query.ts
@@ -189,7 +189,20 @@ export function useImportGithubPluginMarketplace() {
         );
       }
       if (data.failed.length > 0) {
-        toast.warning(`${data.failed.length} plugin import failed`);
+        const reasons = data.failed
+          .slice(0, 3)
+          .map((failure) => `${failure.name}: ${failure.error}`)
+          .join(" · ");
+        toast.warning(
+          `${data.failed.length} plugin import${data.failed.length === 1 ? "" : "s"} failed`,
+          {
+            description:
+              data.failed.length > 3
+                ? `${reasons} · +${data.failed.length - 3} more`
+                : reasons,
+            duration: 10_000,
+          },
+        );
       }
     },
   });


### PR DESCRIPTION
## Summary

- resolve reviewed GitHub commits deterministically and fetch plugin files with bounded concurrency
- show actionable per-plugin import failure reasons
- keep the pinned OpenAPPA row standard while highlighting only its install action

## Testing

- backend plugin import/routes tests (31 passed)
- frontend plugin query/page tests (11 passed)
- backend/frontend lint and type-check

Task: [T-1164](https://slack.com/archives/C0B2AGC0AFQ/p1787691586837809?thread_ts=1787691586.153419&cid=C0B2AGC0AFQ)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>