### PR TITLE
fix(mcp): wait for cold servers to be ready

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -9472,6 +9472,169 @@ describe("readResource (assignment + all-tools dynamic access, end to end)", () 
     ).rejects.toThrow(/Resource not found/);
     expect(mockReadResource).not.toHaveBeenCalled();
   });
+
+  describe("transient retry", () => {
+    const RETRY_RESULT = {
+      contents: [
+        {
+          uri: RESOURCE_URI,
+          mimeType: "text/html",
+          text: "<html>recovered</html>",
+        },
+      ],
+    };
+
+    function retryRead() {
+      return (
+        mcpClient as unknown as {
+          doReadResourceWithRetry: (params: unknown) => Promise<unknown>;
+        }
+      ).doReadResourceWithRetry({
+        uri: RESOURCE_URI,
+        agentId: randomUUID(),
+        mcpServer: {
+          server: { id: randomUUID() },
+          catalogItem: {},
+        },
+      });
+    }
+
+    test("reconnects and retries an idempotent resource read after a transport failure", async () => {
+      const transportError = new Error("fetch failed", {
+        cause: Object.assign(new Error("connect refused"), {
+          code: "ECONNREFUSED",
+        }),
+      });
+      const doReadResource = vi
+        .spyOn(
+          mcpClient as unknown as { doReadResource: () => Promise<unknown> },
+          "doReadResource",
+        )
+        .mockRejectedValueOnce(transportError)
+        .mockResolvedValueOnce(RETRY_RESULT);
+      const invalidate = vi
+        .spyOn(mcpClient, "invalidateConnectionsForServer")
+        .mockResolvedValue(undefined);
+      const random = vi.spyOn(Math, "random").mockReturnValue(0);
+
+      try {
+        await expect(retryRead()).resolves.toEqual(RETRY_RESULT);
+        expect(doReadResource).toHaveBeenCalledTimes(2);
+        expect(invalidate).toHaveBeenCalledTimes(1);
+      } finally {
+        doReadResource.mockRestore();
+        invalidate.mockRestore();
+        random.mockRestore();
+      }
+    });
+
+    test("applies the same retry policy to server-scoped UI resource reads", async () => {
+      const directRead = vi
+        .spyOn(
+          mcpClient as unknown as {
+            withDirectServerClient: () => Promise<unknown>;
+          },
+          "withDirectServerClient",
+        )
+        .mockRejectedValueOnce(new Error("fetch failed"))
+        .mockResolvedValueOnce(RETRY_RESULT);
+      const random = vi.spyOn(Math, "random").mockReturnValue(0);
+
+      try {
+        await expect(
+          mcpClient.readResourceForServer({
+            mcpServerId: randomUUID(),
+            uri: RESOURCE_URI,
+          }),
+        ).resolves.toEqual(RETRY_RESULT);
+        expect(directRead).toHaveBeenCalledTimes(2);
+      } finally {
+        directRead.mockRestore();
+        random.mockRestore();
+      }
+    });
+
+    test("does not spend the retry deadline while waiting for a cold wake", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      const directRead = vi
+        .spyOn(
+          mcpClient as unknown as {
+            withDirectServerClient: () => Promise<unknown>;
+          },
+          "withDirectServerClient",
+        )
+        .mockImplementationOnce(async () => {
+          vi.setSystemTime(Date.now() + 30_000);
+          throw new Error("fetch failed");
+        })
+        .mockResolvedValueOnce(RETRY_RESULT);
+      const random = vi.spyOn(Math, "random").mockReturnValue(0);
+
+      try {
+        const read = mcpClient.readResourceForServer({
+          mcpServerId: randomUUID(),
+          uri: RESOURCE_URI,
+        });
+        await vi.runAllTimersAsync();
+        await expect(read).resolves.toEqual(RETRY_RESULT);
+        expect(directRead).toHaveBeenCalledTimes(2);
+      } finally {
+        directRead.mockRestore();
+        random.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
+    test("does not retry protocol errors", async () => {
+      const doReadResource = vi
+        .spyOn(
+          mcpClient as unknown as { doReadResource: () => Promise<unknown> },
+          "doReadResource",
+        )
+        .mockRejectedValue(new Error("Method not found"));
+      const invalidate = vi
+        .spyOn(mcpClient, "invalidateConnectionsForServer")
+        .mockResolvedValue(undefined);
+
+      try {
+        await expect(retryRead()).rejects.toThrow("Method not found");
+        expect(doReadResource).toHaveBeenCalledTimes(1);
+        expect(invalidate).not.toHaveBeenCalled();
+      } finally {
+        doReadResource.mockRestore();
+        invalidate.mockRestore();
+      }
+    });
+
+    test("stops after the hard attempt limit", async () => {
+      vi.useFakeTimers();
+      const doReadResource = vi
+        .spyOn(
+          mcpClient as unknown as { doReadResource: () => Promise<unknown> },
+          "doReadResource",
+        )
+        .mockRejectedValue(new Error("fetch failed"));
+      const invalidate = vi
+        .spyOn(mcpClient, "invalidateConnectionsForServer")
+        .mockResolvedValue(undefined);
+      const random = vi.spyOn(Math, "random").mockReturnValue(0);
+
+      try {
+        const read = retryRead();
+        const rejected = expect(read).rejects.toThrow("fetch failed");
+        await vi.runAllTimersAsync();
+        await rejected;
+        expect(doReadResource).toHaveBeenCalledTimes(8);
+        expect(invalidate).toHaveBeenCalledTimes(7);
+      } finally {
+        doReadResource.mockRestore();
+        invalidate.mockRestore();
+        random.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+  });
 });
 
 // Every upstream call runs under some credential the gateway resolves — the

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -115,6 +115,11 @@ import { agentOwner } from "@/types";
 import type { ClientCapabilitiesWithExtensions } from "@/types/mcp-capabilities";
 import { deriveAuthMethod } from "@/utils/auth-method";
 import { buildMcpClientInfo } from "@/utils/mcp-client-info";
+import {
+  collectErrorCodes,
+  isConnectionErrno,
+  isTimeoutErrno,
+} from "@/utils/network-errors";
 import { previewToolResultContent } from "@/utils/tool-result-preview";
 import { K8sAttachTransport } from "./k8s-attach-transport";
 import {
@@ -216,6 +221,56 @@ function isStaleSessionError(error: unknown): boolean {
     error instanceof StaleSessionError ||
     (error instanceof StreamableHTTPError &&
       String(error.message).includes("Session not found"))
+  );
+}
+
+const RESOURCE_READ_RETRY_MAX_ATTEMPTS = 8;
+const RESOURCE_READ_RETRY_BASE_DELAY_MS = 500;
+const RESOURCE_READ_RETRY_MAX_DELAY_MS = 2_000;
+const RESOURCE_READ_RETRY_DEADLINE_MS = 10_000;
+const TRANSIENT_RESOURCE_HTTP_STATUSES = new Set([
+  408, 425, 429, 502, 503, 504,
+]);
+
+/**
+ * Resource reads are idempotent, so transport failures that occur around a
+ * cold start are safe to reconnect and retry. Protocol, authorization, and
+ * resource errors are intentionally excluded.
+ */
+function isTransientResourceReadError(error: unknown): boolean {
+  if (
+    error instanceof McpServerWakeError ||
+    isStaleSessionError(error) ||
+    collectErrorCodes(error).some(
+      (code) => isConnectionErrno(code) || isTimeoutErrno(code),
+    )
+  ) {
+    return true;
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const candidate = error as {
+      code?: unknown;
+      status?: unknown;
+      statusCode?: unknown;
+    };
+    for (const status of [
+      candidate.code,
+      candidate.status,
+      candidate.statusCode,
+    ]) {
+      if (
+        typeof status === "number" &&
+        TRANSIENT_RESOURCE_HTTP_STATUSES.has(status)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return /\bfetch failed\b|\bconnection (?:closed|reset|refused)\b|\bsocket hang up\b/i.test(
+    message,
   );
 }
 
@@ -3997,13 +4052,18 @@ class McpClient {
     mcpServerId: string;
     uri: string;
   }): Promise<unknown> {
-    return this.withDirectServerClient(params.mcpServerId, (client) =>
-      this.raceWithTimeout(
-        client.readResource({ uri: params.uri }),
-        30000,
-        "Read resource timeout",
-      ),
-    );
+    return this.retryTransientResourceRead({
+      uri: params.uri,
+      mcpServerId: params.mcpServerId,
+      read: () =>
+        this.withDirectServerClient(params.mcpServerId, (client) =>
+          this.raceWithTimeout(
+            client.readResource({ uri: params.uri }),
+            30000,
+            "Read resource timeout",
+          ),
+        ),
+    });
   }
 
   /** Call a tool directly on one installed server (server-scoped run path). */
@@ -4233,15 +4293,15 @@ class McpClient {
     }
 
     try {
-      const result = await this.doReadResource(
+      const result = await this.doReadResourceWithRetry({
         uri,
         agentId,
         mcpServer,
         tokenAuth,
-      );
+      });
       this.resourceCache.set(cacheKey, {
         result,
-        ttl: now + RESOURCE_CACHE_TTL_MS,
+        ttl: Date.now() + RESOURCE_CACHE_TTL_MS,
       });
       logger.info(
         { uri, agentId, serverId: mcpServer.server.id },
@@ -4257,6 +4317,89 @@ class McpClient {
         return staleCache.result;
       }
       throw error;
+    }
+  }
+
+  private async doReadResourceWithRetry(params: {
+    uri: string;
+    agentId: string;
+    mcpServer: {
+      server: NonNullable<Awaited<ReturnType<typeof McpServerModel.findById>>>;
+      catalogItem: NonNullable<
+        Awaited<ReturnType<typeof InternalMcpCatalogModel.findById>>
+      >;
+    };
+    tokenAuth?: TokenAuthContext;
+  }): Promise<ResourceContents> {
+    return this.retryTransientResourceRead({
+      uri: params.uri,
+      mcpServerId: params.mcpServer.server.id,
+      read: () =>
+        this.doReadResource(
+          params.uri,
+          params.agentId,
+          params.mcpServer,
+          params.tokenAuth,
+        ),
+      resetConnection: () =>
+        this.invalidateConnectionsForServer(params.mcpServer.server.id),
+    });
+  }
+
+  private async retryTransientResourceRead<T>(params: {
+    uri: string;
+    mcpServerId: string;
+    read: () => Promise<T>;
+    resetConnection?: () => Promise<void>;
+  }): Promise<T> {
+    let deadlineAt: number | undefined;
+
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await params.read();
+      } catch (error) {
+        const exhausted = attempt >= RESOURCE_READ_RETRY_MAX_ATTEMPTS;
+        if (exhausted || !isTransientResourceReadError(error)) {
+          throw error;
+        }
+
+        // A direct read includes the managed wake. Start the retry deadline at
+        // the first transient transport failure, not before the wake; otherwise
+        // any cold start longer than the retry window disables retries entirely.
+        deadlineAt ??= Date.now() + RESOURCE_READ_RETRY_DEADLINE_MS;
+        if (Date.now() >= deadlineAt) throw error;
+
+        // Cached clients must not reuse the transport or HTTP session that
+        // failed. Direct reads create and close a fresh client per attempt.
+        await params.resetConnection?.();
+
+        const backoffCeilingMs = Math.min(
+          RESOURCE_READ_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+          RESOURCE_READ_RETRY_MAX_DELAY_MS,
+        );
+        // Equal jitter keeps retries spread out while retaining enough minimum
+        // delay to cover bounded service/endpoint propagation after a wake.
+        const backoffFloorMs = Math.floor(backoffCeilingMs / 2);
+        const jitteredDelayMs =
+          backoffFloorMs +
+          Math.floor(Math.random() * (backoffCeilingMs - backoffFloorMs + 1));
+        const remainingMs = deadlineAt - Date.now();
+        if (remainingMs <= 0) throw error;
+        const delayMs = Math.min(jitteredDelayMs, remainingMs);
+
+        logger.warn(
+          {
+            err: error,
+            uri: params.uri,
+            mcpServerId: params.mcpServerId,
+            attempt,
+            nextAttempt: attempt + 1,
+            delayMs,
+          },
+          "Transient MCP resource read failed; reconnecting and retrying",
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
     }
   }
 

--- a/platform/backend/src/k8s/mcp-server-runtime/hibernation-foreign-scaler.ee.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/hibernation-foreign-scaler.ee.test.ts
@@ -171,6 +171,7 @@ class FakeK8sCluster {
         },
         status: {
           phase: running ? "Running" : "Pending",
+          conditions: [{ type: "Ready", status: running ? "True" : "False" }],
           containerStatuses: [
             {
               name: "mcp-server",

--- a/platform/backend/src/k8s/mcp-server-runtime/hibernation-multi-replica.ee.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/hibernation-multi-replica.ee.test.ts
@@ -145,6 +145,7 @@ class FakeK8sCluster {
         },
         status: {
           phase: running ? "Running" : "Pending",
+          conditions: [{ type: "Ready", status: running ? "True" : "False" }],
           containerStatuses: [
             {
               name: "mcp-server",

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -679,6 +679,9 @@ describe("K8sDeployment.generateDeploymentSpec", () => {
     expect(container?.stdin).toBe(true);
     expect(container?.tty).toBe(false);
     expect(container?.ports).toBeUndefined();
+    expect(container?.startupProbe).toBeUndefined();
+    expect(container?.readinessProbe).toBeUndefined();
+    expect(container?.livenessProbe).toBeUndefined();
     expect(templateSpec?.enableServiceLinks).toBe(false);
     expect(templateSpec?.restartPolicy).toBe("Always");
   });
@@ -717,6 +720,25 @@ describe("K8sDeployment.generateDeploymentSpec", () => {
         protocol: "TCP",
       },
     ]);
+    expect(container?.startupProbe).toEqual({
+      tcpSocket: { port: 3000 },
+      periodSeconds: 2,
+      timeoutSeconds: 1,
+      failureThreshold: 60,
+    });
+    expect(container?.readinessProbe).toEqual({
+      tcpSocket: { port: 3000 },
+      periodSeconds: 2,
+      timeoutSeconds: 1,
+      failureThreshold: 2,
+      successThreshold: 1,
+    });
+    expect(container?.livenessProbe).toEqual({
+      tcpSocket: { port: 3000 },
+      periodSeconds: 30,
+      timeoutSeconds: 1,
+      failureThreshold: 3,
+    });
   });
 
   test("generates deploymentSpec without command when no command is provided", () => {
@@ -2675,6 +2697,43 @@ spec:
       catalogItem: catalogItem,
     });
   }
+
+  test("fills missing TCP probes for custom HTTP YAML and preserves explicit probes", () => {
+    const deployment = createK8sDeploymentWithYaml(`
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: mcp-server
+          image: test:latest
+          readinessProbe:
+            tcpSocket:
+              port: 9191
+            periodSeconds: 7
+`);
+
+    const spec = deployment.generateDeploymentSpec(
+      "test:latest",
+      {
+        command: "node",
+        arguments: ["server.js"],
+        transportType: "streamable-http",
+        httpPort: 9191,
+      },
+      true,
+      9191,
+    );
+    const container = spec.spec?.template.spec?.containers[0];
+
+    expect(container?.readinessProbe).toEqual({
+      tcpSocket: { port: 9191 },
+      periodSeconds: 7,
+    });
+    expect(container?.startupProbe?.tcpSocket).toEqual({ port: 9191 });
+    expect(container?.livenessProbe?.tcpSocket).toEqual({ port: 9191 });
+  });
 
   test("applies platform nodeSelector when YAML has none", () => {
     const k8sDeployment = createK8sDeploymentWithYaml(minimalYaml);
@@ -7181,6 +7240,7 @@ describe("K8sDeployment image pull failure handling", () => {
     },
     status: {
       phase: "Running",
+      conditions: [{ type: "Ready", status: "True" }],
       containerStatuses: [
         {
           name: "mcp-server",
@@ -7300,6 +7360,29 @@ describe("K8sDeployment image pull failure handling", () => {
       ).resolves.toBeUndefined();
       expect(deployment.statusSummary.state).toBe("running");
       expect(deployment.statusSummary.error).toBeNull();
+    });
+
+    test("waits for the Kubernetes Pod Ready condition, not only Running phase", async () => {
+      const runningButUnready = {
+        ...runningPod,
+        status: {
+          ...runningPod.status,
+          conditions: [{ type: "Ready", status: "False" }],
+        },
+      } as k8s.V1Pod;
+      const listNamespacedPod = vi
+        .fn()
+        .mockResolvedValueOnce({ items: [runningButUnready] })
+        .mockResolvedValue({ items: [runningPod] });
+      const deployment = makeDeploymentWithMockedApis({
+        listNamespacedPod,
+        readNamespacedDeployment: vi.fn(),
+      });
+
+      await expect(
+        deployment.waitForDeploymentReady(3, 1),
+      ).resolves.toBeUndefined();
+      expect(listNamespacedPod).toHaveBeenCalledTimes(2);
     });
 
     test("fails fast on terminal container states", async () => {
@@ -7947,6 +8030,7 @@ describe("K8sDeployment idle hibernation", () => {
     metadata: { name: "test-server-abc123", creationTimestamp: new Date() },
     status: {
       phase: "Running",
+      conditions: [{ type: "Ready", status: "True" }],
       containerStatuses: [
         {
           name: "mcp-server",

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -111,6 +111,50 @@ const AWS_APPLICATION_NETWORK_POLICY_RESOURCE = {
 const POD_READY_WAIT_MS = 5 * TimeInMs.Minute;
 
 /**
+ * Default transport-level health contract for managed HTTP MCP servers.
+ *
+ * TCP probes deliberately avoid making protocol-version, authentication, or
+ * session assumptions. The startup budget covers slow application bootstrap;
+ * once it succeeds, readiness controls Service routing and the conservative
+ * liveness cadence only restarts a server whose listening socket stays down.
+ */
+function buildHttpTcpProbes(
+  httpPort: number,
+): Pick<k8s.V1Container, "startupProbe" | "readinessProbe" | "livenessProbe"> {
+  return {
+    startupProbe: {
+      tcpSocket: { port: httpPort },
+      periodSeconds: 2,
+      timeoutSeconds: 1,
+      failureThreshold: 60,
+    },
+    readinessProbe: {
+      tcpSocket: { port: httpPort },
+      periodSeconds: 2,
+      timeoutSeconds: 1,
+      failureThreshold: 2,
+      successThreshold: 1,
+    },
+    livenessProbe: {
+      tcpSocket: { port: httpPort },
+      periodSeconds: 30,
+      timeoutSeconds: 1,
+      failureThreshold: 3,
+    },
+  };
+}
+
+/** Kubernetes' direct serving signal, including the configured readiness probe. */
+function isPodReady(pod: k8s.V1Pod): boolean {
+  return (
+    pod.status?.phase === "Running" &&
+    pod.status.conditions?.some(
+      (condition) => condition.type === "Ready" && condition.status === "True",
+    ) === true
+  );
+}
+
+/**
  * Thrown when a user's MCP server deployment fails to come up (crashing
  * container, unschedulable pod, bad image/config). A condition of the user's
  * server or environment, not a bug of ours: error tracking drops it by name,
@@ -2119,6 +2163,7 @@ export default class K8sDeployment {
                     protocol: "TCP",
                   },
                 ],
+                ...buildHttpTcpProbes(httpPort),
               }
             : {
                 stdin: true,
@@ -2500,6 +2545,13 @@ export default class K8sDeployment {
             },
           ];
         }
+        // Custom YAML may tune any probe explicitly. Fill only missing probes
+        // so every managed HTTP workload gets the transport-level defaults
+        // without overriding an operator's health contract.
+        const defaultProbes = buildHttpTcpProbes(httpPort);
+        container.startupProbe ??= defaultProbes.startupProbe;
+        container.readinessProbe ??= defaultProbes.readinessProbe;
+        container.livenessProbe ??= defaultProbes.livenessProbe;
       } else {
         // Stdio transport: enable stdin for JSON-RPC communication
         if (container.stdin === undefined) {
@@ -4306,33 +4358,23 @@ export default class K8sDeployment {
 
     for (let i = 0; i < maxAttempts; i++) {
       try {
-        const deployment = await this.k8sAppsApi.readNamespacedDeployment({
-          name: this.deploymentName,
-          namespace: this.namespace,
-        });
-
-        if (
-          deployment.status?.availableReplicas &&
-          deployment.status.availableReplicas > 0
-        ) {
-          // Also check if we can find the pod
-          const pod = await this.findPodForDeployment();
-          if (pod && pod.status?.phase === "Running") {
-            await this.assignHttpPortIfNeeded(pod);
-            // Update state to running now that deployment is confirmed ready
-            if (this.observeState("running")) {
-              this.errorMessage = null;
-            }
-            return;
-          }
-        }
-
-        // Check for failures in latest pods
         const sanitizedId = sanitizeLabelValue(this.getPodSelectorServerId());
         const pods = await this.k8sApi.listNamespacedPod({
           namespace: this.namespace,
           labelSelector: `mcp-server-id=${sanitizedId}`,
         });
+
+        // Pod Ready is the kubelet-owned result of the readiness probe. Waiting
+        // on it directly avoids treating a merely Running container as able to
+        // serve while keeping wake completion intentionally simple.
+        const readyPod = pods.items.find(isPodReady);
+        if (readyPod) {
+          await this.assignHttpPortIfNeeded(readyPod);
+          if (this.observeState("running")) {
+            this.errorMessage = null;
+          }
+          return;
+        }
 
         // Check for failure events (every 5th iteration to reduce API calls)
         // Start checking after first 10 seconds (iteration 5)

--- a/platform/backend/src/k8s/mcp-server-runtime/manager-deployment-integration.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager-deployment-integration.test.ts
@@ -206,6 +206,7 @@ class FakeK8sCluster {
         },
         status: {
           phase: running ? "Running" : "Pending",
+          conditions: [{ type: "Ready", status: running ? "True" : "False" }],
           containerStatuses: [
             {
               name: "mcp-server",

--- a/platform/backend/src/routes/mcp-server.hard-reset.test.ts
+++ b/platform/backend/src/routes/mcp-server.hard-reset.test.ts
@@ -147,6 +147,12 @@ class FakeCluster {
             },
             status: {
               phase: pod.phase,
+              conditions: [
+                {
+                  type: "Ready",
+                  status: pod.phase === "Running" ? "True" : "False",
+                },
+              ],
               containerStatuses: pod.waitingReason
                 ? [
                     {

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -1770,11 +1770,7 @@ describe("McpAppSection error handling", () => {
     vi.clearAllMocks();
   });
 
-  it("degrades silently for a third-party app when the UI resource can't be read", async () => {
-    // A third-party tool advertises a ui:// resource its upstream server can't
-    // serve (e.g. -32601 Method not found). The tool result is shown regardless,
-    // so the failed app load must fold away rather than show a "Failed to load
-    // app" card. defaultProps is an agent (third-party) render — no appId.
+  it("shows a retryable error for a third-party app when the UI resource can't be read", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockRejectedValue(new Error("MCP error -32601: Method not found"));
@@ -1792,10 +1788,12 @@ describe("McpAppSection error handling", () => {
     // Flush the rejection handler + re-render.
     await act(async () => {});
 
-    expect(screen.queryByText(/failed to load app/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/failed to load app/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
     expect(document.querySelector("iframe")).not.toBeInTheDocument();
-    // The app folded away, but its tool-call details stay inspectable.
-    expect(screen.getByTestId("tool-details")).toBeInTheDocument();
+    expect(
+      screen.queryByText("This app rendered nothing to display."),
+    ).not.toBeInTheDocument();
 
     fetchSpy.mockRestore();
   });

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -300,7 +300,7 @@ export function McpAppEntryContent({
   );
   const [resourceState, setResourceState] = useState<{
     key: string;
-    state: "unknown" | "renderable" | "empty";
+    state: "unknown" | "renderable" | "empty" | "error";
   }>(() => ({
     key: resourceKey,
     state: preloadedResource
@@ -381,7 +381,7 @@ export function McpAppEntryContent({
   };
 
   const handleResourceStateChange = useCallback(
-    (state: "renderable" | "empty") => {
+    (state: "renderable" | "empty" | "error") => {
       setResourceState({ key: resourceKey, state });
     },
     [resourceKey],
@@ -473,12 +473,8 @@ export function McpAppEntryContent({
       // which the runtime gates on a non-null version.
       appVersion={appVersion ?? ownedApp?.latestVersion ?? null}
       reloadNonce={reloadNonce}
+      onReload={reload}
       recorder={appId ? recorder.runtimeHooks : undefined}
-      // Third-party apps (no appId) are incidental to a tool call: if their
-      // upstream can't serve the advertised ui:// resource, fold the app away
-      // and keep the plain tool result rather than showing a load error.
-      // Owned apps keep surfacing errors — a failure there is an authoring bug.
-      degradeResourceLoadError={!appId}
       // Owned apps only: their file store is what agent-side copy_file writes
       // into, and their SDK is what reports display state back.
       filesRevision={appId ? (appFilesRevisions.get(appId) ?? 0) : undefined}

--- a/platform/frontend/src/components/mcp-app/app-frame.tsx
+++ b/platform/frontend/src/components/mcp-app/app-frame.tsx
@@ -41,6 +41,7 @@ export function AppFrame({
     displayMode,
     setDisplayMode,
     reloadNonce,
+    reload,
     resourceState,
     setResourceState,
   } = useAppRuntimeControls();
@@ -61,6 +62,7 @@ export function AppFrame({
       onSizeChange={noopSizeChange}
       onResourceStateChange={setResourceState}
       reloadNonce={reloadNonce}
+      onReload={reload}
     />
   ) : null;
 

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -22,6 +22,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AppSessionRecorderRuntimeHooks } from "@/components/app-session-recording/use-app-session-recorder";
 import { INITIAL_INLINE_HEIGHT } from "@/components/mcp-app/app-height";
 import { McpAppAuthBanner } from "@/components/mcp-app/mcp-app-auth-banner";
+import { Button } from "@/components/ui/button";
 import {
   getAppDiagnostics,
   parseForwardedDiagnostic,
@@ -104,7 +105,7 @@ export const McpAppRuntime = function McpAppRuntime({
   containerDimensions,
   reloadNonce,
   inlineInitialHeight,
-  degradeResourceLoadError,
+  onReload,
   recorder,
   filesRevision,
   onModelContextUpdate,
@@ -121,7 +122,7 @@ export const McpAppRuntime = function McpAppRuntime({
   onSendMessage?: (text: string) => void;
   /** HTML pre-fetched by the backend — skips the in-browser HTTP fetch to avoid SSE deadlock */
   preloadedResource?: AppResourceMeta;
-  onResourceStateChange: (state: "renderable" | "empty") => void;
+  onResourceStateChange: (state: "renderable" | "empty" | "error") => void;
   /** Owned-app version this render shows — keys the render-loop diagnostics. */
   appVersion?: number | null;
   /** Container size hint forwarded to the guest (SEP-1865 `containerDimensions`).
@@ -134,18 +135,8 @@ export const McpAppRuntime = function McpAppRuntime({
   /** Last measured inline height; seeds the iframe + loading box so a fresh
    * mount (e.g. returning from the panel) doesn't collapse before the app loads. */
   inlineInitialHeight?: number;
-  /**
-   * Degrade silently instead of showing a "Failed to load app" card when the
-   * UI resource can't be read. Set for incidental chat renders of third-party
-   * apps: a tool advertises a `ui://` resource its upstream server may not
-   * actually serve (e.g. a server that added MCP-UI hints without implementing
-   * `resources/read`, which fails with -32601 Method not found), and the tool
-   * result is shown regardless — so a failed app load falls back to that plain
-   * result rather than a scary error. Left false where the app was opened
-   * deliberately (run pages) or is Archestra-authored (an authoring bug the
-   * author must see), so failures stay visible there.
-   */
-  degradeResourceLoadError?: boolean;
+  /** Retry the resource load by rebuilding the runtime. */
+  onReload?: () => void;
   /**
    * Session-recorder hooks from {@link useAppSessionRecorder}: the runtime
    * reports its proxied MCP exchanges, the served HTML it renders, the live
@@ -211,8 +202,6 @@ export const McpAppRuntime = function McpAppRuntime({
   onModelContextUpdateRef.current = onModelContextUpdate;
   const onResourceStateChangeRef = useRef(onResourceStateChange);
   onResourceStateChangeRef.current = onResourceStateChange;
-  const degradeResourceLoadErrorRef = useRef(degradeResourceLoadError);
-  degradeResourceLoadErrorRef.current = degradeResourceLoadError;
   // Ref to the latest bridge for teardown — avoids capturing a stale closure
   const latestBridgeRef = useRef<AppBridge | null>(null);
   // Monotonic counter for JSON-RPC IDs to avoid collisions from Date.now() in rapid calls.
@@ -335,6 +324,7 @@ export const McpAppRuntime = function McpAppRuntime({
   useEffect(() => {
     let cancelled = false;
     fetchCancelledRef.current = false;
+    setLoadError(null);
 
     const appBridge = new AppBridge(
       null,
@@ -705,19 +695,9 @@ export const McpAppRuntime = function McpAppRuntime({
       } catch (err) {
         if (!cancelled && !fetchCancelledRef.current) {
           const error = err instanceof Error ? err : new Error(String(err));
-          if (degradeResourceLoadErrorRef.current) {
-            // Incidental third-party app whose upstream couldn't serve the UI
-            // resource: fall back to the plain tool result (state "empty" folds
-            // the app away) rather than a "Failed to load app" card. The tool
-            // output itself is shown independently, so nothing is lost.
-            // biome-ignore lint/suspicious/noConsole: intentional — helps support diagnose a silently-skipped app
-            console.debug("[MCP App] resource unavailable, degrading", error);
-            onResourceStateChangeRef.current("empty");
-          } else {
-            setLoadError(error.message);
-            onResourceStateChangeRef.current("renderable");
-            onErrorRef.current?.(error);
-          }
+          setLoadError(error.message);
+          onResourceStateChangeRef.current("error");
+          onErrorRef.current?.(error);
         }
       }
     })();
@@ -847,6 +827,16 @@ export const McpAppRuntime = function McpAppRuntime({
               Failed to load app
             </span>
             <span className="text-xs text-muted-foreground">{loadError}</span>
+            {onReload && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onReload}
+              >
+                Retry
+              </Button>
+            )}
           </div>
         </div>
       )}

--- a/platform/frontend/src/components/mcp-app/use-app-runtime-controls.ts
+++ b/platform/frontend/src/components/mcp-app/use-app-runtime-controls.ts
@@ -2,13 +2,13 @@ import type { McpUiDisplayMode } from "@modelcontextprotocol/ext-apps";
 import { useCallback, useState } from "react";
 import { isRenderableMcpAppHtml } from "@/components/mcp-app/mcp-app-view";
 
-type ResourceState = "unknown" | "renderable" | "empty";
+type ResourceState = "unknown" | "renderable" | "empty" | "error";
 
 /**
  * Shared runtime-frame state every MCP App surface needs: the display mode
  * (inline ↔ fullscreen), a reload nonce that remounts the sandboxed iframe, and
- * the resolved resource state (renderable vs. empty). Extracted so the page
- * frame ({@link AppFrame}) and chat's `McpAppSection` don't each re-implement
+ * the resolved resource state (renderable, empty, or failed). Extracted so the
+ * page frame ({@link AppFrame}) and chat's `McpAppSection` don't each re-implement
  * the same `useState` + handlers.
  *
  * `initialHtml` seeds `resourceState` from a pre-fetched (SSE) resource so a


### PR DESCRIPTION
## What

- add TCP startup, readiness, and liveness probes to managed HTTP MCP deployments
- wait for Kubernetes Pod Ready on cold wake and retry transient UI resource reads with bounded jitter
- keep MCP app resource failures visible and retryable instead of collapsing them into "rendered nothing"

## Why

Cold-waking MCP pods were counted as available before their listening socket was ready, causing intermittent `ui://` resource read failures in the chat Apps panel.

## Verification

- reproduced the exact T-1118 chat-panel message in the VM Kind cluster without probes
- verified the delayed pod remained `0/1` until its TCP listener started with probes
- verified the same cold-wake chat rendered the app after the fix
- backend targeted tests: 474 passed
- frontend targeted tests: 44 passed
- backend and frontend type-checks plus Biome passed

Origin: T-1118 · [Slack thread](https://slack.com/archives/C0B2AGC0AFQ/p1787169595394549?thread_ts=1787169572.928199&cid=C0B2AGC0AFQ)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>