### PR TITLE
fix(docker): pin openssl >=3.5.8-r0 in both scanned images

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -352,6 +352,13 @@ RUN apk --no-cache upgrade && \
     # never re-ran against the newer index — pin curl/libcurl explicitly so the fixed version
     # is guaranteed (and adding this line busts the stale cache).
     apk add --no-cache --upgrade "curl>=8.20.0-r0" "libcurl>=8.20.0-r0" && \
+    # CVE-2026-63076, CVE-2026-63075, CVE-2026-63072, CVE-2026-54874, CVE-2026-18798,
+    # CVE-2026-14457, CVE-2026-14456: OpenSSL vulnerabilities (HIGH) fixed in 3.5.8-r0.
+    # The pinned base ships 3.5.6-r0 and only the libraries are installed here — the
+    # `openssl` CLI package is not — so the floors go on libcrypto3/libssl3. Same stale-layer
+    # hazard as the curl pin above: the bare `apk upgrade` cannot lift a Docker-cached layer,
+    # so the explicit floors both guarantee the fixed version and bust the cache.
+    apk add --no-cache --upgrade "libcrypto3>=3.5.8-r0" "libssl3>=3.5.8-r0" && \
     # Install PostgreSQL 17, pgvector, supervisord, and git.
     # The skill-marketplace clone endpoint needs the git CLI (materialize.ts) and
     # git-http-backend, the smart-HTTP CGI — which Alpine ships in git-daemon, not git.

--- a/platform/mcp_server_docker_image/Dockerfile
+++ b/platform/mcp_server_docker_image/Dockerfile
@@ -146,7 +146,16 @@ RUN apk add --no-cache \
    # No 1.25.x release carries the CVE-2026-46600 fix (the line ends at 1.25.13
    # upstream), so this moves to the same 1.26.6 toolchain the platform image's
    # go-builder stage already uses.
-   apk upgrade --no-cache nodejs bind openssl zlib expat curl libcurl sqlite-libs
+   apk upgrade --no-cache nodejs bind openssl zlib expat curl libcurl sqlite-libs && \
+   # CVE-2026-63076, CVE-2026-63075, CVE-2026-63072, CVE-2026-54874, CVE-2026-18798,
+   # CVE-2026-14457, CVE-2026-14456: OpenSSL vulnerabilities (HIGH) fixed in 3.5.8-r0.
+   # `openssl` is already in the bare `apk upgrade` list above, but that cannot express a
+   # version floor and this RUN layer is Docker-cached on its instruction text, so it never
+   # re-ran against the newer index and the image stayed on 3.5.7-r0. Explicit floors on all
+   # four installed openssl-origin packages both guarantee the fixed version and bust the
+   # stale cache.
+   apk add --no-cache --upgrade "openssl>=3.5.8-r0" "openssl-dev>=3.5.8-r0" \
+       "libcrypto3>=3.5.8-r0" "libssl3>=3.5.8-r0"
 
 # Go toolchain sourced from upstream Alpine-based image (Alpine apk currently ships go-1.25.9-r0)
 COPY --from=go-bin /usr/local/go /usr/local/go


### PR DESCRIPTION
## Problem

Docker Scout is failing **both** scanned images on the same 7 HIGH OpenSSL CVEs, which blocks the merge queue for every PR:

| CVE | Severity | Fixed in |
| --- | --- | --- |
| CVE-2026-63076 | HIGH | openssl 3.5.8-r0 |
| CVE-2026-63075 | HIGH | openssl 3.5.8-r0 |
| CVE-2026-63072 | HIGH | openssl 3.5.8-r0 |
| CVE-2026-54874 | HIGH | openssl 3.5.8-r0 |
| CVE-2026-18798 | HIGH | openssl 3.5.8-r0 |
| CVE-2026-14457 | HIGH | openssl 3.5.8-r0 |
| CVE-2026-14456 | HIGH | openssl 3.5.8-r0 |

Both images sat on `openssl 3.5.7-r0`; Alpine 3.23 ships the fix as `3.5.8-r0`.

## Root cause

Neither image was missing an upgrade step — both already ran an `apk upgrade` that covered openssl. This is the familiar stale-layer hazard: **a `RUN` layer is Docker-cached on its instruction text, so it never re-runs against a newer apk index.** The cached layers were built when 3.5.7-r0 was current and have been serving that ever since.

Editing the line with explicit version floors does both jobs at once: it guarantees the fixed version *and* busts the stale cache.

## Changes

- **`platform/Dockerfile`** (`unified-slim` stage) — only the *libraries* are installed here; the `openssl` CLI package is not in this image at all, so the floors go on `libcrypto3`/`libssl3`.
- **`platform/mcp_server_docker_image/Dockerfile`** — `openssl` was already listed in the bare `apk upgrade`, but that form cannot express a version floor. Adds explicit floors on all four installed openssl-origin packages (`openssl`, `openssl-dev`, `libcrypto3`, `libssl3`).

## Verification

Replayed each stage's exact apk sequence against the pinned base digests locally (`linux/amd64`):

- All openssl-origin packages resolve to **3.5.8-r0** in both images.
- Every pre-existing CVE pin still holds — curl 8.20.0-r0, postgresql17 17.11-r0, postgresql18 18.6-r0, python3 3.12.14-r0, sqlite-libs 3.53.4-r0, zlib 1.3.2-r0, nodejs 24.18.1-r0, bind 9.20.26-r0.
- Runtime is healthy: `openssl version` runs, node `crypto` hashes, and Python reports `OpenSSL 3.5.8 25 Aug 2026`.

Worth noting the fresh (uncached) builds already resolved to 3.5.8-r0 *before* the floors were added, which is the direct confirmation that the CI failure was cache staleness rather than a missing upgrade.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>