### PR TITLE
fix(llm-proxy): validate provider-key filter param with the server's zod schema

### DIFF
--- a/platform/frontend/src/components/provider-key-filter-select.tsx
+++ b/platform/frontend/src/components/provider-key-filter-select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { z } from "zod";
 import { filterControlClass } from "@/components/filter-bar";
 import { LlmProviderApiKeyDropdown } from "@/components/llm-provider-api-key-dropdown";
 import { useLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
@@ -15,18 +16,18 @@ import { useLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
  * the sibling `keyType` / `scope` / `grantType` params already use: an
  * unrecognised value reads as "no filter".
  *
+ * The guard is the same `z.string().uuid()` schema the list endpoints apply
+ * server-side, so the two can never diverge on what counts as a valid id.
+ *
  * A well-formed id that matches nothing is deliberately *not* filtered out —
  * that one belongs to the server, which answers with an empty page the table
  * can explain and offer to clear.
  */
 export function isProviderApiKeyId(value: string | null): value is string {
-  return (
-    value !== null &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      value,
-    )
-  );
+  return value !== null && providerApiKeyIdSchema.safeParse(value).success;
 }
+
+const providerApiKeyIdSchema = z.string().uuid();
 
 /**
  * The "Filter by provider key" control used by the Virtual Keys and OAuth


### PR DESCRIPTION
## Summary

Follow-up to #7476, addressing [review feedback](https://github.com/archestra-ai/archestra-private/pull/94#issuecomment-5425748819) on the original change.

`isProviderApiKeyId` hand-rolled a loose hex UUID regex that duplicated — and could silently diverge from — the `z.string().uuid()` validation the virtual-key and OAuth-client list endpoints apply server-side (`backend/src/types/virtual-api-key.ts`, `backend/src/types/llm-oauth-client.ts`). A value that passes the loose client guard but fails the stricter server schema (e.g. a hex string with invalid version/variant nibbles) would be sent anyway, rejected with a 400, and strand the user on a `QueryLoadError` panel that has no filter bar above it to clear the filter — exactly the dead-end the guard exists to prevent.

The guard now delegates to the same `z.string().uuid()` schema the backend types use, so client and server can never disagree on what counts as a valid id.

## Test plan

- `pnpm type-check` and `biome check` pass on the changed file.
- No new test: the function is now a one-line delegation to the same zod schema the server uses — a test would only re-assert zod's own UUID semantics. The existing behavior (invalid param reads as "no filter") is unchanged in shape.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>