### PR TITLE
fix(frontend): normalize bulk action spacing

### DIFF
--- a/platform/frontend/src/app/account/_components/sessions-card.tsx
+++ b/platform/frontend/src/app/account/_components/sessions-card.tsx
@@ -164,7 +164,7 @@ export function SessionsCard() {
 
   return (
     <section className="w-full space-y-5">
-      <div className="space-y-1">
+      <div className={isLoadingError ? "space-y-1" : "space-y-1 !mb-3"}>
         <h2 className="text-sm font-medium leading-5">Sessions</h2>
         <p className="text-sm leading-5 text-muted-foreground">
           Manage where your account is signed in.

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -616,7 +616,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
       <TableCardView storageKey="archestra-agents-view">
         <div>
           <div>
-            <div className="mb-6 flex flex-col gap-2">
+            <div className="mb-3 flex flex-col gap-2">
               <FilterBar
                 actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
               >

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -364,7 +364,7 @@ export function AppSection({
   if (apps.length === 0) return null;
 
   return (
-    <section className="space-y-[11px]">
+    <section className="space-y-3">
       <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
         {title}
       </h2>

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
@@ -281,7 +281,7 @@ export function ConnectorDocumentsTable({
 
   return (
     <div className="space-y-4">
-      <FilterBar className="mb-4">
+      <FilterBar className="!mb-3">
         <SearchInput
           value={search}
           syncQueryParams={false}

--- a/platform/frontend/src/app/knowledge/connectors/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/page.client.tsx
@@ -426,7 +426,9 @@ function ConnectorsList() {
     >
       <TableCardView storageKey="archestra-connectors-view">
         <div>
-          <div className="mb-6 flex flex-col gap-2">
+          <div
+            className={`${!isDeletedView && !isConnectorsLoadError ? "mb-3" : "mb-6"} flex flex-col gap-2`}
+          >
             <FilterBar
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
             >

--- a/platform/frontend/src/app/knowledge/files/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/files/page.client.tsx
@@ -505,6 +505,7 @@ export default function KnowledgeFilesPage() {
     >
       <div className="space-y-6">
         <FilterBar
+          className="!mb-3"
           onClearFilters={
             search
               ? () => {

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -449,7 +449,9 @@ function KnowledgeBasesList() {
     >
       <TableCardView storageKey="knowledge-bases-view">
         <div>
-          <div className="mb-6 flex flex-col gap-2">
+          <div
+            className={`${!isDeletedView ? "mb-3" : "mb-6"} flex flex-col gap-2`}
+          >
             <FilterBar
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
             >

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -762,7 +762,9 @@ export default function LimitsPage() {
         </Alert>
       </WithPermissions>
 
-      <div className="flex flex-wrap gap-3">
+      <div
+        className={`flex flex-wrap gap-3 ${(isPending || isFetching) && limits.length === 0 ? "" : "!mb-3"}`}
+      >
         <Select
           value={statusFilter}
           onValueChange={(value) =>

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -796,7 +796,7 @@ export default function ApiKeysPage() {
       actionButton={addApiKeyButton}
     >
       <div className="space-y-4">
-        <FilterBar className="mb-4">
+        <FilterBar className="!mb-3">
           <SearchInput
             objectNamePlural="credentials"
             searchFields={["name"]}
@@ -829,7 +829,7 @@ export default function ApiKeysPage() {
 
         {byosEnabled &&
           apiKeys.some((key) => key.secretStorageType === "database") && (
-            <Alert variant="destructive">
+            <Alert variant="destructive" className="!mb-3">
               <AlertTriangle className="h-4 w-4" />
               <AlertTitle>Database-stored API keys detected</AlertTitle>
               <AlertDescription>

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -521,7 +521,7 @@ export default function ModelsPage() {
     >
       <div className="space-y-4">
         {models.length > 0 && (
-          <FilterBar className="mb-4">
+          <FilterBar className="!mb-3">
             <SearchInput
               objectNamePlural="models"
               searchFields={["model ID"]}

--- a/platform/frontend/src/app/llm/proxy/oauth-clients/page.tsx
+++ b/platform/frontend/src/app/llm/proxy/oauth-clients/page.tsx
@@ -38,7 +38,7 @@ import {
 } from "@/components/table-card-view";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Badge } from "@/components/ui/badge";
-import { BulkActionsBar } from "@/components/ui/bulk-actions-bar";
+import { BulkActions } from "@/components/ui/bulk-actions-bar";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -300,7 +300,7 @@ function OauthClientsTable() {
   return (
     <TableCardView storageKey="archestra-llm-oauth-clients-view">
       <div>
-        <div className="mb-6">
+        <div className="mb-3">
           <FilterBar actions={<TableCardViewToggle />}>
             <SearchInput
               objectNamePlural="OAuth clients"
@@ -332,12 +332,11 @@ function OauthClientsTable() {
           </FilterBar>
         </div>
 
-        <BulkActionsBar
+        <BulkActions
           count={selectedClients.length}
           noun="client"
           onClear={clearSelection}
           busy={bulkDelete.isPending}
-          className="mb-3"
         >
           <PermissionButton
             permissions={{ llmOauthClient: ["delete"] }}
@@ -348,7 +347,7 @@ function OauthClientsTable() {
             <Trash2 className="h-4 w-4" />
             <span>Delete</span>
           </PermissionButton>
-        </BulkActionsBar>
+        </BulkActions>
 
         <TableCardViewContent
           cards={

--- a/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
@@ -44,7 +44,7 @@ import {
 } from "@/components/table-card-view";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Badge } from "@/components/ui/badge";
-import { BulkActionsBar } from "@/components/ui/bulk-actions-bar";
+import { BulkActions } from "@/components/ui/bulk-actions-bar";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -331,7 +331,7 @@ function VirtualKeysTable() {
   return (
     <TableCardView storageKey="archestra-llm-virtual-keys-view">
       <div>
-        <div className="mb-6">
+        <div className="mb-3">
           <FilterBar actions={<TableCardViewToggle />}>
             <SearchInput
               objectNamePlural="keys"
@@ -379,12 +379,11 @@ function VirtualKeysTable() {
           </FilterBar>
         </div>
 
-        <BulkActionsBar
+        <BulkActions
           count={selectedKeys.length}
           noun="key"
           onClear={clearSelection}
           busy={bulkDelete.isPending}
-          className="mb-3"
         >
           <PermissionButton
             permissions={{ llmVirtualKey: ["delete"] }}
@@ -395,7 +394,7 @@ function VirtualKeysTable() {
             <Trash2 className="h-4 w-4" />
             <span>Delete</span>
           </PermissionButton>
-        </BulkActionsBar>
+        </BulkActions>
 
         <TableCardViewContent
           cards={

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -685,7 +685,7 @@ function McpGateways({
       <TableCardView storageKey="archestra-mcp-gateways-view">
         <div>
           <div>
-            <div className="mb-6 flex flex-col gap-2">
+            <div className="mb-3 flex flex-col gap-2">
               <FilterBar
                 actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
               >

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1109,6 +1109,12 @@ export function InternalMCPCatalog({
     filters.author.size > 0 ||
     filters.status.has(INSTALLED_STATUS_VALUE) ||
     filters.status.has(NOT_INSTALLED_STATUS_VALUE);
+  const hasFilterChips =
+    filters.issue.size > 0 ||
+    filters.environment.size > 0 ||
+    filters.author.size > 0 ||
+    filters.status.has(INSTALLED_STATUS_VALUE) ||
+    filters.status.has(NOT_INSTALLED_STATUS_VALUE);
   const handleClearAllFilters = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString());
     params.delete("search");
@@ -1140,7 +1146,13 @@ export function InternalMCPCatalog({
   return (
     <TableCardView storageKey="archestra-mcp-registry-view" defaultMode="table">
       <div className="space-y-4">
-        <div className="space-y-3">
+        <div
+          className={
+            !hasLabelFilters && !hasFilterChips
+              ? "space-y-3 !mb-3"
+              : "space-y-3"
+          }
+        >
           <FilterBar
             onClearFilters={
               hasAppliedBarFilters ? handleClearBarFilters : undefined
@@ -1214,9 +1226,12 @@ export function InternalMCPCatalog({
           </FilterBar>
         </div>
         {hasLabelFilters && (
-          <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
+          <div className={!hasFilterChips ? "!mb-3" : undefined}>
+            <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
+          </div>
         )}
         <RegistryFilterChips
+          className="!mb-3"
           selected={filters}
           onRemove={removeFilter}
           onClearAll={clearAdvancedFilters}

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -7,7 +7,7 @@ import {
   MCP_CATALOG_SERVER_QUERY_PARAM,
   type McpDeploymentStatusEntry,
 } from "@archestra/shared";
-import { CheckCircle2, Download, Route, Trash2 } from "lucide-react";
+import { CheckCircle2, Route, Trash2 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -1490,7 +1490,9 @@ function McpServerCatalogSection({
   showTitle: boolean;
 }) {
   const canSelect = (item: CatalogItem) =>
-    installingItemId !== item.id && !getServerInfo(item).isInstallInProgress;
+    !!getServerInfo(item).installedServer &&
+    installingItemId !== item.id &&
+    !getServerInfo(item).isInstallInProgress;
   const {
     rowSelection,
     setRowSelection,
@@ -1513,9 +1515,6 @@ function McpServerCatalogSection({
     canSelect,
   });
 
-  const selectedToInstall = selected.filter(
-    (item) => !getServerInfo(item).installedServer,
-  );
   const selectedToUninstall = selected
     .filter((item) => getServerInfo(item).installedServer)
     .map((item) => ({
@@ -1532,11 +1531,9 @@ function McpServerCatalogSection({
       )}
       <McpServerBulkActions
         selected={selected}
-        selectedToInstall={selectedToInstall}
         selectedToUninstall={selectedToUninstall}
         clearSelection={clearSelection}
         selectAllMatching={selectAllMatching}
-        onInstall={onInstall}
       />
       <TableCardViewContent
         table={
@@ -1610,18 +1607,14 @@ function McpServerCatalogSection({
 
 function McpServerBulkActions({
   selected,
-  selectedToInstall,
   selectedToUninstall,
   clearSelection,
   selectAllMatching,
-  onInstall,
 }: {
   selected: readonly CatalogItem[];
-  selectedToInstall: readonly CatalogItem[];
   selectedToUninstall: Array<{ id: string; name: string }>;
   clearSelection: () => void;
   selectAllMatching: SelectAllMatching;
-  onInstall: (item: CatalogItem) => void;
 }) {
   const [bulkUninstallOpen, setBulkUninstallOpen] = useState(false);
   const bulkUninstall = useBulkUninstallMcpServers();
@@ -1635,30 +1628,6 @@ function McpServerBulkActions({
         busy={bulkUninstall.isPending}
         selectAllMatching={selectAllMatching}
       >
-        <PermissionButton
-          permissions={{ mcpServerInstallation: ["create"] }}
-          variant="outline"
-          size="sm"
-          disabled={selectedToInstall.length !== 1}
-          tooltip={
-            selectedToInstall.length === 0
-              ? "Every selected server is already installed."
-              : selectedToInstall.length > 1
-                ? "Install servers one at a time so each configuration can be reviewed."
-                : undefined
-          }
-          onClick={() => {
-            const item = selectedToInstall[0];
-            if (!item) return;
-            onInstall(item);
-            clearSelection();
-          }}
-        >
-          <Download className="h-4 w-4" />
-          <span>
-            Install{countSuffix(selectedToInstall.length, selected.length)}
-          </span>
-        </PermissionButton>
         <PermissionButton
           permissions={{ mcpServerInstallation: ["delete"] }}
           variant="destructive"

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
@@ -133,14 +133,19 @@ export function McpServerTable({
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
   const canSelect = (item: CatalogItem) =>
-    installingItemId !== item.id && !getServerInfo(item).isInstallInProgress;
+    (!!attention || !!getServerInfo(item).installedServer) &&
+    installingItemId !== item.id &&
+    !getServerInfo(item).isInstallInProgress;
 
   const standardColumns: ColumnDef<CatalogItem>[] = [
     createSelectColumn<CatalogItem>({
       rowLabel: (item) => `Select ${item.name}`,
       allLabel: "Select all MCP servers on this page",
       canSelect,
-      disabledReason: () => "Wait for installation to finish",
+      disabledReason: (item) =>
+        !attention && !getServerInfo(item).installedServer
+          ? "Install this server before selecting it"
+          : "Wait for installation to finish",
     }),
     {
       id: "name",

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-tools-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-tools-dialog.tsx
@@ -133,7 +133,7 @@ export function McpToolsDialog({
       description="View and manage tools provided by this MCP server"
       size="large"
       className="max-h-[80vh]"
-      bodyClassName="space-y-4"
+      bodyClassName="space-y-3"
     >
       {!isLoading && tools.length > 0 && (
         <div className="relative">

--- a/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
@@ -345,10 +345,12 @@ function FilterOptionList({
 }
 
 export function RegistryFilterChips({
+  className,
   selected,
   onRemove,
   onClearAll,
 }: {
+  className?: string;
   selected: RegistryFilters;
   onRemove: (group: FilterGroup, value: string) => void;
   onClearAll: () => void;
@@ -375,7 +377,7 @@ export function RegistryFilterChips({
   if (entries.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
       {entries.map((entry) => (
         <Badge
           key={`${entry.group}-${entry.value}`}

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
@@ -632,7 +632,7 @@ export function AssignedToolsTable({
 
   return (
     <div className="space-y-6">
-      <FilterBar className="mb-4">
+      <FilterBar className="!mb-3">
         <SearchInput
           objectNamePlural="tools"
           searchFields={["name"]}

--- a/platform/frontend/src/app/plugins/page.client.tsx
+++ b/platform/frontend/src/app/plugins/page.client.tsx
@@ -619,7 +619,7 @@ function PluginsList() {
             <PluginsEmptyState />
           ) : (
             <>
-              <div className="mb-2 flex flex-col gap-2">
+              <div className="mb-3 flex flex-col gap-2">
                 <FilterBar
                   onClearFilters={hasActiveFilters ? clearFilters : undefined}
                   moreFilters={[

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -252,6 +252,9 @@ function ProjectsList() {
         )}
         <div className="space-y-6">
           <FilterBar
+            className={
+              !isDeletedView && projects.length > 0 ? "!mb-3" : undefined
+            }
             actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
           >
             {/* Hidden in the trash: the backend serves that slice whole, ignoring

--- a/platform/frontend/src/app/settings/service-accounts/page.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/page.tsx
@@ -260,7 +260,7 @@ export default function ServiceAccountsSettingsPage() {
         >
           <div>
             <FilterBar
-              className="mb-4"
+              className="mb-3"
               onClearFilters={
                 search
                   ? () => updateQueryParams({ search: null, page: "1" })

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -608,7 +608,7 @@ function MembersTab({
   return (
     <>
       <FilterBar
-        className="mb-4"
+        className={isPending ? "mb-4" : "mb-3"}
         actions={<TabButtons activeTab={activeTab} onTabChange={onTabChange} />}
       >
         <SearchInput

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -710,7 +710,7 @@ function SkillsList() {
             <SkillsEmptyState />
           ) : (
             <>
-              <div className="mb-6 flex flex-col gap-2">
+              <div className="mb-3 flex flex-col gap-2">
                 <FilterBar
                   onClearFilters={hasActiveFilters ? clearFilters : undefined}
                   actions={!isDeletedView ? <TableCardViewToggle /> : undefined}

--- a/platform/frontend/src/components/roles/roles-list.ee.tsx
+++ b/platform/frontend/src/components/roles/roles-list.ee.tsx
@@ -421,6 +421,7 @@ export function RolesList({ headerAction }: { headerAction?: ReactNode }) {
     <>
       <div className="space-y-6">
         <FilterBar
+          className={isLoadingError ? undefined : "!mb-3"}
           onClearFilters={
             nameFilter
               ? () => updateQueryParams({ name: null, page: "1" })

--- a/platform/frontend/src/components/settings/api-keys-card.tsx
+++ b/platform/frontend/src/components/settings/api-keys-card.tsx
@@ -321,7 +321,7 @@ function ApiKeysCardContent() {
         >
           <div>
             <FilterBar
-              className="mb-4"
+              className="mb-3"
               onClearFilters={
                 search
                   ? () => updateQueryParams({ search: null, page: "1" })

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -296,7 +296,7 @@ export function TeamsList() {
   return (
     <>
       <div className="space-y-6">
-        <FilterBar>
+        <FilterBar className={!hasLabelFilters ? "!mb-3" : undefined}>
           <SearchInput
             objectNamePlural="teams"
             searchFields={["name"]}
@@ -310,7 +310,9 @@ export function TeamsList() {
         </FilterBar>
 
         {hasLabelFilters && (
-          <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
+          <div className="!mb-3">
+            <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
+          </div>
         )}
 
         <BulkActions

--- a/platform/frontend/src/components/ui/bulk-actions-bar.test.tsx
+++ b/platform/frontend/src/components/ui/bulk-actions-bar.test.tsx
@@ -87,7 +87,10 @@ describe("BulkActionsBar", () => {
       <BulkActions count={0} noun="skill" countTestId="count" />,
     );
 
-    expect(container.querySelector("div")?.className).toContain("h-[42px]");
+    const emptySlot = container.querySelector('[data-slot="bulk-actions-bar"]');
+    expect(emptySlot?.className).toContain("h-[42px]");
+    expect(emptySlot?.className).toContain("!mb-3");
+    expect(emptySlot?.className).toContain("[&+*]:!mt-0");
     expect(screen.queryByRole("button")).toBeNull();
     expect(container.querySelector('[aria-live="polite"]')?.textContent).toBe(
       "",
@@ -95,7 +98,18 @@ describe("BulkActionsBar", () => {
 
     rerender(<BulkActions count={2} noun="skill" countTestId="count" />);
 
-    expect(container.querySelector("div")?.className).not.toContain("h-[42px]");
+    const selectedSlot = container.querySelector(
+      '[data-slot="bulk-actions-bar"]',
+    );
+    expect(selectedSlot?.className).toContain("h-[42px]");
+    expect(selectedSlot?.className).toContain("!mb-3");
+    expect(selectedSlot?.className).toContain("[&+*]:!mt-0");
+    expect(selectedSlot?.querySelector("div")?.className).toContain(
+      "flex-nowrap",
+    );
+    expect(selectedSlot?.querySelector("div")?.className).toContain(
+      "overflow-x-auto",
+    );
     expect(screen.getByTestId("count").textContent).toBe("2 skills selected");
   });
 

--- a/platform/frontend/src/components/ui/bulk-actions-bar.tsx
+++ b/platform/frontend/src/components/ui/bulk-actions-bar.tsx
@@ -64,7 +64,7 @@ export interface BulkActionsBarProps {
   countTestId?: string;
   /** Omit to keep the selection confined to the current page. */
   selectAllMatching?: SelectAllMatching;
-  /** The bar carries no outer spacing of its own; place it in the caller's flow. */
+  /** Additional classes for the action rail. */
   className?: string;
   /**
    * Keeps a compact, invisible bar mounted at zero selection so showing the
@@ -78,7 +78,8 @@ export interface BulkActionsBarProps {
 /**
  * Default collection bulk actions. Unlike the low-level bar, this keeps the
  * compact action box in normal flow at zero selection so table and card
- * layouts never move when the controls appear.
+ * layouts never move when the controls appear. The slot also owns its 12px
+ * spacing before the collection immediately after it.
  */
 export function BulkActions({
   selectAllMatching,
@@ -171,12 +172,17 @@ export function BulkActionsBar({
       </span>
 
       {count === 0 && reserveSpace ? (
-        <div aria-hidden="true" className={cn("h-[42px]", className)} />
+        <div
+          aria-hidden="true"
+          data-slot="bulk-actions-bar"
+          className={cn("h-[42px] !mt-0 !mb-3 [&+*]:!mt-0", className)}
+        />
       ) : count > 0 ? (
         <div
+          data-slot="bulk-actions-bar"
           className={cn(
             "rounded-md border bg-muted/40 px-3 py-2",
-            reserveSpace && "px-2 py-1",
+            reserveSpace && "h-[42px] !mt-0 !mb-3 px-2 py-1 [&+*]:!mt-0",
             className,
           )}
         >

--- a/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
+++ b/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
@@ -1,3 +1,4 @@
+import type { Locator } from "@playwright/test";
 import { shareableSkillsSeed } from "../src/mocks/data/skill-share";
 import { expect, test } from "./fixtures";
 
@@ -59,6 +60,68 @@ test.describe("Bulk actions bar", () => {
     ).toBeHidden();
   });
 
+  test("keeps one fixed rail and collection gap before and after selection", async ({
+    page,
+  }) => {
+    await page.goto("/skills");
+
+    const bar = page.locator('[data-slot="bulk-actions-bar"]');
+    const beforeSelection = await bulkLayoutGeometry(bar);
+    expect(beforeSelection).toMatchObject({
+      height: 42,
+      gapAbove: 12,
+      gapBelow: 12,
+    });
+
+    await page
+      .getByRole("checkbox", {
+        name: `Select ${shareableSkillsSeed.data[0].name}`,
+      })
+      .click();
+
+    const afterSelection = await bulkLayoutGeometry(bar);
+    expect(afterSelection).toMatchObject({
+      height: 42,
+      gapAbove: 12,
+      gapBelow: 12,
+    });
+    expect(afterSelection.collectionTop).toBe(beforeSelection.collectionTop);
+  });
+
+  test("scrolls crowded actions inside the fixed mobile rail", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/skills");
+    await page
+      .getByRole("checkbox", {
+        name: `Select ${shareableSkillsSeed.data[0].name}`,
+      })
+      .click();
+
+    const metrics = await page
+      .locator('[data-slot="bulk-actions-bar"]')
+      .evaluate((bar) => {
+        const rail = bar.firstElementChild as HTMLElement;
+        return {
+          height: bar.getBoundingClientRect().height,
+          overflowX: getComputedStyle(rail).overflowX,
+          clientWidth: rail.clientWidth,
+          scrollWidth: rail.scrollWidth,
+          bodyOverflow:
+            document.documentElement.scrollWidth -
+            document.documentElement.clientWidth,
+        };
+      });
+
+    expect(metrics).toMatchObject({
+      height: 42,
+      overflowX: "auto",
+      bodyOverflow: 0,
+    });
+    expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+  });
+
   test("offers the whole matching set once the page is exhausted", async ({
     page,
     mswControl,
@@ -116,3 +179,31 @@ test.describe("Bulk actions bar", () => {
     await expect(page).toHaveURL(/\/skills(\?.*)?$/);
   });
 });
+
+async function bulkLayoutGeometry(bar: Locator): Promise<{
+  height: number;
+  gapAbove: number;
+  gapBelow: number;
+  collectionTop: number;
+}> {
+  return bar.evaluate((element) => {
+    let branch = element as HTMLElement | null;
+    let previous: HTMLElement | null = null;
+    while (branch && !previous) {
+      previous = branch.previousElementSibling as HTMLElement | null;
+      while (previous?.classList.contains("sr-only")) {
+        previous = previous.previousElementSibling as HTMLElement | null;
+      }
+      branch = branch.parentElement;
+    }
+    const collection = element.nextElementSibling as HTMLElement;
+    const barRect = element.getBoundingClientRect();
+
+    return {
+      height: barRect.height,
+      gapAbove: barRect.top - (previous?.getBoundingClientRect().bottom ?? 0),
+      gapBelow: collection.getBoundingClientRect().top - barRect.bottom,
+      collectionTop: collection.getBoundingClientRect().top,
+    };
+  });
+}

--- a/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
+++ b/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
@@ -68,6 +68,14 @@ const CATALOG = [
     },
     toolCount: 22,
   }),
+  makeCatalogItem({
+    id: "cat-not-installed",
+    name: "not-installed",
+    description: "Catalog server that has not been installed.",
+    scope: "org",
+    serverType: "local",
+    toolCount: 3,
+  }),
 ];
 
 // Seven distinct connections on the crowded card: one org-wide plus six
@@ -229,5 +237,27 @@ test.describe("MCP Registry layout", () => {
     });
 
     expect(spills).toEqual([]);
+  });
+
+  test("offers only Uninstall as a table bulk action", async ({
+    mcpRegistryPage,
+    mswControl,
+    page,
+  }) => {
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+    await page.getByRole("button", { name: "View as table" }).click();
+    await expect(
+      page.getByRole("checkbox", { name: "Select not-installed" }),
+    ).toBeDisabled();
+    await page.getByRole("checkbox", { name: "Select org-crowded" }).click();
+
+    const bulkBar = page.locator('[data-slot="bulk-actions-bar"]');
+    await expect(
+      bulkBar.getByRole("button", { name: "Uninstall" }),
+    ).toBeVisible();
+    await expect(bulkBar.getByRole("button", { name: /^Install/ })).toHaveCount(
+      0,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- enforce one 42px bulk-action slot with 12px spacing above and below every collection
- preserve loading, error, deleted, and unrelated filter spacing
- keep MCP Registry bulk selection uninstall-only and restrict it to installed servers
- migrate the remaining legacy bars and add desktop/mobile pixel regressions

## Validation
- 4,843 frontend unit tests
- bulk-action and MCP Registry Playwright integration coverage
- frontend type-check, lint, and knip
- live desktop/mobile browser geometry verification

Follow-up to #7475.

Task: [T-1162](https://slack.com/archives/C0B2AGC0AFQ/p1787689977598079?thread_ts=1787689977.006719&cid=C0B2AGC0AFQ)