### PR TITLE
fix(staging): bound retained platform data

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -89,6 +89,12 @@ archestra:
     ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED: "true"
     ARCHESTRA_ENTERPRISE_LICENSE_FULL_WHITE_LABELING: "true"
     ARCHESTRA_ENTERPRISE_LICENSE_KNOWLEDGE_BASE_ACTIVATED: "true"
+    # Bound staging database growth while retaining lower-volume operational
+    # history longer than the high-volume LLM and MCP payload logs.
+    ARCHESTRA_AUDIT_LOG_RETENTION_DAYS: "90"
+    ARCHESTRA_CHAT_CONVERSATIONS_RETENTION_DAYS: "90"
+    ARCHESTRA_LLM_LOGS_RETENTION_DAYS: "30"
+    ARCHESTRA_MCP_LOGS_RETENTION_DAYS: "30"
     # Apps Hackathon session recording. The documented flag deliberately cannot
     # open this on a licensed deployment (see parseHackathonRecorderEnabled),
     # and staging activates the enterprise license above — so it takes the


### PR DESCRIPTION
## Summary

- retain staging audit logs and chat conversations for 90 days
- retain high-volume LLM and MCP logs for 30 days
- keep product defaults and customer deployments unchanged

This is the immediate containment from [T-1142](https://slack.com/archives/C0B2AGC0AFQ/p1787272816461289). The task remains open for the broader database-growth investigation.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>