### PR TITLE
fix(llm-proxy): repair direct calls to app tools hidden behind run_tool

### DIFF
--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -282,6 +282,53 @@ describe("planDispatchModeToolCallRewrites", () => {
       "gh__read",
     );
   });
+
+  // Regression: the app-authoring built-ins are hidden from the tool list under
+  // `search_and_run_only` exactly like a third-party tool, so a direct call to
+  // one needs the same repair. Exempting every built-in from the rewrite left
+  // these calls neither repaired nor refused — they reached the caller as a
+  // name it never declared and died there as an unknown-tool error.
+  test.each([
+    "archestra__read_app",
+    "archestra__edit_app",
+    "archestra__list_apps",
+    "archestra__render_app",
+  ])("re-addresses a direct call to %s through run_tool", (toolName) => {
+    const result = planDispatchModeToolCallRewrites({
+      toolCalls: [
+        { id: "call_1", name: toolName, arguments: '{"appId":"a1"}' },
+      ],
+      enabledToolNames: DISPATCH_PAIR,
+    });
+
+    expect(result).toEqual([
+      {
+        id: "call_1",
+        name: "archestra__run_tool",
+        arguments: JSON.stringify({
+          tool_name: toolName,
+          tool_args: { appId: "a1" },
+        }),
+      },
+    ]);
+  });
+
+  // The other half of the contract: built-ins that `filterExposedTools` keeps
+  // top-level in every exposure mode are genuinely directly callable, so
+  // wrapping them would add a pointless dispatch hop.
+  test.each([
+    "archestra__read_file",
+    "archestra__run_command",
+    "archestra__load_skill",
+    "archestra__list_skills",
+  ])("leaves the always-exposed built-in %s directly callable", (toolName) => {
+    expect(
+      planDispatchModeToolCallRewrites({
+        toolCalls: [{ id: "a", name: toolName, arguments: "{}" }],
+        enabledToolNames: DISPATCH_PAIR,
+      }),
+    ).toBeNull();
+  });
 });
 
 // --------------------------------------------------------------------------

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -10,6 +10,7 @@ import {
   ArchestraInternalErrorCode,
   type BillingMode,
   type InteractionSource,
+  isAlwaysExposedArchestraToolShortName,
   type SupportedProvider,
   type SupportedProviderDiscriminator,
   TOOL_RUN_TOOL_SHORT_NAME,
@@ -144,10 +145,11 @@ export interface AccumulatedToolCall {
  * Rewrite a dispatch-mode agent's *direct* tool calls into `run_tool` calls.
  *
  * In `search_and_run_only` exposure (which Auto tool mode implies) every
- * third-party tool is reachable through `run_tool` but deliberately absent from
- * the request's tool list. When the model calls one directly — which it does
- * routinely, because it learned the exact name from `search_tools`, a skill
- * body, or its own earlier turn — the name is not in `enabledToolNames` and the
+ * third-party tool — and the app-authoring built-ins along with them — is
+ * reachable through `run_tool` but deliberately absent from the request's tool
+ * list. When the model calls one directly — which it does routinely, because it
+ * learned the exact name from `search_tools`, a skill body, the system prompt,
+ * or its own earlier turn — the name is not in `enabledToolNames` and the
  * guardrail drops the whole batch, ending the turn with a steer the user reads
  * as an assistant message. The tool was never unreachable; only the calling
  * convention was wrong.
@@ -182,11 +184,11 @@ export function planDispatchModeToolCallRewrites(params: {
   const rewritten = toolCalls.map((toolCall) => {
     const canonicalName = canonicalizeToolName(toolCall.name);
 
-    // Already callable, or one of the built-ins that bypass the enabled-tools
-    // filter entirely (`run_tool` itself included — a genuine dispatch must not
+    // Already callable, or one of the built-ins that stay top-level in every
+    // exposure mode (`run_tool` itself included — a genuine dispatch must not
     // be wrapped a second time).
     if (
-      archestraMcpBranding.isToolName(canonicalName) ||
+      isAlwaysDirectlyCallableBuiltIn(canonicalName) ||
       enabledToolNames.has(canonicalName)
     ) {
       return toolCall;
@@ -255,6 +257,34 @@ function hasSearchToolsName(declaredToolNames: Set<string>): boolean {
     }
   }
   return false;
+}
+
+/**
+ * True for the built-ins that `filterExposedTools` keeps top-level whatever the
+ * agent's exposure mode — the search_tools/run_tool pair and the always-exposed
+ * skill/sandbox/persistent-file surface.
+ *
+ * Deliberately narrower than `archestraMcpBranding.isToolName`. Not every
+ * built-in is directly callable: under `search_and_run_only` the app-authoring
+ * surface (`read_app`, `edit_app`, `render_app`, `list_apps`, …) is hidden from
+ * the tool list on purpose and reached through `run_tool`, exactly like a
+ * third-party tool. Exempting *every* built-in from the repair therefore
+ * skipped the one group that most needs it: a direct call to a hidden app tool
+ * was neither rewritten here nor refused by the guardrail (which applies the
+ * same built-in exemption), so it reached the caller as a name the caller never
+ * declared and died there as an unknown-tool error the model had to recover
+ * from on its own.
+ */
+function isAlwaysDirectlyCallableBuiltIn(toolName: string): boolean {
+  const shortName = archestraMcpBranding.getToolShortName(toolName);
+  if (shortName === null) {
+    return false;
+  }
+  return (
+    shortName === TOOL_SEARCH_TOOLS_SHORT_NAME ||
+    shortName === TOOL_RUN_TOOL_SHORT_NAME ||
+    isAlwaysExposedArchestraToolShortName(shortName)
+  );
 }
 
 /**


### PR DESCRIPTION
## The bug

Under `search_and_run_only` exposure — which **Auto tool mode implies** — the app-authoring built-ins (`read_app`, `edit_app`, `render_app`, `list_apps`, …) are deliberately absent from the advertised tool list and reached through `run_tool`, exactly like a third-party tool. `ALWAYS_EXPOSED_ARCHESTRA_TOOL_SHORT_NAMES` says so explicitly, and the `search_and_run_only` system-prompt section names `scaffold_app` verbatim — so the model routinely holds an exact app-tool name and calls one **directly**.

Nothing along the path helped it when it did:

- `planDispatchModeToolCallRewrites` exempted *every* branded built-in from its repair, on the assumption that a built-in is always directly callable;
- the tool-invocation guardrail applies the same built-in exemption (`isToolEnabled`), so the call was not refused either.

So the call was neither re-addressed to `run_tool` nor blocked — it was forwarded verbatim to a caller that never declared it. There it dies as an unknown-tool error. On our own chat surface that error is at least translated into a "call it through `run_tool`" steer the model can act on; on a caller that does no such translation, it surfaces as a raw SDK `NoSuchToolError` and the model is left to recover unaided.

This is the gap left by #7342, which introduced the repair but exempted built-ins wholesale.

## The fix

Narrow the exemption to the built-ins that genuinely stay top-level in **every** exposure mode — the `search_tools`/`run_tool` pair plus the always-exposed skill, sandbox and persistent-file surface, mirroring `filterExposedTools`. Everything else now takes the same repair a third-party tool takes: re-addressed to `run_tool` with the model's own name and arguments moved into `tool_name` / `tool_args`.

## Enforcement is unchanged

- The repair runs **before** policy evaluation, and `normalizeToolCallsForPolicy` unwraps the rewritten call straight back to the same target — so it faces exactly the gate a `run_tool` dispatch the model wrote itself would face.
- `run_tool` still applies its own existence, assignment, RBAC and per-conversation-enabled checks on dispatch.
- Both existing guards are untouched: a bare name colliding with an Archestra short name (which would come out of the wrapper as a *different*, policy-bypassed built-in), and arguments that are not a JSON object, still fall through to the pre-existing refusal.

## Tests

- Four app-authoring built-ins are re-addressed through `run_tool`, preserving call id and arguments. Verified red before the fix / green after.
- Four always-exposed built-ins (`read_file`, `run_command`, `load_skill`, `list_skills`) stay directly callable — the regression guard for narrowing the exemption.

`llm-proxy-helpers`, `tool-invocation` and `tool-call-rewrite-sweep` suites all pass (131 tests); `tsc --noEmit`, Biome and `knip` (dev + production) are clean.

## Docs

No docs change: this is internal dispatch behavior with no user-facing configuration or API surface.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>