### PR TITLE
fix(frontend): reset the re-auth marker when starting a fresh MCP OAuth install

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -430,6 +430,10 @@ export function InternalMCPCatalog({
         setOAuthMcpServerId(reauthServerId);
         setOAuthReturnUrl(window.location.href);
         setReauthServerId(null);
+      } else {
+        // A fresh install must state that it is not a re-authentication, so a
+        // stale ID from an earlier re-auth in this tab cannot divert it.
+        setOAuthMcpServerId(null);
       }
 
       window.location.href = authorizationUrl;

--- a/platform/frontend/src/lib/auth/oauth-session.test.ts
+++ b/platform/frontend/src/lib/auth/oauth-session.test.ts
@@ -1,12 +1,30 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  clearInstallContext,
   clearOAuthPendingChatResume,
+  getOAuthMcpServerId,
   getOAuthPendingChatResume,
   getOAuthUserConfigValues,
   setOAuthInstallChatResume,
+  setOAuthMcpServerId,
   setOAuthReauthChatResume,
   setOAuthUserConfigValues,
 } from "./oauth-session";
+
+describe("oauth-session install context", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("drops the re-authentication server ID so a later install is not diverted", () => {
+    setOAuthMcpServerId("server_abc");
+    expect(getOAuthMcpServerId()).toBe("server_abc");
+
+    clearInstallContext();
+
+    expect(getOAuthMcpServerId()).toBeNull();
+  });
+});
 
 describe("oauth-session reauth chat resume", () => {
   beforeEach(() => {

--- a/platform/frontend/src/lib/auth/oauth-session.ts
+++ b/platform/frontend/src/lib/auth/oauth-session.ts
@@ -300,6 +300,7 @@ export function clearReauthContext() {
 
 /** Remove all install-flow context stored before the OAuth redirect. */
 export function clearInstallContext() {
+  sessionStorage.removeItem(OAUTH_MCP_SERVER_ID);
   sessionStorage.removeItem(OAUTH_STATE);
   sessionStorage.removeItem(OAUTH_CATALOG_ID);
   sessionStorage.removeItem(OAUTH_TEAM_ID);

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
@@ -145,11 +145,14 @@ describe("useMcpInstallOrchestrator", () => {
       });
     });
 
-    // New behavior: first-time installs remember where they started so the
-    // callback can return the user there (e.g. a chat conversation) instead of
-    // the registry. This is not a re-auth flow.
+    // First-time installs remember where they started so the callback can
+    // return the user there (e.g. a chat conversation) instead of the
+    // registry. This is not a re-auth flow, and it says so explicitly: any
+    // server ID left behind by an earlier re-authentication in this tab has to
+    // be cleared, or the callback would route this install down the re-auth
+    // path and never install anything.
     expect(setOAuthReturnUrlMock).toHaveBeenCalledWith(window.location.href);
-    expect(setOAuthMcpServerIdMock).not.toHaveBeenCalled();
+    expect(setOAuthMcpServerIdMock).toHaveBeenCalledWith(null);
     expect(redirectBrowserToUrlMock).toHaveBeenCalledWith(
       "https://posthog.example.com/oauth/authorize",
     );

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
@@ -116,6 +116,12 @@ export function useMcpInstallOrchestrator(options?: { enabled?: boolean }) {
           setOAuthReturnUrl(window.location.href);
           setReauthServerId(null);
         } else {
+          // A fresh install must state that it is not a re-authentication.
+          // Without this, an ID left in session storage by an earlier
+          // re-authentication in the same tab makes the callback take the
+          // re-auth path and the install never happens.
+          setOAuthMcpServerId(null);
+
           const isFirstInstallation = !installedServers?.some(
             (server) => server.catalogId === params.catalogItem.id,
           );


### PR DESCRIPTION
## Problem

The OAuth callback chooses between "install this server" and "re-authenticate an existing server" by reading a server ID out of session storage. Only the re-authentication path wrote that ID, and only its success path cleared it — so the value could outlive the flow that set it.

An install started later in the same tab then inherited the stale ID and was routed down the re-authentication path, aimed at a server the user was not re-authenticating (and which may no longer be installed).

The authorization itself succeeded, so from the outside it looked fine: a normal consent screen, no error surfaced. But the server never got installed, and the credential created during the exchange was left orphaned. Because a new tab starts with empty session storage, retrying there worked — which made the whole thing read as flaky rather than deterministic.

## Fix

Make the flow selection explicit instead of inherited:

- Both entry points that start an OAuth install now state that the flow is **not** a re-authentication, rather than leaving the marker untouched.
- Clearing the install context also drops the marker, so it cannot leak into a later flow.

## Tests

- New case covering that clearing the install context removes the marker.
- Updated the existing first-time-install case, which previously asserted the marker was left alone — that assertion pinned the buggy behaviour.

Both fail without the source change and pass with it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>