### PR TITLE
docs(environments): document the Allow all egress floor

### DIFF
--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -3,7 +3,7 @@ title: "Environments"
 category: Administration
 description: "Isolate tools, knowledge, skills, subagents, runtimes, and cost limits across deployment environments"
 order: 3
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-26
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -20,7 +20,8 @@ This document is the canonical reference for deployment Environments. Include:
   Default tools as a shared baseline; built-in servers and built-in skills
   are exempt)
 - Network egress policies (namespace + egress policy applied to MCP server pods AND
-  agent code sandboxes), provider support matrix, and domain presets
+  agent code sandboxes), the always-on Allow all floor, provider support matrix,
+  and domain presets
 - How environments scope per-environment cost limits
 - Link out to: agents, mcp gateway, knowledge connectors, costs & limits
 -->
@@ -81,7 +82,7 @@ This applies to both explicitly assigned resources and the implicit **Auto** acc
 
 ## Network egress policies
 
-An environment can define a Kubernetes **namespace** and a **network egress policy**. Both MCP server pods and agent [code sandboxes](/docs/platform-code-sandbox) for that environment run in its namespace and inherit its egress policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Block all** (`off`) denies all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Allow all** (`unrestricted`) permits everything — cluster-hosted workloads still get a fixed floor of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
+An environment can define a Kubernetes **namespace** and a **network egress policy**. Both MCP server pods and agent [code sandboxes](/docs/platform-code-sandbox) for that environment run in its namespace and inherit its egress policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Block all** (`off`) denies all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Allow all** (`unrestricted`) permits egress to the public internet — pods in your cluster still get a [fixed floor](#the-allow-all-floor) of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
 
 When a workload runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in Allow all policy (`unrestricted`).
 
@@ -100,6 +101,21 @@ A **remote MCP server** runs outside Archestra and is reached over HTTP, so the 
 See Kubernetes [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/), Cilium [DNS policy](https://docs.cilium.io/en/latest/security/dns/), GKE [FQDN network policy](https://cloud.google.com/kubernetes-engine/docs/how-to/fqdn-network-policies), and EKS Auto Mode [network policy](https://docs.aws.amazon.com/eks/latest/userguide/auto-net-pol.html) docs for provider details. AWS DNS-based rules apply only to workloads running on EKS Auto Mode-launched EC2 instances.
 
 On EKS Auto Mode, `ApplicationNetworkPolicy` only supports IP and domain egress peers, so Archestra automatically adds a DNS bootstrap rule allowing port 53 to the cluster DNS service IP (recorded in the `archestra.io/network-policy-cluster-dns` annotation).
+
+### The Allow All Floor
+
+Allow all blocks a fixed set of destinations for pods in your cluster:
+
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` — private ranges, where your other pods, services, and nodes live
+- `169.254.0.0/16` — link-local, including the AWS, GCP, and Azure metadata endpoints
+- `168.63.129.16/32` — Azure platform metadata, a public address outside the ranges above
+- `100.64.0.0/10` — carrier-grade NAT
+- `127.0.0.0/8` and `0.0.0.0/8` — loopback
+- `::1/128`, `fc00::/7`, `fe80::/10`, `64:ff9b::/96` — the IPv6 equivalents
+
+The floor stops a server that fetches a URL from reaching your internal network or a cloud metadata endpoint. It is not configurable, and no environment setting turns it off. DNS to the cluster resolver stays allowed.
+
+To let a workload reach a private address, use Allowlist mode and list the range. Allowlist entries are not checked against the floor.
 
 ### Domain Presets
 


### PR DESCRIPTION
## What

The Environments page described `unrestricted` ("Allow all") as permitting everything, qualified by a single clause about "a fixed floor of blocked reserved ranges". The two halves read as a contradiction, and the details that matter were missing.

Adds a **The Allow All Floor** subsection under Network egress policies that:

- lists the blocked IPv4 and IPv6 ranges, with a word on what each one covers
- states plainly that the floor is not configurable and no environment setting disables it
- notes that DNS to the cluster resolver stays allowed
- points at Allowlist mode as the supported way to reach a private address, and notes that allowlist entries are not filtered against the floor

Also rewords the mode summary from "permits everything" to "permits egress to the public internet", and links it to the new subsection.

## Why

Anyone whose MCP server needs to reach a cluster-internal service hits this floor and has no way to tell from the docs whether it is deliberate, whether it can be overridden, or what the alternative is. The answers are yes, no, and Allowlist mode.

## Accuracy

The range list mirrors `FLOOR_DENIED_IPV4_CIDRS` / `FLOOR_DENIED_IPV6_CIDRS` in `platform/backend/src/k8s/mcp-server-runtime/network-policy.ts`. The Allowlist escape hatch reflects `shouldManageK8sNetworkPolicy` — only `off` and `restricted` build a managed policy, so `unrestricted` always falls through to the floor — and `isValidCidr`, which validates syntax only and does not reject private ranges.

Docs-only change. `check-docs-links.py` passes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>