### PR TITLE
fix(agents): apply prompt caching to headless runs

### DIFF
--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -163,6 +163,21 @@ function modelEmitting(...attempts: ModelStreamPart[][]): MockLanguageModelV3 {
   });
 }
 
+function modelCapturingPrompt(
+  capture: (prompt: unknown) => void,
+): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async (options) => {
+      capture(options.prompt);
+      return {
+        stream: simulateReadableStream({
+          chunks: textChunks("cache-aware response"),
+        }),
+      };
+    },
+  });
+}
+
 // Primes only the non-DB boundaries (LLM selection, model factory, MCP tools).
 // The agent itself is a real row created per test; findById hits real PGlite.
 function primeAgent(model: MockLanguageModelV3) {
@@ -176,6 +191,26 @@ function primeAgent(model: MockLanguageModelV3) {
     model,
     provider: "gemini",
     apiKeySource: "org",
+  });
+}
+
+function primePromptCacheAgent(params: {
+  model: MockLanguageModelV3;
+  provider: "anthropic" | "bedrock";
+  selectedModel: string;
+  anthropicNativeEndpoint: boolean;
+}) {
+  mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
+    chatApiKeyId: "org-key",
+    selectedModel: params.selectedModel,
+    selectedProvider: params.provider,
+  });
+  mockGetChatMcpTools.mockResolvedValue({});
+  mockCreateLLMModelForAgent.mockResolvedValue({
+    model: params.model,
+    provider: params.provider,
+    apiKeySource: "org",
+    anthropicNativeEndpoint: params.anthropicNativeEndpoint,
   });
 }
 
@@ -239,6 +274,66 @@ describe("executeA2AMessage real stream boundary", () => {
     expect(result.responseUiMessage.role).toBe("assistant");
     expect(result.usage?.promptTokens).toBe(5);
     expect(result.usage?.completionTokens).toBe(2);
+  });
+
+  test("sends Anthropic cache control through the real A2A stream boundary", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    let modelPrompt: unknown;
+    primePromptCacheAgent({
+      provider: "anthropic",
+      selectedModel: "claude-opus-4-8",
+      anthropicNativeEndpoint: true,
+      model: modelCapturingPrompt((prompt) => {
+        modelPrompt = prompt;
+      }),
+    });
+
+    await executeA2AMessage({
+      agentId: agent.id,
+      message: "Handle this",
+      organizationId: org.id,
+      userId: user.id,
+    });
+
+    expect(JSON.stringify(modelPrompt)).toContain(
+      '"cacheControl":{"type":"ephemeral","ttl":"1h"}',
+    );
+  });
+
+  test("sends Bedrock cache control through the real A2A stream boundary", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    let modelPrompt: unknown;
+    primePromptCacheAgent({
+      provider: "bedrock",
+      selectedModel: "amazon.nova-lite-v1:0",
+      anthropicNativeEndpoint: false,
+      model: modelCapturingPrompt((prompt) => {
+        modelPrompt = prompt;
+      }),
+    });
+
+    await executeA2AMessage({
+      agentId: agent.id,
+      message: "Handle this",
+      organizationId: org.id,
+      userId: user.id,
+    });
+
+    expect(JSON.stringify(modelPrompt)).toContain(
+      '"cachePoint":{"type":"default"}',
+    );
   });
 
   test("forwards each incremental text delta to onTextDelta while still returning the buffered result", async ({

--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -610,7 +610,7 @@ describe("executeA2AMessage current turn assembly", () => {
 
     const config = mockStreamText.mock.calls[0]?.[0];
     expect(config.messages).toHaveLength(history.length + 1);
-    expect(config.messages.at(-1)).toEqual({
+    expect(config.messages.at(-1)).toMatchObject({
       role: "user",
       content: "current question",
     });
@@ -639,7 +639,7 @@ describe("executeA2AMessage current turn assembly", () => {
     });
 
     const config = mockStreamText.mock.calls[0]?.[0];
-    expect(config.messages).toEqual(history);
+    expect(config.messages).toMatchObject(history);
   });
 
   test("stops the run once the model repeatedly calls a tool outside the tool list", async ({

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -629,6 +629,11 @@ export async function executeA2AMessage(
     try {
       const runStream = await runAgentStream({
         config: streamConfig,
+        promptCache: {
+          provider,
+          model: selectedModel,
+          anthropicNativeEndpoint,
+        },
         recovery: {
           logContext: { agentId: agent.id, sessionId },
           ...(openAiReasoningSummaryKey !== null

--- a/platform/backend/src/agents/agent-run-stream.ts
+++ b/platform/backend/src/agents/agent-run-stream.ts
@@ -21,6 +21,7 @@ import {
   trimMessagesToTokenLimit,
 } from "@/routes/chat/context-trimming";
 import { EmptyModelResponseError } from "@/routes/chat/errors";
+import { applyPromptCacheBreakpoints } from "@/routes/chat/normalization/apply-prompt-cache";
 import {
   parseTokenBucketError,
   refitOutputBudgetToTokenBucket,
@@ -66,6 +67,11 @@ type StreamTextConfig = Parameters<typeof streamText>[0];
  */
 export async function runAgentStream(params: {
   config: StreamTextConfig;
+  promptCache?: {
+    provider: string;
+    model: string;
+    anthropicNativeEndpoint: boolean;
+  };
   recovery?: {
     logContext?: Record<string, unknown>;
     /**
@@ -93,7 +99,7 @@ export async function runAgentStream(params: {
    */
   getAbortiveFinishReason: () => string | null;
 }> {
-  const { config, recovery } = params;
+  const { config, promptCache, recovery } = params;
   const logContext = recovery?.logContext ?? {};
   // Set when the committed attempt is abortive; read by the abortive-turn
   // tracker to classify a `length` truncation as non-retryable.
@@ -147,6 +153,16 @@ export async function runAgentStream(params: {
   // empty-response retry reuses the trimmed payload instead of resending the
   // original (too-large) one.
   let currentConfig: StreamTextConfig = { ...config, onError };
+  if (promptCache && Array.isArray(currentConfig.messages)) {
+    currentConfig = {
+      ...currentConfig,
+      prompt: undefined,
+      messages: applyPromptCacheBreakpoints({
+        ...promptCache,
+        messages: currentConfig.messages,
+      }),
+    };
+  }
   // Reset before each attempt so a discarded retry's error never leaks into the
   // committed mapping. This is safe only because the loop always probes an
   // attempt to a terminal event (finish/error/done) before deciding to retry —
@@ -172,12 +188,12 @@ export async function runAgentStream(params: {
       const contextError = parseContextLengthError(probe.error);
       if (
         contextError !== null &&
-        Array.isArray(config.messages) &&
+        Array.isArray(currentConfig.messages) &&
         contextTrimAttempts < MAX_CONTEXT_TRIM_ATTEMPTS
       ) {
         contextTrimAttempts++;
         const trimmed = trimMessagesToTokenLimit({
-          messages: config.messages,
+          messages: currentConfig.messages,
           maxTokens: contextError.maxInputTokens,
           requestedTokens: contextError.requestedTokens,
           systemPrompt:
@@ -188,14 +204,15 @@ export async function runAgentStream(params: {
             ...logContext,
             maxTokens: contextError.maxInputTokens,
             requestedTokens: contextError.requestedTokens,
-            originalMessages: config.messages.length,
+            originalMessages: currentConfig.messages.length,
             trimmedMessages: trimmed.length,
           },
           "[ContextTrimming] retrying with trimmed messages",
         );
         // `prompt: undefined` keeps the object on the `messages` side of the
         // streamText `messages | prompt` union after the spread (the trim branch
-        // only runs when `config.messages` is an array, so there is no prompt).
+        // only runs when `currentConfig.messages` is an array, so there is no
+        // prompt).
         currentConfig = {
           ...currentConfig,
           prompt: undefined,


### PR DESCRIPTION
## Summary
- apply provider-specific prompt cache breakpoints at the shared headless agent stream boundary
- preserve cache metadata across context-trimming retries
- cover Anthropic and Bedrock through the real AI SDK stream boundary

## Verification
- 116 affected backend tests
- backend type-check, lint, and knip
- real A2A Anthropic run: 3,637 cache tokens read on the follow-up turn
- real A2A Bedrock run: 5,570 cache tokens written, then 5,570 read

Origin: [T-1202](https://slack.com/archives/C0B2AGC0AFQ/p1787827286902929?thread_ts=1787827286.197249&cid=C0B2AGC0AFQ)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>