### PR TITLE
feat(chat): add provider keys from credential selector

### DIFF
--- a/platform/frontend/src/components/chat/llm-provider-api-key-selector.test.tsx
+++ b/platform/frontend/src/components/chat/llm-provider-api-key-selector.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/lib/llm-provider-api-keys.query", () => ({
 vi.mock("@/components/llm-provider-api-key-dropdown", () => ({
   LlmProviderApiKeyDropdown: ({
     availableKeys,
+    onAddApiKey,
     onSelectKey,
     selectedApiKeyId,
   }: {
@@ -30,9 +31,15 @@ vi.mock("@/components/llm-provider-api-key-dropdown", () => ({
       connectRequired?: boolean;
     }>;
     onSelectKey: (id: string) => void;
+    onAddApiKey?: () => void;
     selectedApiKeyId: string | null;
   }) => (
     <div>
+      {onAddApiKey && (
+        <button type="button" onClick={onAddApiKey}>
+          Add provider key
+        </button>
+      )}
       {availableKeys.map((key) => (
         <button key={key.id} type="button" onClick={() => onSelectKey(key.id)}>
           {key.name} {key.connectRequired ? "Connect" : "Connected"}
@@ -47,24 +54,32 @@ vi.mock("@/components/create-llm-provider-api-key-dialog", () => ({
   CreateLlmProviderApiKeyDialog: ({
     title,
     defaultValues,
+    onSuccess,
+    open,
     reconnectKeyId,
     requiresExactSubscriptionCredential,
   }: {
     title: string;
-    defaultValues: { provider?: string; authMethod?: string };
+    defaultValues?: { provider?: string; authMethod?: string };
+    onSuccess?: (keyId?: string) => void;
+    open: boolean;
     reconnectKeyId?: string;
     requiresExactSubscriptionCredential?: boolean;
-  }) => (
-    <div>
-      <span>{title}</span>
-      <span>{defaultValues.provider}</span>
-      <span>{defaultValues.authMethod}</span>
-      {reconnectKeyId && <span>{`reconnect:${reconnectKeyId}`}</span>}
-      {requiresExactSubscriptionCredential && (
-        <span>exact-subscription-required</span>
-      )}
-    </div>
-  ),
+  }) =>
+    open ? (
+      <div>
+        <span>{title}</span>
+        <span>{defaultValues?.provider}</span>
+        <span>{defaultValues?.authMethod}</span>
+        {reconnectKeyId && <span>{`reconnect:${reconnectKeyId}`}</span>}
+        {requiresExactSubscriptionCredential && (
+          <span>exact-subscription-required</span>
+        )}
+        <button type="button" onClick={() => onSuccess?.("new-key-id")}>
+          Create key
+        </button>
+      </div>
+    ) : null,
 }));
 
 import { LlmProviderApiKeySelector } from "./llm-provider-api-key-selector";
@@ -312,6 +327,113 @@ describe("LlmProviderApiKeySelector subscriptions", () => {
     expect(screen.getByText("Sign in with ChatGPT")).toBeInTheDocument();
     expect(screen.getByText("openai")).toBeInTheDocument();
     expect(screen.getByText("subscription")).toBeInTheDocument();
+  });
+
+  it("creates a provider key in chat and selects it after the keys refetch", async () => {
+    const user = userEvent.setup();
+    const onApiKeyChange = vi.fn();
+    const onProviderChange = vi.fn();
+    const { rerender } = render(
+      <LlmProviderApiKeySelector
+        currentConversationChatApiKeyId={null}
+        currentProvider="anthropic"
+        onApiKeyChange={onApiKeyChange}
+        onProviderChange={onProviderChange}
+        suppressAutoSelect
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add provider key" }));
+    expect(screen.getByText("Add API Key")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Create key" }));
+
+    vi.mocked(useAvailableLlmProviderApiKeys).mockReturnValue({
+      data: [
+        {
+          id: "new-key-id",
+          name: "New OpenAI key",
+          provider: "openai",
+          scope: "personal",
+          userId: "current-user",
+        } as LlmProviderApiKey,
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAvailableLlmProviderApiKeys>);
+    rerender(
+      <LlmProviderApiKeySelector
+        currentConversationChatApiKeyId={null}
+        currentProvider="anthropic"
+        onApiKeyChange={onApiKeyChange}
+        onProviderChange={onProviderChange}
+        suppressAutoSelect
+      />,
+    );
+
+    expect(onApiKeyChange).toHaveBeenCalledWith("new-key-id");
+    expect(onProviderChange).toHaveBeenCalledWith("openai", "new-key-id");
+  });
+
+  it("does not override a manual key choice while a created key is refetching", async () => {
+    const user = userEvent.setup();
+    const onApiKeyChange = vi.fn();
+    const onProviderChange = vi.fn();
+    const existingKey = {
+      id: "existing-key-id",
+      name: "Existing Anthropic key",
+      provider: "anthropic",
+      scope: "personal",
+      userId: "current-user",
+    } as LlmProviderApiKey;
+    vi.mocked(useAvailableLlmProviderApiKeys).mockReturnValue({
+      data: [existingKey],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAvailableLlmProviderApiKeys>);
+    const { rerender } = render(
+      <LlmProviderApiKeySelector
+        currentConversationChatApiKeyId={null}
+        currentProvider="anthropic"
+        onApiKeyChange={onApiKeyChange}
+        onProviderChange={onProviderChange}
+        suppressAutoSelect
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add provider key" }));
+    await user.click(screen.getByRole("button", { name: "Create key" }));
+    await user.click(
+      screen.getByRole("button", { name: "Existing Anthropic key Connected" }),
+    );
+
+    vi.mocked(useAvailableLlmProviderApiKeys).mockReturnValue({
+      data: [
+        existingKey,
+        {
+          id: "new-key-id",
+          name: "New OpenAI key",
+          provider: "openai",
+          scope: "personal",
+          userId: "current-user",
+        } as LlmProviderApiKey,
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAvailableLlmProviderApiKeys>);
+    rerender(
+      <LlmProviderApiKeySelector
+        currentConversationChatApiKeyId={null}
+        currentProvider="anthropic"
+        onApiKeyChange={onApiKeyChange}
+        onProviderChange={onProviderChange}
+        suppressAutoSelect
+      />,
+    );
+
+    expect(onApiKeyChange).toHaveBeenCalledTimes(1);
+    expect(onApiKeyChange).toHaveBeenCalledWith("existing-key-id");
+    expect(onProviderChange).toHaveBeenCalledTimes(1);
+    expect(onProviderChange).toHaveBeenCalledWith(
+      "anthropic",
+      "existing-key-id",
+    );
   });
 
   it("recognizes an X Premium key as connected without absorbing plain xAI API keys", () => {

--- a/platform/frontend/src/components/chat/llm-provider-api-key-selector.tsx
+++ b/platform/frontend/src/components/chat/llm-provider-api-key-selector.tsx
@@ -160,6 +160,11 @@ export function LlmProviderApiKeySelector({
   const [reconnectKeyId, setReconnectKeyId] = useState<string | null>(null);
   const [connectedKindToSelect, setConnectedKindToSelect] =
     useState<SubscriptionCredentialKind | null>(null);
+  const [isCreateApiKeyDialogOpen, setIsCreateApiKeyDialogOpen] =
+    useState(false);
+  const [createdKeyIdToSelect, setCreatedKeyIdToSelect] = useState<
+    string | null
+  >(null);
   const handledConnectRequestRef = useRef(0);
   const handleOpenChange = (newOpen: boolean) => {
     setOpen(newOpen);
@@ -342,7 +347,16 @@ export function LlmProviderApiKeySelector({
     setConnectedKindToSelect(null);
   }, [availableKeys, applyKeyChange, connectedKindToSelect]);
 
+  useEffect(() => {
+    if (!createdKeyIdToSelect) return;
+    if (!availableKeys.some((key) => key.id === createdKeyIdToSelect)) return;
+
+    applyKeyChange(createdKeyIdToSelect);
+    setCreatedKeyIdToSelect(null);
+  }, [availableKeys, applyKeyChange, createdKeyIdToSelect]);
+
   const handleSelectKey = (keyId: string) => {
+    setCreatedKeyIdToSelect(null);
     const connectOption = subscriptionOptions.find(
       (option) => option.id === keyId,
     );
@@ -394,9 +408,25 @@ export function LlmProviderApiKeySelector({
         open={open}
         onOpenChange={handleOpenChange}
         onSelectKey={handleSelectKey}
+        onAddApiKey={() => {
+          setCreatedKeyIdToSelect(null);
+          handleOpenChange(false);
+          setIsCreateApiKeyDialogOpen(true);
+        }}
         currentProvider={currentProvider}
         searchPlaceholder="Search credentials..."
         showChatTestIds
+      />
+      <CreateLlmProviderApiKeyDialog
+        open={isCreateApiKeyDialogOpen}
+        onOpenChange={setIsCreateApiKeyDialogOpen}
+        title="Add API Key"
+        description="Add an LLM provider API key and use it in this chat"
+        credentialMode="api-key"
+        showConsoleLink
+        onSuccess={(keyId) => {
+          if (keyId) setCreatedKeyIdToSelect(keyId);
+        }}
       />
       {subscriptionToConnect && (
         <CreateLlmProviderApiKeyDialog

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.test.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.test.tsx
@@ -63,9 +63,9 @@ vi.mock("@/lib/organization.query");
 describe("CreateLlmProviderApiKeyDialog", () => {
   beforeEach(() => {
     mutateAsync.mockReset();
-    mutateAsync.mockResolvedValue({});
+    mutateAsync.mockResolvedValue({ id: "created-key-id" });
     reconnectMutateAsync.mockReset();
-    reconnectMutateAsync.mockResolvedValue({});
+    reconnectMutateAsync.mockResolvedValue({ id: "existing-key-id" });
     vi.mocked(useFeature).mockReturnValue(false);
     vi.mocked(useHasPermissions).mockReset();
     vi.mocked(useHasPermissions).mockReturnValue({
@@ -108,7 +108,7 @@ describe("CreateLlmProviderApiKeyDialog", () => {
       vaultSecretKey: undefined,
     });
     expect(onOpenChange).toHaveBeenCalledWith(false);
-    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onSuccess).toHaveBeenCalledWith("created-key-id");
   });
 
   it("falls back to the provider name when the name field is empty", async () => {
@@ -191,7 +191,7 @@ describe("CreateLlmProviderApiKeyDialog", () => {
         scope: "personal",
       }),
     );
-    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onSuccess).toHaveBeenCalledWith("created-key-id");
   });
 
   it("forces personal scope for a subscription sign-in even when the form holds a shared scope", async () => {
@@ -259,6 +259,6 @@ describe("CreateLlmProviderApiKeyDialog", () => {
     });
     expect(mutateAsync).not.toHaveBeenCalled();
     expect(onOpenChange).toHaveBeenCalledWith(false);
-    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onSuccess).toHaveBeenCalledWith("existing-key-id");
   });
 });

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
@@ -45,7 +45,7 @@ export type CreateLlmProviderApiKeyDialogProps = {
   /** This dialog must connect the exact subscription kind pinned by an agent. */
   requiresExactSubscriptionCredential?: boolean;
   showConsoleLink?: boolean;
-  onSuccess?: () => void;
+  onSuccess?: (keyId?: string) => void;
   /**
    * Re-authentication mode: rotate this existing key's credential in place
    * instead of creating a new key. Used to reconnect an expired personal
@@ -123,7 +123,7 @@ export function CreateLlmProviderApiKeyDialog({
     // same tick the credential lands — before any effect has run.
     const scope = subscriptionKind ? "personal" : values.scope;
     try {
-      await createMutation.mutateAsync({
+      const createdKey = await createMutation.mutateAsync({
         name:
           values.name?.trim() ||
           (subscriptionKind
@@ -156,7 +156,7 @@ export function CreateLlmProviderApiKeyDialog({
           : undefined,
       });
       onOpenChange(false);
-      onSuccess?.();
+      onSuccess?.(createdKey?.id);
       return true;
     } catch {
       // Error handled by mutation
@@ -171,12 +171,12 @@ export function CreateLlmProviderApiKeyDialog({
       // stale one still selected in conversations. Uses the self-service
       // reconnect endpoint rather than the permission-gated PATCH, so default
       // members can refresh their own expired sign-in.
-      await reconnectMutation.mutateAsync({
+      const reconnectedKey = await reconnectMutation.mutateAsync({
         id: reconnectKeyId,
         apiKey: credential,
       });
       onOpenChange(false);
-      onSuccess?.();
+      onSuccess?.(reconnectedKey?.id ?? reconnectKeyId);
       return;
     }
     const values = { ...form.getValues(), apiKey: credential };

--- a/platform/frontend/src/components/llm-provider-api-key-dropdown.test.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-dropdown.test.tsx
@@ -125,6 +125,63 @@ describe("LlmProviderApiKeyDropdown", () => {
     expect(options[0]).toHaveTextContent("Staging key");
   });
 
+  it("offers provider-key creation inside the selector", async () => {
+    const user = userEvent.setup();
+    const onAddApiKey = vi.fn();
+
+    renderDropdown({
+      availableKeys: [],
+      selectedApiKeyId: null,
+      onSelectKey: () => {},
+      onAddApiKey,
+      triggerVariant: "button",
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /select provider key/i }),
+    );
+    await user.click(screen.getByRole("option", { name: "Add provider key" }));
+
+    expect(onAddApiKey).toHaveBeenCalledOnce();
+  });
+
+  it("places provider-key creation at the top of the API keys section", async () => {
+    const user = userEvent.setup();
+
+    renderDropdown({
+      availableKeys: [
+        {
+          id: "chatgpt-subscription",
+          name: "ChatGPT Subscription",
+          provider: "openai",
+          scope: "personal",
+          subscriptionKind: "chatgpt",
+        },
+        {
+          id: "openai-key",
+          name: "OpenAI production",
+          provider: "openai",
+          scope: "org",
+        },
+      ] as LlmProviderApiKey[],
+      selectedApiKeyId: null,
+      onSelectKey: () => {},
+      onAddApiKey: () => {},
+      triggerVariant: "button",
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /select provider key/i }),
+    );
+
+    const options = screen.getAllByRole("option");
+    expect(options.map((option) => option.textContent)).toEqual([
+      expect.stringContaining("ChatGPT Subscription"),
+      "Add provider key",
+      expect.stringContaining("OpenAI production"),
+    ]);
+  });
+
   it("separates personal subscriptions from API keys", async () => {
     const user = userEvent.setup();
 

--- a/platform/frontend/src/components/llm-provider-api-key-dropdown.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-dropdown.tsx
@@ -7,7 +7,7 @@ import {
   type ResourceVisibilityScope,
   type SupportedProvider,
 } from "@archestra/shared";
-import { CheckIcon, ChevronDown, Key } from "lucide-react";
+import { CheckIcon, ChevronDown, Key, Plus } from "lucide-react";
 import Image from "next/image";
 import { useMemo } from "react";
 import { PromptInputButton } from "@/components/ai-elements/prompt-input";
@@ -50,6 +50,7 @@ interface LlmProviderApiKeyDropdownProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSelectKey: (keyId: string) => void;
+  onAddApiKey?: () => void;
   currentProvider?: SupportedProvider;
   triggerVariant?: "prompt-input" | "button" | "select";
   triggerClassName?: string;
@@ -81,6 +82,7 @@ export function LlmProviderApiKeyDropdown({
   open,
   onOpenChange,
   onSelectKey,
+  onAddApiKey,
   currentProvider,
   triggerVariant = "prompt-input",
   triggerClassName,
@@ -281,13 +283,21 @@ export function LlmProviderApiKeyDropdown({
                 ))}
               </CommandGroup>
             )}
-            {availableProviders.length > 0 && (
+            {(availableProviders.length > 0 || onAddApiKey) && (
               <div className="border-t px-3 pb-1 pt-2 text-xs">
                 <div className="font-medium text-foreground">API keys</div>
                 <div className="text-muted-foreground">
                   Stored credentials shared according to scope
                 </div>
               </div>
+            )}
+            {onAddApiKey && (
+              <CommandGroup>
+                <CommandItem onSelect={onAddApiKey} className="cursor-pointer">
+                  <Plus className="h-4 w-4 shrink-0" />
+                  <span>Add provider key</span>
+                </CommandItem>
+              </CommandGroup>
             )}
             {availableProviders.map((provider) => (
               <CommandGroup


### PR DESCRIPTION
Add an in-chat provider-key creation action at the top of the API keys section.

The existing provider form opens without leaving chat, and the created key is selected after the credential list refreshes without overriding a newer manual choice. Personal self-service remains available to members.

Task: https://slack.com/archives/C0B2AGC0AFQ/p1787828103495129

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>