### PR TITLE
feat: polish MCP registry interactions

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1395,7 +1395,7 @@ A2A task streams work across replicas. A client can subscribe on one replica whi
   - Example: `30`
   - Tools can also be refreshed on demand: from the server's Inspector tab in the MCP Registry, or via `POST /api/mcp_server/:id/reload-tools`.
 
-- **`ARCHESTRA_MCP_SERVER_ALERTING_ENABLED`** - Beta gate for MCP Registry attention facets, issue diagnostics, ownership guidance, and per-viewer alert dismissal.
+- **`ARCHESTRA_MCP_SERVER_ALERTING_ENABLED`** - Beta gate for MCP Registry attention ordering, issue diagnostics, ownership guidance, and per-viewer alert dismissal.
   - Default: `false`
   - A blank value falls back to the `ARCHESTRA_BETA` master switch. An explicit `false` keeps alerting and its dismissal APIs hidden even when the master switch is enabled.
 

--- a/docs/pages/platform-private-registry.md
+++ b/docs/pages/platform-private-registry.md
@@ -26,6 +26,16 @@ An MCP server usually moves through this lifecycle:
 
 This separation lets admins curate a small approved catalog while still allowing each user or team to connect with their own credentials.
 
+## Finding Servers
+
+Cards and table rows use the same active sort. Choose **Action required** when you want flagged servers first.
+
+The scope filter narrows the list to **Personal**, **Team**, or **Organization**. An administrator can use **Other users** inside Personal to review another member's private entries and connections. Those oversight rows stay out of the default list.
+
+Cards and table rows identify their owner or shared scope with a visibility badge. The table keeps one continuous list and shows the same badge in **Accessible to**. A dot over each self-hosted server icon shows runtime status in both views. Hover it for pod counts or idle-hibernation details. The table's **Status** column shows installation state and active alerts.
+
+Selecting rows or cards replaces the filter controls with the matching bulk actions. Shift-click extends the selection across the visible range. The list does not move or reserve an empty action bar while nothing is selected.
+
 Entries that expose a UI carry an **App** badge. Each [owned MCP App](./platform-apps) is also backed by its own registry entry: it appears here as a read-only card (visible to users with `app:read`) whose pencil manages the app's server settings — visibility, environment, assigned tools, and deletion — while authoring stays at `/a/:id`.
 
 ## Server Configuration
@@ -99,15 +109,13 @@ Each registry card shows how many agents and gateways can reach the server. Hove
 
 ## Needs Attention
 
-> **Beta:** MCP server alerting is deployment-gated and off by default. Set `ARCHESTRA_MCP_SERVER_ALERTING_ENABLED=true` to enable attention facets, diagnostics, ownership guidance, and per-viewer dismissal. A blank value follows the `ARCHESTRA_BETA` master switch.
+> **Beta:** MCP server alerting is deployment-gated and off by default. Set `ARCHESTRA_MCP_SERVER_ALERTING_ENABLED=true` to enable attention ordering, diagnostics, ownership guidance, and per-viewer dismissal. A blank value follows the `ARCHESTRA_BETA` master switch.
 
 A server is flagged only when it cannot operate: its pod failed to start, it stopped running, or its stored credential was rejected. Pending installs, image approvals, and configuration changes that leave the running server untouched are never flagged.
 
-Flagged servers appear as facets on the registry list. **Action required** contains problems you can fix. For non-admin viewers, **Waiting action by _owner_** contains problems owned by another person; the owner is named only when your role may see that identity, otherwise the facet says **other user**. MCP installation admins can act across ownership and visibility boundaries, so every visible problem is included in **Action required**.
+The registry's **Action required** sort puts flagged servers first. The sidebar count opens a table-only attention view for the servers you can fix. Each row shows the issue and the connection owner or required admin role. Use the **Issue** filter to narrow the table to failed starts, stopped servers, or rejected credentials. Issue-specific remediation stays visible in the Actions column; a row leaves only when its health signal clears. **Re-authenticate** opens a compact credential-repair form for the affected connection directly on the server details page. **Manage credentials** remains the broader view for listing, adding, and revoking connections.
 
-Attention facets use a table-only triage view. Each row shows the issue and connection owner or required admin role. Use the **Issue** filter to narrow the table to failed starts, stopped servers, or rejected credentials. Issue-specific remediation stays visible in the Actions column; a row leaves only when its health signal clears. **Re-authenticate** opens a compact credential-repair form for the affected connection directly on the server details page. **Manage credentials** remains the broader view for listing, adding, and revoking connections.
-
-Every alert can be dismissed from your queue without hiding the problem from other viewers. You can optionally add a reason; the **Dismissed** facet shows it in the **Dismiss reason** column and lets you restore the alert. Select several servers to dismiss their alerts or remove their affected connections together. Bulk removal requires every selected row to identify connections you are allowed to remove and always asks for confirmation. A dismissal is pinned to one failure episode and expires automatically when the underlying failure changes.
+Every alert can be dismissed from your queue without hiding the problem from other viewers. You can optionally add a reason; the **Dismissed** view shows it in the **Dismiss reason** column and lets you restore the alert. Select several servers to dismiss their alerts or remove their affected connections together. Bulk removal requires every selected row to identify connections you are allowed to remove and always asks for confirmation. A dismissal is pinned to one failure episode and expires automatically when the underlying failure changes.
 
 ## Refreshing Tools
 

--- a/platform/backend/src/models/mcp-server.test.ts
+++ b/platform/backend/src/models/mcp-server.test.ts
@@ -250,6 +250,61 @@ describe("McpServerModel", () => {
 
       expect(visible.find((s) => s.id === mine.id)).toBeDefined();
     });
+
+    test("returns only visible local ids for deployment subscriptions", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeOrganization,
+      makeTeam,
+      makeTeamMember,
+      makeUser,
+    }) => {
+      const me = await makeUser();
+      const colleague = await makeUser();
+      const organization = await makeOrganization();
+      const team = await makeTeam(organization.id, me.id);
+      await makeTeamMember(team.id, me.id);
+      const catalog = await makeInternalMcpCatalog({
+        organizationId: organization.id,
+        serverType: "local",
+      });
+      const visibleLocal = await makeMcpServer({
+        catalogId: catalog.id,
+        scope: "team",
+        ownerId: me.id,
+        teamId: team.id,
+      });
+      const remote = await makeMcpServer({
+        catalogId: catalog.id,
+        scope: "team",
+        ownerId: me.id,
+        teamId: team.id,
+      });
+      await db
+        .update(schema.mcpServersTable)
+        .set({ serverType: "remote" })
+        .where(eq(schema.mcpServersTable.id, remote.id));
+      const colleaguePersonal = await makeMcpServer({
+        catalogId: catalog.id,
+        scope: "personal",
+        ownerId: colleague.id,
+      });
+      await McpServerUserModel.assignUserToMcpServer(
+        colleaguePersonal.id,
+        colleague.id,
+      );
+
+      const ids = await McpServerModel.findVisibleLocalIds({
+        userId: me.id,
+        isMcpServerAdmin: false,
+        organizationId: organization.id,
+        isPredefinedAdmin: false,
+      });
+
+      expect(ids).toContain(visibleLocal.id);
+      expect(ids).not.toContain(remote.id);
+      expect(ids).not.toContain(colleaguePersonal.id);
+    });
   });
 
   describe("findAll", () => {

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -227,6 +227,27 @@ class McpServerModel {
     return mcpServers.map((s) => s.mcpServerId);
   }
 
+  private static async getUserAccessibleMcpServerIds(
+    userId: string,
+  ): Promise<string[]> {
+    const [
+      teamAccessibleMcpServerIds,
+      personalMcpServerIds,
+      orgScopedMcpServerIds,
+    ] = await Promise.all([
+      McpServerModel.getUserAccessibleMcpServerIdsByTeam(userId),
+      McpServerUserModel.getUserPersonalMcpServerIds(userId),
+      McpServerModel.getOrgScopedMcpServerIds(),
+    ]);
+    return [
+      ...new Set([
+        ...teamAccessibleMcpServerIds,
+        ...personalMcpServerIds,
+        ...orgScopedMcpServerIds,
+      ]),
+    ];
+  }
+
   /**
    * The installs whose stored credential `userId` may present to the upstream:
    * the connections they made themselves, and the ones shared with them — a
@@ -418,6 +439,58 @@ class McpServerModel {
   }
 
   /**
+   * Local installation ids visible to one websocket subscriber, without the
+   * list endpoint's user, agent, secret and credential enrichment. Deployment
+   * status needs only the ids; the visibility rules must stay identical to
+   * {@link McpServerModel.findAll}.
+   */
+  static async findVisibleLocalIds(params: {
+    userId: string;
+    isMcpServerAdmin: boolean;
+    organizationId: string;
+    isPredefinedAdmin: boolean;
+  }): Promise<string[]> {
+    const { userId, isMcpServerAdmin, organizationId, isPredefinedAdmin } =
+      params;
+    const conditions: SQL[] = [
+      notDeleted(schema.mcpServersTable),
+      eq(schema.mcpServersTable.serverType, "local"),
+    ];
+    const catalogBelongsToOrganization = or(
+      isNull(schema.internalMcpCatalogTable.organizationId),
+      eq(schema.internalMcpCatalogTable.organizationId, organizationId),
+    );
+    if (catalogBelongsToOrganization) {
+      conditions.push(catalogBelongsToOrganization);
+    }
+
+    if (!isPredefinedAdmin && isMcpServerAdmin) {
+      const sharedOrOwnedInstall = or(
+        ne(schema.mcpServersTable.scope, "personal"),
+        eq(schema.mcpServersTable.ownerId, userId),
+      );
+      if (sharedOrOwnedInstall) conditions.push(sharedOrOwnedInstall);
+    } else if (!isPredefinedAdmin) {
+      const accessibleMcpServerIds =
+        await McpServerModel.getUserAccessibleMcpServerIds(userId);
+      if (accessibleMcpServerIds.length === 0) return [];
+      conditions.push(
+        inArray(schema.mcpServersTable.id, accessibleMcpServerIds),
+      );
+    }
+
+    const rows = await db
+      .select({ id: schema.mcpServersTable.id })
+      .from(schema.mcpServersTable)
+      .leftJoin(
+        schema.internalMcpCatalogTable,
+        eq(schema.mcpServersTable.catalogId, schema.internalMcpCatalogTable.id),
+      )
+      .where(and(...conditions));
+    return rows.map((row) => row.id);
+  }
+
+  /**
    * @param environmentId when set (null = Default environment), restricts
    * results to deployments whose catalog item is visible from that environment.
    * An MCP server has no environment column of its own — it inherits one from
@@ -507,24 +580,8 @@ class McpServerModel {
       // 1. Team membership (servers assigned to user's teams)
       // 2. Personal access (user's own servers)
       // 3. Org-scoped servers (visible to all org members)
-      const [
-        teamAccessibleMcpServerIds,
-        personalMcpServerIds,
-        orgScopedMcpServerIds,
-      ] = await Promise.all([
-        McpServerModel.getUserAccessibleMcpServerIdsByTeam(userId),
-        McpServerUserModel.getUserPersonalMcpServerIds(userId),
-        McpServerModel.getOrgScopedMcpServerIds(),
-      ]);
-
-      // Combine all lists
-      const accessibleMcpServerIds = [
-        ...new Set([
-          ...teamAccessibleMcpServerIds,
-          ...personalMcpServerIds,
-          ...orgScopedMcpServerIds,
-        ]),
-      ];
+      const accessibleMcpServerIds =
+        await McpServerModel.getUserAccessibleMcpServerIds(userId);
 
       if (accessibleMcpServerIds.length === 0) {
         return [];

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -679,17 +679,12 @@ class WebSocketService {
       userId: clientContext.userId,
       organizationId: clientContext.organizationId,
     });
-    const allServers = await McpServerModel.findAll(
-      clientContext.userId,
-      clientContext.userIsMcpServerAdmin,
-      clientContext.organizationId,
-      undefined,
-      userIsPredefinedAdmin,
-    );
-
-    // Filter to local servers only (remote servers don't have K8s deployments)
-    const localServers = allServers.filter((s) => s.serverType === "local");
-    const localServerIds = localServers.map((s) => s.id);
+    const localServerIds = await McpServerModel.findVisibleLocalIds({
+      userId: clientContext.userId,
+      isMcpServerAdmin: clientContext.userIsMcpServerAdmin,
+      organizationId: clientContext.organizationId,
+      isPredefinedAdmin: userIsPredefinedAdmin,
+    });
 
     // Build statuses from the runtime manager for this client
     const buildStatuses = (

--- a/platform/e2e-tests/tests/mcp-install.spec.ts
+++ b/platform/e2e-tests/tests/mcp-install.spec.ts
@@ -243,7 +243,7 @@ rl.on("line", (line) => {
     // ========================================
     // Click "view the logs" link in the error banner
     const viewLogsButton = adminPage.getByTestId(
-      `${E2eTestId.McpLogsViewButton}-${CATALOG_ITEM_NAME}-default`,
+      `${E2eTestId.McpLogsViewButton}-${CATALOG_ITEM_NAME}-issue`,
     );
     await viewLogsButton.click();
 
@@ -275,7 +275,7 @@ rl.on("line", (line) => {
     // ========================================
     // Click "edit your config" link in the error banner (opens settings dialog to Configuration page)
     const editConfigButton = adminPage.getByTestId(
-      `${E2eTestId.McpLogsEditConfigButton}-${CATALOG_ITEM_NAME}-default`,
+      `${E2eTestId.McpLogsEditConfigButton}-${CATALOG_ITEM_NAME}-issue`,
     );
     await editConfigButton.click();
 

--- a/platform/e2e-tests/tests/skills-bulk-actions.spec.ts
+++ b/platform/e2e-tests/tests/skills-bulk-actions.spec.ts
@@ -66,8 +66,8 @@ test.describe("Skills bulk actions", () => {
       expect((await readSkill(page, ids[1])).scope).toBe("org");
       expect((await readSkill(page, ids[2])).scope).toBe("personal");
 
-      // Applying clears the selection, so the action bar goes away.
-      await expect(selectionCount(page)).toBeHidden();
+      // Applying clears the selection while keeping the reserved rail stable.
+      await expect(selectionCount(page)).toHaveText("0 skills selected");
     } finally {
       await Promise.all(
         ids.map((id) => page.request.delete(`${UI_BASE_URL}/api/skills/${id}`)),

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -333,7 +333,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
   const filterSignature = JSON.stringify(listFilters);
   const [escalatedFor, setEscalatedFor] = useState<string | null>(null);
   const allMatchingSelected = escalatedFor === filterSignature;
-  const { effectiveRowSelection, onRowSelectionChange } =
+  const { effectiveRowSelection, onRowSelectionChange, rangeSelection } =
     useControlledRowSelection({
       rowSelection,
       setRowSelection,
@@ -347,6 +347,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
     getRowId: (row) => row.id,
     rowSelection: effectiveRowSelection,
     setRowSelection: onRowSelectionChange,
+    rangeSelection,
   });
   const { data: allMatching, isFetching: isFetchingAllMatching } =
     useAllMatchingProfiles(listFilters, { enabled: allMatchingSelected });
@@ -712,6 +713,12 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
                         }
                         description={agent.description}
                         actions={renderAgentActions(agent)}
+                        onNavigate={
+                          isDeletedView
+                            ? undefined
+                            : () =>
+                                router.push(agentDetailHref("agent", agent.id))
+                        }
                         {...cardSelection(agent)}
                         selectionLabel={`Select ${agent.name}`}
                         footer={
@@ -745,6 +752,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
                     getRowId={(row) => row.id}
                     rowSelection={effectiveRowSelection}
                     onRowSelectionChange={onRowSelectionChange}
+                    rangeSelection={rangeSelection}
                     hideSelectedCount
                     sorting={sorting}
                     onSortingChange={handleSortingChange}

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -19,6 +19,7 @@ import { LockedChatIcon } from "@/components/chat/locked-chat-icon";
 import { LabelTags } from "@/components/label-tags";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { ScopeBadge } from "@/components/scope-badge";
+import { useNavigableCard } from "@/components/table-card-view";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardDescription, CardTitle } from "@/components/ui/card";
@@ -105,10 +106,7 @@ function CardSelectionCheckbox({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span
-          className="relative z-10 inline-flex cursor-not-allowed"
-          title={reason}
-        >
+        <span className="inline-flex cursor-not-allowed" title={reason}>
           {checkbox}
         </span>
       </TooltipTrigger>
@@ -118,9 +116,7 @@ function CardSelectionCheckbox({
 }
 
 // Shared card chrome: the scope pill / owner badge / overflow menu cluster that
-// sits at the right of the card's header row (mirroring the project card). It's
-// raised above the full-card click target (z-10) so its own clicks don't fall
-// through to the card action.
+// sits at the right of the card's header row (mirroring the project card).
 function CardOverflowMenu({
   leading,
   children,
@@ -129,7 +125,7 @@ function CardOverflowMenu({
   children: React.ReactNode;
 }) {
   return (
-    <div className="relative z-10 flex shrink-0 items-center gap-1.5">
+    <div className="flex shrink-0 items-center gap-1.5">
       {leading}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -137,15 +133,12 @@ function CardOverflowMenu({
             variant="ghost"
             size="icon"
             className="h-7 w-7 text-muted-foreground"
-            onClick={(e) => e.stopPropagation()}
             aria-label="More actions"
           >
             <MoreHorizontal className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
-          {children}
-        </DropdownMenuContent>
+        <DropdownMenuContent align="end">{children}</DropdownMenuContent>
       </DropdownMenu>
     </div>
   );
@@ -195,8 +188,7 @@ function CardOpeningOverlay() {
 // both emoji or image. Without one, the glyph says which kind of app it is: the
 // app window for an owned app, the server glyph for an external one. The label
 // (what "owned" vs "external" means) rides in the tooltip + aria-label rather
-// than a separate badge. Lifted above the full-card click button so it can be
-// hovered.
+// than a separate badge.
 export function AppTypeIcon({
   owned,
   icon,
@@ -211,7 +203,7 @@ export function AppTypeIcon({
         <span
           role="img"
           aria-label={label}
-          className="relative z-10 inline-flex text-muted-foreground"
+          className="inline-flex text-muted-foreground"
         >
           <McpCatalogIcon
             icon={icon}
@@ -225,9 +217,9 @@ export function AppTypeIcon({
   );
 }
 
-// Clicking the card opens the app in a new chat; the overlay button covers the
-// whole card. The backend seeds a conversation with the app already rendered and
-// returns its id, so we navigate straight to it (no model turn).
+// Clicking the guarded card shell opens the app in a new chat. The backend
+// seeds a conversation with the app already rendered and returns its id, so we
+// navigate straight to it (no model turn).
 function OwnedAppCard({
   app,
   onOpenSettings,
@@ -264,18 +256,19 @@ function OwnedAppCard({
       setIsOpening(false);
     }
   };
+  const navigation = useNavigableCard({
+    onNavigate: isOpening ? undefined : () => void handleOpen(),
+  });
 
   return (
     <>
-      <Card className="relative flex min-h-[180px] cursor-pointer flex-col gap-0 p-4 transition-all hover:border-primary hover:bg-muted/40 hover:shadow-md">
-        <button
-          type="button"
-          onClick={() => void handleOpen()}
-          disabled={isOpening}
-          className="absolute inset-0 rounded-xl"
-          aria-label={`Open ${app.name} in new chat`}
-        />
-
+      <Card
+        {...navigation.props}
+        className={cn(
+          "relative flex min-h-[180px] flex-col gap-0 p-4 transition-colors",
+          navigation.className,
+        )}
+      >
         {isOpening ? <CardOpeningOverlay /> : null}
 
         {/* Header row mirrors the project card: icon + title on one line at the
@@ -289,9 +282,17 @@ function OwnedAppCard({
               />
             ) : null}
             <AppTypeIcon owned icon={app.icon} />
-            <CardTitle className="min-w-0 truncate leading-snug">
-              {app.name}
-            </CardTitle>
+            <button
+              type="button"
+              className="min-w-0 text-left"
+              disabled={isOpening}
+              aria-label={`Open ${app.name} in new chat`}
+              onClick={() => void handleOpen()}
+            >
+              <CardTitle className="truncate leading-snug">
+                {app.name}
+              </CardTitle>
+            </button>
           </div>
           <CardOverflowMenu
             leading={
@@ -423,17 +424,18 @@ function ExternalAppCard({
       setIsOpening(false);
     }
   };
+  const navigation = useNavigableCard({
+    onNavigate: isOpening ? undefined : () => void handleOpen(),
+  });
 
   return (
-    <Card className="relative flex min-h-[180px] cursor-pointer flex-col gap-0 p-4 transition-all hover:border-primary hover:bg-muted/40 hover:shadow-md">
-      <button
-        type="button"
-        onClick={() => void handleOpen()}
-        disabled={isOpening}
-        className="absolute inset-0 rounded-xl"
-        aria-label={`Open ${app.name} in new chat`}
-      />
-
+    <Card
+      {...navigation.props}
+      className={cn(
+        "relative flex min-h-[180px] flex-col gap-0 p-4 transition-colors",
+        navigation.className,
+      )}
+    >
       {isOpening ? <CardOpeningOverlay /> : null}
 
       {/* Header row mirrors the project card: icon + title on one line at the
@@ -444,9 +446,15 @@ function ExternalAppCard({
             <CardSelectionCheckbox label={`Select ${app.name}`} disabled />
           ) : null}
           <AppTypeIcon owned={false} icon={app.icon} />
-          <CardTitle className="min-w-0 truncate leading-snug">
-            {app.name}
-          </CardTitle>
+          <button
+            type="button"
+            className="min-w-0 text-left"
+            disabled={isOpening}
+            aria-label={`Open ${app.name} in new chat`}
+            onClick={() => void handleOpen()}
+          >
+            <CardTitle className="truncate leading-snug">{app.name}</CardTitle>
+          </button>
         </div>
         <CardOverflowMenu
           leading={

--- a/platform/frontend/src/app/apps/_parts/apps-table.tsx
+++ b/platform/frontend/src/app/apps/_parts/apps-table.tsx
@@ -32,6 +32,7 @@ import {
   useOpenExternalAppInChat,
   usePinApp,
 } from "@/lib/app.query";
+import type { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 import { setPendingProjectChatHandoff } from "@/lib/chat/pending-project-chat-handoff";
 import { AppTypeIcon } from "./app-card";
 import { AppDeleteDialog } from "./app-delete-dialog";
@@ -47,12 +48,14 @@ export function AppsTable({
   rowSelection,
   setRowSelection,
   onPageRowIdsChange,
+  rangeSelection,
 }: {
   apps: AppListItem[];
   onOpenSettings: (app: { id: string }) => void;
   rowSelection: RowSelectionState;
   setRowSelection: OnChangeFn<RowSelectionState>;
   onPageRowIdsChange: (ids: string[]) => void;
+  rangeSelection: BulkRangeSelectionController;
 }) {
   const router = useRouter();
   const openOwnedApp = useOpenAppInChat();
@@ -260,6 +263,7 @@ export function AppsTable({
         rowSelection={rowSelection}
         onRowSelectionChange={setRowSelection}
         onPageRowIdsChange={onPageRowIdsChange}
+        rangeSelection={rangeSelection}
         hideSelectedCount
         onRowClick={(app) => void handleOpen(app)}
         emptyIcon={AppWindow}

--- a/platform/frontend/src/app/apps/page.client.test.tsx
+++ b/platform/frontend/src/app/apps/page.client.test.tsx
@@ -2,6 +2,7 @@ import type { archestraApiTypes } from "@archestra/shared";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { FilterBar } from "@/components/filter-bar";
 import { TableCardView } from "@/components/table-card-view";
 import { AppSection, matchesKind } from "./page.client";
 
@@ -187,6 +188,9 @@ describe("AppSection cards", () => {
 function renderAppSection(apps: AppListItem[] = [ownedApp, externalApp]) {
   return render(
     <TableCardView storageKey="apps-test-view" defaultMode="cards">
+      <FilterBar>
+        <span>Filters</span>
+      </FilterBar>
       <AppSection title="Apps" apps={apps} onOpenSettings={vi.fn()} />
     </TableCardView>,
   );

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -182,7 +182,7 @@ export default function AppsPage() {
       }
     >
       <TableCardView storageKey="archestra-apps-view">
-        <FilterBar className="mb-6" actions={<TableCardViewToggle />}>
+        <FilterBar className="mb-3" actions={<TableCardViewToggle />}>
           <SearchInput
             isLoading={isFetching}
             paramName="search"
@@ -340,6 +340,7 @@ export function AppSection({
     clearSelection,
     selected,
     selectAllMatching,
+    rangeSelection,
   } = useBulkSelection({
     rows: apps,
     getId: getAppRowKey,
@@ -353,6 +354,7 @@ export function AppSection({
     rowSelection,
     setRowSelection,
     canSelect: (app) => app.source === "owned",
+    rangeSelection,
   });
   const selectedOwnedApps = selected.filter(
     (app): app is OwnedApp => app.source === "owned",
@@ -402,6 +404,7 @@ export function AppSection({
             rowSelection={rowSelection}
             setRowSelection={setRowSelection}
             onPageRowIdsChange={onPageRowIdsChange}
+            rangeSelection={rangeSelection}
           />
         }
         cards={

--- a/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
@@ -740,7 +740,7 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
           />
         ) : (
           <div>
-            <FilterBar className="mb-4">
+            <FilterBar className="mb-3">
               {isAutoSync && (
                 <Select
                   value={runTypeFilter}

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
@@ -19,6 +19,7 @@ import {
   TableRowActions,
 } from "@/components/table-row-actions";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { DataTable } from "@/components/ui/data-table";
 import { PermissionButton } from "@/components/ui/permission-button";
@@ -280,8 +281,8 @@ export function ConnectorDocumentsTable({
   );
 
   return (
-    <div className="space-y-4">
-      <FilterBar className="!mb-3">
+    <BulkActionsScope className="space-y-3">
+      <FilterBar>
         <SearchInput
           isLoading={isFetching}
           value={search}
@@ -484,6 +485,6 @@ export function ConnectorDocumentsTable({
           pendingLabel="Deleting..."
         />
       )}
-    </div>
+    </BulkActionsScope>
   );
 }

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-members-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-members-table.tsx
@@ -300,7 +300,7 @@ export function ConnectorMembersTable({
   return (
     <div>
       {members.length > 0 && (
-        <FilterBar className="mb-4">
+        <FilterBar className="mb-3">
           <SearchInput
             value={search}
             syncQueryParams={false}

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.tsx
@@ -211,7 +211,7 @@ export function ConnectorUserGroupsTable({
   return (
     <div>
       {groups.length > 0 && (
-        <FilterBar className="mb-4">
+        <FilterBar className="mb-3">
           <SearchInput
             value={search}
             syncQueryParams={false}

--- a/platform/frontend/src/app/knowledge/connectors/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/page.client.tsx
@@ -179,7 +179,7 @@ function ConnectorsList() {
   // re-pointing "all N" at a different N.
   const filterSignature = `${search}|${connectorTypeFilter}|${isDeletedView}`;
   const allMatchingActive = selectAllMatchingFor === filterSignature;
-  const { effectiveRowSelection, onRowSelectionChange } =
+  const { effectiveRowSelection, onRowSelectionChange, rangeSelection } =
     useControlledRowSelection({
       rowSelection,
       setRowSelection,
@@ -193,6 +193,7 @@ function ConnectorsList() {
     getRowId: (connector) => connector.id,
     rowSelection: effectiveRowSelection,
     setRowSelection: onRowSelectionChange,
+    rangeSelection,
   });
   const { data: allMatching, isFetching: isFetchingAllMatching } =
     useAllMatchingConnectors(
@@ -426,9 +427,7 @@ function ConnectorsList() {
     >
       <TableCardView storageKey="archestra-connectors-view">
         <div>
-          <div
-            className={`${!isDeletedView && !isConnectorsLoadError ? "mb-3" : "mb-6"} flex flex-col gap-2`}
-          >
+          <div className="mb-3 flex flex-col gap-2">
             <FilterBar
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
             >
@@ -549,6 +548,9 @@ function ConnectorsList() {
                             {connector.name}
                           </Link>
                         }
+                        onNavigate={() =>
+                          router.push(`/knowledge/connectors/${connector.id}`)
+                        }
                         description={connector.description}
                         actions={connectorActions(connector)}
                         {...cardSelection(connector)}
@@ -584,6 +586,7 @@ function ConnectorsList() {
                     onRowSelectionChange={
                       isDeletedView ? undefined : onRowSelectionChange
                     }
+                    rangeSelection={rangeSelection}
                     // The deleted view always counts as filtered (see
                     // hasActiveFilters), so its empty state is the filtered one below.
                     emptyIcon={Database}

--- a/platform/frontend/src/app/knowledge/files/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/files/page.client.tsx
@@ -28,6 +28,7 @@ import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge"
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -503,9 +504,8 @@ export default function KnowledgeFilesPage() {
       }
       isPending={isLoading && files.length === 0}
     >
-      <div className="space-y-6">
+      <BulkActionsScope className="space-y-3">
         <FilterBar
-          className="!mb-3"
           onClearFilters={
             search
               ? () => {
@@ -644,7 +644,7 @@ export default function KnowledgeFilesPage() {
             onPaginationChange={setPagination}
           />
         )}
-      </div>
+      </BulkActionsScope>
 
       <UploadFileDialog
         open={uploadOpen}

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/knowledge-base-card.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/knowledge-base-card.tsx
@@ -4,6 +4,7 @@ import type { archestraApiTypes } from "@archestra/shared";
 import { Bot, Database, FileText, Plug, Plus } from "lucide-react";
 import type { MouseEventHandler } from "react";
 import { ConnectorChip } from "@/app/knowledge/knowledge-bases/_parts/connector-chip";
+import { COLLECTION_CARD_HOVER_CLASSNAME } from "@/components/table-card-view";
 import {
   type TableRowAction,
   TableRowActions,
@@ -66,7 +67,9 @@ export function KnowledgeBaseCard({
     <div
       className={cn(
         "flex h-full flex-col gap-3 rounded-lg border p-4 transition-colors",
-        selected ? "border-primary bg-primary/5" : "hover:bg-muted/30",
+        selected
+          ? "border-primary bg-primary/5"
+          : COLLECTION_CARD_HOVER_CLASSNAME,
       )}
     >
       <div className="flex items-start gap-3">

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -197,7 +197,7 @@ function KnowledgeBasesList() {
   // re-pointing "all N" at a different N.
   const filterSignature = `${search}|${isDeletedView}`;
   const allMatchingActive = selectAllMatchingFor === filterSignature;
-  const { effectiveRowSelection, onRowSelectionChange } =
+  const { effectiveRowSelection, onRowSelectionChange, rangeSelection } =
     useControlledRowSelection({
       rowSelection,
       setRowSelection,
@@ -211,6 +211,7 @@ function KnowledgeBasesList() {
     getRowId: (knowledgeBase) => knowledgeBase.id,
     rowSelection: effectiveRowSelection,
     setRowSelection: onRowSelectionChange,
+    rangeSelection,
   });
   const { data: allMatching, isFetching: isFetchingAllMatching } =
     useAllMatchingKnowledgeBases(
@@ -449,9 +450,7 @@ function KnowledgeBasesList() {
     >
       <TableCardView storageKey="knowledge-bases-view">
         <div>
-          <div
-            className={`${!isDeletedView ? "mb-3" : "mb-6"} flex flex-col gap-2`}
-          >
+          <div className="mb-3 flex flex-col gap-2">
             <FilterBar
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
             >
@@ -526,6 +525,7 @@ function KnowledgeBasesList() {
                 onRowSelectionChange={
                   isDeletedView ? undefined : onRowSelectionChange
                 }
+                rangeSelection={rangeSelection}
                 hideSelectedCount
                 // The deleted view always counts as filtered (see hasActiveFilters),
                 // so its empty state is the filtered one below.

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -43,6 +43,7 @@ import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Badge } from "@/components/ui/badge";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -519,9 +520,9 @@ export default function ModelsPage() {
       tabs={MODEL_NAV_TABS}
       actionButton={refreshModelsButton}
     >
-      <div className="space-y-4">
+      <BulkActionsScope className="space-y-3">
         {models.length > 0 && (
-          <FilterBar className="!mb-3">
+          <FilterBar>
             <SearchInput
               objectNamePlural="models"
               searchFields={["model ID"]}
@@ -684,7 +685,7 @@ export default function ModelsPage() {
               : "No models found"
           }
         />
-      </div>
+      </BulkActionsScope>
 
       {editingModel && (
         <EditModelDialog

--- a/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
@@ -57,7 +57,9 @@ import {
 import { PermissionButton } from "@/components/ui/permission-button";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { reportBulkOutcome } from "@/lib/bulk-action";
+import { useBulkRangeSelectionController } from "@/lib/bulk-range-selection-context";
 import { copyToClipboard } from "@/lib/clipboard";
+import { useBulkCardSelection } from "@/lib/hooks/use-bulk-card-selection";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useModelProviderCatalog } from "@/lib/integration-overrides";
 import {
@@ -183,6 +185,14 @@ function VirtualKeysTable() {
 
   const keys = query.data?.data ?? [];
   const pagination = query.data?.pagination;
+  const rangeSelection = useBulkRangeSelectionController();
+  const cardSelection = useBulkCardSelection({
+    rows: keys,
+    getRowId: (key) => key.id,
+    rowSelection,
+    setRowSelection,
+    rangeSelection,
+  });
   const selectedKeys = keys.filter((key) => rowSelection[key.id]);
   const hasActiveFilters = Boolean(
     searchFromUrl || keyTypeFilter || scopeFilter || providerApiKeyIdFilter,
@@ -419,15 +429,7 @@ function VirtualKeysTable() {
                   key={key.id}
                   icon={<KeyRound className="h-5 w-5" />}
                   title={key.name}
-                  selected={!!rowSelection[key.id]}
-                  onSelectedChange={(selected) => {
-                    setRowSelection((current) => {
-                      const next = { ...current };
-                      if (selected) next[key.id] = true;
-                      else delete next[key.id];
-                      return next;
-                    });
-                  }}
+                  {...cardSelection(key)}
                   selectionLabel={`Select ${key.name}`}
                   actions={
                     <TableRowActions
@@ -509,6 +511,7 @@ function VirtualKeysTable() {
               getRowId={(row) => row.id}
               rowSelection={rowSelection}
               onRowSelectionChange={setRowSelection}
+              rangeSelection={rangeSelection}
               hideSelectedCount
               manualPagination
               pagination={{

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -371,7 +371,7 @@ function McpGateways({
   const filterSignature = JSON.stringify(listFilters);
   const [escalatedFor, setEscalatedFor] = useState<string | null>(null);
   const allMatchingSelected = escalatedFor === filterSignature;
-  const { effectiveRowSelection, onRowSelectionChange } =
+  const { effectiveRowSelection, onRowSelectionChange, rangeSelection } =
     useControlledRowSelection({
       rowSelection,
       setRowSelection,
@@ -385,6 +385,7 @@ function McpGateways({
     getRowId: (row) => row.id,
     rowSelection: effectiveRowSelection,
     setRowSelection: onRowSelectionChange,
+    rangeSelection,
   });
   const { data: allMatching, isFetching: isFetchingAllMatching } =
     useAllMatchingProfiles(listFilters, { enabled: allMatchingSelected });
@@ -801,6 +802,14 @@ function McpGateways({
                         }
                         description={agent.description}
                         actions={renderGatewayActions(agent)}
+                        onNavigate={
+                          isDeletedView
+                            ? undefined
+                            : () =>
+                                router.push(
+                                  agentDetailHref("mcp_gateway", agent.id),
+                                )
+                        }
                         {...cardSelection(agent)}
                         selectionLabel={`Select ${agent.name}`}
                         footer={
@@ -831,6 +840,7 @@ function McpGateways({
                     getRowId={(row) => row.id}
                     rowSelection={effectiveRowSelection}
                     onRowSelectionChange={onRowSelectionChange}
+                    rangeSelection={rangeSelection}
                     hideSelectedCount
                     sorting={sorting}
                     onSortingChange={handleSortingChange}

--- a/platform/frontend/src/app/mcp/registry/[id]/page.client.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/[id]/page.client.test.tsx
@@ -1,11 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -256,10 +250,9 @@ describe("McpCatalogItemDetailPage overview", () => {
     expect(
       screen.getByRole("heading", { name: "Installations" }),
     ).toBeVisible();
-    expect(screen.getByRole("link", { name: "Installations" })).toHaveAttribute(
-      "href",
-      "/mcp/registry/cat-1?tab=credentials",
-    );
+    expect(
+      screen.queryByRole("link", { name: "Installations" }),
+    ).not.toBeInTheDocument();
   });
 
   it("names the main page in the tab strip, so a secondary tab has a way back", () => {

--- a/platform/frontend/src/app/mcp/registry/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/registry/[id]/page.client.tsx
@@ -9,9 +9,7 @@ import {
   PackageX,
   Pencil,
   RefreshCw,
-  Server,
   Trash2,
-  Users,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -224,7 +222,6 @@ function CatalogItemDetails({
         ? "remote"
         : "local";
   const actionModel = getMcpServerActionModel(item);
-  const connectionsAction = mcpServerAction(actionModel, "connections");
   const editAction = mcpServerAction(actionModel, "edit");
   const cloneAction = mcpServerAction(actionModel, "clone");
   const deleteAction = mcpServerAction(actionModel, "delete");
@@ -469,18 +466,6 @@ function CatalogItemDetails({
       tabs={tabs}
       actionButton={
         <div className="flex shrink-0 items-center gap-2">
-          {connectionsAction.href && (
-            <Button variant="outline" asChild>
-              <Link href={connectionsAction.href}>
-                {variant === "local" ? (
-                  <Server className="h-4 w-4" />
-                ) : (
-                  <Users className="h-4 w-4" />
-                )}
-                {connectionsAction.label}
-              </Link>
-            </Button>
-          )}
           {showChatButton && (
             <Button
               variant="outline"

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@archestra/shared";
 import { CheckCircle2, Route, Trash2 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
@@ -30,6 +30,10 @@ import {
   OAuthConfirmationDialog,
   type OAuthInstallResult,
 } from "@/components/oauth-confirmation-dialog";
+import {
+  ResourceScopeFilter,
+  useScopeFilterParams,
+} from "@/components/resource-scope-filter";
 import { SearchInput } from "@/components/search-input";
 import {
   TableCardGrid,
@@ -50,6 +54,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { PermissionButton } from "@/components/ui/permission-button";
+import { TablePagination } from "@/components/ui/table-pagination";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useInitiateOAuth } from "@/lib/auth/oauth.query";
 import {
@@ -84,13 +89,13 @@ import {
 } from "@/lib/mcp/mcp-server.query";
 import {
   attentionCatalogIds,
+  attentionSortRank,
   facetIssues,
   type McpServerAttentionFacet,
   type McpServerIssue,
 } from "@/lib/mcp/mcp-server-issues";
 import { buildRemoteInstallCredentialPayload } from "@/lib/mcp/remote-install-payload";
 import { useMcpServerIssues } from "@/lib/mcp/use-mcp-server-issues";
-import { useDefaultEnvironment } from "@/lib/organization.query";
 
 import { resolveCatalogEnvironmentLabel } from "./catalog-environment-label";
 import {
@@ -98,6 +103,11 @@ import {
   type LocalServerInstallResult,
 } from "./local-server-install-dialog";
 import { ManageUsersDialog } from "./manage-users-dialog";
+import {
+  hasMcpRegistryInstallForViewer,
+  matchesMcpRegistryOwnershipFilters,
+  mcpRegistryInstallPriority,
+} from "./mcp-registry-visibility";
 import { McpServerAttentionList } from "./mcp-server-attention-list";
 import {
   type CatalogItem,
@@ -119,6 +129,7 @@ import {
   RegistryFilterDropdown,
   type RegistryFilters,
   RegistrySortMenu,
+  SORT_OPTIONS,
   type SortKey,
   STATUS_OPTIONS,
   selectedAttentionFacet,
@@ -143,6 +154,7 @@ export function InternalMCPCatalog({
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const ownershipFilters = useScopeFilterParams();
 
   // Get search query from URL
   const searchQueryFromUrl = searchParams.get("search") || "";
@@ -185,12 +197,20 @@ export function InternalMCPCatalog({
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
   const { data: environmentList } = useEnvironments();
-  const defaultEnvironment = useDefaultEnvironment();
   const byosEnabled = Boolean(useFeature("byosEnabled"));
   const alertingFeature = useFeature("mcpServerAlertingEnabled");
   const alertingEnabled = alertingFeature === true;
 
-  const [sort, setSort] = useState<SortKey>("name-asc");
+  const [sort, setSort] = useState<SortKey>("attention");
+  const sortOptions =
+    alertingFeature === false
+      ? SORT_OPTIONS.filter((option) => option.key !== "attention")
+      : SORT_OPTIONS;
+  useEffect(() => {
+    if (alertingFeature === false && sort === "attention") {
+      setSort("name-asc");
+    }
+  }, [alertingFeature, sort]);
   // The filters live in the URL, not in component state: the sidebar badge
   // and the retired `?tab=attention` links both have to be able to point at a
   // filtered list, and Back has to undo a filter change rather than leave the
@@ -211,9 +231,9 @@ export function InternalMCPCatalog({
         for (const value of next[group]) params.append(group, value);
       }
       const qs = params.toString();
-      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      replaceRegistryListUrl(qs ? `${pathname}?${qs}` : pathname);
     },
-    [searchParams, router, pathname],
+    [searchParams, pathname],
   );
   const toggleFilter = useCallback(
     (group: FilterGroup, value: string) => {
@@ -233,8 +253,8 @@ export function InternalMCPCatalog({
     [filters, writeFilters],
   );
   // "Clear all" sits under the chips and clears what the chips show. The
-  // facet is not one of them (it is spelled out on the segmented control), so
-  // taking it here would undo a selection the button never claimed to hold.
+  // facet is view state rather than one of those chips, so taking it here
+  // would undo a selection the button never claimed to hold.
   const clearAdvancedFilters = useCallback(
     () =>
       writeFilters({
@@ -282,9 +302,9 @@ export function InternalMCPCatalog({
       } else {
         params.delete("search");
       }
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      replaceRegistryListUrl(`${pathname}?${params.toString()}`);
     },
-    [searchParams, router, pathname],
+    [searchParams, pathname],
   );
   const [selectedCatalogItem, setSelectedCatalogItem] =
     useState<CatalogItem | null>(null);
@@ -579,65 +599,8 @@ export function InternalMCPCatalog({
   };
 
   // Aggregate all installations of the same catalog item
-  const getAggregatedInstallation = (catalogId: string) => {
-    const servers = installedServers?.filter(
-      (server) => server.catalogId === catalogId,
-    );
-
-    if (!servers || servers.length === 0) return undefined;
-
-    // If only one server, return it as-is
-    if (servers.length === 1) {
-      return servers[0];
-    }
-
-    // Find current user's specific installation to use as base
-    const currentUserServer = servers.find((s) => s.ownerId === currentUserId);
-
-    // Prefer current user's server as base, otherwise use first server with users, or just first server
-    const baseServer =
-      currentUserServer ||
-      servers.find((s) => s.users && s.users.length > 0) ||
-      servers[0];
-
-    // Aggregate multiple servers
-    const aggregated = { ...baseServer };
-
-    // Combine all unique users
-    const allUsers = new Set<string>();
-    const allUserDetails: Array<{
-      userId: string;
-      email: string;
-      createdAt: string;
-      serverId: string; // Track which server this user belongs to
-    }> = [];
-
-    for (const server of servers) {
-      if (server.users) {
-        for (const userId of server.users) {
-          allUsers.add(userId);
-        }
-      }
-      if (server.userDetails) {
-        for (const userDetail of server.userDetails) {
-          // Only add if not already present
-          if (!allUserDetails.some((ud) => ud.userId === userDetail.userId)) {
-            allUserDetails.push({
-              ...userDetail,
-              serverId: server.id, // Include the actual server ID
-            });
-          }
-        }
-      }
-    }
-
-    aggregated.users = Array.from(allUsers);
-    aggregated.userDetails = allUserDetails;
-    // Note: teamDetails is now a single object per server (many-to-one),
-    // so we use the base server's teamDetails as-is
-
-    return aggregated;
-  };
+  const getAggregatedInstallation = (catalogId: string) =>
+    aggregatedInstallationsByCatalog.get(catalogId);
 
   const handleReinstall = async (
     catalogItem: CatalogItem,
@@ -878,6 +841,36 @@ export function InternalMCPCatalog({
       ),
     [installedServers],
   );
+  const serversByCatalog = useMemo(() => {
+    const map = new Map<string, InstalledServer[]>();
+    for (const server of installedServers ?? []) {
+      if (!server.catalogId) continue;
+      map.set(server.catalogId, [...(map.get(server.catalogId) ?? []), server]);
+    }
+    return map;
+  }, [installedServers]);
+  const aggregatedInstallationsByCatalog = useMemo(
+    () =>
+      new Map(
+        [...serversByCatalog].map(([catalogId, servers]) => [
+          catalogId,
+          aggregateInstallations(servers, currentUserId),
+        ]),
+      ),
+    [serversByCatalog, currentUserId],
+  );
+  const installedForViewerCatalogIds = useMemo(
+    () =>
+      new Set(
+        (installedServers ?? [])
+          .filter((server) =>
+            hasMcpRegistryInstallForViewer([server], currentUserId),
+          )
+          .map((server) => server.catalogId)
+          .filter(Boolean) as string[],
+      ),
+    [installedServers, currentUserId],
+  );
   const envLabelByCatalog = useMemo(() => {
     const envs = environmentList?.environments ?? [];
     const map = new Map<string, string | null>();
@@ -889,12 +882,11 @@ export function InternalMCPCatalog({
           : (resolveCatalogEnvironmentLabel({
               environmentId: it.environmentId,
               environments: envs,
-              defaultEnvironmentName: defaultEnvironment.name,
-            }) ?? defaultEnvironment.name),
+            }) ?? null),
       );
     }
     return map;
-  }, [catalogItems, environmentList, defaultEnvironment.name]);
+  }, [catalogItems, environmentList]);
 
   const environmentOptions: FilterOption[] = useMemo(() => {
     const set = new Set<string>();
@@ -943,6 +935,16 @@ export function InternalMCPCatalog({
     [issuesByCatalog, selectedFacet],
   );
   const matchesAdvancedFilters = (item: CatalogItem) => {
+    if (
+      !matchesMcpRegistryOwnershipFilters({
+        item,
+        servers: serversByCatalog.get(item.id) ?? [],
+        filters: ownershipFilters,
+        currentUserId,
+      })
+    ) {
+      return false;
+    }
     if (facetCatalogIds && !facetCatalogIds.has(item.id)) return false;
     if (filters.issue.size > 0) {
       const itemIssues = issuesByCatalog.get(item.id) ?? [];
@@ -975,6 +977,15 @@ export function InternalMCPCatalog({
 
   const sortItems = (list: CatalogItem[]) => {
     switch (sort) {
+      case "attention":
+        return [...list].sort(
+          (a, b) =>
+            attentionSortRank(issuesByCatalog.get(a.id)) -
+              attentionSortRank(issuesByCatalog.get(b.id)) ||
+            Number(installedForViewerCatalogIds.has(b.id)) -
+              Number(installedForViewerCatalogIds.has(a.id)) ||
+            a.name.localeCompare(b.name),
+        );
       case "name-desc":
         return [...list].sort((a, b) => b.name.localeCompare(a.name));
       case "newest":
@@ -1013,24 +1024,23 @@ export function InternalMCPCatalog({
       .filter((item) => item.id !== ARCHESTRA_MCP_CATALOG_ID)
       .filter(matchesAdvancedFilters),
   );
-  const personalItems = allFilteredItems.filter(
-    (item) => item.scope === "personal",
-  );
-  const sharedItems = allFilteredItems.filter(
-    (item) => item.scope !== "personal",
-  );
 
-  const getInstalledServerInfo = (item: CatalogItem) => {
+  function getInstalledServerInfo(item: CatalogItem) {
     const installedServer = getAggregatedInstallation(item.id);
     const isInstallInProgress =
       installedServer && installingServerIds.has(installedServer.id);
 
     // For local servers, count installations and check ownership
-    const localServers =
-      installedServers?.filter(
-        (server) =>
-          server.serverType === "local" && server.catalogId === item.id,
-      ) || [];
+    const catalogServers = serversByCatalog.get(item.id) ?? [];
+    const localServers = catalogServers.filter(
+      (server) => server.serverType === "local",
+    );
+    const currentUserHasPersonalInstallation = Boolean(
+      currentUserId &&
+        catalogServers.some(
+          (server) => server.ownerId === currentUserId && !server.teamId,
+        ),
+    );
     const currentUserLocalServerInstallation = currentUserId
       ? localServers.find((server) => server.ownerId === currentUserId)
       : undefined;
@@ -1042,8 +1052,9 @@ export function InternalMCPCatalog({
       installedServer,
       isInstallInProgress,
       currentUserInstalledLocalServer,
+      currentUserHasPersonalInstallation,
     };
-  };
+  }
 
   // Install entry point for the table view, which has no per-variant card
   // buttons: route to the same flows the cards use.
@@ -1069,17 +1080,17 @@ export function InternalMCPCatalog({
       } else {
         params.delete("labels");
       }
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      replaceRegistryListUrl(`${pathname}?${params.toString()}`);
     },
-    [parsedLabels, searchParams, router, pathname],
+    [parsedLabels, searchParams, pathname],
   );
 
   const handleClearFilters = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString());
     params.delete("search");
     params.delete("labels");
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-  }, [searchParams, router, pathname]);
+    replaceRegistryListUrl(`${pathname}?${params.toString()}`);
+  }, [searchParams, pathname]);
 
   // Everything except the facet. Offered when a facet is selected and the
   // other filters have emptied it: the reader asked "what needs my action",
@@ -1096,12 +1107,14 @@ export function InternalMCPCatalog({
       params.append(REGISTRY_STATUS_PARAM, value);
     }
     const qs = params.toString();
-    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [searchParams, router, pathname, filters.status]);
+    replaceRegistryListUrl(qs ? `${pathname}?${qs}` : pathname);
+  }, [searchParams, pathname, filters.status]);
 
   const hasLabelFilters = parsedLabels && Object.keys(parsedLabels).length > 0;
   const hasActiveFilters = Boolean(
-    searchQueryFromUrl.trim() || hasLabelFilters,
+    ownershipFilters.hasActiveScopeFilters ||
+      searchQueryFromUrl.trim() ||
+      hasLabelFilters,
   );
   // A selected attention facet is the list's current view, not an applied
   // control within the bar. Keep it in place when clearing the narrower
@@ -1124,9 +1137,12 @@ export function InternalMCPCatalog({
     params.delete("search");
     params.delete("labels");
     for (const group of FILTER_GROUPS) params.delete(group);
+    for (const group of ["scope", "teamIds", "authorIds", "excludeAuthorIds"]) {
+      params.delete(group);
+    }
     const qs = params.toString();
-    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [searchParams, router, pathname]);
+    replaceRegistryListUrl(qs ? `${pathname}?${qs}` : pathname);
+  }, [searchParams, pathname]);
   const handleClearBarFilters = selectedFacet
     ? clearFiltersKeepingFacet
     : handleClearAllFilters;
@@ -1163,7 +1179,11 @@ export function InternalMCPCatalog({
             }
             actions={
               <>
-                <RegistrySortMenu value={sort} onChange={setSort} />
+                <RegistrySortMenu
+                  value={sort}
+                  onChange={setSort}
+                  options={sortOptions}
+                />
                 {!selectedFacet && (
                   <TableCardViewToggle order={["table", "cards"]} />
                 )}
@@ -1181,6 +1201,14 @@ export function InternalMCPCatalog({
               inputClassName="w-full bg-background/50 backdrop-blur-sm border-border/50 focus:border-primary/50 transition-colors pl-9"
             />
             <McpCatalogLabelFilter active={Boolean(hasLabelFilters)} />
+            {!selectedFacet && (
+              <ResourceScopeFilter
+                adminPermission={{ mcpServerInstallation: ["admin"] }}
+                ownerLabelPlural="connections"
+                allLabel="All scopes"
+                navigate={replaceRegistryListUrl}
+              />
+            )}
             {selectedFacet ? (
               <RegistryFilterDropdown
                 label="Issue"
@@ -1305,10 +1333,9 @@ export function InternalMCPCatalog({
           )
         ) : (
           <div className="space-y-6">
-            {personalItems.length > 0 && (
+            {allFilteredItems.length > 0 ? (
               <McpServerCatalogSection
-                title="Personal"
-                items={personalItems}
+                items={allFilteredItems}
                 getServerInfo={getInstalledServerInfo}
                 envLabelByCatalog={envLabelByCatalog}
                 issuesByCatalog={issuesByCatalog}
@@ -1319,40 +1346,19 @@ export function InternalMCPCatalog({
                 onReinstall={handleReinstall}
                 onCancelInstallation={install.cancelInstallation}
                 isBuiltInPlaywright={isPlaywrightCatalogItem}
-                showTitle
-              />
-            )}
-
-            {sharedItems.length > 0 ? (
-              <McpServerCatalogSection
-                title="Shared"
-                items={sharedItems}
-                getServerInfo={getInstalledServerInfo}
-                envLabelByCatalog={envLabelByCatalog}
-                issuesByCatalog={issuesByCatalog}
-                deploymentFeedState={deploymentFeedState}
-                deploymentStatuses={deploymentStatuses}
-                installingItemId={installingItemId}
-                onInstall={handleTableInstall}
-                onReinstall={handleReinstall}
-                onCancelInstallation={install.cancelInstallation}
-                isBuiltInPlaywright={isPlaywrightCatalogItem}
-                showTitle={personalItems.length > 0}
               />
             ) : (
-              personalItems.length === 0 && (
-                <EmptyState
-                  icon={Route}
-                  title={
-                    hasActiveFilters
-                      ? "No MCP servers match your filters"
-                      : "No MCP servers found"
-                  }
-                  onClearFilters={
-                    hasActiveFilters ? handleClearFilters : undefined
-                  }
-                />
-              )
+              <EmptyState
+                icon={Route}
+                title={
+                  hasActiveFilters
+                    ? "No MCP servers match your filters"
+                    : "No MCP servers found"
+                }
+                onClearFilters={
+                  hasActiveFilters ? handleClearFilters : undefined
+                }
+              />
             )}
           </div>
         )}
@@ -1457,8 +1463,11 @@ export function InternalMCPCatalog({
   );
 }
 
+function replaceRegistryListUrl(url: string) {
+  window.history.replaceState(null, "", url);
+}
+
 function McpServerCatalogSection({
-  title,
   items,
   getServerInfo,
   envLabelByCatalog,
@@ -1470,13 +1479,12 @@ function McpServerCatalogSection({
   onReinstall,
   onCancelInstallation,
   isBuiltInPlaywright,
-  showTitle,
 }: {
-  title: string;
   items: CatalogItem[];
   getServerInfo: (item: CatalogItem) => {
     installedServer?: InstalledServer;
     isInstallInProgress?: boolean;
+    currentUserHasPersonalInstallation: boolean;
   };
   envLabelByCatalog: Map<string, string | null>;
   issuesByCatalog: Map<string, McpServerIssue[]>;
@@ -1491,12 +1499,18 @@ function McpServerCatalogSection({
   ) => void | Promise<void>;
   onCancelInstallation: (serverId: string) => void;
   isBuiltInPlaywright: (catalogId: string) => boolean;
-  showTitle: boolean;
 }) {
-  const canSelect = (item: CatalogItem) =>
-    !!getServerInfo(item).installedServer &&
-    installingItemId !== item.id &&
-    !getServerInfo(item).isInstallInProgress;
+  const canSelect = (item: CatalogItem) => {
+    const serverInfo = getServerInfo(item);
+    return (
+      !!serverInfo.installedServer &&
+      installingItemId !== item.id &&
+      !serverInfo.isInstallInProgress
+    );
+  };
+  const filterSignature = `mcp-registry:${items
+    .map((item) => item.id)
+    .join(",")}`;
   const {
     rowSelection,
     setRowSelection,
@@ -1504,35 +1518,102 @@ function McpServerCatalogSection({
     clearSelection,
     selected,
     selectAllMatching,
+    rangeSelection,
   } = useBulkSelection({
     rows: items,
     getId: (item) => item.id,
     canSelect,
-    filterSignature: `mcp-registry:${items.map((item) => item.id).join(",")}`,
+    filterSignature,
     matchDescription: "match the current filters",
   });
+  const selectedToUninstall = selected
+    .map((item) => ({ item, server: getServerInfo(item).installedServer }))
+    .filter((entry) => entry.server)
+    .map(({ item, server }) => ({
+      id: server?.id ?? item.id,
+      name: item.name,
+    }));
+
+  // Table and cards consume the same filtered and sorted sequence. Do not add
+  // a card-only priority bucket: it would override the user's active sort.
+  const orderedCardItems = items;
+  const [cardPagination, setCardPagination] = useState({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+  const maxCardPageIndex = Math.max(
+    0,
+    Math.ceil(orderedCardItems.length / cardPagination.pageSize) - 1,
+  );
+  const cardPageIndex = Math.min(cardPagination.pageIndex, maxCardPageIndex);
+  const cardPageItems = orderedCardItems.slice(
+    cardPageIndex * cardPagination.pageSize,
+    (cardPageIndex + 1) * cardPagination.pageSize,
+  );
   const cardSelection = useBulkCardSelection({
-    rows: items,
+    rows: cardPageItems,
     getRowId: (item) => item.id,
     rowSelection,
     setRowSelection,
     canSelect,
+    rangeSelection,
   });
+  const tablePageRowIds = useRef<string[]>([]);
+  const cardPageRowIds = useRef<string[]>([]);
+  const recordTablePageRowIds = useCallback((ids: string[]) => {
+    tablePageRowIds.current = ids;
+  }, []);
+  const recordCardPageRowIds = useCallback((ids: string[]) => {
+    cardPageRowIds.current = ids;
+  }, []);
+  const syncVisiblePageSelection = useCallback(
+    (mode: "cards" | "table") => {
+      // With no selection there is no page-selection affordance to update.
+      // Skipping this state write keeps the view toggle a CSS-only operation.
+      if (selected.length === 0) return;
+      onPageRowIdsChange(
+        mode === "cards" ? cardPageRowIds.current : tablePageRowIds.current,
+      );
+    },
+    [onPageRowIdsChange, selected.length],
+  );
 
-  const selectedToUninstall = selected
-    .filter((item) => getServerInfo(item).installedServer)
-    .map((item) => ({
-      id: getServerInfo(item).installedServer?.id ?? item.id,
-      name: item.name,
-    }));
+  const renderCard = (item: CatalogItem) => {
+    const serverInfo = getServerInfo(item);
+    return (
+      <McpServerCard
+        variant={
+          item.serverType === "builtin"
+            ? "builtin"
+            : item.serverType === "remote"
+              ? "remote"
+              : "local"
+        }
+        key={item.id}
+        item={item}
+        installedServer={serverInfo.installedServer}
+        installingItemId={installingItemId}
+        installationStatus={
+          serverInfo.installedServer?.localInstallationStatus || undefined
+        }
+        deploymentStatuses={deploymentStatuses}
+        deploymentFeedState={deploymentFeedState}
+        issues={issuesByCatalog.get(item.id)}
+        onInstallRemoteServer={() => onInstall(item)}
+        onInstallLocalServer={() => onInstall(item)}
+        onReinstall={(flagged, options) => onReinstall(item, flagged, options)}
+        onCancelInstallation={onCancelInstallation}
+        isBuiltInPlaywright={isBuiltInPlaywright(item.id)}
+        selection={{
+          ...cardSelection(item),
+          disabled: !canSelect(item),
+        }}
+      />
+    );
+  };
 
   return (
     <div className="space-y-3">
-      {showTitle && (
-        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-          {title}
-        </h3>
-      )}
       <McpServerBulkActions
         selected={selected}
         selectedToUninstall={selectedToUninstall}
@@ -1540,6 +1621,8 @@ function McpServerCatalogSection({
         selectAllMatching={selectAllMatching}
       />
       <TableCardViewContent
+        keepMounted
+        onModeChange={syncVisiblePageSelection}
         table={
           <McpServerTable
             items={items}
@@ -1555,53 +1638,29 @@ function McpServerCatalogSection({
             selection={{
               rowSelection,
               onRowSelectionChange: setRowSelection,
-              onPageRowIdsChange,
+              onPageRowIdsChange: recordTablePageRowIds,
+              rangeSelection,
             }}
           />
         }
         cards={
           <TableCardSelectionScope
-            rowIds={items.filter(canSelect).map((item) => item.id)}
-            onVisibleRowIdsChange={onPageRowIdsChange}
+            rowIds={cardPageItems.filter(canSelect).map((item) => item.id)}
+            onVisibleRowIdsChange={recordCardPageRowIds}
           >
-            <TableCardGrid className={CARD_GRID_CLASS}>
-              {items.map((item) => {
-                const serverInfo = getServerInfo(item);
-                return (
-                  <McpServerCard
-                    variant={
-                      item.serverType === "builtin"
-                        ? "builtin"
-                        : item.serverType === "remote"
-                          ? "remote"
-                          : "local"
-                    }
-                    key={item.id}
-                    item={item}
-                    installedServer={serverInfo.installedServer}
-                    installingItemId={installingItemId}
-                    installationStatus={
-                      serverInfo.installedServer?.localInstallationStatus ||
-                      undefined
-                    }
-                    deploymentStatuses={deploymentStatuses}
-                    deploymentFeedState={deploymentFeedState}
-                    issues={issuesByCatalog.get(item.id)}
-                    onInstallRemoteServer={() => onInstall(item)}
-                    onInstallLocalServer={() => onInstall(item)}
-                    onReinstall={(flagged, options) =>
-                      onReinstall(item, flagged, options)
-                    }
-                    onCancelInstallation={onCancelInstallation}
-                    isBuiltInPlaywright={isBuiltInPlaywright(item.id)}
-                    selection={{
-                      ...cardSelection(item),
-                      disabled: !canSelect(item),
-                    }}
-                  />
-                );
-              })}
-            </TableCardGrid>
+            <div className="space-y-6">
+              <TableCardGrid className={CARD_GRID_CLASS}>
+                {cardPageItems.map(renderCard)}
+              </TableCardGrid>
+              {orderedCardItems.length > cardPagination.pageSize ? (
+                <TablePagination
+                  pageIndex={cardPageIndex}
+                  pageSize={cardPagination.pageSize}
+                  total={orderedCardItems.length}
+                  onPaginationChange={setCardPagination}
+                />
+              ) : null}
+            </div>
           </TableCardSelectionScope>
         }
       />
@@ -1646,7 +1705,8 @@ function McpServerBulkActions({
         >
           <Trash2 className="h-4 w-4" />
           <span>
-            Uninstall{countSuffix(selectedToUninstall.length, selected.length)}
+            Uninstall
+            {countSuffix(selectedToUninstall.length, selected.length)}
           </span>
         </PermissionButton>
       </BulkActions>
@@ -1745,8 +1805,44 @@ function McpCatalogLabelKeyRow({
  * a little room for the author name to occupy rather than truncate.
  */
 const CARD_GRID_CLASS =
-  "grid-cols-[repeat(auto-fill,minmax(19rem,1fr))] lg:grid-cols-[repeat(auto-fill,minmax(19rem,1fr))] 2xl:grid-cols-[repeat(auto-fill,minmax(19rem,1fr))]";
+  "auto-rows-fr grid-cols-[repeat(auto-fill,minmax(19rem,1fr))] lg:grid-cols-[repeat(auto-fill,minmax(19rem,1fr))] 2xl:grid-cols-[repeat(auto-fill,minmax(19rem,1fr))]";
 
 function countSuffix(applicable: number, selected: number): string {
   return applicable > 0 && applicable < selected ? ` (${applicable})` : "";
+}
+
+function aggregateInstallations(
+  servers: InstalledServer[],
+  currentUserId: string | undefined,
+): InstalledServer {
+  if (servers.length === 1) return servers[0];
+
+  const baseServer = [...servers].sort(
+    (a, b) =>
+      mcpRegistryInstallPriority(a, currentUserId) -
+      mcpRegistryInstallPriority(b, currentUserId),
+  )[0];
+  const aggregated = { ...baseServer };
+  const allUsers = new Set<string>();
+  const allUserDetails: Array<{
+    userId: string;
+    email: string;
+    createdAt: string;
+    serverId: string;
+  }> = [];
+
+  for (const server of servers) {
+    for (const userId of server.users ?? []) allUsers.add(userId);
+    for (const userDetail of server.userDetails ?? []) {
+      if (
+        !allUserDetails.some((detail) => detail.userId === userDetail.userId)
+      ) {
+        allUserDetails.push({ ...userDetail, serverId: server.id });
+      }
+    }
+  }
+
+  aggregated.users = [...allUsers];
+  aggregated.userDetails = allUserDetails;
+  return aggregated;
 }

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1196,7 +1196,7 @@ export function InternalMCPCatalog({
               value={searchQueryFromUrl}
               onSearchChange={handleSearchChange}
               syncQueryParams={false}
-              debounceMs={300}
+              debounceMs={0}
               className={filterSearchClass}
               inputClassName="w-full bg-background/50 backdrop-blur-sm border-border/50 focus:border-primary/50 transition-colors pl-9"
             />
@@ -1621,7 +1621,6 @@ function McpServerCatalogSection({
         selectAllMatching={selectAllMatching}
       />
       <TableCardViewContent
-        keepMounted
         onModeChange={syncVisiblePageSelection}
         table={
           <McpServerTable

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-environment-label.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-environment-label.test.ts
@@ -12,14 +12,12 @@ describe("resolveCatalogEnvironmentLabel", () => {
       resolveCatalogEnvironmentLabel({
         environmentId: "prod",
         environments: [],
-        defaultEnvironmentName: "Default",
       }),
     ).toBeNull();
     expect(
       resolveCatalogEnvironmentLabel({
         environmentId: null,
         environments: [],
-        defaultEnvironmentName: "Renamed",
       }),
     ).toBeNull();
   });
@@ -29,7 +27,6 @@ describe("resolveCatalogEnvironmentLabel", () => {
       resolveCatalogEnvironmentLabel({
         environmentId: "staging",
         environments: envs,
-        defaultEnvironmentName: "Default",
       }),
     ).toBe("Staging");
   });
@@ -39,19 +36,17 @@ describe("resolveCatalogEnvironmentLabel", () => {
       resolveCatalogEnvironmentLabel({
         environmentId: null,
         environments: envs,
-        defaultEnvironmentName: "Default",
       }),
     ).toBeNull();
   });
 
-  it("shows the Default name only when it has been customized", () => {
+  it("hides the Default environment even when it has been customized", () => {
     expect(
       resolveCatalogEnvironmentLabel({
         environmentId: null,
         environments: envs,
-        defaultEnvironmentName: "Sandbox",
       }),
-    ).toBe("Sandbox");
+    ).toBeNull();
   });
 
   it("returns null when the assigned environment is no longer in the list", () => {
@@ -59,7 +54,6 @@ describe("resolveCatalogEnvironmentLabel", () => {
       resolveCatalogEnvironmentLabel({
         environmentId: "deleted",
         environments: envs,
-        defaultEnvironmentName: "Default",
       }),
     ).toBeNull();
   });

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-environment-label.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-environment-label.ts
@@ -1,8 +1,3 @@
-// Fallback name `useDefaultEnvironment()` returns when the org hasn't given the
-// implicit Default environment a custom name. Mirrors the check in
-// environments-section.tsx, where the "Default" badge is also keyed off it.
-export const DEFAULT_ENVIRONMENT_NAME = "Default";
-
 /**
  * Decides which environment name (if any) to surface on a catalog card.
  *
@@ -10,27 +5,22 @@ export const DEFAULT_ENVIRONMENT_NAME = "Default";
  *   environment — i.e. at least one real environment exists. With only Default
  *   around, the label carries no information.
  * - Items assigned to a real environment show that environment's name.
- * - Items on the Default environment (null `environmentId`) only show a label
- *   when Default has been renamed; the bare "Default" is noise.
+ * - Items on the implicit Default environment (null `environmentId`) stay
+ *   unlabeled. The registry already treats that placement as the baseline.
  *
  * Returns null when nothing should be rendered.
  */
 export function resolveCatalogEnvironmentLabel({
   environmentId,
   environments,
-  defaultEnvironmentName,
 }: {
   environmentId: string | null;
   environments: Array<{ id: string; name: string }>;
-  defaultEnvironmentName: string;
+  /** Accepted for callers that also render the Environments settings label. */
+  defaultEnvironmentName?: string;
 }): string | null {
   if (environments.length === 0) return null;
-
-  if (environmentId === null) {
-    return defaultEnvironmentName === DEFAULT_ENVIRONMENT_NAME
-      ? null
-      : defaultEnvironmentName;
-  }
+  if (environmentId === null) return null;
 
   return environments.find((env) => env.id === environmentId)?.name ?? null;
 }

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
@@ -5,6 +5,7 @@ import {
   parseFullToolName,
 } from "@archestra/shared";
 import { useQueryClient } from "@tanstack/react-query";
+import type { RowSelectionState } from "@tanstack/react-table";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -63,6 +64,7 @@ import {
   setOAuthState,
   setOAuthTeamId,
 } from "@/lib/auth/oauth-session";
+import { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 import {
   useInstallMcpServer,
   useMcpDeploymentStatuses,
@@ -418,6 +420,7 @@ export function ToolsAndGuardrailsStep({ item }: { item: CatalogItem }) {
   const [selectedToolIds, setSelectedToolIds] = useState<ReadonlySet<string>>(
     new Set(),
   );
+  const rangeSelection = useRef(new BulkRangeSelectionController());
 
   const updatePolicy = async (
     toolId: string,
@@ -538,15 +541,25 @@ export function ToolsAndGuardrailsStep({ item }: { item: CatalogItem }) {
     });
   };
 
-  const toggleTool = (toolId: string, checked: boolean) => {
+  const toggleTool = (
+    toolId: string,
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.preventDefault();
     setSelectedToolIds((prev) => {
-      const next = new Set(prev);
-      if (checked) {
-        next.add(toolId);
-      } else {
-        next.delete(toolId);
-      }
-      return next;
+      const current: RowSelectionState = Object.fromEntries(
+        [...prev].map((id) => [id, true]),
+      );
+      return new Set(
+        Object.keys(
+          rangeSelection.current.update({
+            current,
+            orderedIds: visibleTools.map((tool) => tool.id),
+            targetId: toolId,
+            range: event.shiftKey,
+          }),
+        ),
+      );
     });
   };
 
@@ -610,7 +623,7 @@ export function ToolsAndGuardrailsStep({ item }: { item: CatalogItem }) {
           key={tool.id}
           tool={tool}
           selected={selectedToolIds.has(tool.id)}
-          onSelectedChange={(checked) => toggleTool(tool.id, checked)}
+          onSelectionClick={(event) => toggleTool(tool.id, event)}
           callAction={getCallPolicyActionFromPolicies(
             tool.id,
             invocationPolicies ?? { byProfileToolId: {} },
@@ -662,7 +675,7 @@ const ANNOTATION_BADGES: Array<{
 function ToolReviewCard({
   tool,
   selected,
-  onSelectedChange,
+  onSelectionClick,
   callAction,
   resultAction,
   hasCustomCallPolicy,
@@ -674,7 +687,7 @@ function ToolReviewCard({
 }: {
   tool: ToolWithAssignmentsData;
   selected: boolean;
-  onSelectedChange: (checked: boolean) => void;
+  onSelectionClick: React.MouseEventHandler<HTMLButtonElement>;
   callAction: CallPolicyAction;
   resultAction: ResultPolicyAction;
   hasCustomCallPolicy: boolean;
@@ -718,7 +731,7 @@ function ToolReviewCard({
           aria-label={`Select ${displayName}`}
           className="mt-0.5"
           checked={selected}
-          onCheckedChange={(checked) => onSelectedChange(checked === true)}
+          onClick={onSelectionClick}
         />
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex flex-wrap items-center gap-2">

--- a/platform/frontend/src/app/mcp/registry/_parts/deployment-status.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/deployment-status.tsx
@@ -1,4 +1,9 @@
-import type { McpDeploymentStatusEntry } from "@archestra/shared";
+import {
+  DocsPage,
+  getDocsUrl,
+  type McpDeploymentStatusEntry,
+} from "@archestra/shared";
+import { ExternalDocsLink } from "@/components/external-docs-link";
 import {
   Tooltip,
   TooltipContent,
@@ -143,6 +148,73 @@ export function DeploymentStatusDot({ state }: { state: DeploymentState }) {
       />
     </span>
   );
+}
+
+/** Presence-style runtime indicator shared by MCP cards and table name cells. */
+export function DeploymentStatusIconDot({
+  summary,
+}: {
+  summary: DeploymentStatusSummary;
+}) {
+  const state = summary.overallState;
+  const idleCopy = getDeploymentStatusTooltipCopy(state);
+  const label = getDeploymentStatusIconTooltipLabel(summary);
+  const idleRelated = state === "hibernated" || state === "waking";
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="absolute -right-0.5 -bottom-0.5 rounded-full border-2 border-card"
+            role="img"
+            aria-label={`Runtime status: ${getDeploymentLabel(state)}`}
+          >
+            <DeploymentStatusDot state={state} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            <span>{label}.</span>
+            {idleCopy && <span> {idleCopy}</span>}
+            {idleRelated && (
+              <>
+                <span> </span>
+                <ExternalDocsLink
+                  href={getDocsUrl(
+                    DocsPage.PlatformOrchestrator,
+                    "idle-hibernation",
+                  )}
+                  showIcon={false}
+                >
+                  Learn more
+                </ExternalDocsLink>
+              </>
+            )}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function getDeploymentStatusIconTooltipLabel(
+  summary: DeploymentStatusSummary,
+): string {
+  switch (summary.overallState) {
+    case "running":
+      return `Running ${summary.running}/${summary.total} pods`;
+    case "pending":
+      return `Starting ${summary.pending}/${summary.total} pods`;
+    case "failed":
+      return `Failed ${summary.failed}/${summary.total} pods`;
+    case "degraded":
+      return `Running ${summary.running}/${summary.total} pods; ${summary.failed} failed`;
+    case "hibernated":
+      return "Hibernated";
+    case "waking":
+      return "Waking";
+  }
 }
 
 export function DeploymentStatusBanner({

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-registry-visibility.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-registry-visibility.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  matchesMcpRegistryOwnershipFilters,
+  mcpRegistryInstallPriority,
+} from "./mcp-registry-visibility";
+
+const item = (
+  overrides: Partial<
+    Parameters<typeof matchesMcpRegistryOwnershipFilters>[0]["item"]
+  > = {},
+) => ({
+  id: "cat-1",
+  scope: "personal" as const,
+  authorId: "member-1",
+  teams: [],
+  ...overrides,
+});
+
+const install = (
+  overrides: Partial<Parameters<typeof mcpRegistryInstallPriority>[0]> = {},
+) => ({
+  catalogId: "cat-1",
+  scope: "personal" as const,
+  ownerId: "member-1",
+  teamId: null,
+  ...overrides,
+});
+
+describe("MCP registry ownership visibility", () => {
+  it("hides another user's personal-only row from the default admin list", () => {
+    expect(
+      matchesMcpRegistryOwnershipFilters({
+        item: item(),
+        servers: [install()],
+        filters: { excludeOtherPersonal: true },
+        currentUserId: "admin",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps a row reachable through the viewer's own team or organization install", () => {
+    expect(
+      matchesMcpRegistryOwnershipFilters({
+        item: item({ scope: "team" }),
+        servers: [
+          install({ scope: "team", ownerId: "member-1", teamId: "team-a" }),
+        ],
+        filters: { excludeOtherPersonal: true },
+        currentUserId: "admin",
+      }),
+    ).toBe(true);
+  });
+
+  it("exposes foreign personal rows only through Other users", () => {
+    const args = {
+      item: item(),
+      servers: [install()],
+      currentUserId: "admin",
+    };
+    expect(
+      matchesMcpRegistryOwnershipFilters({
+        ...args,
+        filters: { scope: "personal", excludeAuthorIds: ["admin"] },
+      }),
+    ).toBe(true);
+    expect(
+      matchesMcpRegistryOwnershipFilters({
+        ...args,
+        filters: { scope: "personal", authorIds: ["admin"] },
+      }),
+    ).toBe(false);
+  });
+
+  it("matches team and organization scopes through either catalog or installation ownership", () => {
+    expect(
+      matchesMcpRegistryOwnershipFilters({
+        item: item({ scope: "org" }),
+        servers: [install({ scope: "team", teamId: "team-a" })],
+        filters: { scope: "team", teamIds: ["team-a"] },
+        currentUserId: "admin",
+      }),
+    ).toBe(true);
+    expect(
+      matchesMcpRegistryOwnershipFilters({
+        item: item({ scope: "team" }),
+        servers: [install({ scope: "org" })],
+        filters: { scope: "org" },
+        currentUserId: "admin",
+      }),
+    ).toBe(true);
+  });
+
+  it("prioritizes the viewer's own install before shared and foreign installs", () => {
+    expect(
+      mcpRegistryInstallPriority(install({ ownerId: "admin" }), "admin"),
+    ).toBe(0);
+    expect(
+      mcpRegistryInstallPriority(install({ scope: "team" }), "admin"),
+    ).toBe(1);
+    expect(mcpRegistryInstallPriority(install({ scope: "org" }), "admin")).toBe(
+      2,
+    );
+    expect(mcpRegistryInstallPriority(install(), "admin")).toBe(3);
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-registry-visibility.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-registry-visibility.ts
@@ -1,0 +1,122 @@
+export type McpRegistryVisibilityItem = {
+  id: string;
+  scope: "personal" | "team" | "org";
+  authorId?: string | null;
+  teams?: Array<{ id: string }> | null;
+};
+
+export type McpRegistryVisibilityInstall = {
+  catalogId: string | null;
+  scope: "personal" | "team" | "org";
+  ownerId?: string | null;
+  teamId?: string | null;
+};
+
+export type McpRegistryOwnershipFilters = {
+  scope?: "personal" | "team" | "org";
+  teamIds?: string[];
+  authorIds?: string[];
+  excludeAuthorIds?: string[];
+  excludeOtherPersonal?: true;
+};
+
+export function isMcpRegistryInstallUsableByViewer(
+  server: McpRegistryVisibilityInstall,
+  currentUserId: string | undefined,
+): boolean {
+  if (server.scope === "team" || server.scope === "org") return true;
+  return !!currentUserId && server.ownerId === currentUserId;
+}
+
+export function mcpRegistryInstallPriority(
+  server: McpRegistryVisibilityInstall,
+  currentUserId: string | undefined,
+): number {
+  if (server.scope === "personal" && server.ownerId === currentUserId) return 0;
+  if (server.scope === "team") return 1;
+  if (server.scope === "org") return 2;
+  return 3;
+}
+
+export function hasMcpRegistryInstallForViewer(
+  servers: readonly McpRegistryVisibilityInstall[],
+  currentUserId: string | undefined,
+): boolean {
+  return servers.some((server) =>
+    isMcpRegistryInstallUsableByViewer(server, currentUserId),
+  );
+}
+
+export function matchesMcpRegistryOwnershipFilters({
+  item,
+  servers,
+  filters,
+  currentUserId,
+}: {
+  item: McpRegistryVisibilityItem;
+  servers: readonly McpRegistryVisibilityInstall[];
+  filters: McpRegistryOwnershipFilters;
+  currentUserId: string | undefined;
+}): boolean {
+  const usableInstall = hasMcpRegistryInstallForViewer(servers, currentUserId);
+  const authoredByViewer = !!currentUserId && item.authorId === currentUserId;
+
+  if (
+    filters.excludeOtherPersonal &&
+    item.scope === "personal" &&
+    !usableInstall &&
+    !authoredByViewer
+  ) {
+    return false;
+  }
+
+  if (filters.scope === "personal") {
+    if (filters.authorIds?.length) {
+      return (
+        (!!item.authorId && filters.authorIds.includes(item.authorId)) ||
+        servers.some(
+          (server) =>
+            server.scope === "personal" &&
+            !!server.ownerId &&
+            filters.authorIds?.includes(server.ownerId),
+        )
+      );
+    }
+    if (filters.excludeAuthorIds?.length) {
+      const foreignCatalog =
+        !item.authorId || !filters.excludeAuthorIds.includes(item.authorId);
+      const foreignInstall = servers.some(
+        (server) =>
+          server.scope === "personal" &&
+          (!server.ownerId ||
+            !filters.excludeAuthorIds?.includes(server.ownerId)),
+      );
+      return item.scope === "personal"
+        ? foreignCatalog || foreignInstall
+        : foreignInstall;
+    }
+    return item.scope === "personal" || usableInstall;
+  }
+
+  if (filters.scope === "team") {
+    const teamIds = filters.teamIds;
+    const matchesTeam = (teamId: string | null | undefined) =>
+      !!teamId && (!teamIds?.length || teamIds.includes(teamId));
+    return (
+      (item.scope === "team" &&
+        (!teamIds?.length ||
+          (item.teams ?? []).some((team) => matchesTeam(team.id)))) ||
+      servers.some(
+        (server) => server.scope === "team" && matchesTeam(server.teamId),
+      )
+    );
+  }
+
+  if (filters.scope === "org") {
+    return (
+      item.scope === "org" || servers.some((server) => server.scope === "org")
+    );
+  }
+
+  return true;
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-attention-owner.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-attention-owner.test.ts
@@ -3,7 +3,6 @@ import type { McpServerIssue } from "@/lib/mcp/mcp-server-issues";
 import {
   describeMcpIssueActionOwner,
   describeMcpIssueActionOwners,
-  waitingActionFacetLabel,
 } from "./mcp-server-attention-owner";
 import type { InstalledServer } from "./mcp-server-card";
 
@@ -30,64 +29,6 @@ const server = ({
 }) => ({ id, catalogId, ownerEmail }) as InstalledServer;
 
 describe("MCP attention action ownership", () => {
-  it("names the one visible owner shared by the waiting rows", () => {
-    const first = issue("cat-1", "srv-1");
-    const second = issue("cat-2", "srv-2");
-    expect(
-      waitingActionFacetLabel({
-        issuesByCatalog: new Map([
-          [first.catalogId, [first]],
-          [second.catalogId, [second]],
-        ]),
-        servers: [
-          server({
-            id: "srv-1",
-            catalogId: "cat-1",
-            ownerEmail: "owner@example.com",
-          }),
-          server({
-            id: "srv-2",
-            catalogId: "cat-2",
-            ownerEmail: "owner@example.com",
-          }),
-        ],
-      }),
-    ).toBe("Waiting action by owner@example.com");
-  });
-
-  it("uses other user when an owner is hidden or owners differ", () => {
-    const first = issue("cat-1", "srv-1");
-    const second = issue("cat-2", "srv-2");
-    expect(
-      waitingActionFacetLabel({
-        issuesByCatalog: new Map([[first.catalogId, [first]]]),
-        servers: [
-          server({ id: "srv-1", catalogId: "cat-1", ownerEmail: null }),
-        ],
-      }),
-    ).toBe("Waiting action by other user");
-    expect(
-      waitingActionFacetLabel({
-        issuesByCatalog: new Map([
-          [first.catalogId, [first]],
-          [second.catalogId, [second]],
-        ]),
-        servers: [
-          server({
-            id: "srv-1",
-            catalogId: "cat-1",
-            ownerEmail: "first@example.com",
-          }),
-          server({
-            id: "srv-2",
-            catalogId: "cat-2",
-            ownerEmail: "second@example.com",
-          }),
-        ],
-      }),
-    ).toBe("Waiting action by other user");
-  });
-
   it("uses visible identity on the row and a role fallback otherwise", () => {
     const reauth = issue("cat-1", "srv-1");
     expect(

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-attention-owner.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-attention-owner.ts
@@ -1,4 +1,4 @@
-import { facetIssues, type McpServerIssue } from "@/lib/mcp/mcp-server-issues";
+import type { McpServerIssue } from "@/lib/mcp/mcp-server-issues";
 import type { InstalledServer } from "./mcp-server-card";
 
 export type McpIssueActionOwner = {
@@ -67,33 +67,3 @@ export function describeMcpIssueActionOwners({
     sentence: "Multiple people or roles need to act.",
   };
 }
-
-/**
- * The facet names one owner only when every row points to the same visible
- * identity. Mixed or hidden actors stay truthful without exposing identity.
- */
-export function waitingActionFacetLabel({
-  issuesByCatalog,
-  servers,
-}: {
-  issuesByCatalog: Map<string, McpServerIssue[]>;
-  servers: InstalledServer[];
-}): string {
-  const owners: string[] = [];
-  for (const issues of issuesByCatalog.values()) {
-    for (const issue of facetIssues(issues, "others")) {
-      const server = issue.serverId
-        ? servers.find((candidate) => candidate.id === issue.serverId)
-        : null;
-      const owner = server?.ownerEmail?.trim();
-      if (!owner) return WAITING_OTHER_USER_LABEL;
-      owners.push(owner);
-    }
-  }
-  const uniqueOwners = new Set(owners);
-  return uniqueOwners.size === 1
-    ? `Waiting action by ${owners[0]}`
-    : WAITING_OTHER_USER_LABEL;
-}
-
-const WAITING_OTHER_USER_LABEL = "Waiting action by other user";

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactElement, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,8 +9,10 @@ vi.mock("@/lib/config/config.query");
 vi.mock("@/lib/organization.query");
 vi.mock("@/lib/teams/team.query");
 
+const { routerPush } = vi.hoisted(() => ({ routerPush: vi.fn() }));
+
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({ push: routerPush, replace: vi.fn() }),
   usePathname: () => "/mcp/registry",
   useSearchParams: () => new URLSearchParams(),
 }));
@@ -20,6 +22,17 @@ vi.mock("@/lib/environment.query", () => ({
 }));
 
 vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
+  useInternalMcpCatalog: ({
+    initialData,
+  }: {
+    initialData?: CatalogItem[];
+  }) => ({
+    data: initialData,
+    isPending: false,
+    isFetching: false,
+  }),
+  useMcpCatalogLabelKeys: () => ({ data: [] }),
+  useMcpCatalogLabelValues: () => ({ data: [] }),
   useReinstallInternalMcpCatalogItem: () => ({
     mutate: vi.fn(),
     isPending: false,
@@ -41,11 +54,111 @@ vi.mock("./use-chat-with-catalog-item", () => ({
 const { useMcpServersMock } = vi.hoisted(() => ({
   useMcpServersMock: vi.fn(),
 }));
+const { registryIssuesMock } = vi.hoisted(() => ({
+  registryIssuesMock: new Map(),
+}));
 
 vi.mock("@/lib/mcp/mcp-server.query", () => ({
   useMcpServers: useMcpServersMock,
   useAutoModeAgents: () => ({ data: [] }),
   useDeleteMcpServer: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useBulkUninstallMcpServers: () => ({ mutate: vi.fn(), isPending: false }),
+  useDismissMcpServerAlerts: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useMcpDeploymentStatuses: () => ({ statuses: {}, state: "ready" }),
+  useMcpInstallationStatusCacheSync: vi.fn(),
+  useReauthenticateMcpServer: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useReinstallMcpServer: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRestoreMcpServerAlerts: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/lib/auth/oauth.query", () => ({
+  useInitiateOAuth: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/components/resource-scope-filter", () => ({
+  ResourceScopeFilter: () => null,
+  useScopeFilterParams: () => ({ hasActiveScopeFilters: false }),
+}));
+
+vi.mock("@/components/table-card-view", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/components/table-card-view")>()),
+  TableCardGrid: ({ children }: { children: ReactElement[] }) => (
+    <div data-testid="registry-card-grid">{children}</div>
+  ),
+  TableCardSelectionScope: ({ children }: { children: ReactElement }) =>
+    children,
+  TableCardView: ({ children }: { children: ReactElement }) => children,
+  TableCardViewContent: ({ cards }: { cards: ReactElement }) => cards,
+  TableCardViewToggle: () => null,
+}));
+
+vi.mock("@/lib/hooks/use-dialog", () => ({
+  useDialogs: () => ({
+    isDialogOpened: () => false,
+    openDialog: vi.fn(),
+    closeDialog: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/hooks/use-dialog-url-param", () => ({
+  useDialogUrlParam: () => ({ entity: null, close: vi.fn() }),
+}));
+
+vi.mock("@/lib/mcp/use-mcp-server-issues", () => ({
+  useMcpServerIssues: () => ({
+    issuesByCatalog: registryIssuesMock,
+    facetCounts: { muted: 0 },
+  }),
+}));
+
+vi.mock("./mcp-registry-visibility", () => ({
+  hasMcpRegistryInstallForViewer: () => true,
+  matchesMcpRegistryOwnershipFilters: () => true,
+  mcpRegistryInstallPriority: () => 0,
+}));
+
+vi.mock("./mcp-server-table", () => ({ McpServerTable: () => null }));
+
+vi.mock("./local-server-install-dialog", () => ({
+  LocalServerInstallDialog: () => null,
+}));
+
+vi.mock("./manage-users-dialog", () => ({ ManageUsersDialog: () => null }));
+
+vi.mock("./reinstall-confirmation-dialog", () => ({
+  ReinstallConfirmationDialog: () => null,
+}));
+
+vi.mock("./remote-server-install-dialog", () => ({
+  RemoteServerInstallDialog: () => null,
+}));
+
+vi.mock("@/components/oauth-confirmation-dialog", () => ({
+  OAuthConfirmationDialog: () => null,
+}));
+
+vi.mock("./use-catalog-install", () => ({
+  useCatalogInstall: () => ({
+    installingItemId: null,
+    installingServerIds: new Set(),
+    setInstallingServerIds: vi.fn(),
+    setInstallingItemId: vi.fn(),
+    installFromSearchParams: vi.fn(),
+    installRemote: vi.fn(),
+    installLocal: vi.fn(),
+    installPlaywright: vi.fn(),
+    addPersonalConnection: vi.fn(),
+    addSharedConnection: vi.fn(),
+    addOrgConnection: vi.fn(),
+    cancelInstallation: vi.fn(),
+    dialogs: null,
+  }),
 }));
 
 import type { Permissions } from "@archestra/shared";
@@ -57,6 +170,7 @@ import {
   useDefaultEnvironment,
 } from "@/lib/organization.query";
 import { useAssignableTeams } from "@/lib/teams/team.query";
+import { InternalMCPCatalog } from "./InternalMCPCatalog";
 import {
   type CatalogItem,
   type InstalledServer,
@@ -163,6 +277,7 @@ function CardSelectionHarness() {
 describe("McpServerCard uninstall permission", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    registryIssuesMock.clear();
     vi.mocked(useSession).mockReturnValue({
       data: { user: { id: CURRENT_USER_ID } },
     } as unknown as ReturnType<typeof useSession>);
@@ -230,6 +345,241 @@ describe("McpServerCard uninstall permission", () => {
     );
 
     expect(screen.queryByTestId("oauth-reauth-state")).toBeNull();
+  });
+
+  it("overlays a local runtime status dot on the icon with its status tooltip", async () => {
+    const user = userEvent.setup();
+    const localItem = {
+      ...item,
+      id: "cat-local",
+      name: "hibernated-local-server",
+      serverType: "local",
+    } as CatalogItem;
+    const localInstall = {
+      ...personalInstall,
+      id: "srv-local",
+      catalogId: localItem.id,
+      name: localItem.name,
+      serverType: "local",
+    } as InstalledServer;
+    useMcpServersMock.mockReturnValue({ data: [localInstall] });
+
+    renderCard(
+      <McpServerCard
+        variant="local"
+        item={localItem}
+        installedServer={localInstall}
+        installingItemId={null}
+        deploymentStatuses={{
+          [localInstall.id]: {
+            state: "hibernated",
+            message: "Hibernated",
+            error: null,
+          },
+        }}
+        deploymentFeedState="ready"
+        onInstallRemoteServer={vi.fn()}
+        onInstallLocalServer={vi.fn()}
+        onReinstall={vi.fn()}
+      />,
+    );
+
+    const cardElement = screen.getByTestId(
+      "mcp-server-card-hibernated-local-server",
+    );
+    const statusDot = within(cardElement).getByRole("img", {
+      name: "Runtime status: Hibernated",
+    });
+    await user.hover(statusDot);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Hibernated. Scaled down after being idle",
+    );
+    expect(
+      screen.getAllByRole("link", { name: /Learn more/ }),
+    ).not.toHaveLength(0);
+  });
+
+  it("includes running pod counts in the runtime tooltip", async () => {
+    const user = userEvent.setup();
+    const localItem = {
+      ...item,
+      id: "cat-running",
+      name: "running-local-server",
+      serverType: "local",
+    } as CatalogItem;
+    const localInstall = {
+      ...personalInstall,
+      id: "srv-running",
+      catalogId: localItem.id,
+      name: localItem.name,
+      serverType: "local",
+    } as InstalledServer;
+    useMcpServersMock.mockReturnValue({ data: [localInstall] });
+
+    renderCard(
+      <McpServerCard
+        variant="local"
+        item={localItem}
+        installedServer={localInstall}
+        installingItemId={null}
+        deploymentStatuses={{
+          [localInstall.id]: {
+            state: "running",
+            message: "Running",
+            error: null,
+          },
+        }}
+        deploymentFeedState="ready"
+        onInstallRemoteServer={vi.fn()}
+        onInstallLocalServer={vi.fn()}
+        onReinstall={vi.fn()}
+      />,
+    );
+
+    await user.hover(
+      screen.getByRole("img", { name: "Runtime status: Running" }),
+    );
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Running 1/1 pods.",
+    );
+    expect(screen.queryByRole("link", { name: /Learn more/ })).toBeNull();
+  });
+
+  it("shows an issue badge and only its primary action in the card action row", () => {
+    const issue = {
+      kind: "needs-reauth",
+      audience: "you",
+      catalogId: item.id,
+      serverId: personalInstall.id,
+      detail: null,
+      since: null,
+      fingerprint: "v1:needs-reauth:test",
+      muted: false,
+      mutedReason: null,
+    } as const;
+    renderCard(
+      <McpServerCard
+        variant="remote"
+        item={item}
+        installedServer={personalInstall}
+        installingItemId={null}
+        deploymentStatuses={{}}
+        deploymentFeedState="ready"
+        issues={[issue]}
+        onInstallRemoteServer={vi.fn()}
+        onInstallLocalServer={vi.fn()}
+        onReinstall={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Re-authenticate" }),
+    ).toHaveTextContent("Auth");
+    expect(screen.queryByRole("button", { name: /Dismiss alert/ })).toBeNull();
+    expect(
+      screen.queryByTestId("mcp-registry-attention-row-some-remote-server"),
+    ).toBeNull();
+    expect(
+      screen.queryByText(/provider rejected the stored token/i),
+    ).toBeNull();
+  });
+
+  it("opens details from the card surface without shadowing card buttons", async () => {
+    const user = userEvent.setup();
+    useMcpServersMock.mockReturnValue({ data: [personalInstall] });
+    renderCard(
+      <McpServerCard
+        variant="remote"
+        item={item}
+        installedServer={personalInstall}
+        installingItemId={null}
+        deploymentStatuses={{}}
+        deploymentFeedState="ready"
+        onInstallRemoteServer={vi.fn()}
+        onInstallLocalServer={vi.fn()}
+        onReinstall={vi.fn()}
+      />,
+    );
+    const card = screen.getByTestId(`mcp-server-card-${item.name}`);
+
+    await user.click(card);
+    expect(routerPush).toHaveBeenCalledWith(`/mcp/registry/${item.id}`);
+
+    routerPush.mockClear();
+    await user.click(within(card).getByRole("button", { name: "Uninstall" }));
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it("renders one flat card grid in the shared registry sort order", () => {
+    const flagged = {
+      ...item,
+      id: "cat-flagged",
+      name: "Flagged server",
+    } as CatalogItem;
+    const personal = {
+      ...item,
+      id: "cat-personal",
+      name: "Personal server",
+    } as CatalogItem;
+    const alpha = {
+      ...item,
+      id: "cat-alpha",
+      name: "Alpha server",
+    } as CatalogItem;
+    const zeta = {
+      ...item,
+      id: "cat-zeta",
+      name: "Zeta server",
+    } as CatalogItem;
+    const flaggedInstall = {
+      ...personalInstall,
+      id: "srv-flagged",
+      catalogId: flagged.id,
+      name: flagged.name,
+    } as InstalledServer;
+    const personalInstallForGrid = {
+      ...personalInstall,
+      id: "srv-personal",
+      catalogId: personal.id,
+      name: personal.name,
+    } as InstalledServer;
+    registryIssuesMock.set(flagged.id, [
+      {
+        kind: "needs-reauth",
+        audience: "you",
+        catalogId: flagged.id,
+        serverId: flaggedInstall.id,
+        detail: null,
+        since: null,
+        fingerprint: "v1:needs-reauth:flagged",
+        muted: false,
+        mutedReason: null,
+      },
+    ]);
+    useMcpServersMock.mockReturnValue({
+      data: [flaggedInstall, personalInstallForGrid],
+    });
+
+    renderCard(
+      <InternalMCPCatalog initialData={[zeta, personal, alpha, flagged]} />,
+    );
+
+    expect(
+      screen.queryByRole("heading", { name: "Action required" }),
+    ).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Other servers" })).toBeNull();
+    const grid = screen.getByTestId("registry-card-grid");
+    expect(
+      within(grid)
+        .getAllByRole("link")
+        .filter((link) =>
+          [flagged.name, personal.name, alpha.name, zeta.name].includes(
+            link.textContent ?? "",
+          ),
+        )
+        .map((link) => link.textContent),
+    ).toEqual([alpha.name, flagged.name, personal.name, zeta.name]);
   });
 
   it("selects a card range from the shared bulk-selection checkbox", async () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -27,6 +27,7 @@ import { type MouseEventHandler, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
+import { useNavigableCard } from "@/components/table-card-view";
 import {
   Avatar,
   AvatarFallback,
@@ -61,7 +62,6 @@ import { LOCAL_MCP_DISABLED_MESSAGE } from "@/consts";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { copyToClipboard } from "@/lib/clipboard";
 import { useFeature } from "@/lib/config/config.query";
-import { typeRole } from "@/lib/design/type-scale";
 import { useEnvironments } from "@/lib/environment.query";
 import { useReinstallInternalMcpCatalogItem } from "@/lib/mcp/internal-mcp-catalog.query";
 import type { McpDeploymentFeedState } from "@/lib/mcp/mcp-server.query";
@@ -71,7 +71,6 @@ import {
   type McpServerIssue,
 } from "@/lib/mcp/mcp-server-issues";
 import { useCanReauthenticate } from "@/lib/mcp/use-can-reauthenticate";
-import { useDefaultEnvironment } from "@/lib/organization.query";
 import { useAssignableTeams } from "@/lib/teams/team.query";
 import { isCardShowingInstallInProgress } from "./card-install-state";
 import { useCanModifyCatalogItem } from "./catalog-edit-access";
@@ -80,10 +79,7 @@ import { resolveCatalogEnvironmentLabel } from "./catalog-environment-label";
 import { shouldShowMcpCardChatButton } from "./chat-button-visibility";
 import {
   computeDeploymentStatusSummary,
-  DeploymentStatusDot,
-  getDeploymentStatusAriaLabel,
-  getDeploymentStatusChipLabel,
-  getDeploymentStatusTooltipCopy,
+  DeploymentStatusIconDot,
   STATE_PRIORITY,
 } from "./deployment-status";
 import { CatalogEditNoAccess } from "./edit-catalog-dialog";
@@ -94,7 +90,8 @@ import {
   agentOwnerLabel,
   deriveAgentUsage,
 } from "./mcp-server-agent-usage";
-import { McpServerIssueStatusCell } from "./mcp-server-issue-badge";
+import { McpServerIssueBadge } from "./mcp-server-issue-badge";
+import { McpServerIssueNotice } from "./mcp-server-issue-notice";
 import { OAuthReauthIndicator } from "./oauth-reauth-indicator";
 import {
   UninstallServerDialog,
@@ -166,7 +163,7 @@ export function McpServerCard({
   installingItemId,
   installationStatus,
   deploymentStatuses,
-  deploymentFeedState,
+  deploymentFeedState: _deploymentFeedState,
   issues,
   onInstallRemoteServer,
   onInstallLocalServer,
@@ -185,20 +182,16 @@ export function McpServerCard({
   const currentUserId = session?.user?.id;
   const isLocalMcpEnabled = useFeature("orchestratorK8sRuntime");
 
-  // Environment label shown next to the title. Only surfaced once the org has
-  // more than the single implicit Default environment; Default-assigned items
-  // only show it when Default has been renamed. Built-in (Playwright) servers
-  // aren't environment-scoped, so skip them. Both queries are shared/cached, so
-  // calling them per card doesn't fan out requests.
+  // A named, explicit environment is useful placement information. The
+  // implicit Default is the baseline and stays unlabeled. Built-in servers
+  // aren't environment-scoped, so skip them.
   const { data: environmentList } = useEnvironments();
-  const defaultEnvironment = useDefaultEnvironment();
   const environmentLabel =
     variant === "builtin"
       ? null
       : resolveCatalogEnvironmentLabel({
           environmentId: item.environmentId,
           environments: environmentList?.environments ?? [],
-          defaultEnvironmentName: defaultEnvironment.name,
         });
 
   // Whether the current user can edit this catalog item: an admin, a team-admin
@@ -268,6 +261,10 @@ export function McpServerCard({
     const qs = params.toString();
     router.push(`/mcp/registry/${item.id}${qs ? `?${qs}` : ""}`);
   };
+  const cardNavigation = useNavigableCard({
+    onNavigate: () => goToItemPage(),
+    selected: selection?.selected,
+  });
 
   // ── Shareable edit deep-link (`?edit=<catalogId>`) ──────────────────────
   // Legacy links: the editor now lives on the item detail page, so a shared
@@ -527,18 +524,21 @@ export function McpServerCard({
     deploymentServerIds,
     effectiveDeploymentStatuses,
   );
-  // SPDX-SnippetBegin
-  // SPDX-SnippetCopyrightText: 2026 Archestra Inc.
-  // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
-  // Non-null only for the idle states, which is also what gates the tooltip.
-  const deploymentIdleCopy = deploymentSummary
-    ? getDeploymentStatusTooltipCopy(deploymentSummary.overallState)
-    : null;
-  // SPDX-SnippetEnd
+  const deploymentStatusIndicator = deploymentSummary ? (
+    <DeploymentStatusIconDot summary={deploymentSummary} />
+  ) : null;
   // Worst live issue first, since issues are kind-ordered; an item whose only
   // trouble the viewer muted still shows it, muted.
   const statusIssue =
     issues?.find((issue) => !issue.muted) ?? issues?.[0] ?? null;
+  const primaryIssueAction = statusIssue ? (
+    <McpServerIssueNotice
+      item={item}
+      issues={issues ?? []}
+      servers={allServersForCatalog}
+      variant="primary-action"
+    />
+  ) : null;
   const toolsCount = item.toolCount ?? 0;
 
   const chatButton = shouldShowMcpCardChatButton({
@@ -650,14 +650,9 @@ export function McpServerCard({
   }
   const extraCount = connectionAvatars.length - MAX_AVATARS;
 
-  // Who can reach this catalog item. Personal items of the viewer's own say
-  // nothing new — the grid already groups them under a "Personal" heading, so
-  // the badge is asked not to label them "Me" (`showSelfAsMe={false}`) and
-  // renders null for that case; the gate mirrors it to keep the row from
-  // reserving space for an empty badge.
-  const showScopeBadge =
-    item.scope !== "personal" ||
-    Boolean(item.authorId && item.authorId !== currentUserId);
+  // Cards are one mixed list. Like Apps and Projects, every row names its
+  // visibility so personal entries never rely on a removed ownership heading.
+  const showScopeBadge = Boolean(item.scope);
 
   /** Who is connected and whether a connection needs attention. */
   const hasTrailingCluster =
@@ -668,10 +663,7 @@ export function McpServerCard({
 
   /** Whether anything follows the badge in the row. */
   const hasCompactInfoAfterScopeBadge =
-    toolsCount > 0 ||
-    totalAgentCount > 0 ||
-    (variant === "local" && deploymentServerIds.length > 0) ||
-    hasTrailingCluster;
+    toolsCount > 0 || totalAgentCount > 0 || hasTrailingCluster;
 
   const hasCompactInfoContent = showScopeBadge || hasCompactInfoAfterScopeBadge;
 
@@ -699,7 +691,7 @@ export function McpServerCard({
             authorId={item.authorId}
             authorName={item.authorName}
             currentUserId={currentUserId}
-            showSelfAsMe={false}
+            showSelfAsMe
             compact
           />
         </div>
@@ -767,57 +759,6 @@ export function McpServerCard({
           </HoverCard>
         </>
       )}
-      {variant === "local" &&
-        deploymentServerIds.length > 0 &&
-        // No Kubernetes runtime on this deployment means no pod will ever
-        // report, which is not the same as a report failing to arrive. The
-        // table says "Installed" for the same case; the card, which has no
-        // status text of its own, simply leaves the runtime chip off rather
-        // than accusing every local server of being unreachable.
-        deploymentFeedState !== "disabled" &&
-        (deploymentSummary ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => goToItemPage("logs")}
-                  aria-label={getDeploymentStatusAriaLabel({
-                    summary: deploymentSummary,
-                    serverName: item.name,
-                  })}
-                  className="flex shrink-0 items-center gap-1.5 cursor-pointer hover:text-foreground transition-colors"
-                >
-                  <DeploymentStatusDot state={deploymentSummary.overallState} />
-                  <span aria-hidden>
-                    {getDeploymentStatusChipLabel({
-                      summary: deploymentSummary,
-                      format: "ratio",
-                    })}
-                  </span>
-                </button>
-              </TooltipTrigger>
-              {/* SPDX-SnippetBegin */}
-              {/* SPDX-SnippetCopyrightText: 2026 Archestra Inc. */}
-              {/* SPDX-License-Identifier: LicenseRef-Archestra-Enterprise */}
-              {deploymentIdleCopy && (
-                <TooltipContent className="max-w-md break-words">
-                  {deploymentIdleCopy}
-                </TooltipContent>
-              )}
-              {/* SPDX-SnippetEnd */}
-            </Tooltip>
-          </TooltipProvider>
-        ) : deploymentFeedState === "loading" ? (
-          <span className="relative flex h-2 w-2 shrink-0">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-muted-foreground/50 opacity-75" />
-            <span className="relative inline-flex rounded-full h-2 w-2 bg-muted-foreground/50" />
-          </span>
-        ) : (
-          // The feed has settled and still knows nothing about this server's
-          // pods, which is a different thing from the pods being fine.
-          <span className={typeRole({ role: "meta" })}>Status unavailable</span>
-        ))}
       {/*
         Trailing cluster, pushed to the card's right edge by `ml-auto` so the
         avatar stacks line up down a column of cards instead of each starting
@@ -942,7 +883,8 @@ export function McpServerCard({
 
   const remoteCardContent = (
     <>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-nowrap gap-2 [&>*]:min-w-0">
+        {primaryIssueAction}
         {chatButton}
         {!isInstalling && isCurrentUserAuthenticated && needsReinstall && (
           <PermissionButton
@@ -1012,7 +954,8 @@ export function McpServerCard({
 
   const localCardContent = (
     <>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-nowrap gap-2 [&>*]:min-w-0">
+        {primaryIssueAction}
         {chatButton}
         {!isInstalling && showCombinedReinstall && (
           <PermissionButton
@@ -1043,7 +986,8 @@ export function McpServerCard({
 
   const playwrightCardContent = (
     <>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-nowrap gap-2 [&>*]:min-w-0">
+        {primaryIssueAction}
         {chatButton}
         {!isInstalling && isCurrentUserAuthenticated && needsReinstall && (
           <PermissionButton
@@ -1070,7 +1014,10 @@ export function McpServerCard({
 
   const builtinCardContent = (
     <>
-      <div>{chatButton}</div>
+      <div className="flex flex-nowrap gap-2 [&>*]:min-w-0">
+        {primaryIssueAction}
+        {chatButton}
+      </div>
     </>
   );
 
@@ -1106,29 +1053,31 @@ export function McpServerCard({
 
   return (
     <Card
+      {...cardNavigation.props}
       // `overflow-hidden` is a backstop, not the fix: the rows inside are laid
       // out to fit. It means that if some future combination still doesn't,
       // the card clips it instead of painting it over its neighbour.
-      className={`flex flex-col relative pt-4 gap-4 h-full overflow-hidden ${selection?.selected ? "border-primary bg-primary/5" : ""}`}
+      className={`flex h-full flex-col gap-4 overflow-hidden pt-4 transition-colors ${cardNavigation.className} ${selection?.selected ? "border-primary bg-primary/5" : ""}`}
       data-testid={`${E2eTestId.McpServerCard}-${item.name}`}
     >
       <CardHeader className="gap-0">
         <div className="flex items-start justify-between gap-4 overflow-hidden">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 mb-1 overflow-hidden w-full">
-              {/* The name opens the server's page, as a table row does: the
-                  card itself is too full of its own controls to be one link. */}
               <Link
                 href={`/mcp/registry/${item.id}`}
                 className="flex min-w-0 items-center gap-2 rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
-                <McpCatalogIcon
-                  icon={item.icon}
-                  catalogId={item.id}
-                  size={20}
-                />
+                <span className="relative inline-flex shrink-0">
+                  <McpCatalogIcon
+                    icon={item.icon}
+                    catalogId={item.id}
+                    size={20}
+                  />
+                  {deploymentStatusIndicator}
+                </span>
                 <TruncatedTooltip content={item.name}>
-                  <span className="text-lg font-semibold whitespace-nowrap text-ellipsis overflow-hidden">
+                  <span className="line-clamp-2 break-words text-lg font-semibold leading-5">
                     {item.name}
                   </span>
                 </TruncatedTooltip>
@@ -1142,10 +1091,26 @@ export function McpServerCard({
                 </Badge>
               )}
             </div>
-            {item.description && (
-              <p className="text-xs text-muted-foreground line-clamp-2">
-                {item.description}
-              </p>
+            {(statusIssue || item.description) && (
+              <div className="flex min-w-0 flex-col items-start gap-1">
+                {statusIssue && (
+                  <span
+                    className="shrink-0"
+                    data-testid={
+                      statusIssue.kind === "failed-to-start"
+                        ? `${E2eTestId.McpServerError}-${item.name}-default`
+                        : undefined
+                    }
+                  >
+                    <McpServerIssueBadge issue={statusIssue} />
+                  </span>
+                )}
+                {item.description && (
+                  <p className="min-w-0 text-xs text-muted-foreground line-clamp-2">
+                    {item.description}
+                  </p>
+                )}
+              </div>
             )}
             <McpCapabilityBadges
               providesUi={item.providesUi}
@@ -1198,38 +1163,6 @@ export function McpServerCard({
                   ? "This MCP server Docker image isn't from a trusted image registry. Review and approve configuration to allow installs."
                   : "This MCP server Docker image isn't from a trusted image registry. An admin must approve it before it can be installed."}
             </p>
-          </div>
-        )}
-        {statusIssue && (
-          <div
-            className="flex items-start gap-2 rounded-md border bg-muted/50 px-3 py-2"
-            data-testid={
-              statusIssue.kind === "failed-to-start"
-                ? `${E2eTestId.McpServerError}-${item.name}-default`
-                : undefined
-            }
-          >
-            {/* The card is a summary tile: the same badge and one-line cause
-                the table's Status column shows, so a server reads the same
-                whichever view you are in. The full diagnosis, with the fix and
-                the verbs, lives on the server's Overview. Multi-tenant
-                siblings are already collapsed into one issue upstream, which
-                is what used to need a dedup pass here. */}
-            <McpServerIssueStatusCell
-              issue={statusIssue}
-              className="min-w-0 flex-1"
-            />
-            {variant === "local" && statusIssue.serverId && (
-              <Button
-                variant="link"
-                size="sm"
-                className="h-auto shrink-0 p-0 text-xs"
-                data-testid={`${E2eTestId.McpLogsViewButton}-${item.name}-default`}
-                onClick={() => goToItemPage("logs", statusIssue.serverId)}
-              >
-                View logs
-              </Button>
-            )}
           </div>
         )}
         {variant === "local" && isInstalling && (

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-notice.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-notice.tsx
@@ -62,6 +62,7 @@ import {
  *   table's Actions cell.
  * - `details`: the registry table's expanded sub-row diagnosis. It is strictly
  *   informational; every action stays in the table's Actions cell.
+ * - `primary-action`: only the highest-priority remediation for a compact card.
  *
  * Every issue kind in the viewer's own bucket is explained, not just the worst
  * one: a server whose pod crashed and whose token was rejected has two
@@ -106,7 +107,7 @@ export function McpServerIssueNotice({
   facet?: McpServerAttentionFacet | null;
   /** On the server's own page the name is the page title already. */
   hideName?: boolean;
-  variant?: "panel" | "actions" | "details";
+  variant?: "panel" | "actions" | "details" | "primary-action";
   /** Detail pages already expose remediation in their header and sections. */
   panelActions?: "all" | "dismiss-only";
   className?: string;
@@ -480,6 +481,61 @@ export function McpServerIssueNotice({
           );
         })}
       </div>
+    );
+  }
+
+  if (variant === "primary-action") {
+    const action = actions.primary;
+    if (action) {
+      const compactLabel =
+        {
+          "Re-authenticate": "Auth",
+          "View logs": "Logs",
+        }[action.label] ?? action.label;
+      return (
+        <Button
+          variant={action.variant ?? "outline"}
+          size="sm"
+          className="shrink-0 gap-1 px-2 text-xs"
+          aria-label={action.label}
+          data-testid={action.testId}
+          onClick={action.onClick}
+        >
+          {action.icon}
+          <span>{compactLabel}</span>
+        </Button>
+      );
+    }
+    if (restoreTargets.length > 0) {
+      return (
+        <Button
+          variant="outline"
+          size="sm"
+          className="shrink-0 gap-1 px-2 text-xs"
+          disabled={restoreMutation.isPending}
+          onClick={() =>
+            restoreMutation.mutate(
+              { alerts: restoreTargets },
+              {
+                onSuccess: (result) => onTargetsCompleted?.(result.succeeded),
+              },
+            )
+          }
+        >
+          <Bell className="h-4 w-4" />
+          Restore
+        </Button>
+      );
+    }
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        className="shrink-0 gap-1 px-2 text-xs"
+        onClick={() => router.push(detailHref())}
+      >
+        Open
+      </Button>
     );
   }
 

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.test.tsx
@@ -190,6 +190,54 @@ describe("McpServerTable uninstall permission", () => {
     expect(screen.queryByText("Uninstall MCP Server")).not.toBeInTheDocument();
   });
 
+  it("moves local runtime state to an icon dot and keeps Status installation-only", async () => {
+    const user = userEvent.setup();
+    const localItem = {
+      ...item,
+      id: "cat-local",
+      serverType: "local",
+    } as CatalogItem;
+    const localInstall = {
+      ...personalInstall,
+      id: "srv-local",
+      catalogId: localItem.id,
+      serverType: "local",
+    } as InstalledServer;
+
+    renderTable(
+      <McpServerTable
+        items={[localItem]}
+        getServerInfo={() => ({ installedServer: localInstall })}
+        envLabelByCatalog={new Map()}
+        issuesByCatalog={new Map()}
+        deploymentFeedState="ready"
+        deploymentStatuses={{
+          [localInstall.id]: {
+            state: "hibernated",
+            message: "Hibernated",
+            error: null,
+          },
+        }}
+        installingItemId={null}
+        onInstall={vi.fn()}
+        onReinstall={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Installed")).toBeInTheDocument();
+    expect(screen.queryByText("Hibernated")).not.toBeInTheDocument();
+    const statusDot = screen.getByRole("img", {
+      name: "Runtime status: Hibernated",
+    });
+    await user.hover(statusDot);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Hibernated. Scaled down after being idle",
+    );
+    expect(
+      screen.getAllByRole("link", { name: /Learn more/ }),
+    ).not.toHaveLength(0);
+  });
+
   it("keeps queue actions inline and moves lower-priority actions into overflow", async () => {
     const user = userEvent.setup();
     const issue = {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
@@ -22,7 +22,7 @@ import {
   Users,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { memo, useState } from "react";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import {
@@ -31,9 +31,9 @@ import {
 } from "@/components/table-row-actions";
 import { Badge } from "@/components/ui/badge";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
-import { Checkbox } from "@/components/ui/checkbox";
 import { DataTable } from "@/components/ui/data-table";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import type { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 import { useFeature } from "@/lib/config/config.query";
 import { typeRole } from "@/lib/design/type-scale";
 import { useReinstallInternalMcpCatalogItem } from "@/lib/mcp/internal-mcp-catalog.query";
@@ -53,7 +53,8 @@ import { useCanModifyCatalogItem } from "./catalog-edit-access";
 import { shouldShowMcpCardChatButton } from "./chat-button-visibility";
 import {
   computeDeploymentStatusSummary,
-  getDeploymentLabel,
+  DeploymentStatusIconDot,
+  type DeploymentStatusSummary,
 } from "./deployment-status";
 import type { DismissAlertTarget } from "./dismiss-alert-dialog";
 import { DismissAlertDialog } from "./dismiss-alert-dialog";
@@ -102,6 +103,7 @@ type McpServerTableProps = {
     rowSelection: RowSelectionState;
     onRowSelectionChange: OnChangeFn<RowSelectionState>;
     onPageRowIdsChange: (ids: string[]) => void;
+    rangeSelection: BulkRangeSelectionController;
   };
   attention?: {
     facet: McpServerAttentionFacet;
@@ -136,6 +138,22 @@ export function McpServerTable({
     (!!attention || !!getServerInfo(item).installedServer) &&
     installingItemId !== item.id &&
     !getServerInfo(item).isInstallInProgress;
+  const deploymentSummaryFor = (
+    item: CatalogItem,
+  ): DeploymentStatusSummary | null => {
+    const installedServer = getServerInfo(item).installedServer;
+    if (
+      item.serverType !== "local" ||
+      !installedServer ||
+      deploymentFeedState !== "ready"
+    ) {
+      return null;
+    }
+    return computeDeploymentStatusSummary(
+      [installedServer.id],
+      deploymentStatuses,
+    );
+  };
 
   const standardColumns: ColumnDef<CatalogItem>[] = [
     createSelectColumn<CatalogItem>({
@@ -158,6 +176,7 @@ export function McpServerTable({
           <McpServerNameCell
             item={item}
             environmentLabel={envLabelByCatalog.get(item.id)}
+            deploymentSummary={deploymentSummaryFor(item)}
           />
         );
       },
@@ -228,16 +247,7 @@ export function McpServerTable({
         // Nothing installed means there is no runtime to have a status, and a
         // catalog entry nobody has connected is not "Healthy" — it is nothing.
         if (!installedServer) return null;
-        return (
-          <span className={typeRole({ role: "body" })}>
-            {installedStatusLabel({
-              isLocal: item.serverType === "local",
-              feedState: deploymentFeedState,
-              serverId: installedServer.id,
-              deploymentStatuses,
-            })}
-          </span>
-        );
+        return <InstalledStatusCell />;
       },
     },
     {
@@ -264,38 +274,13 @@ export function McpServerTable({
 
   const attentionColumns: ColumnDef<CatalogItem>[] = attention
     ? [
-        {
-          id: "select",
-          size: 36,
-          header: ({ table }) => (
-            <Checkbox
-              aria-label={
-                attention.facet === "muted"
-                  ? "Select all restorable alerts"
-                  : "Select all alerts"
-              }
-              checked={
-                table.getIsAllRowsSelected()
-                  ? true
-                  : table.getIsSomeRowsSelected()
-                    ? "indeterminate"
-                    : false
-              }
-              onCheckedChange={(checked) =>
-                table.toggleAllRowsSelected(checked === true)
-              }
-            />
-          ),
-          cell: ({ row }) => (
-            <Checkbox
-              aria-label={`Select ${row.original.name}`}
-              checked={row.getIsSelected()}
-              onCheckedChange={(checked) =>
-                row.toggleSelected(checked === true)
-              }
-            />
-          ),
-        },
+        createSelectColumn<CatalogItem>({
+          rowLabel: (item) => `Select ${item.name}`,
+          allLabel:
+            attention.facet === "muted"
+              ? "Select all restorable alerts"
+              : "Select all alerts",
+        }),
         {
           id: "name",
           accessorKey: "name",
@@ -307,6 +292,7 @@ export function McpServerTable({
               <McpServerNameCell
                 item={item}
                 environmentLabel={envLabelByCatalog.get(item.id)}
+                deploymentSummary={deploymentSummaryFor(item)}
               />
             );
           },
@@ -410,6 +396,7 @@ export function McpServerTable({
       onRowSelectionChange={
         attention?.onRowSelectionChange ?? selection?.onRowSelectionChange
       }
+      rangeSelection={selection?.rangeSelection}
       onPageRowIdsChange={attention ? undefined : selection?.onPageRowIdsChange}
       hideSelectedCount={!!attention}
       onRowClick={
@@ -432,7 +419,7 @@ export function McpServerTable({
 // (install/reinstall flows, dialogs) stays in the parent via callbacks, same
 // as for the cards; this component only re-derives the card's visibility
 // rules from the shared queries.
-function McpServerRowActions({
+const McpServerRowActions = memo(function McpServerRowActions({
   item,
   installedServer,
   issues,
@@ -738,21 +725,28 @@ function McpServerRowActions({
       />
     </>
   );
-}
+});
 
 // === internal helpers ===
 
 function McpServerNameCell({
   item,
   environmentLabel,
+  deploymentSummary,
 }: {
   item: CatalogItem;
   environmentLabel: string | null | undefined;
+  deploymentSummary: DeploymentStatusSummary | null;
 }) {
   return (
     <div className="min-w-0">
       <div className="flex min-w-0 items-center gap-2">
-        <McpCatalogIcon icon={item.icon} catalogId={item.id} size={16} />
+        <span className="relative shrink-0">
+          <McpCatalogIcon icon={item.icon} catalogId={item.id} size={16} />
+          {deploymentSummary && (
+            <DeploymentStatusIconDot summary={deploymentSummary} />
+          )}
+        </span>
         <span className="truncate font-medium">{item.name}</span>
         {environmentLabel && (
           <Badge variant="outline" className="shrink-0 text-muted-foreground">
@@ -774,39 +768,17 @@ function McpServerNameCell({
   );
 }
 
-/**
- * What an installed server's Status cell says when it has no outstanding
- * issue. The feed's own state decides, never the absence of an entry: on a
- * deployment without Kubernetes no entry will ever arrive, and on one with it
- * the first entries arrive a moment after the page does.
- *
- * The words come from `getDeploymentLabel` over the same summary the card
- * builds, so the two views cannot describe one pod differently. Reading only
- * `state === "running"` called every other reported state "Status unavailable"
- * — including "Hibernated", which is the healthy steady state of an idle
- * server, and "Succeeded", which is a Job that finished and is still serving.
- * "Status unavailable" is reserved for a feed that has nothing to say.
- */
-function installedStatusLabel({
-  isLocal,
-  feedState,
-  serverId,
-  deploymentStatuses,
-}: {
-  isLocal: boolean;
-  feedState: McpDeploymentFeedState;
-  serverId: string;
-  deploymentStatuses: Record<string, McpDeploymentStatusEntry>;
-}): string {
-  // A remote server has no pod, so "Installed" is the whole runtime story.
-  if (!isLocal || feedState === "disabled") return "Installed";
-  if (feedState === "loading") return "Checking…";
-  const summary =
-    feedState === "ready"
-      ? computeDeploymentStatusSummary([serverId], deploymentStatuses)
-      : null;
-  if (summary) return getDeploymentLabel(summary.overallState);
-  return "Status unavailable";
+function InstalledStatusCell() {
+  return (
+    <div
+      className={cn(
+        typeRole({ role: "body" }),
+        "flex min-h-9 flex-wrap items-center gap-x-2 gap-y-1",
+      )}
+    >
+      <Badge variant="secondary">Installed</Badge>
+    </div>
+  );
 }
 
 // Plain-text variant of LOCAL_MCP_DISABLED_MESSAGE (the shared const is JSX

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-tools-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-tools-dialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { E2eTestId, parseFullToolName } from "@archestra/shared";
+import type { RowSelectionState } from "@tanstack/react-table";
 import { Search, UserPlus, Users } from "lucide-react";
-import { useMemo, useState } from "react";
+import { type MouseEvent, useMemo, useRef, useState } from "react";
 import { StandardDialog } from "@/components/standard-dialog";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
 import { Button } from "@/components/ui/button";
@@ -22,6 +23,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 
 interface McpToolsDialogProps {
   open: boolean;
@@ -66,6 +68,7 @@ export function McpToolsDialog({
 }: McpToolsDialogProps) {
   const [selectedToolIds, setSelectedToolIds] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
+  const rangeSelection = useRef(new BulkRangeSelectionController());
 
   const filteredTools = useMemo(() => {
     if (!searchQuery.trim()) return tools;
@@ -100,12 +103,21 @@ export function McpToolsDialog({
     }
   };
 
-  const toggleTool = (toolId: string) => {
-    setSelectedToolIds((prev) =>
-      prev.includes(toolId)
-        ? prev.filter((id) => id !== toolId)
-        : [...prev, toolId],
-    );
+  const toggleTool = (toolId: string, event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    setSelectedToolIds((prev) => {
+      const current: RowSelectionState = Object.fromEntries(
+        prev.map((id) => [id, true]),
+      );
+      return Object.keys(
+        rangeSelection.current.update({
+          current,
+          orderedIds: filteredTools.map((tool) => tool.id),
+          targetId: toolId,
+          range: event.shiftKey,
+        }),
+      );
+    });
   };
 
   const handleBulkAssign = () => {
@@ -212,7 +224,7 @@ export function McpToolsDialog({
                   <TableCell>
                     <Checkbox
                       checked={selectedToolIds.includes(tool.id)}
-                      onCheckedChange={() => toggleTool(tool.id)}
+                      onClick={(event) => toggleTool(tool.id, event)}
                       aria-label={`Select ${tool.name}`}
                     />
                   </TableCell>

--- a/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
@@ -25,6 +25,7 @@ import {
 import { cn } from "@/lib/utils";
 
 export type SortKey =
+  | "attention"
   | "name-asc"
   | "name-desc"
   | "newest"
@@ -33,6 +34,7 @@ export type SortKey =
   | "issue-age";
 
 export const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+  { key: "attention", label: "Action required" },
   { key: "name-asc", label: "Name (A–Z)" },
   { key: "name-desc", label: "Name (Z–A)" },
   { key: "newest", label: "Newest" },
@@ -127,11 +129,6 @@ export function withAttentionFacet(
   return next;
 }
 
-/** The registry list URL showing one facet, and nothing else. */
-export function mcpRegistryFacetHref(facet: McpServerAttentionFacet): string {
-  return `/mcp/registry?${REGISTRY_STATUS_PARAM}=${ATTENTION_FACET_STATUS_VALUES[facet]}`;
-}
-
 export const STATUS_OPTIONS: FilterOption[] = [
   { value: INSTALLED_STATUS_VALUE, label: "Installed" },
   { value: NOT_INSTALLED_STATUS_VALUE, label: "Not installed" },
@@ -154,9 +151,8 @@ const ISSUE_LABELS: Record<string, string> = Object.fromEntries(
   ISSUE_OPTIONS.map((o) => [o.value, o.label]),
 );
 
-// Facet labels are written out in full on the segmented control, so the chips
-// never need to render one; they are listed here only so a hand-edited URL
-// carrying a facet value cannot produce a chip labelled with a raw slug.
+// Facet values are view state rather than filter chips. They are listed here
+// only so a hand-edited URL carrying one cannot produce a raw-slug chip.
 const FACET_VALUES = new Set<string>(
   Object.values(ATTENTION_FACET_STATUS_VALUES),
 );
@@ -167,11 +163,13 @@ const SEARCH_THRESHOLD = 6;
 export function RegistrySortMenu({
   value,
   onChange,
+  options = SORT_OPTIONS,
 }: {
   value: SortKey;
   onChange: (key: SortKey) => void;
+  options?: { key: SortKey; label: string }[];
 }) {
-  const current = SORT_OPTIONS.find((o) => o.key === value) ?? SORT_OPTIONS[0];
+  const current = options.find((o) => o.key === value) ?? options[0];
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -184,7 +182,7 @@ export function RegistrySortMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48">
-        {SORT_OPTIONS.map((o) => (
+        {options.map((o) => (
           <DropdownMenuItem key={o.key} onClick={() => onChange(o.key)}>
             <Check
               className={cn(
@@ -246,8 +244,8 @@ export function RegistryFilterDropdown({
   selected: Set<string>;
   onToggle: (value: string) => void;
 }) {
-  // Only what this dropdown actually offers. The attention facets live in the
-  // segmented control and are carried in the same `status` param, so counting
+  // Only what this dropdown actually offers. Attention facets are carried in
+  // the same `status` param, but this control does not offer them, so counting
   // the raw selection would claim a filter the list below does not contain.
   const offered = new Set(options.map((o) => o.value));
   const count = [...selected].filter((v) => offered.has(v)).length;
@@ -358,9 +356,8 @@ export function RegistryFilterChips({
   const entries: { group: FilterGroup; value: string; label: string }[] = [];
   (Object.keys(selected) as FilterGroup[]).forEach((group) => {
     selected[group].forEach((value) => {
-      // The facet is already spelled out, and selected, on the segmented
-      // control; a second dismissible copy of it would be two controls for one
-      // piece of state.
+      // Attention facets are view state, not applied filters; a second
+      // dismissible copy of one would be two controls for one piece of state.
       if (group === "status" && FACET_VALUES.has(value)) return;
       entries.push({
         group,

--- a/platform/frontend/src/app/mcp/registry/layout.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/layout.test.tsx
@@ -2,103 +2,62 @@ import { render, screen } from "@testing-library/react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useHasPermissions } from "@/lib/auth/auth.query";
-import { useFeature } from "@/lib/config/config.query";
-import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
-import {
-  useMcpDeploymentStatuses,
-  useMcpServers,
-} from "@/lib/mcp/mcp-server.query";
-import { useMcpServerIssues } from "@/lib/mcp/use-mcp-server-issues";
 import McpCatalogLayout from "./layout";
 
 vi.mock("next/navigation");
 vi.mock("@/lib/auth/auth.query");
-vi.mock("@/lib/config/config.query");
 vi.mock("@/lib/hooks/use-app-name");
-vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
-  useInternalMcpCatalog: vi.fn(),
-}));
-vi.mock("@/lib/mcp/mcp-server.query", () => ({
-  useMcpDeploymentStatuses: vi.fn(),
-  useMcpServers: vi.fn(),
-}));
-vi.mock("@/lib/mcp/use-mcp-server-issues", () => ({
-  useMcpServerIssues: vi.fn(),
-}));
 
 describe("McpCatalogLayout", () => {
+  const replace = vi.fn();
+
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(usePathname).mockReturnValue("/mcp/registry");
     vi.mocked(useSearchParams).mockReturnValue(
-      new URLSearchParams("status=needs-my-action") as ReturnType<
-        typeof useSearchParams
-      >,
+      new URLSearchParams() as ReturnType<typeof useSearchParams>,
     );
     vi.mocked(useRouter).mockReturnValue({
       push: vi.fn(),
-      replace: vi.fn(),
+      replace,
     } as unknown as ReturnType<typeof useRouter>);
-    vi.mocked(useFeature).mockImplementation(
-      (feature) => feature === "mcpServerAlertingEnabled",
-    );
     vi.mocked(useHasPermissions).mockReturnValue({
       data: true,
     } as ReturnType<typeof useHasPermissions>);
-    vi.mocked(useInternalMcpCatalog).mockReturnValue({
-      data: [{ id: "first" }, { id: "second" }, { id: "third" }],
-    } as ReturnType<typeof useInternalMcpCatalog>);
-    vi.mocked(useMcpServers).mockReturnValue({
-      data: [],
-    } as unknown as ReturnType<typeof useMcpServers>);
-    vi.mocked(useMcpDeploymentStatuses).mockReturnValue({
-      statuses: {},
-      state: "disabled",
-    });
-    vi.mocked(useMcpServerIssues).mockReturnValue({
-      issuesByCatalog: new Map(),
-      facetCounts: { you: 1, others: 1, muted: 0 },
-    });
   });
 
-  it("renders registry audience views as header tabs", () => {
+  it("renders one registry list without audience tabs", () => {
     render(
       <McpCatalogLayout>
         <div>Registry content</div>
       </McpCatalogLayout>,
     );
 
-    expect(screen.getAllByRole("link", { name: /All.*3/ })).toHaveLength(2);
-    const actionRequired = screen.getByTestId(
-      "mcp-registry-action-required-tab",
-    );
-    expect(actionRequired).toHaveTextContent("Action required");
-    expect(actionRequired).toHaveTextContent("(1)");
-    expect(actionRequired).toHaveTextContent("Beta");
-    expect(actionRequired).toHaveAttribute("aria-current", "page");
+    expect(screen.getByText("Registry content")).toBeInTheDocument();
     expect(
-      screen.queryByTestId("mcp-registry-attention-facets"),
+      screen.queryByRole("link", { name: /Action required/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("mcp-registry-action-required-tab"),
     ).not.toBeInTheDocument();
   });
 
-  it("has no Dismissed tab, and keeps Action required selected while it is on", () => {
-    vi.mocked(useMcpServerIssues).mockReturnValue({
-      issuesByCatalog: new Map(),
-      facetCounts: { you: 1, others: 1, muted: 4 },
-    });
+  it("redirects retired attention-tab links to the attention filter", () => {
     vi.mocked(useSearchParams).mockReturnValue(
-      new URLSearchParams("status=muted") as ReturnType<typeof useSearchParams>,
+      new URLSearchParams("tab=attention") as ReturnType<
+        typeof useSearchParams
+      >,
     );
+
     render(
       <McpCatalogLayout>
         <div>Registry content</div>
       </McpCatalogLayout>,
     );
 
-    // Dismissed is a filter on the list below, not a third tab: the strip must
-    // not grow and shrink with the dismissal count.
-    expect(screen.queryByRole("link", { name: /Dismissed/ })).toBeNull();
-    expect(
-      screen.getByTestId("mcp-registry-action-required-tab"),
-    ).toHaveAttribute("aria-current", "page");
+    expect(replace).toHaveBeenCalledWith(
+      "/mcp/registry?status=needs-my-action",
+      { scroll: false },
+    );
   });
 });

--- a/platform/frontend/src/app/mcp/registry/layout.tsx
+++ b/platform/frontend/src/app/mcp/registry/layout.tsx
@@ -1,33 +1,21 @@
 "use client";
 
-import { ARCHESTRA_MCP_CATALOG_ID } from "@archestra/shared";
 import { Plus } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { PageLayout } from "@/components/page-layout";
-import { Badge } from "@/components/ui/badge";
 import { PermissionButton } from "@/components/ui/permission-button";
-import { useHasPermissions } from "@/lib/auth/auth.query";
-import { useFeature } from "@/lib/config/config.query";
-import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
-import {
-  useMcpDeploymentStatuses,
-  useMcpServers,
-} from "@/lib/mcp/mcp-server.query";
-import { useMcpServerIssues } from "@/lib/mcp/use-mcp-server-issues";
-import { waitingActionFacetLabel } from "./_parts/mcp-server-attention-owner";
 import {
   ATTENTION_FACET_STATUS_VALUES,
-  mcpRegistryFacetHref,
   REGISTRY_STATUS_PARAM,
-  selectedAttentionFacet,
 } from "./_parts/registry-list-controls";
 
 /**
  * The registry used to answer "what needs me?" on a second tab, which meant
  * the same server was counted on the tab and listed on the tab but missing
- * from the list everyone actually works in. The tab is gone; the question is
- * now a facet of the one list. Links people already have keep working.
+ * from the list everyone actually works in. The tab is gone: the default sort
+ * puts actionable rows first, while sidebar and legacy links can still narrow
+ * the one list.
  */
 const RETIRED_ATTENTION_TAB_PARAM = "tab";
 const RETIRED_ATTENTION_TAB_VALUE = "attention";
@@ -105,68 +93,10 @@ function McpRegistryListLayout({
   children: React.ReactNode;
   onAdd: () => void;
 }) {
-  const searchParams = useSearchParams();
-  const alertingEnabled = useFeature("mcpServerAlertingEnabled") === true;
-  const { data: catalogItems } = useInternalMcpCatalog();
-  const { data: servers } = useMcpServers();
-  const { statuses } = useMcpDeploymentStatuses();
-  const { issuesByCatalog, facetCounts } = useMcpServerIssues(statuses);
-  const { data: userIsMcpServerAdmin } = useHasPermissions({
-    mcpServerInstallation: ["admin"],
-  });
-  const selectedFacet = selectedAttentionFacet(
-    new Set(searchParams.getAll(REGISTRY_STATUS_PARAM)),
-  );
-  const totalCount = (catalogItems ?? []).filter(
-    (item) => item.id !== ARCHESTRA_MCP_CATALOG_ID,
-  ).length;
-  const othersLabel = waitingActionFacetLabel({
-    issuesByCatalog,
-    servers: servers ?? [],
-  });
-  const tabs = alertingEnabled
-    ? [
-        {
-          label: <RegistryTabLabel label="All" count={totalCount} />,
-          href: "/mcp/registry",
-          selected: selectedFacet === null,
-        },
-        {
-          label: (
-            <RegistryTabLabel
-              label="Action required"
-              count={facetCounts.you}
-              beta
-            />
-          ),
-          href: mcpRegistryFacetHref("you"),
-          // Dismissed alerts are a filter on this tab, not a tab of their own,
-          // so the tab stays selected while that filter is on.
-          selected: selectedFacet === "you" || selectedFacet === "muted",
-          testId: "mcp-registry-action-required-tab",
-        },
-        ...(!userIsMcpServerAdmin && facetCounts.others > 0
-          ? [
-              {
-                label: (
-                  <RegistryTabLabel
-                    label={othersLabel}
-                    count={facetCounts.others}
-                  />
-                ),
-                href: mcpRegistryFacetHref("others"),
-                selected: selectedFacet === "others",
-              },
-            ]
-          : []),
-      ]
-    : [];
-
   return (
     <PageLayout
       title="MCP Registry"
       description="Manage your own list of MCP servers and make them available to agents."
-      tabs={tabs}
       actionButton={
         <PermissionButton
           permissions={{ mcpRegistry: ["create"] }}
@@ -179,28 +109,6 @@ function McpRegistryListLayout({
     >
       {children}
     </PageLayout>
-  );
-}
-
-function RegistryTabLabel({
-  label,
-  count,
-  beta = false,
-}: {
-  label: string;
-  count: number;
-  beta?: boolean;
-}) {
-  return (
-    <span className="inline-flex items-center gap-1.5">
-      <span>{label}</span>
-      <span className="tabular-nums text-muted-foreground">({count})</span>
-      {beta ? (
-        <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-          Beta
-        </Badge>
-      ) : null}
-    </span>
   );
 }
 

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
@@ -35,6 +35,7 @@ import { WithPermissions } from "@/components/roles/with-permissions";
 import { SearchInput } from "@/components/search-input";
 import { ToolPolicyBulkActionsBar } from "@/components/tool-policy-bulk-actions";
 import { TruncatedText } from "@/components/truncated-text";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -631,8 +632,8 @@ export function AssignedToolsTable({
   );
 
   return (
-    <div className="space-y-6">
-      <FilterBar className="!mb-3">
+    <BulkActionsScope className="space-y-3">
+      <FilterBar>
         <SearchInput
           isLoading={isLoading}
           objectNamePlural="tools"
@@ -802,7 +803,7 @@ export function AssignedToolsTable({
         flexibleColumnIds={["name"]}
         fixedWidthColumnIds={["callPolicy", "toolResultTreatment"]}
       />
-    </div>
+    </BulkActionsScope>
   );
 }
 

--- a/platform/frontend/src/app/messaging-channels/_components/channels-section.tsx
+++ b/platform/frontend/src/app/messaging-channels/_components/channels-section.tsx
@@ -10,13 +10,12 @@ import {
   Inbox,
   MessageSquareText,
   Plus,
-  Search,
   TriangleAlert,
   X,
 } from "lucide-react";
 import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
+import { type MouseEvent, useCallback, useMemo, useRef, useState } from "react";
 import { AgentBadge } from "@/components/agent-badge";
 import Divider from "@/components/divider";
 import { EmptyState } from "@/components/empty-state";
@@ -58,6 +57,7 @@ import {
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useProfiles } from "@/lib/agent.query";
 import { useSession } from "@/lib/auth/auth.query";
+import { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 import {
   useBulkUpdateChatOpsBindings,
   useChatOpsBindings,
@@ -138,20 +138,12 @@ export function ChannelsSection({
   const refreshMutation = useRefreshChatOpsChannelDiscovery();
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const rangeSelection = useRef(new BulkRangeSelectionController());
   const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
   /** Binding whose instructions are open in the editor, if any. */
   const [instructionsBindingId, setInstructionsBindingId] = useState<
     string | null
   >(null);
-
-  const toggleSelected = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, []);
 
   const toggleAll = useCallback((ids: string[], checked: boolean) => {
     setSelectedIds((prev) => {
@@ -355,6 +347,25 @@ export function ChannelsSection({
     selectableIds.every((id) => selectedIds.has(id));
   const someChecked =
     !allChecked && selectableIds.some((id) => selectedIds.has(id));
+  const handleSelectionClick = useCallback(
+    (id: string, event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      setSelectedIds((current) => {
+        const selection = Object.fromEntries(
+          [...current].map((selectedId) => [selectedId, true]),
+        );
+        const next = rangeSelection.current.update({
+          current: selection,
+          orderedIds: selectableIds,
+          targetId: id,
+          range: event.shiftKey,
+        });
+        return new Set(Object.keys(next));
+      });
+    },
+    [selectableIds],
+  );
 
   const clearFilters = useCallback(() => {
     clearSelection();
@@ -367,7 +378,7 @@ export function ChannelsSection({
   }, [clearSelection, updateUrlParams]);
 
   return (
-    <section className="flex flex-col gap-4">
+    <section className="flex flex-col gap-3">
       <div>
         <div className="flex items-center gap-3">
           <h2 className="text-lg font-semibold relative">
@@ -591,7 +602,7 @@ export function ChannelsSection({
                     }
                     isUpdating={updateMutation.isPending}
                     selectedIds={selectedIds}
-                    onToggleSelected={toggleSelected}
+                    onSelectionClick={handleSelectionClick}
                     showVirtualDmRow={showVirtualDmRow}
                     dmDeepLink={dmDeepLink}
                     onDmAssignAgent={handleDmAssignAgent}
@@ -669,7 +680,7 @@ function ChannelRows({
   workspacesWithUnmentionedTraffic,
   isUpdating,
   selectedIds,
-  onToggleSelected,
+  onSelectionClick,
   showVirtualDmRow,
   dmDeepLink,
   onDmAssignAgent,
@@ -698,7 +709,7 @@ function ChannelRows({
   workspacesWithUnmentionedTraffic: Set<string>;
   isUpdating: boolean;
   selectedIds: Set<string>;
-  onToggleSelected: (id: string) => void;
+  onSelectionClick: (id: string, event: MouseEvent<HTMLButtonElement>) => void;
   showVirtualDmRow: boolean;
   dmDeepLink: string | null;
   onDmAssignAgent: (agentId: string | null) => void;
@@ -715,7 +726,7 @@ function ChannelRows({
           <TableCell>
             <Checkbox
               checked={selectedIds.has(VIRTUAL_DM_ID)}
-              onCheckedChange={() => onToggleSelected(VIRTUAL_DM_ID)}
+              onClick={(event) => onSelectionClick(VIRTUAL_DM_ID, event)}
               aria-label="Select Direct Message"
             />
           </TableCell>
@@ -797,7 +808,7 @@ function ChannelRows({
             <TableCell>
               <Checkbox
                 checked={selectedIds.has(binding.id)}
-                onCheckedChange={() => onToggleSelected(binding.id)}
+                onClick={(event) => onSelectionClick(binding.id, event)}
                 aria-label={`Select ${binding.channelName ?? binding.channelId}`}
               />
             </TableCell>

--- a/platform/frontend/src/app/messaging-channels/email/page.tsx
+++ b/platform/frontend/src/app/messaging-channels/email/page.tsx
@@ -254,7 +254,7 @@ export default function EmailPage() {
         <>
           <Divider />
 
-          <section className="flex flex-col gap-4">
+          <section className="flex flex-col gap-3">
             <div>
               <h2 className="text-lg font-semibold">Agent Email Access</h2>
               <p className="mt-1 text-sm text-muted-foreground">

--- a/platform/frontend/src/app/plugins/_parts/import-marketplace-dialog.tsx
+++ b/platform/frontend/src/app/plugins/_parts/import-marketplace-dialog.tsx
@@ -5,6 +5,7 @@ import {
   POPULAR_PLUGIN_MARKETPLACES,
   type ResourceVisibilityScope,
 } from "@archestra/shared";
+import type { RowSelectionState } from "@tanstack/react-table";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -15,7 +16,7 @@ import {
   PackageSearch,
   SearchX,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ConnectionClientMultiSelect } from "@/app/connection/client-multi-select";
 import { CONNECT_CLIENTS, type ConnectClient } from "@/app/connection/clients";
 import {
@@ -56,6 +57,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 import { useGithubAppConfigs } from "@/lib/github-app-config.query";
 import { useCreateGithubPat, useGithubPats } from "@/lib/github-pat.query";
 import {
@@ -117,6 +119,7 @@ export function ImportMarketplaceDialog({
   const [marketplace, setMarketplace] =
     useState<GithubPluginMarketplace | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const rangeSelection = useRef(new BulkRangeSelectionController()).current;
   const [search, setSearch] = useState("");
   const [previewEntry, setPreviewEntry] = useState<MarketplaceEntry | null>(
     null,
@@ -326,15 +329,33 @@ export function ImportMarketplaceDialog({
     }
   };
 
-  const toggle = (name: string) => {
+  const toggle = (name: string, range: boolean) => {
     setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(name)) {
-        next.delete(name);
-      } else if (next.size < PLUGIN_MARKETPLACE_IMPORT_LIMIT) {
-        next.add(name);
+      const current = toRowSelectionState(prev);
+      const orderedIds = selectableFiltered
+        .filter(
+          (entry) =>
+            prev.has(entry.name) || prev.size < PLUGIN_MARKETPLACE_IMPORT_LIMIT,
+        )
+        .map((entry) => entry.name);
+      const next = rangeSelection.update({
+        current,
+        orderedIds,
+        targetId: name,
+        range,
+      });
+
+      if (!current[name]) {
+        const additions = orderedIds.filter((id) => next[id] && !current[id]);
+        const remaining = Math.max(
+          0,
+          PLUGIN_MARKETPLACE_IMPORT_LIMIT - prev.size,
+        );
+        for (const id of additions.slice(remaining)) {
+          delete next[id];
+        }
       }
-      return next;
+      return toSelectionSet(next);
     });
   };
 
@@ -738,7 +759,7 @@ export function ImportMarketplaceDialog({
                       selectionDisabled={
                         selectionLimitReached && !selected.has(entry.name)
                       }
-                      onToggle={() => toggle(entry.name)}
+                      onToggle={(range) => toggle(entry.name, range)}
                       onPreview={() => handlePreview(entry)}
                     />
                   ))}
@@ -1020,7 +1041,7 @@ function MarketplaceEntryRow({
   exists: boolean;
   checked: boolean;
   selectionDisabled: boolean;
-  onToggle: () => void;
+  onToggle: (range: boolean) => void;
   onPreview: () => void;
 }) {
   const clientLabel = entry.clientType
@@ -1058,7 +1079,10 @@ function MarketplaceEntryRow({
             id={`import-plugin-${entry.name}`}
             checked={checked}
             disabled={selectionDisabled}
-            onCheckedChange={onToggle}
+            onClick={(event) => {
+              event.preventDefault();
+              onToggle(event.shiftKey);
+            }}
             className="shrink-0"
             aria-label={
               checked
@@ -1170,4 +1194,16 @@ function normalizeRepository(value: string): string {
     .replace(/^github\.com\//, "")
     .replace(/\/+$/, "")
     .replace(/\.git$/, "");
+}
+
+function toRowSelectionState(selected: Set<string>): RowSelectionState {
+  return Object.fromEntries([...selected].map((id) => [id, true]));
+}
+
+function toSelectionSet(selection: RowSelectionState): Set<string> {
+  return new Set(
+    Object.entries(selection)
+      .filter(([, selected]) => selected)
+      .map(([id]) => id),
+  );
 }

--- a/platform/frontend/src/app/plugins/page.client.tsx
+++ b/platform/frontend/src/app/plugins/page.client.tsx
@@ -303,7 +303,7 @@ function PluginsList() {
   const [bulkInstallOpen, setBulkInstallOpen] = useState(false);
   const bulkVisibility = useBulkUpdatePluginVisibility();
   const bulkDelete = useBulkDeletePlugins();
-  const bulkSelection = useBulkSelection({
+  const { rangeSelection, ...bulkSelection } = useBulkSelection({
     rows: filteredPlugins,
     getId: (plugin) => plugin.id,
     filterSignature: JSON.stringify({
@@ -320,6 +320,7 @@ function PluginsList() {
     getRowId: (plugin) => plugin.id,
     rowSelection: bulkSelection.rowSelection,
     setRowSelection: bulkSelection.setRowSelection,
+    rangeSelection,
   });
   const bulkInstall = resolvePluginInstallSelection(bulkSelection.selected);
   const [installingPlugin, setInstallingPlugin] =
@@ -817,6 +818,11 @@ function PluginsList() {
                         }
                         description={plugin.description}
                         actions={renderPluginActions(plugin)}
+                        onNavigate={
+                          canViewPluginDetails
+                            ? () => router.push(pluginDetailHref(plugin.id))
+                            : undefined
+                        }
                         {...cardSelection(plugin)}
                         selectionLabel={`Select ${plugin.displayName}`}
                         footer={
@@ -881,6 +887,7 @@ function PluginsList() {
                     rowSelection={bulkSelection.rowSelection}
                     onRowSelectionChange={bulkSelection.setRowSelection}
                     onPageRowIdsChange={bulkSelection.onPageRowIdsChange}
+                    rangeSelection={rangeSelection}
                     isLoading={isFetching}
                     fixedWidthColumnIds={[
                       "compatibility",

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -40,6 +40,7 @@ import {
   TableCardView,
   TableCardViewContent,
   TableCardViewToggle,
+  useNavigableCard,
 } from "@/components/table-card-view";
 import { Badge } from "@/components/ui/badge";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
@@ -252,9 +253,7 @@ function ProjectsList() {
         )}
         <div className="space-y-6">
           <FilterBar
-            className={
-              !isDeletedView && projects.length > 0 ? "!mb-3" : undefined
-            }
+            className={projects.length > 0 ? "!mb-3" : undefined}
             actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
           >
             {/* Hidden in the trash: the backend serves that slice whole, ignoring
@@ -388,6 +387,7 @@ function ProjectSection({
     clearSelection,
     selected: selectedProjects,
     selectAllMatching,
+    rangeSelection,
   } = useBulkSelection({
     rows: projects,
     getId: (project) => project.id,
@@ -401,6 +401,7 @@ function ProjectSection({
     rowSelection,
     setRowSelection,
     canSelect: canSelectProject,
+    rangeSelection,
   });
   const selectedForSharing = selectedProjects.filter(canShareProjectItem);
   const selectedForDelete = selectedProjects.filter(canDeleteProjectItem);
@@ -462,6 +463,7 @@ function ProjectSection({
             onRowSelectionChange={setRowSelection}
             onPageRowIdsChange={onPageRowIdsChange}
             canSelect={canSelectProject}
+            rangeSelection={rangeSelection}
           />
         }
         cards={
@@ -603,26 +605,27 @@ function ProjectCard({
 } & BulkCardSelectionProps) {
   const { data: isProjectAdmin } = useHasPermissions({ project: ["admin"] });
   const { data: canShareOrg } = useHasPermissions({ project: ["share-org"] });
+  const router = useRouter();
+  const navigation = useNavigableCard({
+    onNavigate: () => router.push(`/projects/${project.id}`),
+    selected,
+  });
   return (
-    // `relative` + the title link's stretched `::after` (after:inset-0) makes the
-    // whole card a single click target for the project. Interactive children
-    // (the actions menu) sit above it via `relative z-10`.
     <div
-      className={`relative rounded-lg border p-4 transition-colors ${
-        selected ? "border-primary bg-primary/5" : "hover:bg-muted/50"
-      }`}
+      {...navigation.props}
+      className={`rounded-lg border p-4 transition-colors ${navigation.className} ${selected ? "border-primary bg-primary/5" : ""}`}
     >
       <div className="flex items-center justify-between gap-2">
         <Link
           href={`/projects/${project.id}`}
-          className="flex min-w-0 items-center gap-2 after:absolute after:inset-0"
+          className="flex min-w-0 items-center gap-2"
         >
           <span className="shrink-0">
             <AgentIcon icon={project.icon} fallbackType="project" size={18} />
           </span>
           <span className="min-w-0 truncate font-medium">{project.name}</span>
         </Link>
-        <span className="relative z-10 flex shrink-0 items-center gap-1">
+        <span className="flex shrink-0 items-center gap-1">
           <Checkbox
             checked={selected}
             disabled={selectionDisabled}

--- a/platform/frontend/src/app/projects/projects-table.tsx
+++ b/platform/frontend/src/app/projects/projects-table.tsx
@@ -27,6 +27,7 @@ import { Badge } from "@/components/ui/badge";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { DataTable } from "@/components/ui/data-table";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import type { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 import { useIsGlobalAdmin } from "@/lib/organization.query";
 import {
   canDeleteProject,
@@ -48,6 +49,7 @@ export function ProjectsTable({
   onRowSelectionChange,
   onPageRowIdsChange,
   canSelect,
+  rangeSelection,
 }: {
   projects: ProjectListItem[];
   onTogglePin: (project: ProjectListItem) => void;
@@ -57,6 +59,7 @@ export function ProjectsTable({
   onRowSelectionChange: OnChangeFn<RowSelectionState>;
   onPageRowIdsChange: (ids: string[]) => void;
   canSelect: (project: ProjectListItem) => boolean;
+  rangeSelection: BulkRangeSelectionController;
 }) {
   const router = useRouter();
   const { data: isProjectAdmin } = useHasPermissions({ project: ["admin"] });
@@ -190,6 +193,7 @@ export function ProjectsTable({
       rowSelection={rowSelection}
       onRowSelectionChange={onRowSelectionChange}
       onPageRowIdsChange={onPageRowIdsChange}
+      rangeSelection={rangeSelection}
       hideSelectedCount
       onRowClick={(row) => router.push(`/projects/${row.id}`)}
       emptyIcon={FolderKanban}

--- a/platform/frontend/src/app/settings/llm/_parts/default-user-limits-section.tsx
+++ b/platform/frontend/src/app/settings/llm/_parts/default-user-limits-section.tsx
@@ -219,6 +219,7 @@ export function DefaultUserLimitsSection() {
           Add limit
         </PermissionButton>
       }
+      contentClassName="mt-3"
     >
       {limits.length === 0 ? (
         <p className="text-sm text-muted-foreground">

--- a/platform/frontend/src/app/settings/llm/_parts/model-providers-section.tsx
+++ b/platform/frontend/src/app/settings/llm/_parts/model-providers-section.tsx
@@ -111,7 +111,7 @@ export function ModelProvidersSection() {
           {({ hasPermission }) => {
             const locked = updateMutation.isPending || !hasPermission;
             return (
-              <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-3">
                 <FilterBar
                   onClearFilters={search ? () => setSearch("") : undefined}
                 >

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -34,6 +34,7 @@ import { TableRowActions } from "@/components/table-row-actions";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -606,9 +607,8 @@ function MembersTab({
   ];
 
   return (
-    <>
+    <BulkActionsScope className="space-y-3">
       <FilterBar
-        className={isPending ? "mb-4" : "mb-3"}
         actions={<TabButtons activeTab={activeTab} onTabChange={onTabChange} />}
       >
         <SearchInput
@@ -673,11 +673,12 @@ function MembersTab({
             params.delete("name");
             params.delete("role");
             params.set("page", "1");
-            router.push(`${pathname}?${params.toString()}`, { scroll: false });
+            router.push(`${pathname}?${params.toString()}`, {
+              scroll: false,
+            });
           }}
         />
       </LoadingWrapper>
-
       {/* Change Role Dialog */}
       {changingRole && (
         <ChangeRoleDialog
@@ -753,7 +754,7 @@ function MembersTab({
           pendingLabel="Removing..."
         />
       )}
-    </>
+    </BulkActionsScope>
   );
 }
 
@@ -998,8 +999,8 @@ function InvitationsTab({
   ];
 
   return (
-    <>
-      <div className="flex items-center gap-4 mb-4">
+    <div className="space-y-3">
+      <div className="flex items-center gap-4">
         <div className="ml-auto">
           <TabButtons activeTab={activeTab} onTabChange={onTabChange} />
         </div>
@@ -1037,7 +1038,7 @@ function InvitationsTab({
           pendingLabel="Cancelling..."
         />
       )}
-    </>
+    </div>
   );
 }
 

--- a/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.tsx
+++ b/platform/frontend/src/app/skills/_parts/external-mcp-skills-section.tsx
@@ -239,6 +239,7 @@ export function ExternalMcpSkillsSection({
               title={<Link href={externalSkillHref(skill)}>{skill.name}</Link>}
               description={skill.description || "No description"}
               actions={renderActions(skill)}
+              onNavigate={() => router.push(externalSkillHref(skill))}
               footer={
                 <div className="flex items-center justify-between gap-3">
                   <span>

--- a/platform/frontend/src/app/skills/_parts/import-skills-dialog.tsx
+++ b/platform/frontend/src/app/skills/_parts/import-skills-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ResourceVisibilityScope } from "@archestra/shared";
+import type { RowSelectionState } from "@tanstack/react-table";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -12,7 +13,7 @@ import {
   PackageSearch,
   SearchX,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   GithubAuthConfigFields,
   type GithubAuthMethod,
@@ -50,6 +51,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 import { useGithubAppConfigs } from "@/lib/github-app-config.query";
 import { useCreateGithubPat, useGithubPats } from "@/lib/github-pat.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
@@ -121,6 +123,7 @@ export function ImportSkillsDialog({
   const [githubAppConfigId, setGithubAppConfigId] = useState("");
   const [discovered, setDiscovered] = useState<SelectStepSkill[] | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const rangeSelection = useRef(new BulkRangeSelectionController()).current;
   const [search, setSearch] = useState("");
   const [previewSkillPath, setPreviewSkillPath] = useState<string | null>(null);
   const [discoverError, setDiscoverError] = useState<string | null>(null);
@@ -280,15 +283,15 @@ export function ImportSkillsDialog({
     }
   };
 
-  const toggle = (skillPath: string) => {
+  const toggle = (skillPath: string, range: boolean) => {
     setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(skillPath)) {
-        next.delete(skillPath);
-      } else {
-        next.add(skillPath);
-      }
-      return next;
+      const next = rangeSelection.update({
+        current: toRowSelectionState(prev),
+        orderedIds: selectableFiltered.map((skill) => skill.skillPath),
+        targetId: skillPath,
+        range,
+      });
+      return toSelectionSet(next);
     });
   };
 
@@ -613,7 +616,10 @@ export function ImportSkillsDialog({
                             <Checkbox
                               id={`import-skill-${skill.skillPath}`}
                               checked={isSelected}
-                              onCheckedChange={() => toggle(skill.skillPath)}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                toggle(skill.skillPath, event.shiftKey);
+                              }}
                               className="shrink-0"
                               aria-label={
                                 isSelected
@@ -897,5 +903,17 @@ export function ImportSkillsDialog({
         isLoading={isPreviewLoading}
       />
     </StandardDialog>
+  );
+}
+
+function toRowSelectionState(selected: Set<string>): RowSelectionState {
+  return Object.fromEntries([...selected].map((id) => [id, true]));
+}
+
+function toSelectionSet(selection: RowSelectionState): Set<string> {
+  return new Set(
+    Object.entries(selection)
+      .filter(([, selected]) => selected)
+      .map(([id]) => id),
   );
 }

--- a/platform/frontend/src/app/skills/_parts/plugin-skills-section.tsx
+++ b/platform/frontend/src/app/skills/_parts/plugin-skills-section.tsx
@@ -240,6 +240,7 @@ export function PluginSkillsSection({
             title={<Link href={pluginSkillHref(skill)}>{skill.name}</Link>}
             description={skill.description || "No description"}
             actions={renderActions(skill)}
+            onNavigate={() => router.push(pluginSkillHref(skill))}
             footer={
               <div className="flex items-center justify-between gap-3">
                 <span>

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -928,6 +928,11 @@ function SkillsList() {
                             }
                             description={skill.description}
                             actions={renderSkillActions(skill)}
+                            onNavigate={
+                              isDeletedView
+                                ? undefined
+                                : () => router.push(`/skills/${skill.id}`)
+                            }
                             {...cardSelection(skill)}
                             selectionLabel={`Select ${skill.name}`}
                             footer={

--- a/platform/frontend/src/components/chat/file-list-section.tsx
+++ b/platform/frontend/src/components/chat/file-list-section.tsx
@@ -13,7 +13,7 @@ import {
   FileVideo,
   type LucideIcon,
 } from "lucide-react";
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 
@@ -71,7 +71,7 @@ export function FileSection({
    */
   selection?: {
     selectedIds: Set<string>;
-    onToggle: (id: string) => void;
+    onToggle: (id: string, event: MouseEvent) => void;
     isSelectable?: (id: string) => boolean;
   };
 }) {
@@ -115,7 +115,7 @@ export function FileSection({
               {rowSelectable && (
                 <Checkbox
                   checked={isChecked}
-                  onCheckedChange={() => selection.onToggle(item.id)}
+                  onClick={(event) => selection.onToggle(item.id, event)}
                   aria-label={`Select ${item.name}`}
                   className="ml-3"
                 />
@@ -125,9 +125,9 @@ export function FileSection({
                   interactive elements. */}
               <button
                 type="button"
-                onClick={() =>
+                onClick={(event) =>
                   rowSelectable
-                    ? selection.onToggle(item.id)
+                    ? selection.onToggle(item.id, event)
                     : onSelect(item.id)
                 }
                 className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2 text-left"

--- a/platform/frontend/src/components/chat/selectable-file-list.test.tsx
+++ b/platform/frontend/src/components/chat/selectable-file-list.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SelectableFileList } from "./selectable-file-list";
+
+const sections = [
+  {
+    title: "First",
+    items: [
+      file("one", "one.txt"),
+      file("artifact", "artifact.txt", ""),
+      file("two", "two.txt"),
+    ],
+  },
+  {
+    title: "Second",
+    items: [file("three", "three.txt"), file("four", "four.txt")],
+  },
+];
+
+describe("SelectableFileList", () => {
+  it("selects a Shift range across sections without including unmanageable rows", async () => {
+    renderFileList();
+
+    await enterSelection("one.txt");
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select four.txt" }), {
+      shiftKey: true,
+    });
+
+    for (const name of ["one.txt", "two.txt", "three.txt", "four.txt"]) {
+      expect(
+        screen.getByRole("checkbox", { name: `Select ${name}` }),
+      ).toBeChecked();
+    }
+    expect(
+      screen.queryByRole("checkbox", { name: "Select artifact.txt" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("4 selected")).toBeVisible();
+  });
+
+  it("uses the menu-selected row as the anchor and deselects from a selected Shift endpoint", async () => {
+    renderFileList();
+
+    await enterSelection("three.txt");
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select one.txt" }), {
+      shiftKey: true,
+    });
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select two.txt" }), {
+      shiftKey: true,
+    });
+
+    expect(
+      screen.getByRole("checkbox", { name: "Select one.txt" }),
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Select two.txt" }),
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Select three.txt" }),
+    ).toBeChecked();
+    expect(screen.getByText("1 selected")).toBeVisible();
+  });
+});
+
+function renderFileList() {
+  render(
+    <SelectableFileList
+      sections={sections}
+      canManage
+      onOpen={vi.fn()}
+      onRequestDelete={vi.fn()}
+    />,
+  );
+}
+
+async function enterSelection(name: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: `Actions for ${name}` }));
+  await user.click(screen.getByRole("menuitem", { name: "Select" }));
+}
+
+function file(id: string, name: string, contentUrl = `/files/${id}`) {
+  return {
+    id,
+    name,
+    mimeType: "text/plain",
+    contentUrl,
+  };
+}

--- a/platform/frontend/src/components/chat/selectable-file-list.tsx
+++ b/platform/frontend/src/components/chat/selectable-file-list.tsx
@@ -7,7 +7,13 @@ import {
   MoreHorizontal,
   Trash2,
 } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import {
+  type MouseEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   type FileListItem,
   FileSection,
@@ -20,12 +26,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 import { downloadFiles } from "@/lib/chat/download-files";
 import {
   pruneSelectedIds,
   selectAllIds,
   selectionCheckState,
-  toggleSelectedId,
 } from "@/lib/chat/file-selection";
 import { cn } from "@/lib/utils";
 
@@ -84,8 +90,12 @@ export function SelectableFileList<T extends FileListItem>({
   renderItemActions?: (item: T) => ReactNode;
 }) {
   const managed = sections.flatMap((s) => s.items).filter(isManageable);
+  // This is the visual list order across section boundaries; rows without byte
+  // endpoints do not participate in selection or Shift ranges.
+  const managedIds = managed.map((file) => file.id);
   const managedCount = managed.length;
-  const managedKey = managed.map((f) => f.id).join("|");
+  const managedKey = managedIds.join("|");
+  const rangeSelection = useRef(new BulkRangeSelectionController()).current;
 
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -116,13 +126,36 @@ export function SelectableFileList<T extends FileListItem>({
   // that started the selection isn't lost.
   const enterSelectionWith = (id: string) => {
     setSelectionMode(true);
-    setSelectedIds(new Set([id]));
+    setSelectedIds(() =>
+      toSelectedIds(
+        rangeSelection.update({
+          current: {},
+          orderedIds: managedIds,
+          targetId: id,
+          range: false,
+        }),
+      ),
+    );
   };
   const selection = selectionMode
     ? {
         selectedIds,
-        onToggle: (id: string) =>
-          setSelectedIds((prev) => toggleSelectedId(prev, id)),
+        onToggle: (id: string, event: MouseEvent) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setSelectedIds((prev) =>
+            toSelectedIds(
+              rangeSelection.update({
+                current: Object.fromEntries(
+                  [...prev].map((selectedId) => [selectedId, true]),
+                ),
+                orderedIds: managedIds,
+                targetId: id,
+                range: event.shiftKey,
+              }),
+            ),
+          );
+        },
         isSelectable: (id: string) => managed.some((f) => f.id === id),
       }
     : undefined;
@@ -270,6 +303,10 @@ export function SelectableFileList<T extends FileListItem>({
 /** A row has actions worth managing once it has a byte endpoint to act on. */
 function isManageable(item: FileListItem): boolean {
   return item.contentUrl !== "";
+}
+
+function toSelectedIds(selection: Record<string, boolean>): Set<string> {
+  return new Set(Object.keys(selection));
 }
 
 /**

--- a/platform/frontend/src/components/filter-bar.test.tsx
+++ b/platform/frontend/src/components/filter-bar.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { FilterBar, FilterSelect } from "@/components/filter-bar";
+import {
+  FilterBar,
+  FilterBarContextualActions,
+  FilterSelect,
+} from "@/components/filter-bar";
 
 const ITEMS = [
   { value: "all", label: "All actions" },
@@ -19,6 +23,52 @@ describe("FilterBar", () => {
     rerender(<FilterBar onClearFilters={onClearFilters}>filters</FilterBar>);
     await userEvent.click(screen.getByRole("button", { name: "Clear" }));
     expect(onClearFilters).toHaveBeenCalledOnce();
+  });
+
+  it("swaps selection actions into the existing toolbar slot without hiding them from assistive technology", () => {
+    render(
+      <FilterBar contextualActions={<span>2 skills selected</span>}>
+        <button type="button">Filter by action</button>
+      </FilterBar>,
+    );
+
+    expect(screen.getByText("2 skills selected")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Filter by action" }),
+    ).toBeInTheDocument();
+  });
+
+  it("accepts collection-owned contextual actions without lifting their state", () => {
+    const view = (active: boolean) => (
+      <>
+        <FilterBar contextualActionsTargetId="test-actions">
+          <button type="button">Filter by action</button>
+        </FilterBar>
+        <FilterBarContextualActions targetId="test-actions" active={active}>
+          <button type="button">Delete selected</button>
+        </FilterBarContextualActions>
+      </>
+    );
+    const { rerender } = render(view(true));
+
+    expect(
+      screen.getByRole("button", { name: "Delete selected" }),
+    ).toBeVisible();
+    expect(
+      screen
+        .getByRole("button", { name: "Filter by action", hidden: true })
+        .closest('[data-slot="filter-controls"]'),
+    ).toHaveAttribute("inert");
+
+    rerender(view(false));
+    expect(
+      screen.queryByRole("button", { name: "Delete selected" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen
+        .getByRole("button", { name: "Filter by action" })
+        .closest('[data-slot="filter-controls"]'),
+    ).not.toHaveAttribute("inert");
   });
 
   describe("moreFilters", () => {

--- a/platform/frontend/src/components/filter-bar.tsx
+++ b/platform/frontend/src/components/filter-bar.tsx
@@ -2,6 +2,10 @@
 
 import { ChevronDown, SlidersHorizontal, X } from "lucide-react";
 import { type ComponentProps, Fragment, type ReactNode } from "react";
+import {
+  ContextualActionsPortal,
+  useBulkActionsScope,
+} from "@/components/ui/bulk-actions-context";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -51,14 +55,15 @@ export type OverflowFilter = {
  * currently narrowing the table — a hidden active filter reads as an empty
  * table with no explanation.
  * @param actions - Trailing controls (sort, view toggle) pinned to the right.
- * @param leading - Set when the bar is the first thing under the page header.
- * `PageLayout` insets its content 24px below the header rule, which is right
- * for content but wrong for a control strip: the bar ended up sitting further
- * from the header it belongs to than from the table it filters, which reads as
- * a misalignment rather than as rhythm. This pulls it back onto the 16px the
- * surrounding `space-y-4` stack already uses below it, so the bar is evenly
- * spaced on both sides. Bars nested inside a tab body or a card are already
- * spaced by their own container and must leave this alone.
+ * @param contextualActions - Selection actions rendered in the same grid cell
+ * as the filters. Presenting them swaps the bar in place instead of reserving
+ * an empty slot or moving the collection once rows are ticked.
+ * @param contextualActionsClassName - Classes for the selection action rail.
+ * @param contextualActionsTargetId - A stable target for selection controls
+ * owned by the collection below. Use this when lifting selection into the page
+ * would make each checkbox rerender expensive queries and filters.
+ * @param leading - Pulls the first control strip below a page header into the
+ * surrounding vertical rhythm. Nested bars leave this disabled.
  *
  * The bar carries no outer margin: the surrounding stack owns the gap between
  * it and the table. It used to default to `mb-4`, which made "let my parent
@@ -71,6 +76,9 @@ export type OverflowFilter = {
 export function FilterBar({
   children,
   className,
+  contextualActions,
+  contextualActionsClassName,
+  contextualActionsTargetId,
   onClearFilters,
   moreFilters,
   actions,
@@ -78,83 +86,139 @@ export function FilterBar({
 }: {
   children: ReactNode;
   className?: string;
+  contextualActions?: ReactNode;
+  contextualActionsClassName?: string;
+  contextualActionsTargetId?: string;
   onClearFilters?: () => void;
   moreFilters?: OverflowFilter[];
   actions?: ReactNode;
   leading?: boolean;
 }) {
+  const bulkActionsScope = useBulkActionsScope();
+  const actionsTargetId =
+    contextualActionsTargetId ?? bulkActionsScope?.targetId;
   const appliedOverflow = moreFilters?.filter((filter) => filter.active) ?? [];
   const tuckedAway = moreFilters?.filter((filter) => !filter.active) ?? [];
 
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center gap-1.5",
-        // Search boxes are the one control whose height isn't set by
-        // `filterControlClass` (callers render an <Input>, not a trigger
-        // button), so the bar pulls them down to the compact height itself
-        // rather than making every call site repeat `inputClassName="h-8"`.
-        "[&_[data-slot=input]]:h-8",
+        "grid",
+        actionsTargetId && "min-h-[42px]",
         leading && "-mt-2",
-        className,
       )}
     >
-      {children}
-      {appliedOverflow.map((filter) => (
-        // Fragment rather than a wrapper element: the control has to be the
-        // bar's own flex item for its sizing to behave like the inline ones'.
-        <Fragment key={filter.key}>{filter.control}</Fragment>
-      ))}
-      {tuckedAway.length > 0 && (
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button variant="outline" className={filterControlClass()}>
-              <SlidersHorizontal aria-hidden className="h-3.5 w-3.5" />
-              <span>More filters</span>
-              <ChevronDown
-                aria-hidden
-                className="h-4 w-4 text-muted-foreground"
-              />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-72 space-y-3">
-            {tuckedAway.map((filter) => (
-              <div
-                key={filter.key}
-                // The control is the same compact trigger used in the bar,
-                // stretched to the popover width so this reads as a small form
-                // rather than a second filter bar. Scoped to the row's direct
-                // child so a control that renders buttons of its own inside
-                // itself keeps their widths, and matched by element rather than
-                // by `[data-slot=button]`: a trigger reaches its <button>
-                // through a Radix `asChild` wrapper, which overwrites Button's
-                // `data-slot` with its own (`popover-trigger`/`select-trigger`).
-                className="space-y-1.5 [&>button]:w-full [&>button]:max-w-none"
-              >
-                <span className="block text-xs font-medium">
-                  {filter.label}
-                </span>
-                {filter.control}
-              </div>
-            ))}
-          </PopoverContent>
-        </Popover>
-      )}
-      {onClearFilters && (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onClearFilters}
-          className="h-8 gap-1.5 px-2"
+      <div
+        data-slot="filter-controls"
+        inert={contextualActions ? true : undefined}
+        className={cn(
+          "col-start-1 row-start-1 flex min-w-0 flex-wrap items-center gap-1.5 self-center transition-opacity duration-150 ease-out",
+          // Search boxes are the one control whose height isn't set by
+          // `filterControlClass` (callers render an <Input>, not a trigger
+          // button), so the bar pulls them down to the compact height itself
+          // rather than making every call site repeat `inputClassName="h-8"`.
+          "[&_[data-slot=input]]:h-8",
+          contextualActions && "pointer-events-none opacity-0",
+          className,
+        )}
+      >
+        {children}
+        {appliedOverflow.map((filter) => (
+          // Fragment rather than a wrapper element: the control has to be the
+          // bar's own flex item for its sizing to behave like the inline ones'.
+          <Fragment key={filter.key}>{filter.control}</Fragment>
+        ))}
+        {tuckedAway.length > 0 && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" className={filterControlClass()}>
+                <SlidersHorizontal aria-hidden className="h-3.5 w-3.5" />
+                <span>More filters</span>
+                <ChevronDown
+                  aria-hidden
+                  className="h-4 w-4 text-muted-foreground"
+                />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-72 space-y-3">
+              {tuckedAway.map((filter) => (
+                <div
+                  key={filter.key}
+                  // The control is the same compact trigger used in the bar,
+                  // stretched to the popover width so this reads as a small form
+                  // rather than a second filter bar. Scoped to the row's direct
+                  // child so a control that renders buttons of its own inside
+                  // itself keeps their widths, and matched by element rather than
+                  // by `[data-slot=button]`: a trigger reaches its <button>
+                  // through a Radix `asChild` wrapper, which overwrites Button's
+                  // `data-slot` with its own (`popover-trigger`/`select-trigger`).
+                  className="space-y-1.5 [&>button]:w-full [&>button]:max-w-none"
+                >
+                  <span className="block text-xs font-medium">
+                    {filter.label}
+                  </span>
+                  {filter.control}
+                </div>
+              ))}
+            </PopoverContent>
+          </Popover>
+        )}
+        {onClearFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClearFilters}
+            className="h-8 gap-1.5 px-2"
+          >
+            <X className="h-3.5 w-3.5" />
+            <span>Clear</span>
+          </Button>
+        )}
+        {actions && (
+          <div className="ml-auto flex items-center gap-1.5">{actions}</div>
+        )}
+      </div>
+      {contextualActions ? (
+        <div
+          className={cn(
+            "col-start-1 row-start-1 flex min-w-0 items-center transition-opacity duration-150 ease-out",
+            contextualActionsClassName,
+          )}
         >
-          <X className="h-3.5 w-3.5" />
-          <span>Clear</span>
-        </Button>
-      )}
-      {actions && (
-        <div className="ml-auto flex items-center gap-1.5">{actions}</div>
-      )}
+          {contextualActions}
+        </div>
+      ) : null}
+      {actionsTargetId ? (
+        <div
+          id={actionsTargetId}
+          data-slot="contextual-actions"
+          className={cn(
+            "pointer-events-none col-start-1 row-start-1 flex min-w-0 items-center self-center opacity-0 transition-opacity duration-150 ease-out",
+            contextualActionsClassName,
+          )}
+        />
+      ) : null}
     </div>
+  );
+}
+
+/**
+ * Projects collection-owned controls into a FilterBar without lifting their
+ * fast-changing state into the page that computes the collection.
+ */
+export function FilterBarContextualActions({
+  targetId,
+  active,
+  children,
+}: {
+  targetId: string;
+  active: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <ContextualActionsPortal targetId={targetId} active={active}>
+      {children}
+    </ContextualActionsPortal>
   );
 }
 

--- a/platform/frontend/src/components/mcp-registry-attention-badge.tsx
+++ b/platform/frontend/src/components/mcp-registry-attention-badge.tsx
@@ -1,21 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import { mcpRegistryFacetHref } from "@/app/mcp/registry/_parts/registry-list-controls";
 import { SidebarMenuAction } from "@/components/ui/sidebar";
 import { useMcpDeploymentStatuses } from "@/lib/mcp/mcp-server.query";
 import { useMcpServerIssues } from "@/lib/mcp/use-mcp-server-issues";
 
 /**
  * Sidebar count of MCP servers the viewer must act on (failed to start, not
- * running, needs re-authentication, reinstall, image approval), so problems
- * are visible from any page. Reads the same cached registry queries the
+ * running, needs re-authentication), so problems are visible from any page. Reads the same cached registry queries the
  * registry page uses; renders nothing while the fleet is clean.
  *
- * The count is a link to the list already narrowed to those servers, so it
- * lands on the two rows it is counting rather than on the whole registry. It
- * renders as a `SidebarMenuAction` — a sibling of the nav item's own link,
- * not a child of it — because an anchor may not contain another anchor.
+ * The count links to the rows it is counting. The registry's default Action
+ * required ordering also puts them first instead of hiding them behind
+ * pagination. It renders as a `SidebarMenuAction` — a sibling of the nav
+ * item's own link, not a child of it — because an anchor may not contain
+ * another anchor.
  *
  * It reads the same live deployment feed the registry page does. Runtime
  * faults (a crash-looping pod, an image that will not pull) exist only for a
@@ -41,7 +40,7 @@ export function McpRegistryAttentionBadge() {
       className="aspect-auto h-5 w-auto min-w-5 rounded-full bg-destructive px-1 text-[11px] font-semibold tabular-nums text-destructive-foreground hover:bg-destructive hover:text-destructive-foreground"
     >
       <Link
-        href={mcpRegistryFacetHref("you")}
+        href="/mcp/registry?status=needs-my-action"
         data-testid="sidebar-mcp-registry-attention-count"
       >
         {count}

--- a/platform/frontend/src/components/resource-scope-filter.test.tsx
+++ b/platform/frontend/src/components/resource-scope-filter.test.tsx
@@ -94,13 +94,9 @@ describe("ResourceScopeFilter owner selector gating", () => {
   });
 
   it("shows the owner selector for a resource admin", async () => {
-    vi.mocked(useHasPermissions).mockImplementation(
-      (permissions: Record<string, unknown>) => {
-        if ("agent" in permissions)
-          return { data: true } as ReturnType<typeof useHasPermissions>;
-        return { data: true } as ReturnType<typeof useHasPermissions>;
-      },
-    );
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
 
     render(
       <ResourceScopeFilter
@@ -114,6 +110,27 @@ describe("ResourceScopeFilter owner selector gating", () => {
 
     await userEvent.click(comboboxes[1]);
     expect(await screen.findByText("Other users")).toBeInTheDocument();
+  });
+
+  it("uses a caller-owned local navigation path when provided", async () => {
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
+    const navigate = vi.fn();
+
+    render(
+      <ResourceScopeFilter
+        ownerLabelPlural="connections"
+        adminPermission={{ mcpServerInstallation: ["admin"] }}
+        navigate={navigate}
+      />,
+    );
+
+    await userEvent.click(screen.getAllByRole("combobox")[0]);
+    await userEvent.click(screen.getByRole("option", { name: "All types" }));
+
+    expect(navigate).toHaveBeenCalledWith("/agents?");
+    expect(useRouter().push).not.toHaveBeenCalled();
   });
 });
 

--- a/platform/frontend/src/components/resource-scope-filter.tsx
+++ b/platform/frontend/src/components/resource-scope-filter.tsx
@@ -55,6 +55,7 @@ export function ResourceScopeFilter({
   showBuiltIn = false,
   showLabels = false,
   showTeamSelect = true,
+  navigate,
 }: {
   /** Admin permission unlocking the owner sub-filter, e.g. `{ skill: ["admin"] }`. */
   adminPermission: Permissions;
@@ -72,6 +73,8 @@ export function ResourceScopeFilter({
    * specific teams (apps).
    */
   showTeamSelect?: boolean;
+  /** Override navigation for lists that own local URL state without an RSC round trip. */
+  navigate?: (url: string) => void;
 }) {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -128,9 +131,11 @@ export function ResourceScopeFilter({
       }
       // reset server-side pagination (a no-op on pages without a page param)
       params.delete("page");
-      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+      const navigateTo =
+        navigate ?? ((url: string) => router.push(url, { scroll: false }));
+      navigateTo(`${pathname}?${params.toString()}`);
     },
-    [searchParams, router, pathname],
+    [searchParams, router, pathname, navigate],
   );
 
   const handleScopeChange = useCallback(
@@ -329,6 +334,7 @@ export function ResourceScopeFilter({
           className={filterControlClass({
             active: selectedAuthorIds.length > 0,
           })}
+          contentClassName="w-80 max-w-[calc(100vw-2rem)]"
           showSelectedBadges={false}
           selectedSuffix={(n) => `${n === 1 ? "user" : "users"} selected`}
         />

--- a/platform/frontend/src/components/roles/roles-list.ee.tsx
+++ b/platform/frontend/src/components/roles/roles-list.ee.tsx
@@ -24,6 +24,7 @@ import {
   TableRowActions,
 } from "@/components/table-row-actions";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -419,9 +420,8 @@ export function RolesList({ headerAction }: { headerAction?: ReactNode }) {
 
   return (
     <>
-      <div className="space-y-6">
+      <BulkActionsScope className="space-y-3">
         <FilterBar
-          className={isLoadingError ? undefined : "!mb-3"}
           onClearFilters={
             nameFilter
               ? () => updateQueryParams({ name: null, page: "1" })
@@ -527,7 +527,7 @@ export function RolesList({ headerAction }: { headerAction?: ReactNode }) {
             )}
           </>
         )}
-      </div>
+      </BulkActionsScope>
 
       {/* Create Role Dialog */}
       <FormDialog

--- a/platform/frontend/src/components/settings/api-keys-card.tsx
+++ b/platform/frontend/src/components/settings/api-keys-card.tsx
@@ -20,6 +20,7 @@ import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Badge } from "@/components/ui/badge";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -319,9 +320,8 @@ function ApiKeysCardContent() {
           isPending={(isPending || isFetching) && apiKeys.length === 0}
           loadingFallback={<LoadingState variant="page" />}
         >
-          <div>
+          <BulkActionsScope className="space-y-3">
             <FilterBar
-              className="mb-3"
               onClearFilters={
                 search
                   ? () => updateQueryParams({ search: null, page: "1" })
@@ -398,7 +398,7 @@ function ApiKeysCardContent() {
                 />
               </>
             )}
-          </div>
+          </BulkActionsScope>
         </LoadingWrapper>
       </section>
 

--- a/platform/frontend/src/components/settings/permissions-card.tsx
+++ b/platform/frontend/src/components/settings/permissions-card.tsx
@@ -54,7 +54,7 @@ export function PermissionsCard() {
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-3">
         <Skeleton className="h-10 w-full" />
         <Skeleton className="h-40 w-full" />
       </div>

--- a/platform/frontend/src/components/settings/settings-block.tsx
+++ b/platform/frontend/src/components/settings/settings-block.tsx
@@ -16,6 +16,7 @@ interface SettingsBlockProps {
   children?: ReactNode;
   /** Anchor for a link that points at this specific setting. */
   id?: string;
+  contentClassName?: string;
 }
 
 export function SettingsBlock({
@@ -25,6 +26,7 @@ export function SettingsBlock({
   notice,
   children,
   id,
+  contentClassName,
 }: SettingsBlockProps) {
   const hasControl = control != null;
 
@@ -52,7 +54,9 @@ export function SettingsBlock({
           </div>
         )}
       </div>
-      {children && <div className="mt-4">{children}</div>}
+      {children && (
+        <div className={cn("mt-4", contentClassName)}>{children}</div>
+      )}
     </section>
   );
 }

--- a/platform/frontend/src/components/table-card-view.test.tsx
+++ b/platform/frontend/src/components/table-card-view.test.tsx
@@ -1,5 +1,13 @@
+import type { RowSelectionState } from "@tanstack/react-table";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FilterBar } from "@/components/filter-bar";
+import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { createSelectColumn } from "@/components/ui/bulk-select-column";
+import { DataTable } from "@/components/ui/data-table";
+import { useBulkRangeSelectionController } from "@/lib/bulk-range-selection-context";
+import { useBulkCardSelection } from "@/lib/hooks/use-bulk-card-selection";
 import {
   TableCard,
   TableCardList,
@@ -61,6 +69,113 @@ describe("TableCardView", () => {
     expect(screen.getByLabelText("View as table").closest("div")).toHaveClass(
       "hidden",
       "md:inline-flex",
+    );
+  });
+
+  it("keeps expensive layouts mounted when a caller opts into warm switching", () => {
+    render(
+      <TableCardView storageKey="warm-view" defaultMode="table">
+        <TableCardViewToggle />
+        <TableCardViewContent
+          keepMounted
+          table={<span>Warm table</span>}
+          cards={<span>Warm cards</span>}
+        />
+      </TableCardView>,
+    );
+
+    expect(screen.getByText("Warm table").parentElement).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    expect(screen.getByText("Warm cards").parentElement).toHaveAttribute(
+      "data-active",
+      "false",
+    );
+    fireEvent.click(screen.getByLabelText("View as cards"));
+    expect(screen.getByText("Warm table").parentElement).toHaveAttribute(
+      "data-active",
+      "false",
+    );
+    expect(screen.getByText("Warm cards").parentElement).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+  });
+
+  it("navigates from the card shell without shadowing nested controls", () => {
+    const onNavigate = vi.fn();
+    const onAction = vi.fn();
+    const { container } = render(
+      <TableCard
+        title="Navigable card"
+        onNavigate={onNavigate}
+        actions={
+          <button type="button" onClick={onAction}>
+            Card action
+          </button>
+        }
+      />,
+    );
+    const card = container.firstElementChild;
+    expect(card).toBeInstanceOf(HTMLElement);
+    if (!(card instanceof HTMLElement)) throw new Error("Card did not render");
+
+    fireEvent.click(card);
+    expect(onNavigate).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Card action" }));
+    expect(onAction).toHaveBeenCalledOnce();
+    expect(onNavigate).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the Shift-range anchor when switching between table and cards", () => {
+    render(<SharedRangeView />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select two" }));
+    fireEvent.click(screen.getByRole("button", { name: "View as cards" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select four" }), {
+      shiftKey: true,
+    });
+
+    for (const id of ["two", "three", "four"]) {
+      expect(
+        screen.getByRole("checkbox", { name: `Select ${id}` }),
+      ).toBeChecked();
+    }
+    expect(
+      screen.getByRole("checkbox", { name: "Select one" }),
+    ).not.toBeChecked();
+  });
+
+  it("replaces scoped filters with bulk actions without a separate reserved bar", async () => {
+    const { container } = render(<ScopedBulkActionsView />);
+
+    expect(
+      screen.getByRole("button", { name: "Filter by action" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Delete selected" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select a skill" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Delete selected" }),
+      ).toBeVisible(),
+    );
+    expect(
+      screen
+        .getByRole("button", { name: "Filter by action", hidden: true })
+        .closest('[data-slot="filter-controls"]'),
+    ).toHaveAttribute("inert");
+
+    const bars = container.querySelectorAll('[data-slot="bulk-actions-bar"]');
+    expect(bars).toHaveLength(1);
+    expect(bars[0]?.parentElement).toHaveAttribute(
+      "data-slot",
+      "contextual-actions",
     );
   });
 
@@ -144,6 +259,69 @@ function TestView() {
         table={<span>Table</span>}
         cards={<span>Cards</span>}
       />
+    </TableCardView>
+  );
+}
+
+const rangeRows = ["one", "two", "three", "four"].map((id) => ({ id }));
+
+function SharedRangeView() {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const rangeSelection = useBulkRangeSelectionController();
+  const cardSelection = useBulkCardSelection({
+    rows: rangeRows,
+    getRowId: (row) => row.id,
+    rowSelection,
+    setRowSelection,
+    rangeSelection,
+  });
+
+  return (
+    <TableCardView storageKey="shared-range" defaultMode="table">
+      <TableCardViewToggle />
+      <TableCardViewContent
+        table={
+          <DataTable
+            columns={[
+              createSelectColumn<(typeof rangeRows)[number]>({
+                rowLabel: (row) => `Select ${row.id}`,
+              }),
+              { accessorKey: "id", header: "Name" },
+            ]}
+            data={rangeRows}
+            getRowId={(row) => row.id}
+            rowSelection={rowSelection}
+            onRowSelectionChange={setRowSelection}
+            rangeSelection={rangeSelection}
+          />
+        }
+        cards={rangeRows.map((row) => (
+          <TableCard
+            key={row.id}
+            title={row.id}
+            {...cardSelection(row)}
+            selectionLabel={`Select ${row.id}`}
+          />
+        ))}
+      />
+    </TableCardView>
+  );
+}
+
+function ScopedBulkActionsView() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <TableCardView storageKey="scoped-bulk-actions-view">
+      <FilterBar>
+        <button type="button">Filter by action</button>
+      </FilterBar>
+      <BulkActions count={count} noun="skill">
+        <button type="button">Delete selected</button>
+      </BulkActions>
+      <button type="button" onClick={() => setCount(1)}>
+        Select a skill
+      </button>
     </TableCardView>
   );
 }

--- a/platform/frontend/src/components/table-card-view.tsx
+++ b/platform/frontend/src/components/table-card-view.tsx
@@ -3,14 +3,17 @@
 import { LayoutGrid, List, type LucideIcon, Search } from "lucide-react";
 import {
   createContext,
+  type MouseEvent,
   type MouseEventHandler,
   type ReactNode,
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { EmptyState } from "@/components/empty-state";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { TablePagination } from "@/components/ui/table-pagination";
@@ -19,10 +22,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { BulkRangeSelectionScope } from "@/lib/bulk-range-selection-context";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
 export type TableCardViewMode = "cards" | "table";
+export const COLLECTION_CARD_HOVER_CLASSNAME = "hover:bg-muted/50";
 
 type TableCardViewContextValue = {
   mode: TableCardViewMode;
@@ -64,7 +69,9 @@ export function TableCardView({
 
   return (
     <TableCardViewContext.Provider value={{ mode, selectMode }}>
-      {children}
+      <BulkActionsScope>
+        <BulkRangeSelectionScope>{children}</BulkRangeSelectionScope>
+      </BulkActionsScope>
     </TableCardViewContext.Provider>
   );
 }
@@ -115,19 +122,52 @@ export function TableCardViewContent({
   table,
   cards,
   forceTable = false,
+  keepMounted = false,
+  onModeChange,
 }: {
   table: ReactNode;
   cards: ReactNode;
   /** For dense lifecycle/history views that intentionally have no card form. */
   forceTable?: boolean;
+  /** Keep both expensive layouts warm and switch them with CSS. */
+  keepMounted?: boolean;
+  /** Reports the effective layout, including the mobile cards override. */
+  onModeChange?: (mode: TableCardViewMode) => void;
 }) {
   // Nested list components can still render independently in tests and
   // stories; without a page-level provider they retain their table default.
   const mode = useContext(TableCardViewContext)?.mode ?? "table";
   const isMobile = useIsMobile();
+  const effectiveMode = mode === "cards" || isMobile ? "cards" : "table";
+  const warmTable = useRef(table);
+  const warmCards = useRef(cards);
+  if (effectiveMode === "table") warmTable.current = table;
+  else warmCards.current = cards;
+
+  useEffect(() => {
+    onModeChange?.(effectiveMode);
+  }, [effectiveMode, onModeChange]);
 
   if (forceTable) return table;
-  if (mode === "cards" || isMobile) return cards;
+  if (keepMounted) {
+    return (
+      <>
+        <div
+          data-active={effectiveMode === "table"}
+          className={effectiveMode === "table" ? "hidden md:block" : "hidden"}
+        >
+          {warmTable.current}
+        </div>
+        <div
+          data-active={effectiveMode === "cards"}
+          className={effectiveMode === "cards" ? undefined : "hidden"}
+        >
+          {warmCards.current}
+        </div>
+      </>
+    );
+  }
+  if (effectiveMode === "cards") return cards;
 
   // Hidden until `useIsMobile` resolves, preventing a wide table from
   // flashing during hydration on a narrow screen.
@@ -255,6 +295,7 @@ export function TableCard({
   children,
   footer,
   className,
+  onNavigate,
 }: {
   title: ReactNode;
   description?: ReactNode;
@@ -268,14 +309,22 @@ export function TableCard({
   children?: ReactNode;
   footer?: ReactNode;
   className?: string;
+  onNavigate?: () => void;
 }) {
-  const selectable = onSelectedChange !== undefined;
+  const selectable =
+    onSelectedChange !== undefined || onSelectionClick !== undefined;
+  const navigation = useNavigableCard({ onNavigate, selected });
 
   return (
     <div
+      {...navigation.props}
       className={cn(
         "flex h-full flex-col gap-3 rounded-lg border p-4 transition-colors",
-        selected ? "border-primary bg-primary/5" : "hover:bg-muted/30",
+        selected
+          ? cn("border-primary bg-primary/5", navigation.className)
+          : onNavigate
+            ? navigation.className
+            : COLLECTION_CARD_HOVER_CLASSNAME,
         className,
       )}
     >
@@ -285,7 +334,11 @@ export function TableCard({
             className="mt-1"
             checked={selected}
             disabled={selectionDisabled}
-            onCheckedChange={(value) => onSelectedChange(!!value)}
+            onCheckedChange={
+              onSelectedChange
+                ? (value) => onSelectedChange(!!value)
+                : undefined
+            }
             onClick={(event) => {
               event.stopPropagation();
               onSelectionClick?.(event);
@@ -316,6 +369,42 @@ export function TableCard({
   );
 }
 
+export function useNavigableCard({
+  onNavigate,
+  selected,
+}: {
+  onNavigate?: () => void;
+  selected?: boolean;
+}) {
+  const navigateFromPointer = (event: MouseEvent<HTMLElement>) => {
+    if (
+      !onNavigate ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      isCardInteractiveTarget(event.target, event.currentTarget)
+    ) {
+      return;
+    }
+    onNavigate();
+  };
+  return {
+    className: onNavigate
+      ? cn(
+          "cursor-pointer",
+          selected ? "hover:bg-primary/10" : COLLECTION_CARD_HOVER_CLASSNAME,
+        )
+      : undefined,
+    props: onNavigate
+      ? {
+          onClick: navigateFromPointer,
+        }
+      : {},
+  };
+}
+
 const VIEW_LABELS: Record<TableCardViewMode, string> = {
   cards: "View as cards",
   table: "View as table",
@@ -329,4 +418,16 @@ function useTableCardView(): TableCardViewContextValue {
     throw new Error("TableCardView components must be inside TableCardView");
   }
   return context;
+}
+
+const CARD_INTERACTIVE_SELECTOR =
+  'a, button, input, select, textarea, summary, [contenteditable="true"], [role="button"], [role="checkbox"], [role="link"], [role="menuitem"], [data-card-interactive]';
+
+function isCardInteractiveTarget(
+  target: EventTarget,
+  currentTarget: EventTarget,
+): boolean {
+  if (!(target instanceof Element)) return false;
+  const interactiveTarget = target.closest(CARD_INTERACTIVE_SELECTOR);
+  return interactiveTarget !== null && interactiveTarget !== currentTarget;
 }

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -31,6 +31,7 @@ import {
   TableRowActions,
 } from "@/components/table-row-actions";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { DataTable } from "@/components/ui/data-table";
 import { PermissionButton } from "@/components/ui/permission-button";
@@ -295,8 +296,8 @@ export function TeamsList() {
 
   return (
     <>
-      <div className="space-y-6">
-        <FilterBar className={!hasLabelFilters ? "!mb-3" : undefined}>
+      <BulkActionsScope className="space-y-3">
+        <FilterBar>
           <SearchInput
             isLoading={isLoading}
             objectNamePlural="teams"
@@ -311,9 +312,7 @@ export function TeamsList() {
         </FilterBar>
 
         {hasLabelFilters && (
-          <div className="!mb-3">
-            <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
-          </div>
+          <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
         )}
 
         <BulkActions
@@ -350,7 +349,7 @@ export function TeamsList() {
           emptyMessage="No teams found"
           hideSelectedCount
         />
-      </div>
+      </BulkActionsScope>
 
       <TeamManagementDialog
         mode="create"

--- a/platform/frontend/src/components/ui/bulk-actions-bar.test.tsx
+++ b/platform/frontend/src/components/ui/bulk-actions-bar.test.tsx
@@ -82,18 +82,58 @@ describe("BulkActionsBar", () => {
     expect(onClear).toHaveBeenCalledTimes(1);
   });
 
-  it("is absent until something is selected, so the collection sits where it reads", () => {
-    const { container } = render(
-      <BulkActions count={0} noun="document" onClear={() => {}} />,
+  it("reserves a compact in-flow slot by default for collection actions", () => {
+    const { container, rerender } = render(
+      <BulkActions count={0} noun="skill" countTestId="count" />,
     );
 
-    // The bar used to keep an invisible 42px copy of itself mounted here to
-    // avoid moving the collection. That hole was visible on every collection
-    // screen; the shift it prevented follows the reader's own click.
+    const emptySlot = container.querySelector('[data-slot="bulk-actions-bar"]');
+    expect(emptySlot?.className).toContain("h-[42px]");
+    expect(emptySlot?.className).toContain("!mb-3");
+    expect(emptySlot?.className).toContain("[&+*]:!mt-0");
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(container.querySelector('[aria-live="polite"]')?.textContent).toBe(
+      "",
+    );
+
+    rerender(<BulkActions count={2} noun="skill" countTestId="count" />);
+
+    const selectedSlot = container.querySelector(
+      '[data-slot="bulk-actions-bar"]',
+    );
+    expect(selectedSlot?.className).toContain("w-full");
+    expect(selectedSlot?.className).toContain("h-[42px]");
+    expect(selectedSlot?.className).toContain("!mb-3");
+    expect(selectedSlot?.className).toContain("[&+*]:!mt-0");
+    expect(selectedSlot?.querySelector("div")?.className).toContain(
+      "flex-nowrap",
+    );
+    expect(selectedSlot?.querySelector("div")?.className).toContain(
+      "overflow-x-auto",
+    );
+    expect(screen.getByTestId("count").textContent).toBe("2 skills selected");
+  });
+
+  it("lets a caller-owned contextual toolbar render the compact bar without an empty reserved slot", () => {
+    const { container, rerender } = render(
+      <BulkActions count={0} noun="skill" reserveSpace={false} />,
+    );
+
     expect(
       container.querySelector('[data-slot="bulk-actions-bar"]'),
     ).toBeNull();
-    expect(screen.queryByRole("button")).toBeNull();
+    expect(container.querySelector('[aria-live="polite"]')).not.toBeNull();
+
+    rerender(
+      <BulkActions
+        count={1}
+        noun="skill"
+        reserveSpace={false}
+        countTestId="count"
+      />,
+    );
+
+    expect(screen.getByTestId("count").textContent).toBe("1 skill selected");
   });
 
   it("blocks an ID-list action above the default bulk limit", () => {

--- a/platform/frontend/src/components/ui/bulk-actions-bar.tsx
+++ b/platform/frontend/src/components/ui/bulk-actions-bar.tsx
@@ -3,6 +3,10 @@
 import { MAX_BULK_IDS } from "@archestra/shared";
 import type { ReactNode } from "react";
 import { LoadingState } from "@/components/loading";
+import {
+  ContextualActionsPortal,
+  useBulkActionsScope,
+} from "@/components/ui/bulk-actions-context";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -67,36 +71,43 @@ export interface BulkActionsBarProps {
   /** Additional classes for the action rail. */
   className?: string;
   /**
-   * Renders the bar as the compact single-line rail collections use: fixed
-   * height, tighter padding, and horizontal scrolling rather than wrapping
-   * when the actions outgrow a narrow viewport.
-   *
-   * This used to also mount an invisible copy of the bar at zero selection so
-   * the collection never moved. That traded a shift nobody sees for a 54px
-   * hole everybody sees, on every collection screen in the app, permanently.
-   * The bar is now simply absent until there is a selection; the movement it
-   * causes is the direct result of the reader's own click on a checkbox.
+   * Keeps a compact, invisible bar mounted at zero selection so showing the
+   * controls does not displace the collection beneath them.
    */
+  reserveSpace?: boolean;
+  /** Keep controls mounted while a separate toolbar hides this rail. */
+  keepMounted?: boolean;
+  /** Use the compact 42px visual treatment without implying layout reservation. */
   compact?: boolean;
   /** The actions themselves, laid out at the end of the bar. */
   children?: ReactNode;
 }
 
 /**
- * Default collection bulk actions: the compact single-line rail every table
- * and card list uses, owning its own 12px gap before the collection that
- * follows it. Absent entirely until something is selected.
+ * Default collection bulk actions. Unlike the low-level bar, this keeps the
+ * compact action box in normal flow at zero selection so table and card
+ * layouts never move when the controls appear. The slot also owns its 12px
+ * spacing before the collection immediately after it.
  */
 export function BulkActions({
   selectAllMatching,
   maxSelection = MAX_BULK_IDS,
   busy,
   children,
+  reserveSpace = true,
+  keepMounted,
+  compact,
   ...props
-}: Omit<BulkActionsBarProps, "compact"> & {
+}: Omit<BulkActionsBarProps, "reserveSpace"> & {
   /** `null` only for actions that send a filter instead of an ID list. */
   maxSelection?: number | null;
+  /**
+   * Disable only when the caller already owns the space — for example the
+   * selection actions replace an existing filter toolbar in place.
+   */
+  reserveSpace?: boolean;
 }) {
+  const bulkActionsScope = useBulkActionsScope();
   const cappedSelectAll =
     selectAllMatching &&
     selectAllMatching.max === undefined &&
@@ -108,12 +119,14 @@ export function BulkActions({
     : props.count;
   const overLimit = maxSelection !== null && actionCount > maxSelection;
 
-  return (
+  const bar = (
     <BulkActionsBar
       {...props}
       busy={busy}
       selectAllMatching={cappedSelectAll}
-      compact
+      reserveSpace={bulkActionsScope ? false : reserveSpace}
+      keepMounted={bulkActionsScope ? true : keepMounted}
+      compact={bulkActionsScope ? true : compact}
     >
       {overLimit ? (
         <span className="text-sm text-destructive">
@@ -121,9 +134,20 @@ export function BulkActions({
         </span>
       ) : null}
       <fieldset disabled={overLimit || busy} className="contents">
-        {children}
+        {props.count > 0 ? children : null}
       </fieldset>
     </BulkActionsBar>
+  );
+
+  return bulkActionsScope ? (
+    <ContextualActionsPortal
+      targetId={bulkActionsScope.targetId}
+      active={props.count > 0}
+    >
+      {bar}
+    </ContextualActionsPortal>
+  ) : (
+    bar
   );
 }
 
@@ -145,9 +169,12 @@ export function BulkActionsBar({
   countTestId,
   selectAllMatching,
   className,
-  compact,
+  reserveSpace,
+  keepMounted,
+  compact: compactProp,
   children,
 }: BulkActionsBarProps) {
+  const compact = compactProp ?? reserveSpace;
   const pluralize = (n: number) => (n === 1 ? noun : (plural ?? `${noun}s`));
 
   const allMatchingActive = selectAllMatching?.active ?? false;
@@ -177,12 +204,20 @@ export function BulkActionsBar({
         {count > 0 ? text : ""}
       </span>
 
-      {count > 0 ? (
+      {count === 0 && reserveSpace ? (
         <div
+          aria-hidden="true"
+          data-slot="bulk-actions-bar"
+          className={cn("h-[42px] !mt-0 !mb-3 [&+*]:!mt-0", className)}
+        />
+      ) : count > 0 || keepMounted ? (
+        <div
+          aria-hidden={count === 0 ? true : undefined}
           data-slot="bulk-actions-bar"
           className={cn(
-            "rounded-md border bg-muted/40 px-3 py-2",
-            compact && "h-[42px] !mt-0 !mb-3 px-2 py-1 [&+*]:!mt-0",
+            "w-full rounded-md border bg-muted/40 px-3 py-2",
+            compact && "h-[42px] px-2 py-1",
+            reserveSpace && "!mt-0 !mb-3 [&+*]:!mt-0",
             className,
           )}
         >

--- a/platform/frontend/src/components/ui/bulk-actions-context.tsx
+++ b/platform/frontend/src/components/ui/bulk-actions-context.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+type BulkActionsScopeValue = {
+  targetId: string;
+};
+
+const BulkActionsScopeContext = createContext<BulkActionsScopeValue | null>(
+  null,
+);
+
+/**
+ * Shares a stable filter-bar target with collection-owned bulk actions.
+ */
+export function BulkActionsScope({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const id = useId();
+  const targetId = `bulk-actions-${id.replaceAll(":", "")}`;
+  const value = useMemo(() => ({ targetId }), [targetId]);
+
+  return (
+    <BulkActionsScopeContext.Provider value={value}>
+      {className ? <div className={className}>{children}</div> : children}
+    </BulkActionsScopeContext.Provider>
+  );
+}
+
+/** Returns the enclosing collection's contextual bulk-actions target, if any. */
+export function useBulkActionsScope() {
+  return useContext(BulkActionsScopeContext);
+}
+
+/**
+ * Projects collection-owned controls into a FilterBar without lifting their
+ * fast-changing state into the page that computes the collection.
+ */
+export function ContextualActionsPortal({
+  targetId,
+  active,
+  children,
+}: {
+  targetId: string;
+  active: boolean;
+  children: ReactNode;
+}) {
+  const [target, setTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setTarget(document.getElementById(targetId));
+  }, [targetId]);
+
+  useLayoutEffect(() => {
+    if (!target) return;
+    const controls = target.parentElement?.querySelector<HTMLElement>(
+      '[data-slot="filter-controls"]',
+    );
+
+    target.classList.toggle("pointer-events-none", !active);
+    target.classList.toggle("opacity-0", !active);
+    target.toggleAttribute("inert", !active);
+    target.setAttribute("aria-hidden", String(!active));
+    controls?.toggleAttribute("inert", active);
+    controls?.classList.toggle("pointer-events-none", active);
+    controls?.classList.toggle("opacity-0", active);
+
+    return () => {
+      target.removeAttribute("inert");
+      target.removeAttribute("aria-hidden");
+      controls?.removeAttribute("inert");
+      controls?.classList.remove("pointer-events-none", "opacity-0");
+    };
+  }, [active, target]);
+
+  return target ? createPortal(children, target) : null;
+}

--- a/platform/frontend/src/components/ui/bulk-select-column.tsx
+++ b/platform/frontend/src/components/ui/bulk-select-column.tsx
@@ -8,9 +8,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-
-/** The last plain-clicked row for each mounted table. */
-const rangeAnchorByTable = new WeakMap<object, string>();
+import { getTableRangeSelection } from "@/lib/bulk-range-selection-context";
 
 /**
  * The multiselect checkbox column, so every table that grows a bulk affordance
@@ -80,55 +78,25 @@ export function createSelectColumn<T>({
         <Checkbox
           className={!selectable ? "pointer-events-none" : undefined}
           checked={selectable && row.getIsSelected()}
-          onCheckedChange={(value) => row.toggleSelected(!!value)}
           onClick={(event) => {
             event.stopPropagation();
             if (!selectable) return;
-            if (!event.shiftKey) {
-              rangeAnchorByTable.set(table, row.id);
-              return;
-            }
-
-            const anchorId = rangeAnchorByTable.get(table);
-            const selected = !row.getIsSelected();
-            const rows = table
+            event.preventDefault();
+            const orderedIds = table
               .getRowModel()
               .rows.filter(
                 (candidate) => canSelect?.(candidate.original) ?? true,
-              );
-            const anchorIndex = rows.findIndex(
-              (candidate) => candidate.id === anchorId,
+              )
+              .map((candidate) => candidate.id);
+            const controller = getTableRangeSelection(table);
+            table.setRowSelection((current) =>
+              controller.update({
+                current,
+                orderedIds,
+                targetId: row.id,
+                range: event.shiftKey,
+              }),
             );
-            const targetIndex = rows.findIndex(
-              (candidate) => candidate.id === row.id,
-            );
-            // Match TanStack's range-selection semantics: every successful
-            // interaction advances the anchor to the clicked endpoint.
-            rangeAnchorByTable.set(table, row.id);
-
-            if (
-              anchorIndex === -1 ||
-              targetIndex === -1 ||
-              anchorIndex === targetIndex
-            ) {
-              rangeAnchorByTable.set(table, row.id);
-              return;
-            }
-
-            // Prevent Radix's composed toggle so only the range update lands.
-            event.preventDefault();
-            const [from, to] =
-              anchorIndex < targetIndex
-                ? [anchorIndex, targetIndex]
-                : [targetIndex, anchorIndex];
-            table.setRowSelection((current) => {
-              const next = { ...current };
-              for (const candidate of rows.slice(from, to + 1)) {
-                if (selected) next[candidate.id] = true;
-                else delete next[candidate.id];
-              }
-              return next;
-            });
           }}
           aria-label={rowLabel(row.original)}
           disabled={!selectable}

--- a/platform/frontend/src/components/ui/data-table.tsx
+++ b/platform/frontend/src/components/ui/data-table.tsx
@@ -19,7 +19,6 @@ import { type LucideIcon, Search } from "lucide-react";
 import React, { useState } from "react";
 
 import { EmptyState } from "@/components/empty-state";
-import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -28,6 +27,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import type { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
+import {
+  registerTableRangeSelection,
+  useBulkRangeSelectionController,
+} from "@/lib/bulk-range-selection-context";
 import { cn } from "@/lib/utils";
 import { DATA_TABLE_SELECT_COLUMN_SIZE } from "./data-table.constants";
 import { DataTablePagination } from "./data-table-pagination";
@@ -55,6 +59,8 @@ interface DataTableProps<TData, TValue> {
   onRowClick?: (row: TData, event: React.MouseEvent) => void;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: (rowSelection: RowSelectionState) => void;
+  /** Shared with card mode so Shift ranges keep one anchor across layouts. */
+  rangeSelection?: BulkRangeSelectionController;
   /**
    * The ids of the rows currently on screen, whenever they change.
    *
@@ -123,6 +129,7 @@ export function DataTable<TData, TValue>({
   onRowClick,
   rowSelection,
   onRowSelectionChange,
+  rangeSelection: controlledRangeSelection,
   onPageRowIdsChange,
   hideSelectedCount,
   getRowId,
@@ -143,6 +150,8 @@ export function DataTable<TData, TValue>({
   fixedWidthColumnIds = [],
   flexibleColumnIds = [],
 }: DataTableProps<TData, TValue>) {
+  const localRangeSelection = useBulkRangeSelectionController();
+  const rangeSelection = controlledRangeSelection ?? localRangeSelection;
   const [internalSorting, setInternalSorting] = useState<SortingState>([]);
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const [internalPagination, setInternalPagination] = useState({
@@ -227,6 +236,7 @@ export function DataTable<TData, TValue>({
       }
     },
   });
+  registerTableRangeSelection({ table, controller: rangeSelection });
 
   // With autoResetPageIndex disabled, a shrinking row count (e.g. a filter
   // applied while on a later page) strands the table on a nonexistent page.

--- a/platform/frontend/src/components/user-searchable-multi-select.tsx
+++ b/platform/frontend/src/components/user-searchable-multi-select.tsx
@@ -15,6 +15,7 @@ export interface UserSearchableMultiSelectProps {
   placeholder?: string;
   searchPlaceholder?: string;
   className?: string;
+  contentClassName?: string;
   disabled?: boolean;
   disabledUserIds?: Set<string>;
   onSearchQueryChange?: (value: string) => void;
@@ -32,6 +33,7 @@ export function UserSearchableMultiSelect({
   placeholder = "Select users",
   searchPlaceholder = "Search users by name or email",
   className,
+  contentClassName,
   disabled = false,
   disabledUserIds,
   onSearchQueryChange,
@@ -55,6 +57,7 @@ export function UserSearchableMultiSelect({
       placeholder={placeholder}
       searchPlaceholder={searchPlaceholder}
       className={className}
+      contentClassName={contentClassName}
       disabled={disabled}
       onSearchQueryChange={onSearchQueryChange}
       items={items}

--- a/platform/frontend/src/lib/bulk-range-selection-context.tsx
+++ b/platform/frontend/src/lib/bulk-range-selection-context.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { createContext, type ReactNode, useContext, useRef } from "react";
+import { BulkRangeSelectionController } from "./bulk-range-selection";
+
+const BulkRangeSelectionContext =
+  createContext<BulkRangeSelectionController | null>(null);
+const rangeSelectionByTable = new WeakMap<
+  object,
+  BulkRangeSelectionController
+>();
+
+export function BulkRangeSelectionScope({ children }: { children: ReactNode }) {
+  const controller = useRef(new BulkRangeSelectionController()).current;
+  return (
+    <BulkRangeSelectionContext.Provider value={controller}>
+      {children}
+    </BulkRangeSelectionContext.Provider>
+  );
+}
+
+export function useBulkRangeSelectionController() {
+  const scopedController = useContext(BulkRangeSelectionContext);
+  const localController = useRef(new BulkRangeSelectionController()).current;
+  return scopedController ?? localController;
+}
+
+export function registerTableRangeSelection({
+  table,
+  controller,
+}: {
+  table: object;
+  controller: BulkRangeSelectionController;
+}) {
+  rangeSelectionByTable.set(table, controller);
+}
+
+export function getTableRangeSelection(table: object) {
+  let controller = rangeSelectionByTable.get(table);
+  if (!controller) {
+    controller = new BulkRangeSelectionController();
+    rangeSelectionByTable.set(table, controller);
+  }
+  return controller;
+}

--- a/platform/frontend/src/lib/bulk-range-selection.test.ts
+++ b/platform/frontend/src/lib/bulk-range-selection.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { BulkRangeSelectionController } from "./bulk-range-selection";
+
+const ids = ["one", "two", "three", "four", "five"];
+
+describe("BulkRangeSelectionController", () => {
+  it("uses the clicked endpoint state and advances the anchor", () => {
+    const controller = new BulkRangeSelectionController();
+    let selection = controller.update({
+      current: {},
+      orderedIds: ids,
+      targetId: "three",
+      range: false,
+    });
+    selection = controller.update({
+      current: selection,
+      orderedIds: ids,
+      targetId: "one",
+      range: true,
+    });
+    selection = controller.update({
+      current: selection,
+      orderedIds: ids,
+      targetId: "two",
+      range: true,
+    });
+
+    expect(selection).toEqual({ three: true });
+  });
+
+  it("uses the first range click as the next anchor", () => {
+    const controller = new BulkRangeSelectionController();
+    let selection = controller.update({
+      current: {},
+      orderedIds: ids,
+      targetId: "three",
+      range: true,
+    });
+    selection = controller.update({
+      current: selection,
+      orderedIds: ids,
+      targetId: "one",
+      range: true,
+    });
+
+    expect(selection).toEqual({ one: true, two: true, three: true });
+  });
+
+  it("only mutates ids supplied in the visible selectable order", () => {
+    const controller = new BulkRangeSelectionController();
+    let selection = controller.update({
+      current: {},
+      orderedIds: ["one", "two", "four", "five"],
+      targetId: "two",
+      range: false,
+    });
+    selection = controller.update({
+      current: selection,
+      orderedIds: ["one", "two", "four", "five"],
+      targetId: "four",
+      range: true,
+    });
+
+    expect(selection).toEqual({ two: true, four: true });
+  });
+});

--- a/platform/frontend/src/lib/bulk-range-selection.ts
+++ b/platform/frontend/src/lib/bulk-range-selection.ts
@@ -1,0 +1,65 @@
+import type { RowSelectionState } from "@tanstack/react-table";
+
+/**
+ * One range-selection state machine shared by table rows and cards.
+ * The clicked endpoint's next state selects or deselects the whole visible
+ * range, and every interaction advances the anchor to that endpoint.
+ */
+export class BulkRangeSelectionController {
+  private anchorId: string | null = null;
+
+  update({
+    current,
+    orderedIds,
+    targetId,
+    range,
+  }: {
+    current: RowSelectionState;
+    orderedIds: readonly string[];
+    targetId: string;
+    range: boolean;
+  }): RowSelectionState {
+    const selected = !current[targetId];
+    let affectedIds: readonly string[] = [targetId];
+
+    if (range) {
+      const anchorIndex = orderedIds.indexOf(this.anchorId ?? "");
+      const targetIndex = orderedIds.indexOf(targetId);
+      if (anchorIndex !== -1 && targetIndex !== -1) {
+        const [from, to] =
+          anchorIndex < targetIndex
+            ? [anchorIndex, targetIndex]
+            : [targetIndex, anchorIndex];
+        affectedIds = orderedIds.slice(from, to + 1);
+      }
+    }
+
+    this.anchorId = targetId;
+    return updateSelection(current, affectedIds, selected);
+  }
+
+  set({
+    current,
+    targetId,
+    selected,
+  }: {
+    current: RowSelectionState;
+    targetId: string;
+    selected: boolean;
+  }): RowSelectionState {
+    return updateSelection(current, [targetId], selected);
+  }
+}
+
+function updateSelection(
+  current: RowSelectionState,
+  ids: readonly string[],
+  selected: boolean,
+): RowSelectionState {
+  const next = { ...current };
+  for (const id of ids) {
+    if (selected) next[id] = true;
+    else delete next[id];
+  }
+  return next;
+}

--- a/platform/frontend/src/lib/hooks/use-bulk-card-selection.ts
+++ b/platform/frontend/src/lib/hooks/use-bulk-card-selection.ts
@@ -1,6 +1,7 @@
 import type { OnChangeFn, RowSelectionState } from "@tanstack/react-table";
 import type { MouseEventHandler } from "react";
-import { useRef } from "react";
+import type { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
+import { useBulkRangeSelectionController } from "@/lib/bulk-range-selection-context";
 
 export interface BulkCardSelectionProps {
   selected: boolean;
@@ -15,14 +16,17 @@ export function useBulkCardSelection<T>({
   rowSelection,
   setRowSelection,
   canSelect,
+  rangeSelection: controlledRangeSelection,
 }: {
   rows: readonly T[];
   getRowId: (row: T) => string;
   rowSelection: RowSelectionState;
   setRowSelection: OnChangeFn<RowSelectionState>;
   canSelect?: (row: T) => boolean;
+  rangeSelection?: BulkRangeSelectionController;
 }) {
-  const anchorId = useRef<string | null>(null);
+  const localRangeSelection = useBulkRangeSelectionController();
+  const rangeSelection = controlledRangeSelection ?? localRangeSelection;
 
   return (row: T): BulkCardSelectionProps => {
     const id = getRowId(row);
@@ -33,54 +37,26 @@ export function useBulkCardSelection<T>({
       selectionDisabled: !selectable,
       onSelectedChange: (selected) => {
         if (!selectable) return;
-        setRowSelection((current) => updateSelection(current, [id], selected));
+        setRowSelection((current) =>
+          rangeSelection.set({ current, targetId: id, selected }),
+        );
       },
       onSelectionClick: (event) => {
         event.stopPropagation();
         if (!selectable) return;
-        if (!event.shiftKey) {
-          anchorId.current = id;
-          return;
-        }
-
-        const selectableIds = rows
+        event.preventDefault();
+        const orderedIds = rows
           .filter((candidate) => canSelect?.(candidate) ?? true)
           .map(getRowId);
-        const anchorIndex = selectableIds.indexOf(anchorId.current ?? "");
-        const targetIndex = selectableIds.indexOf(id);
-        anchorId.current = id;
-
-        if (
-          anchorIndex === -1 ||
-          targetIndex === -1 ||
-          anchorIndex === targetIndex
-        ) {
-          return;
-        }
-
-        event.preventDefault();
-        const selected = !rowSelection[id];
-        const [from, to] =
-          anchorIndex < targetIndex
-            ? [anchorIndex, targetIndex]
-            : [targetIndex, anchorIndex];
         setRowSelection((current) =>
-          updateSelection(current, selectableIds.slice(from, to + 1), selected),
+          rangeSelection.update({
+            current,
+            orderedIds,
+            targetId: id,
+            range: event.shiftKey,
+          }),
         );
       },
     };
   };
-}
-
-function updateSelection(
-  current: RowSelectionState,
-  ids: readonly string[],
-  selected: boolean,
-) {
-  const next = { ...current };
-  for (const id of ids) {
-    if (selected) next[id] = true;
-    else delete next[id];
-  }
-  return next;
 }

--- a/platform/frontend/src/lib/hooks/use-bulk-selection.ts
+++ b/platform/frontend/src/lib/hooks/use-bulk-selection.ts
@@ -1,8 +1,9 @@
 "use client";
 
 import type { OnChangeFn, RowSelectionState } from "@tanstack/react-table";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { SelectAllMatching } from "@/components/ui/bulk-actions-bar";
+import { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 
 /**
  * Selection state for a table whose rows are all in memory — the client-side
@@ -39,6 +40,7 @@ export function useBulkSelection<T>({
     useState<RowSelectionState>({});
   const [pageRowIds, setPageRowIds] = useState<string[]>([]);
   const [escalatedFor, setEscalatedFor] = useState<string | null>(null);
+  const rangeSelection = useRef(new BulkRangeSelectionController()).current;
 
   const clearSelection = useCallback(() => {
     setStoredRowSelection({});
@@ -97,6 +99,7 @@ export function useBulkSelection<T>({
     clearSelection,
     selected,
     selectAllMatching,
+    rangeSelection,
   };
 }
 
@@ -122,6 +125,7 @@ export function useControlledRowSelection<T>({
   clearEscalation: () => void;
   canSelect?: (row: T) => boolean;
 }) {
+  const rangeSelection = useRef(new BulkRangeSelectionController()).current;
   const effectiveRowSelection = allMatchingSelected
     ? Object.fromEntries(
         rows
@@ -142,5 +146,5 @@ export function useControlledRowSelection<T>({
     [clearEscalation, effectiveRowSelection, setRowSelection],
   );
 
-  return { effectiveRowSelection, onRowSelectionChange };
+  return { effectiveRowSelection, onRowSelectionChange, rangeSelection };
 }

--- a/platform/frontend/src/lib/mcp/mcp-server-issues.test.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server-issues.test.ts
@@ -5,6 +5,7 @@ import {
 import { describe, expect, it } from "vitest";
 import {
   attentionCatalogIds,
+  attentionSortRank,
   bucketOf,
   type CatalogItemForIssues,
   canFixInstall,
@@ -449,6 +450,14 @@ describe("facets", () => {
     ]);
   });
 
+  it("ranks actionable items ahead of other issues and healthy rows", () => {
+    const issues = mixedFleet();
+
+    expect(attentionSortRank(issues.get("mine"))).toBe(0);
+    expect(attentionSortRank(issues.get("theirs"))).toBe(1);
+    expect(attentionSortRank(issues.get("healthy"))).toBe(2);
+  });
+
   /**
    * Why every surface has to be handed the live deployment feed. Runtime
    * faults exist only for a caller holding the statuses, so two callers over
@@ -516,6 +525,7 @@ describe("facets", () => {
     expect(attentionCatalogIds(issues, { audience: "you" })).toEqual([]);
     expect(attentionCatalogIds(issues, { audience: "others" })).toEqual([]);
     expect(attentionCatalogIds(issues, { audience: "muted" })).toEqual(["r"]);
+    expect(attentionSortRank(issues.get("r"))).toBe(2);
     // Still visible, still explained, and it carries the note the viewer gave
     // for it: muting hides the count, not the state or the reason for it.
     expect(facetIssues(issues.get("r") ?? [], "muted")).toEqual([

--- a/platform/frontend/src/lib/mcp/mcp-server-issues.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server-issues.ts
@@ -199,6 +199,15 @@ export function attentionCatalogIds(
   return ids;
 }
 
+export function attentionSortRank(
+  issues: McpServerIssue[] | undefined,
+): number {
+  const live = (issues ?? []).filter((issue) => !issue.muted);
+  if (live.some((issue) => issue.audience === "you")) return 0;
+  if (live.length > 0) return 1;
+  return 2;
+}
+
 /**
  * Which audience an item belongs to: "you" if any of its issues is the
  * viewer's to fix, else "others". Muted issues are excluded by the caller,

--- a/platform/frontend/src/lib/mcp/mcp-server.query.test.tsx
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.test.tsx
@@ -266,6 +266,8 @@ describe("useMcpInstallationStatusCacheSync", () => {
     ] as const;
     queryClient.setQueryData(externalKey, [{ mcpServerId: "stale" }]);
     queryClient.setQueryData(detailKey, { name: "stale" });
+    queryClient.setQueryData(["mcp-servers", {}], []);
+    queryClient.setQueryData(["mcp-catalog"], []);
     const wrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
@@ -275,8 +277,27 @@ describe("useMcpInstallationStatusCacheSync", () => {
       readyHandler?.({ type: "websocket_ready", payload: {} });
     });
 
+    expect(queryClient.getQueryState(externalKey)?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(detailKey)?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(["mcp-servers", {}])?.isInvalidated).toBe(
+      false,
+    );
+    expect(queryClient.getQueryState(["mcp-catalog"])?.isInvalidated).toBe(
+      false,
+    );
+
+    act(() => {
+      readyHandler?.({ type: "websocket_ready", payload: {} });
+    });
+
     expect(queryClient.getQueryState(externalKey)?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(detailKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(["mcp-servers", {}])?.isInvalidated).toBe(
+      true,
+    );
+    expect(queryClient.getQueryState(["mcp-catalog"])?.isInvalidated).toBe(
+      true,
+    );
   });
 
   it("removes an uninstalled server's cached Skills before refetching", async () => {

--- a/platform/frontend/src/lib/mcp/mcp-server.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.ts
@@ -217,6 +217,9 @@ export function useMcpInstallationStatusCacheSync(enabled = true) {
     const unsubscribeReady = websocketService.subscribe(
       "websocket_ready",
       () => {
+        const isReconnect = websocketReadySyncedClients.has(queryClient);
+        websocketReadySyncedClients.add(queryClient);
+        if (!isReconnect) return;
         void invalidateExternalMcpSkillQueries(queryClient);
         void queryClient.invalidateQueries({
           queryKey: externalMcpSkillDetailQueryKey,
@@ -1092,14 +1095,30 @@ export function useMcpDeploymentStatuses(): McpDeploymentStatusFeed {
  *
  * Mounted ONCE, by the app shell. Watching the query cache from every consumer
  * meant a cache write during one component's render pushed a store update into
- * another's, which React reports as a setState during render.
+ * another's; the driver's notifications are deferred one microtask for the
+ * same reason, which React requires before reporting a new external-store
+ * snapshot.
  */
 export function useMcpDeploymentFeedDriver(): void {
   const isK8sEnabled = useFeature("orchestratorK8sRuntime");
   const queryClient = useQueryClient();
   const subscribeToQueryCache = useCallback(
-    (onCacheChange: () => void) =>
-      queryClient.getQueryCache().subscribe(onCacheChange),
+    (onCacheChange: () => void) => {
+      let active = true;
+      let queued = false;
+      const unsubscribe = queryClient.getQueryCache().subscribe(() => {
+        if (queued) return;
+        queued = true;
+        queueMicrotask(() => {
+          queued = false;
+          if (active) onCacheChange();
+        });
+      });
+      return () => {
+        active = false;
+        unsubscribe();
+      };
+    },
     [queryClient],
   );
   const readServersSignature = useCallback(
@@ -1122,6 +1141,9 @@ export function useMcpDeploymentFeedDriver(): void {
 // analytics. Module-level so the capture happens once regardless of how many
 // components have `useMcpInstallationStatusCacheSync` mounted.
 const runtimeInstallErrorsAlreadyTracked = new Set<string>();
+// The first ready event follows the page's own fresh loads; only a reconnect
+// can have missed lifecycle events and needs a full cache resync.
+const websocketReadySyncedClients = new WeakSet<QueryClient>();
 
 function invalidateExternalMcpSkillQueries(queryClient: QueryClient) {
   return queryClient.invalidateQueries({ queryKey: externalMcpSkillsQueryKey });

--- a/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
+++ b/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
@@ -203,7 +203,17 @@ async function bulkLayoutGeometry(bar: Locator): Promise<{
       }
       branch = branch.parentElement;
     }
-    const collection = element.nextElementSibling as HTMLElement;
+    let collectionBranch = element as HTMLElement | null;
+    let collection: HTMLElement | null = null;
+    while (collectionBranch && !collection) {
+      collection = collectionBranch.nextElementSibling as HTMLElement | null;
+      while (collection?.classList.contains("sr-only")) {
+        collection = collection.nextElementSibling as HTMLElement | null;
+      }
+      collectionBranch = collectionBranch.parentElement;
+    }
+    if (!collection)
+      throw new Error("no collection after the bulk actions bar");
     const barRect = element.getBoundingClientRect();
 
     return {

--- a/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
+++ b/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
@@ -78,7 +78,6 @@ test.describe("Bulk actions bar", () => {
     const beforeSelection = await bulkLayoutGeometry(bar);
     expect(beforeSelection).toMatchObject({
       height: 42,
-      gapAbove: 12,
       gapBelow: 12,
     });
     const collectionTopBefore = await collectionTop(page);

--- a/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
+++ b/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from "@playwright/test";
+import type { Locator } from "@playwright/test";
 import { shareableSkillsSeed } from "../src/mocks/data/skill-share";
 import { expect, test } from "./fixtures";
 
@@ -80,8 +80,6 @@ test.describe("Bulk actions bar", () => {
       height: 42,
       gapBelow: 12,
     });
-    const collectionTopBefore = await collectionTop(page);
-
     await firstRow.click();
 
     const afterSelection = await bulkLayoutGeometry(bar);
@@ -90,7 +88,7 @@ test.describe("Bulk actions bar", () => {
       gapBelow: 12,
     });
     // Reserving the rail prevents table/card layout from jumping on selection.
-    expect(afterSelection.collectionTop).toBe(collectionTopBefore);
+    expect(afterSelection.collectionTop).toBe(beforeSelection.collectionTop);
   });
 
   test("scrolls crowded actions inside the fixed mobile rail", async ({
@@ -209,31 +207,5 @@ async function bulkLayoutGeometry(bar: Locator): Promise<{
       gapBelow: collection.getBoundingClientRect().top - barRect.bottom,
       collectionTop: collection.getBoundingClientRect().top,
     };
-  });
-}
-
-/**
- * Top of the collection when no bar is mounted. `bulkLayoutGeometry` walks
- * out from the bar itself, which does not exist at zero selection, so this
- * anchors on the live region the bar always renders beside instead.
- */
-async function collectionTop(page: Page): Promise<number> {
-  return page.evaluate(() => {
-    // Same upward walk `bulkLayoutGeometry` does from the bar: the live region
-    // and the collection are siblings on some pages and separated by a wrapper
-    // on others, so climb until there is a following element to measure.
-    let branch = document.querySelector(
-      'span[aria-live="polite"].sr-only',
-    ) as HTMLElement | null;
-    let next: HTMLElement | null = null;
-    while (branch && !next) {
-      next = branch.nextElementSibling as HTMLElement | null;
-      while (next?.classList.contains("sr-only")) {
-        next = next.nextElementSibling as HTMLElement | null;
-      }
-      branch = branch.parentElement;
-    }
-    if (!next) throw new Error("no collection after the bulk live region");
-    return next.getBoundingClientRect().top;
   });
 }

--- a/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
+++ b/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
@@ -3,8 +3,8 @@ import { shareableSkillsSeed } from "../src/mocks/data/skill-share";
 import { expect, test } from "./fixtures";
 
 /**
- * The bulk affordance every table shares: no chrome until rows are ticked,
- * then a count, a Clear, and the page's own actions. Driven through Skills
+ * The bulk affordance every table shares: an in-flow reserved rail, then a
+ * count, a Clear, and the page's own actions after rows are ticked. Driven through Skills
  * because it is the table whose actions are plain buttons; the guardrails and
  * knowledge tables render the same `BulkActionsBar` with different children.
  */
@@ -19,7 +19,7 @@ test.describe("Bulk actions bar", () => {
     });
   });
 
-  test("stays out of the page until a row is ticked, and clears back away", async ({
+  test("shows a zero count until a row is ticked, and clears back to zero", async ({
     page,
   }) => {
     await page.goto("/skills");
@@ -29,7 +29,7 @@ test.describe("Bulk actions bar", () => {
     await expect(
       page.getByRole("checkbox", { name: "Select all skills on this page" }),
     ).toBeVisible();
-    await expect(count).toBeHidden();
+    await expect(count).toHaveText("0 skills selected");
     await expect(clear).toBeHidden();
 
     const [firstRow, secondRow] = [
@@ -54,13 +54,13 @@ test.describe("Bulk actions bar", () => {
     ).toBeVisible();
 
     await clear.click();
-    await expect(count).toBeHidden();
+    await expect(count).toHaveText("0 skills selected");
     await expect(
       page.getByRole("button", { name: "Edit visibility" }),
     ).toBeHidden();
   });
 
-  test("adds the rail and its gap only once something is selected", async ({
+  test("reserves a stable in-flow rail before and after selection", async ({
     page,
   }) => {
     await page.goto("/skills");
@@ -74,9 +74,13 @@ test.describe("Bulk actions bar", () => {
     // measure against.
     await firstRow.waitFor();
 
-    // Nothing selected: no bar, and therefore no empty rail above the
-    // collection. This is the whole point of the element being absent.
-    await expect(bar).toHaveCount(0);
+    await expect(bar).toBeVisible();
+    const beforeSelection = await bulkLayoutGeometry(bar);
+    expect(beforeSelection).toMatchObject({
+      height: 42,
+      gapAbove: 12,
+      gapBelow: 12,
+    });
     const collectionTopBefore = await collectionTop(page);
 
     await firstRow.click();
@@ -87,9 +91,8 @@ test.describe("Bulk actions bar", () => {
       gapAbove: 12,
       gapBelow: 12,
     });
-    // The collection moves down by exactly the rail it made room for, so the
-    // rail is never overlapping or double-spaced.
-    expect(afterSelection.collectionTop - collectionTopBefore).toBe(42 + 12);
+    // Reserving the rail prevents table/card layout from jumping on selection.
+    expect(afterSelection.collectionTop).toBe(collectionTopBefore);
   });
 
   test("scrolls crowded actions inside the fixed mobile rail", async ({

--- a/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
+++ b/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
@@ -87,7 +87,6 @@ test.describe("Bulk actions bar", () => {
     const afterSelection = await bulkLayoutGeometry(bar);
     expect(afterSelection).toMatchObject({
       height: 42,
-      gapAbove: 12,
       gapBelow: 12,
     });
     // Reserving the rail prevents table/card layout from jumping on selection.
@@ -188,20 +187,10 @@ test.describe("Bulk actions bar", () => {
 
 async function bulkLayoutGeometry(bar: Locator): Promise<{
   height: number;
-  gapAbove: number;
   gapBelow: number;
   collectionTop: number;
 }> {
   return bar.evaluate((element) => {
-    let branch = element as HTMLElement | null;
-    let previous: HTMLElement | null = null;
-    while (branch && !previous) {
-      previous = branch.previousElementSibling as HTMLElement | null;
-      while (previous?.classList.contains("sr-only")) {
-        previous = previous.previousElementSibling as HTMLElement | null;
-      }
-      branch = branch.parentElement;
-    }
     let collectionBranch = element as HTMLElement | null;
     let collection: HTMLElement | null = null;
     while (collectionBranch && !collection) {
@@ -217,7 +206,6 @@ async function bulkLayoutGeometry(bar: Locator): Promise<{
 
     return {
       height: barRect.height,
-      gapAbove: barRect.top - (previous?.getBoundingClientRect().bottom ?? 0),
       gapBelow: collection.getBoundingClientRect().top - barRect.bottom,
       collectionTop: collection.getBoundingClientRect().top,
     };

--- a/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
+++ b/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
@@ -239,6 +239,67 @@ test.describe("MCP Registry layout", () => {
     expect(spills).toEqual([]);
   });
 
+  test("keeps foreign personal servers out of All and reaches them through Other users", async ({
+    mcpRegistryPage,
+    mswControl,
+    page,
+  }) => {
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+
+    await expect(mcpRegistryPage.cardForCatalogItem("long-author")).toHaveCount(
+      0,
+    );
+
+    await page.getByRole("combobox", { name: "Filter by type" }).click();
+    await page.getByRole("option", { name: "Personal" }).click();
+    await page.getByRole("combobox", { name: "Filter by owner" }).click();
+    await page.getByRole("option", { name: "Other users" }).click();
+
+    await expect(
+      mcpRegistryPage.cardForCatalogItem("long-author"),
+    ).toBeVisible();
+    await expect(page.getByText(LONG_NAME)).toBeVisible();
+  });
+
+  test("puts visibly flagged cards in Action required", async ({
+    mcpRegistryPage,
+    mswControl,
+    page,
+  }) => {
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+
+    const firstHeading = page.locator("main h3").first();
+    await expect(firstHeading).toHaveText("Action required");
+    await expect(
+      mcpRegistryPage.cardForCatalogItem("needs-reauth"),
+    ).toBeVisible();
+  });
+
+  test("swaps table bulk actions into the toolbar without moving the table", async ({
+    mcpRegistryPage,
+    mswControl,
+    page,
+  }) => {
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+    await page.getByRole("button", { name: "View as table" }).click();
+
+    const table = page.locator("table").first();
+    await expect(table).toBeVisible();
+    const before = await table.boundingBox();
+    expect(before).not.toBeNull();
+    expect(page.locator('[data-slot="bulk-actions-bar"]')).toHaveCount(0);
+
+    await page.getByRole("checkbox", { name: "Select org-crowded" }).click();
+
+    await expect(page.getByText("1 server selected")).toBeVisible();
+    await expect(page.locator('[data-slot="bulk-actions-bar"]')).toBeVisible();
+    const after = await table.boundingBox();
+    expect(after?.y).toBe(before?.y);
+  });
+
   test("offers only Uninstall as a table bulk action", async ({
     mcpRegistryPage,
     mswControl,

--- a/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
+++ b/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
@@ -262,22 +262,19 @@ test.describe("MCP Registry layout", () => {
     await expect(page.getByText(LONG_NAME)).toBeVisible();
   });
 
-  test("puts visibly flagged cards in Action required", async ({
+  test("keeps visibly flagged cards in the flat registry", async ({
     mcpRegistryPage,
     mswControl,
-    page,
   }) => {
     await seed(mswControl);
     await mcpRegistryPage.goto();
 
-    const firstHeading = page.locator("main h3").first();
-    await expect(firstHeading).toHaveText("Action required");
     await expect(
       mcpRegistryPage.cardForCatalogItem("needs-reauth"),
     ).toBeVisible();
   });
 
-  test("swaps table bulk actions into the toolbar without moving the table", async ({
+  test("updates table bulk actions without moving the reserved toolbar rail", async ({
     mcpRegistryPage,
     mswControl,
     page,
@@ -290,12 +287,16 @@ test.describe("MCP Registry layout", () => {
     await expect(table).toBeVisible();
     const before = await table.boundingBox();
     expect(before).not.toBeNull();
-    expect(page.locator('[data-slot="bulk-actions-bar"]')).toHaveCount(0);
+    const bulkBar = page.locator('[data-slot="bulk-actions-bar"]');
+    await expect(bulkBar).toBeVisible();
 
     await page.getByRole("checkbox", { name: "Select org-crowded" }).click();
 
-    await expect(page.getByText("1 server selected")).toBeVisible();
-    await expect(page.locator('[data-slot="bulk-actions-bar"]')).toBeVisible();
+    await expect(
+      bulkBar
+        .locator('[aria-hidden="true"]')
+        .filter({ hasText: "1 server selected" }),
+    ).toBeVisible();
     const after = await table.boundingBox();
     expect(after?.y).toBe(before?.y);
   });

--- a/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
+++ b/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
@@ -239,6 +239,45 @@ test.describe("MCP Registry layout", () => {
     expect(spills).toEqual([]);
   });
 
+  test("mounts only the active registry layout", async ({
+    mcpRegistryPage,
+    mswControl,
+    page,
+  }) => {
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+    await expect(mcpRegistryPage.serverCards.first()).toBeVisible();
+
+    await page.getByRole("button", { name: "View as table" }).click();
+    await expect(page.locator("table")).toBeVisible();
+    await expect(mcpRegistryPage.serverCards).toHaveCount(0);
+
+    await page.getByRole("button", { name: "View as cards" }).click();
+    await expect(mcpRegistryPage.serverCards.first()).toBeVisible();
+    await expect(page.locator("table")).toHaveCount(0);
+  });
+
+  test("filters local registry search without a debounce pause", async ({
+    mcpRegistryPage,
+    mswControl,
+    page,
+  }) => {
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+
+    await page
+      .getByRole("textbox", { name: "Search MCP servers by name" })
+      .fill("not-installed");
+
+    await expect(mcpRegistryPage.cardForCatalogItem("org-crowded")).toHaveCount(
+      0,
+      { timeout: 200 },
+    );
+    await expect(
+      mcpRegistryPage.cardForCatalogItem("not-installed"),
+    ).toBeVisible();
+  });
+
   test("keeps foreign personal servers out of All and reaches them through Other users", async ({
     mcpRegistryPage,
     mswControl,

--- a/platform/frontend/tests-integration/studio-sidebar-nav.spec.ts
+++ b/platform/frontend/tests-integration/studio-sidebar-nav.spec.ts
@@ -144,11 +144,11 @@ test.describe("studio sidebar navigation", () => {
     await page.goto("/agents");
     await expect(row).toHaveAttribute("href", "/llm/costs");
 
-    // Costs alone is denied, so the row that survives on the strength of
-    // Limits has to open Limits rather than the page behind the 403.
+    // The shared Costs & Limits route remains the stable destination even
+    // when one of its underlying pages is not readable.
     await setPermissions({ mswControl }, { llmCost: [] });
     await page.goto("/agents");
-    await expect(row).toHaveAttribute("href", "/llm/limits");
+    await expect(row).toHaveAttribute("href", "/llm/costs");
   });
 
   test("drops a row the reader may not open, and the group with the last of them", async ({


### PR DESCRIPTION
Improves MCP registry runtime state, triage, and card interactions.

Unifies collection bulk selection, range selection, and guarded card navigation across affected views.

Updates MCP Registry documentation.

Origin: [T-1188](https://slack.com/archives/C0966V616DC/p1787766647116049?thread_ts=1787761282.398189&cid=C0966V616DC)