### PR TITLE
docs(knowledge): simplify settings and guide copy

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -8,7 +8,7 @@ lastUpdated: 2026-08-27
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
 
-A Knowledge Base is a set of connectors that index your data for retrieval. Connectors pull from tools such as Jira, Confluence, GitHub, Notion, SharePoint, Google Drive, Salesforce, and M-Files. An agent assigned a Knowledge Base can query that data to answer questions.
+A Knowledge Base contains connectors that index data for retrieval. Connectors get data from Jira, Confluence, GitHub, Notion, SharePoint, Google Drive, Salesforce, and M-Files. An agent with a Knowledge Base can query that data to answer questions.
 
 > **Enterprise feature** (team-scoped access control) — see the [Pricing Model](/docs/platform-pricing-model).
 
@@ -16,18 +16,18 @@ A Knowledge Base is a set of connectors that index your data for retrieval. Conn
 
 ## How Retrieval Works
 
-The whole pipeline runs inside Archestra on PostgreSQL with pgvector. There is no external vector database and no separate retrieval service to operate.
+Archestra runs the complete pipeline on PostgreSQL with pgvector. You do not operate an external vector database or a separate retrieval service.
 
 ### Indexing
 
-Connectors run on a cron schedule. Each document goes through the same four steps.
+Connectors run on a cron schedule. Each document uses these four steps.
 
-1. **Extract.** Text is pulled from the source. Office documents and PDFs are read through format-specific extractors; PDF text comes from the document's text layer. A PDF without a text layer — a scan, for example — is skipped and counted in the sync run details. With a multimodal embedding model configured, images are embedded directly rather than described.
-2. **Chunk.** The document is split into passages of roughly 512 tokens, on paragraph and sentence boundaries. Each chunk carries its document title and the document's metadata, so it can be matched on its own. Each passage can be split again into smaller chunks — see [Multi-Granularity Indexing](#multi-granularity-indexing).
-3. **Add context.** Optionally, add document-wide or passage-specific context to each chunk before indexing it. See [Contextual Retrieval](#contextual-retrieval).
-4. **Embed.** Each chunk is vectorized with the configured embedding model and stored alongside a keyword index of the same text.
+1. **Extract.** Archestra gets text from the source. Format-specific extractors read Office documents and PDFs. PDF text comes from the document text layer. Archestra skips a PDF without a text layer, such as a scan. The sync run details count skipped PDFs. A configured multimodal embedding model embeds images directly.
+2. **Chunk.** Archestra divides the document into passages of about 512 tokens. It uses paragraph and sentence boundaries. Each chunk includes its document title and metadata. The system can match each chunk independently. It can divide each passage into smaller chunks. See [Multi-Granularity Indexing](#multi-granularity-indexing).
+3. **Add context.** You can add document-wide or passage-specific context before indexing each chunk. See [Contextual Retrieval](#contextual-retrieval).
+4. **Embed.** The configured embedding model vectorizes each chunk. Archestra stores the vector with a keyword index of the same text.
 
-A document whose content has not changed since the last sync is skipped, so a re-sync only pays for what actually changed.
+Archestra skips documents unchanged since the last sync. You pay only for changed content during a re-sync.
 
 ```mermaid
 flowchart LR
@@ -40,14 +40,14 @@ flowchart LR
 
 ### Querying
 
-A search runs both a semantic and a keyword pass, then narrows the results.
+A search runs semantic and keyword passes. It then narrows the results.
 
-1. **Expand the query.** The reranking model rewrites the question into a semantic phrasing and a set of keyword queries. This catches documents that use different words than the asker did. Identifiers, ticket numbers, and error codes are preserved verbatim.
-2. **Search both ways.** Every query variant runs against the vector index and the keyword index in parallel.
-3. **Fuse.** Results are merged with Reciprocal Rank Fusion, which favors chunks that rank well across several variants rather than one.
-4. **Rerank.** The reranking model scores each surviving chunk against the original question and drops the irrelevant ones. See [Query Results Ranking](#query-results-ranking).
-5. **Filter by access.** Chunks the asking user cannot read are removed. This applies to every result, at every stage.
-6. **Widen.** The chunks either side of each hit are stitched back on, so a passage that starts mid-sentence arrives with its surroundings. See [Context Expansion](#context-expansion). A hit on a child chunk is widened to its own passage instead.
+1. **Expand the query.** The reranking model changes the question into semantic wording and keyword queries. This finds documents that use different words. The system keeps identifiers, ticket numbers, and error codes unchanged.
+2. **Search both ways.** Each query variant searches the vector index and keyword index in parallel.
+3. **Fuse.** Reciprocal Rank Fusion merges the results. It favors chunks that rank well in several variants.
+4. **Rerank.** The reranking model scores each remaining chunk against the original question. It removes irrelevant chunks. See [Query Results Ranking](#query-results-ranking).
+5. **Filter by access.** Archestra removes chunks the asking user cannot read. This filter applies to every result at every stage.
+6. **Widen.** Archestra adds neighboring chunks to each hit. The agent receives the surrounding text when a passage starts mid-sentence. See [Context Expansion](#context-expansion). A child-chunk hit expands to its parent passage.
 
 ```mermaid
 flowchart LR
@@ -64,17 +64,17 @@ flowchart LR
 
 ### Query Results Ranking
 
-A short primer on the terms behind the settings, and how Archestra puts them together. Each search runs the stages below in order, and every stage is on by default except reranking.
+This section defines the settings terms. Each search runs these stages in order. All stages except reranking are enabled by default.
 
-- **RAG (retrieval-augmented generation).** The agent does not know your documents. For each question it retrieves the most relevant passages and answers from them. Retrieval quality caps answer quality — the ranking below decides what the agent gets to read.
-- **Vector ranking (semantic search).** At sync, the embedding model turns every chunk into a vector. At query time the question is embedded the same way and chunks are ranked by how close their vectors are — close in meaning, even when the words differ. Configured under [Embedding Configuration](#embedding-configuration); pgvector does the arithmetic.
-- **Keyword ranking.** Passages that contain the question's words are ranked by how well the words match. It catches what embeddings blur — an identifier, an error code, a product name. Fine-tuned under [Keyword Ranking](#keyword-ranking).
-- **BM25.** The standard keyword scoring function, used by Lucene, Elasticsearch, and most search engines — and Archestra's keyword ranker. Rare words count more than common ones, a word that repeats earns less each time, and long passages are held back, so a short passage that answers directly beats a long one that merely repeats the words. Archestra computes it in plain SQL, so it runs on any PostgreSQL with no extension.
-- **Hybrid search.** Vector and keyword ranking run together, each finding what the other misses: the meaning without the words, the words without the meaning. Archestra always runs both; `ARCHESTRA_KNOWLEDGE_BASE_HYBRID_SEARCH_ENABLED=false` drops the keyword leg.
-- **Reciprocal Rank Fusion (RRF).** Vector and keyword scores are on different scales, so the two lists are merged by rank position, not score. A chunk near the top of both lists wins. Nothing to configure.
-- **Cross-encoder reranking.** A model reads the question and one chunk together and scores that pair — more accurate than comparing vectors, and far more expensive, so it runs only on the fused shortlist. In Archestra the reranking model is a chat model, or a Cohere Rerank model (a purpose-built cross-encoder). Optional, configured under [Search Ranking Configuration](#search-ranking-configuration).
+- **RAG (retrieval-augmented generation).** The agent does not contain your documents. For each question, it retrieves relevant passages and answers from them. Retrieval quality limits answer quality. The ranking determines what the agent reads.
+- **Vector ranking (semantic search).** During sync, the embedding model converts each chunk into a vector. At query time, it converts the question the same way. Archestra ranks chunks by vector similarity. Similar vectors can use different words. Configure this under [Embedding Configuration](#embedding-configuration). pgvector performs the calculation.
+- **Keyword ranking.** Archestra ranks passages that contain the question words by match quality. This finds identifiers, error codes, and product names that embeddings can blur. Configure it under [Keyword Ranking](#keyword-ranking).
+- **BM25.** BM25 is the standard keyword scoring function. Lucene, Elasticsearch, most search engines, and Archestra use it. Rare words have more weight than common words. Repeated words have less added weight. Long passages have less weight. A short direct answer can rank above a long repeated match. Archestra calculates BM25 in SQL. It works on any PostgreSQL without an extension.
+- **Hybrid search.** Vector and keyword ranking run together. Each method finds matches that the other misses. Archestra always runs both. Set `ARCHESTRA_KNOWLEDGE_BASE_HYBRID_SEARCH_ENABLED=false` to disable keyword ranking.
+- **Reciprocal Rank Fusion (RRF).** Vector and keyword scores use different scales. RRF merges lists by rank position, not score. A chunk near the top of both lists ranks higher. This stage needs no configuration.
+- **Cross-encoder reranking.** A model reads the question and one chunk together. It scores that pair. This is more accurate than vector comparison. It also costs more. It runs only on the fused shortlist. Archestra uses a chat model or a Cohere Rerank model, which is a purpose-built cross-encoder. Configure this optional feature under [Search Ranking Configuration](#search-ranking-configuration).
 
-In order, a search is: question → [query expansion](#querying) → vector ranking and keyword ranking in parallel → RRF → reranking → [access filtering](#querying) → [context expansion](#context-expansion). Keyword ranking and reranking are two stages of one search, not alternatives: keyword ranking decides which chunks reach the shortlist, reranking decides the final order of that shortlist. Both live under **Settings > Knowledge > Search Ranking Configuration**, in that order.
+A search uses this order: question → [query expansion](#querying) → vector ranking and keyword ranking in parallel → RRF → reranking → [access filtering](#querying) → [context expansion](#context-expansion). Keyword ranking and reranking are stages in one search. Keyword ranking selects chunks for the shortlist. Reranking sets the final shortlist order. Both settings appear under **Settings > Knowledge > Search Ranking Configuration**, in that order.
 
 ```mermaid
 flowchart LR
@@ -86,74 +86,74 @@ flowchart LR
     RR --> R[Ranked results]
 ```
 
-Why it is set up this way: BM25 is simply better than PostgreSQL's built-in `ts_rank` at ordering keyword matches, so it is the keyword ranker rather than an option — computed without an extension so it works on managed PostgreSQL. Reranking is off until a model is chosen because it costs one model call per search.
+BM25 orders keyword matches better than PostgreSQL's built-in `ts_rank`. Archestra uses it as the keyword ranker, not as an option. SQL calculation lets it work on managed PostgreSQL without an extension. Reranking stays disabled until you select a model because it uses one model call per search.
 
 #### Keyword Ranking
 
-Step 1 of search ranking. Passages that contain the question's words are scored with BM25 and merged with the passages that match by meaning. There is nothing to set up. Two factors under **Settings > Knowledge > Search Ranking Configuration** fine-tune it — a change applies to the next search, and nothing is re-indexed. The defaults suit almost every knowledge base.
+This is step 1 of search ranking. BM25 scores passages that contain the question words. Archestra merges them with passages that match by meaning. No setup is required. Two factors under **Settings > Knowledge > Search Ranking Configuration** tune the result. Changes apply to the next search. Archestra does not re-index documents. The defaults suit most knowledge bases.
 
-- **Term Saturation** (`k1`, 0–10, default 1.2) — how much repeating a word keeps helping a passage. Lower it when long, repetitive documents keep crowding out concise answers; raise it when the best passages genuinely use a term over and over.
-- **Length Normalization** (`b`, 0–1, default 0.75) — how much long passages are held back. Lower it when long, detailed passages deserve an equal chance; raise it when short, focused passages should pull ahead.
+- **Term Saturation** (`k1`, 0–10, default 1.2) — sets how much repeated words help a passage. Lower it if long repeated documents displace concise answers. Raise it if the best passages repeat an important term.
+- **Length Normalization** (`b`, 0–1, default 0.75) — sets how much Archestra reduces long-passage scores. Lower it if long detailed passages need equal ranking. Raise it if short focused passages should rank higher.
 
-Each field shows the deployment default until you change it; setting it back to the default returns it to following that default. The defaults come from `ARCHESTRA_KNOWLEDGE_BASE_BM25_K1` and `_B` — see [Deployment](/docs/platform-deployment#knowledge-base-configuration).
+Each field shows the deployment default until you change it. Resetting a field to its default makes it follow that default again. `ARCHESTRA_KNOWLEDGE_BASE_BM25_K1` and `_B` set the defaults. See [Deployment](/docs/platform-deployment#knowledge-base-configuration).
 
-BM25 scores from statistics that Archestra rebuilds in the background — right after startup, then hourly. The statistics cover the whole deployment, not one organization. Until the first build, keyword matches rank with PostgreSQL's built-in full-text ranking. The Keyword ranking section shows where this stands: ready, still building — with when the next update runs — updating right now, nothing indexed yet, or the last update failed.
+Archestra rebuilds BM25 statistics in the background after startup and then hourly. The statistics cover the deployment, not one organization. Before the first build, keyword matches use PostgreSQL built-in full-text ranking. The Keyword ranking section shows the status. The status is ready, building, updating, no indexed documents, or failed. The building status shows the next update time.
 
 #### Reranking
 
-Step 2 of search ranking. The reranking model reads each shortlisted chunk together with the question, scores it, reorders the list, and drops the chunks it finds irrelevant. A chunk that matched on words alone — the right terms in the wrong context — falls away here.
+This is step 2 of search ranking. The reranking model reads each shortlisted chunk with the question. It scores the chunk and reorders the list. It removes irrelevant chunks. This removes a word match that has the wrong context.
 
-Reranking is optional. Without it, results come back in fused order. Query expansion and [contextual retrieval](#contextual-retrieval) use the same model, so they are off too. Reranking costs one model call per search, recorded in [LLM cost statistics](/docs/platform-llm-proxy) under "Knowledge - Reranker". Set it up under [Search Ranking Configuration](#search-ranking-configuration).
+Reranking is optional. Without it, results use fused order. Query expansion and [contextual retrieval](#contextual-retrieval) use the same model. Archestra also disables them. Reranking uses one model call per search. [LLM cost statistics](/docs/platform-llm-proxy) records this as "Knowledge - Reranker". Configure it under [Search Ranking Configuration](#search-ranking-configuration).
 
 ### Citations
 
-Every result carries the document title, its URL in the source system, the connector it came from, and the position of the chunk within the document. An agent answering from a Knowledge Base cites those sources in its reply, so a reader can open the original.
+Each result includes the document title, source-system URL, connector, and chunk position. An agent that answers from a Knowledge Base cites these sources. Readers can open the original document.
 
-In the built-in chat, the agent also marks each claim with a numbered reference and lists a short verbatim quote for each — tagged with the chunk it came from — in a Sources section at the end of the answer. Archestra checks each quote against the chunk it cites — a quote found in no returned chunk is logged as a likely fabrication. The check never blocks or alters an answer, and it covers the built-in chat only. Set `ARCHESTRA_KNOWLEDGE_BASE_QUOTE_VERIFICATION_ENABLED` to `false` to turn it off.
+In the built-in chat, the agent marks each claim with a numbered reference. It lists a short verbatim quote for each claim in a Sources section. Each quote names its source chunk. Archestra checks each quote against the cited chunk. It logs a quote absent from all returned chunks as a likely fabrication. The check only applies to the built-in chat. It does not block or change an answer. Set `ARCHESTRA_KNOWLEDGE_BASE_QUOTE_VERIFICATION_ENABLED` to `false` to disable it.
 
 ### Contextual Retrieval
 
-Chunking separates a passage from the context it sits in. A chunk reading "the limit was raised to 5,000 per minute" is a poor match for "what is the rate limit on the billing API", because neither the product nor the subject appears in it.
+Chunking separates a passage from its context. For example, "the limit was raised to 5,000 per minute" does not name the billing API. It is a poor match for "what is the rate limit on the billing API".
 
-Under **Settings > Knowledge > Search Ranking Configuration**, choose how context is generated:
+Under **Settings > Knowledge > Search Ranking Configuration**, select the context generation mode:
 
 - **Disabled** — index each chunk without generated context.
-- **Per document — lower cost** — generate one document-wide context and index it with every chunk. This costs one model call per changed document.
-- **Per passage — higher recall** — generate context specific to each chunk, so a passage can name its own section or subject instead of inheriting only a broad document summary. Longer documents are processed in batches of up to eight passages. Documents with fewer than six chunks use the lower-cost document mode because passage-specific calls rarely improve them enough to justify the extra spend.
+- **Per document — lower cost** — generate one document-wide context. Index it with every chunk. This uses one model call per changed document.
+- **Per passage — higher recall** — generate context for each chunk. A passage can name its own section or subject. It does not use only a broad document summary. Archestra processes long documents in batches of up to eight passages. Documents with fewer than six chunks use the lower-cost document mode. Passage-specific calls rarely add enough value for these documents.
 
-The generated context shapes matching only — it is never added to the text the agent reads. Per-passage generation reuses a stable document prefix so providers that support prompt caching can discount later batches. Calls and cache-token costs appear in [LLM cost statistics](/docs/platform-llm-proxy) under "Knowledge - Contextual Retrieval".
+Generated context affects matching only. It is not included in the text the agent reads. Per-passage generation reuses a stable document prefix. Providers with prompt caching can discount later batches. [LLM cost statistics](/docs/platform-llm-proxy) records calls and cache-token costs as "Knowledge - Contextual Retrieval".
 
-Both enabled modes require a reranking model that can generate text. A dedicated Cohere Rerank model can only score results, so contextual retrieval is skipped with one configured. The deployment flag `ARCHESTRA_KNOWLEDGE_BASE_CONTEXTUAL_RETRIEVAL_ENABLED` sets the default for organizations that have not saved a mode; `true` means **Per document**.
+Both enabled modes require a reranking model that generates text. A dedicated Cohere Rerank model only scores results. Archestra skips contextual retrieval when you configure one. `ARCHESTRA_KNOWLEDGE_BASE_CONTEXTUAL_RETRIEVAL_ENABLED` sets the default for organizations without a saved mode. `true` selects **Per document**.
 
 ### Context Expansion
 
-Search ranks chunks, but a chunk boundary falls wherever the chunker put it. A hit can begin mid-sentence or cut a table in half.
+Search ranks chunks. A chunk boundary can occur mid-sentence or in a table.
 
-After ranking, the neighbouring chunks are stitched back onto each hit. Ranking is unaffected — this only widens the passage the agent reads. Expansion stops at any chunk the user cannot read, so it never becomes a way around access control. Set the radius with `ARCHESTRA_KNOWLEDGE_BASE_CONTEXT_EXPANSION_RADIUS`.
+After ranking, Archestra adds neighboring chunks to each hit. This does not change ranking. It only expands the passage the agent reads. Expansion stops at a chunk the user cannot read. It cannot bypass access control. Set the radius with `ARCHESTRA_KNOWLEDGE_BASE_CONTEXT_EXPANSION_RADIUS`.
 
 ### Multi-Granularity Indexing
 
-One chunk size serves one kind of question. A chunk small enough that a port number stands out is too small to explain what the port belongs to. A chunk large enough to carry that explanation buries the port number among everything else in it.
+One chunk size suits one type of question. A small chunk can show a port number but omit its purpose. A large chunk can explain the port but hide the number in more text.
 
-Multi-granularity indexing splits each passage a second time, into smaller child chunks, and indexes only the children. A search matches a child, and the agent reads the whole passage that child came from. Precise lookups and broad questions are then served by the same corpus.
+Multi-granularity indexing divides each passage again into smaller child chunks. It indexes only the children. Search matches a child. The agent reads the full parent passage. The same corpus supports precise lookups and broad questions.
 
-Set the child size with `ARCHESTRA_KNOWLEDGE_BASE_CHILD_CHUNK_SIZE_TOKENS`. It is off by default, and `0` turns it off.
+Set the child size with `ARCHESTRA_KNOWLEDGE_BASE_CHILD_CHUNK_SIZE_TOKENS`. The feature is disabled by default. `0` disables it.
 
-Two consequences are worth knowing. Several children of one passage often match together, so only the best-ranked one is kept — a passage is never returned twice in one result set. And [context expansion](#context-expansion) does not apply to a hit served this way, because the passage around it has already been returned.
+Several children from one passage can match. Archestra keeps only the highest-ranked child. A result set never returns the same passage twice. [Context expansion](#context-expansion) does not apply to these hits. The result already contains the parent passage.
 
-The cost lands on index size rather than on your embedding bill. The children cover the same text the passages did, so the tokens sent to the embedding model barely change — a measured 4% more on a sample document. What grows is the number of stored vectors, roughly the ratio of the two sizes. Contextual retrieval is unaffected: context is still generated once per passage.
+This increases index size instead of embedding cost. Children cover the same text as passages. A sample document used 4% more embedding tokens. The number of stored vectors increases by roughly the size ratio. Contextual retrieval remains unchanged. Archestra still generates context once per passage.
 
-Like chunk size, this applies at ingest. Documents already indexed keep their existing shape until their connector re-syncs, and both shapes are searched together in the meantime.
+Like chunk size, this setting applies during ingest. Indexed documents keep their existing form until the connector re-syncs. Until then, search uses both forms.
 
 ### Keyword Search Language
 
-The keyword index stems words so that different forms of one word match. Stemming is language-specific: "Katzen" and "Katze" only collapse to the same term under German rules.
+The keyword index stems words so different forms match. Stemming is language-specific. "Katzen" and "Katze" match only under German rules.
 
-Set the language on each connector under **Advanced > Keyword Search Language**, to match the language its documents are written in. Choose **Simple** to turn stemming off, which suits source code and mixed-language sources. One deployment can index an English wiki and a German one correctly at the same time. The setting applies on the connector's next sync.
+Set each connector language under **Advanced > Keyword Search Language**. Use the language of its documents. Select **Simple** to disable stemming. This suits source code and mixed-language sources. One deployment can index English and German sources correctly at the same time. The setting applies on the next connector sync.
 
 ### Tuning
 
-These settings are deployment-wide. See [Deployment](/docs/platform-deployment#knowledge-base-configuration) for the full reference.
+These settings apply across the deployment. See [Deployment](/docs/platform-deployment#knowledge-base-configuration) for the full reference.
 
 | Setting | Default | Controls |
 | --- | --- | --- |
@@ -163,26 +163,26 @@ These settings are deployment-wide. See [Deployment](/docs/platform-deployment#k
 | `ARCHESTRA_KNOWLEDGE_BASE_CONTEXT_EXPANSION_RADIUS` | `1` | How many neighbouring chunks are stitched onto a hit |
 | `ARCHESTRA_KNOWLEDGE_BASE_CONTEXTUAL_RETRIEVAL_ENABLED` | `false` | Default contextual retrieval mode for organizations without a saved choice (`true` = per document) |
 
-Chunk sizes and contextual retrieval apply at ingest. A normal sync updates changed documents; force a connector re-sync to rebuild context for documents whose source content has not changed.
+Chunk sizes and contextual retrieval apply during ingest. A normal sync updates changed documents. Force a connector re-sync to rebuild context for unchanged source documents.
 
 ## Configuration
 
-Open **Settings > Knowledge**. An embedding model must be set before Knowledge Bases can be used. Document OCR, a reranking model, and [contextual retrieval](#contextual-retrieval) are optional. Keyword ranking needs no setup, though two factors can be tuned — see [Keyword Ranking](#keyword-ranking).
+Open **Settings > Knowledge**. Set an embedding model before you use Knowledge Bases. Document OCR, a reranking model, and [contextual retrieval](#contextual-retrieval) are optional. Keyword ranking needs no setup. You can tune two factors. See [Keyword Ranking](#keyword-ranking).
 
 ### Embedding Configuration
 
 ![Embedding Configuration card in Settings > Knowledge](/docs/automated_screenshots/platform-knowledge-bases_embedding-configuration.webp)
 
-Pick the API key and embedding model. The embedding model vectorizes ingested documents so they can be queried semantically. The same model is used for both indexing and querying, which is why it is locked once saved.
+Select the API key and embedding model. The model vectorizes ingested documents for semantic queries. Archestra uses the same model for indexing and queries. It locks the model after you save it.
 
-- **Key** — only keys whose synced models have configured embedding dimensions appear in this list. If yours is missing, go to **LLM Providers > Models**, sync the provider, and set the dimensions for the embedding model. Supported dimensions: 384, 768, 1024, 1408, 1536, 3072. Keys connected through a subscription sign-in (an X Premium login, for example) do not appear — Knowledge needs an API key.
-- **Model** — any embedding-capable model exposed by the selected key.
+- **Key** — this list shows only keys with synced models that have configured embedding dimensions. If your key is missing, go to **LLM Providers > Models**. Sync the provider. Set the embedding model dimensions. Supported dimensions are 384, 768, 1024, 1408, 1536, and 3072. Subscription sign-in keys, such as an X Premium login, do not appear. Knowledge requires an API key.
+- **Model** — any embedding-capable model available through the selected key.
 
-To change the embedding model, click **Drop** to clear the existing index — every document will need to be re-embedded on the next connector sync. The lock also applies in **LLM Providers > Models**: the configured model's embedding dimensions and input modalities cannot be edited until the configuration is dropped.
+To change the embedding model, select **Drop** to clear the index. The next connector sync re-embeds every document. The lock also applies in **LLM Providers > Models**. You cannot edit the configured model embedding dimensions or input modalities until you drop the configuration.
 
 ### Image Embedding
 
-Connectors index image files only when the configured embedding model accepts image input. These models do:
+Connectors index image files only if the configured embedding model accepts image input. The models below accept image input.
 
 | Provider    | Model                                                                 | Image formats                |
 | ----------- | --------------------------------------------------------------------- | ---------------------------- |
@@ -193,65 +193,65 @@ Connectors index image files only when the configured embedding model accepts im
 | Cohere      | Cohere Embed v4 (`embed-v4.0`)                                        | JPEG, PNG, WebP, GIF         |
 | Cohere      | Cohere Embed English v3, Multilingual v3, and their Light variants    | JPEG, PNG, WebP, GIF         |
 
-Archestra currently treats embedding models not listed above as text-only, even when their providers may offer multimodal variants that are not yet supported by the knowledge-base client. They cannot be marked as accepting image input in **LLM Providers > Models**. Connectors skip image formats the model does not accept — SVG, for example. Images ingested under an earlier configuration are skipped at embedding time. The document completes without them, and the run shows the skipped count.
+Archestra treats unlisted embedding models as text-only. A provider can offer an unsupported multimodal variant. You cannot mark these models as image-capable in **LLM Providers > Models**. Connectors skip unsupported image formats, such as SVG. Archestra skips images ingested under an earlier configuration during embedding. The document completes without those images. The run shows the skipped count.
 
-Titan Multimodal G1 accepts 256 text tokens per input. Cohere Embed v3 accepts 512 text tokens per input — on Bedrock, 2048 characters. Longer text chunks are truncated before embedding — only the start of the chunk lands in the vector. Use a text embedding model, or Cohere Embed v4, when your corpus is mostly documents.
+Titan Multimodal G1 accepts 256 text tokens per input. Cohere Embed v3 accepts 512 text tokens per input. On Bedrock, it accepts 2048 characters. Archestra truncates longer text chunks before embedding. Only the chunk start enters the vector. Use a text embedding model or Cohere Embed v4 for mostly document-based corpora.
 
-Vertex AI's `multimodalembedding@001` is available when [Vertex AI mode](/docs/platform-supported-llm-providers#using-vertex-ai) is enabled. It embeds at 1408 dimensions. Archestra trims text above the API's 1024-byte cap, then the model shortens text past 32 tokens internally. It also embeds one input per request under a per-project rate limit, which makes large document backfills slower than with `gemini-embedding-2`.
+Vertex AI `multimodalembedding@001` is available with [Vertex AI mode](/docs/platform-supported-llm-providers#using-vertex-ai). It uses 1408 dimensions. Archestra trims text above the API 1024-byte limit. The model then shortens text after 32 tokens internally. It embeds one input per request under a per-project rate limit. Large document backfills are slower than with `gemini-embedding-2`.
 
-Cohere embedding models come from the Cohere key's model list in **LLM Providers > Models** with their dimensions preset — Embed v4 at 1536 (256, 512, or 1024 on request), v3 at 1024, and the Light variants at 384.
+Cohere embedding models appear in the Cohere key model list under **LLM Providers > Models**. Their dimensions are preset. Embed v4 uses 1536 dimensions, or 256, 512, or 1024 on request. v3 uses 1024. Light variants use 384.
 
-With a text-only embedding model, image files are skipped and the connector page says so. Scanned pages inside PDFs are a separate case: [Document OCR](#document-ocr) transcribes them whatever the embedding model is. It does not read standalone image files.
+With a text-only embedding model, Archestra skips image files. The connector page reports this. [Document OCR](#document-ocr) handles scanned PDF pages separately. It transcribes these pages regardless of the embedding model. It does not read standalone image files.
 
 ### Search Ranking Configuration
 
 ![Search Ranking Configuration card in Settings > Knowledge](/docs/automated_screenshots/platform-knowledge_search-ranking.webp)
 
-One card for both ranking stages — what each does is described under [Query Results Ranking](#query-results-ranking).
+This card configures both ranking stages. [Query Results Ranking](#query-results-ranking) describes each stage.
 
-**Keyword ranking** is always on. Its two settings — Term Saturation and Length Normalization — are explained under [Keyword Ranking](#keyword-ranking); they show the defaults until you change them.
+**Keyword ranking** is always enabled. [Keyword Ranking](#keyword-ranking) explains Term Saturation and Length Normalization. These fields show defaults until you change them.
 
-**Reranking** takes the model that scores and reorders search results by relevance. It is optional; without it, results come back in fused order.
+**Reranking** selects the model that scores and reorders results by relevance. It is optional. Without it, results use fused order.
 
-- **Key** — any LLM provider API key. Subscription sign-ins do not appear here either.
-- **Model** — any chat model from that provider. Cohere Rerank models are also supported, on Cohere keys and Azure AI Foundry keys, and are called through their native rerank API.
+- **Key** — any LLM provider API key. Subscription sign-ins do not appear here.
+- **Model** — any chat model from that provider. Cohere Rerank models also work with Cohere keys and Azure AI Foundry keys. Archestra calls their native rerank API.
 
-A chat model also powers query expansion and [contextual retrieval](#contextual-retrieval). A Cohere Rerank model only scores results, so both are skipped with one configured.
+A chat model also performs query expansion and [contextual retrieval](#contextual-retrieval). A Cohere Rerank model only scores results. Archestra skips both features when you configure one.
 
-A chat reranker scores passages by returning a JSON object, so Archestra asks the endpoint to constrain the model's output to that shape. **Test connection** checks that it does. If the test reports that the model replied without a JSON object, the endpoint is not applying the constraint. Enable structured outputs on it — a self-hosted vLLM server needs this — or choose a model that supports them.
+A chat reranker scores passages by returning a JSON object. Archestra asks the endpoint to constrain output to that form. **Test connection** verifies the constraint. If the test says the model returned no JSON object, the endpoint does not apply the constraint. Enable structured outputs. A self-hosted vLLM server requires them. You can also select a model that supports them.
 
 ### Document OCR
 
 ![Document OCR card in Settings > Knowledge](/docs/automated_screenshots/platform-knowledge_document-ocr.webp)
 
-A scanned PDF has no text layer, so connectors cannot index it — the run reports it under "No text extracted". Configure Document OCR and syncs transcribe those pages with a vision model instead. The text becomes searchable like any other document.
+A scanned PDF has no text layer. Connectors cannot index it. The run reports it as "No text extracted". Configure Document OCR to transcribe these pages with a vision model during sync. The transcribed text becomes searchable like other documents.
 
-- **Key** — an API key on a provider that accepts PDF input: Anthropic, OpenAI, Gemini, Bedrock, Azure, OpenRouter, or vLLM.
-- **Model** — a vision-capable model from that provider. Self-hosted models (a vLLM server, for example) sync without modality metadata: mark the model's image or PDF input modality in **LLM Providers > Models** to make it selectable. **Test connection** sends a synthetic PDF page to verify the pair works.
+- **Key** — an API key for a provider that accepts PDF input: Anthropic, OpenAI, Gemini, Bedrock, Azure, OpenRouter, or vLLM.
+- **Model** — a vision-capable model from that provider. Self-hosted models, such as a vLLM server, sync without modality metadata. Mark the model image or PDF input modality in **LLM Providers > Models** to select it. **Test connection** sends a synthetic PDF page to verify the pair.
 
-OCR runs only on pages that yielded no text. A mixed document — a contract with a scanned signature page, for example — keeps its digital text and gets the scanned pages transcribed. Each transcribed page is one metered model call, recorded in [LLM cost statistics](/docs/platform-llm-proxy) under "Knowledge - OCR". A single document is capped at `ARCHESTRA_KNOWLEDGE_BASE_OCR_MAX_PAGES_PER_DOCUMENT` pages (default 100); pages past the cap stay untranscribed and the run says so.
+OCR runs only on pages that yield no text. A mixed document keeps its digital text. For example, OCR transcribes the scanned signature page in a contract. Each transcribed page uses one metered model call. [LLM cost statistics](/docs/platform-llm-proxy) records it as "Knowledge - OCR". One document is limited to `ARCHESTRA_KNOWLEDGE_BASE_OCR_MAX_PAGES_PER_DOCUMENT` pages. The default is 100. Pages after the limit remain untranscribed. The run reports them.
 
-Saving the configuration for the first time resets every connector's sync checkpoint. The next sync re-reads all sources, so documents previously skipped as unreadable are picked up. A run also carries an overall transcription budget: a document whose pages did not fit is indexed with a warning naming what was left out, and its untranscribed pages are only revisited when the source modifies the document or after another full re-sync.
+The first configuration save resets every connector sync checkpoint. The next sync reads all sources again. It can index documents that were previously unreadable. A run also has an overall transcription budget. Archestra indexes a document whose pages exceed that budget with a warning. The warning names omitted pages. It revisits untranscribed pages only after a source change or another full re-sync.
 
 ## Creating a Knowledge Base
 
-A Knowledge Base is a set of connectors. Create one from the **Knowledge** page and assign connectors to get data from. The same Knowledge Base can be reused across multiple agents and MCP Gateways.
+A Knowledge Base is a set of connectors. Create one on the **Knowledge** page. Assign connectors that supply its data. You can reuse one Knowledge Base with multiple agents and MCP Gateways.
 
 ## Knowledge Files
 
-Knowledge Files is a repository for documents you upload directly — a signed contract that arrived by email, for example. A connector pulls from a source system; here you bring the file yourself. Open **Knowledge > Files**.
+Knowledge Files stores documents that you upload directly. For example, upload a signed contract that arrived by email. A connector gets files from a source system. Knowledge Files lets you add the file. Open **Knowledge > Files**.
 
-Upload PDF, Word, Markdown, CSV, JSON, HTML or plain text. The text is read at upload, and a file that cannot be read is refused right there — so nothing lands in the repository that would retrieve nothing later. A scanned PDF is accepted when [Document OCR](#document-ocr) is configured; its pages are transcribed when the file is indexed.
+Upload PDF, Word, Markdown, CSV, JSON, HTML, or plain text files. Archestra reads text during upload. It rejects unreadable files. A configured [Document OCR](#document-ocr) accepts scanned PDFs. It transcribes their pages during indexing.
 
-Directories group documents and are flat — no sub-directories. Every document and directory has an audience: **Organization**, **Teams**, or **Only me**. Visibility follows the document into retrieval, so sharing a Knowledge Base with an agent does not widen who can read what is inside it.
+Directories group documents. They do not support sub-directories. Each document and directory has an audience: **Organization**, **Teams**, or **Only me**. Retrieval uses document visibility. Sharing a Knowledge Base with an agent does not expand document access.
 
-Uploading stores a document; indexing makes it retrievable. Select documents or whole directories, choose **Add to knowledge base**, and pick an existing base or create one from the selection.
+Uploading stores a document. Indexing makes it retrievable. Select documents or directories. Select **Add to knowledge base**. Select an existing base or create one from the selection.
 
-A file attached to a chat belongs to that conversation. To keep it, save it to the repository — from the attachment in the message, or from the Files panel, where you can select several at once. You choose the name, directory and visibility as you save, and can index it in one step.
+A chat attachment belongs to that conversation. Save it to the repository to keep it. Save it from the message attachment or the Files panel. The Files panel supports multiple selections. Select the name, directory, and visibility when you save it. You can index it in the same step.
 
 ### Chat, Project, and Knowledge Files
 
-Files live in three places, and each answers a different need.
+Files can exist in three locations. Each location supports a different need.
 
 |                   | Chat attachments | Project files | Knowledge Files |
 | ----------------- | ---------------- | ------------- | --------------- |
@@ -260,39 +260,39 @@ Files live in three places, and each answers a different need.
 | How agents use them | Sent to the model with your message | Read on demand by any chat in the project | Retrieved from a Knowledge Base, with citations |
 | Use them for      | A one-off question about a file | Working files for one piece of work | Reference documents agents should answer from |
 
-A file can move up this ladder: save a chat attachment to the repository, then index it into a Knowledge Base.
+You can save a chat attachment to the repository. You can then index it in a Knowledge Base.
 
 ### Use Case: Vendor Security Reviews
 
-A security analyst reviews vendor documents that arrive by email.
+A security analyst reviews vendor documents received by email.
 
-1. Upload the questionnaires and SOC 2 reports into a **Vendor contracts** directory, scoped to the security team.
-2. Select the directory and add it to a **Vendor security review** Knowledge Base.
-3. Assign that base to the review agent.
-4. Ask the agent which vendors store customer data outside the EU. Every answer cites the document it came from.
+1. Upload questionnaires and SOC 2 reports to the **Vendor contracts** directory. Set the audience to the security team.
+2. Select the directory. Add it to the **Vendor security review** Knowledge Base.
+3. Assign the base to the review agent.
+4. Ask which vendors store customer data outside the EU. Each answer cites its source document.
 
 ## Assigning to an Agent
 
-An agent — or an [MCP Gateway](/docs/platform-mcp-gateway) — reaches knowledge through the **Tools & Knowledge Sources** setting in its dialog, which has two modes:
+An agent or [MCP Gateway](/docs/platform-mcp-gateway) accesses knowledge through **Tools & Knowledge Sources**. This dialog has two modes:
 
-- **Auto** — the agent can search every Knowledge Base and connector the chatting user can access, within the agent's environment. Nothing is assigned; the reachable set follows each user's own visibility.
-- **Custom** — the agent searches only the Knowledge Bases and connectors you assign to it. Pick them under **Knowledge sources**; the picker stays disabled until an embedding model is set (see [Configuration](#configuration)).
+- **Auto** — the agent can search every Knowledge Base and connector the chatting user can access within the agent's environment. You do not assign sources. The reachable sources follow user visibility.
+- **Custom** — the agent searches only Knowledge Bases and connectors that you assign. Select them under **Knowledge sources**. The selector stays disabled until you set an embedding model. See [Configuration](#configuration).
 
-Either mode is still filtered by the chatting user's own visibility, so an agent never surfaces a source the user could not read themselves. Once the agent has at least one reachable source, it gains a `query_knowledge_sources` tool that searches across them and returns the most relevant documents.
+Both modes use the chatting user visibility. An agent cannot show a source that the user cannot read. An agent with at least one reachable source gets the `query_knowledge_sources` tool. This tool searches those sources and returns the most relevant documents.
 
-The output of `query_knowledge_sources` is treated as sensitive by default, which can impact the ability to use subsequent tools. See [Archestra MCP Server](/docs/platform-archestra-mcp-server#auth), and [AI Tool Guardrails](/docs/platform-ai-tool-guardrails), for more details.
+Archestra treats `query_knowledge_sources` output as sensitive by default. This can affect use of later tools. See [Archestra MCP Server](/docs/platform-archestra-mcp-server#auth) and [AI Tool Guardrails](/docs/platform-ai-tool-guardrails).
 
 ![Assigning Knowledge Bases and connectors to an agent in Custom mode](/docs/automated_screenshots/platform-knowledge-bases_assign-to-agent.webp)
 
-Connectors pull data from external tools into Knowledge Bases. A connector can be assigned to multiple Knowledge Bases.
+Connectors get external-tool data into Knowledge Bases. You can assign one connector to multiple Knowledge Bases.
 
 ## Narrowing a Search
 
-A search covers every document in the sources an agent can reach. Some questions only concern a slice of that — the docs for the current release, for example.
+A search covers every document in sources an agent can access. Some questions concern only a subset. For example, use the documents for the current release.
 
-`query_knowledge_sources` takes an optional `documentFilter` for this. It matches documents on the metadata their connector supplied, such as `spaceKey`, `labels`, `repo`, or `state`.
+`query_knowledge_sources` accepts an optional `documentFilter`. It matches documents using connector metadata, such as `spaceKey`, `labels`, `repo`, or `state`.
 
-Keys are combined with AND. Several values for one key are combined with OR.
+The filter combines keys with AND. It combines multiple values for one key with OR.
 
 ```json
 {
@@ -301,25 +301,25 @@ Keys are combined with AND. Several values for one key are combined with OR.
 }
 ```
 
-That searches only pages in the DEV space labelled `release-2.0`. One agent can answer for the current release and another for the archive, from the same connector.
+This searches only DEV space pages with the `release-2.0` label. One agent can answer for the current release. Another can answer for the archive. Both can use the same connector.
 
-A filter reads single values and lists the same way. Confluence stores one `spaceKey` per page and many `labels`, and the syntax above matches both.
+A filter handles single values and lists the same way. Confluence stores one `spaceKey` per page and many `labels`. The example syntax matches both.
 
-Filtering never widens access. [Visibility](#visibility) is applied separately, so a filter only ever removes documents from what you could already read.
+Filtering does not expand access. [Visibility](#visibility) applies separately. A filter only removes documents you could otherwise read.
 
-If a filter matches nothing, the reply names the values that do exist for the keys you used. The agent retries with a real one instead of reporting that it found nothing.
+If a filter matches nothing, the reply lists existing values for the keys. The agent retries with an existing value. It does not report an empty result immediately.
 
-Tell the agent which slice to search in your instructions or your question. It filters when a request names a subset, not when it guesses one from the topic.
+Name the required subset in your instructions or question. The agent filters only when the request names a subset. It does not infer one from the topic.
 
 ## Sync Runs
 
-Open a connector to review its document sync runs and progress. You can cancel a running document sync from its **Actions** column. Cancellation stops new source batches and keeps documents already ingested by the run. A later sync continues from the saved connector checkpoint.
+Open a connector to review document sync runs and progress. You can cancel a running document sync from its **Actions** column. Cancellation stops new source batches. It keeps documents already ingested by the run. A later sync continues from the saved connector checkpoint.
 
-Open a run's details to review warnings and connector errors. The logs name documents whose content exceeded an indexing limit. Unsupported file types are counted as skipped. A document that produces no chunks finishes with an error.
+Open run details to review warnings and connector errors. Logs name documents whose content exceeded an indexing limit. The run counts unsupported file types as skipped. A document that produces no chunks ends with an error.
 
 ## Visibility
 
-Each connector has a visibility setting that determines which users can retrieve its data when an agent calls `query_knowledge_sources`. Connectors and Knowledge Bases are filtered by visibility throughout the UI: users only see sources they have access to, and only those can be assigned to agents and MCP Gateways.
+Each connector has a visibility setting. It determines which users can retrieve data through `query_knowledge_sources`. The UI filters connectors and Knowledge Bases by visibility. Users see only accessible sources. They can assign only accessible sources to agents and MCP Gateways.
 
 | Mode                      | Behavior                                                                          |
 | ------------------------- | --------------------------------------------------------------------------------- |
@@ -327,9 +327,9 @@ Each connector has a visibility setting that determines which users can retrieve
 | **Team-scoped**           | Documents accessible only to members of the assigned teams.                       |
 | **Auto-sync permissions** | Per-document ACLs synced from the source system, so each user sees only what they can see upstream. See [Auto-Sync Permissions](#auto-sync-permissions). |
 
-Users with `knowledgeSource:admin` bypass document ACLs while querying. This permission does not grant access to manage auto-sync connectors.
+Users with `knowledgeSource:admin` bypass document ACLs during queries. This permission does not allow auto-sync connector management.
 
-Auto-sync connectors use dedicated `knowledgeSourceAutoSync` permissions for read, create, update, and delete actions. Admin and Platform Admin roles receive all four actions by default. Grant them to other users through a [custom role](/docs/platform-access-control). Users without these management actions can still query documents allowed by the synced ACLs.
+Auto-sync connectors use `knowledgeSourceAutoSync` permissions for read, create, update, and delete actions. Admin and Platform Admin roles receive all four actions by default. Grant them to other users with a [custom role](/docs/platform-access-control). Users without management actions can still query documents allowed by synced ACLs.
 
 > **Enterprise feature** (team-scoped visibility and auto-synced ACLs) — see the [Pricing Model](/docs/platform-pricing-model).
 
@@ -337,11 +337,11 @@ Auto-sync connectors use dedicated `knowledgeSourceAutoSync` permissions for rea
 
 > **Beta feature** — off by default. Set `ARCHESTRA_KNOWLEDGE_BASE_AUTO_SYNC_PERMISSIONS_ENABLED=true` (or the `ARCHESTRA_BETA` master switch) to show the visibility option and its Users and Groups tabs. See [Deployment](/docs/platform-deployment).
 
-Auto-sync permissions mirrors the source system's access control into Archestra. Each query returns only documents allowed by the latest permission snapshot. Users with `knowledgeSource:admin` bypass this filter.
+Auto-sync permissions mirrors source-system access control in Archestra. Each query returns only documents allowed by the latest permission snapshot. Users with `knowledgeSource:admin` bypass this filter.
 
-The option appears when the beta flag and Knowledge enterprise feature are enabled. It also requires a supported connector and the applicable `knowledgeSourceAutoSync:create` or `update` action.
+The option appears when the beta flag and Knowledge enterprise feature are enabled. It also requires a supported connector. You need `knowledgeSourceAutoSync:create` or `update`.
 
-Auto-sync permissions works with the connectors marked *Supported* below. *Limited* means the source's access control is mirrored with a coarser audience model — the row says which. The others do not support it yet.
+Auto-sync permissions works with connectors marked *Supported* below. *Limited* means Archestra mirrors source access with a coarser audience model. The table states that model. Other connectors do not yet support it.
 
 | Connector    | Auto-sync permissions                                                                                     |
 | ------------ | --------------------------------------------------------------------------------------------------------- |
@@ -351,7 +351,7 @@ Auto-sync permissions works with the connectors marked *Supported* below. *Limit
 | GitHub       | Supported ([setup](#github-auto-sync-permissions))                                                        |
 | GitLab       | Supported ([setup](#gitlab-auto-sync-permissions))                                                        |
 | Google Drive | Limited by authentication mode ([details](#google-drive-auto-sync-permissions))                            |
-| Jira         | Jira Cloud only; issue security unsupported ([details](#jira-auto-sync-permissions))                      |
+| Jira         | Jira Cloud only. Issue security is unsupported ([details](#jira-auto-sync-permissions))                    |
 | Linear       | Supported ([setup](#linear-auto-sync-permissions))                                                        |
 | M-Files      | Supported with the VAF Add On ([setup](#m-files-auto-sync-permissions))                                   |
 | Notion       | Limited: every synced page is visible to all workspace members ([details](#notion-auto-sync-permissions)) |
@@ -365,41 +365,41 @@ Auto-sync permissions works with the connectors marked *Supported* below. *Limit
 
 #### Credentials and Email Resolution
 
-Permission sync uses the connector's upstream identity. That identity must read both content and its permission settings. Unreadable permission data fails closed, so the affected documents grant no access.
+Permission sync uses the connector's upstream identity. That identity must read content and permission settings. Unreadable permission data fails closed. Affected documents grant no access.
 
-External accounts match Archestra users by email. A hidden or empty email leaves that account unassigned and removes it from resolved audiences. Accounts listed under **Users** can be assigned manually. An empty group roster must be fixed upstream because manual assignment cannot add members to it.
+Archestra matches external accounts to users by email. A hidden or empty email leaves an account unassigned. It removes that account from resolved audiences. You can manually assign accounts listed under **Users**. Fix an empty group roster in the source system. Manual assignment cannot add group members.
 
-Each connector section lists its credential type, required scopes, and upstream setup. Use a dedicated identity whose visibility covers every configured source. **Test connection** validates authentication, but a successful test cannot prove access to every project or permission table.
+Each connector section lists credential type, required scopes, and source-system setup. Use a dedicated identity that can access every configured source. **Test connection** validates authentication. It cannot prove access to every project or permission table.
 
-**Editing a connector.** Saving new settings or credentials stops the permission sync running against the old ones — that run ends as **Superseded**. A replacement run starts straight away, so you don't wait for the next scheduled one.
+**Editing a connector.** Saving settings or credentials stops the old permission sync. That run ends as **Superseded**. A replacement run starts immediately. You do not wait for the next scheduled run.
 
 #### Atlassian Organization Admin API Key
 
-An organization admin API key reads managed accounts' emails through the Atlassian admin APIs. Add it to a Jira or Confluence Cloud connector. Permission sync can then resolve managed users whose profile email is private.
+An organization admin API key reads managed account emails through Atlassian admin APIs. Add it to a Jira or Confluence Cloud connector. Permission sync can resolve managed users with private profile emails.
 
 Create the key in [Atlassian administration](https://admin.atlassian.com) under **Settings → API keys**:
 
-1. Select **Create API key** and name it.
-2. Leave the key **without scopes**. Permission sync calls the classic admin APIs, which scopes do not cover.
-3. Copy the key into the connector's **Organization admin API key** field.
+1. Select **Create API key**. Enter a name.
+2. Leave the key **without scopes**. Permission sync uses classic admin APIs. Scopes do not cover these APIs.
+3. Copy the key to the connector **Organization admin API key** field.
 
-The API token stays required. Atlassian does not accept admin API keys on the Jira and Confluence APIs.
+The API token is still required. Atlassian does not accept admin API keys for Jira and Confluence APIs.
 
-Changing **Cloud Instance** on an existing Jira or Confluence connector changes its authentication method, so re-enter the token or password. Switching to Cloud also requires the Atlassian account email. Switching away from Cloud removes the stored organization admin key. For Server or Data Center, leave **Username** empty while entering a new personal access token to select PAT authentication; re-enter the username when changing a Basic-auth password.
+Changing **Cloud Instance** on an existing Jira or Confluence connector changes authentication. Enter the token or password again. Switching to Cloud also requires the Atlassian account email. Switching from Cloud removes the stored organization admin key. For Server or Data Center, leave **Username** empty when entering a personal access token. This selects PAT authentication. Enter the username again when changing a Basic-auth password.
 
 ## Deleting and Restoring Knowledge Bases and Connectors
 
-Deleting a knowledge base or connector moves it to a trash — the record is hidden but kept. Deleting a knowledge base leaves its connectors alone: they are unlinked from it, but they are not deleted and keep syncing. Deleting a connector does stop its syncs, and destroys its stored credential.
+Deleting a knowledge base or connector moves it to trash. The record is hidden but retained. Deleting a knowledge base unlinks its connectors. It does not delete them. They continue syncing. Deleting a connector stops its syncs. It destroys the stored credential.
 
-Anyone with `knowledgeSource:delete` switches the status filter to **Deleted** to open the trash. **Restore** returns the entry to active. A restored knowledge base is immediately live for its previously-assigned agents. A restored connector comes back disabled — re-authenticate it, then enable it to resume syncing.
+Users with `knowledgeSource:delete` select **Deleted** in the status filter to open trash. **Restore** returns the entry to active. A restored knowledge base immediately works for previously assigned agents. A restored connector is disabled. Authenticate it again. Then enable it to resume syncs.
 
-Global admins can also delete an entry from the trash for good, with **Delete permanently**. For a knowledge base this destroys the record and its agent and connector assignments; its connectors survive. For a connector it destroys every document it has indexed, along with its run history and access mappings. Nothing brings either back.
+Global admins can select **Delete permanently** in trash. This permanently deletes the entry. For a knowledge base, this deletes the record and agent and connector assignments. Its connectors remain. For a connector, this deletes indexed documents, run history, and access mappings. You cannot restore either type.
 
 ## Supported Connectors
 
-Archestra ships with these built-in connector types. Go to **Settings → Knowledge → Available connectors** to remove any your organization does not allow. A connector type you remove disappears from the pickers, and the API refuses to configure it. Connectors that already exist keep syncing until you delete them.
+Archestra includes these connector types. Go to **Settings → Knowledge → Available connectors** to remove types your organization does not allow. A removed type disappears from selectors. The API refuses its configuration. Existing connectors continue syncing until you delete them.
 
-A sync that indexes nothing, on a connector that holds nothing, finishes as **No documents** rather than a success. The run names the likely cause -- content that was never shared with the credential, a folder that identity cannot see, or a file-type filter that excludes everything. A later sync that finds no changes is an ordinary success.
+A sync that indexes nothing from an empty connector ends as **No documents**, not as success. The run names the likely cause. Causes include content not shared with the credential, an inaccessible folder, or a file-type filter that excludes all content. A later sync with no changes ends as a normal success.
 
 ### Jira
 
@@ -407,7 +407,7 @@ Sync issues and discussions from Atlassian Jira.
 
 **Indexed:** issue descriptions, comments, and metadata from Jira Cloud or Server.
 
-**Authentication:** Jira Cloud uses an Atlassian account email and API token. Jira Server and Data Center use a personal access token with the Username field empty. On releases without personal access tokens, enter the account username and password for Basic authentication.
+**Authentication:** Jira Cloud uses an Atlassian account email and API token. Jira Server and Data Center use a personal access token with an empty Username field. On releases without personal access tokens, enter the account username and password for Basic authentication.
 
 | Field                   | Description                                                        |
 | ----------------------- | ------------------------------------------------------------------ |
@@ -422,16 +422,16 @@ Sync issues and discussions from Atlassian Jira.
 
 For Jira Cloud, use a dedicated Jira administrator:
 
-1. Create an API token from [Atlassian account security](https://id.atlassian.com/manage-profile/security/api-tokens). Choose an unscoped token for the connector's site URL.
-2. Grant the account **Administer Jira** and **Browse users and groups** global permissions.
-3. Grant **Browse Projects** on every synced project. Add the account to every issue-security level whose issues it must index.
+1. Create an API token in [Atlassian account security](https://id.atlassian.com/manage-profile/security/api-tokens). Select an unscoped token for the connector site URL.
+2. Grant **Administer Jira** and **Browse users and groups** global permissions to the account.
+3. Grant **Browse Projects** for each synced project. Add the account to every required issue-security level.
 4. Create a separate [organization admin API key](#atlassian-organization-admin-api-key) to resolve private managed-account emails.
 
-The product API token reads Jira data. The organization key reads managed-account profiles only. External accounts still need public profile emails or [manual assignment](#credentials-and-email-resolution).
+The product API token reads Jira data. The organization key reads only managed-account profiles. External accounts still need public profile emails or [manual assignment](#credentials-and-email-resolution).
 
-Jira Server and Data Center content sync remains supported, but auto-sync permissions is not. Its permission APIs differ from Jira Cloud, and Jira exposes no equivalent REST API for issue-security membership. Personal access tokens require Jira Core or Software 8.14+, or Jira Service Management 4.15+. On older releases, enter the username in **Username** and the password in **API Token / Personal Access Token** to use Basic authentication.
+Jira Server and Data Center content sync remains supported. Auto-sync permissions does not. Its permission APIs differ from Jira Cloud. Jira has no equivalent REST API for issue-security membership. Personal access tokens require Jira Core or Software 8.14+, or Jira Service Management 4.15+. On older releases, enter the username in **Username**. Enter the password in **API Token / Personal Access Token**. This uses Basic authentication.
 
-Do not enable auto-sync permissions for Jira Cloud projects that use issue security. Jira requires both **Browse Projects** and issue-security membership, but the connector cannot currently enforce that intersection. Browse Projects grants through Project Lead or user/group custom fields, and dynamic issue-security holders such as Reporter and Assignee, are also unsupported.
+Do not enable auto-sync permissions for Jira Cloud projects that use issue security. Jira requires **Browse Projects** and issue-security membership. The connector cannot enforce both requirements together. It also does not support Browse Projects through Project Lead or user/group custom fields. It does not support dynamic issue-security holders such as Reporter and Assignee.
 
 ### Confluence
 
@@ -439,7 +439,7 @@ Sync wiki pages from Atlassian Confluence.
 
 **Indexed:** pages from Confluence Cloud or Server.
 
-**Authentication:** Confluence Cloud uses an Atlassian account email and API token. Confluence Server and Data Center 7.9+ use a personal access token with the Username field empty. On older releases, enter the account username and password for Basic authentication.
+**Authentication:** Confluence Cloud uses an Atlassian account email and API token. Confluence Server and Data Center 7.9+ use a personal access token with an empty Username field. On older releases, enter the account username and password for Basic authentication.
 
 | Field          | Description                                                                   |
 | -------------- | ----------------------------------------------------------------------------- |
@@ -455,15 +455,15 @@ Sync wiki pages from Atlassian Confluence.
 
 For Confluence Cloud, use a dedicated account with product access:
 
-1. Create an unscoped API token from [Atlassian account security](https://id.atlassian.com/manage-profile/security/api-tokens).
-2. Enter the site root, such as `https://example.atlassian.net`, without `/wiki`.
-3. Grant **View** on every synced space. Add the account to every page and ancestor restriction it must index.
-4. Grant **Confluence Administrator** when audit-based incremental permission reads are required.
+1. Create an unscoped API token in [Atlassian account security](https://id.atlassian.com/manage-profile/security/api-tokens).
+2. Enter the site root without `/wiki`, such as `https://example.atlassian.net`.
+3. Grant **View** for each synced space. Add the account to required page and ancestor restrictions.
+4. Grant **Confluence Administrator** if you require audit-based incremental permission reads.
 5. Create a separate [organization admin API key](#atlassian-organization-admin-api-key) to resolve private managed-account emails.
 
-A Cloud administrator does not automatically bypass page restrictions through the API. Unreadable pages never enter the index.
+A Cloud administrator does not automatically bypass page restrictions through the API. Unreadable pages do not enter the index.
 
-For Confluence Server or Data Center 7.9+, create a token under **Profile > Personal access tokens** and leave **Username** empty. On older releases, enter the username in **Username** and the password in **API Token / Personal Access Token**. Membership in the `confluence-administrators` group provides the broadest space and restricted-page visibility.
+For Confluence Server or Data Center 7.9+, create a token under **Profile > Personal access tokens**. Leave **Username** empty. On older releases, enter the username in **Username**. Enter the password in **API Token / Personal Access Token**. The `confluence-administrators` group has the broadest space and restricted-page visibility.
 
 ### GitHub
 
@@ -471,7 +471,7 @@ Sync issues, pull request discussions, and repository files from GitHub.
 
 **Indexed:** issues, pull requests, comments, and selected text files from GitHub.com or GitHub Enterprise Server. Repository file indexing defaults to Markdown and YAML files.
 
-**Authentication:** a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) or a GitHub App. GitHub App credentials (App ID, installation ID, and private key) are stored once as an organization-level configuration under **Settings -> GitHub**; the connector references a saved configuration instead of holding its own credentials, so one App can back many connectors and skill imports.
+**Authentication:** a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) or a GitHub App. Archestra stores GitHub App credentials once as an organization-level configuration under **Settings -> GitHub**. These credentials include App ID, installation ID, and private key. The connector references the saved configuration. It does not store its own credentials. One App can support many connectors and skill imports.
 
 | Field                 | Description                                                                                     |
 | --------------------- | ----------------------------------------------------------------------------------------------- |
@@ -489,7 +489,7 @@ Sync issues, pull request discussions, and repository files from GitHub.
 
 #### GitHub Auto-Sync Permissions
 
-A GitHub App is the preferred credential. Create one under **Settings > Developer settings > GitHub Apps** with these read-only permissions:
+A GitHub App is the preferred credential. Create one under **Settings > Developer settings > GitHub Apps**. Grant these read-only permissions:
 
 | Permission type | Read permission |
 | --- | --- |
@@ -497,17 +497,17 @@ A GitHub App is the preferred credential. Create one under **Settings > Develope
 | Repository, when files are indexed | Contents |
 | Organization | Members |
 
-Install the App on every target repository. Generate a private key and copy its PEM value. Save the App ID, installation ID, API URL, and private key under **Settings > GitHub**, then select that configuration in the connector.
+Install the App on each target repository. Generate a private key. Copy its PEM value. Save the App ID, installation ID, API URL, and private key under **Settings > GitHub**. Select this configuration in the connector.
 
-A fine-grained personal access token needs the same repository and organization permissions. Select every target repository. Its owner also needs write, maintain, or admin access to list collaborators. A classic token needs `repo` and `read:org`; authorize it for SAML SSO when the organization requires SSO.
+A fine-grained personal access token needs the same repository and organization permissions. Select each target repository. The token owner needs write, maintain, or admin access to list collaborators. A classic token needs `repo` and `read:org`. Authorize it for SAML SSO if the organization requires SSO.
 
-GitHub exposes only each user's public profile email. No App or token permission reveals a private email, so those users need [manual assignment](#credentials-and-email-resolution).
+GitHub exposes only public profile emails. No App or token permission reveals a private email. These users need [manual assignment](#credentials-and-email-resolution).
 
 ### GitLab
 
 Sync issues and merge request discussions from GitLab.
 
-**Indexed:** issues, merge requests, their comments, and (optionally) Markdown files from GitLab.com or self-hosted GitLab instances. System-generated notes (assignment changes, label updates, etc.) are filtered out.
+**Indexed:** issues, merge requests, comments, and optional Markdown files from GitLab.com or self-hosted GitLab. Archestra filters system-generated notes such as assignment changes and label updates.
 
 **Authentication:** a [personal access token](https://docs.gitlab.com/user/profile/personal_access_tokens/).
 
@@ -523,17 +523,17 @@ Sync issues and merge request discussions from GitLab.
 
 #### GitLab Auto-Sync Permissions
 
-Create a personal access token under **Edit profile > Access > Personal access tokens**. Grant only the `read_api` scope and set an expiry. The token's user needs **Reporter** or higher on every private project. Use an **Owner** of the configured top-level group for broad project discovery.
+Create a personal access token under **Edit profile > Access > Personal access tokens**. Grant only `read_api`. Set an expiry. The token user needs **Reporter** or higher for each private project. Use an **Owner** of the configured top-level group for broad project discovery.
 
-A regular token receives only `public_email`. On self-managed GitLab, an instance administrator token can read private email. Add `admin_mode` when Admin Mode is enabled. GitLab.com users without public email need [manual assignment](#credentials-and-email-resolution).
+A regular token receives only `public_email`. In self-managed GitLab, an instance administrator token can read private email. Add `admin_mode` when Admin Mode is enabled. GitLab.com users without public email need [manual assignment](#credentials-and-email-resolution).
 
-Each project is one permission scope. Its audience is the project's members with the **Reporter** role or higher — direct members, members inherited from ancestor groups, and members of invited groups, each at their effective access level. Guests are excluded: GitLab does not let them read code or confidential issues, so including them would over-share. **Public** and **internal** projects are readable by everyone in your Archestra organization.
+Each project is one permission scope. Its audience includes project members with **Reporter** or higher. This includes direct members, ancestor-group members, and invited-group members at their effective access level. Guests are excluded. GitLab does not allow them to read code or confidential issues. **Public** and **internal** projects are readable by all users in your Archestra organization.
 
-Each sync snapshots one member roster per project, shown in the connector's **Users** and **Groups** tabs as `<project path> members`. A member whose email is hidden upstream stays unresolvable — assign them to an Archestra user from the Users tab, or ask them to set a public email on their GitLab profile.
+Each sync saves one member roster per project. The connector **Users** and **Groups** tabs show it as `<project path> members`. A member with a hidden source email remains unresolved. Assign them to an Archestra user in the Users tab. You can also ask them to set a public GitLab profile email.
 
 ### Asana
 
-Sync tasks and discussions from Asana projects.
+Sync project tasks and discussions from Asana.
 
 **Indexed:** tasks and their user comments from selected Asana projects.
 
@@ -549,25 +549,25 @@ Sync tasks and discussions from Asana projects.
 
 Create a token in the [Asana Developer Console](https://app.asana.com/0/my-apps). Personal access tokens have no selectable scopes and inherit the user's visibility. Add that user to every private project and team the connector syncs.
 
-Asana Enterprise organizations can use a service account instead. A super admin creates it under **Admin console > Apps > Service accounts**. Grant **Full Permissions**, because standard task and membership APIs require that level.
+Asana Enterprise organizations can use a service account. A super admin creates it under **Admin console > Apps > Service accounts**. Grant **Full Permissions**. Standard task and membership APIs require this level.
 
-Both credentials expose workspace-member emails. A missing email still needs [manual assignment](#credentials-and-email-resolution).
+Both credentials expose workspace member emails. A missing email still needs [manual assignment](#credentials-and-email-resolution).
 
-Each project is one permission scope. A project shared with the whole workspace grants every workspace member — guests excluded. Any other project grants its explicit members: users directly, teams through their team rosters. A task in several projects is readable through any of them; its scope is the union of those audiences. Task collaborators are granted individually on their tasks.
+Each project is one permission scope. A workspace-wide project grants all workspace members except guests. Other projects grant explicit members. This includes direct users and teams through team rosters. A task in several projects is readable through any project. Its scope combines these audiences. Task collaborators receive direct task grants.
 
-Each permission sync also snapshots workspace members and team rosters — the connector's **Users** and **Groups** tabs show every member with their assignment status, and an account whose email is hidden upstream can be assigned manually from the Users tab. Users added to a project directly — guests included — appear there too, under the synthetic **Direct project members** group. Limited-access team members get only the projects they are explicitly added to. Guests get only explicit project and task grants.
+Each permission sync saves workspace-member and team rosters. The connector **Users** and **Groups** tabs show each member and assignment status. You can manually assign an account with a hidden source email in the Users tab. Direct project users, including guests, appear under **Direct project members**. Limited-access team members receive only explicitly assigned projects. Guests receive only explicit project and task grants.
 
-Permission reads run as the token's user. A project or roster the token cannot read stays fail-closed — use a token from a user who can see every synced project. A task removed from every synced project is hidden until a sync sees it again.
+Permission reads use the token user. A project or roster that the token cannot read fails closed. Use a token for a user who can read every synced project. A task removed from every synced project remains hidden until a sync finds it again.
 
 ### ServiceNow
 
 Sync ITSM records from a ServiceNow instance.
 
-**Indexed:** incidents, change requests, change tasks, problems, business applications, and published knowledge articles. Incidents are enabled by default; the rest are opt-in.
+**Indexed:** incidents, change requests, change tasks, problems, business applications, and published knowledge articles. Incidents are enabled by default. Select the other entities to include them.
 
-**Authentication:** the connector form uses basic auth. Create a dedicated user under **User Administration > Users**, enable **Web service access only**, and set a password. API-created connectors can instead leave Email empty and store a pre-issued OAuth bearer token in the API Token field; the connector does not refresh that token.
+**Authentication:** the connector form uses basic authentication. Create a dedicated user under **User Administration > Users**. Enable **Web service access only**. Set a password. API-created connectors can leave Email empty. Store a pre-issued OAuth bearer token in the API Token field. The connector does not refresh this token.
 
-**Required roles.** Use a dedicated service account ("Web service access only" is fine). The account needs roles that can read every synced table:
+**Required roles.** Use a dedicated service account. **Web service access only** is acceptable. The account needs roles that can read each synced table:
 
 | Role | Grants read on |
 | --- | --- |
@@ -575,15 +575,15 @@ Sync ITSM records from a ServiceNow instance.
 | `knowledge` | Knowledge articles |
 | `user_criteria_admin`, `user_admin` | User criteria definitions and the user, group, and role tables auto-sync reads |
 
-The Can Read / Cannot Read criteria mappings (`kb_uc_can_read_mtom`, `kb_uc_cannot_read_mtom`) have no role-based read access out of the box — built-in roles such as `knowledge_admin` do not open them. Auto-sync permissions needs explicit access control lists (ACLs) on both tables.
+The Can Read / Cannot Read criteria mappings (`kb_uc_can_read_mtom`, `kb_uc_cannot_read_mtom`) have no default role-based read access. Built-in roles such as `knowledge_admin` do not grant this access. Auto-sync permissions requires explicit access control lists (ACLs) on both tables.
 
-Creating ACLs requires the `security_admin` role. ServiceNow grants it by elevation for the current session, and hides the **New** button on the ACL list until you elevate: open the profile menu, select **Elevate role**, and check **security_admin**. Then:
+Creating ACLs requires the `security_admin` role. ServiceNow grants it by elevation for the current session. It hides the ACL-list **New** button until you elevate. Open the profile menu. Select **Elevate role**. Select **security_admin**. Then complete these steps:
 
-1. Go to **System Security → Access Control (ACL)** and select **New**. Set Type `record`, Operation `read`, and Name `kb_uc_can_read_mtom` with the field left as `--None--`. Under **Requires role**, add a role the service account holds. Submit.
-2. Create a second ACL for the same table with the field set to `*`, which grants read on its fields.
+1. Go to **System Security → Access Control (ACL)**. Select **New**. Set Type to `record`. Set Operation to `read`. Set Name to `kb_uc_can_read_mtom`. Leave the field as `--None--`. Under **Requires role**, add a service-account role. Submit.
+2. Create another ACL for this table. Set its field to `*`. This grants read access to the fields.
 3. Repeat both ACLs for `kb_uc_cannot_read_mtom`.
 
-An account without the right roles fails in one of two ways, depending on the instance's ACLs: the sync errors with HTTP 403 "Insufficient rights to query records", or ServiceNow silently filters the rows and the sync succeeds with nothing ingested. Test the account directly before connecting: `curl -u '<user>:<password>' 'https://<instance>.service-now.com/api/now/table/incident?sysparm_limit=1'` should return a record, not an error and not an empty result.
+An account without required roles can fail in two ways. The result depends on instance ACLs. The sync can return HTTP 403 "Insufficient rights to query records". ServiceNow can also filter rows silently. The sync then succeeds with no ingested content. Test the account before connecting. `curl -u '<user>:<password>' 'https://<instance>.service-now.com/api/now/table/incident?sysparm_limit=1'` must return a record. It must not return an error or empty result.
 
 | Field                         | Description                                                                                                                   |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
@@ -601,9 +601,9 @@ An account without the right roles fails in one of two ways, depending on the in
 
 #### ServiceNow Auto-Sync Permissions
 
-ServiceNow decides record access with ACL rules, and those rules cannot be read through its REST API. For ITSM records and business applications, the connector grants each record to its participants instead: assignment group members plus the referenced users — the caller, the opener, and the assignee. Custom ACL conditions can make this audience differ from ServiceNow. To widen a table's audience, add role names under **Role audiences** (`itil`, for example) only when every holder can read every synced record in that table.
+ServiceNow uses ACL rules for record access. Its REST API cannot read these rules. For ITSM records and business applications, the connector instead grants each record to participants. Participants include assignment-group members, the caller, the opener, and the assignee. Custom ACL conditions can produce a different ServiceNow audience. To expand a table audience, add role names under **Role audiences**. For example, add `itil`. Do this only if every role holder can read every synced record in the table.
 
-Knowledge articles follow ServiceNow's own permission model: **Can Read** and **Cannot Read** user criteria at knowledge-base and article level. The connector expands each criteria to its users, groups, roles, companies, departments, and locations. Script-based (advanced) criteria cannot be evaluated over the API: on an allow path they grant nobody; on a deny path the affected knowledge base or article is hidden from everyone. A knowledge base without criteria follows the instance's `glide.knowman.block_access_with_no_user_criteria` property — open to your whole Archestra organization when `false`, hidden when `true` or unreadable.
+Knowledge articles use ServiceNow **Can Read** and **Cannot Read** criteria at knowledge-base and article level. The connector expands each criterion to users, groups, roles, companies, departments, and locations. The API cannot evaluate script-based advanced criteria. An allow path grants no users. A deny path hides the affected knowledge base or article from all users. A knowledge base without criteria follows `glide.knowman.block_access_with_no_user_criteria`. It is open to the whole Archestra organization when `false`. It is hidden when `true` or unreadable.
 
 **Required access.** The connector account needs read access to these tables:
 
@@ -614,11 +614,11 @@ Knowledge articles follow ServiceNow's own permission model: **Can Read** and **
 | `user_criteria`, `kb_uc_can_read_mtom`, `kb_uc_cannot_read_mtom`, `sys_properties` | Knowledge-article audiences |
 | `core_company`, `cmn_department`, `cmn_location` | Expanding criteria that reference them |
 
-The [Required roles](#servicenow) section above covers these, including the explicit ACLs the criteria mapping tables need.
+The [Required roles](#servicenow) section lists these roles. It includes required explicit ACLs for criteria mapping tables.
 
-**Misconfiguration behaves silently.** ServiceNow filters out rows an account cannot read instead of returning an error. An under-privileged account therefore looks like missing data: content sync ingests nothing from a table it cannot read, and a permission table it cannot read makes the affected audiences fail closed — the documents exist but nobody can retrieve them. Each permission sync run reports how many audiences it could not read, so check the run details when documents seem to be missing or hidden. Knowledge bases in the HR Service Delivery scope (`sn_hr_core`) additionally need the `sn_hr_core.content_reader` role; without it their criteria read as empty and the articles fail closed.
+**Misconfiguration behaves silently.** ServiceNow filters rows that an account cannot read. It does not return an error. An under-privileged account can look like missing data. Content sync ingests nothing from unreadable tables. An unreadable permission table makes affected audiences fail closed. The documents exist, but no user can retrieve them. Each permission sync run reports unreadable audience counts. Check run details when documents are missing or hidden. Knowledge bases in the HR Service Delivery scope (`sn_hr_core`) also need `sn_hr_core.content_reader`. Without it, criteria are empty and articles fail closed.
 
-Users granted directly on records appear in the connector's **Users** tab under the synthetic `direct-grants` group. A user whose `sys_user` email is empty stays unresolvable; assign such an account manually from the Users tab.
+Direct record grantees appear in the connector **Users** tab under `direct-grants`. A user with an empty `sys_user` email remains unresolved. Assign this account manually in the Users tab.
 
 ### Notion
 
@@ -626,7 +626,7 @@ Sync pages and databases from a Notion workspace.
 
 **Indexed:** pages from a Notion workspace.
 
-**Authentication:** an internal connection's installation access token. A Workspace Owner creates the connection in the [Notion Developer portal](https://app.notion.com/developers/connections) and copies the token from its **Configuration** tab.
+**Authentication:** an internal connection installation access token. A Workspace Owner creates the connection in the [Notion Developer portal](https://app.notion.com/developers/connections). Copy the token from its **Configuration** tab.
 
 | Field        | Description                                                                                        |
 | ------------ | -------------------------------------------------------------------------------------------------- |
@@ -638,32 +638,32 @@ Sync pages and databases from a Notion workspace.
 Create the credential in the [Notion Developer portal](https://app.notion.com/developers/connections):
 
 1. As a Workspace Owner, create an internal connection in the target workspace.
-2. Enable **Read content** and **User information with email addresses** capabilities.
-3. Copy the installation access token into **Integration Token**.
-4. Under **Content access**, connect every page or database root to sync. Access flows to child pages.
+2. Enable **Read content** and **User information with email addresses**.
+3. Copy the installation access token to **Integration Token**.
+4. Under **Content access**, connect each page or database root to sync. Child pages inherit access.
 
-Support is *Limited*. Notion's API does not say who can see a page — there is no sharing endpoint, and teamspaces are not exposed. Archestra cannot mirror per-page access, so every synced page shares one workspace-wide audience:
+Support is *Limited*. Notion API does not identify page viewers. It has no sharing endpoint. It does not expose teamspaces. Archestra cannot mirror per-page access. Each synced page uses one workspace-wide audience:
 
-- A synced page is visible to every workspace member whose Notion email matches an Archestra user's email.
-- Each permission sync refreshes the member roster from Notion's users API. The connector page shows a **Workspaces** tab in place of Groups, with one row per connector: the workspace, named as it is in Notion.
-- Guests are never in Notion's member listing, so a guest never gains access through Archestra.
-- Member emails need the integration capability **"read user information including email addresses"** (integration settings, **Capabilities** tab). A member without a readable email stays unresolvable (fail-closed) until you assign them from the Users tab.
+- A synced page is visible to each workspace member whose Notion email matches an Archestra user email.
+- Each permission sync updates the member roster from the Notion users API. The connector page shows a **Workspaces** tab instead of Groups. It has one connector row named for the Notion workspace.
+- Notion member listings exclude guests. Guests cannot gain access through Archestra.
+- Member emails require **"read user information including email addresses"** in integration settings under **Capabilities**. A member without a readable email remains unresolved and fails closed. Assign them from the Users tab.
 
-A page that is private or teamspace-restricted in Notion, but shared with the integration, becomes readable by every workspace member through Archestra. Set up the integration's access with that in mind:
+A Notion private or teamspace-restricted page shared with the integration becomes readable by every workspace member through Archestra. Configure integration access with this effect in mind:
 
-- Share only workspace-appropriate content with the integration — a company wiki teamspace, for example.
+- Share only workspace-appropriate content with the integration. For example, share a company wiki teamspace.
 - Do not share private pages or restricted teamspaces with the integration.
-- For content that must reach a narrower audience, use a separate connector with **Team-scoped** visibility.
+- Use a separate connector with **Team-scoped** visibility for a smaller audience.
 
-This is still stricter than an org-wide connector: access stops at the workspace member roster instead of your whole Archestra organization, and it updates as members join and leave.
+This is stricter than an org-wide connector. Access ends at the workspace-member roster, not the full Archestra organization. It updates when members join or leave.
 
 ### SharePoint
 
 Sync documents and site pages from SharePoint Online.
 
-**Indexed:** documents and site pages from SharePoint Online. Supported document types include `.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`, `.htm`, `.yaml`, `.log`, `.docx`, `.pdf`, and `.pptx`. When a multimodal embedding model is configured, image files (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`) up to 4 MB are also indexed.
+**Indexed:** SharePoint Online documents and site pages. Supported document types are `.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`, `.htm`, `.yaml`, `.log`, `.docx`, `.pdf`, and `.pptx`. A configured multimodal embedding model also indexes image files (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`) up to 4 MB.
 
-**Authentication:** an Azure AD app registration with client credentials (OAuth2). The app needs the `Sites.Read.All` application permission on Microsoft Graph, with admin consent granted.
+**Authentication:** an Azure AD app registration with OAuth2 client credentials. The app requires Microsoft Graph `Sites.Read.All` application permission. Grant admin consent.
 
 | Field         | Description                                                                                       |
 | ------------- | ------------------------------------------------------------------------------------------------- |
@@ -676,7 +676,7 @@ Sync documents and site pages from SharePoint Online.
 | Recursive     | Traverse subfolders within each drive or Folder Path (default: on)                                |
 | Include Pages | Toggle to sync site pages and their web part content (default: on)                                |
 
-Where to find each value:
+Find values here:
 
 - **Tenant ID** — **Microsoft Entra ID > App registrations > <your app> > Overview > Directory (tenant) ID**.
 - **Client ID** — Application (client) ID on the same page.
@@ -685,7 +685,7 @@ Where to find each value:
 
 #### SharePoint Auto-Sync Permissions
 
-Create one single-tenant application under **Microsoft Entra ID > App registrations**. Add a client secret under **Certificates & secrets**, then copy its **Value**. Under **API permissions**, add the application permissions below and select **Grant admin consent**:
+Create one single-tenant application under **Microsoft Entra ID > App registrations**. Add a client secret under **Certificates & secrets**. Copy its **Value**. Under **API permissions**, add these application permissions. Select **Grant admin consent**:
 
 | API | Application permission | Purpose |
 | --- | --- | --- |
@@ -694,13 +694,13 @@ Create one single-tenant application under **Microsoft Entra ID > App registrati
 | Microsoft Graph | `GroupMember.Read.All` | Microsoft 365 and Entra group rosters |
 | Microsoft Graph | `Sites.FullControl.All` | Sharing-aware delta permission scans |
 
-Each document library is one permission scope, and an item (file or folder) that breaks permission inheritance becomes its own scope — a document inherits its nearest such ancestor. Site pages follow the site's default library audience; per-page unique sharing is not modeled. Anonymous sharing links map to everyone in your Archestra organization; "people in your organization" links expand to the tenant's active users.
+Each document library is one permission scope. A file or folder that breaks permission inheritance becomes its own scope. A document inherits its nearest scope ancestor. Site pages use the site default library audience. Archestra does not model unique per-page sharing. Anonymous sharing links grant all users in your Archestra organization. "people in your organization" links grant active tenant users.
 
-Microsoft 365 and Entra group grants carry the group's identity, and each permission sync snapshots their member rosters. Direct grantees appear under the synthetic `direct-grants` group. A group granted only on a single item is not discovered by roster sync. Its grant remains fail-closed until that group also appears on a library root.
+Microsoft 365 and Entra group grants include the group identity. Each permission sync saves their member rosters. Direct grantees appear under `direct-grants`. Roster sync does not discover a group granted only on one item. This grant fails closed until the group also appears on a library root.
 
-SharePoint site groups are not currently expandable. The connector accepts a client secret, while SharePoint Online requires certificate authentication for app-only REST calls. Site-group grants remain fail-closed until certificate credentials are supported.
+Archestra cannot currently expand SharePoint site groups. The connector accepts a client secret. SharePoint Online requires certificate authentication for app-only REST calls. Site-group grants fail closed until certificate credentials are supported.
 
-`Sites.Read.All` covers library and item grants. Extra permissions unlock more, progressively:
+`Sites.Read.All` covers library and item grants. Extra permissions add capabilities in stages:
 
 | Extra permission | Unlocks |
 | ---------------- | ------- |
@@ -708,11 +708,11 @@ SharePoint site groups are not currently expandable. The connector accepts a cli
 | `GroupMember.Read.All` | Microsoft 365 / Entra group member rosters (the Users and Groups tabs, and group-based document access). |
 | Microsoft Graph `Sites.FullControl.All` | Permission sync switches to cheaper sharing-aware delta runs. |
 
-Each tier is detected at runtime: without it, that kind of grant or roster drops (fail-closed) and the rest of the sync proceeds.
+Archestra detects each tier at runtime. Without a tier, its grants or rosters are omitted and fail closed. The remaining sync continues.
 
 ### OneDrive
 
-Ingests files from OneDrive for Business (personal drives of specified users) via the Microsoft Graph API. Text is extracted from `.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`, `.htm`, `.yaml`, `.log` files, as well as `.docx`, `.pdf`, and `.pptx` documents. When a multimodal embedding model is configured (see [Image Embedding](#image-embedding)), image files (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`) up to 4 MB are also ingested and embedded directly.
+Sync files from specified OneDrive for Business personal drives through the Microsoft Graph API. Archestra extracts text from `.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`, `.htm`, `.yaml`, and `.log` files. It also extracts text from `.docx`, `.pdf`, and `.pptx` documents. A configured multimodal embedding model also directly ingests and embeds image files (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`) up to 4 MB. See [Image Embedding](#image-embedding).
 
 | Field         | Description                                                                                                          |
 | ------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -724,31 +724,31 @@ Ingests files from OneDrive for Business (personal drives of specified users) vi
 | File Types    | Comma-separated file extensions to include, e.g. `.pdf, .docx` (optional -- leave blank for all supported types)  |
 | Recursive     | Traverse subfolders within each user's drive (default: on)                                                          |
 
-Authentication uses an Azure AD app registration with client credentials (OAuth2). The app registration requires the `Files.Read.All` application permission on Microsoft Graph, and admin consent must be granted.
+Authentication uses an Azure AD app registration with OAuth2 client credentials. The app registration requires Microsoft Graph `Files.Read.All` application permission. Grant admin consent.
 
-To configure the connector:
+Configure the connector:
 
-- `Tenant ID` comes from **Microsoft Entra ID > App registrations > <your app> > Overview > Directory (tenant) ID**
-- `Client ID` comes from **Application (client) ID** on the same page
-- `Client Secret` is the secret **Value** from **Certificates & secrets**, not the secret ID
-- `User IDs` should be user principal names (UPNs, e.g. `user@company.com`) or Azure AD object IDs for the users whose drives you want to sync
+- Get `Tenant ID` from **Microsoft Entra ID > App registrations > <your app> > Overview > Directory (tenant) ID**.
+- Get `Client ID` from **Application (client) ID** on the same page.
+- Use the secret **Value** from **Certificates & secrets** for `Client Secret`. Do not use the secret ID.
+- Set `User IDs` to user principal names (UPNs, such as `user@company.com`) or Azure AD object IDs for drives to sync.
 
-Incremental sync uses the `lastModifiedDateTime` field to fetch only items modified since the last run.
+Incremental sync uses `lastModifiedDateTime`. It gets only items changed since the last run.
 
 #### OneDrive Auto-Sync Permissions
 
-Create one single-tenant application under **Microsoft Entra ID > App registrations**. Add a client secret and copy its **Value**. Add these Microsoft Graph application permissions, then grant tenant-wide admin consent:
+Create one single-tenant application under **Microsoft Entra ID > App registrations**. Add a client secret. Copy its **Value**. Add these Microsoft Graph application permissions. Then grant tenant-wide admin consent:
 
 - `Files.Read.All` reads drive content and item permissions.
 - `User.Read.All` resolves owners and direct user grants to emails.
 - `GroupMember.Read.All` expands Microsoft 365 and Entra groups.
 - `Sites.FullControl.All` enables sharing-aware delta permission scans.
 
-Each configured user's drive is one permission scope, and an item (file or folder) that breaks permission inheritance becomes its own scope — a document inherits its nearest such ancestor. The drive's owner is always part of its audience. Anonymous sharing links map to everyone in your Archestra organization; "people in your organization" links expand to the tenant's active users.
+Each configured user drive is one permission scope. A file or folder that breaks permission inheritance becomes its own scope. A document inherits its nearest scope ancestor. The drive owner is always in its audience. Anonymous sharing links grant all users in your Archestra organization. "people in your organization" links grant active tenant users.
 
-Only groups granted on drive roots are expanded. A Microsoft 365 or Entra group granted only on a uniquely shared item gets no roster and remains fail-closed; manual assignment cannot repair it. Direct grantees appear under the synthetic `direct-grants` group. SharePoint site groups on personal drives also resolve no members and remain fail-closed.
+Archestra expands only groups granted on drive roots. A Microsoft 365 or Entra group granted only on a uniquely shared item has no roster. It fails closed. Manual assignment cannot repair it. Direct grantees appear under `direct-grants`. SharePoint site groups on personal drives also resolve no members and fail closed.
 
-`Files.Read.All` covers drive and item grants. Three more application permissions unlock more, progressively:
+`Files.Read.All` covers drive and item grants. Three more application permissions add capabilities in stages:
 
 | Extra permission | Unlocks |
 | ---------------- | ------- |
@@ -756,85 +756,85 @@ Only groups granted on drive roots are expanded. A Microsoft 365 or Entra group 
 | `GroupMember.Read.All` | Microsoft 365 / Entra group member rosters (the Users and Groups tabs, and group-based document access). |
 | `Sites.FullControl.All` | Permission sync switches to cheaper sharing-aware delta runs. |
 
-Each tier is detected at runtime: without it, that kind of grant or roster drops (fail-closed) and the rest of the sync proceeds.
+Archestra detects each tier at runtime. Without a tier, its grants or rosters are omitted and fail closed. The remaining sync continues.
 
 #### Known Limitations
 
-- Only OneDrive for Business (work/school accounts) is supported. Consumer OneDrive is not supported.
-- Syncs the personal drive (`/drive`) of each specified user; shared libraries are not traversed.
+- Archestra supports only OneDrive for Business work or school accounts. It does not support consumer OneDrive.
+- It syncs the personal drive (`/drive`) of each specified user. It does not traverse shared libraries.
 
 ### Google Drive
 
-Sync files from Google Drive (My Drive and Shared Drives).
+Sync files from Google Drive, including My Drive and Shared Drives.
 
-**Indexed:** files from My Drive and Shared Drives. Supported document types include `.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`, `.htm`, `.yaml`, `.log`, `.docx`, `.pdf`, and `.pptx`. Google Workspace files (Docs, Sheets, Slides) are also indexed. When a multimodal embedding model is configured, image files (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`) are indexed too. Files larger than 10 MB are skipped.
+**Indexed:** My Drive and Shared Drive files. Supported document types are `.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`, `.htm`, `.yaml`, `.log`, `.docx`, `.pdf`, and `.pptx`. Archestra also indexes Google Workspace Docs, Sheets, and Slides. A configured multimodal embedding model also indexes image files (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`). It skips files larger than 10 MB.
 
-**Authentication:** pick one of three modes. The mode decides which Google identity the connector acts as, and so what it can index.
+**Authentication:** select one of three modes. The mode selects the Google identity for the connector. This determines what it can index.
 
 | Mode                        | What it indexes                                                    | Who signs in to Google    | The catch                                                              |
 | --------------------------- | ------------------------------------------------------------------ | ------------------------- | ---------------------------------------------------------------------- |
 | **Google Workspace domain** | Every shared drive, plus every user's My Drive, across your domain | Nobody                    | A super admin has to authorize delegation once, in the Admin console   |
 | **One Google account**      | Whatever that one person can already see in Drive                  | That person, once         | Everyone the Knowledge Base reaches sees whatever that person can see  |
-| **Service account only**    | Only what has been shared with the key's own address               | Nobody                    | Somebody has to share every folder with it, by hand, forever           |
+| **Service account only**    | Only content shared with the key address                            | Nobody                    | A user must share every folder with it manually                         |
 
-Use the Workspace domain mode if you have a Workspace tenant -- coverage keeps up with the organization on its own. Reach for one Google account when a single person's Drive is the corpus, or when nobody can change Admin console settings. Service account only suits a small, fixed set of folders somebody is willing to maintain.
+Use Workspace domain mode for a Workspace tenant. Its coverage updates with the organization. Use one Google account when a single person's Drive is the corpus. Use it when no user can change Admin console settings. Service account only suits a small fixed folder set that someone maintains.
 
 #### Google Workspace Domain
 
-A service account with domain-wide delegation impersonates users across your domain. Coverage follows the organization -- a drive created next week is picked up by the next sync, with nobody sharing anything by hand.
+A service account with domain-wide delegation impersonates domain users. Coverage follows the organization. The next sync includes a drive created next week. No user must share it manually.
 
-In the [Google Cloud Console](https://console.cloud.google.com/), create a service account, enable the Google Drive API and the Admin SDK API, and download the JSON key. Copy the service account's client ID from its **Advanced settings**.
+In the [Google Cloud Console](https://console.cloud.google.com/), create a service account. Enable the Google Drive API and Admin SDK API. Download the JSON key. Copy the service account client ID from **Advanced settings**.
 
-In the [Google Admin console](https://admin.google.com/), go to **Security > Access and data control > API controls > Domain-wide delegation**. Add that client ID with the two base scopes:
+In the [Google Admin console](https://admin.google.com/), open **Security > Access and data control > API controls > Domain-wide delegation**. Add the client ID with these base scopes:
 
 ```
 https://www.googleapis.com/auth/drive.readonly
 https://www.googleapis.com/auth/admin.directory.user.readonly
 ```
 
-Paste the JSON key into the connector and enter a Workspace admin address as the **Delegated admin email**. Setting a Folder ID or Drive IDs scopes the sync to those instead, and the connector then acts as that one admin.
+Paste the JSON key into the connector. Enter a Workspace admin address as **Delegated admin email**. A Folder ID or Drive IDs limits the sync to those locations. The connector then acts as that admin.
 
 #### One Google Account
 
-Someone authorizes their own Drive through Google, and the connector indexes what they can see. Archestra stores a refresh token, so the sync keeps working once the first hour is up.
+A user authorizes their Google Drive. The connector indexes content they can see. Archestra stores a refresh token. The sync continues after the first hour.
 
-Only that one person authorizes -- whoever sets the connector up. Nobody else signs in to Google, and there is no per-user prompt. What they can see becomes readable by everyone the Knowledge Base is shared with, so pick the account whose view of Drive matches the audience you intend.
+Only the person who sets up the connector authorizes access. Other users do not sign in to Google. There is no per-user prompt. Everyone who shares the Knowledge Base can read content visible to that account. Select an account whose Drive visibility matches the intended audience.
 
-This mode needs a Google OAuth client on the deployment. Create a **Web application** client in the Cloud Console, enable the Google Drive API, and register the redirect URI the connector form shows you. Set `ARCHESTRA_KNOWLEDGE_BASE_GOOGLE_DRIVE_OAUTH_CLIENT_ID` and `ARCHESTRA_KNOWLEDGE_BASE_GOOGLE_DRIVE_OAUTH_CLIENT_SECRET` to that client's credentials.
+This mode requires a Google OAuth client on the deployment. Create a **Web application** client in Cloud Console. Enable the Google Drive API. Register the redirect URI shown by the connector form. Set `ARCHESTRA_KNOWLEDGE_BASE_GOOGLE_DRIVE_OAUTH_CLIENT_ID` and `ARCHESTRA_KNOWLEDGE_BASE_GOOGLE_DRIVE_OAUTH_CLIENT_SECRET` to the client credentials.
 
-Saving the connector sends you to Google. The connector page then names the connected account and offers **Reconnect** -- you need it if that account ever revokes access.
+Saving the connector redirects you to Google. The connector page then shows the connected account and **Reconnect**. Use **Reconnect** if the account revokes access.
 
 #### Service Account Only
 
-The connector sees only what someone has shared with the service account's email address. Create the service account and key as above, then share each target folder or drive with that address.
+The connector sees only content shared with the service account email address. Create the service account and key as above. Share each target folder or drive with that address.
 
 | Field                 | Description                                                                                                                                                 |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delegated admin email | Workspace admin the service account impersonates (Google Workspace domain mode)                                                                             |
-| Drive IDs             | Comma-separated shared drive IDs to sync (optional -- providing Drive IDs automatically enables shared-drive API access; leave blank to sync from My Drive) |
+| Drive IDs             | Comma-separated shared drive IDs to sync (optional -- Drive IDs enable shared-drive API access automatically. Leave blank to sync from My Drive) |
 | Folder ID             | Restrict sync to a specific folder (optional -- find the ID in the folder's Google Drive URL)                                                               |
 | File Types            | Comma-separated file extensions to include, e.g. `.pdf, .docx` (optional -- leave blank for all)                                                            |
 | Recursive Traversal   | Sync files from all nested subfolders when a Folder ID is set (default: on)                                                                                 |
 
-**Test connection** checks the setup rather than just the credential. It confirms that impersonation works for the delegated admin, that the directory can be read when the sync will enumerate one, and that any folder or shared drive you named is reachable. The result says which of those failed.
+**Test connection** checks the setup, not only the credential. It verifies delegated-admin impersonation. It verifies directory access if the sync lists a directory. It verifies each named folder or shared drive. The result identifies failures.
 
 #### Google Drive Auto-Sync Permissions
 
-Use **Google Workspace domain** mode to resolve users and Google Groups. In addition to the two base scopes above, authorize `https://www.googleapis.com/auth/admin.directory.group.readonly` for group and group-member reads. The delegated account needs directory privileges to read users, groups, and group members. **Test connection** checks the base scopes but does not validate the group-directory scope.
+Use **Google Workspace domain** mode to resolve users and Google Groups. Also authorize `https://www.googleapis.com/auth/admin.directory.group.readonly` for group and group-member reads. The delegated account needs directory privileges for users, groups, and group members. **Test connection** checks base scopes. It does not validate the group-directory scope.
 
-Domain mode currently indexes every user's Drive, but permission sync lists files only as the delegated admin. Files visible only while impersonating another user remain fail-closed. Do not use domain-wide auto-sync permissions until per-user permission enumeration is supported.
+Domain mode currently indexes every user's Drive. Permission sync lists files only as the delegated admin. Files visible only through another user impersonation fail closed. Do not use domain-wide auto-sync permissions until Archestra supports per-user permission enumeration.
 
-For files the delegated admin can see, direct user grants resolve from the email in the permission list and group grants expand through the Admin SDK directory. Nested groups are not inherited into their parent roster; flatten the parent group upstream, or grant the child group or users directly.
+For files visible to the delegated admin, direct user grants resolve from permission-list emails. Group grants expand through the Admin SDK directory. Parent rosters do not inherit nested groups. Flatten the parent group in the source system. You can also grant the child group or users directly.
 
-**One Google account** and **Service account only** modes cannot read the Workspace directory. Their direct user grants work, but Google Group grants remain unresolved and fail closed.
+**One Google account** and **Service account only** cannot read the Workspace directory. Their direct user grants work. Google Group grants remain unresolved and fail closed.
 
 ### Dropbox
 
 Sync text and source files from a Dropbox account or team folder.
 
-**Indexed:** files from a Dropbox account or team folder — text and source files (`.md`, `.txt`, `.ts`, `.js`, `.py`, `.json`, `.yaml`, `.yml`, `.html`, `.css`, `.csv`, `.xml`, `.sh`, `.toml`, `.ini`, `.conf`), documents (`.pdf`, `.docx`, `.pptx`, `.xlsx` — every sheet of a workbook, not just the first), and images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`) when the configured embedding model accepts image input. Files the connector cannot extract are reported as skipped on the run.
+**Indexed:** Dropbox account or team-folder files. This includes text and source files (`.md`, `.txt`, `.ts`, `.js`, `.py`, `.json`, `.yaml`, `.yml`, `.html`, `.css`, `.csv`, `.xml`, `.sh`, `.toml`, `.ini`, `.conf`). It includes documents (`.pdf`, `.docx`, `.pptx`, `.xlsx`). Archestra reads every workbook sheet. A configured image-capable embedding model indexes images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`). The run reports files that the connector cannot extract as skipped.
 
-**Authentication:** a Dropbox access token from the [Dropbox App Console](https://www.dropbox.com/developers/apps). The connector stores this token directly and does not refresh it.
+**Authentication:** a Dropbox access token from the [Dropbox App Console](https://www.dropbox.com/developers/apps). The connector stores this token directly. It does not refresh it.
 
 | Field      | Description                                                                                              |
 | ---------- | -------------------------------------------------------------------------------------------------------- |
@@ -843,17 +843,17 @@ Sync text and source files from a Dropbox account or team folder.
 
 #### Dropbox Auto-Sync Permissions
 
-Create a scoped app with **Full Dropbox** access. Add `account_info.read`, `files.metadata.read`, `files.content.read`, and `sharing.read`. Generate a member token when direct user and shared-folder grants are enough.
+Create a scoped app with **Full Dropbox** access. Add `account_info.read`, `files.metadata.read`, `files.content.read`, and `sharing.read`. Generate a member token if direct user and shared-folder grants are sufficient.
 
-Group expansion requires a Dropbox Business team app. Add `team_info.read`, `team_data.member`, and `groups.read`, then have an active team administrator authorize the app. Paste the resulting team-linked token into **Access Token**.
+Group expansion requires a Dropbox Business team app. Add `team_info.read`, `team_data.member`, and `groups.read`. Have an active team administrator authorize the app. Paste the resulting team-linked token into **Access Token**.
 
-App Console generated access tokens are short-lived testing credentials. The connector stores only the access token and cannot refresh it, so scheduled content and permission sync stop after expiration. Reconnect with a new token; durable background sync requires an offline OAuth flow, which is not yet supported.
+App Console access tokens are short-lived test credentials. The connector stores only the access token. It cannot refresh the token. Scheduled content and permission sync stop after expiration. Reconnect with a new token. Durable background sync requires an offline OAuth flow. Archestra does not yet support this flow.
 
-Each shared folder is one permission scope — a file belongs to its nearest containing shared folder. Files outside every shared folder are visible only to the token's account. Shared-folder members resolve to their emails directly; pending invitees are excluded until they accept. A file shared with extra people directly carries those people as additional grants. A file shared directly with a group does not carry that group — only shared-folder group grants are mirrored.
+Each shared folder is one permission scope. A file uses its nearest containing shared folder. Files outside shared folders are visible only to the token account. Shared-folder members resolve directly to email addresses. Pending invitees are excluded until acceptance. A directly shared file adds direct grantees. A file directly shared with a group does not add that group. Archestra mirrors only shared-folder group grants.
 
-A team-linked token expands granted groups, including the automatic team-wide group, to active members. A member token leaves group rosters empty and fail-closed; manual assignment cannot populate them. Direct grantees appear under the synthetic `direct-grants` group.
+A team-linked token expands granted groups to active members. This includes the automatic team-wide group. A member token leaves group rosters empty and fail-closed. Manual assignment cannot populate them. Direct grantees appear under `direct-grants`.
 
-Shared links are not reflected. A file shared only by link stays visible to the audiences above, nobody more.
+Archestra does not mirror shared links. A file shared only by link remains visible only to the audiences above.
 
 ### Linear
 
@@ -861,7 +861,7 @@ Sync issues, projects, and cycles from a Linear workspace.
 
 **Indexed:** issues by default, with optional projects (and recent updates) and cycles.
 
-**Authentication:** a Linear personal API key. Create one under **Settings > Security & access > Personal API keys** in Linear, then paste it into the connector's **Personal Access Token** field.
+**Authentication:** a Linear personal API key. Create it under **Settings > Security & access > Personal API keys** in Linear. Paste it into the connector **Personal Access Token** field.
 
 | Field            | Description                                                                |
 | ---------------- | -------------------------------------------------------------------------- |
@@ -876,13 +876,13 @@ Sync issues, projects, and cycles from a Linear workspace.
 
 #### Linear Auto-Sync Permissions
 
-Create a personal API key under **Settings > Account > Security & Access > Personal API keys**. Select **Read** and every team the connector will sync. Use a dedicated workspace owner or administrator that belongs to every private team; the role alone does not grant private-team access.
+Create a personal API key under **Settings > Account > Security & Access > Personal API keys**. Select **Read** and each team that the connector syncs. Use a dedicated workspace owner or administrator in each private team. The role alone does not grant private-team access.
 
-Linear returns member emails through the same key. No extra scope is required.
+Linear returns member emails through the same key. No additional scope is required.
 
-Linear's access unit is the team. Issues and cycles get their team's audience: a public team admits every workspace member, a private team only its listed members. Guests get access only through teams they were invited to. A project's audience is the members of its teams plus the users listed on the project. Each sync also snapshots every team's roster, so the connector's **Users** and **Groups** tabs show each member with their assignment status. Suspended accounts belong to no audience.
+Linear uses the team as its access unit. Issues and cycles use the team audience. A public team grants all workspace members. A private team grants only listed members. Guests receive access only through invited teams. A project audience includes its team members and listed users. Each sync saves each team roster. The connector **Users** and **Groups** tabs show members and assignment status. Suspended accounts belong to no audience.
 
-The API key sees what its owner can see. A private team the owner does not belong to syncs no content and grants no access. Use a key from an owner whose access matches what you want indexed.
+The API key can see only content visible to its owner. A private team outside the owner membership syncs no content. It grants no access. Use a key whose owner can access the required content.
 
 ### Outline
 
@@ -890,7 +890,7 @@ Sync published documents from an [Outline](https://www.getoutline.com/) workspac
 
 **Indexed:** published documents. Both Outline cloud (`https://app.getoutline.com`) and self-hosted instances are supported.
 
-**Authentication:** an Outline API key. Create one under **Settings > API & Apps** in your Outline workspace. Only documents the key has access to are synced.
+**Authentication:** an Outline API key. Create it under **Settings > API & Apps** in the Outline workspace. The connector syncs only documents that the key can access.
 
 | Field          | Description                                                                                            |
 | -------------- | ------------------------------------------------------------------------------------------------------ |
@@ -900,33 +900,33 @@ Sync published documents from an [Outline](https://www.getoutline.com/) workspac
 
 #### Outline Auto-Sync Permissions
 
-Create an API key under **Settings > API Keys**. An unscoped key inherits its creator's endpoint and collection access. For a scoped key, grant `auth.info`, `documents.list`, `users.list`, `groups.list`, `groups.memberships`, `collections.list`, `collections.info`, `collections.memberships`, `collections.group_memberships`, and `shares.list`.
+Create an API key under **Settings > API Keys**. An unscoped key inherits the creator endpoint and collection access. For a scoped key, grant `auth.info`, `documents.list`, `users.list`, `groups.list`, `groups.memberships`, `collections.list`, `collections.info`, `collections.memberships`, `collections.group_memberships`, and `shares.list`.
 
-Use a dedicated admin that belongs to every private target collection. Admin status does not automatically reveal a private collection. User emails come from `users.list`, so an account that cannot list users leaves all members unresolved.
+Use a dedicated admin that belongs to each private target collection. Admin status does not automatically reveal a private collection. `users.list` returns user emails. An account that cannot list users leaves all members unresolved.
 
-Each collection is one permission scope. A collection's audience is its individual members, its granted groups, and — when the collection has workspace-wide default access — every active workspace member except guests. Guests only see collections they are explicitly added to, directly or through a group.
+Each collection is one permission scope. Its audience includes individual members and granted groups. A collection with workspace-wide default access includes all active workspace members except guests. Guests see only directly granted collections or collections granted through a group.
 
-Each permission sync also snapshots group member rosters, so the connector's **Users** and **Groups** tabs show every member with their assignment status. Members granted a collection individually appear there too, under the synthetic `direct-grants` group. Workspace-wide default access appears as a group named after your workspace, holding every active non-guest member.
+Each permission sync saves group member rosters. The connector **Users** and **Groups** tabs show members and assignment status. Individual collection members appear under `direct-grants`. Workspace-wide default access appears as a group named for the workspace. It includes every active non-guest member.
 
-Published share links are the only public surface. A published document share maps that document — and its child documents, when the share includes them — to everyone in your Archestra organization. A published collection share does the same for the whole collection.
+Published share links are the only public surface. A published document share grants that document to everyone in your Archestra organization. It also grants included child documents. A published collection share grants the full collection.
 
-A collection whose permissions cannot be read hides its documents from everyone until a later sync reads them. Documents an Outline user can only reach through a direct per-document share (not a public link) are not carried over; they stay limited to the collection's audience.
+A collection with unreadable permissions hides its documents from all users until a later sync reads them. Archestra does not carry over documents that an Outline user reaches only through a direct per-document share. This does not apply to public links. These documents remain limited to the collection audience.
 
 ### Salesforce
 
 Sync CRM records from a Salesforce org.
 
-**Indexed:** CRM records from a Salesforce org. By default the connector syncs `Account`, `Contact`, `Opportunity`, and `Case`. You can list other object API names in the **Objects** field, or use **Advanced Object Config JSON** to pick exact fields and associations per object.
+**Indexed:** CRM records from a Salesforce org. By default, the connector syncs `Account`, `Contact`, `Opportunity`, and `Case`. List other object API names in **Objects**. You can use **Advanced Object Config JSON** to select fields and associations for each object.
 
-**Authentication:** a Salesforce username, password, and security token. The password field must contain the password directly concatenated with the security token (no separator). To get the token: log in to Salesforce, click your **User Avatar > Settings**, then go to **My Personal Information > Reset My Security Token** and check your email.
+**Authentication:** a Salesforce username, password, and security token. The password field must contain the password immediately followed by the security token. Do not use a separator. Sign in to Salesforce to get the token. Select **User Avatar > Settings**. Open **My Personal Information > Reset My Security Token**. Check your email.
 
 | Field                          | Description                                                                                                  |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| Login URL                      | Salesforce login endpoint (default: `https://login.salesforce.com`; use `https://test.salesforce.com` for sandbox orgs) |
+| Login URL                      | Salesforce login endpoint (default: `https://login.salesforce.com`). Use `https://test.salesforce.com` for sandbox orgs. |
 | Email                          | Your Salesforce username (e.g., `user@company.com`)                                                          |
 | Password + Security Token      | Your Salesforce password concatenated with your security token (e.g., `MyPassword123XXYYZZ`)                 |
 | Objects                        | Comma-separated Salesforce object API names to sync (e.g., `Account, Contact, Opportunity, Case`). Leave blank for the defaults. |
-| Advanced Object Config JSON    | Optional JSON for precise field and association control. Overrides the Objects field when provided.          |
+| Advanced Object Config JSON    | Optional JSON for precise field and association control. Overrides the Objects field when set.               |
 
 Example advanced config:
 
@@ -942,13 +942,13 @@ Example advanced config:
 }
 ```
 
-`Id`, `Name`, and `LastModifiedDate` are always included automatically.
+Archestra always includes `Id`, `Name`, and `LastModifiedDate`.
 
 #### Salesforce Auto-Sync Permissions
 
-Use a dedicated Salesforce integration user. The same username, password, and security token authenticate content and permission reads. Configure its profile or permission sets with:
+Use a dedicated Salesforce integration user. The same username, password, and security token authenticate content and permission reads. Configure the profile or permission sets with:
 
-- **API Enabled**. In **Setup > User Interface**, enable **SOAP API login()**. If SOAP login restrictions are enforced, also grant **Use Any API Auth**. Salesforce retires this authentication method in Summer '27, so Archestra must migrate to External Client App OAuth before then.
+- **API Enabled**. In **Setup > User Interface**, enable **SOAP API login()**. If SOAP login restrictions apply, also grant **Use Any API Auth**. Salesforce retires this authentication method in Summer '27. Archestra must migrate to External Client App OAuth before then.
 - **Read** object and field permissions for every configured field and association.
 - Read access to each object's owner fields and share object.
 - Read access to `User`, `Group`, and `GroupMember`.
@@ -956,23 +956,23 @@ Use a dedicated Salesforce integration user. The same username, password, and se
 - **View All Records** on every synced object, or **View All Data**, for complete ingestion.
 - **Modify Metadata Through Metadata API Functions**, or **Modify All Data**, for organization-wide defaults.
 
-Each object is one permission scope, decided by its organization-wide default. A public object grants every user in the Archestra organization. A private object resolves records from owners and modeled share rows. A contact inherits its parent account's audience.
+Each object is one permission scope. Its organization-wide default determines the scope. A public object grants every Archestra organization user. A private object resolves records from owners and modeled share rows. A contact inherits its parent account audience.
 
-Restriction rules, territory hierarchies, high-volume portal shares, object CRUD access, and field-level visibility are not modeled. Restriction rules can narrow access upstream, so do not sync restricted objects through auto-sync permissions. Private objects in large organizations resolve per record; use a longer permission-sync interval.
+Archestra does not model restriction rules, territory hierarchies, high-volume portal shares, object CRUD access, or field-level visibility. Restriction rules can narrow source access. Do not sync restricted objects with auto-sync permissions. Private objects in large organizations resolve per record. Use a longer permission-sync interval.
 
-Every permission sync also snapshots the org's groups and queues with their (recursively expanded) memberships, plus record owners and per-user share grantees under the synthetic `direct-grants` group — so the connector's **Users** and **Groups** tabs show every grant-holder with their assignment status, and an account whose email is hidden (or matches no Archestra user's email) can be assigned manually from the Users tab. Inactive users stay visible in the roster but never resolve to access.
+Every permission sync saves organization groups and queues with recursively expanded memberships. It adds record owners and per-user share grantees under `direct-grants`. The connector **Users** and **Groups** tabs show grant holders and assignment status. You can manually assign an account with a hidden email or unmatched Archestra email in the Users tab. Inactive users remain in the roster. They never resolve to access.
 
 ### Web Crawler
 
 Crawl static HTML pages from a documentation site or public web property.
 
-**Indexed:** same-host HTML pages discovered from the start URL. The crawler extracts page text, removes common navigation and layout elements, and stores each page with its canonical URL when one is present.
+**Indexed:** HTML pages on the start URL host. The crawler discovers these pages from the start URL. It extracts page text. It removes common navigation and layout elements. It stores each page with its canonical URL when available.
 
-**Authentication:** none in the initial version. The crawler only fetches pages reachable over HTTP(S).
+**Authentication:** none in the initial version. The crawler fetches only pages available over HTTP(S).
 
-Private and internal network addresses are blocked. Start URLs and discovered pages cannot resolve to loopback, link-local, RFC 1918 private ranges, cloud metadata endpoints, or other reserved address ranges. Hosts are checked before each fetch, but DNS records can change between validation and the final network request.
+The crawler blocks private and internal network addresses. Start URLs and discovered pages cannot resolve to loopback, link-local, RFC 1918 private ranges, cloud metadata endpoints, or other reserved ranges. It checks hosts before each fetch. DNS records can change after validation and before the final request.
 
-If the start URL is the site root, such as `https://example.com/`, and no include path prefixes are configured, the crawler can discover any same-host page within the configured depth and page limits.
+If the start URL is a site root such as `https://example.com/`, the crawler can discover same-host pages. This applies when no include path prefixes are set. It uses configured depth and page limits.
 
 | Field                 | Description                                                                                              |
 | --------------------- | -------------------------------------------------------------------------------------------------------- |
@@ -991,15 +991,15 @@ If the start URL is the site root, such as `https://example.com/`, and no includ
 
 Sync text files from Perforce Helix Core depot paths.
 
-**Indexed:** files matching the configured extensions (defaults to `.md`, `.yaml`, `.yml`) under the configured depot paths, at their latest submitted revision. Files with non-text Perforce filetypes (binary, symlink, etc.) and files larger than 2 MB are skipped regardless of the extension list, so broadening the extensions (e.g. adding `.txt`, `.json`, or `.xml`) is safe even in depots that mix documentation with binary assets. Optional exclude paths carve subtrees (e.g. generated or vendored directories) out of the synced depot paths.
+**Indexed:** latest submitted files under configured depot paths that match configured extensions. The defaults are `.md`, `.yaml`, and `.yml`. Archestra skips non-text Perforce filetypes, including binary and symlink files. It skips files larger than 2 MB regardless of extensions. You can safely add `.txt`, `.json`, or `.xml` in depots with binary assets. Optional exclude paths omit subtrees, such as generated or vendored directories.
 
-**Authentication:** a Perforce username with a login ticket, sent as HTTP basic authentication. The ticket must be valid for all hosts — generate it with `p4 login -a -p`. For long-lived access, use a service account whose group has an unlimited ticket timeout. The account needs read access to the configured depot paths.
+**Authentication:** a Perforce username and login ticket sent with HTTP basic authentication. The ticket applies to all hosts. Generate it with `p4 login -a -p`. For long-lived access, use a service account in a group with unlimited ticket timeout. The account needs read access to configured depot paths.
 
-The connector talks to the [P4 REST API](https://help.perforce.com/helix-core/server-apps/p4sag/current/Content/P4SAG/p4-rest-api.html), served by the built-in P4 web server. An administrator must start the web server on the P4 Server (`p4 webserver start -p <port>`; it serves HTTPS automatically when the server has an SSL certificate configured). The REST API is a Perforce Technology Preview feature (introduced with P4 Server 2025.2), so its behavior may change between server releases. No `p4` client binary and no client workspace (`P4CLIENT`) are required — files are listed and read directly in depot syntax over HTTP. For servers with self-signed certificates, provide the CA to the backend via standard Node.js trust configuration (`NODE_EXTRA_CA_CERTS`).
+The connector uses the [P4 REST API](https://help.perforce.com/helix-core/server-apps/p4sag/current/Content/P4SAG/p4-rest-api.html) served by the built-in P4 web server. An administrator starts the web server on P4 Server with `p4 webserver start -p <port>`. It serves HTTPS automatically if the server has an SSL certificate. The REST API is a Perforce Technology Preview feature introduced with P4 Server 2025.2. Its behavior can change between releases. No `p4` client binary or client workspace (`P4CLIENT`) is required. The connector lists and reads files in depot syntax over HTTP. For self-signed certificates, add the CA through Node.js trust configuration (`NODE_EXTRA_CA_CERTS`).
 
-Incremental syncs are driven by submitted changelist numbers: after the initial sync, only files changed since the last synced changelist are re-indexed. File deletions are not propagated on incremental syncs; use **Force re-sync** to rebuild the index after large depot restructurings.
+Incremental syncs use submitted changelist numbers. After the initial sync, Archestra re-indexes only files changed since the last synced changelist. Incremental syncs do not propagate file deletions. Use **Force re-sync** to rebuild the index after a large depot restructuring.
 
-Each depot path and extension combination is listed in its own REST API request. On very large depots, server `maxresults` limits or per-request response bounds can reject a listing; configure narrower depot paths if the initial sync fails while listing files.
+Each depot path and extension combination uses a separate REST API request. On large depots, server `maxresults` limits or response bounds can reject a listing. Configure narrower depot paths if the initial sync fails during file listing.
 
 | Field         | Description                                                                                            |
 | ------------- | ------------------------------------------------------------------------------------------------------ |
@@ -1014,13 +1014,13 @@ Each depot path and extension combination is listed in its own REST API request.
 
 Use two dedicated Perforce identities:
 
-1. Give the content user `read` access to every configured depot path. Generate its all-host ticket with `p4 login -a -p`.
-2. Give the permission user `admin` access with `dm.protects.allow.admin=1`, or `super` access, plus a password. This identity runs `p4 protects -a`, reads groups, and reads every user spec.
-3. Populate each Perforce user's `Email` field. Missing emails require [manual assignment](#credentials-and-email-resolution).
+1. Grant the content user `read` access to each configured depot path. Generate an all-host ticket with `p4 login -a -p`.
+2. Grant the permission user `admin` access with `dm.protects.allow.admin=1`, or `super` access. Set a password. This identity runs `p4 protects -a`, reads groups, and reads every user specification.
+3. Fill each Perforce user `Email` field. Missing emails require [manual assignment](#credentials-and-email-resolution).
 
-The connector supports [auto-sync permissions](#auto-sync-permissions). The REST API cannot read the protections table, so permission sync runs the `p4` CLI in a dedicated in-cluster pod — the p4 shim. This requires the Kubernetes orchestrator. The shim pod is isolated: it accepts connections only from platform pods and connects out only to the Perforce server. For `ssl:` targets the server's certificate fingerprint is trusted on first use, like `p4 trust`. The image contains no Perforce software; the backend downloads the pinned `p4` binary when it provisions the pod — see [Deployment](/docs/platform-deployment#perforce-permission-sync-p4-shim) for the image and binary-source variables (air-gapped installs point them at an internal mirror).
+The connector supports [auto-sync permissions](#auto-sync-permissions). The REST API cannot read the protections table. Permission sync runs the `p4` CLI in a dedicated in-cluster p4 shim pod. This requires the Kubernetes orchestrator. The shim pod accepts connections only from platform pods. It connects only to the Perforce server. For `ssl:` targets, the first use trusts the server certificate fingerprint, like `p4 trust`. The image has no Perforce software. The backend downloads the pinned `p4` binary when it creates the pod. See [Deployment](/docs/platform-deployment#perforce-permission-sync-p4-shim) for image and binary-source variables. Air-gapped installations point these variables to an internal mirror.
 
-Choosing the auto-sync-permissions visibility adds three fields to the form:
+Selecting auto-sync-permissions visibility adds three fields to the form:
 
 | Field              | Description                                                                       |
 | ------------------ | --------------------------------------------------------------------------------- |
@@ -1028,65 +1028,65 @@ Choosing the auto-sync-permissions visibility adds three fields to the form:
 | Admin Password     | That account's password                                                            |
 | P4 Port            | Wire-protocol address of the server, when that is not the Server URL's host        |
 
-The permission user needs `admin` access with the server configurable `dm.protects.allow.admin=1`, or `super` access, to read the full protections table with `p4 protects -a`. The group and user-list reads require only `list` access.
+The permission user needs `admin` access with the server setting `dm.protects.allow.admin=1`, or `super` access. This reads the full protections table with `p4 protects -a`. Group and user-list reads require only `list` access.
 
-Leave P4 Port empty on a normal server. The P4 web server runs inside the Perforce server, so Archestra dials the Server URL's host on port 1666 and works out the transport by trying plain and SSL. Fill the field in only when something else serves the REST API — an ingress in front of the web server, for example.
+Leave P4 Port empty on a normal server. The P4 web server runs in the Perforce server. Archestra connects to the Server URL host on port 1666. It detects the transport by trying plain and SSL. Enter P4 Port only if another service serves the REST API. For example, use it for an ingress before the web server.
 
-Test Connection checks the whole path. It reaches the server over the wire address, signs the admin user in, and reads the protections table, so a wrong address or an under-privileged account shows up here rather than at the first permission sync.
+Test Connection checks the complete path. It reaches the server at the wire address. It signs in the admin user. It reads the protections table. It reports a wrong address or under-privileged account before the first permission sync.
 
-Permission sync runs in a pod of its own, one per connector. The pod exists while the connector syncs permissions and is removed when it stops — when you delete the connector, disable it, or change its visibility. Changing the server, the admin user or any credential replaces the pod, so a revoked credential stops working straight away.
+Permission sync uses one pod per connector. The pod exists while the connector syncs permissions. Archestra removes it when the connector stops. This includes deletion, disabling, or visibility changes. Changing the server, admin user, or credential replaces the pod. A revoked credential stops working immediately.
 
-A document's audience is the set of users whose effective read access to its depot path the protections table grants, walked with the exclusion lines honored. Access is evaluated as from an unnamed host, so host-restricted lines don't participate. Audiences are always individual users — granting through a group still resolves to its members, because an exclusion line can carve a member out of a granted group.
+A document audience contains users with effective read access to its depot path. Archestra evaluates protection-table exclusion lines. It evaluates access from an unnamed host. Host-restricted lines do not apply. Audiences always contain individual users. A group grant resolves to members because an exclusion line can remove a member from a granted group.
 
-Users are matched to Archestra accounts by the `Email` field of their Perforce user spec. A user without a resolvable email is dropped from audiences (fail-closed); assign such accounts to Archestra users from the connector's Users tab.
+Archestra matches users to accounts through the `Email` field in the Perforce user specification. A user without a resolvable email is removed from audiences and fails closed. Assign this account from the connector Users tab.
 
 ### M-Files
 
-Sync versioned files and their source permissions from an M-Files vault.
+Sync versioned files and source permissions from an M-Files vault.
 
 > **Beta feature** — off by default. Set `ARCHESTRA_KNOWLEDGE_BASE_MFILES_CONNECTOR_ENABLED=true` (or the `ARCHESTRA_BETA` master switch) to show the connector type. See [Deployment](/docs/platform-deployment).
 
-**Indexed:** supported files attached to the configured M-Files object types. The default object type is `0` (documents). Text, Markdown, CSV, JSON, XML, HTML, YAML, Office documents, and PDFs are indexed; supported images are indexed when a multimodal embedding model is configured. Files larger than 25 MB are skipped.
+**Indexed:** supported files attached to configured M-Files object types. The default object type is `0` for documents. Archestra indexes text, Markdown, CSV, JSON, XML, HTML, YAML, Office documents, and PDFs. A configured multimodal embedding model indexes supported images. It skips files larger than 25 MB.
 
-**Authentication:** a dedicated M-Files login account, or an Application Account when `ARCHESTRA_KNOWLEDGE_BASE_MFILES_OAUTH_ENABLED` is enabled. Login accounts exchange a username and password for short-lived MFWS tokens. Application Accounts use OAuth client credentials.
+**Authentication:** a dedicated M-Files login account. You can use an Application Account when `ARCHESTRA_KNOWLEDGE_BASE_MFILES_OAUTH_ENABLED` is enabled. Login accounts exchange a username and password for short-lived MFWS tokens. Application Accounts use OAuth client credentials.
 
 | Field | Description |
 | --- | --- |
-| M-Files Web Service URL | Classic Web/MFWS base URL; `/REST` is appended automatically (for example, `https://mfiles.example.com/m-files`) |
+| M-Files Web Service URL | Classic Web/MFWS base URL. `/REST` is appended automatically (for example, `https://mfiles.example.com/m-files`) |
 | Vault GUID | GUID of the vault to index |
 | Username | Dedicated M-Files login account for the connector |
-| Password | That account's password; exchanged for a short-lived MFWS token |
+| Password | That account's password. Archestra exchanges it for a short-lived MFWS token. |
 | Windows Domain | Optional, under Advanced — only for domain-authenticated accounts |
 
-Three more settings exist on the connector config and are tuned through the API rather than the form: `objectTypeIds` (managed object types, default `0`), `batchSize` (documents per indexing batch, default `50`) and `permissionExtensionMethod` (the installed VAF extension-method name, default `ArchestraKnowledgePermissionSnapshot`). Leaving them unset keeps the backend defaults.
+The connector configuration has three additional API-only settings. `objectTypeIds` selects managed object types. Its default is `0`. `batchSize` sets documents per indexing batch. Its default is `50`. `permissionExtensionMethod` sets the installed VAF extension-method name. Its default is `ArchestraKnowledgePermissionSnapshot`. Leave these settings unset to use backend defaults.
 
 #### M-Files Auto-Sync Permissions
 
-Install the VAF Add On below before creating the connector. In M-Files Admin, add a dedicated login account to the vault and grant **Change full control of vault**. Also grant read access to every configured object, version, and file. The administrative role permits add-on calls but does not grant content visibility by itself.
+Install the VAF Add On below before you create the connector. In M-Files Admin, add a dedicated login account to the vault. Grant **Change full control of vault**. Grant read access to each configured object, version, and file. The administrative role permits add-on calls. It does not independently grant content visibility.
 
-For Application Account authentication, create an [M-Files Application Account](https://userguide.m-files.com/user-guide/manage/latest/eng/application_accounts.html) and map it to a vault user with the same access. Configure an identity-provider application for client credentials. Enter its token endpoint, client ID, client secret, token audience, M-Files authentication configuration name and scope, and Application Account username.
+For Application Account authentication, create an [M-Files Application Account](https://userguide.m-files.com/user-guide/manage/latest/eng/application_accounts.html). Map it to a vault user with identical access. Configure an identity-provider application for client credentials. Enter its token endpoint, client ID, client secret, token audience, M-Files authentication configuration name, scope, and Application Account username.
 
-The add-on returns user and group rosters. Accounts without an email stay unresolved and need [manual assignment](#credentials-and-email-resolution).
+The add-on returns user and group rosters. Accounts without an email remain unresolved. They need [manual assignment](#credentials-and-email-resolution).
 
 #### M-Files VAF Add On
 
-The Archestra VAF Add On is a vault application for M-Files Server. Syncing requires it. MFWS does not expose change tracking, exact permission reads, or group membership — the add-on supplies them from inside the vault. File content never flows through it. Every call requires the **Change full control role**, enforced by M-Files itself. Unreadable permissions fail closed.
+The Archestra VAF Add On is a vault application for M-Files Server. Syncing requires it. MFWS does not expose change tracking, exact permission reads, or group membership. The add-on supplies them inside the vault. File content does not flow through it. Each call requires **Change full control role**. M-Files enforces this role. Unreadable permissions fail closed.
 
-Install it once per connected vault, from the connector form:
+Install it once for each connected vault from the connector form:
 
-- **Installation script** — copy the one-line command and run it in PowerShell on the M-Files server as a system administrator. It downloads the add-on, installs it into the vault you choose, and restarts the vault.
-- **Manual installation** — download the `.mfappx` package and install it in M-Files Admin: right-click the vault, then Applications, then Install.
+- **Installation script** — copy the one-line command. Run it in PowerShell on the M-Files server as a system administrator. It downloads the add-on. It installs it in the selected vault. It restarts the vault.
+- **Manual installation** — download the `.mfappx` package. In M-Files Admin, right-click the vault. Select Applications. Select Install.
 
-Pre-built packages are published as `m-files-vaf-add-on-v<version>` [releases on GitHub](https://github.com/archestra-ai/archestra/releases). The source lives in [`integrations/m-files-vaf-add-on`](https://github.com/archestra-ai/archestra/tree/main/integrations/m-files-vaf-add-on); its README covers building from source and the add-on contract. For development deployments, two variables override where the install script gets the package — see [Deployment](/docs/platform-deployment).
+Pre-built packages are published as `m-files-vaf-add-on-v<version>` [releases on GitHub](https://github.com/archestra-ai/archestra/releases). The source is in [`integrations/m-files-vaf-add-on`](https://github.com/archestra-ai/archestra/tree/main/integrations/m-files-vaf-add-on). Its README explains source builds and the add-on contract. For development deployments, two variables change where the installation script gets the package. See [Deployment](/docs/platform-deployment).
 
 ## Environments
 
-A connector can be assigned a deployment environment. Only agents and gateways in the same environment can use its knowledge — a "dev" agent cannot query a "prod" connector. Unassigned connectors belong to the Default environment. See [Environments](/docs/platform-environments).
+You can assign a connector to a deployment environment. Only agents and gateways in that environment can use its knowledge. A "dev" agent cannot query a "prod" connector. Unassigned connectors use the Default environment. See [Environments](/docs/platform-environments).
 
 ## Adding New Connector Types
 
-See [Adding Knowledge Connectors](/docs/platform-adding-knowledge-connectors) for a developer guide on implementing new connector types.
+See [Adding Knowledge Connectors](/docs/platform-adding-knowledge-connectors) for a developer guide that explains how to add new connector types.
 
 ## Adding Retrieval Backends
 
-See [Adding Knowledge Retrieval Backends](/docs/platform-adding-knowledge-retrieval-backends) for a developer guide on implementing a new search index.
+See [Adding Knowledge Retrieval Backends](/docs/platform-adding-knowledge-retrieval-backends) for a developer guide that explains how to add a search index.

--- a/platform/frontend/src/app/knowledge/_parts/embedding-model-image-support-notice.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/embedding-model-image-support-notice.tsx
@@ -100,8 +100,8 @@ export function EmbeddingModelImageSupportNotice({
             <code className="break-all">{modelKey}</code>
           </p>
           <p className="leading-relaxed">
-            Handles text only. Choose a multimodal embedding model to sync
-            supported image files.{" "}
+            This model processes text only. Use a multimodal embedding model to
+            sync supported image files.{" "}
             <a
               href={getDocsUrl(DocsPage.PlatformKnowledge, "image-embedding")}
               target="_blank"

--- a/platform/frontend/src/app/settings/knowledge/page.test.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.test.tsx
@@ -197,7 +197,7 @@ function getEmbeddingModelTrigger() {
 function getRerankerModelTrigger() {
   const modelTrigger = screen
     .getAllByRole("combobox")
-    .find((el) => el.textContent?.includes("Select reranking model"));
+    .find((el) => el.textContent?.includes("Select a reranking model"));
 
   if (!modelTrigger) {
     throw new Error("Reranking model trigger not found");
@@ -484,11 +484,11 @@ describe("KnowledgeSettingsPage", () => {
       await user.click(getEmbeddingModelTrigger());
 
       expect(
-        screen.getByText('No embedding models detected for "Vertex AI".'),
+        screen.getByText('No embedding models found for "Vertex AI".'),
       ).toBeInTheDocument();
       expect(
         screen.getByRole("link", {
-          name: /Sync models and configure embedding dimensions/,
+          name: /Sync models and set embedding dimensions/,
         }),
       ).toHaveAttribute("href", "/llm/models");
     });
@@ -960,7 +960,7 @@ describe("KnowledgeSettingsPage", () => {
       renderPage();
 
       expect(
-        screen.getByText("Select a reranker API key first..."),
+        screen.getByText("Select a reranking API key first..."),
       ).toBeInTheDocument();
     });
 
@@ -1209,7 +1209,7 @@ describe("KnowledgeSettingsPage", () => {
       expect(screen.getByText(/ready in 40 minutes/)).toBeInTheDocument();
       // The consequence moved to the hover detail to keep the line glanceable.
       expect(
-        screen.getByTitle(/rank with PostgreSQL's built-in ranking/),
+        screen.getByTitle(/use PostgreSQL's built-in ranking/),
       ).toBeInTheDocument();
       unmountPending();
 
@@ -1232,7 +1232,7 @@ describe("KnowledgeSettingsPage", () => {
       // A flag, never the raw database error: one rebuild covers every
       // organization, so its message can describe another tenant's corpus.
       expect(
-        screen.getByTitle(/last rebuild of the ranking statistics/i),
+        screen.getByTitle(/last ranking statistics rebuild/i),
       ).toBeInTheDocument();
     });
 
@@ -1252,7 +1252,7 @@ describe("KnowledgeSettingsPage", () => {
 
       expect(screen.getByText("No documents indexed yet")).toBeInTheDocument();
       expect(
-        screen.getByTitle(/statistics build after the first sync/i),
+        screen.getByTitle(/builds ranking statistics after the first sync/i),
       ).toBeInTheDocument();
     });
 

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -241,11 +241,11 @@ function AddApiKeyDialog({
     <FormDialog
       open={open}
       onOpenChange={onOpenChange}
-      title="Add LLM Provider Key"
+      title="Add LLM provider key"
       description={
         forEmbedding
-          ? "Add an API key for knowledge base embeddings."
-          : "Add an LLM provider API key for knowledge base reranking."
+          ? "Add a key for knowledge base embeddings."
+          : "Add an LLM provider key for knowledge base reranking."
       }
       size="small"
     >
@@ -278,7 +278,7 @@ function AddApiKeyDialog({
             {createMutation.isPending && (
               <Loader2 className="h-4 w-4 animate-spin" />
             )}
-            <span>Test & Create</span>
+            <span>Test and create</span>
           </Button>
         </DialogStickyFooter>
       </DialogForm>
@@ -418,7 +418,7 @@ function RerankerModelSelector({
       <LlmModelSearchableSelect
         value=""
         onValueChange={() => {}}
-        placeholder="Select a reranker API key first..."
+        placeholder="Select a reranking API key first..."
         options={[]}
         className={cn("w-full")}
         disabled
@@ -446,7 +446,7 @@ function RerankerModelSelector({
       value={value ?? ""}
       onValueChange={(v) => onChange(v || null)}
       options={rerankerItems}
-      placeholder="Select reranking model..."
+      placeholder="Select a reranking model..."
       className={cn("w-full", pulse && SETUP_HIGHLIGHT_CLASS)}
       popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
       popoverListClassName={KNOWLEDGE_MODEL_POPOVER_LIST_CLASS}
@@ -517,9 +517,9 @@ function OcrModelSelector({
         model: model.modelId,
         provider: model.provider,
       }))}
-      placeholder="Select vision model..."
+      placeholder="Select a vision model..."
       searchPlaceholder="Search vision models..."
-      emptyMessage="No vision-capable models for this key's provider. Mark your model's image or PDF input modality in LLM Providers > Models."
+      emptyMessage="No vision-capable models are available for the selected provider. Set the image or PDF input modality in LLM Providers > Models."
       className={cn("w-full")}
       popoverContentClassName={KNOWLEDGE_MODEL_POPOVER_CLASS}
       popoverListClassName={KNOWLEDGE_MODEL_POPOVER_LIST_CLASS}
@@ -569,7 +569,7 @@ function DropEmbeddingConfigDialog({
       open={open}
       onOpenChange={onOpenChange}
       title="Drop embedding configuration?"
-      description="This deletes all embedded documents. Connectors and knowledge bases are preserved — the next sync will re-ingest everything with the new embedding model."
+      description="This deletes all embedded documents. Connectors and knowledge bases remain. The next sync re-ingests all documents with the new embedding model."
       isPending={dropMutation.isPending}
       onConfirm={handleDrop}
       confirmLabel="Drop"
@@ -640,7 +640,7 @@ function KeywordRankingStatusLine({
       <span>No documents indexed yet</span>,
       {
         title:
-          "Ranking statistics build after the first sync indexes documents.",
+          "The system builds ranking statistics after the first sync indexes documents.",
       },
     );
   }
@@ -656,7 +656,7 @@ function KeywordRankingStatusLine({
       {
         tone: "destructive",
         title:
-          "The last rebuild of the ranking statistics did not finish. Searches keep using the statistics from the last successful one; the server logs carry the error.",
+          "The last ranking statistics rebuild did not finish. Searches use statistics from the last successful rebuild. The server logs contain the error.",
       },
     );
   }
@@ -671,7 +671,7 @@ function KeywordRankingStatusLine({
       </span>,
       {
         title:
-          "Documents indexed since the last statistics update rank with PostgreSQL's built-in ranking until the next one.",
+          "Documents indexed since the last statistics update use PostgreSQL's built-in ranking until the next update.",
       },
     );
   }
@@ -717,8 +717,8 @@ function KnowledgeSettingsContent() {
     refetch: refetchApiKeys,
   } = useAvailableLlmProviderApiKeys({ toastOnError: false });
   const updateKnowledgeSettings = useUpdateKnowledgeSettings(
-    "Knowledge settings updated",
-    "Failed to update knowledge settings",
+    "Knowledge settings saved",
+    "Could not save knowledge settings",
   );
   const testConnection = useTestEmbeddingConnection();
   const { data: keywordRankingStatus } = useKeywordRankingStatus();
@@ -837,7 +837,7 @@ function KnowledgeSettingsContent() {
     selectedEmbeddingModel?.provider ??
     null;
   const embeddingEmptyMessage = selectedEmbeddingApiKey
-    ? `No embedding models detected for "${selectedEmbeddingApiKey.name}".`
+    ? `No embedding models found for "${selectedEmbeddingApiKey.name}".`
     : "Select an embedding API key first.";
   const noticeDismissalScope =
     organization?.id && session?.user.id
@@ -1146,7 +1146,7 @@ function KnowledgeSettingsContent() {
   if (!isInitialLoading && isLoadError) {
     return (
       <QueryLoadError
-        title="Couldn't load your knowledge settings"
+        title="Could not load knowledge settings"
         onRetry={() => {
           refetchApiKeys();
           refetchModelsWithApiKeys();
@@ -1166,12 +1166,11 @@ function KnowledgeSettingsContent() {
           title="Embedding Configuration"
           description={
             <>
-              The model that turns your documents into searchable meaning. It
-              decides how well a search finds passages that say what was asked
-              in different words. Pick it once — changing it later means
-              re-indexing everything. A key appears here once its embedding
-              models are synced with dimensions set (384, 768, 1024, 1536 or
-              3072).
+              Select the model that converts documents to searchable meaning. It
+              defines how well searches find passages that use different words.
+              Select it once. A later change requires you to re-index all
+              documents. A key appears after the system synchronizes embedding
+              models with dimensions of 384, 768, 1024, 1536, or 3072.
             </>
           }
         >
@@ -1234,12 +1233,12 @@ function KnowledgeSettingsContent() {
                   />
                 </CardRow>
                 <p className="text-sm text-muted-foreground sm:ml-auto sm:w-80">
-                  Don't see your model?{" "}
+                  Model not listed?{" "}
                   <Link
                     href="/llm/models"
                     className="inline-flex items-center gap-0.5 text-primary underline-offset-2 hover:underline"
                   >
-                    Sync models and configure embedding dimensions
+                    Sync models and set embedding dimensions
                     <ArrowUpRight className="h-3.5 w-3.5" />
                   </Link>
                 </p>
@@ -1266,8 +1265,8 @@ function KnowledgeSettingsContent() {
                     <p className="flex items-start gap-2 text-xs text-muted-foreground sm:ml-auto sm:w-80">
                       <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                       <span>
-                        Gemini will truncate from its native 3072 dimensions via
-                        outputDimensionality.
+                        Gemini uses outputDimensionality to truncate its native
+                        3072 dimensions.
                       </span>
                     </p>
                   )}
@@ -1304,8 +1303,8 @@ function KnowledgeSettingsContent() {
                       Embedding index locked
                     </p>
                     <p className="text-sm leading-relaxed text-muted-foreground">
-                      Drop the index to change models. All documents will need
-                      to be re-embedded afterward.
+                      Drop the index to change models. Then re-embed all
+                      documents.
                     </p>
                   </div>
                 </div>
@@ -1356,11 +1355,10 @@ function KnowledgeSettingsContent() {
           title="Search Ranking Configuration"
           description={
             <>
-              Orders the passages a search has found. Reranking reads the
-              shortlist and puts the passages that answer the question first;
-              keyword ranking scores them by the words they share with the
-              question. Changes apply to the next search — nothing is
-              re-indexed.
+              Controls the order of passages found in a search. Reranking reads
+              the shortlist and places passages that answer the question first.
+              Keyword ranking scores shared words. Changes apply to the next
+              search. No documents are re-indexed.
             </>
           }
         >
@@ -1372,10 +1370,10 @@ function KnowledgeSettingsContent() {
               <div className="space-y-1">
                 <h4 className="text-sm font-medium">Reranking</h4>
                 <p className="text-sm text-muted-foreground">
-                  Reads the shortlisted passages with a model and puts the ones
-                  that answer the question first. Works with any chat model, or
-                  a Cohere Rerank model on Cohere and Azure AI Foundry keys.
-                  Optional.{" "}
+                  A model reads shortlisted passages and places passages that
+                  answer the question first. Use any chat model, or use a Cohere
+                  Rerank model with a Cohere or Azure AI Foundry key. This is
+                  optional.{" "}
                   <ExternalDocsLink
                     href={getDocsUrl(DocsPage.PlatformKnowledge, "reranking")}
                     className="text-primary hover:underline"
@@ -1437,8 +1435,8 @@ function KnowledgeSettingsContent() {
                   )}
                 </div>
                 <p className="text-sm text-muted-foreground">
-                  Scores each passage by the words it shares with the question,
-                  using BM25 — rare, specific words count most. Always on.{" "}
+                  BM25 scores each passage by shared words. Rare, specific words
+                  have the highest weight. This is always enabled.{" "}
                   <ExternalDocsLink
                     href={getDocsUrl(
                       DocsPage.PlatformKnowledge,
@@ -1531,7 +1529,7 @@ function KnowledgeSettingsContent() {
                   Adds search-only context to passages during ingestion. The
                   document option makes one model call per document. The passage
                   option generates specific context in batches for longer
-                  documents and uses the document option for short ones.
+                  documents. It uses the document option for short documents.
                   Requires a chat reranking model.{" "}
                   <ExternalDocsLink
                     href={getDocsUrl(
@@ -1639,11 +1637,11 @@ function KnowledgeSettingsContent() {
           title="Document OCR"
           description={
             <>
-              Reads the text in scanned or image-only PDF pages — a signed
-              contract that was scanned, for example — so those documents show
-              up in search like any other. Without it, such pages are skipped.
-              Each transcribed page is one metered model call, visible in LLM
-              cost statistics. Optional.
+              Reads text from scanned or image-only PDF pages. For example, it
+              reads a scanned signed contract. This makes the pages searchable.
+              Without OCR, the system skips them. Each transcribed page uses one
+              metered model call, which appears in LLM cost statistics. This
+              feature is optional.
             </>
           }
         >
@@ -1672,12 +1670,12 @@ function KnowledgeSettingsContent() {
                   />
                 </CardRow>
                 <p className="text-sm text-muted-foreground sm:ml-auto sm:w-80">
-                  Don't see your model?{" "}
+                  Model not listed?{" "}
                   <Link
                     href="/llm/models"
                     className="inline-flex items-center gap-0.5 text-primary underline-offset-2 hover:underline"
                   >
-                    Mark its image or PDF input modality
+                    Set its image or PDF input modality
                     <ArrowUpRight className="h-3.5 w-3.5" />
                   </Link>
                 </p>
@@ -1685,8 +1683,9 @@ function KnowledgeSettingsContent() {
                   <p className="flex items-start gap-2 text-xs text-muted-foreground sm:ml-auto sm:w-80">
                     <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                     <span>
-                      Saving triggers a full re-sync of every connector so
-                      documents previously skipped as unreadable are picked up.
+                      When you save, the system starts a full re-sync for every
+                      connector. It then includes documents it skipped because
+                      it could not read them.
                     </span>
                   </p>
                 )}
@@ -1756,7 +1755,7 @@ function KnowledgeSettingsContent() {
           catalogKey="knowledgeConnectorOverrides"
           catalog={CONNECTOR_TYPES}
           title="Available connectors"
-          description="Which connector types this deployment offers. A type you remove leaves the pickers, and the API refuses to configure it. Connectors that already exist keep syncing until you delete them."
+          description="This deployment offers these connector types. If you remove a type, it disappears from the pickers, and the API does not let you configure it. Existing connectors continue to sync until you delete them."
           options={CONNECTOR_TYPES.map((type) => ({
             value: type,
             label: CONNECTOR_TYPE_LABELS[type],
@@ -1765,8 +1764,8 @@ function KnowledgeSettingsContent() {
             ),
           }))}
           placeholder="Select connector types…"
-          emptyMessage="No connector types found."
-          savedMessage="Available connectors updated"
+          emptyMessage="No connector types are available."
+          savedMessage="Available connectors saved"
         />
       </SettingsSectionStack>
     </LoadingWrapper>

--- a/platform/frontend/src/app/settings/layout.tsx
+++ b/platform/frontend/src/app/settings/layout.tsx
@@ -47,7 +47,7 @@ const PAGE_CONFIG: Record<string, { title: string; description: ReactNode }> = {
   "/settings/knowledge": {
     title: "Knowledge",
     description:
-      "Configure embedding, reranking, and knowledge system defaults.",
+      "Configure defaults for embedding, reranking, and the knowledge system.",
   },
   "/settings/connection": {
     title: "Connection",


### PR DESCRIPTION
## Summary

- Rewrite the Knowledge settings copy with shorter, direct sentences.
- Rewrite the public Knowledge guide with the same ASD-STE100 rules.
- Preserve product terms, configuration values, links, and behavior.

## Copy scores

- Settings: `3.35` to `0.21` violations per 100 words.
- Public guide: `3.31` to `0.84` violations per 100 words.

## Checks

- `pnpm --filter @frontend test --run src/app/settings/knowledge/page.test.tsx`
- `pnpm --filter @frontend type-check`
- `pnpm exec biome check` on changed frontend files
- `python3 .github/scripts/check-docs-links.py`
- ASD-STE100 lint for the settings copy and public guide

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>