### PR TITLE
fix(skills): filter plugin artifacts from derived skills

### DIFF
--- a/docs/pages/platform-agent-plugins.md
+++ b/docs/pages/platform-agent-plugins.md
@@ -115,4 +115,4 @@ An authorized platform administrator selects the plugin and runs the setup comma
 
 Use a plugin when the coding client must own the behavior. Use a Skill when the model needs reusable guidance.
 
-Skills embedded in a plugin also appear under **Skills from plugins** on the Skills page. This read-only Beta category ignores the plugin's client and platform when listing `SKILL.md` files. Agents in any connected client can discover and load these Skills without creating standalone copies. The source client remains visible because scripts or tool names inside the Skill may still depend on it.
+Skills embedded at any depth in a plugin also appear under **Skills from plugins** on the Skills page. This read-only Beta category ignores the plugin's client and platform when listing `SKILL.md` files. It shares Skill resources plus readable context from README and license files, commands, agents, output styles, and MCP or LSP configuration. Hooks, manifests, settings, installers, and runtime files stay with the source plugin. Agents in any connected client can discover and load these Skills without creating standalone copies.

--- a/docs/pages/platform-agent-skills.md
+++ b/docs/pages/platform-agent-skills.md
@@ -127,7 +127,7 @@ Plugins can contain one or more `SKILL.md` trees. Every valid Skill inside a plu
 
 The category does not filter by the plugin's client or operating system. Skill instructions are usually portable, so a Skill from a Claude Code plugin can still help in another client. The source client and platforms stay visible because bundled scripts and tool names may depend on them.
 
-Plugin Skills are read-only and remain managed by their source plugin. Anyone with access can load their instructions and bundled files through the same `list_skills` and `load_skill` tools as other Skills. Activations contribute to the shared usage view. Archestra reads the source bytes directly instead of copying them into standalone Skills.
+Plugin Skills are read-only and remain managed by their source plugin. Archestra shares Skill resources plus readable context from README and license files, commands, agents, output styles, and MCP or LSP configuration. Client hooks, manifests, settings, installers, and runtime files remain private to the plugin. Anyone with access can load these files through the same `list_skills` and `load_skill` tools as other Skills. Activations contribute to the shared usage view. Archestra reads the source bytes directly instead of copying them into standalone Skills.
 
 ## Permissions and scope
 

--- a/platform/backend/src/archestra-mcp-server/skills.test.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.test.ts
@@ -384,6 +384,18 @@ describe("skill tool execution", () => {
           encoding: "utf8",
           mode: "100644",
         },
+        {
+          path: "skills/release/hooks/hooks.json",
+          content: '{"hooks":{}}\n',
+          encoding: "utf8",
+          mode: "100644",
+        },
+        {
+          path: "skills/release/.mcp.json",
+          content: "{}\n",
+          encoding: "utf8",
+          mode: "100644",
+        },
       ],
     };
     const plugin = await PluginModel.create({
@@ -414,6 +426,8 @@ describe("skill tool execution", () => {
     );
     expect(textOf(activation)).toContain("Ship carefully.");
     expect(textOf(activation)).toContain("references/checklist.md");
+    expect(textOf(activation)).toContain(".mcp.json");
+    expect(textOf(activation)).not.toContain("hooks/hooks.json");
     await drainBackgroundWork();
     let usage = await PluginSkillUsageEventModel.getSummaries([
       { pluginId: plugin.id, skillPath: "skills/release" },
@@ -426,6 +440,20 @@ describe("skill tool execution", () => {
       context,
     );
     expect(textOf(file)).toContain("# Checklist");
+    const mcpConfig = await executeArchestraTool(
+      TOOL_LOAD_SKILL_FULL_NAME,
+      { name: loadName, path: ".mcp.json" },
+      context,
+    );
+    expect(mcpConfig.isError).toBe(false);
+    expect(textOf(mcpConfig)).toContain("{}\n");
+    const hookArtifact = await executeArchestraTool(
+      TOOL_LOAD_SKILL_FULL_NAME,
+      { name: loadName, path: "hooks/hooks.json" },
+      context,
+    );
+    expect(hookArtifact.isError).toBe(true);
+    expect(textOf(hookArtifact)).toContain("has no file");
     await drainBackgroundWork();
     usage = await PluginSkillUsageEventModel.getSummaries([
       { pluginId: plugin.id, skillPath: "skills/release" },

--- a/platform/backend/src/plugins/plugin-skills.ts
+++ b/platform/backend/src/plugins/plugin-skills.ts
@@ -211,10 +211,41 @@ function skillRootOf(manifestPath: string): string {
   return index === -1 ? "" : manifestPath.slice(0, index);
 }
 
-/**
- * File paths belonging to one skill tree: everything under its root except
- * the manifest itself and anything a deeper skill root owns.
- */
+const ADOPTABLE_SKILL_RESOURCE_DIRECTORIES = new Set([
+  "agents",
+  "assets",
+  "commands",
+  "licenses",
+  "lsp-config",
+  "output-styles",
+  "references",
+  "scripts",
+]);
+
+const ADOPTABLE_PLUGIN_CONFIG_PATHS = new Set([
+  ".lsp.json",
+  ".mcp.json",
+  ".cursor/mcp.json",
+  ".copilot/mcp-config.json",
+  ".github/lsp.json",
+  ".github/mcp.json",
+  ".vscode/mcp.json",
+  "lsp.json",
+  "mcp.json",
+]);
+
+const ADOPTABLE_PLUGIN_CONTEXT_PREFIXES = [
+  ".claude/agents/",
+  ".claude/commands/",
+  ".claude/output-styles/",
+  ".codex/agents/",
+  ".cursor/agents/",
+  ".cursor/commands/",
+  ".github/agents/",
+  ".github/prompts/",
+];
+
+/** Keep Skill-owned resources and explicitly adoptable plugin context. */
 function resourcePathsOf(
   filePaths: string[],
   manifestPath: string,
@@ -228,8 +259,27 @@ function resourcePathsOf(
   return filePaths.filter((path) => {
     if (path === manifestPath) return false;
     if (root !== "" && !path.startsWith(`${root}/`)) return false;
-    return !deeperRoots.some(
-      (deeper) => deeper !== "" && path.startsWith(`${deeper}/`),
+    if (
+      deeperRoots.some(
+        (deeper) => deeper !== "" && path.startsWith(`${deeper}/`),
+      )
+    ) {
+      return false;
+    }
+    const relativePath = root === "" ? path : path.slice(root.length + 1);
+    const resourceRoot = relativePath.split("/", 1)[0].toLowerCase();
+    const isRootFile = !relativePath.includes("/");
+    return (
+      ADOPTABLE_SKILL_RESOURCE_DIRECTORIES.has(resourceRoot) ||
+      ADOPTABLE_PLUGIN_CONFIG_PATHS.has(relativePath) ||
+      ADOPTABLE_PLUGIN_CONTEXT_PREFIXES.some((prefix) =>
+        relativePath.startsWith(prefix),
+      ) ||
+      (isRootFile && /^README(?:[._-].+)?$/i.test(relativePath)) ||
+      (isRootFile &&
+        /^(?:LICENSE|LICENCE|COPYING|NOTICE|COPYRIGHT)(?:[._-].+)?$/i.test(
+          relativePath,
+        ))
     );
   });
 }

--- a/platform/backend/src/routes/skill/plugin-skill.routes.test.ts
+++ b/platform/backend/src/routes/skill/plugin-skill.routes.test.ts
@@ -296,7 +296,7 @@ describe("plugin Skill routes", () => {
     expect(missing.statusCode).toBe(404);
   });
 
-  test("nested skill trees keep their own files", async () => {
+  test("projects only portable resources from root and nested skill trees", async () => {
     mockUserHasPermission.mockResolvedValue(true);
     const plugin = await seedPlugin(
       stePlugin({
@@ -310,22 +310,112 @@ describe("plugin Skill routes", () => {
           },
           {
             path: "notes.md",
-            content: "root note\n",
+            content: "plugin note\n",
+            encoding: "utf8",
+            mode: "100644",
+          },
+          ...[
+            ".claude-plugin/plugin.json",
+            ".codex-plugin/plugin.json",
+            ".github/plugin/plugin.json",
+            ".cursor-plugin/plugin.json",
+            "hooks/hooks.json",
+            ".claude/settings.json",
+            ".codex/config.toml",
+            ".cursor/rules/project.mdc",
+            ".github/copilot-instructions.md",
+            "install.ps1",
+            "package.json",
+            "hooks/README.md",
+            "install/NOTICE",
+            "runtime/LICENSE",
+            "settings/.mcp.json",
+          ].map((path) => ({
+            path,
+            content: "plugin-specific\n",
+            encoding: "utf8" as const,
+            mode: "100644" as const,
+          })),
+          ...[
+            ".mcp.json",
+            ".lsp.json",
+            "LICENSE.md",
+            "LICENSE-MIT",
+            "LICENSES/Apache.txt",
+            "README.md",
+            "agents/reviewer.md",
+            "commands/release.md",
+            "output-styles/concise.md",
+            ".claude/agents/reviewer.md",
+            ".claude/commands/release.md",
+            ".claude/output-styles/concise.md",
+            ".codex/agents/reviewer.toml",
+            ".cursor/agents/reviewer.md",
+            ".cursor/commands/release.md",
+            ".github/agents/reviewer.agent.md",
+            ".github/prompts/release.prompt.md",
+            ".copilot/mcp-config.json",
+            ".cursor/mcp.json",
+            ".github/mcp.json",
+          ].map((path) => ({
+            path,
+            content: "adoptable context\n",
+            encoding: "utf8" as const,
+            mode: "100644" as const,
+          })),
+          {
+            path: "scripts/root-check.sh",
+            content: "#!/bin/sh\n",
+            encoding: "utf8",
+            mode: "100755",
+          },
+          {
+            path: "references/root-notes.md",
+            content: "root reference\n",
             encoding: "utf8",
             mode: "100644",
           },
           {
-            path: "skills/ste-writing/SKILL.md",
+            path: "assets/root-template.txt",
+            content: "root template\n",
+            encoding: "utf8",
+            mode: "100644",
+          },
+          {
+            path: "bundles/client/skills/ste-writing/SKILL.md",
             content: SKILL_MD,
             encoding: "utf8",
             mode: "100644",
           },
           {
-            path: "skills/ste-writing/scripts/ste-lint.py",
+            path: "bundles/client/skills/ste-writing/scripts/ste-lint.py",
             content: "print('lint')\n",
             encoding: "utf8",
             mode: "100755",
           },
+          {
+            path: "bundles/client/skills/ste-writing/hooks/hooks.json",
+            content: "{}\n",
+            encoding: "utf8",
+            mode: "100644",
+          },
+          {
+            path: "bundles/client/skills/ste-writing/custom/context.md",
+            content: "non-standard resource\n",
+            encoding: "utf8",
+            mode: "100644",
+          },
+          ...[
+            "bundles/client/skills/ste-writing/.mcp.json",
+            "bundles/client/skills/ste-writing/NOTICE",
+            "bundles/client/skills/ste-writing/README.md",
+            "bundles/client/skills/ste-writing/agents/editor.md",
+          ].map((path) => ({
+            path,
+            content: "nested adoptable context\n",
+            encoding: "utf8" as const,
+            mode: "100644" as const,
+          })),
         ],
       }),
     );
@@ -340,11 +430,11 @@ describe("plugin Skill routes", () => {
       (item: { skillPath: string }) => item.skillPath === "",
     );
     const nestedItem = items.find(
-      (item: { skillPath: string }) => item.skillPath === "skills/ste-writing",
+      (item: { skillPath: string }) =>
+        item.skillPath === "bundles/client/skills/ste-writing",
     );
-    // the root tree owns only its note; the nested tree owns its script
-    expect(rootItem).toMatchObject({ name: "root-guide", fileCount: 1 });
-    expect(nestedItem).toMatchObject({ name: "ste-writing", fileCount: 1 });
+    expect(rootItem).toMatchObject({ name: "root-guide", fileCount: 23 });
+    expect(nestedItem).toMatchObject({ name: "ste-writing", fileCount: 5 });
 
     const rootDetail = await ctx.app.inject({
       method: "GET",
@@ -352,7 +442,42 @@ describe("plugin Skill routes", () => {
     });
     expect(rootDetail.statusCode).toBe(200);
     expect(rootDetail.json().files).toEqual([
-      expect.objectContaining({ path: "notes.md" }),
+      expect.objectContaining({ path: ".claude/agents/reviewer.md" }),
+      expect.objectContaining({ path: ".claude/commands/release.md" }),
+      expect.objectContaining({ path: ".claude/output-styles/concise.md" }),
+      expect.objectContaining({ path: ".codex/agents/reviewer.toml" }),
+      expect.objectContaining({ path: ".copilot/mcp-config.json" }),
+      expect.objectContaining({ path: ".cursor/agents/reviewer.md" }),
+      expect.objectContaining({ path: ".cursor/commands/release.md" }),
+      expect.objectContaining({ path: ".cursor/mcp.json" }),
+      expect.objectContaining({ path: ".github/agents/reviewer.agent.md" }),
+      expect.objectContaining({ path: ".github/mcp.json" }),
+      expect.objectContaining({ path: ".github/prompts/release.prompt.md" }),
+      expect.objectContaining({ path: ".lsp.json" }),
+      expect.objectContaining({ path: ".mcp.json" }),
+      expect.objectContaining({ path: "LICENSE-MIT" }),
+      expect.objectContaining({ path: "LICENSE.md" }),
+      expect.objectContaining({ path: "LICENSES/Apache.txt" }),
+      expect.objectContaining({ path: "README.md" }),
+      expect.objectContaining({ path: "agents/reviewer.md" }),
+      expect.objectContaining({ path: "assets/root-template.txt" }),
+      expect.objectContaining({ path: "commands/release.md" }),
+      expect.objectContaining({ path: "output-styles/concise.md" }),
+      expect.objectContaining({ path: "references/root-notes.md" }),
+      expect.objectContaining({ path: "scripts/root-check.sh" }),
+    ]);
+
+    const nestedDetail = await ctx.app.inject({
+      method: "GET",
+      url: `/api/skills/plugins/${plugin.id}?skillPath=bundles/client/skills/ste-writing`,
+    });
+    expect(nestedDetail.statusCode).toBe(200);
+    expect(nestedDetail.json().files).toEqual([
+      expect.objectContaining({ path: ".mcp.json" }),
+      expect.objectContaining({ path: "NOTICE" }),
+      expect.objectContaining({ path: "README.md" }),
+      expect.objectContaining({ path: "agents/editor.md" }),
+      expect.objectContaining({ path: "scripts/ste-lint.py" }),
     ]);
   });
 


### PR DESCRIPTION
## Summary
- project plugin Skills from arbitrary nested `SKILL.md` roots without leaking the whole plugin tree
- retain standard Skill resources plus adoptable README/license, command, agent, output-style, MCP, and LSP context
- exclude hooks, manifests, settings, rules, installers, packages, binaries, and runtime artifacts, including basename-bypass cases

## Research
Reviewed official plugin and Skill conventions for Claude Code, Codex, GitHub Copilot CLI, and Cursor across POSIX and Windows. The projection is client/platform agnostic and applies ownership relative to each concrete Skill root.

## Validation
- backend commit gate
- 70 targeted REST and MCP Skill tests
- live VM REST projection and MCP Gateway `list_skills` / `load_skill` checks
- nested default-plugin discovery and activation

Task: [T-1196](https://slack.com/archives/C0B2AGC0AFQ/p1787821901277729?thread_ts=1787821900.629289&cid=C0B2AGC0AFQ)
Follow-up to #7509

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>