### PR TITLE
fix: accept valid HTTP header names

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -43738,7 +43738,7 @@
                       "type": "string",
                       "minLength": 1,
                       "maxLength": 128,
-                      "pattern": "^[a-zA-Z0-9-]+$"
+                      "pattern": "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$"
                     }
                   },
                   "toolExposureMode": {
@@ -46827,7 +46827,7 @@
                           "type": "string",
                           "minLength": 1,
                           "maxLength": 128,
-                          "pattern": "^[a-zA-Z0-9-]+$"
+                          "pattern": "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$"
                         }
                       }
                     },
@@ -48809,7 +48809,7 @@
                       "type": "string",
                       "minLength": 1,
                       "maxLength": 128,
-                      "pattern": "^[a-zA-Z0-9-]+$"
+                      "pattern": "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$"
                     }
                   },
                   "toolExposureMode": {

--- a/platform/backend/src/types/agent.test.ts
+++ b/platform/backend/src/types/agent.test.ts
@@ -27,10 +27,10 @@ describe("PassthroughHeadersSchema", () => {
   test("accepts valid header names and lowercases them", () => {
     const result = PassthroughHeadersSchema.safeParse([
       "X-Correlation-Id",
-      "x-tenant-id",
+      "X_Tenant.Id",
     ]);
     expect(result.success).toBe(true);
-    expect(result.data).toEqual(["x-correlation-id", "x-tenant-id"]);
+    expect(result.data).toEqual(["x-correlation-id", "x_tenant.id"]);
   });
 
   test("accepts null", () => {

--- a/platform/backend/src/types/agent.ts
+++ b/platform/backend/src/types/agent.ts
@@ -2,6 +2,8 @@ import {
   BLOCKED_PASSTHROUGH_HEADERS,
   BUILT_IN_AGENT_IDS,
   DOMAIN_VALIDATION_REGEX,
+  HEADER_NAME_REGEX,
+  HEADER_NAME_VALIDATION_MESSAGE,
   IncomingEmailSecurityModeSchema,
   MAX_DOMAIN_LENGTH,
   MAX_PASSTHROUGH_HEADERS,
@@ -184,10 +186,7 @@ const PassthroughHeaderSchema = z
   .string()
   .min(1)
   .max(128)
-  .regex(
-    /^[a-zA-Z0-9-]+$/,
-    "Header name must contain only alphanumeric characters and hyphens",
-  )
+  .regex(HEADER_NAME_REGEX, HEADER_NAME_VALIDATION_MESSAGE)
   .transform((h) => h.toLowerCase())
   .refine((h) => !BLOCKED_PASSTHROUGH_HEADERS.has(h), {
     message: "This header name is not allowed (hop-by-hop or protocol-level)",

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.test.ts
@@ -87,6 +87,26 @@ describe("formSchema", () => {
       expect(formSchema.parse(data)).toEqual(data);
     });
 
+    it("accepts RFC-valid punctuation in header names", () => {
+      const data = {
+        ...baseValidData,
+        serverType: "remote" as const,
+        serverUrl: "https://api.example.com/mcp",
+        additionalHeaders: [
+          {
+            headerName: "X_API.KEY",
+            promptOnInstallation: true,
+            required: false,
+            value: "",
+            description: "",
+          },
+        ],
+        localConfig: undefined,
+      };
+
+      expect(formSchema.safeParse(data).success).toBe(true);
+    });
+
     it("should reject remote server without URL", () => {
       const data = {
         ...baseValidData,
@@ -154,7 +174,7 @@ describe("formSchema", () => {
       };
 
       expect(() => formSchema.parse(data)).toThrow(
-        "Header name must contain only alphanumeric characters and hyphens",
+        "Header name contains invalid HTTP header characters",
       );
     });
   });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
@@ -1,7 +1,10 @@
-import { LocalConfigFormSchema } from "@archestra/shared";
+import {
+  HEADER_NAME_REGEX,
+  HEADER_NAME_VALIDATION_MESSAGE,
+  LocalConfigFormSchema,
+} from "@archestra/shared";
 import { z } from "zod";
 
-const HEADER_NAME_REGEX = /^[A-Za-z0-9-]+$/;
 const SSO_CALLBACK_PATH = "/api/auth/sso/callback";
 
 const headerNameSchema = z
@@ -9,10 +12,7 @@ const headerNameSchema = z
   .trim()
   .min(1, "Header name is required")
   .max(128, "Header name is too long")
-  .regex(
-    HEADER_NAME_REGEX,
-    "Header name must contain only alphanumeric characters and hyphens",
-  );
+  .regex(HEADER_NAME_REGEX, HEADER_NAME_VALIDATION_MESSAGE);
 
 const additionalHeaderSchema = z.object({
   fieldName: z.string().optional(),

--- a/platform/frontend/src/components/agent-form.tsx
+++ b/platform/frontend/src/components/agent-form.tsx
@@ -14,6 +14,7 @@ import {
   getDocsUrl,
   getResourceForAgentType,
   HEADER_NAME_REGEX,
+  HEADER_NAME_VALIDATION_MESSAGE,
   MAX_PASSTHROUGH_HEADERS,
   MAX_SUGGESTED_PROMPT_TEXT_LENGTH,
   MAX_SUGGESTED_PROMPT_TITLE_LENGTH,
@@ -3670,9 +3671,7 @@ export function AgentForm({
                             .toLowerCase();
                           if (!value) return;
                           if (!HEADER_NAME_REGEX.test(value)) {
-                            toast.error(
-                              "Header name must contain only alphanumeric characters and hyphens",
-                            );
+                            toast.error(HEADER_NAME_VALIDATION_MESSAGE);
                             return;
                           }
                           if (BLOCKED_PASSTHROUGH_HEADERS.has(value)) {

--- a/platform/frontend/src/components/headers-read-only-table.test.tsx
+++ b/platform/frontend/src/components/headers-read-only-table.test.tsx
@@ -1,0 +1,65 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useFieldArray, useForm } from "react-hook-form";
+import {
+  formSchema,
+  type McpCatalogFormValues,
+} from "@/app/mcp/registry/_parts/mcp-catalog-form.types";
+import { HeadersReadOnlyTable } from "@/components/headers-read-only-table";
+
+describe("HeadersReadOnlyTable", () => {
+  it("shows a header-name error that blocks form submission", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(<TestForm onSubmit={onSubmit} />);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Header name contains invalid HTTP header characters",
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+function TestForm({ onSubmit }: { onSubmit: () => void }) {
+  const form = useForm<McpCatalogFormValues>({
+    // biome-ignore lint/suspicious/noExplicitAny: Version mismatch between @hookform/resolvers and Zod
+    resolver: zodResolver(formSchema as any),
+    defaultValues: {
+      name: "Remote MCP",
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com",
+      authMethod: "none",
+      includeBearerPrefix: true,
+      authHeaderName: "",
+      additionalHeaders: [
+        {
+          headerName: "invalid header",
+          promptOnInstallation: true,
+          required: false,
+          value: "",
+          description: "",
+        },
+      ],
+    },
+  });
+  const { fields, remove } = useFieldArray({
+    control: form.control,
+    name: "additionalHeaders",
+  });
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      <HeadersReadOnlyTable
+        form={form}
+        fields={fields}
+        fieldNamePrefix="additionalHeaders"
+        onEdit={vi.fn()}
+        onDelete={remove}
+      />
+      <button type="submit">Submit</button>
+    </form>
+  );
+}

--- a/platform/frontend/src/components/headers-read-only-table.tsx
+++ b/platform/frontend/src/components/headers-read-only-table.tsx
@@ -5,13 +5,16 @@ import type {
   FieldArrayWithId,
   FieldPath,
   FieldValues,
-  UseFormWatch,
+  UseFormReturn,
 } from "react-hook-form";
 import type { FieldScopeValue } from "@/components/field-scope-select";
 import { Button } from "@/components/ui/button";
 
 interface HeadersReadOnlyTableProps<TFieldValues extends FieldValues> {
-  form: { watch: UseFormWatch<TFieldValues> };
+  form: Pick<
+    UseFormReturn<TFieldValues>,
+    "formState" | "getFieldState" | "watch"
+  >;
   // biome-ignore lint/suspicious/noExplicitAny: field arrays require generic any
   fields: FieldArrayWithId<TFieldValues, any, "id">[];
   fieldNamePrefix: string;
@@ -43,9 +46,13 @@ export function HeadersReadOnlyTable<TFieldValues extends FieldValues>({
         <div className="w-9" />
       </div>
       {fields.map((field, index) => {
-        const headerName = form.watch(
-          `${fieldNamePrefix}.${index}.headerName` as FieldPath<TFieldValues>,
-        ) as string | undefined;
+        const headerNamePath =
+          `${fieldNamePrefix}.${index}.headerName` as FieldPath<TFieldValues>;
+        const headerName = form.watch(headerNamePath) as string | undefined;
+        const headerNameError = form.getFieldState(
+          headerNamePath,
+          form.formState,
+        ).error?.message;
         const required = Boolean(
           form.watch(
             `${fieldNamePrefix}.${index}.required` as FieldPath<TFieldValues>,
@@ -91,9 +98,16 @@ export function HeadersReadOnlyTable<TFieldValues extends FieldValues>({
             }}
             className={`${GRID_CLASS} group items-center border-b py-3 text-xs last:border-b-0 cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
           >
-            <div className="min-w-0 truncate font-mono">
-              {headerName || (
-                <span className="text-muted-foreground italic">unnamed</span>
+            <div className="min-w-0">
+              <div className="truncate font-mono">
+                {headerName || (
+                  <span className="text-muted-foreground italic">unnamed</span>
+                )}
+              </div>
+              {headerNameError && (
+                <p className="mt-1 text-xs text-destructive" role="alert">
+                  {headerNameError}
+                </p>
               )}
             </div>
             <div className="min-w-0 truncate">

--- a/platform/shared/agents.ts
+++ b/platform/shared/agents.ts
@@ -54,4 +54,8 @@ export const BLOCKED_PASSTHROUGH_HEADERS = new Set([
 
 export const MAX_PASSTHROUGH_HEADERS = 20;
 
-export const HEADER_NAME_REGEX = /^[a-zA-Z0-9-]+$/;
+/** RFC 9110 `field-name` is an RFC 9110 `token`. */
+export const HEADER_NAME_REGEX = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+export const HEADER_NAME_VALIDATION_MESSAGE =
+  "Header name contains invalid HTTP header characters";


### PR DESCRIPTION
## Summary

- validate HTTP header names using the RFC token character set
- share the validation rule across MCP catalog and gateway passthrough headers
- display blocking header validation errors directly in the read-only headers table