### PR TITLE
feat(costs): show client activity in personal usage

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -353537,6 +353537,9 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "lastActiveAt": {
+                            "type": "string"
+                          },
                           "requests": {
                             "type": "number"
                           },
@@ -353564,6 +353567,7 @@
                         },
                         "required": [
                           "client",
+                          "lastActiveAt",
                           "requests",
                           "inputTokens",
                           "outputTokens",

--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -2,7 +2,7 @@
 title: Costs & Limits
 category: LLM Proxy
 order: 4
-lastUpdated: 2026-08-26
+lastUpdated: 2026-08-27
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -34,7 +34,7 @@ Reading organization-wide costs requires the `llmCost:read` permission. You can 
 
 ## My Usage
 
-The **My Usage** page at `/llm/usage` shows your own activity: billed spend, requests, tokens, active days, and how spend moved over the selected timeframe. It then provides separate model and client tables with each entry's token share, requests, tokens, and cost.
+The **My Usage** page at `/llm/usage` shows your own activity: billed spend, requests, tokens, active days, and how spend moved over the selected timeframe. It then provides separate model and client tables with each entry's token share, requests, tokens, and cost. The client table distinguishes known client variants and shows when each one was last active.
 
 The lower sections explain the shape of that usage:
 

--- a/platform/backend/src/models/statistics.ts
+++ b/platform/backend/src/models/statistics.ts
@@ -1,5 +1,5 @@
 import {
-  clientForExternalAgentIds,
+  clientUsageLabelForExternalAgentId,
   getStatisticsBucketIntervalMinutes,
   type PaginationQuery,
   parseCustomStatisticsTimeframe,
@@ -998,6 +998,7 @@ class StatisticsModel {
       db
         .select({
           client: interactions.externalAgentId,
+          lastActiveAt: sql<string>`MAX(${interactions.createdAt})`,
           requests: sql<number>`CAST(COUNT(*) AS INTEGER)`,
           inputTokens: tokenSum(interactions.inputTokens),
           outputTokens: tokenSum(interactions.outputTokens),
@@ -1065,8 +1066,10 @@ class StatisticsModel {
     const clientsByLabel = new Map<string | null, MyClientUsage>();
     for (const row of clientRows) {
       const client = formatUsageClient(row.client, clientAgentNames);
+      const lastActiveAt = new Date(row.lastActiveAt).toISOString();
       const current = clientsByLabel.get(client) ?? {
         client,
+        lastActiveAt,
         requests: 0,
         inputTokens: 0,
         outputTokens: 0,
@@ -1083,6 +1086,9 @@ class StatisticsModel {
       current.totalTokens = current.inputTokens + current.outputTokens;
       current.billedCost += Number(row.billedCost) || 0;
       current.subscriptionCost += Number(row.subscriptionCost) || 0;
+      if (lastActiveAt > current.lastActiveAt) {
+        current.lastActiveAt = lastActiveAt;
+      }
       clientsByLabel.set(client, current);
     }
     const clientTotalTokens = Array.from(clientsByLabel.values()).reduce(
@@ -2361,8 +2367,8 @@ function formatUsageClient(
 ): string | null {
   if (!externalAgentId) return null;
 
-  const family = clientForExternalAgentIds([externalAgentId]);
-  if (family) return family.label;
+  const knownClientLabel = clientUsageLabelForExternalAgentId(externalAgentId);
+  if (knownClientLabel) return knownClientLabel;
 
   const agentId = extractUsageClientAgentId(externalAgentId);
   if (agentId) {

--- a/platform/backend/src/routes/statistics.test.ts
+++ b/platform/backend/src/routes/statistics.test.ts
@@ -744,7 +744,7 @@ describe("GET /api/statistics/me/breakdown", () => {
       outputTokens: 10,
       cost: "0.5000000000",
       model: "gpt-4o",
-      externalAgentId: "anthropic_claude",
+      externalAgentId: "anthropic_claude_code",
       createdAt: start,
     });
     await makeInteraction(agent.id, {
@@ -754,7 +754,7 @@ describe("GET /api/statistics/me/breakdown", () => {
       outputTokens: 100,
       cost: "4.0000000000",
       model: "claude-opus-4",
-      externalAgentId: "anthropic_claude",
+      externalAgentId: "anthropic_claude_code",
       createdAt: start,
     });
     await makeInteraction(agent.id, {
@@ -764,7 +764,7 @@ describe("GET /api/statistics/me/breakdown", () => {
       outputTokens: 100,
       cost: "4.0000000000",
       model: "claude-opus-4",
-      externalAgentId: "anthropic_claude",
+      externalAgentId: "anthropic_claude_code",
       createdAt: new Date(start.getTime() + 30 * 60 * 1000),
     });
     // No session id: real traffic, attributable to no session.
@@ -793,20 +793,22 @@ describe("GET /api/statistics/me/breakdown", () => {
     expect(top).toMatchObject({
       requests: 2,
       model: "claude-opus-4",
-      client: "Claude",
+      client: "Claude Code",
       durationMinutes: 30,
     });
     expect(top.cost).toBeCloseTo(8, 10);
 
     expect(body.clients).toEqual([
       expect.objectContaining({
-        client: "Claude",
+        client: "Claude Code",
+        lastActiveAt: top.lastActiveAt,
         requests: 3,
         totalTokens: 420,
         percentage: expect.closeTo(95.454545, 5),
       }),
       expect.objectContaining({
         client: null,
+        lastActiveAt: expect.any(String),
         requests: 1,
         totalTokens: 20,
         percentage: expect.closeTo(4.545455, 5),
@@ -817,6 +819,45 @@ describe("GET /api/statistics/me/breakdown", () => {
     // unsessioned request, so "these sessions were N% of your usage" is honest.
     expect(body.totalCost).toBeCloseTo(9.5, 10);
     expect(body.unsessionedRequests).toBe(1);
+  });
+
+  test("keeps explicit client variants separate in the usage breakdown", async ({
+    makeAgent,
+    makeInteraction,
+  }) => {
+    const agent = await makeAgent({ organizationId, authorId: currentUser.id });
+
+    await makeInteraction(agent.id, {
+      userId: currentUser.id,
+      externalAgentId: "anthropic_claude_code",
+      inputTokens: 100,
+      outputTokens: 20,
+      cost: "1.0000000000",
+    });
+    await makeInteraction(agent.id, {
+      userId: currentUser.id,
+      externalAgentId: "anthropic_claude_desktop",
+      inputTokens: 40,
+      outputTokens: 10,
+      cost: "0.5000000000",
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/statistics/me/breakdown?timeframe=24h",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().clients).toEqual([
+      expect.objectContaining({
+        client: "Claude Code",
+        totalTokens: 120,
+      }),
+      expect.objectContaining({
+        client: "Claude Desktop",
+        totalTokens: 50,
+      }),
+    ]);
   });
 
   test("resolves internal agent ids instead of exposing opaque client labels", async ({

--- a/platform/backend/src/types/statistics.ts
+++ b/platform/backend/src/types/statistics.ts
@@ -60,8 +60,10 @@ export const UserModelUsageSchema = z.object({
 
 /** One client application's slice of the caller's usage. */
 export const MyClientUsageSchema = z.object({
-  /** Known client-family label, raw attribution value, or null when absent. */
+  /** Known client label, raw attribution value, or null when absent. */
   client: z.string().nullable(),
+  /** Most recent request attributed to this client in the selected timeframe. */
+  lastActiveAt: z.string(),
   requests: z.number(),
   inputTokens: z.number(),
   outputTokens: z.number(),

--- a/platform/frontend/src/app/llm/usage/_parts/usage-dimension-cards.test.tsx
+++ b/platform/frontend/src/app/llm/usage/_parts/usage-dimension-cards.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ClientUsageCard, ModelUsageCard } from "./usage-dimension-cards";
 
 describe("usage dimension cards", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("expands model usage into shares, requests, tokens, and billed spend", () => {
     render(
       <ModelUsageCard
@@ -33,11 +37,15 @@ describe("usage dimension cards", () => {
   });
 
   it("groups client usage and keeps subscription-covered value out of spend", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-27T16:00:00.000Z"));
+
     render(
       <ClientUsageCard
         clients={[
           {
             client: "Example coding client",
+            lastActiveAt: "2026-08-27T15:00:00.000Z",
             requests: 40,
             inputTokens: 2_000,
             outputTokens: 500,
@@ -52,6 +60,8 @@ describe("usage dimension cards", () => {
     );
 
     expect(screen.getByText("Example coding client")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("about 1 hour ago")).toBeInTheDocument();
     expect(screen.getByText("$0.00")).toBeInTheDocument();
     expect(screen.getByText("Sub")).toHaveAccessibleName(
       "Subscription-covered usage",
@@ -60,11 +70,15 @@ describe("usage dimension cards", () => {
   });
 
   it("labels requests that do not report a client", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-27T16:00:00.000Z"));
+
     render(
       <ClientUsageCard
         clients={[
           {
             client: null,
+            lastActiveAt: "2026-08-25T16:00:00.000Z",
             requests: 1,
             inputTokens: 1,
             outputTokens: 0,
@@ -79,5 +93,6 @@ describe("usage dimension cards", () => {
     );
 
     expect(screen.getByText("Not reported")).toBeInTheDocument();
+    expect(screen.getByText("Idle")).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/app/llm/usage/_parts/usage-dimension-cards.tsx
+++ b/platform/frontend/src/app/llm/usage/_parts/usage-dimension-cards.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import type { archestraApiTypes } from "@archestra/shared";
+import { subHours } from "date-fns";
 import { BilledCost } from "@/components/billed-cost";
+import { RelativeTime } from "@/components/relative-time";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -47,9 +50,10 @@ export function ClientUsageCard({
   return (
     <UsageDimensionCard
       title="Clients"
-      description="Where your requests came from, including connected coding clients."
+      description="Connections seen through the proxy, with their latest activity and usage."
       dimensionLabel="Client"
       emptyMessage="No client usage recorded for the selected timeframe."
+      showActivity
       rows={clients.map((client) => ({
         ...client,
         label: client.client ?? "Not reported",
@@ -68,6 +72,7 @@ type UsageRow = {
   percentage: number;
   billedCost: number;
   subscriptionCost: number;
+  lastActiveAt?: string;
 };
 
 function UsageDimensionCard({
@@ -76,12 +81,14 @@ function UsageDimensionCard({
   dimensionLabel,
   emptyMessage,
   rows,
+  showActivity = false,
 }: {
   title: string;
   description: string;
   dimensionLabel: string;
   emptyMessage: string;
   rows: UsageRow[];
+  showActivity?: boolean;
 }) {
   return (
     <Card className="min-w-0">
@@ -99,13 +106,30 @@ function UsageDimensionCard({
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead
+                    className={
+                      showActivity
+                        ? "bg-card sticky top-0 z-10 w-36 min-w-36"
+                        : "bg-card sticky top-0 z-10 min-w-36"
+                    }
+                  >
                     {dimensionLabel}
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead
+                    className={
+                      showActivity
+                        ? "bg-card sticky top-0 z-10 hidden lg:table-cell"
+                        : "bg-card sticky top-0 z-10"
+                    }
+                  >
                     Share
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  {showActivity && (
+                    <TableHead className="bg-card sticky top-0 z-10">
+                      Status
+                    </TableHead>
+                  )}
+                  <TableHead className="bg-card sticky top-0 z-10 whitespace-nowrap text-right">
                     Requests
                   </TableHead>
                   <TableHead className="bg-card sticky top-0 z-10 text-right">
@@ -119,12 +143,25 @@ function UsageDimensionCard({
               <TableBody>
                 {rows.map((row) => (
                   <TableRow key={row.label}>
-                    <TableCell className="max-w-[20ch] font-medium">
-                      <span className="block truncate" title={row.label}>
+                    <TableCell
+                      className={
+                        showActivity
+                          ? "w-36 min-w-36 whitespace-nowrap font-medium"
+                          : "max-w-[20ch] min-w-36 font-medium"
+                      }
+                    >
+                      <span
+                        className={showActivity ? undefined : "block truncate"}
+                        title={row.label}
+                      >
                         {row.label}
                       </span>
                     </TableCell>
-                    <TableCell className="min-w-28">
+                    <TableCell
+                      className={
+                        showActivity ? "hidden lg:table-cell" : "min-w-28"
+                      }
+                    >
                       <div className="flex items-center gap-2">
                         <div
                           className="bg-muted h-1.5 min-w-14 flex-1 overflow-hidden rounded-full"
@@ -143,6 +180,11 @@ function UsageDimensionCard({
                         </span>
                       </div>
                     </TableCell>
+                    {showActivity && (
+                      <TableCell className="min-w-36">
+                        <ClientActivity lastActiveAt={row.lastActiveAt} />
+                      </TableCell>
+                    )}
                     <TableCell className="text-right tabular-nums">
                       {row.requests.toLocaleString()}
                     </TableCell>
@@ -187,6 +229,30 @@ function UsageDimensionCard({
         )}
       </CardContent>
     </Card>
+  );
+}
+
+function ClientActivity({ lastActiveAt }: { lastActiveAt?: string }) {
+  if (!lastActiveAt) return null;
+
+  const lastActiveDate = new Date(lastActiveAt);
+  const isActive = lastActiveDate >= subHours(new Date(), 24);
+
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      <Badge variant="outline" className="gap-1.5 font-normal">
+        <span
+          className={
+            isActive
+              ? "size-1.5 rounded-full bg-emerald-500"
+              : "size-1.5 rounded-full bg-muted-foreground"
+          }
+          aria-hidden="true"
+        />
+        <span>{isActive ? "Active" : "Idle"}</span>
+      </Badge>
+      <RelativeTime date={lastActiveAt} className="text-xs" />
+    </div>
   );
 }
 

--- a/platform/frontend/src/app/llm/usage/page.tsx
+++ b/platform/frontend/src/app/llm/usage/page.tsx
@@ -114,10 +114,8 @@ export default function MyUsagePage() {
           </p>
         ) : (
           <>
-            <div className="grid gap-6 xl:grid-cols-2">
-              <ModelUsageCard models={statisticsQuery.data.models} />
-              <ClientUsageCard clients={breakdownQuery.data.clients} />
-            </div>
+            <ModelUsageCard models={statisticsQuery.data.models} />
+            <ClientUsageCard clients={breakdownQuery.data.clients} />
 
             <div className="grid gap-6 xl:grid-cols-2">
               <TokenMixCard mix={breakdownQuery.data.tokenMix} />

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -91205,6 +91205,7 @@ export type GetMyUsageBreakdownResponses = {
         };
         clients: Array<{
             client: string | null;
+            lastActiveAt: string;
             requests: number;
             inputTokens: number;
             outputTokens: number;

--- a/platform/shared/interactions/client.ts
+++ b/platform/shared/interactions/client.ts
@@ -7,8 +7,9 @@ import type { SupportedProvider } from "../model-constants";
  * `X-Archestra-Agent-Id` header (e.g. the connect-page setup scripts send
  * {@link CLAUDE_CODE_CLIENT_ID} / {@link CLAUDE_DESKTOP_CLIENT_ID}) or, when
  * absent, from auto-discovery of a Claude client (recorded as the generic
- * {@link CLAUDE_CLIENT_ID}). Every Claude-family id renders as a single
- * {@link CLAUDE_CLIENT_LABEL} in the UI.
+ * {@link CLAUDE_CLIENT_ID}). Family-level surfaces render every Claude id as
+ * {@link CLAUDE_CLIENT_LABEL}; usage surfaces preserve the explicit Code and
+ * Desktop variants via {@link clientUsageLabelForExternalAgentId}.
  */
 
 /**
@@ -21,7 +22,7 @@ import type { SupportedProvider } from "../model-constants";
  */
 export const CLIENT_MCP_TOOL_NAME_PREFIX = "mcp__";
 
-/** Human-readable label for every Claude client id in the UI. */
+/** Human-readable family label for Claude clients in grouped UI surfaces. */
 export const CLAUDE_CLIENT_LABEL = "Claude";
 
 /** Human-readable label for the Codex client id in the UI. */
@@ -239,6 +240,35 @@ export function isCursorClientAgentId(
     return false;
   }
   return CURSOR_CLIENT_AGENT_ID_SET.has(externalAgentId.trim().toLowerCase());
+}
+
+/**
+ * Exact client label used by personal usage analytics.
+ *
+ * Unlike the logs filter, this intentionally preserves explicit Connect-page
+ * variants. Someone who configured Claude Desktop should not see that traffic
+ * merged into Claude Code just because both belong to the Claude family.
+ */
+export function clientUsageLabelForExternalAgentId(
+  externalAgentId: string | null | undefined,
+): string | null {
+  const normalized = externalAgentId?.trim().toLowerCase();
+  switch (normalized) {
+    case CLAUDE_CLIENT_ID:
+      return CLAUDE_CLIENT_LABEL;
+    case CLAUDE_CODE_CLIENT_ID:
+      return "Claude Code";
+    case CLAUDE_DESKTOP_CLIENT_ID:
+      return "Claude Desktop";
+    case CODEX_CLIENT_ID:
+      return CODEX_CLIENT_LABEL;
+    case COPILOT_CLI_CLIENT_ID:
+      return COPILOT_CLI_CLIENT_LABEL;
+    case CURSOR_CLIENT_ID:
+      return CURSOR_CLIENT_LABEL;
+    default:
+      return null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- preserve connected client variants in personal usage analytics
- show active or idle status and last activity alongside client usage statistics
- keep model and client analytics readable across desktop and narrower layouts

## Validation

- `pnpm exec vitest run src/app/llm/usage/_parts/usage-dimension-cards.test.tsx src/app/llm/usage/page.test.tsx`
- `ARCHESTRA_DATABASE_URL=postgresql://tests:tests@127.0.0.1:1/tests pnpm exec vitest run src/routes/statistics.test.ts`
- `pnpm type-check`
- `ARCHESTRA_DATABASE_URL=postgresql://checks:checks@127.0.0.1:1/checks pnpm knip`
- tested locally in Chrome at desktop and 900px widths, covering populated and empty states

## Documentation

- updated the existing Costs & Limits guide for client activity details

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>