### PR TITLE
fix(skills): narrow plugin artifact filtering

### DIFF
--- a/docs/pages/platform-agent-plugins.md
+++ b/docs/pages/platform-agent-plugins.md
@@ -115,4 +115,4 @@ An authorized platform administrator selects the plugin and runs the setup comma
 
 Use a plugin when the coding client must own the behavior. Use a Skill when the model needs reusable guidance.
 
-Skills embedded at any depth in a plugin also appear under **Skills from plugins** on the Skills page. This read-only Beta category ignores the plugin's client and platform when listing `SKILL.md` files. It shares Skill resources plus readable context from README and license files, commands, agents, output styles, and MCP or LSP configuration. Hooks, manifests, settings, installers, and runtime files stay with the source plugin. Agents in any connected client can discover and load these Skills without creating standalone copies.
+Skills embedded at any depth in a plugin also appear under **Skills from plugins** on the Skills page. This read-only Beta category ignores the plugin's client and platform when listing `SKILL.md` files. Every file owned by the Skill tree is shared except hooks, hook manifests, plugin or marketplace metadata, and installation files. Agents in any connected client can discover and load these Skills without creating standalone copies.

--- a/docs/pages/platform-agent-skills.md
+++ b/docs/pages/platform-agent-skills.md
@@ -127,7 +127,7 @@ Plugins can contain one or more `SKILL.md` trees. Every valid Skill inside a plu
 
 The category does not filter by the plugin's client or operating system. Skill instructions are usually portable, so a Skill from a Claude Code plugin can still help in another client. The source client and platforms stay visible because bundled scripts and tool names may depend on them.
 
-Plugin Skills are read-only and remain managed by their source plugin. Archestra shares Skill resources plus readable context from README and license files, commands, agents, output styles, and MCP or LSP configuration. Client hooks, manifests, settings, installers, and runtime files remain private to the plugin. Anyone with access can load these files through the same `list_skills` and `load_skill` tools as other Skills. Activations contribute to the shared usage view. Archestra reads the source bytes directly instead of copying them into standalone Skills.
+Plugin Skills are read-only and remain managed by their source plugin. Archestra shares every file owned by the Skill tree except hooks, hook manifests, plugin or marketplace metadata, and installation files. Anyone with access can load the remaining files through the same `list_skills` and `load_skill` tools as other Skills. Activations contribute to the shared usage view. Archestra reads the source bytes directly instead of copying them into standalone Skills.
 
 ## Permissions and scope
 

--- a/platform/backend/src/archestra-mcp-server/skills.test.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.test.ts
@@ -396,6 +396,48 @@ describe("skill tool execution", () => {
           encoding: "utf8",
           mode: "100644",
         },
+        {
+          path: "skills/release/output-style.md",
+          content: "Prefer concise release notes.\n",
+          encoding: "utf8",
+          mode: "100644",
+        },
+        {
+          path: "skills/release/custom/context.dat",
+          content: "arbitrary adoptable context\n",
+          encoding: "utf8",
+          mode: "100644",
+        },
+        {
+          path: "skills/release/package.json",
+          content: '{"dependencies":{}}\n',
+          encoding: "utf8",
+          mode: "100644",
+        },
+        {
+          path: "skills/release/install.py",
+          content: "print('install')\n",
+          encoding: "utf8",
+          mode: "100755",
+        },
+        {
+          path: "skills/release/.claude-plugin/plugin.json",
+          content: "{}\n",
+          encoding: "utf8",
+          mode: "100644",
+        },
+        {
+          path: "skills/release/references/plugin.json",
+          content: '{"portable":true}\n',
+          encoding: "utf8",
+          mode: "100644",
+        },
+        {
+          path: "skills/release/tools/preinstall.js",
+          content: "process.exit(0);\n",
+          encoding: "utf8",
+          mode: "100755",
+        },
       ],
     };
     const plugin = await PluginModel.create({
@@ -427,6 +469,13 @@ describe("skill tool execution", () => {
     expect(textOf(activation)).toContain("Ship carefully.");
     expect(textOf(activation)).toContain("references/checklist.md");
     expect(textOf(activation)).toContain(".mcp.json");
+    expect(textOf(activation)).toContain("custom/context.dat");
+    expect(textOf(activation)).toContain("output-style.md");
+    expect(textOf(activation)).toContain("package.json");
+    expect(textOf(activation)).toContain("references/plugin.json");
+    expect(textOf(activation)).not.toContain("install.py");
+    expect(textOf(activation)).not.toContain("tools/preinstall.js");
+    expect(textOf(activation)).not.toContain(".claude-plugin/plugin.json");
     expect(textOf(activation)).not.toContain("hooks/hooks.json");
     await drainBackgroundWork();
     let usage = await PluginSkillUsageEventModel.getSummaries([
@@ -447,6 +496,20 @@ describe("skill tool execution", () => {
     );
     expect(mcpConfig.isError).toBe(false);
     expect(textOf(mcpConfig)).toContain("{}\n");
+    const outputStyle = await executeArchestraTool(
+      TOOL_LOAD_SKILL_FULL_NAME,
+      { name: loadName, path: "output-style.md" },
+      context,
+    );
+    expect(outputStyle.isError).toBe(false);
+    expect(textOf(outputStyle)).toContain("Prefer concise release notes.");
+    const arbitraryContext = await executeArchestraTool(
+      TOOL_LOAD_SKILL_FULL_NAME,
+      { name: loadName, path: "custom/context.dat" },
+      context,
+    );
+    expect(arbitraryContext.isError).toBe(false);
+    expect(textOf(arbitraryContext)).toContain("arbitrary adoptable context");
     const hookArtifact = await executeArchestraTool(
       TOOL_LOAD_SKILL_FULL_NAME,
       { name: loadName, path: "hooks/hooks.json" },

--- a/platform/backend/src/plugins/plugin-skills.ts
+++ b/platform/backend/src/plugins/plugin-skills.ts
@@ -211,39 +211,23 @@ function skillRootOf(manifestPath: string): string {
   return index === -1 ? "" : manifestPath.slice(0, index);
 }
 
-const ADOPTABLE_SKILL_RESOURCE_DIRECTORIES = new Set([
-  "agents",
-  "assets",
-  "commands",
-  "licenses",
-  "lsp-config",
-  "output-styles",
-  "references",
-  "scripts",
+const PLUGIN_METADATA_DIRECTORY_NAMES = new Set([
+  ".claude-plugin",
+  ".codex-plugin",
+  ".cursor-plugin",
+  ".plugin",
 ]);
 
-const ADOPTABLE_PLUGIN_CONFIG_PATHS = new Set([
-  ".lsp.json",
-  ".mcp.json",
-  ".cursor/mcp.json",
-  ".copilot/mcp-config.json",
-  ".github/lsp.json",
-  ".github/mcp.json",
-  ".vscode/mcp.json",
-  "lsp.json",
-  "mcp.json",
-]);
+const PLUGIN_METADATA_DIRECTORY_PATHS = [".agents/plugins", ".github/plugin"];
 
-const ADOPTABLE_PLUGIN_CONTEXT_PREFIXES = [
-  ".claude/agents/",
-  ".claude/commands/",
-  ".claude/output-styles/",
-  ".codex/agents/",
-  ".cursor/agents/",
-  ".cursor/commands/",
-  ".github/agents/",
-  ".github/prompts/",
-];
+const INSTALLATION_DIRECTORY_NAMES = new Set([
+  "bootstrap",
+  "install",
+  "installation",
+  "installer",
+  "setup",
+  "uninstall",
+]);
 
 /** Keep Skill-owned resources and explicitly adoptable plugin context. */
 function resourcePathsOf(
@@ -267,19 +251,38 @@ function resourcePathsOf(
       return false;
     }
     const relativePath = root === "" ? path : path.slice(root.length + 1);
-    const resourceRoot = relativePath.split("/", 1)[0].toLowerCase();
-    const isRootFile = !relativePath.includes("/");
-    return (
-      ADOPTABLE_SKILL_RESOURCE_DIRECTORIES.has(resourceRoot) ||
-      ADOPTABLE_PLUGIN_CONFIG_PATHS.has(relativePath) ||
-      ADOPTABLE_PLUGIN_CONTEXT_PREFIXES.some((prefix) =>
-        relativePath.startsWith(prefix),
-      ) ||
-      (isRootFile && /^README(?:[._-].+)?$/i.test(relativePath)) ||
-      (isRootFile &&
-        /^(?:LICENSE|LICENCE|COPYING|NOTICE|COPYRIGHT)(?:[._-].+)?$/i.test(
-          relativePath,
-        ))
-    );
+    return !isPluginOnlyArtifact(relativePath);
   });
+}
+
+function isPluginOnlyArtifact(relativePath: string): boolean {
+  const lowerPath = relativePath.toLowerCase();
+  const segments = lowerPath.split("/");
+  const filename = segments.at(-1) ?? "";
+  if (segments.includes("hooks") || /^hooks?\.json$/.test(filename)) {
+    return true;
+  }
+  if (
+    segments.some((segment) => PLUGIN_METADATA_DIRECTORY_NAMES.has(segment)) ||
+    PLUGIN_METADATA_DIRECTORY_PATHS.some(
+      (path) =>
+        lowerPath === path ||
+        lowerPath.startsWith(`${path}/`) ||
+        lowerPath.includes(`/${path}/`),
+    ) ||
+    (segments.length === 1 && /^(?:plugin|marketplace)\.json$/.test(filename))
+  ) {
+    return true;
+  }
+  if (segments.some((segment) => INSTALLATION_DIRECTORY_NAMES.has(segment))) {
+    return true;
+  }
+  if (
+    /^(?:(?:pre|post)?install(?:er|ation)?|bootstrap(?:per)?|setup|uninstall)(?:[._-].+)?$/.test(
+      filename,
+    )
+  ) {
+    return !/\.(?:md|txt)$/i.test(filename);
+  }
+  return false;
 }

--- a/platform/backend/src/routes/skill/plugin-skill.routes.test.ts
+++ b/platform/backend/src/routes/skill/plugin-skill.routes.test.ts
@@ -330,6 +330,15 @@ describe("plugin Skill routes", () => {
             "install/NOTICE",
             "runtime/LICENSE",
             "settings/.mcp.json",
+            "docs/plugin.json",
+            "plugin.json",
+            "marketplace.json",
+            ".CLAUDE-PLUGIN/PLUGIN.JSON",
+            "preinstall.js",
+            "postinstall.sh",
+            "installer.sh",
+            "bootstrapper.py",
+            "tools/preinstall.js",
           ].map((path) => ({
             path,
             content: "plugin-specific\n",
@@ -345,7 +354,12 @@ describe("plugin Skill routes", () => {
             "README.md",
             "agents/reviewer.md",
             "commands/release.md",
+            "output-format.md",
+            "output-formats/compact.md",
+            "output-style.md",
             "output-styles/concise.md",
+            "output_styles/verbose.md",
+            "references/install.md",
             ".claude/agents/reviewer.md",
             ".claude/commands/release.md",
             ".claude/output-styles/concise.md",
@@ -410,6 +424,10 @@ describe("plugin Skill routes", () => {
             "bundles/client/skills/ste-writing/NOTICE",
             "bundles/client/skills/ste-writing/README.md",
             "bundles/client/skills/ste-writing/agents/editor.md",
+            "bundles/client/skills/ste-writing/output-format.md",
+            "bundles/client/skills/ste-writing/output-formats/compact.md",
+            "bundles/client/skills/ste-writing/references/install.md",
+            "bundles/client/skills/ste-writing/tools/postinstall.sh",
           ].map((path) => ({
             path,
             content: "nested adoptable context\n",
@@ -433,8 +451,8 @@ describe("plugin Skill routes", () => {
       (item: { skillPath: string }) =>
         item.skillPath === "bundles/client/skills/ste-writing",
     );
-    expect(rootItem).toMatchObject({ name: "root-guide", fileCount: 23 });
-    expect(nestedItem).toMatchObject({ name: "ste-writing", fileCount: 5 });
+    expect(rootItem).toMatchObject({ name: "root-guide", fileCount: 37 });
+    expect(nestedItem).toMatchObject({ name: "ste-writing", fileCount: 9 });
 
     const rootDetail = await ctx.app.inject({
       method: "GET",
@@ -445,12 +463,16 @@ describe("plugin Skill routes", () => {
       expect.objectContaining({ path: ".claude/agents/reviewer.md" }),
       expect.objectContaining({ path: ".claude/commands/release.md" }),
       expect.objectContaining({ path: ".claude/output-styles/concise.md" }),
+      expect.objectContaining({ path: ".claude/settings.json" }),
       expect.objectContaining({ path: ".codex/agents/reviewer.toml" }),
+      expect.objectContaining({ path: ".codex/config.toml" }),
       expect.objectContaining({ path: ".copilot/mcp-config.json" }),
       expect.objectContaining({ path: ".cursor/agents/reviewer.md" }),
       expect.objectContaining({ path: ".cursor/commands/release.md" }),
       expect.objectContaining({ path: ".cursor/mcp.json" }),
+      expect.objectContaining({ path: ".cursor/rules/project.mdc" }),
       expect.objectContaining({ path: ".github/agents/reviewer.agent.md" }),
+      expect.objectContaining({ path: ".github/copilot-instructions.md" }),
       expect.objectContaining({ path: ".github/mcp.json" }),
       expect.objectContaining({ path: ".github/prompts/release.prompt.md" }),
       expect.objectContaining({ path: ".lsp.json" }),
@@ -462,9 +484,19 @@ describe("plugin Skill routes", () => {
       expect.objectContaining({ path: "agents/reviewer.md" }),
       expect.objectContaining({ path: "assets/root-template.txt" }),
       expect.objectContaining({ path: "commands/release.md" }),
+      expect.objectContaining({ path: "docs/plugin.json" }),
+      expect.objectContaining({ path: "notes.md" }),
+      expect.objectContaining({ path: "output-format.md" }),
+      expect.objectContaining({ path: "output-formats/compact.md" }),
+      expect.objectContaining({ path: "output-style.md" }),
       expect.objectContaining({ path: "output-styles/concise.md" }),
+      expect.objectContaining({ path: "output_styles/verbose.md" }),
+      expect.objectContaining({ path: "package.json" }),
+      expect.objectContaining({ path: "references/install.md" }),
       expect.objectContaining({ path: "references/root-notes.md" }),
+      expect.objectContaining({ path: "runtime/LICENSE" }),
       expect.objectContaining({ path: "scripts/root-check.sh" }),
+      expect.objectContaining({ path: "settings/.mcp.json" }),
     ]);
 
     const nestedDetail = await ctx.app.inject({
@@ -477,6 +509,10 @@ describe("plugin Skill routes", () => {
       expect.objectContaining({ path: "NOTICE" }),
       expect.objectContaining({ path: "README.md" }),
       expect.objectContaining({ path: "agents/editor.md" }),
+      expect.objectContaining({ path: "custom/context.md" }),
+      expect.objectContaining({ path: "output-format.md" }),
+      expect.objectContaining({ path: "output-formats/compact.md" }),
+      expect.objectContaining({ path: "references/install.md" }),
       expect.objectContaining({ path: "scripts/ste-lint.py" }),
     ]);
   });


### PR DESCRIPTION
## Summary
- include every file owned by a derived plugin Skill by default, including arbitrary custom folders, package metadata, binaries, and output format files
- exclude only hook artifacts, supported client plugin/marketplace metadata, and installation/bootstrap artifacts
- preserve arbitrary-depth Skill ownership so nested Skills do not claim one another

## Validation
- backend commit gate
- 70 targeted REST and MCP Skill tests
- live REST projection and MCP Gateway `list_skills` / `load_skill` checks

Task: [T-1196](https://slack.com/archives/C0B2AGC0AFQ/p1787821901277729?thread_ts=1787821900.629289&cid=C0B2AGC0AFQ)
Follow-up to #7519

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>