### PR TITLE
fix(frontend): keep MCP alert dismiss on current page

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-badge.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-badge.tsx
@@ -55,7 +55,11 @@ export function McpServerIssueBadge({
   const badge = (
     <Badge
       variant="secondary"
-      className={cn("max-w-full", ISSUE_TONE[issue.kind], className)}
+      className={cn(
+        "max-w-full",
+        !issue.muted && ISSUE_TONE[issue.kind],
+        className,
+      )}
       data-testid={`mcp-server-issue-${issue.kind}`}
     >
       {issue.muted && <BellOff aria-hidden className="size-3" />}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-notice.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-notice.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { McpServerIssue } from "@/lib/mcp/mcp-server-issues";
+import { McpServerIssueBadge } from "./mcp-server-issue-badge";
 import { McpServerIssueNotice } from "./mcp-server-issue-notice";
 
 const { routerPush } = vi.hoisted(() => ({ routerPush: vi.fn() }));
@@ -380,6 +381,25 @@ describe("McpServerIssueNotice", () => {
         ],
       },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it("distinguishes a dismissed alert from an active warning", () => {
+    render(
+      <>
+        <McpServerIssueBadge issue={needsReauth()} />
+        <McpServerIssueBadge issue={needsReauth({ muted: true })} />
+      </>,
+    );
+
+    const [activeBadge, dismissedBadge] = screen
+      .getAllByText("Needs re-authentication")
+      .map((label) => label.closest('[data-slot="badge"]'));
+    expect(activeBadge).toHaveClass("bg-orange-500/5", "text-orange-900/80");
+    expect(dismissedBadge).toHaveAttribute("data-variant", "secondary");
+    expect(dismissedBadge).not.toHaveClass(
+      "bg-orange-500/5",
+      "text-orange-900/80",
     );
   });
 

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,8 +8,10 @@ vi.mock("@/lib/auth/auth.query");
 vi.mock("@/lib/config/config.query");
 vi.mock("@/lib/organization.query");
 
+const { routerPush } = vi.hoisted(() => ({ routerPush: vi.fn() }));
+
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({ push: routerPush, replace: vi.fn() }),
 }));
 
 vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
@@ -139,6 +141,7 @@ describe("McpServerTable uninstall permission", () => {
       data: undefined,
     } as unknown as ReturnType<typeof useAppearanceSettings>);
     useMcpServersMock.mockReturnValue({ data: [personalInstall] });
+    dismissMutateAsync.mockResolvedValue({ succeeded: [], failed: [] });
     grantAllExcept({});
   });
 
@@ -238,7 +241,7 @@ describe("McpServerTable uninstall permission", () => {
     ).not.toHaveLength(0);
   });
 
-  it("keeps queue actions inline and moves lower-priority actions into overflow", async () => {
+  it("keeps queue actions inline without triggering row navigation", async () => {
     const user = userEvent.setup();
     const issue = {
       kind: "needs-reauth",
@@ -279,7 +282,14 @@ describe("McpServerTable uninstall permission", () => {
     expect(
       screen.getByRole("heading", { name: "Dismiss alert" }),
     ).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(routerPush).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("heading", { name: "Dismiss alert" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(routerPush).not.toHaveBeenCalled();
 
     expect(
       screen.getByRole("link", {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-table.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { memo, useState } from "react";
+import { RowClickShield } from "@/components/agent-pages/row-click-shield";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import {
@@ -258,15 +259,19 @@ export function McpServerTable({
         const item = row.original;
         const { installedServer, isInstallInProgress } = getServerInfo(item);
         return (
-          <McpServerRowActions
-            item={item}
-            installedServer={installedServer}
-            issues={issuesByCatalog.get(item.id) ?? []}
-            isInstalling={installingItemId === item.id || !!isInstallInProgress}
-            onInstall={onInstall}
-            onReinstall={onReinstall}
-            onCancelInstallation={onCancelInstallation}
-          />
+          <RowClickShield>
+            <McpServerRowActions
+              item={item}
+              installedServer={installedServer}
+              issues={issuesByCatalog.get(item.id) ?? []}
+              isInstalling={
+                installingItemId === item.id || !!isInstallInProgress
+              }
+              onInstall={onInstall}
+              onReinstall={onReinstall}
+              onCancelInstallation={onCancelInstallation}
+            />
+          </RowClickShield>
         );
       },
     },


### PR DESCRIPTION
Prevents MCP registry row navigation from consuming alert action clicks.

- Wraps the standard table action cell in the established row click shield so dismissing an alert leaves the current registry page open.
- Renders dismissed alert badges with the same neutral secondary treatment as Installed while retaining warning colors for active alerts.
- Adds regression coverage for completed dismissal without navigation and active-versus-dismissed badge styling.

Origin: T-1188