### PR TITLE
feat(frontend): preview SVG files in the Files panel

### DIFF
--- a/platform/frontend/src/components/chat/file-preview.test.tsx
+++ b/platform/frontend/src/components/chat/file-preview.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { FilePreview } from "@/components/chat/file-preview";
+import {
+  LOCKED_CHAT_KEY_HEADER,
+  storeLockedChatKey,
+} from "@/lib/chat/locked-chat";
+
+const API_ORIGIN = "http://localhost:9000";
+const ARTIFACT_URL = `${API_ORIGIN}/api/skill-sandbox/artifacts/svg-1`;
+const SEALED_URL = "/api/chat/attachments/att-1/content";
+const CONVERSATION_ID = "conv-1";
+const LOCKED_CHAT_KEY = "a".repeat(43);
+const SVG_PREVIEW_MAX_BYTES = 10 * 1024 * 1024;
+
+// A non-ASCII character pins that the bytes reach the data URL untouched
+// rather than round-tripping through a text decode.
+const SVG_BYTES = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg"><title>café</title></svg>',
+);
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
+afterEach(() => {
+  server.resetHandlers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+afterAll(() => server.close());
+
+/** The byte route serves SVG download-only; the preview must cope with that. */
+function serveArtifact(body: Uint8Array) {
+  server.use(
+    http.get(
+      ARTIFACT_URL,
+      () =>
+        new HttpResponse(body, {
+          headers: {
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": 'attachment; filename="chart.svg"',
+          },
+        }),
+    ),
+  );
+}
+
+/** Decoded bytes as a plain array: jsdom and node typed arrays are different realms. */
+function decodeDataUrl(src: string): number[] {
+  const [header, payload] = src.split(",");
+  expect(header).toBe("data:image/svg+xml;base64");
+  return Array.from(atob(payload), (c) => c.charCodeAt(0));
+}
+
+/**
+ * jsdom implements neither `URL.createObjectURL` nor a `blob:`-capable fetch,
+ * so the locked-chat path runs against a hand-rolled fetch: the sealed route
+ * answers with a Blob, the resulting `blob:` URL answers with bytes.
+ */
+function stubLockedChatFetch(blobBytes: Uint8Array) {
+  const fetchSpy = vi.fn(async (url: string, _init?: RequestInit) => {
+    if (url === SEALED_URL) {
+      return { ok: true, blob: async () => new Blob([SVG_BYTES]) };
+    }
+    if (url === "blob:sealed") {
+      return { ok: true, arrayBuffer: async () => blobBytes.buffer.slice(0) };
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchSpy);
+  URL.createObjectURL = vi.fn(() => "blob:sealed");
+  URL.revokeObjectURL = vi.fn();
+  storeLockedChatKey(CONVERSATION_ID, LOCKED_CHAT_KEY);
+  return fetchSpy;
+}
+
+describe("FilePreview svg", () => {
+  it("renders the served bytes as an image/svg+xml data URL", async () => {
+    serveArtifact(SVG_BYTES);
+
+    render(
+      <FilePreview
+        file={{
+          name: "chart.svg",
+          mimeType: "image/svg+xml",
+          contentUrl: ARTIFACT_URL,
+        }}
+      />,
+    );
+
+    const img = await screen.findByRole<HTMLImageElement>("img", {
+      name: "chart.svg",
+    });
+    expect(decodeDataUrl(img.src)).toEqual(Array.from(SVG_BYTES));
+  });
+
+  it("falls back to download above the size cap", async () => {
+    serveArtifact(new Uint8Array(SVG_PREVIEW_MAX_BYTES + 1));
+
+    render(
+      <FilePreview
+        file={{
+          name: "huge.svg",
+          mimeType: "image/svg+xml",
+          contentUrl: ARTIFACT_URL,
+        }}
+      />,
+    );
+
+    const link = await screen.findByRole<HTMLAnchorElement>("link", {
+      name: /download/i,
+    });
+    expect(link.href).toBe(ARTIFACT_URL);
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("in a locked chat, reads the sealed bytes once with the key and converts the blob", async () => {
+    const fetchSpy = stubLockedChatFetch(SVG_BYTES);
+
+    render(
+      <FilePreview
+        file={{
+          name: "sealed.svg",
+          mimeType: "image/svg+xml",
+          contentUrl: SEALED_URL,
+        }}
+        conversationId={CONVERSATION_ID}
+      />,
+    );
+
+    const img = await screen.findByRole<HTMLImageElement>("img", {
+      name: "sealed.svg",
+    });
+    expect(decodeDataUrl(img.src)).toEqual(Array.from(SVG_BYTES));
+
+    const sealedCalls = fetchSpy.mock.calls.filter(
+      ([url]) => url === SEALED_URL,
+    );
+    expect(sealedCalls).toHaveLength(1);
+    expect(sealedCalls[0]?.[1]).toEqual({
+      headers: { [LOCKED_CHAT_KEY_HEADER]: LOCKED_CHAT_KEY },
+    });
+  });
+
+  it("in a locked chat, the size-cap fallback downloads the resolved blob", async () => {
+    stubLockedChatFetch(new Uint8Array(SVG_PREVIEW_MAX_BYTES + 1));
+
+    render(
+      <FilePreview
+        file={{
+          name: "sealed-huge.svg",
+          mimeType: "image/svg+xml",
+          contentUrl: SEALED_URL,
+        }}
+        conversationId={CONVERSATION_ID}
+      />,
+    );
+
+    const link = await screen.findByRole<HTMLAnchorElement>("link", {
+      name: /download/i,
+    });
+    expect(link.getAttribute("href")).toBe("blob:sealed");
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+});

--- a/platform/frontend/src/components/chat/file-preview.test.tsx
+++ b/platform/frontend/src/components/chat/file-preview.test.tsx
@@ -74,10 +74,19 @@ function decodeDataUrl(src: string): number[] {
 function stubLockedChatFetch(blobBytes: Uint8Array) {
   const fetchSpy = vi.fn(async (url: string, _init?: RequestInit) => {
     if (url === SEALED_URL) {
-      return { ok: true, blob: async () => new Blob([SVG_BYTES]) };
+      return {
+        ok: true,
+        headers: new Headers(),
+        blob: async () => new Blob([SVG_BYTES]),
+      };
     }
     if (url === "blob:sealed") {
-      return { ok: true, arrayBuffer: async () => blobBytes.buffer.slice(0) };
+      // A real blob: fetch reports its length; the cap is enforced from it.
+      return {
+        ok: true,
+        headers: new Headers({ "Content-Length": String(blobBytes.length) }),
+        arrayBuffer: async () => blobBytes.buffer.slice(0),
+      };
     }
     throw new Error(`unexpected fetch ${url}`);
   });
@@ -126,6 +135,35 @@ describe("FilePreview svg", () => {
     });
     expect(link.href).toBe(ARTIFACT_URL);
     expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("refuses an oversize file on its length header, without reading the body", async () => {
+    const arrayBuffer = vi.fn(async () => {
+      throw new Error("body must not be read");
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        headers: new Headers({
+          "Content-Length": String(SVG_PREVIEW_MAX_BYTES + 1),
+        }),
+        arrayBuffer,
+      })),
+    );
+
+    render(
+      <FilePreview
+        file={{
+          name: "huge.svg",
+          mimeType: "image/svg+xml",
+          contentUrl: ARTIFACT_URL,
+        }}
+      />,
+    );
+
+    await screen.findByRole("link", { name: /download/i });
+    expect(arrayBuffer).not.toHaveBeenCalled();
   });
 
   it("in a locked chat, reads the sealed bytes once with the key and converts the blob", async () => {

--- a/platform/frontend/src/components/chat/file-preview.tsx
+++ b/platform/frontend/src/components/chat/file-preview.tsx
@@ -25,8 +25,8 @@ export type PreviewableFile = {
 
 /**
  * Content-only preview for a file served from a byte endpoint: markdown
- * rendered, images inline, text/CSV as text/table, everything else a download
- * prompt. Extracted from the chat Files panel so the project pages preview
+ * rendered, images (SVG included) inline, text/CSV as text/table, everything
+ * else a download prompt. Extracted from the chat Files panel so the project pages preview
  * identically.
  *
  * Editing is controlled by the caller: when `editing` is true and a row-backed
@@ -117,6 +117,9 @@ export function FilePreview({
           />
         </div>
       )}
+      {kind === "svg" && (
+        <SvgPreview contentUrl={contentUrl} name={file.name} />
+      )}
       {kind === "html" && <HtmlPreview contentUrl={contentUrl} />}
       {kind === "pdf" && (
         <iframe
@@ -128,7 +131,9 @@ export function FilePreview({
       {(kind === "text" || kind === "csv") && (
         <FileTextPreview contentUrl={contentUrl} asTable={kind === "csv"} />
       )}
-      {kind === "unsupported" && <UnsupportedPreview file={file} />}
+      {kind === "unsupported" && (
+        <UnsupportedPreview name={file.name} contentUrl={contentUrl} />
+      )}
     </div>
   );
 }
@@ -298,6 +303,112 @@ function HtmlPreview({ contentUrl }: { contentUrl: string }) {
   );
 }
 
+/**
+ * Largest SVG the preview will turn into a data: URL. Bigger files fall back
+ * to download; the byte routes cap uploads at 25 MiB, so this bounds the
+ * base64 copy held in the DOM.
+ */
+const SVG_PREVIEW_MAX_BYTES = 10 * 1024 * 1024;
+
+type SvgPreviewSource =
+  | { status: "loading" }
+  | { status: "ready"; dataUrl: string }
+  | { status: "too-large" }
+  | { status: "failed" };
+
+/**
+ * SVG rendered through <img> from a client-built data: URL. The byte endpoint
+ * deliberately serves SVG download-only (it is a script carrier), so the bytes
+ * are fetched and re-typed here. <img> is the security control: browsers load
+ * SVG images with scripts, external references and interactivity disabled,
+ * while SMIL and CSS animations still play. A data: URL rather than a blob:
+ * one so "open image in new tab" lands in an opaque origin, never ours.
+ */
+function SvgPreview({
+  contentUrl,
+  name,
+}: {
+  contentUrl: string;
+  name: string;
+}) {
+  const source = useSvgDataUrl(contentUrl);
+  switch (source.status) {
+    case "loading":
+      return <p className="p-4 text-xs text-muted-foreground">Loading…</p>;
+    case "failed":
+      return (
+        <p className="p-4 text-xs text-muted-foreground">
+          Failed to load preview.
+        </p>
+      );
+    case "too-large":
+      return (
+        <UnsupportedPreview
+          name={name}
+          contentUrl={contentUrl}
+          reason={`This SVG is larger than ${SVG_PREVIEW_MAX_BYTES / (1024 * 1024)} MB, so it can't be previewed.`}
+        />
+      );
+    case "ready":
+      return (
+        <div className="flex h-full items-center justify-center p-4">
+          <img
+            src={source.dataUrl}
+            alt={name}
+            className="max-h-full max-w-full object-contain"
+          />
+        </div>
+      );
+  }
+}
+
+/** Fetch an SVG's bytes and encode them as an `image/svg+xml` data: URL. */
+function useSvgDataUrl(contentUrl: string): SvgPreviewSource {
+  const [source, setSource] = useState<SvgPreviewSource>({
+    status: "loading",
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setSource({ status: "loading" });
+    fetch(contentUrl)
+      .then(async (r): Promise<SvgPreviewSource> => {
+        if (!r.ok) throw new Error(`status ${r.status}`);
+        // Raw bytes, not text(): an SVG declaring a non-UTF-8 encoding must
+        // reach the image decoder untouched.
+        const bytes = await r.arrayBuffer();
+        if (bytes.byteLength > SVG_PREVIEW_MAX_BYTES) {
+          return { status: "too-large" };
+        }
+        const blob = new Blob([bytes], { type: "image/svg+xml" });
+        return { status: "ready", dataUrl: await readAsDataUrl(blob) };
+      })
+      .then((next) => {
+        if (!cancelled) setSource(next);
+      })
+      .catch(() => {
+        if (!cancelled) setSource({ status: "failed" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contentUrl]);
+
+  return source;
+}
+
+function readAsDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") resolve(reader.result);
+      else reject(new Error("FileReader produced no data URL"));
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
 function FileTextPreview({
   contentUrl,
   asTable,
@@ -352,18 +463,28 @@ function FileTextPreview({
   );
 }
 
-function UnsupportedPreview({ file }: { file: PreviewableFile }) {
+/**
+ * Download-only fallback. `contentUrl` is the resolved URL (a `blob:` in a
+ * locked chat), so the download link works wherever the preview would have.
+ */
+function UnsupportedPreview({
+  name,
+  contentUrl,
+  reason = "Preview isn't available for this file type.",
+}: {
+  name: string;
+  contentUrl: string;
+  reason?: string;
+}) {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3 px-6 py-8 text-center">
       <span className="rounded-md border px-3 py-2 text-xs font-semibold uppercase text-muted-foreground">
-        {fileTag(file.name)}
+        {fileTag(name)}
       </span>
-      <p className="text-xs text-muted-foreground">
-        Preview isn't available for this file type.
-      </p>
-      {file.contentUrl && (
+      <p className="text-xs text-muted-foreground">{reason}</p>
+      {contentUrl && (
         <Button asChild variant="secondary" size="sm" className="gap-1">
-          <a href={file.contentUrl} download={file.name}>
+          <a href={contentUrl} download={name}>
             <Download className="h-4 w-4" />
             Download
           </a>

--- a/platform/frontend/src/components/chat/file-preview.tsx
+++ b/platform/frontend/src/components/chat/file-preview.tsx
@@ -370,16 +370,26 @@ function useSvgDataUrl(contentUrl: string): SvgPreviewSource {
 
   useEffect(() => {
     let cancelled = false;
+    // Closing the preview mid-transfer must not leave a multi-MB body
+    // downloading, nor encode bytes nothing will render.
+    const abort = new AbortController();
     setSource({ status: "loading" });
-    fetch(contentUrl)
+    fetch(contentUrl, { signal: abort.signal })
       .then(async (r): Promise<SvgPreviewSource> => {
         if (!r.ok) throw new Error(`status ${r.status}`);
+        // The byte routes always send Content-Length, so an oversize file is
+        // refused before its body is transferred. byteLength below stays the
+        // authority for sources that report no length.
+        if (exceedsSvgCap(r.headers.get("Content-Length"))) {
+          return { status: "too-large" };
+        }
         // Raw bytes, not text(): an SVG declaring a non-UTF-8 encoding must
         // reach the image decoder untouched.
         const bytes = await r.arrayBuffer();
         if (bytes.byteLength > SVG_PREVIEW_MAX_BYTES) {
           return { status: "too-large" };
         }
+        if (cancelled) return { status: "loading" };
         const blob = new Blob([bytes], { type: "image/svg+xml" });
         return { status: "ready", dataUrl: await readAsDataUrl(blob) };
       })
@@ -391,10 +401,18 @@ function useSvgDataUrl(contentUrl: string): SvgPreviewSource {
       });
     return () => {
       cancelled = true;
+      abort.abort();
     };
   }, [contentUrl]);
 
   return source;
+}
+
+/** True only for a well-formed length header that is over the cap. */
+function exceedsSvgCap(contentLength: string | null): boolean {
+  if (contentLength === null) return false;
+  const length = Number(contentLength);
+  return Number.isFinite(length) && length > SVG_PREVIEW_MAX_BYTES;
 }
 
 function readAsDataUrl(blob: Blob): Promise<string> {

--- a/platform/frontend/src/lib/chat/file-preview-kind.test.ts
+++ b/platform/frontend/src/lib/chat/file-preview-kind.test.ts
@@ -9,12 +9,18 @@ describe("getFilePreviewKind", () => {
     );
   });
 
-  it("renders only the inline-safe image whitelist", () => {
+  it("renders only the inline-safe image whitelist as image", () => {
     for (const m of ["image/png", "image/jpeg", "image/webp", "image/gif"]) {
       expect(getFilePreviewKind(m, "x")).toBe("image");
     }
-    // Not inline-safe → backend serves octet-stream → cannot <img>.
-    expect(getFilePreviewKind("image/svg+xml", "x.svg")).toBe("unsupported");
+    expect(getFilePreviewKind("image/bmp", "x.bmp")).toBe("unsupported");
+  });
+
+  it("treats svg by mime or .svg extension", () => {
+    expect(getFilePreviewKind("image/svg+xml", "x")).toBe("svg");
+    expect(getFilePreviewKind("application/octet-stream", "logo.svg")).toBe(
+      "svg",
+    );
   });
 
   it("detects html by mime or extension, before generic text", () => {

--- a/platform/frontend/src/lib/chat/file-preview-kind.ts
+++ b/platform/frontend/src/lib/chat/file-preview-kind.ts
@@ -2,12 +2,17 @@ export type FilePreviewKind =
   | "markdown"
   | "html"
   | "image"
+  | "svg"
   | "text"
   | "csv"
   | "pdf"
   | "unsupported";
 
-/** Image mimes the backend serves inline; only these can render via <img>. */
+/**
+ * Image mimes the backend serves inline, so an <img> can point straight at the
+ * byte endpoint. SVG is deliberately not here: it is served download-only and
+ * rendered from a client-built data: URL instead (see the `svg` kind).
+ */
 const INLINE_IMAGE_MIMES = new Set([
   "image/png",
   "image/jpeg",
@@ -35,6 +40,7 @@ export function getFilePreviewKind(
   ) {
     return "html";
   }
+  if (mime === "image/svg+xml" || lowerName.endsWith(".svg")) return "svg";
   if (INLINE_IMAGE_MIMES.has(mime)) return "image";
   // Rendered via an iframe pointing at the byte endpoint, which serves PDFs
   // inline — the browser's own viewer does the work.


### PR DESCRIPTION
SVG files now preview inline in the Files panel like other images — static, SMIL-animated and CSS-animated.

The byte routes deliberately serve SVG download-only (it is a script carrier), so the bytes are fetched and re-typed client-side into an `image/svg+xml` data URL rendered through `<img>`. Browsers load SVG images with scripts, external references and interactivity disabled, while SMIL and CSS animations still play. A `data:` URL rather than `blob:` keeps "open image in new tab" in an opaque origin.

One shared `FilePreview` covers the project Files sidebar, the chat Files panel and the knowledge modal, so all three get it.

Backend is unchanged; the existing SVG serving rules and their tests stand.

## Changes

- `file-preview-kind.ts`: new `svg` kind (`image/svg+xml` or a `.svg` name, since sandbox listings label by extension and uploads may arrive as `application/octet-stream`)
- `file-preview.tsx`: `SvgPreview` + `useSvgDataUrl`, rendering the same centered `<img>` box as raster images. Files over 10 MiB fall back to download, refused on `Content-Length` before the body transfers; the fetch aborts on unmount
- `UnsupportedPreview` now takes the resolved content URL, fixing its download link in locked chats (it previously linked the sealed URL, which 400s on a bare GET)

## Testing

- New `file-preview.test.tsx`: the data URL decodes to exactly the served bytes (non-ASCII included), the size cap falls back without reading the body, and two locked-chat cases pin that the sealed endpoint is fetched once with the key and only the resulting `blob:` is converted
- Verified in Chromium that SMIL and CSS animations play in `<img>` mode while a script-carrying SVG renders with no script execution and no external requests
- Manually verified in the project Files panel

Out of scope: chat message bubbles, script-driven SVG (needs script execution, which `<img>` correctly denies).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>