### PR TITLE
fix(frontend): normalize collection layouts

### DIFF
--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -88,7 +88,7 @@ function CardSelectionCheckbox({
 }) {
   const checkbox = (
     <Checkbox
-      className={cn("relative z-10 mt-0.5", disabled && "pointer-events-none")}
+      className={cn("mt-1", disabled && "pointer-events-none")}
       checked={selection?.selected ?? false}
       onCheckedChange={(value) => selection?.onSelectedChange(!!value)}
       onClick={(event) => {
@@ -273,8 +273,8 @@ function OwnedAppCard({
 
         {/* Header row mirrors the project card: icon + title on one line at the
             left, the scope pill / owner badge / overflow menu at the right. */}
-        <div className="mb-1 flex items-center justify-between gap-2">
-          <div className="flex min-w-0 items-center gap-2">
+        <div className="mb-1 flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-start gap-3">
             {selection ? (
               <CardSelectionCheckbox
                 label={`Select ${app.name}`}
@@ -440,8 +440,8 @@ function ExternalAppCard({
 
       {/* Header row mirrors the project card: icon + title on one line at the
           left, the scope pill / overflow menu at the right. */}
-      <div className="mb-1 flex items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-2">
+      <div className="mb-1 flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-start gap-3">
           {showDisabledSelection ? (
             <CardSelectionCheckbox label={`Select ${app.name}`} disabled />
           ) : null}

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -222,7 +222,7 @@ export default function AppsPage() {
         </FilterBar>
 
         {parsedLabels && (
-          <div className="mb-6">
+          <div className="mb-3">
             <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
           </div>
         )}

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
@@ -564,7 +564,7 @@ export function AuditLogTable() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <FilterBar
         leading
         onClearFilters={hasFilters ? clearFilters : undefined}

--- a/platform/frontend/src/app/llm/logs/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.tsx
@@ -491,7 +491,7 @@ function SessionsTable() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <FilterBar leading onClearFilters={hasFilters ? clearFilters : undefined}>
         {/* Anchor the "not a session ID" hint as a floating overlay under the
             input so toggling it never reflows the filter bar or the table. */}

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -49,6 +49,7 @@ import { TableRowActions } from "@/components/table-row-actions";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -683,90 +684,92 @@ export default function ApiKeysPage() {
           </p>
         </div>
 
-        <FilterBar className="!mb-3">
-          <SearchInput
-            isLoading={isFetching}
-            objectNamePlural="credentials"
-            searchFields={["name"]}
-            paramName="search"
-            className={filterSearchClass}
-          />
-          <Select
-            value={providerFilter}
-            onValueChange={(value) =>
-              updateQueryParams({
-                provider: value === "all" ? null : value,
-              })
-            }
-          >
-            <SelectTrigger
-              size="sm"
-              aria-label="Filter by provider"
-              className={filterControlClass({
-                active: providerFilter !== "all",
-              })}
+        <BulkActionsScope className="space-y-3">
+          <FilterBar>
+            <SearchInput
+              isLoading={isFetching}
+              objectNamePlural="credentials"
+              searchFields={["name"]}
+              paramName="search"
+              className={filterSearchClass}
+            />
+            <Select
+              value={providerFilter}
+              onValueChange={(value) =>
+                updateQueryParams({
+                  provider: value === "all" ? null : value,
+                })
+              }
             >
-              <SelectValue placeholder="All providers" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All providers</SelectItem>
-              <LlmProviderSelectItems options={providerOptions} />
-            </SelectContent>
-          </Select>
-        </FilterBar>
+              <SelectTrigger
+                size="sm"
+                aria-label="Filter by provider"
+                className={filterControlClass({
+                  active: providerFilter !== "all",
+                })}
+              >
+                <SelectValue placeholder="All providers" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All providers</SelectItem>
+                <LlmProviderSelectItems options={providerOptions} />
+              </SelectContent>
+            </Select>
+          </FilterBar>
 
-        {byosEnabled &&
-          apiKeys.some((key) => key.secretStorageType === "database") && (
-            <Alert variant="destructive" className="!mb-3">
-              <AlertTriangle className="h-4 w-4" />
-              <AlertTitle>Database-stored API keys detected</AlertTitle>
-              <AlertDescription>
-                External Vault storage is enabled, but some of your API keys are
-                still stored in the database. To migrate them to the vault,
-                delete them and create new ones with vault references.
-              </AlertDescription>
-            </Alert>
-          )}
+          {byosEnabled &&
+            apiKeys.some((key) => key.secretStorageType === "database") && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Database-stored API keys detected</AlertTitle>
+                <AlertDescription>
+                  External Vault storage is enabled, but some of your API keys
+                  are still stored in the database. To migrate them to the
+                  vault, delete them and create new ones with vault references.
+                </AlertDescription>
+              </Alert>
+            )}
 
-        <div data-testid={E2eTestId.ChatApiKeysTable}>
-          <BulkActions
-            count={selectedApiKeys.length}
-            noun="API key"
-            onClear={clearSelection}
-            busy={bulkDeleteMutation.isPending}
-            selectAllMatching={selectAllMatching}
-          >
-            <PermissionButton
-              permissions={{ llmProviderApiKey: ["delete"] }}
-              variant="destructive"
-              size="sm"
-              onClick={() => setIsBulkDeleteDialogOpen(true)}
+          <div data-testid={E2eTestId.ChatApiKeysTable}>
+            <BulkActions
+              count={selectedApiKeys.length}
+              noun="API key"
+              onClear={clearSelection}
+              busy={bulkDeleteMutation.isPending}
+              selectAllMatching={selectAllMatching}
             >
-              <Trash2 className="h-4 w-4" />
-              <span>Delete</span>
-            </PermissionButton>
-          </BulkActions>
-          <DataTable
-            columns={columns}
-            data={rows}
-            getRowId={(row) => row.id}
-            rowSelection={rowSelection}
-            onRowSelectionChange={setRowSelection}
-            onPageRowIdsChange={onPageRowIdsChange}
-            hideSelectedCount
-            isLoading={permissionsPending || isFetching}
-            emptyIcon={Boxes}
-            emptyMessage="No credentials configured"
-            hasActiveFilters={Boolean(search || providerFilter !== "all")}
-            filteredEmptyMessage="No LLM provider credentials match your filters"
-            onClearFilters={() =>
-              updateQueryParams({
-                search: null,
-                provider: null,
-              })
-            }
-          />
-        </div>
+              <PermissionButton
+                permissions={{ llmProviderApiKey: ["delete"] }}
+                variant="destructive"
+                size="sm"
+                onClick={() => setIsBulkDeleteDialogOpen(true)}
+              >
+                <Trash2 className="h-4 w-4" />
+                <span>Delete</span>
+              </PermissionButton>
+            </BulkActions>
+            <DataTable
+              columns={columns}
+              data={rows}
+              getRowId={(row) => row.id}
+              rowSelection={rowSelection}
+              onRowSelectionChange={setRowSelection}
+              onPageRowIdsChange={onPageRowIdsChange}
+              hideSelectedCount
+              isLoading={permissionsPending || isFetching}
+              emptyIcon={Boxes}
+              emptyMessage="No credentials configured"
+              hasActiveFilters={Boolean(search || providerFilter !== "all")}
+              filteredEmptyMessage="No LLM provider credentials match your filters"
+              onClearFilters={() =>
+                updateQueryParams({
+                  search: null,
+                  provider: null,
+                })
+              }
+            />
+          </div>
+        </BulkActionsScope>
 
         {/* Create Dialog */}
         <CreateLlmProviderApiKeyDialog

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -502,7 +502,7 @@ function McpToolCallsTable({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <FilterBar leading onClearFilters={hasFilters ? clearFilters : undefined}>
         {searchInputComponent}
         {/* Two people's personal gateways can both be called "My Gateway", so

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1607,6 +1607,9 @@ function McpServerCatalogSection({
         selection={{
           ...cardSelection(item),
           disabled: !canSelect(item),
+          disabledTooltip: !serverInfo.installedServer
+            ? "Install this server before selecting it"
+            : "Wait for installation to finish",
         }}
       />
     );
@@ -1647,10 +1650,8 @@ function McpServerCatalogSection({
             rowIds={cardPageItems.filter(canSelect).map((item) => item.id)}
             onVisibleRowIdsChange={recordCardPageRowIds}
           >
-            <div className="space-y-6">
-              <TableCardGrid className={CARD_GRID_CLASS}>
-                {cardPageItems.map(renderCard)}
-              </TableCardGrid>
+            <div className="space-y-4">
+              <TableCardGrid>{cardPageItems.map(renderCard)}</TableCardGrid>
               {orderedCardItems.length > cardPagination.pageSize ? (
                 <TablePagination
                   pageIndex={cardPageIndex}
@@ -1790,21 +1791,6 @@ function McpCatalogLabelKeyRow({
     />
   );
 }
-
-/**
- * Columns are sized from what a card needs, not from viewport breakpoints. The
- * breakpoints measured the window rather than the space left after the nav, so
- * `lg:grid-cols-3` kept promising three columns while handing each card ~190px
- * — far less than its metadata row (scope badge, tool and agent counts,
- * deployment state, connection avatars) can lay out on one line. Sizing from
- * the content drops a column at those widths instead of squeezing.
- *
- * 19rem: measured against the widest real cards, every one of them fits by
- * 296px and the worst overflows by 1px at 288px, so this floor clears it with
- * a little room for the author name to occupy rather than truncate.
- */
-const CARD_GRID_CLASS =
-  "auto-rows-fr grid-cols-[repeat(auto-fill,minmax(19rem,1fr))] lg:grid-cols-[repeat(auto-fill,minmax(19rem,1fr))] 2xl:grid-cols-[repeat(auto-fill,minmax(19rem,1fr))]";
 
 function countSuffix(applicable: number, selected: number): string {
   return applicable > 0 && applicable < selected ? ` (${applicable})` : "";

--- a/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
@@ -146,7 +146,7 @@ export function ArchestraCatalogTab({
   );
 
   return (
-    <div className="w-full space-y-2">
+    <div className="w-full space-y-3">
       <FilterBar
         className="ml-1"
         onClearFilters={

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
@@ -727,34 +727,38 @@ function ToolReviewCard({
   return (
     <div className="rounded-lg border">
       <div className="flex flex-wrap items-start justify-between gap-4 p-4">
-        <Checkbox
-          aria-label={`Select ${displayName}`}
-          className="mt-0.5"
-          checked={selected}
-          onClick={onSelectionClick}
-        />
-        <div className="min-w-0 flex-1 space-y-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <code className="text-sm font-semibold">{displayName}</code>
-            {annotationBadges.map(({ key, label, destructive }) => (
-              <Badge
-                key={key}
-                variant={destructive ? "destructive" : "outline"}
-                className="font-normal"
-              >
-                {label}
-              </Badge>
-            ))}
-            {tool.assignmentCount > 0 && (
-              <Badge variant="secondary" className="font-normal">
-                {tool.assignmentCount}{" "}
-                {tool.assignmentCount === 1 ? "assignment" : "assignments"}
-              </Badge>
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <Checkbox
+            aria-label={`Select ${displayName}`}
+            className="mt-1"
+            checked={selected}
+            onClick={onSelectionClick}
+          />
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <code className="text-sm font-semibold">{displayName}</code>
+              {annotationBadges.map(({ key, label, destructive }) => (
+                <Badge
+                  key={key}
+                  variant={destructive ? "destructive" : "outline"}
+                  className="font-normal"
+                >
+                  {label}
+                </Badge>
+              ))}
+              {tool.assignmentCount > 0 && (
+                <Badge variant="secondary" className="font-normal">
+                  {tool.assignmentCount}{" "}
+                  {tool.assignmentCount === 1 ? "assignment" : "assignments"}
+                </Badge>
+              )}
+            </div>
+            {tool.description && (
+              <p className="text-sm text-muted-foreground">
+                {tool.description}
+              </p>
             )}
           </div>
-          {tool.description && (
-            <p className="text-sm text-muted-foreground">{tool.description}</p>
-          )}
         </div>
 
         <WithPermissions

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.test.tsx
@@ -322,6 +322,32 @@ describe("McpServerCard uninstall permission", () => {
     expect(screen.queryByText("Uninstall MCP Server")).not.toBeInTheDocument();
   });
 
+  it("keeps image approval in the shared metadata and action layout", async () => {
+    const user = userEvent.setup();
+    useMcpServersMock.mockReturnValue({ data: [] });
+    renderCard(
+      <McpServerCard
+        variant="local"
+        item={{
+          ...item,
+          serverType: "local",
+          imageApprovalRequired: true,
+        }}
+        installingItemId={null}
+        deploymentStatuses={{}}
+        deploymentFeedState="ready"
+        onInstallRemoteServer={vi.fn()}
+        onInstallLocalServer={vi.fn()}
+        onReinstall={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Image needs approval")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Review config" }));
+
+    expect(routerPush).toHaveBeenCalledWith("/mcp/registry/cat-1/edit");
+  });
+
   it("hides OAuth failure diagnostics while MCP alerting is disabled", () => {
     useMcpServersMock.mockReturnValue({
       data: [

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.test.tsx
@@ -572,14 +572,30 @@ describe("McpServerCard uninstall permission", () => {
     const grid = screen.getByTestId("registry-card-grid");
     expect(
       within(grid)
-        .getAllByRole("link")
-        .filter((link) =>
+        .getAllByRole("heading", { level: 3 })
+        .filter((heading) =>
           [flagged.name, personal.name, alpha.name, zeta.name].includes(
-            link.textContent ?? "",
+            heading.textContent ?? "",
           ),
         )
-        .map((link) => link.textContent),
+        .map((heading) => heading.textContent),
     ).toEqual([alpha.name, flagged.name, personal.name, zeta.name]);
+  });
+
+  it("explains that an uninstalled card must be installed before selection", async () => {
+    const user = userEvent.setup();
+    useMcpServersMock.mockReturnValue({ data: [] });
+    renderCard(<InternalMCPCatalog initialData={[item]} />);
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Select some-remote-server",
+    });
+    expect(checkbox).toBeDisabled();
+    await user.hover(checkbox.parentElement ?? checkbox);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Install this server before selecting it",
+    );
   });
 
   it("selects a card range from the shared bulk-selection checkbox", async () => {
@@ -618,6 +634,7 @@ describe("McpServerCard uninstall permission", () => {
           onSelectedChange,
           onSelectionClick: vi.fn(),
           disabled: true,
+          disabledTooltip: "Wait for installation to finish",
         }}
       />,
     );
@@ -626,6 +643,10 @@ describe("McpServerCard uninstall permission", () => {
       name: "Select some-remote-server",
     });
     expect(checkbox).toBeDisabled();
+    await user.hover(checkbox.parentElement ?? checkbox);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Wait for installation to finish",
+    );
 
     await user.click(checkbox);
 

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -619,6 +619,7 @@ export function McpServerCard({
   // Cards are one mixed list. Like Apps and Projects, every row names its
   // visibility so personal entries never rely on a removed ownership heading.
   const showScopeBadge = Boolean(item.scope);
+  const showApprovalPanel = item.imageApprovalRequired === true;
 
   /** Who is connected and whether a connection needs attention. */
   const hasTrailingCluster =
@@ -630,8 +631,16 @@ export function McpServerCard({
   /** Whether anything follows the badge in the row. */
   const hasCompactInfoAfterScopeBadge =
     toolsCount > 0 || totalAgentCount > 0 || hasTrailingCluster;
+  const hasCardMetadata = Boolean(
+    environmentLabel ||
+      statusIssue ||
+      item.providesUi ||
+      item.providesSkills ||
+      showApprovalPanel,
+  );
 
-  const hasCompactInfoContent = showScopeBadge || hasCompactInfoAfterScopeBadge;
+  const hasCompactInfoContent =
+    hasCardMetadata || showScopeBadge || hasCompactInfoAfterScopeBadge;
 
   /*
     One line, and it has to stay one line at the grid's card width — which
@@ -649,6 +658,34 @@ export function McpServerCard({
   */
   const compactInfoRow = hasCompactInfoContent ? (
     <div className="flex min-w-0 items-center gap-3 text-sm text-muted-foreground">
+      {environmentLabel && (
+        <Badge variant="outline" className="shrink-0 text-muted-foreground">
+          <span className="max-w-32 truncate">{environmentLabel}</span>
+        </Badge>
+      )}
+      {statusIssue && (
+        <span
+          className="shrink-0"
+          data-testid={
+            statusIssue.kind === "failed-to-start"
+              ? `${E2eTestId.McpServerError}-${item.name}-default`
+              : undefined
+          }
+        >
+          <McpServerIssueBadge issue={statusIssue} />
+        </span>
+      )}
+      <McpCapabilityBadges
+        providesUi={item.providesUi}
+        providesSkills={item.providesSkills}
+        skillCount={item.skillCount}
+        className="shrink-0"
+      />
+      {showApprovalPanel && (
+        <Badge variant="outline" className="shrink-0">
+          Image needs approval
+        </Badge>
+      )}
       {showScopeBadge && (
         <div className="flex min-w-0 items-center">
           <ResourceVisibilityBadge
@@ -842,11 +879,6 @@ export function McpServerCard({
     </PermissionButton>
   );
 
-  // The trusted-image-registry policy holds this catalog's image until an admin
-  // approves it. Declared before the card-content variants since they gate the
-  // reinstall button on it.
-  const showApprovalPanel = item.imageApprovalRequired === true;
-
   const remoteCardContent = (
     <>
       <div className="flex flex-nowrap gap-2 [&>*]:min-w-0">
@@ -1017,113 +1049,49 @@ export function McpServerCard({
     </>
   );
 
+  const approvalAction = showApprovalPanel ? (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="w-full"
+      onClick={
+        isInstallAdmin
+          ? () => router.push(`/mcp/registry/${item.id}/edit`)
+          : copyApprovalLink
+      }
+    >
+      {isInstallAdmin ? <FileSearch /> : <Copy />}
+      <span>{isInstallAdmin ? "Review config" : "Copy approval link"}</span>
+    </Button>
+  ) : null;
+  const cardActions =
+    approvalAction ??
+    (isBuiltinVariant
+      ? builtinCardContent
+      : isPlaywrightVariant
+        ? playwrightCardContent
+        : isRemoteVariant
+          ? remoteCardContent
+          : localCardContent);
   const hasCardBody = Boolean(
-    environmentLabel ||
-      statusIssue ||
-      item.providesUi ||
-      item.providesSkills ||
-      showApprovalPanel ||
-      (variant === "local" && isInstalling),
+    compactInfoRow || (variant === "local" && isInstalling),
   );
   const cardBody = hasCardBody ? (
     <div className="space-y-3">
-      {(environmentLabel ||
-        statusIssue ||
-        item.providesUi ||
-        item.providesSkills) && (
-        <div className="flex flex-wrap items-center gap-1">
-          {environmentLabel && (
-            <Badge variant="outline" className="text-muted-foreground">
-              <span className="max-w-32 truncate">{environmentLabel}</span>
-            </Badge>
-          )}
-          {statusIssue && (
-            <span
-              data-testid={
-                statusIssue.kind === "failed-to-start"
-                  ? `${E2eTestId.McpServerError}-${item.name}-default`
-                  : undefined
-              }
-            >
-              <McpServerIssueBadge issue={statusIssue} />
-            </span>
-          )}
-          <McpCapabilityBadges
-            providesUi={item.providesUi}
-            providesSkills={item.providesSkills}
-            skillCount={item.skillCount}
-          />
-        </div>
-      )}
-      {showApprovalPanel && (
-        <div className="space-y-1 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2.5">
-          <div className="flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-500">
-            <span>
-              {isInstallAdmin
-                ? "Image needs approval"
-                : "Admin review required"}
-            </span>
-            {isInstallAdmin ? (
-              <button
-                type="button"
-                onClick={() => router.push(`/mcp/registry/${item.id}/edit`)}
-                title="Review config"
-                aria-label="Review config"
-                className="shrink-0 rounded p-0.5 hover:bg-amber-500/10"
-              >
-                <FileSearch className="h-4 w-4" />
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={copyApprovalLink}
-                title="Copy link"
-                aria-label="Copy link"
-                className="shrink-0 rounded p-0.5 hover:bg-amber-500/10"
-              >
-                <Copy className="h-4 w-4" />
-              </button>
-            )}
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {allServersForCatalog.length > 0
-              ? "The Docker image was changed to one that isn't from a trusted registry. Existing connections keep running the previous image until an admin approves."
-              : isInstallAdmin
-                ? "This MCP server Docker image isn't from a trusted image registry. Review and approve configuration to allow installs."
-                : "This MCP server Docker image isn't from a trusted image registry. An admin must approve it before it can be installed."}
-          </p>
-        </div>
-      )}
+      {compactInfoRow}
       {variant === "local" && isInstalling && (
-        <div className="overflow-hidden rounded-md bg-muted/50">
-          <div className="px-3 py-2">
-            <InstallationProgress
-              status={
-                installationStatus === "error"
-                  ? null
-                  : (installationStatus ?? null)
-              }
-              serverId={installedServer?.id}
-              deploymentStatuses={deploymentStatuses}
-              onMoreDetails={() => goToItemPage("logs", installedServer?.id)}
-            />
-          </div>
-        </div>
+        <InstallationProgress
+          status={
+            installationStatus === "error" ? null : (installationStatus ?? null)
+          }
+          serverId={installedServer?.id}
+          deploymentStatuses={deploymentStatuses}
+          onMoreDetails={() => goToItemPage("logs", installedServer?.id)}
+        />
       )}
     </div>
   ) : undefined;
-  const cardFooter = (
-    <div className="space-y-3">
-      {compactInfoRow}
-      {isBuiltinVariant
-        ? builtinCardContent
-        : isPlaywrightVariant
-          ? playwrightCardContent
-          : isRemoteVariant
-            ? remoteCardContent
-            : localCardContent}
-    </div>
-  );
 
   return (
     <>
@@ -1145,7 +1113,8 @@ export function McpServerCard({
         onSelectionClick={selection?.onSelectionClick}
         selectionLabel={selection ? `Select ${item.name}` : undefined}
         onNavigate={() => goToItemPage()}
-        footer={cardFooter}
+        footer={cardActions}
+        density="compact"
       >
         {cardBody}
       </TableCard>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -574,6 +574,7 @@ export function McpServerCard({
 
   const selectionCheckbox = selection ? (
     <Checkbox
+      className="mt-1"
       checked={selection.selected}
       disabled={selection.disabled}
       aria-label={`Select ${item.name}`}
@@ -1061,67 +1062,71 @@ export function McpServerCard({
       data-testid={`${E2eTestId.McpServerCard}-${item.name}`}
     >
       <CardHeader className="gap-0">
-        <div className="flex items-start justify-between gap-4 overflow-hidden">
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 mb-1 overflow-hidden w-full">
-              <Link
-                href={`/mcp/registry/${item.id}`}
-                className="flex min-w-0 items-center gap-2 rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <span className="relative inline-flex shrink-0">
-                  <McpCatalogIcon
-                    icon={item.icon}
-                    catalogId={item.id}
-                    size={20}
-                  />
-                  {deploymentStatusIndicator}
-                </span>
-                <TruncatedTooltip content={item.name}>
-                  <span className="line-clamp-2 break-words text-lg font-semibold leading-5">
-                    {item.name}
-                  </span>
-                </TruncatedTooltip>
-              </Link>
-              {environmentLabel && (
-                <Badge
-                  variant="outline"
-                  className="shrink-0 text-muted-foreground"
+        <div className="flex items-start gap-3 overflow-hidden">
+          {selectionControl}
+          <div className="flex min-w-0 flex-1 items-start justify-between gap-4 overflow-hidden">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 mb-1 overflow-hidden w-full">
+                <Link
+                  href={`/mcp/registry/${item.id}`}
+                  className="flex min-w-0 items-center gap-2 rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
-                  <span className="max-w-32 truncate">{environmentLabel}</span>
-                </Badge>
-              )}
-            </div>
-            {(statusIssue || item.description) && (
-              <div className="flex min-w-0 flex-col items-start gap-1">
-                {statusIssue && (
-                  <span
-                    className="shrink-0"
-                    data-testid={
-                      statusIssue.kind === "failed-to-start"
-                        ? `${E2eTestId.McpServerError}-${item.name}-default`
-                        : undefined
-                    }
-                  >
-                    <McpServerIssueBadge issue={statusIssue} />
+                  <span className="relative inline-flex shrink-0">
+                    <McpCatalogIcon
+                      icon={item.icon}
+                      catalogId={item.id}
+                      size={20}
+                    />
+                    {deploymentStatusIndicator}
                   </span>
-                )}
-                {item.description && (
-                  <p className="min-w-0 text-xs text-muted-foreground line-clamp-2">
-                    {item.description}
-                  </p>
+                  <TruncatedTooltip content={item.name}>
+                    <span className="line-clamp-2 break-words text-lg font-semibold leading-5">
+                      {item.name}
+                    </span>
+                  </TruncatedTooltip>
+                </Link>
+                {environmentLabel && (
+                  <Badge
+                    variant="outline"
+                    className="shrink-0 text-muted-foreground"
+                  >
+                    <span className="max-w-32 truncate">
+                      {environmentLabel}
+                    </span>
+                  </Badge>
                 )}
               </div>
-            )}
-            <McpCapabilityBadges
-              providesUi={item.providesUi}
-              providesSkills={item.providesSkills}
-              skillCount={item.skillCount}
-              className="mt-2"
-            />
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            {selectionControl}
-            {canEditCatalog && settingsButton}
+              {(statusIssue || item.description) && (
+                <div className="flex min-w-0 flex-col items-start gap-1">
+                  {statusIssue && (
+                    <span
+                      className="shrink-0"
+                      data-testid={
+                        statusIssue.kind === "failed-to-start"
+                          ? `${E2eTestId.McpServerError}-${item.name}-default`
+                          : undefined
+                      }
+                    >
+                      <McpServerIssueBadge issue={statusIssue} />
+                    </span>
+                  )}
+                  {item.description && (
+                    <p className="min-w-0 text-xs text-muted-foreground line-clamp-2">
+                      {item.description}
+                    </p>
+                  )}
+                </div>
+              )}
+              <McpCapabilityBadges
+                providesUi={item.providesUi}
+                providesSkills={item.providesSkills}
+                skillCount={item.skillCount}
+                className="mt-2"
+              />
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {canEditCatalog && settingsButton}
+            </div>
           </div>
         </div>
       </CardHeader>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -893,7 +893,7 @@ export function McpServerCard({
             disabled={showApprovalPanel}
             size="sm"
             variant="outline"
-            className="flex-1 text-destructive border-destructive/30 hover:bg-destructive/10"
+            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10"
           >
             <RefreshCw className="h-4 w-4" />
             Reinstall
@@ -968,7 +968,7 @@ export function McpServerCard({
             disabled={reinstallCatalogMutation.isPending || showApprovalPanel}
             size="sm"
             variant="outline"
-            className="flex-1 text-destructive border-destructive/30 hover:bg-destructive/10"
+            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10"
           >
             <RefreshCw className="h-4 w-4" />
             Reinstall
@@ -996,7 +996,7 @@ export function McpServerCard({
             disabled={showApprovalPanel}
             size="sm"
             variant="outline"
-            className="flex-1 text-destructive border-destructive/30 hover:bg-destructive/10"
+            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10"
           >
             <RefreshCw className="h-4 w-4" />
             Reinstall

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -1100,8 +1100,8 @@ export function McpServerCard({
         title={item.name}
         description={item.description}
         icon={
-          <span className="relative inline-flex">
-            <McpCatalogIcon icon={item.icon} catalogId={item.id} size={36} />
+          <span className="relative flex size-9 items-center justify-center overflow-hidden rounded-lg border bg-muted/30">
+            <McpCatalogIcon icon={item.icon} catalogId={item.id} size={20} />
             {deploymentStatusIndicator}
           </span>
         }

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -27,7 +27,7 @@ import { type MouseEventHandler, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
-import { useNavigableCard } from "@/components/table-card-view";
+import { TableCard } from "@/components/table-card-view";
 import {
   Avatar,
   AvatarFallback,
@@ -36,8 +36,6 @@ import {
 } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -57,7 +55,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { TruncatedTooltip } from "@/components/ui/truncated-tooltip";
 import { LOCAL_MCP_DISABLED_MESSAGE } from "@/consts";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { copyToClipboard } from "@/lib/clipboard";
@@ -147,6 +144,7 @@ export type McpServerCardProps = {
     onSelectedChange: (selected: boolean) => void;
     onSelectionClick: MouseEventHandler<HTMLButtonElement>;
     disabled?: boolean;
+    disabledTooltip?: string;
   };
 };
 
@@ -261,11 +259,6 @@ export function McpServerCard({
     const qs = params.toString();
     router.push(`/mcp/registry/${item.id}${qs ? `?${qs}` : ""}`);
   };
-  const cardNavigation = useNavigableCard({
-    onNavigate: () => goToItemPage(),
-    selected: selection?.selected,
-  });
-
   // ── Shareable edit deep-link (`?edit=<catalogId>`) ──────────────────────
   // Legacy links: the editor now lives on the item detail page, so a shared
   // `?edit=<id>` link redirects there for users who can edit, and shows a
@@ -357,7 +350,7 @@ export function McpServerCard({
       permissions={{ mcpServerInstallation: ["delete"] }}
       variant="outline"
       size="sm"
-      className="flex-1"
+      className="flex-1 px-2.5"
       onClick={handleUninstallClick}
     >
       Uninstall
@@ -570,34 +563,6 @@ export function McpServerCard({
     >
       <Pencil className="h-4 w-4" />
     </Button>
-  );
-
-  const selectionCheckbox = selection ? (
-    <Checkbox
-      className="mt-1"
-      checked={selection.selected}
-      disabled={selection.disabled}
-      aria-label={`Select ${item.name}`}
-      onCheckedChange={(checked) =>
-        selection.onSelectedChange(checked === true)
-      }
-      onClick={(event) => selection.onSelectionClick(event)}
-    />
-  ) : null;
-  const selectionControl = selection?.disabled ? (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className="inline-flex cursor-not-allowed"
-          title="Wait for installation to finish"
-        >
-          {selectionCheckbox}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent>Wait for installation to finish</TooltipContent>
-    </Tooltip>
-  ) : (
-    selectionCheckbox
   );
 
   // A 4th connection folds into the +N count rather than lengthening the
@@ -894,7 +859,7 @@ export function McpServerCard({
             disabled={showApprovalPanel}
             size="sm"
             variant="outline"
-            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10"
+            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10 sm:flex-1"
           >
             <RefreshCw className="h-4 w-4" />
             Reinstall
@@ -969,7 +934,7 @@ export function McpServerCard({
             disabled={reinstallCatalogMutation.isPending || showApprovalPanel}
             size="sm"
             variant="outline"
-            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10"
+            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10 sm:flex-1"
           >
             <RefreshCw className="h-4 w-4" />
             Reinstall
@@ -997,7 +962,7 @@ export function McpServerCard({
             disabled={showApprovalPanel}
             size="sm"
             variant="outline"
-            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10"
+            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10 sm:flex-1"
           >
             <RefreshCw className="h-4 w-4" />
             Reinstall
@@ -1052,153 +1017,140 @@ export function McpServerCard({
     </>
   );
 
+  const hasCardBody = Boolean(
+    environmentLabel ||
+      statusIssue ||
+      item.providesUi ||
+      item.providesSkills ||
+      showApprovalPanel ||
+      (variant === "local" && isInstalling),
+  );
+  const cardBody = hasCardBody ? (
+    <div className="space-y-3">
+      {(environmentLabel ||
+        statusIssue ||
+        item.providesUi ||
+        item.providesSkills) && (
+        <div className="flex flex-wrap items-center gap-1">
+          {environmentLabel && (
+            <Badge variant="outline" className="text-muted-foreground">
+              <span className="max-w-32 truncate">{environmentLabel}</span>
+            </Badge>
+          )}
+          {statusIssue && (
+            <span
+              data-testid={
+                statusIssue.kind === "failed-to-start"
+                  ? `${E2eTestId.McpServerError}-${item.name}-default`
+                  : undefined
+              }
+            >
+              <McpServerIssueBadge issue={statusIssue} />
+            </span>
+          )}
+          <McpCapabilityBadges
+            providesUi={item.providesUi}
+            providesSkills={item.providesSkills}
+            skillCount={item.skillCount}
+          />
+        </div>
+      )}
+      {showApprovalPanel && (
+        <div className="space-y-1 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2.5">
+          <div className="flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-500">
+            <span>
+              {isInstallAdmin
+                ? "Image needs approval"
+                : "Admin review required"}
+            </span>
+            {isInstallAdmin ? (
+              <button
+                type="button"
+                onClick={() => router.push(`/mcp/registry/${item.id}/edit`)}
+                title="Review config"
+                aria-label="Review config"
+                className="shrink-0 rounded p-0.5 hover:bg-amber-500/10"
+              >
+                <FileSearch className="h-4 w-4" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={copyApprovalLink}
+                title="Copy link"
+                aria-label="Copy link"
+                className="shrink-0 rounded p-0.5 hover:bg-amber-500/10"
+              >
+                <Copy className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {allServersForCatalog.length > 0
+              ? "The Docker image was changed to one that isn't from a trusted registry. Existing connections keep running the previous image until an admin approves."
+              : isInstallAdmin
+                ? "This MCP server Docker image isn't from a trusted image registry. Review and approve configuration to allow installs."
+                : "This MCP server Docker image isn't from a trusted image registry. An admin must approve it before it can be installed."}
+          </p>
+        </div>
+      )}
+      {variant === "local" && isInstalling && (
+        <div className="overflow-hidden rounded-md bg-muted/50">
+          <div className="px-3 py-2">
+            <InstallationProgress
+              status={
+                installationStatus === "error"
+                  ? null
+                  : (installationStatus ?? null)
+              }
+              serverId={installedServer?.id}
+              deploymentStatuses={deploymentStatuses}
+              onMoreDetails={() => goToItemPage("logs", installedServer?.id)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  ) : undefined;
+  const cardFooter = (
+    <div className="space-y-3">
+      {compactInfoRow}
+      {isBuiltinVariant
+        ? builtinCardContent
+        : isPlaywrightVariant
+          ? playwrightCardContent
+          : isRemoteVariant
+            ? remoteCardContent
+            : localCardContent}
+    </div>
+  );
+
   return (
-    <Card
-      {...cardNavigation.props}
-      // `overflow-hidden` is a backstop, not the fix: the rows inside are laid
-      // out to fit. It means that if some future combination still doesn't,
-      // the card clips it instead of painting it over its neighbour.
-      className={`flex h-full flex-col gap-4 overflow-hidden pt-4 transition-colors ${cardNavigation.className} ${selection?.selected ? "border-primary bg-primary/5" : ""}`}
-      data-testid={`${E2eTestId.McpServerCard}-${item.name}`}
-    >
-      <CardHeader className="gap-0">
-        <div className="flex items-start gap-3 overflow-hidden">
-          {selectionControl}
-          <div className="flex min-w-0 flex-1 items-start justify-between gap-4 overflow-hidden">
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2 mb-1 overflow-hidden w-full">
-                <Link
-                  href={`/mcp/registry/${item.id}`}
-                  className="flex min-w-0 items-center gap-2 rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  <span className="relative inline-flex shrink-0">
-                    <McpCatalogIcon
-                      icon={item.icon}
-                      catalogId={item.id}
-                      size={20}
-                    />
-                    {deploymentStatusIndicator}
-                  </span>
-                  <TruncatedTooltip content={item.name}>
-                    <span className="line-clamp-2 break-words text-lg font-semibold leading-5">
-                      {item.name}
-                    </span>
-                  </TruncatedTooltip>
-                </Link>
-                {environmentLabel && (
-                  <Badge
-                    variant="outline"
-                    className="shrink-0 text-muted-foreground"
-                  >
-                    <span className="max-w-32 truncate">
-                      {environmentLabel}
-                    </span>
-                  </Badge>
-                )}
-              </div>
-              {(statusIssue || item.description) && (
-                <div className="flex min-w-0 flex-col items-start gap-1">
-                  {statusIssue && (
-                    <span
-                      className="shrink-0"
-                      data-testid={
-                        statusIssue.kind === "failed-to-start"
-                          ? `${E2eTestId.McpServerError}-${item.name}-default`
-                          : undefined
-                      }
-                    >
-                      <McpServerIssueBadge issue={statusIssue} />
-                    </span>
-                  )}
-                  {item.description && (
-                    <p className="min-w-0 text-xs text-muted-foreground line-clamp-2">
-                      {item.description}
-                    </p>
-                  )}
-                </div>
-              )}
-              <McpCapabilityBadges
-                providesUi={item.providesUi}
-                providesSkills={item.providesSkills}
-                skillCount={item.skillCount}
-                className="mt-2"
-              />
-            </div>
-            <div className="flex shrink-0 items-center gap-1">
-              {canEditCatalog && settingsButton}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4 flex-grow">
-        {showApprovalPanel && (
-          <div className="space-y-1 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2.5">
-            <div className="flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-500">
-              <span>
-                {isInstallAdmin
-                  ? "Image needs approval"
-                  : "Admin review required"}
-              </span>
-              {isInstallAdmin ? (
-                <button
-                  type="button"
-                  onClick={() => router.push(`/mcp/registry/${item.id}/edit`)}
-                  title="Review config"
-                  aria-label="Review config"
-                  className="shrink-0 rounded p-0.5 hover:bg-amber-500/10"
-                >
-                  <FileSearch className="h-4 w-4" />
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  onClick={copyApprovalLink}
-                  title="Copy link"
-                  aria-label="Copy link"
-                  className="shrink-0 rounded p-0.5 hover:bg-amber-500/10"
-                >
-                  <Copy className="h-4 w-4" />
-                </button>
-              )}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {allServersForCatalog.length > 0
-                ? "The Docker image was changed to one that isn't from a trusted registry. Existing connections keep running the previous image until an admin approves."
-                : isInstallAdmin
-                  ? "This MCP server Docker image isn't from a trusted image registry. Review and approve configuration to allow installs."
-                  : "This MCP server Docker image isn't from a trusted image registry. An admin must approve it before it can be installed."}
-            </p>
-          </div>
-        )}
-        {variant === "local" && isInstalling && (
-          <div className="bg-muted/50 rounded-md overflow-hidden">
-            <div className="px-3 py-2">
-              <InstallationProgress
-                status={
-                  installationStatus === "error"
-                    ? null
-                    : (installationStatus ?? null)
-                }
-                serverId={installedServer?.id}
-                deploymentStatuses={deploymentStatuses}
-                onMoreDetails={() => goToItemPage("logs", installedServer?.id)}
-              />
-            </div>
-          </div>
-        )}
-        <div className="mt-auto flex flex-col gap-4">
-          {compactInfoRow}
-          {isBuiltinVariant
-            ? builtinCardContent
-            : isPlaywrightVariant
-              ? playwrightCardContent
-              : isRemoteVariant
-                ? remoteCardContent
-                : localCardContent}
-        </div>
-      </CardContent>
+    <>
+      <TableCard
+        testId={`${E2eTestId.McpServerCard}-${item.name}`}
+        title={item.name}
+        description={item.description}
+        icon={
+          <span className="relative inline-flex">
+            <McpCatalogIcon icon={item.icon} catalogId={item.id} size={36} />
+            {deploymentStatusIndicator}
+          </span>
+        }
+        actions={canEditCatalog ? settingsButton : undefined}
+        selected={selection?.selected}
+        selectionDisabled={selection?.disabled}
+        selectionDisabledTooltip={selection?.disabledTooltip}
+        onSelectedChange={selection?.onSelectedChange}
+        onSelectionClick={selection?.onSelectionClick}
+        selectionLabel={selection ? `Select ${item.name}` : undefined}
+        onNavigate={() => goToItemPage()}
+        footer={cardFooter}
+      >
+        {cardBody}
+      </TableCard>
       {dialogs}
-    </Card>
+    </>
   );
 }
 

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-notice.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-notice.tsx
@@ -496,7 +496,7 @@ export function McpServerIssueNotice({
         <Button
           variant={action.variant ?? "outline"}
           size="sm"
-          className="shrink-0 gap-1 px-2 text-xs"
+          className="shrink-0 gap-1 px-2 text-xs sm:flex-1"
           aria-label={action.label}
           data-testid={action.testId}
           onClick={action.onClick}
@@ -511,7 +511,7 @@ export function McpServerIssueNotice({
         <Button
           variant="outline"
           size="sm"
-          className="shrink-0 gap-1 px-2 text-xs"
+          className="shrink-0 gap-1 px-2 text-xs sm:flex-1"
           disabled={restoreMutation.isPending}
           onClick={() =>
             restoreMutation.mutate(
@@ -531,7 +531,7 @@ export function McpServerIssueNotice({
       <Button
         variant="outline"
         size="sm"
-        className="shrink-0 gap-1 px-2 text-xs"
+        className="shrink-0 gap-1 px-2 text-xs sm:flex-1"
         onClick={() => router.push(detailHref())}
       >
         Open

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -615,61 +615,64 @@ function ProjectCard({
       {...navigation.props}
       className={`rounded-lg border p-4 transition-colors ${navigation.className} ${selected ? "border-primary bg-primary/5" : ""}`}
     >
-      <div className="flex items-center justify-between gap-2">
-        <Link
-          href={`/projects/${project.id}`}
-          className="flex min-w-0 items-center gap-2"
-        >
-          <span className="shrink-0">
-            <AgentIcon icon={project.icon} fallbackType="project" size={18} />
-          </span>
-          <span className="min-w-0 truncate font-medium">{project.name}</span>
-        </Link>
-        <span className="flex shrink-0 items-center gap-1">
-          <Checkbox
-            checked={selected}
-            disabled={selectionDisabled}
-            onCheckedChange={(value) => onSelectedChange(!!value)}
-            onClick={onSelectionClick}
-            aria-label={`Select ${project.name}`}
-            aria-description={
-              selectionDisabled ? "You cannot modify this project" : undefined
-            }
-            title={
-              selectionDisabled ? "You cannot modify this project" : undefined
-            }
-          />
-          {/* Scope pill (personal/team/org) on every card. The owner label is
+      <div className="flex items-start gap-3">
+        <Checkbox
+          className="mt-1"
+          checked={selected}
+          disabled={selectionDisabled}
+          onCheckedChange={(value) => onSelectedChange(!!value)}
+          onClick={onSelectionClick}
+          aria-label={`Select ${project.name}`}
+          aria-description={
+            selectionDisabled ? "You cannot modify this project" : undefined
+          }
+          title={
+            selectionDisabled ? "You cannot modify this project" : undefined
+          }
+        />
+        <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+          <Link
+            href={`/projects/${project.id}`}
+            className="flex min-w-0 items-center gap-2"
+          >
+            <span className="shrink-0">
+              <AgentIcon icon={project.icon} fallbackType="project" size={18} />
+            </span>
+            <span className="min-w-0 truncate font-medium">{project.name}</span>
+          </Link>
+          <span className="flex shrink-0 items-center gap-1">
+            {/* Scope pill (personal/team/org) on every card. The owner label is
               added only on another member's PERSONAL project (admin oversight),
               where the personal pill alone can't say whose it is — for team/org
               the scope pill already conveys the sharing. */}
-          <ScopeBadge
-            scope={projectVisibilityToScope(project.visibility)}
-            teamNames={project.shareTeamNames}
-            userNames={project.shareUserNames}
-          />
-          {project.viewerRole === "admin" && project.visibility === null && (
-            <Badge variant="secondary">
-              {project.ownerName
-                ? `Owned by ${project.ownerName}`
-                : "Other user"}
-            </Badge>
-          )}
-          <ProjectActionsMenu
-            pinned={!!project.pinnedAt}
-            canPin={project.viewerRole !== "admin"}
-            canManage={canManageProject(project.viewerRole, !!isProjectAdmin)}
-            canDelete={canDeleteProject({
-              viewerRole: project.viewerRole,
-              visibility: project.visibility,
-              isProjectAdmin: !!isProjectAdmin,
-              canShareOrg: !!canShareOrg,
-            })}
-            onTogglePin={() => onTogglePin(project)}
-            onEdit={() => onEdit(project)}
-            onDelete={() => onDelete(project)}
-          />
-        </span>
+            <ScopeBadge
+              scope={projectVisibilityToScope(project.visibility)}
+              teamNames={project.shareTeamNames}
+              userNames={project.shareUserNames}
+            />
+            {project.viewerRole === "admin" && project.visibility === null && (
+              <Badge variant="secondary">
+                {project.ownerName
+                  ? `Owned by ${project.ownerName}`
+                  : "Other user"}
+              </Badge>
+            )}
+            <ProjectActionsMenu
+              pinned={!!project.pinnedAt}
+              canPin={project.viewerRole !== "admin"}
+              canManage={canManageProject(project.viewerRole, !!isProjectAdmin)}
+              canDelete={canDeleteProject({
+                viewerRole: project.viewerRole,
+                visibility: project.visibility,
+                isProjectAdmin: !!isProjectAdmin,
+                canShareOrg: !!canShareOrg,
+              })}
+              onTogglePin={() => onTogglePin(project)}
+              onEdit={() => onEdit(project)}
+              onDelete={() => onDelete(project)}
+            />
+          </span>
+        </div>
       </div>
       {/* Always reserve two lines so cards keep a uniform height regardless of
           description length (or absence). */}

--- a/platform/frontend/src/app/settings/messaging-channels/_components/channels-section.tsx
+++ b/platform/frontend/src/app/settings/messaging-channels/_components/channels-section.tsx
@@ -427,7 +427,7 @@ export function ChannelsSection({
           onRetry={() => refetchBindings()}
         />
       ) : hasAnyChannels ? (
-        <>
+        <div className="space-y-3">
           {/* Search + filters + bulk assign */}
           <FilterBar
             onClearFilters={hasActiveFilters ? clearFilters : undefined}
@@ -629,7 +629,7 @@ export function ChannelsSection({
               }
             />
           )}
-        </>
+        </div>
       ) : (
         <ChannelsEmptyState
           onRefresh={() => refreshMutation.mutate(providerConfig.provider)}

--- a/platform/frontend/src/components/table-card-view.test.tsx
+++ b/platform/frontend/src/components/table-card-view.test.tsx
@@ -192,7 +192,6 @@ describe("TableCardView", () => {
     );
 
     const selectionControl = screen.getByLabelText("Select Knowledge source");
-    expect(selectionControl).toHaveClass("size-11");
     fireEvent.click(selectionControl);
 
     expect(onSelectedChange).toHaveBeenCalledWith(true);

--- a/platform/frontend/src/components/table-card-view.test.tsx
+++ b/platform/frontend/src/components/table-card-view.test.tsx
@@ -1,5 +1,6 @@
 import type { RowSelectionState } from "@tanstack/react-table";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FilterBar } from "@/components/filter-bar";
@@ -195,6 +196,32 @@ describe("TableCardView", () => {
     fireEvent.click(selectionControl);
 
     expect(onSelectedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("explains why a card cannot be selected", async () => {
+    const user = userEvent.setup();
+    const onSelectedChange = vi.fn();
+
+    render(
+      <TableCard
+        title="Unavailable source"
+        selected={false}
+        selectionDisabled
+        selectionDisabledTooltip="Install this source before selecting it"
+        onSelectedChange={onSelectedChange}
+        selectionLabel="Select unavailable source"
+      />,
+    );
+
+    const selectionControl = screen.getByLabelText("Select unavailable source");
+    expect(selectionControl).toBeDisabled();
+    await user.hover(selectionControl.parentElement ?? selectionControl);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Install this source before selecting it",
+    );
+    fireEvent.click(selectionControl);
+    expect(onSelectedChange).not.toHaveBeenCalled();
   });
 
   it("reports the rows visible in card mode", () => {

--- a/platform/frontend/src/components/table-card-view.tsx
+++ b/platform/frontend/src/components/table-card-view.tsx
@@ -298,6 +298,7 @@ export function TableCard({
   className,
   onNavigate,
   testId,
+  density = "default",
 }: {
   title: ReactNode;
   description?: ReactNode;
@@ -314,10 +315,12 @@ export function TableCard({
   className?: string;
   onNavigate?: () => void;
   testId?: string;
+  density?: "default" | "compact";
 }) {
   const selectable =
     onSelectedChange !== undefined || onSelectionClick !== undefined;
   const navigation = useNavigableCard({ onNavigate, selected });
+  const compact = density === "compact";
   const selectionControl = selectable ? (
     <Checkbox
       className="mt-1"
@@ -352,7 +355,8 @@ export function TableCard({
       {...navigation.props}
       data-testid={testId}
       className={cn(
-        "flex h-full flex-col gap-3 rounded-lg border p-4 transition-colors",
+        "flex h-full flex-col rounded-lg border p-4 transition-colors",
+        compact ? "gap-2" : "gap-3",
         selected
           ? cn("border-primary bg-primary/5", navigation.className)
           : onNavigate
@@ -378,7 +382,12 @@ export function TableCard({
       </div>
       {children ? <div className="text-sm">{children}</div> : null}
       {footer ? (
-        <div className="mt-auto border-t pt-3 text-xs text-muted-foreground">
+        <div
+          className={cn(
+            "mt-auto border-t text-xs text-muted-foreground",
+            compact ? "pt-2 [&_button]:h-7 [&_button]:text-xs" : "pt-3",
+          )}
+        >
           {footer}
         </div>
       ) : null}

--- a/platform/frontend/src/components/table-card-view.tsx
+++ b/platform/frontend/src/components/table-card-view.tsx
@@ -289,6 +289,7 @@ export function TableCard({
   actions,
   selected,
   selectionDisabled,
+  selectionDisabledTooltip,
   onSelectedChange,
   onSelectionClick,
   selectionLabel,
@@ -296,6 +297,7 @@ export function TableCard({
   footer,
   className,
   onNavigate,
+  testId,
 }: {
   title: ReactNode;
   description?: ReactNode;
@@ -303,6 +305,7 @@ export function TableCard({
   actions?: ReactNode;
   selected?: boolean;
   selectionDisabled?: boolean;
+  selectionDisabledTooltip?: ReactNode;
   onSelectedChange?: (selected: boolean) => void;
   onSelectionClick?: MouseEventHandler<HTMLButtonElement>;
   selectionLabel?: string;
@@ -310,14 +313,44 @@ export function TableCard({
   footer?: ReactNode;
   className?: string;
   onNavigate?: () => void;
+  testId?: string;
 }) {
   const selectable =
     onSelectedChange !== undefined || onSelectionClick !== undefined;
   const navigation = useNavigableCard({ onNavigate, selected });
+  const selectionControl = selectable ? (
+    <Checkbox
+      className="mt-1"
+      checked={selected}
+      disabled={selectionDisabled}
+      onCheckedChange={
+        onSelectedChange ? (value) => onSelectedChange(!!value) : undefined
+      }
+      onClick={(event) => {
+        event.stopPropagation();
+        onSelectionClick?.(event);
+      }}
+      aria-label={selectionLabel}
+    />
+  ) : null;
+  const renderedSelectionControl =
+    selectionDisabled && selectionDisabledTooltip && selectionControl ? (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex cursor-not-allowed">
+            {selectionControl}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{selectionDisabledTooltip}</TooltipContent>
+      </Tooltip>
+    ) : (
+      selectionControl
+    );
 
   return (
     <div
       {...navigation.props}
+      data-testid={testId}
       className={cn(
         "flex h-full flex-col gap-3 rounded-lg border p-4 transition-colors",
         selected
@@ -329,23 +362,7 @@ export function TableCard({
       )}
     >
       <div className="flex items-start gap-3">
-        {selectable ? (
-          <Checkbox
-            className="mt-1"
-            checked={selected}
-            disabled={selectionDisabled}
-            onCheckedChange={
-              onSelectedChange
-                ? (value) => onSelectedChange(!!value)
-                : undefined
-            }
-            onClick={(event) => {
-              event.stopPropagation();
-              onSelectionClick?.(event);
-            }}
-            aria-label={selectionLabel}
-          />
-        ) : null}
+        {renderedSelectionControl}
         {icon ? (
           <span className="mt-0.5 shrink-0 text-muted-foreground">{icon}</span>
         ) : null}

--- a/platform/frontend/src/components/table-card-view.tsx
+++ b/platform/frontend/src/components/table-card-view.tsx
@@ -328,10 +328,10 @@ export function TableCard({
         className,
       )}
     >
-      <div className="flex items-start">
+      <div className="flex items-start gap-3">
         {selectable ? (
           <Checkbox
-            className={CARD_SELECTION_CHECKBOX_CLASSNAME}
+            className="mt-1"
             checked={selected}
             disabled={selectionDisabled}
             onCheckedChange={
@@ -347,11 +347,9 @@ export function TableCard({
           />
         ) : null}
         {icon ? (
-          <span className="flex size-11 shrink-0 items-center justify-center text-muted-foreground">
-            {icon}
-          </span>
+          <span className="mt-0.5 shrink-0 text-muted-foreground">{icon}</span>
         ) : null}
-        <div className={cn("min-w-0 flex-1", icon && "ml-3")}>
+        <div className="min-w-0 flex-1">
           <h3 className="truncate font-medium">{title}</h3>
           {description ? (
             <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
@@ -406,9 +404,6 @@ export function useNavigableCard({
       : {},
   };
 }
-
-const CARD_SELECTION_CHECKBOX_CLASSNAME =
-  "relative size-11 cursor-pointer border-0 bg-transparent shadow-none before:absolute before:size-4 before:rounded-[4px] before:border before:border-input before:bg-background data-[state=checked]:border-0 data-[state=checked]:bg-transparent data-[state=checked]:text-primary-foreground data-[state=checked]:before:border-primary data-[state=checked]:before:bg-primary dark:data-[state=checked]:bg-transparent [&_[data-slot=checkbox-indicator]]:relative";
 
 const VIEW_LABELS: Record<TableCardViewMode, string> = {
   cards: "View as cards",


### PR DESCRIPTION
## Summary
- standardize filter-to-table and filter-to-card spacing at 12px across collection pages
- restore 16px card-selection controls and align shared and custom card headers without oversized or overlapping hit areas
- render MCP Registry cards through the shared `TableCard` and `TableCardGrid` implementations used by Agents, Skills, Plugins, Gateways, Connectors, Virtual Keys, and Service Accounts
- compact MCP operational metadata into one row, remove nested approval/progress panels, and use the shared card compact density for richer operational states
- balance MCP action rows at card breakpoints while preserving intrinsic controls on narrow mobile cards to prevent clipping

## Validation
- 131 branch-targeted frontend tests plus 47 shared-card consumer tests; final compact-card pass: 36 tests
- `pnpm --filter @frontend type-check`
- `pnpm --filter @frontend knip`
- Biome checks for all changed files
- real headless-browser verification against an isolated nine-state MCP matrix: uninstalled, installing, running, failed runtime, reinstall-required, OAuth re-authentication, image approval, four-user multitenancy, and four simultaneous card actions
- exact Registry/Skills grid parity at desktop; no horizontal overflow at a 390px viewport
- normal desktop MCP cards reduced from 172px to 156px while retaining the shared 16px outer padding and header coordinates

Tasks:
- [T-1228](https://slack.com/archives/C0B2AGC0AFQ/p1787922653755309?thread_ts=1787922637.093099&cid=C0B2AGC0AFQ)
- [T-1227](https://slack.com/archives/C0B2AGC0AFQ/p1787922590930899?thread_ts=1787922575.313579&cid=C0B2AGC0AFQ)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>