### PR TITLE
fix: preserve tool names across provider constraints

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1781,7 +1781,7 @@
                         "properties": {
                           "name": {
                             "type": "string",
-                            "description": "The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+                            "description": "The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128."
                           },
                           "description": {
                             "type": "string",
@@ -1859,7 +1859,7 @@
                       "properties": {
                         "name": {
                           "type": "string",
-                          "description": "The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+                          "description": "The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128."
                         },
                         "description": {
                           "type": "string",
@@ -2124,7 +2124,7 @@
                             "properties": {
                               "name": {
                                 "type": "string",
-                                "description": "The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+                                "description": "The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128."
                               },
                               "description": {
                                 "type": "string",
@@ -2202,7 +2202,7 @@
                           "properties": {
                             "name": {
                               "type": "string",
-                              "description": "The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+                              "description": "The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128."
                             },
                             "description": {
                               "type": "string",
@@ -22283,7 +22283,7 @@
                         "properties": {
                           "name": {
                             "type": "string",
-                            "description": "The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+                            "description": "The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128."
                           },
                           "description": {
                             "type": "string",
@@ -22365,7 +22365,7 @@
                       "properties": {
                         "name": {
                           "type": "string",
-                          "description": "The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+                          "description": "The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128."
                         },
                         "description": {
                           "type": "string",
@@ -22640,7 +22640,7 @@
                             "properties": {
                               "name": {
                                 "type": "string",
-                                "description": "The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+                                "description": "The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128."
                               },
                               "description": {
                                 "type": "string",
@@ -22722,7 +22722,7 @@
                           "properties": {
                             "name": {
                               "type": "string",
-                              "description": "The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+                              "description": "The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128."
                             },
                             "description": {
                               "type": "string",

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
+import type { Gemini } from "@/types";
 import { makeGeminiOpenaiAdapterFactory } from "./gemini-openai";
+import { GeminiToolNameCodec } from "./gemini-tool-names";
 
 describe("GeminiOpenaiStreamAdapter", () => {
   test("buffers OpenAI-shaped tool call events for policy evaluation", () => {
@@ -66,5 +68,63 @@ describe("GeminiOpenaiStreamAdapter", () => {
     expect(result.isToolCallChunk).toBe(false);
     expect(result.sseData).toContain('"content":"hello"');
     expect(adapter.getRawToolCallEvents()).toHaveLength(0);
+  });
+
+  test("restores client tool names in OpenAI-shaped stream events", () => {
+    const clientToolName = "1 report/tool";
+    const request = {
+      contents: [{ role: "user", parts: [{ text: "Create the report" }] }],
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: clientToolName,
+              description: "Create a report",
+              parameters: { type: "object" },
+            },
+          ],
+        },
+      ],
+    } as Gemini.Types.GenerateContentRequest;
+    const providerRequest = new GeminiToolNameCodec(request).encodeRequest(
+      request,
+    );
+    const providerTools = Array.isArray(providerRequest.tools)
+      ? providerRequest.tools
+      : [providerRequest.tools];
+    const providerToolName =
+      providerTools[0]?.functionDeclarations?.[0]?.name ?? "";
+    const adapter = makeGeminiOpenaiAdapterFactory({
+      chatcmplId: "chatcmpl-test",
+      createdUnix: 123,
+      requestedModel: "gemini:gemini-2.5-flash",
+    }).createStreamAdapter(request);
+
+    adapter.processChunk({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                functionCall: {
+                  id: "call-1",
+                  name: providerToolName,
+                  args: { reportId: "weekly" },
+                },
+              },
+            ],
+            role: "model",
+          },
+          index: 0,
+        },
+      ],
+      modelVersion: "gemini-2.5-flash",
+      responseId: "gemini-response",
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    expect(adapter.state.toolCalls[0].name).toBe(clientToolName);
+    expect(adapter.getRawToolCallEvents()[0]).toContain(
+      `"name":"${clientToolName}"`,
+    );
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
@@ -15,6 +15,7 @@ import {
   geminiUsageViewToOpenai,
   mapGeminiFinishReason,
 } from "./gemini-openai-translator";
+import { GeminiToolNameCodec } from "./gemini-tool-names";
 import {
   formatOpenAiChunkSse,
   type OpenAiStreamUsage,
@@ -135,11 +136,13 @@ class GeminiOpenaiStreamAdapter
   readonly provider = "gemini" as const;
   private inner: LLMStreamAdapter<GeminiStreamChunk, GeminiResponse>;
   private ctx: GeminiOpenaiContext;
+  private toolNameCodec: GeminiToolNameCodec;
   private pendingToolCallEvents: string[] = [];
 
-  constructor(ctx: GeminiOpenaiContext) {
+  constructor(ctx: GeminiOpenaiContext, request?: GeminiRequest) {
     this.inner = geminiAdapterFactory.createStreamAdapter();
     this.ctx = ctx;
+    this.toolNameCodec = new GeminiToolNameCodec(request);
   }
 
   get state(): StreamAccumulatorState {
@@ -147,8 +150,9 @@ class GeminiOpenaiStreamAdapter
   }
 
   processChunk(chunk: GeminiStreamChunk) {
-    const innerResult = this.inner.processChunk(chunk);
-    const sseData = this.toOpenaiSse(chunk);
+    const decodedChunk = this.toolNameCodec.decodeResponse(chunk);
+    const innerResult = this.inner.processChunk(decodedChunk);
+    const sseData = this.toOpenaiSse(decodedChunk);
 
     if (innerResult.isToolCallChunk && sseData) {
       this.pendingToolCallEvents.push(sseData);
@@ -302,8 +306,8 @@ export function makeGeminiOpenaiAdapterFactory(
     createResponseAdapter(response) {
       return new GeminiOpenaiResponseAdapter(response, ctx);
     },
-    createStreamAdapter() {
-      return new GeminiOpenaiStreamAdapter(ctx);
+    createStreamAdapter(request) {
+      return new GeminiOpenaiStreamAdapter(ctx, request);
     },
   };
 }

--- a/platform/backend/src/routes/proxy/adapters/gemini-tool-names.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-tool-names.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "@/test";
+import type { Gemini } from "@/types";
+import { GeminiToolNameCodec } from "./gemini-tool-names";
+
+type GeminiRequest = Gemini.Types.GenerateContentRequest;
+
+describe("GeminiToolNameCodec", () => {
+  test("keeps names compatible, unique, and reversible", () => {
+    const clientNames = [
+      "valid_name",
+      "server tool",
+      "server@tool",
+      `long_${"segment_".repeat(24)}`,
+    ];
+    const request = makeRequest(clientNames);
+    const codec = new GeminiToolNameCodec(request);
+
+    const encoded = codec.encodeRequest(request);
+    const providerNames = declarations(encoded);
+
+    expect(providerNames[0]).toBe(clientNames[0]);
+    expect(providerNames).toHaveLength(clientNames.length);
+    expect(new Set(providerNames).size).toBe(clientNames.length);
+    for (const providerName of providerNames) {
+      expect(providerName).toMatch(/^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$/);
+    }
+
+    const decoded = codec.decodeResponse({
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: providerNames.map((name) => ({
+              functionCall: { name, args: {} },
+            })),
+          },
+        },
+      ],
+    });
+    const decodedNames = decoded.candidates?.[0].content?.parts?.map(
+      (part) => part.functionCall?.name,
+    );
+
+    expect(decodedNames).toEqual(clientNames);
+    expect(declarations(request)).toEqual(clientNames);
+  });
+});
+
+function makeRequest(names: string[]): GeminiRequest {
+  return {
+    contents: [{ role: "user", parts: [{ text: "Use a tool" }] }],
+    tools: [
+      {
+        functionDeclarations: names.map((name) => ({
+          name,
+          description: "A test tool",
+          parameters: { type: "object" },
+        })),
+      },
+    ],
+  };
+}
+
+function declarations(request: GeminiRequest): string[] {
+  const tools = Array.isArray(request.tools)
+    ? request.tools
+    : request.tools
+      ? [request.tools]
+      : [];
+  return tools.flatMap(
+    (tool) =>
+      tool.functionDeclarations?.map((declaration) => declaration.name) ?? [],
+  );
+}

--- a/platform/backend/src/routes/proxy/adapters/gemini-tool-names.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-tool-names.ts
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto";
+import type { Gemini } from "@/types";
+
+type GeminiRequest = Gemini.Types.GenerateContentRequest;
+type ResponseWithFunctionCalls = {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        functionCall?: { name?: string; [key: string]: unknown };
+        [key: string]: unknown;
+      }>;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+};
+
+// =============================================================================
+// PUBLIC INTERFACE
+// =============================================================================
+
+/**
+ * Reversibly maps client-defined tool names onto Gemini's function-name
+ * contract. Only provider-facing payloads use the encoded names; responses are
+ * decoded before policy evaluation or delivery to the client.
+ */
+export class GeminiToolNameCodec {
+  private readonly toProvider = new Map<string, string>();
+  private readonly toClient = new Map<string, string>();
+
+  constructor(request?: Partial<GeminiRequest>) {
+    const names = collectDeclaredToolNames(request?.tools);
+
+    // Reserve valid client names first so an encoded invalid name can never
+    // force an already-compatible name to change based on declaration order.
+    for (const name of names) {
+      if (isProviderToolName(name)) {
+        this.addMapping(name, name);
+      }
+    }
+    for (const name of names) {
+      if (!this.toProvider.has(name)) {
+        this.addMapping(name, makeUniqueProviderToolName(name, this.toClient));
+      }
+    }
+  }
+
+  encodeRequest<T extends Partial<GeminiRequest>>(request: T): T {
+    return {
+      ...request,
+      ...(request.contents
+        ? { contents: this.encodeContents(request.contents) }
+        : {}),
+      ...(request.tools ? { tools: this.encodeTools(request.tools) } : {}),
+      ...(request.toolConfig
+        ? { toolConfig: this.encodeToolConfig(request.toolConfig) }
+        : {}),
+    } as T;
+  }
+
+  decodeResponse<T>(response: T): T {
+    const shapedResponse = response as T & ResponseWithFunctionCalls;
+    if (!shapedResponse.candidates) return response;
+
+    return {
+      ...shapedResponse,
+      candidates: shapedResponse.candidates.map((candidate) =>
+        candidate.content
+          ? {
+              ...candidate,
+              content: {
+                ...candidate.content,
+                parts: candidate.content.parts?.map((part) =>
+                  part.functionCall
+                    ? {
+                        ...part,
+                        functionCall: {
+                          ...part.functionCall,
+                          name: this.decode(part.functionCall.name ?? ""),
+                        },
+                      }
+                    : part,
+                ),
+              },
+            }
+          : candidate,
+      ),
+    } as T;
+  }
+
+  private addMapping(clientName: string, providerName: string): void {
+    this.toProvider.set(clientName, providerName);
+    this.toClient.set(providerName, clientName);
+  }
+
+  private encode(name: string): string {
+    return this.toProvider.get(name) ?? encodeProviderToolName(name);
+  }
+
+  private decode(name: string): string {
+    return this.toClient.get(name) ?? name;
+  }
+
+  private encodeContents(
+    contents: GeminiRequest["contents"],
+  ): GeminiRequest["contents"] {
+    return contents.map((content) => ({
+      ...content,
+      parts: content.parts?.map((part) => {
+        if ("functionCall" in part && part.functionCall) {
+          return {
+            ...part,
+            functionCall: {
+              ...part.functionCall,
+              name: this.encode(part.functionCall.name ?? ""),
+            },
+          };
+        }
+        if ("functionResponse" in part && part.functionResponse) {
+          return {
+            ...part,
+            functionResponse: {
+              ...part.functionResponse,
+              name: this.encode(part.functionResponse.name ?? ""),
+            },
+          };
+        }
+        return part;
+      }),
+    }));
+  }
+
+  private encodeTools(tools: NonNullable<GeminiRequest["tools"]>) {
+    const toolArray = Array.isArray(tools) ? tools : [tools];
+    const encoded = toolArray.map((tool) => ({
+      ...tool,
+      functionDeclarations: tool.functionDeclarations?.map((declaration) => ({
+        ...declaration,
+        name: this.encode(declaration.name),
+      })),
+    }));
+    return Array.isArray(tools) ? encoded : encoded[0];
+  }
+
+  private encodeToolConfig(
+    toolConfig: NonNullable<GeminiRequest["toolConfig"]>,
+  ): NonNullable<GeminiRequest["toolConfig"]> {
+    const functionCallingConfig = toolConfig.functionCallingConfig;
+    if (!functionCallingConfig?.allowedFunctionNames) return toolConfig;
+
+    return {
+      ...toolConfig,
+      functionCallingConfig: {
+        ...functionCallingConfig,
+        allowedFunctionNames: functionCallingConfig.allowedFunctionNames.map(
+          (name) => this.encode(name),
+        ),
+      },
+    };
+  }
+}
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+const GEMINI_MAX_TOOL_NAME_LENGTH = 128;
+const TOOL_NAME_HASH_LENGTH = 8;
+const GEMINI_TOOL_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$/;
+const GEMINI_INVALID_TOOL_NAME_CHARS = /[^A-Za-z0-9_.:-]+/g;
+
+function collectDeclaredToolNames(
+  tools: GeminiRequest["tools"] | undefined,
+): string[] {
+  if (!tools) return [];
+  const toolArray = Array.isArray(tools) ? tools : [tools];
+  return [
+    ...new Set(
+      toolArray.flatMap(
+        (tool) =>
+          tool.functionDeclarations?.map((declaration) => declaration.name) ??
+          [],
+      ),
+    ),
+  ];
+}
+
+function isProviderToolName(name: string): boolean {
+  return GEMINI_TOOL_NAME_PATTERN.test(name);
+}
+
+function makeUniqueProviderToolName(
+  clientName: string,
+  usedNames: Map<string, string>,
+): string {
+  const base = sanitizedToolNameBase(clientName);
+  const hash = createHash("sha256").update(clientName).digest("hex");
+
+  for (
+    let hashLength = TOOL_NAME_HASH_LENGTH;
+    hashLength <= hash.length;
+    hashLength += 4
+  ) {
+    const suffix = `_${hash.slice(0, hashLength)}`;
+    const candidate = `${base.slice(
+      0,
+      GEMINI_MAX_TOOL_NAME_LENGTH - suffix.length,
+    )}${suffix}`;
+    const existing = usedNames.get(candidate);
+    if (existing === undefined || existing === clientName) return candidate;
+  }
+
+  // A full SHA-256 collision is not practically reachable, but keep the map
+  // total even if one is forced in a test or by a future hash substitution.
+  let discriminator = 2;
+  while (true) {
+    const suffix = `_${hash}_${discriminator}`;
+    const candidate = `${base.slice(
+      0,
+      GEMINI_MAX_TOOL_NAME_LENGTH - suffix.length,
+    )}${suffix}`;
+    if (!usedNames.has(candidate)) return candidate;
+    discriminator++;
+  }
+}
+
+function encodeProviderToolName(name: string): string {
+  if (isProviderToolName(name)) return name;
+  return makeUniqueProviderToolName(name, new Map());
+}
+
+function sanitizedToolNameBase(name: string): string {
+  let sanitized = name.replace(GEMINI_INVALID_TOOL_NAME_CHARS, "_");
+  if (sanitized.length === 0) sanitized = "_";
+  if (!/^[A-Za-z_]/.test(sanitized)) sanitized = `_${sanitized}`;
+  return sanitized;
+}

--- a/platform/backend/src/routes/proxy/adapters/gemini.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.test.ts
@@ -7,6 +7,7 @@ import {
   geminiAdapterFactory,
   restToSdkGenerateContentParams,
 } from "./gemini";
+import { GeminiToolNameCodec } from "./gemini-tool-names";
 
 type GeminiStreamChunk = GenerateContentResponse;
 
@@ -617,6 +618,111 @@ describe("GeminiRequestAdapter", () => {
 });
 
 describe("geminiAdapterFactory", () => {
+  test("uses provider-compatible tool names and restores client names", async () => {
+    const clientToolName = "1 report/tool";
+    let providerToolName = "";
+    let providerParams: Record<string, unknown> = {};
+    const client = {
+      models: {
+        generateContent: vi.fn(async (params: Record<string, unknown>) => {
+          providerParams = params;
+          const config = params.config as {
+            tools: Array<{
+              functionDeclarations: Array<{ name: string }>;
+            }>;
+          };
+          providerToolName = config.tools[0].functionDeclarations[0].name;
+          return createMockResponse([
+            {
+              functionCall: {
+                name: providerToolName,
+                id: "call_123",
+                args: { reportId: "weekly" },
+              },
+            },
+          ]) as unknown as GenerateContentResponse;
+        }),
+      },
+    };
+    const request = createMockRequest(
+      [
+        { role: "user", parts: [{ text: "Create the report" }] },
+        {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                name: clientToolName,
+                id: "call_previous",
+                args: { reportId: "daily" },
+              },
+            },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                name: clientToolName,
+                id: "call_previous",
+                response: { status: "complete" },
+              },
+            },
+          ],
+        },
+      ],
+      {
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: clientToolName,
+                description: "Create a report",
+                parameters: { type: "object" },
+              },
+            ],
+          },
+        ],
+        toolConfig: {
+          functionCallingConfig: {
+            mode: "ANY",
+            allowedFunctionNames: [clientToolName],
+          },
+        },
+      },
+    );
+
+    const response = await geminiAdapterFactory.execute(client, request);
+    const toolCalls = geminiAdapterFactory
+      .createResponseAdapter(response)
+      .getToolCalls();
+
+    expect(providerToolName).toMatch(/^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$/);
+    expect(providerToolName).not.toBe(clientToolName);
+    const providerContents = providerParams.contents as Array<{
+      parts: Array<{
+        functionCall?: { name: string };
+        functionResponse?: { name: string };
+      }>;
+    }>;
+    expect(providerContents[1].parts[0].functionCall?.name).toBe(
+      providerToolName,
+    );
+    expect(providerContents[2].parts[0].functionResponse?.name).toBe(
+      providerToolName,
+    );
+    const providerConfig = providerParams.config as {
+      toolConfig: {
+        functionCallingConfig: { allowedFunctionNames: string[] };
+      };
+    };
+    expect(
+      providerConfig.toolConfig.functionCallingConfig.allowedFunctionNames,
+    ).toEqual([providerToolName]);
+    expect(toolCalls[0].name).toBe(clientToolName);
+  });
+
   describe("extractApiKey", () => {
     test("returns x-goog-api-key header", () => {
       const headers = { "x-goog-api-key": "test-api-key-123" };
@@ -751,6 +857,60 @@ describe("GeminiStreamAdapter", () => {
       expect(result.isToolCallChunk).toBe(true);
       expect(adapter.state.toolCalls).toHaveLength(1);
       expect(adapter.state.toolCalls[0].name).toBe("test_tool");
+    });
+
+    test("restores client tool names in streamed calls", () => {
+      const clientToolName = "1 report/tool";
+      const request = createMockRequest(
+        [{ role: "user", parts: [{ text: "Create the report" }] }],
+        {
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: clientToolName,
+                  description: "Create a report",
+                  parameters: { type: "object" },
+                },
+              ],
+            },
+          ],
+        },
+      );
+      const providerRequest = new GeminiToolNameCodec(request).encodeRequest(
+        request,
+      );
+      const providerTools = Array.isArray(providerRequest.tools)
+        ? providerRequest.tools
+        : [providerRequest.tools];
+      const providerToolName =
+        providerTools[0]?.functionDeclarations?.[0]?.name ?? "";
+      const adapter = geminiAdapterFactory.createStreamAdapter(request);
+
+      adapter.processChunk({
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [
+                {
+                  functionCall: {
+                    name: providerToolName,
+                    id: "call_123",
+                    args: { reportId: "weekly" },
+                  },
+                },
+              ],
+            },
+            index: 0,
+          },
+        ],
+        modelVersion: "gemini-2.5-pro",
+        responseId: "test-response",
+      } as unknown as GeminiStreamChunk);
+
+      expect(adapter.state.toolCalls[0].name).toBe(clientToolName);
+      expect(adapter.getRawToolCallEvents()[0]).toContain(clientToolName);
     });
 
     test("updates usage metadata", () => {

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -45,6 +45,7 @@ import {
 } from "../utils/mcp-image";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
 import { sanitizeGeminiToolSchema } from "./gemini-schema";
+import { GeminiToolNameCodec } from "./gemini-tool-names";
 
 // =============================================================================
 // TYPE ALIASES
@@ -647,6 +648,7 @@ class GeminiStreamAdapter
 {
   readonly provider = "gemini" as const;
   readonly state: StreamAccumulatorState;
+  private readonly toolNameCodec: GeminiToolNameCodec;
   private model: string = "";
   private inlineDataParts: Gemini.Types.MessagePart[] = [];
   // Set to the refusal text when the streamed response was replaced by a policy
@@ -662,7 +664,8 @@ class GeminiStreamAdapter
   private outputTextSignature: string | undefined;
   private toolCallSignatures: Map<number, string> = new Map();
 
-  constructor() {
+  constructor(request?: GeminiRequestWithModel) {
+    this.toolNameCodec = new GeminiToolNameCodec(request);
     this.state = {
       responseId: "",
       model: "",
@@ -679,6 +682,7 @@ class GeminiStreamAdapter
   }
 
   processChunk(chunk: GeminiStreamChunk): ChunkProcessingResult {
+    chunk = this.toolNameCodec.decodeResponse(chunk);
     if (this.state.timing.firstChunkTime === null) {
       this.state.timing.firstChunkTime = Date.now();
     }
@@ -1462,6 +1466,11 @@ export function restToSdkGenerateContentParams(
     params.config.tools = sdkTools;
   }
 
+  if (body.toolConfig) {
+    params.config.toolConfig =
+      body.toolConfig as GenerateContentConfig["toolConfig"];
+  }
+
   if (body.systemInstruction) {
     params.config.systemInstruction = { ...body.systemInstruction };
   }
@@ -1491,8 +1500,10 @@ export const geminiAdapterFactory: LLMProvider<
     return new GeminiResponseAdapter(response);
   },
 
-  createStreamAdapter(): LLMStreamAdapter<GeminiStreamChunk, GeminiResponse> {
-    return new GeminiStreamAdapter();
+  createStreamAdapter(
+    request?: GeminiRequestWithModel,
+  ): LLMStreamAdapter<GeminiStreamChunk, GeminiResponse> {
+    return new GeminiStreamAdapter(request);
   },
 
   extractApiKey(headers: GeminiHeaders): string | undefined {
@@ -1532,18 +1543,20 @@ export const geminiAdapterFactory: LLMProvider<
     request: GeminiRequestWithModel,
   ): Promise<GeminiResponse> {
     const genAI = client as GoogleGenAI;
-    const model = request._model ?? "gemini-2.5-pro";
+    const { providerRequest, toolNameCodec } =
+      prepareGeminiProviderRequest(request);
+    const model = providerRequest._model ?? "gemini-2.5-pro";
 
     // Normalize tools to array
-    const tools = request.tools
-      ? Array.isArray(request.tools)
-        ? request.tools
-        : [request.tools]
+    const tools = providerRequest.tools
+      ? Array.isArray(providerRequest.tools)
+        ? providerRequest.tools
+        : [providerRequest.tools]
       : undefined;
 
     // Convert REST body to SDK params
     const sdkParams = restToSdkGenerateContentParams(
-      { ...request, contents: request.contents || [] },
+      { ...providerRequest, contents: providerRequest.contents || [] },
       model,
       tools,
     );
@@ -1553,7 +1566,9 @@ export const geminiAdapterFactory: LLMProvider<
     );
 
     // Convert SDK response to REST format
-    return sdkResponseToRestResponse(response, model);
+    return toolNameCodec.decodeResponse(
+      sdkResponseToRestResponse(response, model),
+    );
   },
 
   async executeStream(
@@ -1561,18 +1576,19 @@ export const geminiAdapterFactory: LLMProvider<
     request: GeminiRequestWithModel,
   ): Promise<AsyncIterable<GeminiStreamChunk>> {
     const genAI = client as GoogleGenAI;
-    const model = request._model ?? "gemini-2.5-pro";
+    const { providerRequest } = prepareGeminiProviderRequest(request);
+    const model = providerRequest._model ?? "gemini-2.5-pro";
 
     // Normalize tools to array
-    const tools = request.tools
-      ? Array.isArray(request.tools)
-        ? request.tools
-        : [request.tools]
+    const tools = providerRequest.tools
+      ? Array.isArray(providerRequest.tools)
+        ? providerRequest.tools
+        : [providerRequest.tools]
       : undefined;
 
     // Convert REST body to SDK params
     const sdkParams = restToSdkGenerateContentParams(
-      { ...request, contents: request.contents || [] },
+      { ...providerRequest, contents: providerRequest.contents || [] },
       model,
       tools,
     );
@@ -1632,6 +1648,30 @@ export const geminiAdapterFactory: LLMProvider<
     return "Internal server error";
   },
 };
+
+type GeminiProviderRequestContext = {
+  providerRequest: GeminiRequestWithModel;
+  toolNameCodec: GeminiToolNameCodec;
+};
+
+const geminiProviderRequestContexts = new WeakMap<
+  GeminiRequestWithModel,
+  GeminiProviderRequestContext
+>();
+
+function prepareGeminiProviderRequest(
+  request: GeminiRequestWithModel,
+): GeminiProviderRequestContext {
+  const cached = geminiProviderRequestContexts.get(request);
+  if (cached) return cached;
+
+  const toolNameCodec = new GeminiToolNameCodec(request);
+  const providerRequest = toolNameCodec.encodeRequest(request);
+  const context = { providerRequest, toolNameCodec };
+  geminiProviderRequestContexts.set(request, context);
+  geminiProviderRequestContexts.set(providerRequest, context);
+  return context;
+}
 
 /** Rewritten arguments arrive as the JSON string the model emitted; this wire
  * shape carries them as an object. A repaired call always parses (the planner

--- a/platform/backend/src/types/llm-providers/gemini/tools.ts
+++ b/platform/backend/src/types/llm-providers/gemini/tools.ts
@@ -5,7 +5,7 @@ export const FunctionDeclarationSchema = z
     name: z
       .string()
       .describe(
-        "The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.",
+        "The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128.",
       ),
     description: z.string().describe("A brief description of the function."),
     behavior: z

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -640,7 +640,7 @@ export type GeminiGenerateContentRequestInput = {
     tools?: Array<{
         functionDeclarations?: Array<{
             /**
-             * The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.
+             * The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128.
              */
             name: string;
             /**
@@ -686,7 +686,7 @@ export type GeminiGenerateContentRequestInput = {
     }> | {
         functionDeclarations?: Array<{
             /**
-             * The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.
+             * The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128.
              */
             name: string;
             /**
@@ -805,7 +805,7 @@ export type GeminiGenerateContentRequestInput = {
         tools?: Array<{
             functionDeclarations?: Array<{
                 /**
-                 * The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.
+                 * The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128.
                  */
                 name: string;
                 /**
@@ -851,7 +851,7 @@ export type GeminiGenerateContentRequestInput = {
         }> | {
             functionDeclarations?: Array<{
                 /**
-                 * The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.
+                 * The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128.
                  */
                 name: string;
                 /**
@@ -6931,7 +6931,7 @@ export type GeminiGenerateContentRequest = {
     tools?: Array<{
         functionDeclarations?: Array<{
             /**
-             * The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.
+             * The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128.
              */
             name: string;
             /**
@@ -6977,7 +6977,7 @@ export type GeminiGenerateContentRequest = {
     }> | {
         functionDeclarations?: Array<{
             /**
-             * The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.
+             * The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128.
              */
             name: string;
             /**
@@ -7096,7 +7096,7 @@ export type GeminiGenerateContentRequest = {
         tools?: Array<{
             functionDeclarations?: Array<{
                 /**
-                 * The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.
+                 * The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128.
                  */
                 name: string;
                 /**
@@ -7142,7 +7142,7 @@ export type GeminiGenerateContentRequest = {
         }> | {
             functionDeclarations?: Array<{
                 /**
-                 * The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.
+                 * The name of the function. Must start with a letter or underscore and contain only a-z, A-Z, 0-9, underscores, dots, colons, or dashes, with a maximum length of 128.
                  */
                 name: string;
                 /**


### PR DESCRIPTION
## Summary

- encode client-defined tool names only at the provider boundary
- restore original names for streamed and non-streamed tool calls
- keep declarations, history, and forced tool choices consistent
- cover the native and OpenAI-compatible paths with regression tests

## Verification

- manual ADC smoke checks against the global endpoint for streaming and non-streaming requests