### PR TITLE
fix(frontend): contain responsive registry content

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -643,21 +643,20 @@ export function McpServerCard({
     hasCardMetadata || showScopeBadge || hasCompactInfoAfterScopeBadge;
 
   /*
-    One line, and it has to stay one line at the grid's card width — which
-    leaves it roughly 250-300px to seat a scope badge, two counts, a deployment
-    state and a stack of connection avatars. Two rules keep it there.
+    This usually fits on one line at the grid's card width, but operational
+    states can add several badges and connection avatars at once. Let those
+    fixed items wrap rather than paint outside a single-column card.
 
     Fixed items are `shrink-0` and the badge is the single elastic cell, so
     pressure lands on the one thing that can absorb it — a long author or team
-    name truncates (its `title` keeps it readable) instead of every item
-    refusing to shrink and the row spilling over the card edge.
+    name truncates (its `title` keeps it readable) before the row wraps.
 
     Nothing separates the items but the gap. The 1px rules that used to sit
     between them cost ~21px each once their two gaps are counted — around a
     fifth of the row — which is most of what a name has to truncate into.
   */
   const compactInfoRow = hasCompactInfoContent ? (
-    <div className="flex min-w-0 items-center gap-3 text-sm text-muted-foreground">
+    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 text-sm text-muted-foreground">
       {environmentLabel && (
         <Badge variant="outline" className="shrink-0 text-muted-foreground">
           <span className="max-w-32 truncate">{environmentLabel}</span>
@@ -891,7 +890,7 @@ export function McpServerCard({
             disabled={showApprovalPanel}
             size="sm"
             variant="outline"
-            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10 sm:flex-1"
+            className="flex-1 text-destructive border-destructive/30 hover:bg-destructive/10"
           >
             <RefreshCw className="h-4 w-4" />
             Reinstall
@@ -966,7 +965,7 @@ export function McpServerCard({
             disabled={reinstallCatalogMutation.isPending || showApprovalPanel}
             size="sm"
             variant="outline"
-            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10 sm:flex-1"
+            className="flex-1 text-destructive border-destructive/30 hover:bg-destructive/10"
           >
             <RefreshCw className="h-4 w-4" />
             Reinstall
@@ -994,7 +993,7 @@ export function McpServerCard({
             disabled={showApprovalPanel}
             size="sm"
             variant="outline"
-            className="shrink-0 text-destructive border-destructive/30 hover:bg-destructive/10 sm:flex-1"
+            className="flex-1 text-destructive border-destructive/30 hover:bg-destructive/10"
           >
             <RefreshCw className="h-4 w-4" />
             Reinstall

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-notice.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-issue-notice.tsx
@@ -496,7 +496,7 @@ export function McpServerIssueNotice({
         <Button
           variant={action.variant ?? "outline"}
           size="sm"
-          className="shrink-0 gap-1 px-2 text-xs sm:flex-1"
+          className="flex-1 gap-1 px-2 text-xs"
           aria-label={action.label}
           data-testid={action.testId}
           onClick={action.onClick}
@@ -511,7 +511,7 @@ export function McpServerIssueNotice({
         <Button
           variant="outline"
           size="sm"
-          className="shrink-0 gap-1 px-2 text-xs sm:flex-1"
+          className="flex-1 gap-1 px-2 text-xs"
           disabled={restoreMutation.isPending}
           onClick={() =>
             restoreMutation.mutate(
@@ -531,7 +531,7 @@ export function McpServerIssueNotice({
       <Button
         variant="outline"
         size="sm"
-        className="shrink-0 gap-1 px-2 text-xs sm:flex-1"
+        className="flex-1 gap-1 px-2 text-xs"
         onClick={() => router.push(detailHref())}
       >
         Open

--- a/platform/frontend/src/components/filter-bar.tsx
+++ b/platform/frontend/src/components/filter-bar.tsx
@@ -175,7 +175,9 @@ export function FilterBar({
           </Button>
         )}
         {actions && (
-          <div className="ml-auto flex items-center gap-1.5">{actions}</div>
+          <div className="flex basis-full items-center justify-start gap-1.5 md:ml-auto md:basis-auto">
+            {actions}
+          </div>
         )}
       </div>
       {contextualActions ? (
@@ -258,7 +260,7 @@ export function filterControlClass({
  * LLM logs page its "not a session ID" hint, against that positioned ancestor.
  */
 export const filterSearchClass =
-  "relative w-full min-w-[12rem] flex-1 sm:w-auto sm:max-w-[20rem]";
+  "relative w-full min-w-[12rem] basis-full md:w-auto md:max-w-[20rem] md:basis-auto md:flex-1";
 
 /**
  * A {@link SearchableSelect} dressed as a filter-bar control: compact, sized to

--- a/platform/frontend/src/components/table-card-view.tsx
+++ b/platform/frontend/src/components/table-card-view.tsx
@@ -355,7 +355,7 @@ export function TableCard({
       {...navigation.props}
       data-testid={testId}
       className={cn(
-        "flex h-full flex-col rounded-lg border p-4 transition-colors",
+        "flex h-full min-w-80 flex-col rounded-lg border p-4 transition-colors",
         compact ? "gap-2" : "gap-3",
         selected
           ? cn("border-primary bg-primary/5", navigation.className)

--- a/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
+++ b/platform/frontend/tests-integration/mcp-registry-layout.spec.ts
@@ -187,6 +187,27 @@ test.describe("MCP Registry layout", () => {
     expect(spills).toEqual([]);
   });
 
+  test("keeps cards at a usable width below the supported viewport", async ({
+    mcpRegistryPage,
+    mswControl,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 800 });
+    await seed(mswControl);
+    await mcpRegistryPage.goto();
+
+    const card = mcpRegistryPage.cardForCatalogItem("org-crowded");
+    await expect(card).toBeVisible();
+
+    const box = await card.boundingBox();
+    expect(box?.width).toBeGreaterThanOrEqual(320);
+    expect(
+      await page
+        .locator("main")
+        .evaluate((main) => main.scrollWidth > main.clientWidth),
+    ).toBe(true);
+  });
+
   test("a card names the team scope instead of listing every team", async ({
     mcpRegistryPage,
     mswControl,


### PR DESCRIPTION
## Summary
- allow dense MCP Registry card metadata to wrap within card boundaries
- keep mobile filter search and actions on deliberate rows
- equalize compact card footer actions at mobile widths
- enforce a shared 320px minimum width for collection cards across the application

## Verification
- 32 targeted frontend unit tests
- isolated Playwright integration test for the shared 320px card-width contract
- frontend type-check and changed-file Biome checks
- real headless Chromium against the GCP dev stack at 320px, 375px, 390px, 600px, 640px, 734px, 1024px, and 1440px
- cross-page live verification on MCP Registry and Skills

Task: https://slack.com/archives/C0B2AGC0AFQ/p1787944136043729?thread_ts=1787944115.047819&cid=C0B2AGC0AFQ