### PR TITLE
fix(frontend): balance filter spacing and refine backend readiness

### DIFF
--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -619,6 +619,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
           <div>
             <div className="mb-3 flex flex-col gap-2">
               <FilterBar
+                leading
                 actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
               >
                 <SearchInput

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -182,7 +182,7 @@ export default function AppsPage() {
       }
     >
       <TableCardView storageKey="archestra-apps-view">
-        <FilterBar className="mb-3" actions={<TableCardViewToggle />}>
+        <FilterBar leading className="mb-3" actions={<TableCardViewToggle />}>
           <SearchInput
             isLoading={isFetching}
             paramName="search"

--- a/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
+++ b/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
@@ -82,6 +82,7 @@ describe("AuthPageWithInvitationCheck", () => {
       attemptCount: 0,
       estimatedTotalAttempts: 7,
       elapsedMs: 0,
+      nextRetryInMs: null,
       retry: mockRetry,
     });
   });
@@ -352,7 +353,7 @@ describe("AuthPageWithInvitationCheck", () => {
   });
 
   describe("backend connectivity", () => {
-    it("should explain the automatic retry behavior while connecting", () => {
+    it("should show when the next automatic retry will run", () => {
       vi.mocked(useSearchParams).mockReturnValue({
         get: vi.fn().mockReturnValue(null),
       } as unknown as ReturnType<typeof useSearchParams>);
@@ -365,6 +366,7 @@ describe("AuthPageWithInvitationCheck", () => {
         attemptCount: 0,
         estimatedTotalAttempts: 7,
         elapsedMs: 0,
+        nextRetryInMs: 8000,
         retry: mockRetry,
       });
 
@@ -373,6 +375,7 @@ describe("AuthPageWithInvitationCheck", () => {
       expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
       expect(screen.getByText("Connecting to Sparky")).toBeInTheDocument();
       expect(screen.getByText("Retrying automatically")).toBeInTheDocument();
+      expect(screen.getByText("Next retry in 8s")).toBeInTheDocument();
       expect(screen.queryByTestId("auth-view")).not.toBeInTheDocument();
     });
 
@@ -389,6 +392,7 @@ describe("AuthPageWithInvitationCheck", () => {
         attemptCount: 3,
         estimatedTotalAttempts: 7,
         elapsedMs: 5000,
+        nextRetryInMs: 8000,
         retry: mockRetry,
       });
 
@@ -412,6 +416,7 @@ describe("AuthPageWithInvitationCheck", () => {
         attemptCount: 5,
         estimatedTotalAttempts: 7,
         elapsedMs: 60000,
+        nextRetryInMs: null,
         retry: mockRetry,
       });
 
@@ -435,6 +440,7 @@ describe("AuthPageWithInvitationCheck", () => {
         attemptCount: 5,
         estimatedTotalAttempts: 7,
         elapsedMs: 60000,
+        nextRetryInMs: null,
         retry: mockRetry,
       });
 
@@ -459,6 +465,7 @@ describe("AuthPageWithInvitationCheck", () => {
         attemptCount: 0,
         estimatedTotalAttempts: 7,
         elapsedMs: 0,
+        nextRetryInMs: null,
         retry: mockRetry,
       });
 

--- a/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
+++ b/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
@@ -352,7 +352,7 @@ describe("AuthPageWithInvitationCheck", () => {
   });
 
   describe("backend connectivity", () => {
-    it("should show connecting message instead of login form when backend is connecting", () => {
+    it("should preview the sign-in surface while the backend connects", () => {
       vi.mocked(useSearchParams).mockReturnValue({
         get: vi.fn().mockReturnValue(null),
       } as unknown as ReturnType<typeof useSearchParams>);
@@ -370,11 +370,12 @@ describe("AuthPageWithInvitationCheck", () => {
 
       render(<AuthPageWithInvitationCheck path="sign-in" />);
 
-      expect(screen.getByText("Connecting...")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
+      expect(screen.getByText("Starting Sparky")).toBeInTheDocument();
       expect(screen.queryByTestId("auth-view")).not.toBeInTheDocument();
     });
 
-    it("should show retry information when connection attempts have failed", () => {
+    it("should keep retry scheduling out of the connecting interface", () => {
       vi.mocked(useSearchParams).mockReturnValue({
         get: vi.fn().mockReturnValue(null),
       } as unknown as ReturnType<typeof useSearchParams>);
@@ -392,9 +393,8 @@ describe("AuthPageWithInvitationCheck", () => {
 
       render(<AuthPageWithInvitationCheck path="sign-in" />);
 
-      expect(
-        screen.getByText(/Still trying to connect, attempt 3 \/ 7/),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Starting Sparky")).toBeInTheDocument();
+      expect(screen.queryByText(/Attempt \d/)).not.toBeInTheDocument();
       expect(screen.queryByTestId("auth-view")).not.toBeInTheDocument();
     });
 
@@ -416,8 +416,8 @@ describe("AuthPageWithInvitationCheck", () => {
 
       render(<AuthPageWithInvitationCheck path="sign-in" />);
 
-      expect(screen.getByText("Unable to Connect")).toBeInTheDocument();
-      expect(screen.getByText("Server Unreachable")).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText("Backend unavailable")).toBeInTheDocument();
       expect(screen.queryByTestId("auth-view")).not.toBeInTheDocument();
     });
 

--- a/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
+++ b/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
@@ -352,7 +352,7 @@ describe("AuthPageWithInvitationCheck", () => {
   });
 
   describe("backend connectivity", () => {
-    it("should preview the sign-in surface while the backend connects", () => {
+    it("should explain the automatic retry behavior while connecting", () => {
       vi.mocked(useSearchParams).mockReturnValue({
         get: vi.fn().mockReturnValue(null),
       } as unknown as ReturnType<typeof useSearchParams>);
@@ -371,11 +371,12 @@ describe("AuthPageWithInvitationCheck", () => {
       render(<AuthPageWithInvitationCheck path="sign-in" />);
 
       expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
-      expect(screen.getByText("Starting Sparky")).toBeInTheDocument();
+      expect(screen.getByText("Connecting to Sparky")).toBeInTheDocument();
+      expect(screen.getByText("Retrying automatically")).toBeInTheDocument();
       expect(screen.queryByTestId("auth-view")).not.toBeInTheDocument();
     });
 
-    it("should keep retry scheduling out of the connecting interface", () => {
+    it("should keep retry counters out of the connecting interface", () => {
       vi.mocked(useSearchParams).mockReturnValue({
         get: vi.fn().mockReturnValue(null),
       } as unknown as ReturnType<typeof useSearchParams>);
@@ -393,7 +394,7 @@ describe("AuthPageWithInvitationCheck", () => {
 
       render(<AuthPageWithInvitationCheck path="sign-in" />);
 
-      expect(screen.getByText("Starting Sparky")).toBeInTheDocument();
+      expect(screen.getByText("Retrying automatically")).toBeInTheDocument();
       expect(screen.queryByText(/Attempt \d/)).not.toBeInTheDocument();
       expect(screen.queryByTestId("auth-view")).not.toBeInTheDocument();
     });

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
@@ -2,13 +2,15 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BackendConnectivityStatus } from "./backend-connectivity-status";
 
-// Mock the hooks
+vi.mock("@/components/app-logo", () => ({
+  AppLogo: () => <div data-testid="app-logo" />,
+}));
+
 vi.mock("@/lib/config/backend-connectivity", () => ({
   useBackendConnectivity: vi.fn(),
 }));
 
 vi.mock("@/lib/hooks/use-app-name");
-
 vi.mock("next/navigation");
 
 import { useSearchParams } from "next/navigation";
@@ -19,15 +21,19 @@ describe("BackendConnectivityStatus", () => {
   const mockRetry = vi.fn();
 
   beforeEach(() => {
+    mockRetry.mockReset();
     vi.mocked(useAppName).mockReturnValue("Sparky");
     vi.mocked(useSearchParams).mockReturnValue(
       new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
     );
   });
 
-  it("should render nothing when status is initializing", () => {
+  it.each([
+    "initializing",
+    "checking",
+  ] as const)("renders nothing while status is %s", (status) => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
-      status: "initializing",
+      status,
       attemptCount: 0,
       estimatedTotalAttempts: 7,
       elapsedMs: 0,
@@ -42,31 +48,9 @@ describe("BackendConnectivityStatus", () => {
 
     expect(container).toBeEmptyDOMElement();
     expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
-    expect(screen.queryByText("Connecting...")).not.toBeInTheDocument();
   });
 
-  it("should render nothing when status is checking (first health check in progress)", () => {
-    vi.mocked(useBackendConnectivity).mockReturnValue({
-      status: "checking",
-      attemptCount: 0,
-      estimatedTotalAttempts: 7,
-      elapsedMs: 0,
-      retry: mockRetry,
-    });
-
-    const { container } = render(
-      <BackendConnectivityStatus>
-        <div data-testid="child-content">Login Form</div>
-      </BackendConnectivityStatus>,
-    );
-
-    // Should not show any UI during the first health check to avoid flashing
-    expect(container).toBeEmptyDOMElement();
-    expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
-    expect(screen.queryByText("Connecting...")).not.toBeInTheDocument();
-  });
-
-  it("should render children when status is connected", () => {
+  it("renders children immediately when connected", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connected",
       attemptCount: 0,
@@ -82,10 +66,10 @@ describe("BackendConnectivityStatus", () => {
     );
 
     expect(screen.getByTestId("child-content")).toBeInTheDocument();
-    expect(screen.queryByText("Connecting...")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connection restored")).not.toBeInTheDocument();
   });
 
-  it("should show connecting view when status is connecting with no attempts", () => {
+  it("shows a quiet readiness state while the backend starts", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connecting",
       attemptCount: 0,
@@ -100,12 +84,17 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    expect(screen.getByText("Connecting...")).toBeInTheDocument();
-    expect(screen.getByText("Attempting to connect...")).toBeInTheDocument();
+    expect(screen.getByText("Waiting for Sparky")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The Sparky backend is still starting. This page will continue automatically.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Attempt \d/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
   });
 
-  it("should show retry count with estimated total when there are failed attempts", () => {
+  it("shows retry progress after failed attempts", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connecting",
       attemptCount: 3,
@@ -120,12 +109,13 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
+    expect(screen.getByText("Attempt 3 of 7")).toBeInTheDocument();
     expect(
-      screen.getByText(/Still trying to connect, attempt 3 \/ 7/),
-    ).toBeInTheDocument();
+      screen.queryByRole("link", { name: /Report issue/i }),
+    ).not.toBeInTheDocument();
   });
 
-  it("should show unreachable view when status is unreachable", () => {
+  it("shows concise recovery actions when the backend is unavailable", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "unreachable",
       attemptCount: 5,
@@ -140,15 +130,24 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    expect(screen.getByText("Unable to Connect")).toBeInTheDocument();
-    expect(screen.getByText("Server Unreachable")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Backend unavailable")).toBeInTheDocument();
     expect(
-      screen.getByText(/The backend server is not responding/),
+      screen.getByText(
+        "The Sparky backend did not respond. Check that it is running, then try again.",
+      ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Try again" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Report issue" })).toHaveAttribute(
+      "href",
+      expect.stringMatching(/\/issues$/),
+    );
     expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
   });
 
-  it("should call retry when Try Again button is clicked", () => {
+  it("retries immediately when requested", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "unreachable",
       attemptCount: 5,
@@ -163,95 +162,12 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    const retryButton = screen.getByRole("button", { name: /Try Again/i });
-    fireEvent.click(retryButton);
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
 
     expect(mockRetry).toHaveBeenCalledTimes(1);
   });
 
-  it("should display possible causes in unreachable view", () => {
-    vi.mocked(useBackendConnectivity).mockReturnValue({
-      status: "unreachable",
-      attemptCount: 5,
-      estimatedTotalAttempts: 7,
-      elapsedMs: 60000,
-      retry: mockRetry,
-    });
-
-    render(
-      <BackendConnectivityStatus>
-        <div>Login Form</div>
-      </BackendConnectivityStatus>,
-    );
-
-    expect(screen.getByText(/Server is still starting up/)).toBeInTheDocument();
-    expect(screen.getByText(/Network connectivity issue/)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Server configuration problem/),
-    ).toBeInTheDocument();
-  });
-
-  it("should show GitHub issues button in unreachable view", () => {
-    vi.mocked(useBackendConnectivity).mockReturnValue({
-      status: "unreachable",
-      attemptCount: 5,
-      estimatedTotalAttempts: 7,
-      elapsedMs: 60000,
-      retry: mockRetry,
-    });
-
-    render(
-      <BackendConnectivityStatus>
-        <div>Login Form</div>
-      </BackendConnectivityStatus>,
-    );
-
-    expect(screen.getByText("Report issue on GitHub")).toBeInTheDocument();
-  });
-
-  it("should show GitHub issues button when there are attempts", () => {
-    vi.mocked(useBackendConnectivity).mockReturnValue({
-      status: "connecting",
-      attemptCount: 1,
-      estimatedTotalAttempts: 7,
-      elapsedMs: 500,
-      retry: mockRetry,
-    });
-
-    render(
-      <BackendConnectivityStatus>
-        <div>Login Form</div>
-      </BackendConnectivityStatus>,
-    );
-
-    expect(
-      screen.getByText(/Still trying to connect, attempt 1/),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Report issue on GitHub")).toBeInTheDocument();
-  });
-
-  it("should not show GitHub issues button on first attempt", () => {
-    vi.mocked(useBackendConnectivity).mockReturnValue({
-      status: "connecting",
-      attemptCount: 0,
-      estimatedTotalAttempts: 7,
-      elapsedMs: 3500,
-      retry: mockRetry,
-    });
-
-    render(
-      <BackendConnectivityStatus>
-        <div>Login Form</div>
-      </BackendConnectivityStatus>,
-    );
-
-    expect(
-      screen.queryByText("Report issue on GitHub"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("should show Connected message after recovering from connection issues", async () => {
-    // Start with connection issues
+  it("confirms recovery before continuing to sign in", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connecting",
       attemptCount: 2,
@@ -266,10 +182,6 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    // Should show connecting view
-    expect(screen.getByText("Connecting...")).toBeInTheDocument();
-
-    // Now connection succeeds
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connected",
       attemptCount: 2,
@@ -284,22 +196,17 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    // Should show "Connected" message
-    expect(screen.getByText("Connected")).toBeInTheDocument();
-    expect(
-      screen.getByText("Successfully connected to the backend server."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Connection restored")).toBeInTheDocument();
+    expect(screen.getByText("Continuing to sign in.")).toBeInTheDocument();
     expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
   });
 
-  it("should show refreshing message when redirectTo param is present after connection recovery", async () => {
+  it("confirms recovery before reloading an intended destination", () => {
     vi.mocked(useSearchParams).mockReturnValue(
       new URLSearchParams("redirectTo=/agents") as unknown as ReturnType<
         typeof useSearchParams
       >,
     );
-
-    // Start with connection issues
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connecting",
       attemptCount: 2,
@@ -310,11 +217,10 @@ describe("BackendConnectivityStatus", () => {
 
     const { rerender } = render(
       <BackendConnectivityStatus>
-        <div data-testid="child-content">Login Form</div>
+        <div>Login Form</div>
       </BackendConnectivityStatus>,
     );
 
-    // Now connection succeeds
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connected",
       attemptCount: 2,
@@ -325,33 +231,11 @@ describe("BackendConnectivityStatus", () => {
 
     rerender(
       <BackendConnectivityStatus>
-        <div data-testid="child-content">Login Form</div>
+        <div>Login Form</div>
       </BackendConnectivityStatus>,
     );
 
-    // Should show refreshing message since there's a redirectTo param
-    expect(screen.getByText("Connected")).toBeInTheDocument();
-    expect(screen.getByText("Refreshing...")).toBeInTheDocument();
-  });
-
-  it("should render children directly when connected without prior issues", () => {
-    // First render with connected status (no prior connection issues)
-    vi.mocked(useBackendConnectivity).mockReturnValue({
-      status: "connected",
-      attemptCount: 0,
-      estimatedTotalAttempts: 7,
-      elapsedMs: 100,
-      retry: mockRetry,
-    });
-
-    render(
-      <BackendConnectivityStatus>
-        <div data-testid="child-content">Login Form</div>
-      </BackendConnectivityStatus>,
-    );
-
-    // Should render children directly without showing "Connected" message
-    expect(screen.getByTestId("child-content")).toBeInTheDocument();
-    expect(screen.queryByText("Connected")).not.toBeInTheDocument();
+    expect(screen.getByText("Connection restored")).toBeInTheDocument();
+    expect(screen.getByText("Reloading the page.")).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
@@ -37,6 +37,7 @@ describe("BackendConnectivityStatus", () => {
       attemptCount: 0,
       estimatedTotalAttempts: 7,
       elapsedMs: 0,
+      nextRetryInMs: null,
       retry: mockRetry,
     });
 
@@ -56,6 +57,7 @@ describe("BackendConnectivityStatus", () => {
       attemptCount: 0,
       estimatedTotalAttempts: 7,
       elapsedMs: 0,
+      nextRetryInMs: null,
       retry: mockRetry,
     });
 
@@ -69,12 +71,13 @@ describe("BackendConnectivityStatus", () => {
     expect(screen.queryByText("Ready")).not.toBeInTheDocument();
   });
 
-  it("explains the automatic retry behavior while connecting", () => {
+  it("shows when the next automatic retry will run", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connecting",
       attemptCount: 0,
       estimatedTotalAttempts: 7,
       elapsedMs: 0,
+      nextRetryInMs: 8000,
       retry: mockRetry,
     });
 
@@ -92,9 +95,7 @@ describe("BackendConnectivityStatus", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Retrying automatically")).toBeInTheDocument();
-    expect(
-      screen.getByText("Checks pause longer after each unsuccessful attempt."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Next retry in 8s")).toBeInTheDocument();
     expect(screen.queryByText(/Attempt \d/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
   });
@@ -105,6 +106,7 @@ describe("BackendConnectivityStatus", () => {
       attemptCount: 3,
       estimatedTotalAttempts: 7,
       elapsedMs: 5000,
+      nextRetryInMs: null,
       retry: mockRetry,
     });
 
@@ -115,6 +117,7 @@ describe("BackendConnectivityStatus", () => {
     );
 
     expect(screen.getByText("Retrying automatically")).toBeInTheDocument();
+    expect(screen.getByText("Checking now")).toBeInTheDocument();
     expect(screen.queryByText(/Attempt \d/)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: /Report issue/i }),
@@ -127,6 +130,7 @@ describe("BackendConnectivityStatus", () => {
       attemptCount: 5,
       estimatedTotalAttempts: 7,
       elapsedMs: 60000,
+      nextRetryInMs: null,
       retry: mockRetry,
     });
 
@@ -159,6 +163,7 @@ describe("BackendConnectivityStatus", () => {
       attemptCount: 5,
       estimatedTotalAttempts: 7,
       elapsedMs: 60000,
+      nextRetryInMs: null,
       retry: mockRetry,
     });
 
@@ -179,6 +184,7 @@ describe("BackendConnectivityStatus", () => {
       attemptCount: 2,
       estimatedTotalAttempts: 7,
       elapsedMs: 3000,
+      nextRetryInMs: 1000,
       retry: mockRetry,
     });
 
@@ -193,6 +199,7 @@ describe("BackendConnectivityStatus", () => {
       attemptCount: 2,
       estimatedTotalAttempts: 7,
       elapsedMs: 3500,
+      nextRetryInMs: null,
       retry: mockRetry,
     });
 
@@ -218,6 +225,7 @@ describe("BackendConnectivityStatus", () => {
       attemptCount: 2,
       estimatedTotalAttempts: 7,
       elapsedMs: 3000,
+      nextRetryInMs: 1000,
       retry: mockRetry,
     });
 
@@ -232,6 +240,7 @@ describe("BackendConnectivityStatus", () => {
       attemptCount: 2,
       estimatedTotalAttempts: 7,
       elapsedMs: 3500,
+      nextRetryInMs: null,
       retry: mockRetry,
     });
 

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
@@ -66,10 +66,10 @@ describe("BackendConnectivityStatus", () => {
     );
 
     expect(screen.getByTestId("child-content")).toBeInTheDocument();
-    expect(screen.queryByText("Connection restored")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ready")).not.toBeInTheDocument();
   });
 
-  it("shows a quiet readiness state while the backend starts", () => {
+  it("previews the sign-in surface while the backend starts", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connecting",
       attemptCount: 0,
@@ -84,17 +84,16 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    expect(screen.getByText("Waiting for Sparky")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Starting Sparky")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "The Sparky backend is still starting. This page will continue automatically.",
-      ),
+      screen.getByText("Finishing startup. Sign-in will appear automatically."),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Attempt \d/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
   });
 
-  it("shows retry progress after failed attempts", () => {
+  it("keeps retry scheduling out of the interface", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connecting",
       attemptCount: 3,
@@ -109,7 +108,8 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    expect(screen.getByText("Attempt 3 of 7")).toBeInTheDocument();
+    expect(screen.getByText("Starting Sparky")).toBeInTheDocument();
+    expect(screen.queryByText(/Attempt \d/)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: /Report issue/i }),
     ).not.toBeInTheDocument();
@@ -196,7 +196,7 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    expect(screen.getByText("Connection restored")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(screen.getByText("Continuing to sign in.")).toBeInTheDocument();
     expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
   });
@@ -235,7 +235,7 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    expect(screen.getByText("Connection restored")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(screen.getByText("Reloading the page.")).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
@@ -69,7 +69,7 @@ describe("BackendConnectivityStatus", () => {
     expect(screen.queryByText("Ready")).not.toBeInTheDocument();
   });
 
-  it("previews the sign-in surface while the backend starts", () => {
+  it("explains the automatic retry behavior while connecting", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connecting",
       attemptCount: 0,
@@ -85,15 +85,21 @@ describe("BackendConnectivityStatus", () => {
     );
 
     expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
-    expect(screen.getByText("Starting Sparky")).toBeInTheDocument();
+    expect(screen.getByText("Connecting to Sparky")).toBeInTheDocument();
     expect(
-      screen.getByText("Finishing startup. Sign-in will appear automatically."),
+      screen.getByText(
+        "The backend is not responding yet. Sign-in will appear when it is ready.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Retrying automatically")).toBeInTheDocument();
+    expect(
+      screen.getByText("Checks pause longer after each unsuccessful attempt."),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Attempt \d/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
   });
 
-  it("keeps retry scheduling out of the interface", () => {
+  it("keeps retry counters out of the interface", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status: "connecting",
       attemptCount: 3,
@@ -108,7 +114,7 @@ describe("BackendConnectivityStatus", () => {
       </BackendConnectivityStatus>,
     );
 
-    expect(screen.getByText("Starting Sparky")).toBeInTheDocument();
+    expect(screen.getByText("Retrying automatically")).toBeInTheDocument();
     expect(screen.queryByText(/Attempt \d/)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: /Report issue/i }),

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
@@ -1,43 +1,18 @@
 "use client";
 
 import { GITHUB_REPO_URL } from "@archestra/shared";
-import {
-  AlertCircle,
-  CheckCircle2,
-  ExternalLink,
-  RefreshCcw,
-  ServerOff,
-} from "lucide-react";
+import { Check, ExternalLink, RefreshCcw, ServerOff } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { LoadingState } from "@/components/loading";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AppLogo } from "@/components/app-logo";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { useBackendConnectivity } from "@/lib/config/backend-connectivity";
 import { useAppName } from "@/lib/hooks/use-app-name";
 
 interface BackendConnectivityStatusProps {
-  /**
-   * Children to render when the backend is connected
-   */
   children: React.ReactNode;
 }
 
-/**
- * Wrapper component that shows connection status while trying to reach the backend.
- * - Shows a "Connecting..." message while attempting to connect
- * - Shows children only when connected
- * - Shows an error message after 1 minute of failed attempts
- * - Shows "Connected" message briefly after recovering from connection issues
- * - Redirects authenticated users to their intended destination
- */
 export function BackendConnectivityStatus({
   children,
 }: BackendConnectivityStatusProps) {
@@ -49,83 +24,63 @@ export function BackendConnectivityStatus({
   const hadConnectionIssuesRef = useRef(false);
   const hasInitiatedRefreshRef = useRef(false);
 
-  // Track if we had connection issues (were in "connecting" state with attempts)
   useEffect(() => {
     if (status === "connecting" && attemptCount > 0) {
       hadConnectionIssuesRef.current = true;
     }
   }, [status, attemptCount]);
 
-  // When connected after having connection issues, show the connected message
-  // and refresh the page if there's a redirectTo param
   useEffect(() => {
-    if (status === "connected" && hadConnectionIssuesRef.current) {
-      setShowConnectedMessage(true);
-
-      // If there's a redirectTo param, refresh the page after showing the message
-      // The normal auth flow will handle the redirect
-      if (redirectTo && !hasInitiatedRefreshRef.current) {
-        hasInitiatedRefreshRef.current = true;
-        setTimeout(() => {
-          window.location.reload();
-        }, 1000);
-      } else if (!redirectTo) {
-        // No redirectTo, just show connected message briefly then show children
-        const timer = setTimeout(() => {
-          setShowConnectedMessage(false);
-          hadConnectionIssuesRef.current = false;
-        }, 1500);
-        return () => clearTimeout(timer);
-      }
+    if (status !== "connected" || !hadConnectionIssuesRef.current) {
+      return;
     }
+
+    setShowConnectedMessage(true);
+
+    if (redirectTo && !hasInitiatedRefreshRef.current) {
+      hasInitiatedRefreshRef.current = true;
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setShowConnectedMessage(false);
+      hadConnectionIssuesRef.current = false;
+    }, 1500);
+
+    return () => clearTimeout(timer);
   }, [status, redirectTo]);
 
-  // During "initializing" or "checking" (first health check in progress),
-  // don't show any UI to avoid flashing the connecting dialog when backend is up
   if (status === "initializing" || status === "checking") {
     return null;
   }
 
-  // Show "Connected" message briefly after recovering from connection issues
   if (status === "connected" && showConnectedMessage) {
-    return <ConnectedSuccessView hasRedirectTo={!!redirectTo} />;
+    return (
+      <ConnectivityView
+        indicator={<Check className="size-6" strokeWidth={2} />}
+        indicatorClassName="text-emerald-600 dark:text-emerald-400"
+        title="Connection restored"
+        description={
+          redirectTo ? "Reloading the page." : "Continuing to sign in."
+        }
+      />
+    );
   }
 
-  // When connected, render children (the login form)
   if (status === "connected") {
     return <>{children}</>;
   }
 
-  // Show unified connection status view
   return (
     <ConnectionStatusView
       status={status}
       attemptCount={attemptCount}
       estimatedTotalAttempts={estimatedTotalAttempts}
-      retry={retry}
+      onRetry={retry}
     />
-  );
-}
-
-function ConnectedSuccessView({ hasRedirectTo }: { hasRedirectTo: boolean }) {
-  return (
-    <main className="h-full flex items-center justify-center p-4">
-      <Card className="max-w-md w-full">
-        <CardHeader className="text-center">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
-            <CheckCircle2 className="h-6 w-6 text-green-600 dark:text-green-400" />
-          </div>
-          <CardTitle className="text-green-600 dark:text-green-400">
-            Connected
-          </CardTitle>
-          <CardDescription>
-            {hasRedirectTo
-              ? "Refreshing..."
-              : "Successfully connected to the backend server."}
-          </CardDescription>
-        </CardHeader>
-      </Card>
-    </main>
   );
 }
 
@@ -133,106 +88,120 @@ function ConnectionStatusView({
   status,
   attemptCount,
   estimatedTotalAttempts,
-  retry,
+  onRetry,
 }: {
   status: "connecting" | "unreachable";
   attemptCount: number;
   estimatedTotalAttempts: number;
-  retry: () => void;
+  onRetry: () => void;
 }) {
   const appName = useAppName();
   const isUnreachable = status === "unreachable";
 
   return (
-    <main className="h-full flex items-center justify-center p-4">
-      <Card className="max-w-md w-full">
-        <CardHeader className="text-center">
-          <div
-            className={`mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full ${
-              isUnreachable ? "bg-destructive/10" : "bg-muted"
-            }`}
-          >
-            {isUnreachable ? (
-              <ServerOff className="h-6 w-6 text-destructive" />
-            ) : (
-              <LoadingState
-                className="min-h-0 p-0"
-                label="Connecting…"
-                showLabel={false}
-                variant="compact"
-              />
-            )}
-          </div>
-          <CardTitle>
-            {isUnreachable ? "Unable to Connect" : "Connecting..."}
-          </CardTitle>
-          <CardDescription>
-            {isUnreachable
-              ? "Unable to establish a connection to the backend server after multiple attempts."
-              : `Establishing connection to the ${appName} backend server.`}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {isUnreachable ? (
-            <Alert className="border-destructive/50 bg-destructive/10">
-              <AlertCircle className="h-4 w-4 text-destructive" />
-              <AlertTitle className="text-destructive">
-                Server Unreachable
-              </AlertTitle>
-              <AlertDescription className="text-destructive/90">
-                <p className="text-sm mb-3">
-                  The backend server is not responding. Possible causes:
-                </p>
-                <ul className="list-disc list-inside space-y-1 text-sm">
-                  <li>Server is still starting up</li>
-                  <li>Network connectivity issue</li>
-                  <li>Server configuration problem</li>
-                </ul>
-              </AlertDescription>
-            </Alert>
-          ) : (
-            <>
-              {attemptCount === 0 && (
-                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                  <span>Attempting to connect...</span>
-                </div>
-              )}
-              {attemptCount > 0 && (
-                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                  Still trying to connect, attempt {attemptCount} /{" "}
-                  {estimatedTotalAttempts}...
-                </div>
-              )}
-            </>
-          )}
+    <ConnectivityView
+      indicator={
+        isUnreachable ? (
+          <ServerOff className="size-6" strokeWidth={1.75} />
+        ) : (
+          <ConnectionSignal />
+        )
+      }
+      indicatorClassName={isUnreachable ? "text-destructive" : undefined}
+      title={isUnreachable ? "Backend unavailable" : `Waiting for ${appName}`}
+      description={
+        isUnreachable
+          ? `The ${appName} backend did not respond. Check that it is running, then try again.`
+          : `The ${appName} backend is still starting. This page will continue automatically.`
+      }
+      detail={
+        !isUnreachable && attemptCount > 0
+          ? `Attempt ${attemptCount} of ${estimatedTotalAttempts}`
+          : undefined
+      }
+      urgent={isUnreachable}
+      actions={
+        isUnreachable ? (
+          <>
+            <Button type="button" onClick={onRetry}>
+              <RefreshCcw className="size-4" />
+              <span>Try again</span>
+            </Button>
+            <Button variant="ghost" asChild>
+              <a
+                href={`${GITHUB_REPO_URL}/issues`}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                <span>Report issue</span>
+                <ExternalLink className="size-3.5" />
+              </a>
+            </Button>
+          </>
+        ) : undefined
+      }
+    />
+  );
+}
 
-          <div className="flex justify-center gap-2">
-            {isUnreachable && (
-              <Button
-                onClick={retry}
-                variant="outline"
-                size="sm"
-                className="gap-2"
-              >
-                <RefreshCcw className="h-4 w-4" />
-                Try Again
-              </Button>
-            )}
-            {(attemptCount > 0 || isUnreachable) && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() =>
-                  window.open(`${GITHUB_REPO_URL}/issues`, "_blank")
-                }
-              >
-                Report issue on GitHub
-                <ExternalLink className="ml-1 h-3 w-3" />
-              </Button>
-            )}
+function ConnectivityView({
+  indicator,
+  indicatorClassName,
+  title,
+  description,
+  detail,
+  actions,
+  urgent = false,
+}: {
+  indicator: React.ReactNode;
+  indicatorClassName?: string;
+  title: string;
+  description: string;
+  detail?: string;
+  actions?: React.ReactNode;
+  urgent?: boolean;
+}) {
+  return (
+    <main className="flex min-h-full items-center justify-center px-6 py-12">
+      <section
+        className="w-full max-w-sm text-center"
+        role={urgent ? "alert" : "status"}
+      >
+        <AppLogo />
+
+        <div
+          className={`mx-auto mt-10 flex size-10 items-center justify-center text-muted-foreground ${indicatorClassName ?? ""}`}
+          aria-hidden="true"
+        >
+          {indicator}
+        </div>
+
+        <h1 className="mt-5 text-xl font-semibold tracking-tight">{title}</h1>
+        <p className="mx-auto mt-2 max-w-xs text-sm leading-6 text-muted-foreground">
+          {description}
+        </p>
+
+        {detail && (
+          <p className="mt-4 font-mono text-[11px] tracking-wide text-muted-foreground/80">
+            {detail}
+          </p>
+        )}
+
+        {actions && (
+          <div className="mt-7 flex items-center justify-center gap-2">
+            {actions}
           </div>
-        </CardContent>
-      </Card>
+        )}
+      </section>
     </main>
+  );
+}
+
+function ConnectionSignal() {
+  return (
+    <span className="relative flex size-3 items-center justify-center">
+      <span className="absolute size-3 animate-ping rounded-full bg-primary/35 motion-reduce:animate-none" />
+      <span className="relative size-2 rounded-full bg-primary" />
+    </span>
   );
 }

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { GITHUB_REPO_URL } from "@archestra/shared";
-import { ExternalLink, RefreshCcw } from "lucide-react";
+import { ExternalLink, LoaderCircle, RefreshCcw } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { AppLogo } from "@/components/app-logo";
@@ -14,7 +14,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import { useBackendConnectivity } from "@/lib/config/backend-connectivity";
 import { useAppName } from "@/lib/hooks/use-app-name";
 
@@ -96,11 +95,11 @@ function ConnectionStatusView({
   if (!isUnreachable) {
     return (
       <ConnectivityView
-        title={`Starting ${appName}`}
-        description="Finishing startup. Sign-in will appear automatically."
+        title={`Connecting to ${appName}`}
+        description="The backend is not responding yet. Sign-in will appear when it is ready."
         busy
       >
-        <SignInSkeleton />
+        <ConnectionActivity />
       </ConnectivityView>
     );
   }
@@ -173,18 +172,21 @@ function ConnectivityView({
   );
 }
 
-function SignInSkeleton() {
+function ConnectionActivity() {
   return (
-    <CardContent className="space-y-5" aria-hidden="true">
-      <div className="space-y-2">
-        <Skeleton className="h-3 w-12 bg-muted-foreground/15 motion-reduce:animate-none" />
-        <Skeleton className="h-9 w-full bg-muted-foreground/15 motion-reduce:animate-none" />
+    <CardContent>
+      <div className="flex items-start gap-3 rounded-md border bg-muted/30 p-3">
+        <LoaderCircle
+          className="mt-0.5 size-4 shrink-0 animate-spin text-primary motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+        <div className="space-y-0.5">
+          <p className="text-sm font-medium">Retrying automatically</p>
+          <p className="text-xs leading-5 text-muted-foreground">
+            Checks pause longer after each unsuccessful attempt.
+          </p>
+        </div>
       </div>
-      <div className="space-y-2">
-        <Skeleton className="h-3 w-16 bg-muted-foreground/15 motion-reduce:animate-none" />
-        <Skeleton className="h-9 w-full bg-muted-foreground/15 motion-reduce:animate-none" />
-      </div>
-      <Skeleton className="h-9 w-full bg-muted-foreground/15 motion-reduce:animate-none" />
     </CardContent>
   );
 }

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
@@ -1,11 +1,20 @@
 "use client";
 
 import { GITHUB_REPO_URL } from "@archestra/shared";
-import { Check, ExternalLink, RefreshCcw, ServerOff } from "lucide-react";
+import { ExternalLink, RefreshCcw } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { AppLogo } from "@/components/app-logo";
 import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useBackendConnectivity } from "@/lib/config/backend-connectivity";
 import { useAppName } from "@/lib/hooks/use-app-name";
 
@@ -16,8 +25,7 @@ interface BackendConnectivityStatusProps {
 export function BackendConnectivityStatus({
   children,
 }: BackendConnectivityStatusProps) {
-  const { status, attemptCount, estimatedTotalAttempts, retry } =
-    useBackendConnectivity();
+  const { status, attemptCount, retry } = useBackendConnectivity();
   const searchParams = useSearchParams();
   const redirectTo = searchParams.get("redirectTo");
   const [showConnectedMessage, setShowConnectedMessage] = useState(false);
@@ -60,9 +68,7 @@ export function BackendConnectivityStatus({
   if (status === "connected" && showConnectedMessage) {
     return (
       <ConnectivityView
-        indicator={<Check className="size-6" strokeWidth={2} />}
-        indicatorClassName="text-emerald-600 dark:text-emerald-400"
-        title="Connection restored"
+        title="Ready"
         description={
           redirectTo ? "Reloading the page." : "Continuing to sign in."
         }
@@ -74,134 +80,111 @@ export function BackendConnectivityStatus({
     return <>{children}</>;
   }
 
-  return (
-    <ConnectionStatusView
-      status={status}
-      attemptCount={attemptCount}
-      estimatedTotalAttempts={estimatedTotalAttempts}
-      onRetry={retry}
-    />
-  );
+  return <ConnectionStatusView status={status} onRetry={retry} />;
 }
 
 function ConnectionStatusView({
   status,
-  attemptCount,
-  estimatedTotalAttempts,
   onRetry,
 }: {
   status: "connecting" | "unreachable";
-  attemptCount: number;
-  estimatedTotalAttempts: number;
   onRetry: () => void;
 }) {
   const appName = useAppName();
   const isUnreachable = status === "unreachable";
 
+  if (!isUnreachable) {
+    return (
+      <ConnectivityView
+        title={`Starting ${appName}`}
+        description="Finishing startup. Sign-in will appear automatically."
+        busy
+      >
+        <SignInSkeleton />
+      </ConnectivityView>
+    );
+  }
+
   return (
     <ConnectivityView
-      indicator={
-        isUnreachable ? (
-          <ServerOff className="size-6" strokeWidth={1.75} />
-        ) : (
-          <ConnectionSignal />
-        )
-      }
-      indicatorClassName={isUnreachable ? "text-destructive" : undefined}
-      title={isUnreachable ? "Backend unavailable" : `Waiting for ${appName}`}
-      description={
-        isUnreachable
-          ? `The ${appName} backend did not respond. Check that it is running, then try again.`
-          : `The ${appName} backend is still starting. This page will continue automatically.`
-      }
-      detail={
-        !isUnreachable && attemptCount > 0
-          ? `Attempt ${attemptCount} of ${estimatedTotalAttempts}`
-          : undefined
-      }
-      urgent={isUnreachable}
+      title="Backend unavailable"
+      description={`The ${appName} backend did not respond. Check that it is running, then try again.`}
+      urgent
       actions={
-        isUnreachable ? (
-          <>
-            <Button type="button" onClick={onRetry}>
-              <RefreshCcw className="size-4" />
-              <span>Try again</span>
-            </Button>
-            <Button variant="ghost" asChild>
-              <a
-                href={`${GITHUB_REPO_URL}/issues`}
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                <span>Report issue</span>
-                <ExternalLink className="size-3.5" />
-              </a>
-            </Button>
-          </>
-        ) : undefined
+        <>
+          <Button type="button" onClick={onRetry}>
+            <RefreshCcw className="size-4" />
+            <span>Try again</span>
+          </Button>
+          <Button variant="ghost" asChild>
+            <a
+              href={`${GITHUB_REPO_URL}/issues`}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              <span>Report issue</span>
+              <ExternalLink className="size-3.5" />
+            </a>
+          </Button>
+        </>
       }
     />
   );
 }
 
 function ConnectivityView({
-  indicator,
-  indicatorClassName,
   title,
   description,
-  detail,
   actions,
+  children,
+  busy = false,
   urgent = false,
 }: {
-  indicator: React.ReactNode;
-  indicatorClassName?: string;
   title: string;
   description: string;
-  detail?: string;
   actions?: React.ReactNode;
+  children?: React.ReactNode;
+  busy?: boolean;
   urgent?: boolean;
 }) {
   return (
-    <main className="flex min-h-full items-center justify-center px-6 py-12">
-      <section
-        className="w-full max-w-sm text-center"
-        role={urgent ? "alert" : "status"}
-      >
+    <main className="h-full flex items-center justify-center p-4">
+      <div className="space-y-4 w-full max-w-md">
         <AppLogo />
 
-        <div
-          className={`mx-auto mt-10 flex size-10 items-center justify-center text-muted-foreground ${indicatorClassName ?? ""}`}
-          aria-hidden="true"
+        <Card
+          className={urgent ? "border-destructive/40" : undefined}
+          role={urgent ? "alert" : "status"}
+          aria-busy={busy || undefined}
         >
-          {indicator}
-        </div>
+          <CardHeader>
+            <CardTitle className="text-xl">
+              <h1>{title}</h1>
+            </CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </CardHeader>
 
-        <h1 className="mt-5 text-xl font-semibold tracking-tight">{title}</h1>
-        <p className="mx-auto mt-2 max-w-xs text-sm leading-6 text-muted-foreground">
-          {description}
-        </p>
+          {children}
 
-        {detail && (
-          <p className="mt-4 font-mono text-[11px] tracking-wide text-muted-foreground/80">
-            {detail}
-          </p>
-        )}
-
-        {actions && (
-          <div className="mt-7 flex items-center justify-center gap-2">
-            {actions}
-          </div>
-        )}
-      </section>
+          {actions && <CardFooter className="gap-2">{actions}</CardFooter>}
+        </Card>
+      </div>
     </main>
   );
 }
 
-function ConnectionSignal() {
+function SignInSkeleton() {
   return (
-    <span className="relative flex size-3 items-center justify-center">
-      <span className="absolute size-3 animate-ping rounded-full bg-primary/35 motion-reduce:animate-none" />
-      <span className="relative size-2 rounded-full bg-primary" />
-    </span>
+    <CardContent className="space-y-5" aria-hidden="true">
+      <div className="space-y-2">
+        <Skeleton className="h-3 w-12 bg-muted-foreground/15 motion-reduce:animate-none" />
+        <Skeleton className="h-9 w-full bg-muted-foreground/15 motion-reduce:animate-none" />
+      </div>
+      <div className="space-y-2">
+        <Skeleton className="h-3 w-16 bg-muted-foreground/15 motion-reduce:animate-none" />
+        <Skeleton className="h-9 w-full bg-muted-foreground/15 motion-reduce:animate-none" />
+      </div>
+      <Skeleton className="h-9 w-full bg-muted-foreground/15 motion-reduce:animate-none" />
+    </CardContent>
   );
 }

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
@@ -24,7 +24,8 @@ interface BackendConnectivityStatusProps {
 export function BackendConnectivityStatus({
   children,
 }: BackendConnectivityStatusProps) {
-  const { status, attemptCount, retry } = useBackendConnectivity();
+  const { status, attemptCount, nextRetryInMs, retry } =
+    useBackendConnectivity();
   const searchParams = useSearchParams();
   const redirectTo = searchParams.get("redirectTo");
   const [showConnectedMessage, setShowConnectedMessage] = useState(false);
@@ -79,14 +80,22 @@ export function BackendConnectivityStatus({
     return <>{children}</>;
   }
 
-  return <ConnectionStatusView status={status} onRetry={retry} />;
+  return (
+    <ConnectionStatusView
+      status={status}
+      nextRetryInMs={nextRetryInMs}
+      onRetry={retry}
+    />
+  );
 }
 
 function ConnectionStatusView({
   status,
+  nextRetryInMs,
   onRetry,
 }: {
   status: "connecting" | "unreachable";
+  nextRetryInMs: number | null;
   onRetry: () => void;
 }) {
   const appName = useAppName();
@@ -99,7 +108,7 @@ function ConnectionStatusView({
         description="The backend is not responding yet. Sign-in will appear when it is ready."
         busy
       >
-        <ConnectionActivity />
+        <ConnectionActivity nextRetryInMs={nextRetryInMs} />
       </ConnectivityView>
     );
   }
@@ -172,20 +181,32 @@ function ConnectivityView({
   );
 }
 
-function ConnectionActivity() {
+function ConnectionActivity({
+  nextRetryInMs,
+}: {
+  nextRetryInMs: number | null;
+}) {
+  const retryStatus =
+    nextRetryInMs === null
+      ? "Checking now"
+      : `Next retry in ${Math.max(1, Math.ceil(nextRetryInMs / 1000))}s`;
+
   return (
     <CardContent>
-      <div className="flex items-start gap-3 rounded-md border bg-muted/30 p-3">
+      <div className="flex items-center gap-3 rounded-md border bg-muted/30 p-3">
         <LoaderCircle
-          className="mt-0.5 size-4 shrink-0 animate-spin text-primary motion-reduce:animate-none"
+          className="size-4 shrink-0 animate-spin text-primary motion-reduce:animate-none"
           aria-hidden="true"
         />
-        <div className="space-y-0.5">
-          <p className="text-sm font-medium">Retrying automatically</p>
-          <p className="text-xs leading-5 text-muted-foreground">
-            Checks pause longer after each unsuccessful attempt.
-          </p>
-        </div>
+        <p className="min-w-0 flex-1 text-sm font-medium">
+          Retrying automatically
+        </p>
+        <p
+          className="shrink-0 text-xs tabular-nums text-muted-foreground"
+          aria-live="polite"
+        >
+          <span>{retryStatus}</span>
+        </p>
       </div>
     </CardContent>
   );

--- a/platform/frontend/src/app/globals.css
+++ b/platform/frontend/src/app/globals.css
@@ -120,6 +120,7 @@
      Set on both html and body — iOS Safari only honors it reliably when the
      root carries it too. */
   html {
+    @apply bg-background;
     overscroll-behavior-y: none;
   }
   body {

--- a/platform/frontend/src/app/knowledge/connectors/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/page.client.tsx
@@ -429,6 +429,7 @@ function ConnectorsList() {
         <div>
           <div className="mb-3 flex flex-col gap-2">
             <FilterBar
+              leading
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
             >
               <SearchInput

--- a/platform/frontend/src/app/knowledge/files/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/files/page.client.tsx
@@ -506,6 +506,7 @@ export default function KnowledgeFilesPage() {
     >
       <BulkActionsScope className="space-y-3">
         <FilterBar
+          leading
           onClearFilters={
             search
               ? () => {

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -452,6 +452,7 @@ function KnowledgeBasesList() {
         <div>
           <div className="mb-3 flex flex-col gap-2">
             <FilterBar
+              leading
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
             >
               <SearchInput

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -523,7 +523,7 @@ export default function ModelsPage() {
     >
       <BulkActionsScope className="space-y-3">
         {models.length > 0 && (
-          <FilterBar>
+          <FilterBar leading>
             <SearchInput
               objectNamePlural="models"
               searchFields={["model ID"]}

--- a/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
@@ -342,7 +342,7 @@ function VirtualKeysTable() {
     <TableCardView storageKey="archestra-llm-virtual-keys-view">
       <div>
         <div className="mb-3">
-          <FilterBar actions={<TableCardViewToggle />}>
+          <FilterBar leading actions={<TableCardViewToggle />}>
             <SearchInput
               isLoading={query.isFetching}
               objectNamePlural="keys"

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -688,6 +688,7 @@ function McpGateways({
           <div>
             <div className="mb-3 flex flex-col gap-2">
               <FilterBar
+                leading
                 actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
               >
                 <SearchInput

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1174,6 +1174,7 @@ export function InternalMCPCatalog({
           }
         >
           <FilterBar
+            leading
             onClearFilters={
               hasAppliedBarFilters ? handleClearBarFilters : undefined
             }

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
@@ -633,7 +633,7 @@ export function AssignedToolsTable({
 
   return (
     <BulkActionsScope className="space-y-3">
-      <FilterBar>
+      <FilterBar leading>
         <SearchInput
           isLoading={isLoading}
           objectNamePlural="tools"

--- a/platform/frontend/src/app/plugins/page.client.tsx
+++ b/platform/frontend/src/app/plugins/page.client.tsx
@@ -618,6 +618,7 @@ function PluginsList() {
             <>
               <div className="mb-3 flex flex-col gap-2">
                 <FilterBar
+                  leading
                   onClearFilters={hasActiveFilters ? clearFilters : undefined}
                   moreFilters={[
                     {

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -253,6 +253,7 @@ function ProjectsList() {
         )}
         <div className="space-y-6">
           <FilterBar
+            leading
             className={projects.length > 0 ? "!mb-3" : undefined}
             actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
           >

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -794,6 +794,7 @@ function SkillsList() {
             <>
               <div className="mb-3 flex flex-col gap-2">
                 <FilterBar
+                  leading
                   onClearFilters={hasActiveFilters ? clearFilters : undefined}
                   actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
                 >

--- a/platform/frontend/src/lib/config/backend-connectivity.test.ts
+++ b/platform/frontend/src/lib/config/backend-connectivity.test.ts
@@ -23,6 +23,7 @@ describe("useBackendConnectivity", () => {
     expect(result.current.status).toBe("initializing");
     expect(result.current.attemptCount).toBe(0);
     expect(result.current.elapsedMs).toBe(0);
+    expect(result.current.nextRetryInMs).toBeNull();
   });
 
   it("should start in checking state when autoStart is true", () => {
@@ -91,6 +92,7 @@ describe("useBackendConnectivity", () => {
     });
     expect(checkHealthFn).toHaveBeenCalledTimes(1);
     expect(result.current.attemptCount).toBe(1);
+    expect(result.current.nextRetryInMs).toBe(1000);
     // After first failure, transitions to "connecting"
     expect(result.current.status).toBe("connecting");
 
@@ -100,6 +102,7 @@ describe("useBackendConnectivity", () => {
     });
     expect(checkHealthFn).toHaveBeenCalledTimes(2);
     expect(result.current.attemptCount).toBe(2);
+    expect(result.current.nextRetryInMs).toBe(2000);
 
     // Wait for second retry (2s delay after second failure)
     await act(async () => {
@@ -107,6 +110,7 @@ describe("useBackendConnectivity", () => {
     });
     expect(checkHealthFn).toHaveBeenCalledTimes(3);
     expect(result.current.status).toBe("connected");
+    expect(result.current.nextRetryInMs).toBeNull();
   });
 
   it("should respect maxDelayMs for exponential backoff", async () => {

--- a/platform/frontend/src/lib/config/backend-connectivity.ts
+++ b/platform/frontend/src/lib/config/backend-connectivity.ts
@@ -56,6 +56,10 @@ export interface UseBackendConnectivityResult {
    */
   elapsedMs: number;
   /**
+   * Time until the next automatic retry, or null while a check is in progress
+   */
+  nextRetryInMs: number | null;
+  /**
    * Manually retry the connection
    */
   retry: () => void;
@@ -111,6 +115,7 @@ export function useBackendConnectivity(
   const [status, setStatus] = useState<BackendConnectionStatus>("initializing");
   const [attemptCount, setAttemptCount] = useState(0);
   const [elapsedMs, setElapsedMs] = useState(0);
+  const [nextRetryAtMs, setNextRetryAtMs] = useState<number | null>(null);
 
   const estimatedTotalAttempts = calculateEstimatedTotalAttempts(
     timeoutMs,
@@ -157,6 +162,7 @@ export function useBackendConnectivity(
 
       if (isHealthy) {
         clearTimers();
+        setNextRetryAtMs(null);
         setStatus("connected");
         return;
       }
@@ -173,6 +179,7 @@ export function useBackendConnectivity(
 
       if (elapsed >= timeoutMs) {
         clearTimers();
+        setNextRetryAtMs(null);
         setStatus("unreachable");
         return;
       }
@@ -184,9 +191,11 @@ export function useBackendConnectivity(
       );
 
       setAttemptCount(currentAttempt + 1);
+      setNextRetryAtMs(now + nextDelay);
 
       // Schedule next attempt
       timeoutRef.current = setTimeout(() => {
+        setNextRetryAtMs(null);
         attemptConnection(currentAttempt + 1);
       }, nextDelay);
     },
@@ -198,6 +207,7 @@ export function useBackendConnectivity(
     setStatus("checking");
     setAttemptCount(0);
     setElapsedMs(0);
+    setNextRetryAtMs(null);
     clearTimers();
 
     // Record start time
@@ -237,6 +247,8 @@ export function useBackendConnectivity(
     attemptCount,
     estimatedTotalAttempts,
     elapsedMs,
+    nextRetryInMs:
+      nextRetryAtMs === null ? null : Math.max(0, nextRetryAtMs - Date.now()),
     retry,
   };
 }


### PR DESCRIPTION
## Summary

- balance the space above and below top-level search and filter controls across all list pages that use the shared `PageLayout` and `FilterBar` pattern
- make the root page canvas use the same semantic background token as the body and app shell, preventing dark-mode seams anywhere the browser canvas can show through
- replace the backend readiness placeholder with a compact branded connection state
- show the real retry state with `Retrying automatically`, a live next-retry countdown, and `Checking now` while a request is active
- keep exponential backoff and recovery redirects intact, with manual retry and issue-reporting actions only after the backend is declared unavailable
- add semantic status and alert roles plus reduced-motion-safe connection feedback

The connectivity treatment follows the design-taste guidance in preserve mode at low visual variance and motion. It reuses the existing auth card, design-system primitives, and typography, and keeps the status concise and operational.

## Verification

- measured the shared list layout at 16px above and 16px below the filter bar
- exercised the real auth route in dark-mode Chrome against an unavailable local backend, including the live retry countdown and terminal unavailable state
- verified the root, body, and app shell resolve to the same background color and sampled identical pixels from the top through the bottom of the viewport
- `pnpm --filter @frontend test --run src/lib/config/backend-connectivity.test.ts 'src/app/auth/[path]/auth-page-with-invitation-check.test.tsx' src/app/auth/_components/backend-connectivity-status.test.tsx` (47 tests pass)
- `pnpm --filter @frontend check:commit` (passes; reports 9 pre-existing warnings in unrelated files)
- `git diff --check`

## Docs

Audited the docs and found no user-facing documentation changes needed for these UI consistency and readiness-state refinements.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>