### PR TITLE
Add MachineTranslation.com MCP server

### DIFF
--- a/mcp-catalog/data/mcp-servers.json
+++ b/mcp-catalog/data/mcp-servers.json
@@ -888,5 +888,6 @@
   "https://agenttools.wolfram.com/mcp",
   "https://mcp.notion.com/mcp",
   "https://github.com/moorcheh-ai/memanto/tree/main/integrations/mcp",
-  "https://mcp.circleci.com/v1/mcp"
+  "https://mcp.circleci.com/v1/mcp",
+  "https://github.com/Tomedes-Org/machinetranslation.com-mcp"
 ]


### PR DESCRIPTION
Adds the official MachineTranslation.com MCP server to the catalog.

Repo: https://github.com/Tomedes-Org/machinetranslation.com-mcp
Hosted endpoint: https://www.machinetranslation.com/mcp (streamable-http)
Docs: https://developer.machinetranslation.com/mcp

SMART consensus translation — runs text through 22 leading AI translation models at once and returns only the output the models agree on. Two tools: smart_translate and list_languages. Remote server, no install; auth is a browser login with a MachineTranslation.com account.