### PR TITLE
chore: enforce Agent Environment egress for background executions

### DIFF
--- a/docs/pages/platform-agent-background-execution.md
+++ b/docs/pages/platform-agent-background-execution.md
@@ -3,7 +3,7 @@ title: Background Execution
 category: Agents
 order: 7
 description: Run delegated Agent tasks in an isolated deployment
-lastUpdated: 2026-08-28
+lastUpdated: 2026-08-29
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -73,11 +73,29 @@ does not create a different resource type: it supplies a name, instructions,
 image, command, inference protocol, and credential declarations to the same
 form used by **Start from scratch**.
 
-The image field starts with the installation's default Background execution image. The Agent's [environment](/docs/platform-environments) also applies to its deployment, including network egress policy and registry access. Use a purpose-built image for the work the Agent performs. For example, a coding Agent's image can include Git, a language toolchain, and repository tooling.
+The image field starts with the installation's default Background execution image. Use a purpose-built image for the work the Agent performs. For example, a coding Agent's image can include Git, a language toolchain, and repository tooling.
 
 Leave **Command** blank to use the built-in Agent loop supplied by the default image. A custom image can override the command and arguments. Background execution images must include a POSIX shell and `tmux`, which keep the live process attachable from the Executions tab.
 
 The deployment uses the same Agent system prompt and tool access as foreground execution. Keep the Agent's instructions focused on the specialist role you want it to perform in either mode.
+
+### Environments and network egress
+
+Each execution Job uses the Agent's [Environment](/docs/platform-environments),
+including its Kubernetes namespace and network egress policy. If the Agent has
+no Environment policy override, Archestra uses the organization default policy,
+then the built-in **Allow all** policy.
+
+The policy is applied before Kubernetes creates the Job. Archestra emits the
+policy type supported by the cluster: standard Kubernetes `NetworkPolicy`,
+Cilium `CiliumNetworkPolicy`, GKE `FQDNNetworkPolicy`, or AWS
+`ApplicationNetworkPolicy`. This gives executions the same IP, domain, and
+Allow-all floor behavior as MCP server pods and code sandboxes. DNS and the
+Archestra control plane remain reachable so the execution can use the LLM
+proxy and MCP gateway.
+
+See [Network egress policies](/docs/platform-environments#network-egress-policies)
+for policy modes, provider support, and the fixed SSRF floor.
 
 ### Built-in Archestra Agent
 

--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -3,7 +3,7 @@ title: "Environments"
 category: Administration
 description: "Isolate tools, knowledge, skills, subagents, runtimes, and cost limits across deployment environments"
 order: 3
-lastUpdated: 2026-08-26
+lastUpdated: 2026-08-29
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -19,9 +19,9 @@ This document is the canonical reference for deployment Environments. Include:
   restricted to several environments or none = everywhere; MCP Apps accept
   Default tools as a shared baseline; built-in servers and built-in skills
   are exempt)
-- Network egress policies (namespace + egress policy applied to MCP server pods AND
-  agent code sandboxes), the always-on Allow all floor, provider support matrix,
-  and domain presets
+- Network egress policies (namespace + egress policy applied to MCP server pods,
+  agent code sandboxes, and Agent Background execution Jobs), the always-on
+  Allow all floor, provider support matrix, and domain presets
 - How environments scope per-environment cost limits
 - Link out to: agents, mcp gateway, knowledge connectors, costs & limits
 -->
@@ -82,11 +82,11 @@ This applies to both explicitly assigned resources and the implicit **Auto** acc
 
 ## Network egress policies
 
-An environment can define a Kubernetes **namespace** and a **network egress policy**. Both MCP server pods and agent [code sandboxes](/docs/platform-code-sandbox) for that environment run in its namespace and inherit its egress policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Block all** (`off`) denies all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Allow all** (`unrestricted`) permits egress to the public internet — pods in your cluster still get a [fixed floor](#the-allow-all-floor) of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
+An environment can define a Kubernetes **namespace** and a **network egress policy**. Self-hosted MCP server pods, agent [code sandboxes](/docs/platform-code-sandbox), and Agent [Background execution Jobs](/docs/platform-agent-background-execution#environments-and-network-egress) run in that namespace and inherit the policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Block all** (`off`) denies all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Allow all** (`unrestricted`) permits egress to the public internet — pods in your cluster still get a [fixed floor](#the-allow-all-floor) of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
 
 When a workload runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in Allow all policy (`unrestricted`).
 
-How a policy applies depends on the workload. A **self-hosted MCP server** (or agent code sandbox) runs as a pod in your cluster, so the policy is enforced continuously at the network layer — a workload that needs broad outbound access (for example one that visits arbitrary sites) fails under a restrictive policy unless its destinations are allowlisted.
+How a policy applies depends on the workload. A **self-hosted MCP server**, agent code sandbox, or Agent Background execution runs in your cluster, so the policy is enforced continuously at the network layer. Archestra selects the cluster's supported policy type before creating the workload. A workload that needs broad outbound access (for example one that visits arbitrary sites) fails under a restrictive policy unless its destinations are allowlisted.
 
 A **remote MCP server** runs outside Archestra and is reached over HTTP, so the policy cannot constrain what the server itself reaches downstream. What Archestra enforces is its own outbound connection to the server: the server's URL host is checked against the environment's policy both when the catalog entry is created or edited (the error is surfaced in the form) and at runtime on every connection. A server whose host the policy forbids is blocked — including one added before the policy was tightened — and its tool calls return an error to the client.
 

--- a/platform/backend/src/k8s/runner-runtime/manager.ts
+++ b/platform/backend/src/k8s/runner-runtime/manager.ts
@@ -1,8 +1,11 @@
 import type { Readable, Writable } from "node:stream";
 import { Readable as NodeReadable } from "node:stream";
 import type * as k8s from "@kubernetes/client-node";
+import { PatchStrategy, setHeaderOptions } from "@kubernetes/client-node";
 import type WebSocket from "ws";
 import config from "@/config";
+import { getK8sCapabilities } from "@/k8s/capabilities";
+import { clusterDnsResolver } from "@/k8s/cluster-dns";
 import { resolveRuntimeOwnerReferences } from "@/k8s/mcp-server-runtime/runtime-owner";
 import {
   createK8sClients,
@@ -30,7 +33,6 @@ import type {
   AgentRun,
 } from "@/types";
 import {
-  buildRunnerEnvironmentEgressPolicy,
   buildRunnerJob,
   buildRunnerPlatformEgressPolicy,
   buildRunnerSecret,
@@ -39,6 +41,11 @@ import {
   RUNNER_TMUX_SESSION,
 } from "./manifests";
 import { RUNNER_LEASE_SCOPE, runnerNames, runnerPodSelector } from "./naming";
+import {
+  buildRunnerEnvironmentEgressPolicies,
+  RUNNER_EGRESS_POLICY_CRDS,
+  type RunnerEgressPolicyObject,
+} from "./network-policy";
 
 /** `K8sClients` is internal to the shared module, so it is derived here. */
 type K8sClients = ReturnType<typeof createK8sClients>;
@@ -111,8 +118,16 @@ class RunnerRuntimeManager {
       { label: "create runner secret" },
     );
 
-    await this.applyNetworkPolicy(
-      buildRunnerEnvironmentEgressPolicy(withOwner),
+    const capabilities = (await getK8sCapabilities()).networkPolicy;
+    const clusterDnsIps = await clusterDnsResolver.getClusterDnsIps(
+      clients.coreApi,
+    );
+    await this.applyEgressPolicies(
+      buildRunnerEnvironmentEgressPolicies({
+        spec: withOwner,
+        capabilities,
+        clusterDnsIps,
+      }),
     );
     await this.applyNetworkPolicy(
       buildRunnerPlatformEgressPolicy({
@@ -490,6 +505,17 @@ class RunnerRuntimeManager {
             namespace,
           }),
       ],
+      ...(Object.entries(RUNNER_EGRESS_POLICY_CRDS).map(
+        ([kind, coordinates]) => [
+          `environment${kind}`,
+          () =>
+            clients.customObjectsApi.deleteNamespacedCustomObject({
+              ...coordinates,
+              name: names.environmentNetworkPolicy,
+              namespace,
+            }),
+        ],
+      ) as Array<[string, () => Promise<unknown>]>),
     ];
 
     for (const [kind, remove] of deletions) {
@@ -550,6 +576,49 @@ class RunnerRuntimeManager {
         namespace,
         body,
       });
+    }
+  }
+
+  private async applyEgressPolicies(
+    policies: RunnerEgressPolicyObject[],
+  ): Promise<void> {
+    for (const policy of policies) {
+      if (policy.kind === "NetworkPolicy") {
+        await this.applyNetworkPolicy(policy.object);
+        continue;
+      }
+      await this.applyCustomEgressPolicy(policy);
+    }
+  }
+
+  private async applyCustomEgressPolicy(
+    policy: Exclude<RunnerEgressPolicyObject, { kind: "NetworkPolicy" }>,
+  ): Promise<void> {
+    const clients = this.requireClients();
+    const metadata = policy.object.metadata as
+      | { name?: string; namespace?: string }
+      | undefined;
+    if (!metadata?.name || !metadata.namespace) {
+      throw new Error(`Runner ${policy.kind} requires a name and namespace`);
+    }
+    const coordinates = RUNNER_EGRESS_POLICY_CRDS[policy.kind];
+    try {
+      await clients.customObjectsApi.createNamespacedCustomObject({
+        ...coordinates,
+        namespace: metadata.namespace,
+        body: policy.object,
+      });
+    } catch (error) {
+      if (!isK8sConflictError(error)) throw error;
+      await clients.customObjectsApi.patchNamespacedCustomObject(
+        {
+          ...coordinates,
+          namespace: metadata.namespace,
+          name: metadata.name,
+          body: policy.object,
+        },
+        setHeaderOptions("Content-Type", PatchStrategy.MergePatch),
+      );
     }
   }
 

--- a/platform/backend/src/k8s/runner-runtime/manifests.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildRunnerEnvironmentEgressPolicy,
   buildRunnerJob,
   buildRunnerPlatformEgressPolicy,
   buildRunnerSecret,
@@ -260,46 +259,5 @@ describe("buildRunnerPlatformEgressPolicy", () => {
       expect(protocols).toContain("UDP");
       expect(protocols).toContain("TCP");
     }
-  });
-});
-
-describe("buildRunnerEnvironmentEgressPolicy", () => {
-  it("gives the built-in Environment public egress without private-network access", () => {
-    const policy = buildRunnerEnvironmentEgressPolicy(SPEC);
-    const publicRule = policy.spec?.egress?.find((rule) =>
-      rule.to?.some((target) => target.ipBlock?.cidr === "0.0.0.0/0"),
-    );
-
-    expect(policy.metadata?.name).toBe("runner-deploy-app-11111111-egress");
-    expect(policy.spec?.podSelector?.matchLabels).toEqual({
-      [RUNNER_TASK_LABEL]: SPEC.taskId,
-    });
-    expect(publicRule?.to?.[0]?.ipBlock?.except).toContain("10.0.0.0/8");
-  });
-
-  it("uses the shared restricted-policy rules for an Agent Environment", () => {
-    const policy = buildRunnerEnvironmentEgressPolicy({
-      ...SPEC,
-      effectiveNetworkPolicy: {
-        source: "environment",
-        policy: {
-          egressMode: "restricted",
-          domainPreset: "none",
-          allowedDomains: [],
-          allowedCidrs: ["203.0.113.0/24"],
-        },
-      },
-    });
-
-    expect(
-      policy.spec?.egress?.some((rule) =>
-        rule.to?.some((target) => target.ipBlock?.cidr === "203.0.113.0/24"),
-      ),
-    ).toBe(true);
-    expect(
-      policy.spec?.egress?.some((rule) =>
-        rule.to?.some((target) => target.ipBlock?.cidr === "0.0.0.0/0"),
-      ),
-    ).toBe(false);
   });
 });

--- a/platform/backend/src/k8s/runner-runtime/manifests.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.ts
@@ -1,8 +1,4 @@
 import type * as k8s from "@kubernetes/client-node";
-import {
-  buildManagedNetworkPolicy,
-  buildUnrestrictedFloorPolicy,
-} from "@/k8s/mcp-server-runtime/network-policy";
 import type { RunnerLaunchSpec } from "@/services/runners/backends";
 import {
   RUNNER_ATTACHMENTS_DIR,
@@ -311,37 +307,6 @@ export function buildRunnerPlatformEgressPolicy(params: {
  * second policy; Kubernetes unions both rule sets so a restricted execution
  * can always reach Archestra without gaining arbitrary public access.
  */
-export function buildRunnerEnvironmentEgressPolicy(
-  spec: KubernetesRunnerLaunchSpec,
-): k8s.V1NetworkPolicy {
-  const names = runnerNames(spec.frozenName);
-  const labels = runnerLabels({ taskId: spec.taskId, runnerId: spec.runnerId });
-  const podSelectorLabels = { [RUNNER_TASK_LABEL]: spec.taskId };
-  const built =
-    !spec.effectiveNetworkPolicy.policy ||
-    spec.effectiveNetworkPolicy.policy.egressMode === "unrestricted"
-      ? buildUnrestrictedFloorPolicy({
-          name: names.environmentNetworkPolicy,
-          podSelectorLabels,
-          labels,
-        })
-      : buildManagedNetworkPolicy({
-          name: names.environmentNetworkPolicy,
-          podSelectorLabels,
-          effectivePolicy: spec.effectiveNetworkPolicy,
-        });
-
-  return {
-    ...built,
-    metadata: {
-      ...built.metadata,
-      namespace: spec.namespace,
-      labels,
-      ownerReferences: spec.ownerReferences,
-    },
-  };
-}
-
 // ===================== internals =====================
 
 /**

--- a/platform/backend/src/k8s/runner-runtime/network-policy.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/network-policy.test.ts
@@ -1,0 +1,211 @@
+import type * as k8s from "@kubernetes/client-node";
+import { describe, expect, it } from "vitest";
+import type { K8sNetworkPolicyCapabilities } from "@/types";
+import type { KubernetesRunnerLaunchSpec } from "./manifests";
+import { RUNNER_TASK_LABEL } from "./naming";
+import { buildRunnerEnvironmentEgressPolicies } from "./network-policy";
+
+const SPEC: KubernetesRunnerLaunchSpec = {
+  taskId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  runnerId: "11111111-2222-3333-4444-555555555555",
+  frozenName: "runner-deploy-app-11111111",
+  namespace: "archestra-dev",
+  image: "registry.example.test/agent-archestra:latest",
+  command: null,
+  privileged: false,
+  resources: null,
+  env: {},
+  secretEnv: {},
+  activeDeadlineSeconds: 3600,
+  ephemeralStorageLimit: "10Gi",
+  imagePullSecrets: [],
+  ownerReferences: undefined,
+  effectiveNetworkPolicy: { source: "built_in", policy: null },
+  inputFileCount: 0,
+};
+
+const CAPABILITIES: K8sNetworkPolicyCapabilities = {
+  kubernetesNetworkPolicy: true,
+  ciliumNetworkPolicy: false,
+  gkeFqdnNetworkPolicy: false,
+  awsApplicationNetworkPolicy: false,
+  provider: "kubernetes",
+  supportsFqdn: false,
+  supportsHttpMethods: false,
+  message: null,
+  enforcementSource: "probe",
+  enforcementStatus: "verified-enforced",
+  probe: "enforced",
+  probedAt: "2026-08-29T00:00:00.000Z",
+};
+
+describe("buildRunnerEnvironmentEgressPolicies", () => {
+  it("gives the built-in Environment public egress without private-network access", () => {
+    const [policy] = buildRunnerEnvironmentEgressPolicies({
+      spec: SPEC,
+      capabilities: CAPABILITIES,
+      clusterDnsIps: ["10.96.0.10"],
+    });
+    expect(policy?.kind).toBe("NetworkPolicy");
+    const object = policy?.object as k8s.V1NetworkPolicy;
+    const publicRule = object.spec?.egress?.find((rule) =>
+      rule.to?.some((target) => target.ipBlock?.cidr === "0.0.0.0/0"),
+    );
+
+    expect(object.metadata?.name).toBe("runner-deploy-app-11111111-egress");
+    expect(object.metadata?.namespace).toBe("archestra-dev");
+    expect(object.spec?.podSelector?.matchLabels).toEqual({
+      [RUNNER_TASK_LABEL]: SPEC.taskId,
+    });
+    expect(publicRule?.to?.[0]?.ipBlock?.except).toContain("10.0.0.0/8");
+    expect(
+      object.spec?.egress?.some((rule) =>
+        rule.to?.some((target) => target.ipBlock?.cidr === "10.96.0.10/32"),
+      ),
+    ).toBe(true);
+  });
+
+  it("uses Cilium for a domain allowlist when the cluster supports it", () => {
+    const policies = buildRunnerEnvironmentEgressPolicies({
+      spec: restrictedSpec(),
+      capabilities: {
+        ...CAPABILITIES,
+        ciliumNetworkPolicy: true,
+        provider: "cilium",
+        supportsFqdn: true,
+      },
+    });
+
+    expect(policies.map((policy) => policy.kind)).toEqual([
+      "CiliumNetworkPolicy",
+    ]);
+    expect(policies[0]?.object).toMatchObject({
+      metadata: { namespace: "archestra-dev" },
+      spec: {
+        endpointSelector: {
+          matchLabels: { [RUNNER_TASK_LABEL]: SPEC.taskId },
+        },
+        egress: expect.arrayContaining([
+          { toFQDNs: [{ matchName: "api.example.test" }] },
+        ]),
+      },
+    });
+  });
+
+  it("combines GKE FQDN and standard CIDR policies", () => {
+    const policies = buildRunnerEnvironmentEgressPolicies({
+      spec: restrictedSpec(),
+      capabilities: {
+        ...CAPABILITIES,
+        gkeFqdnNetworkPolicy: true,
+        provider: "gke-fqdn",
+        supportsFqdn: true,
+      },
+    });
+
+    expect(policies.map((policy) => policy.kind)).toEqual([
+      "FQDNNetworkPolicy",
+      "NetworkPolicy",
+    ]);
+    expect(policies[0]?.object).toMatchObject({
+      spec: { egress: [{ matches: [{ name: "api.example.test" }] }] },
+    });
+    const standard = policies[1]?.object as k8s.V1NetworkPolicy;
+    expect(
+      standard.spec?.egress?.some((rule) =>
+        rule.to?.some((target) => target.ipBlock?.cidr === "203.0.113.0/24"),
+      ),
+    ).toBe(true);
+  });
+
+  it("uses AWS ApplicationNetworkPolicy for restricted, blocked, and built-in egress", () => {
+    const capabilities: K8sNetworkPolicyCapabilities = {
+      ...CAPABILITIES,
+      awsApplicationNetworkPolicy: true,
+      provider: "aws-application-network-policy",
+      supportsFqdn: true,
+      enforcementSource: "api-discovery",
+      enforcementStatus: "unknown",
+      probe: "absent",
+    };
+
+    const restricted = buildRunnerEnvironmentEgressPolicies({
+      spec: restrictedSpec(),
+      capabilities,
+      clusterDnsIps: ["172.20.0.10"],
+    });
+    const builtIn = buildRunnerEnvironmentEgressPolicies({
+      spec: SPEC,
+      capabilities,
+      clusterDnsIps: ["172.20.0.10"],
+    });
+    const blocked = buildRunnerEnvironmentEgressPolicies({
+      spec: {
+        ...SPEC,
+        effectiveNetworkPolicy: {
+          source: "environment",
+          policy: {
+            egressMode: "off",
+            domainPreset: "none",
+            allowedDomains: [],
+            allowedCidrs: [],
+          },
+        },
+      },
+      capabilities,
+      clusterDnsIps: ["172.20.0.10"],
+    });
+
+    expect(restricted.map((policy) => policy.kind)).toEqual([
+      "ApplicationNetworkPolicy",
+    ]);
+    expect(restricted[0]?.object).toMatchObject({
+      metadata: {
+        annotations: {
+          "archestra.io/network-policy-cluster-dns": "172.20.0.10",
+        },
+      },
+      spec: {
+        egress: expect.arrayContaining([
+          { to: [{ domainNames: ["api.example.test"] }] },
+        ]),
+      },
+    });
+    expect(builtIn.map((policy) => policy.kind)).toEqual([
+      "ApplicationNetworkPolicy",
+    ]);
+    expect(blocked.map((policy) => policy.kind)).toEqual([
+      "ApplicationNetworkPolicy",
+    ]);
+    expect(blocked[0]?.object).toMatchObject({ spec: { egress: [] } });
+  });
+
+  it("falls back to a standard CIDR policy without an FQDN provider", () => {
+    const policies = buildRunnerEnvironmentEgressPolicies({
+      spec: restrictedSpec(),
+      capabilities: CAPABILITIES,
+    });
+
+    expect(policies.map((policy) => policy.kind)).toEqual(["NetworkPolicy"]);
+    expect(
+      (policies[0]?.object as k8s.V1NetworkPolicy).metadata?.annotations?.[
+        "archestra.io/network-policy-domain-enforcement"
+      ],
+    ).toBe("requires-fqdn-policy-provider");
+  });
+});
+
+function restrictedSpec(): KubernetesRunnerLaunchSpec {
+  return {
+    ...SPEC,
+    effectiveNetworkPolicy: {
+      source: "environment",
+      policy: {
+        egressMode: "restricted",
+        domainPreset: "none",
+        allowedDomains: ["api.example.test"],
+        allowedCidrs: ["203.0.113.0/24"],
+      },
+    },
+  };
+}

--- a/platform/backend/src/k8s/runner-runtime/network-policy.ts
+++ b/platform/backend/src/k8s/runner-runtime/network-policy.ts
@@ -1,0 +1,206 @@
+import type * as k8s from "@kubernetes/client-node";
+import {
+  buildManagedAwsApplicationNetworkPolicy,
+  buildManagedCiliumNetworkPolicy,
+  buildManagedGkeFqdnNetworkPolicy,
+  buildManagedNetworkPolicy,
+  buildUnrestrictedFloorAwsApplicationNetworkPolicy,
+  buildUnrestrictedFloorPolicy,
+  isAwsApplicationNetworkPolicyProvider,
+  shouldUseAwsApplicationNetworkPolicy,
+  shouldUseCiliumNetworkPolicy,
+  shouldUseGkeFqdnNetworkPolicy,
+} from "@/k8s/mcp-server-runtime/network-policy";
+import type { K8sNetworkPolicyCapabilities } from "@/types";
+import type { KubernetesRunnerLaunchSpec } from "./manifests";
+import { RUNNER_TASK_LABEL, runnerLabels, runnerNames } from "./naming";
+
+/** A provider-specific Environment egress policy ready for the Kubernetes API. */
+export type RunnerEgressPolicyObject =
+  | { kind: "NetworkPolicy"; object: k8s.V1NetworkPolicy }
+  | {
+      kind:
+        | "CiliumNetworkPolicy"
+        | "FQDNNetworkPolicy"
+        | "ApplicationNetworkPolicy";
+      object: Record<string, unknown>;
+    };
+
+export const RUNNER_EGRESS_POLICY_CRDS = {
+  CiliumNetworkPolicy: {
+    group: "cilium.io",
+    version: "v2",
+    plural: "ciliumnetworkpolicies",
+  },
+  FQDNNetworkPolicy: {
+    group: "networking.gke.io",
+    version: "v1alpha1",
+    plural: "fqdnnetworkpolicies",
+  },
+  ApplicationNetworkPolicy: {
+    group: "networking.k8s.aws",
+    version: "v1alpha1",
+    plural: "applicationnetworkpolicies",
+  },
+} as const;
+
+/**
+ * Apply the Agent Environment's effective egress policy to one execution.
+ *
+ * Provider selection deliberately matches the MCP and Dagger runtimes:
+ * Cilium, then GKE FQDN, then AWS ApplicationNetworkPolicy, then the standard
+ * Kubernetes policy. The GKE path also emits a standard policy for CIDRs.
+ */
+export function buildRunnerEnvironmentEgressPolicies(params: {
+  spec: KubernetesRunnerLaunchSpec;
+  capabilities?: K8sNetworkPolicyCapabilities | null;
+  clusterDnsIps?: string[];
+}): RunnerEgressPolicyObject[] {
+  const { spec, capabilities } = params;
+  const clusterDnsIps = params.clusterDnsIps ?? [];
+  const names = runnerNames(spec.frozenName);
+  const podSelectorLabels = { [RUNNER_TASK_LABEL]: spec.taskId };
+  const metadata = {
+    namespace: spec.namespace,
+    labels: runnerLabels({ taskId: spec.taskId, runnerId: spec.runnerId }),
+    ownerReferences: spec.ownerReferences,
+  };
+
+  if (
+    !spec.effectiveNetworkPolicy.policy ||
+    spec.effectiveNetworkPolicy.policy.egressMode === "unrestricted"
+  ) {
+    const object = isAwsApplicationNetworkPolicyProvider(capabilities)
+      ? buildUnrestrictedFloorAwsApplicationNetworkPolicy({
+          name: names.environmentNetworkPolicy,
+          podSelectorLabels,
+          labels: metadata.labels,
+          clusterDnsIps,
+        })
+      : buildUnrestrictedFloorPolicy({
+          name: names.environmentNetworkPolicy,
+          podSelectorLabels,
+          labels: metadata.labels,
+          clusterDnsIps,
+        });
+    return [
+      withRunnerMetadata({
+        kind: isAwsApplicationNetworkPolicyProvider(capabilities)
+          ? "ApplicationNetworkPolicy"
+          : "NetworkPolicy",
+        object,
+        metadata,
+      }),
+    ];
+  }
+
+  if (
+    shouldUseCiliumNetworkPolicy({
+      effectivePolicy: spec.effectiveNetworkPolicy,
+      capabilities,
+    })
+  ) {
+    return [
+      withRunnerMetadata({
+        kind: "CiliumNetworkPolicy",
+        object: buildManagedCiliumNetworkPolicy({
+          name: names.environmentNetworkPolicy,
+          podSelectorLabels,
+          effectivePolicy: spec.effectiveNetworkPolicy,
+        }),
+        metadata,
+      }),
+    ];
+  }
+
+  if (
+    shouldUseGkeFqdnNetworkPolicy({
+      effectivePolicy: spec.effectiveNetworkPolicy,
+      capabilities,
+    })
+  ) {
+    return [
+      withRunnerMetadata({
+        kind: "FQDNNetworkPolicy",
+        object: buildManagedGkeFqdnNetworkPolicy({
+          name: names.environmentNetworkPolicy,
+          podSelectorLabels,
+          effectivePolicy: spec.effectiveNetworkPolicy,
+        }),
+        metadata,
+      }),
+      withRunnerMetadata({
+        kind: "NetworkPolicy",
+        object: buildManagedNetworkPolicy({
+          name: names.environmentNetworkPolicy,
+          podSelectorLabels,
+          effectivePolicy: spec.effectiveNetworkPolicy,
+        }),
+        metadata,
+      }),
+    ];
+  }
+
+  if (
+    shouldUseAwsApplicationNetworkPolicy({
+      effectivePolicy: spec.effectiveNetworkPolicy,
+      capabilities,
+    })
+  ) {
+    return [
+      withRunnerMetadata({
+        kind: "ApplicationNetworkPolicy",
+        object: buildManagedAwsApplicationNetworkPolicy({
+          name: names.environmentNetworkPolicy,
+          podSelectorLabels,
+          effectivePolicy: spec.effectiveNetworkPolicy,
+          clusterDnsIps,
+        }),
+        metadata,
+      }),
+    ];
+  }
+
+  return [
+    withRunnerMetadata({
+      kind: "NetworkPolicy",
+      object: buildManagedNetworkPolicy({
+        name: names.environmentNetworkPolicy,
+        podSelectorLabels,
+        effectivePolicy: spec.effectiveNetworkPolicy,
+      }),
+      metadata,
+    }),
+  ];
+}
+
+// === Internal helpers ===
+
+function withRunnerMetadata(params: {
+  kind: RunnerEgressPolicyObject["kind"];
+  object: k8s.V1NetworkPolicy | Record<string, unknown>;
+  metadata: {
+    namespace: string;
+    labels: Record<string, string>;
+    ownerReferences: k8s.V1OwnerReference[] | undefined;
+  };
+}): RunnerEgressPolicyObject {
+  const existingMetadata = (params.object.metadata ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const object = {
+    ...params.object,
+    metadata: {
+      ...existingMetadata,
+      namespace: params.metadata.namespace,
+      labels: params.metadata.labels,
+      ...(params.metadata.ownerReferences
+        ? { ownerReferences: params.metadata.ownerReferences }
+        : {}),
+    },
+  };
+  return params.kind === "NetworkPolicy"
+    ? { kind: params.kind, object: object as k8s.V1NetworkPolicy }
+    : { kind: params.kind, object };
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -68,11 +68,11 @@ import { EnvironmentResourceDefaultsDialog } from "./environment-resource-defaul
 import { compileValidationRegex } from "./environment-validation-helpers";
 
 const NETWORK_POLICY_DOCS_URL = getDocsUrl(
-  DocsPage.PlatformPrivateRegistry,
+  DocsPage.PlatformEnvironments,
   "network-egress-policies",
 );
 const DOMAIN_PRESETS_DOCS_URL = getDocsUrl(
-  DocsPage.PlatformPrivateRegistry,
+  DocsPage.PlatformEnvironments,
   "domain-presets",
 );
 
@@ -916,7 +916,7 @@ function EnvironmentEditorDialog({
           <div className="space-y-1">
             <h3 className="font-medium text-sm">Network Egress Policy</h3>
             <p className="text-xs text-muted-foreground">
-              Configure outbound network access for MCP workloads in this
+              Configure outbound network access for workloads in this
               environment.{" "}
               <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
                 View docs


### PR DESCRIPTION
## Summary

Background execution Jobs now inherit the effective network egress policy of the Agent Environment instead of reducing every policy to a plain Kubernetes NetworkPolicy. Resolution remains Environment override, then organization default, then the built-in Allow all policy.

## How it works

- The execution backend inspects cluster network-policy capabilities before creating a Job.
- Domain and CIDR rules use the same provider precedence and policy builders as MCP and sandbox runtimes: Cilium, GKE FQDN plus standard CIDR policy, AWS ApplicationNetworkPolicy, then standard Kubernetes NetworkPolicy.
- The built-in and explicit Allow all modes retain the fixed private, link-local, metadata, loopback, CGNAT, and IPv6 egress floor. EKS Auto Mode receives the equivalent ApplicationNetworkPolicy floor.
- Cluster DNS addresses are resolved for policies that require explicit DNS bootstrap rules.
- Environment policy objects are created before the Job. The existing platform policy remains separate so the LLM proxy and MCP gateway stay reachable without opening unrelated egress.
- Teardown removes standard and provider-specific policy objects.
- Environment settings copy and documentation now describe Agent Background execution Jobs and link to the canonical Environment policy reference.

## Test

Verified policy selection and generated rules for standard Kubernetes, Cilium, GKE, and AWS providers, including restricted, blocked, and Allow all modes. Verified type safety, dependency boundaries, migration consistency, and the Environment settings flow.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>