### PR TITLE
fix(frontend): give settings table actions a 16px outer inset

### DIFF
--- a/platform/frontend/src/app/settings/oauth-clients/page.tsx
+++ b/platform/frontend/src/app/settings/oauth-clients/page.tsx
@@ -298,7 +298,9 @@ function OauthClientsTable() {
     {
       id: "actions",
       header: "Actions",
-      size: 100,
+      // Three icon-sm buttons with the table's px-4 inset on both sides, so
+      // the last icon sits 16px from the frame like every other cell edge.
+      size: 128,
       cell: ({ row }) => {
         const isLlm = row.original.kind === "llm";
         const resource = isLlm ? "llmOauthClient" : "mcpOauthClient";

--- a/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
@@ -303,7 +303,7 @@ export default function ServiceAccountDetailPage({
             {
               id: "actions",
               header: "Actions",
-              size: 84,
+              size: 96,
               cell: ({ row }) => (
                 <TableRowActions
                   itemName={row.original.name}

--- a/platform/frontend/src/app/settings/service-accounts/page.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/page.tsx
@@ -232,7 +232,7 @@ export default function ServiceAccountsSettingsPage() {
   // `DataTable` sets the table's `minWidth` to the sum of these sizes, so the
   // sum has to fit the settings shell's content column (~718px at 1200px wide)
   // or trailing columns disappear behind a horizontal scroll. These add up to
-  // 698 including the 56px select column, and each is wide enough for its own
+  // 710 including the 56px select column, and each is wide enough for its own
   // header to sit on one line.
   const columns: ColumnDef<ServiceAccount>[] = useMemo(() => {
     const baseColumns: ColumnDef<ServiceAccount>[] = [
@@ -298,7 +298,9 @@ export default function ServiceAccountsSettingsPage() {
       {
         id: "actions",
         header: "Actions",
-        size: 84,
+        // Two icon-sm buttons with the table's px-4 inset on both sides, so
+        // the last icon sits 16px from the frame like every other cell edge.
+        size: 96,
         cell: ({ row }) => renderRowActions(row.original),
       },
     ];


### PR DESCRIPTION
## Summary

The OAuth Clients actions column was too narrow for three icon-sm buttons, so the last icon crossed the table divider. Widen it, and the matching Service Accounts actions columns, so the last icon sits 16px from the frame — the same `px-4` inset every other cell edge uses.

- OAuth Clients: 3 buttons → `size: 128`
- Service Accounts list and token table: 2 buttons → `size: 96`

T-1238

## Verification

- measured both tables live: 16px left and 16px last-icon-to-frame, no overflow
- `biome check` on the three changed files
- `vitest run` oauth-clients page + data-table (12 passed)

## Docs

No user-facing docs change; column width only.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>