### PR TITLE
fix(frontend): share collection filter spacing and contain limits usage

### DIFF
--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -47,7 +47,11 @@ import {
   resolveDefaultAgentBadge,
 } from "@/components/default-agent-tag";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
-import { FilterBar, filterSearchClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { ImportAgentDialog } from "@/components/import-agent-dialog";
 import { PageLayout } from "@/components/page-layout";
 import { PERMANENT_DELETE_LABEL } from "@/components/permanent-delete";
@@ -617,7 +621,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
       <TableCardView storageKey="archestra-agents-view">
         <div>
           <div>
-            <div className="mb-3 flex flex-col gap-2">
+            <CollectionFilters>
               <FilterBar
                 leading
                 actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
@@ -646,7 +650,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
                 />
               )}
               <ActiveFilterBadges adminPermission={{ agent: ["admin"] }} />
-            </div>
+            </CollectionFilters>
 
             <BulkActions
               count={selectedAgents.length}

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -8,6 +8,7 @@ import { BulkVisibilityDialog } from "@/components/bulk-visibility-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -182,50 +183,49 @@ export default function AppsPage() {
       }
     >
       <TableCardView storageKey="archestra-apps-view">
-        <FilterBar leading className="mb-3" actions={<TableCardViewToggle />}>
-          <SearchInput
-            isLoading={isFetching}
-            paramName="search"
-            placeholder="Search apps"
-            className={filterSearchClass}
-          />
-          <Select
-            value={kind}
-            onValueChange={(value) =>
-              setParam("kind", value === "all" ? null : value)
-            }
-          >
-            <SelectTrigger
-              size="sm"
-              aria-label="Filter by kind"
-              className={filterControlClass({ active: kind !== "all" })}
+        <CollectionFilters>
+          <FilterBar leading actions={<TableCardViewToggle />}>
+            <SearchInput
+              isLoading={isFetching}
+              paramName="search"
+              placeholder="Search apps"
+              className={filterSearchClass}
+            />
+            <Select
+              value={kind}
+              onValueChange={(value) =>
+                setParam("kind", value === "all" ? null : value)
+              }
             >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent position="popper" side="bottom" align="start">
-              <SelectItem value="all">All kinds</SelectItem>
-              <SelectItem value="owned">Apps</SelectItem>
-              <SelectItem value="external">MCP Server Apps</SelectItem>
-            </SelectContent>
-          </Select>
-          <ResourceScopeFilter
-            ownerLabelPlural="apps"
-            allLabel="All apps"
-            adminPermission={{ app: ["admin"] }}
-            showTeamSelect={false}
-          />
-          <LabelSelect
-            labelKeys={labelKeys}
-            LabelKeyRowComponent={AppLabelKeyRow}
-            className={filterControlClass({ active: Boolean(parsedLabels) })}
-          />
-        </FilterBar>
-
-        {parsedLabels && (
-          <div className="mb-3">
+              <SelectTrigger
+                size="sm"
+                aria-label="Filter by kind"
+                className={filterControlClass({ active: kind !== "all" })}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent position="popper" side="bottom" align="start">
+                <SelectItem value="all">All kinds</SelectItem>
+                <SelectItem value="owned">Apps</SelectItem>
+                <SelectItem value="external">MCP Server Apps</SelectItem>
+              </SelectContent>
+            </Select>
+            <ResourceScopeFilter
+              ownerLabelPlural="apps"
+              allLabel="All apps"
+              adminPermission={{ app: ["admin"] }}
+              showTeamSelect={false}
+            />
+            <LabelSelect
+              labelKeys={labelKeys}
+              LabelKeyRowComponent={AppLabelKeyRow}
+              className={filterControlClass({ active: Boolean(parsedLabels) })}
+            />
+          </FilterBar>
+          {parsedLabels && (
             <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
-          </div>
-        )}
+          )}
+        </CollectionFilters>
 
         <LoadingWrapper
           isPending={(isPending || isFetching) && filtered.length === 0}

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, ChevronUp, User } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 import {
+  CollectionFilters,
   FilterBar,
   FilterSelect,
   filterControlClass,
@@ -564,119 +565,123 @@ export function AuditLogTable() {
   }
 
   return (
-    <div className="space-y-3">
-      <FilterBar
-        leading
-        onClearFilters={hasFilters ? clearFilters : undefined}
-        // Action, outcome and the date range are what people reach for on this
-        // trail day to day; the four identity/resource pickers only matter once
-        // you are chasing a specific thing, so they start tucked away.
-        moreFilters={[
-          {
-            key: "actorType",
-            label: "Actor type",
-            active: !!actorType,
-            control: (
-              <FilterSelect
-                value={actorType ?? ALL_VALUE}
-                onValueChange={handleActorTypeChange}
-                placeholder="Filter by actor type"
-                items={actorTypeOptions}
-                inactiveValue={ALL_VALUE}
-              />
-            ),
-          },
-          {
-            key: "resourceType",
-            label: "Resource type",
-            active: !!resourceType,
-            control: (
-              <FilterSelect
-                value={resourceType ?? ALL_VALUE}
-                onValueChange={handleResourceChange}
-                placeholder="Filter by resource type"
-                items={resourceOptions}
-                inactiveValue={ALL_VALUE}
-              />
-            ),
-          },
-          {
-            key: "resourceId",
-            label: "Resource",
-            active: !!resourceId,
-            control: (
-              <FilterSelect
-                value={resourceId ?? ALL_VALUE}
-                onValueChange={handleEntityChange}
-                placeholder="Filter by resource"
-                items={entityOptions}
-                inactiveValue={ALL_VALUE}
-              />
-            ),
-          },
-          // Without auditLog:admin the server scopes the trail to the caller's
-          // own actions, so an actor filter would be pointless.
-          ...(canSeeAllAuditLogs
-            ? [
-                {
-                  key: "actorId",
-                  label: "Actor",
-                  active: !!actorId,
-                  control: (
-                    <FilterSelect
-                      value={actorId ?? ALL_VALUE}
-                      onValueChange={handleActorChange}
-                      placeholder="Filter by actor"
-                      items={memberOptions}
-                      pinnedItems={[{ value: ALL_VALUE, label: "All actors" }]}
-                      onSearchQueryChange={onActorSearchChange}
-                      emptyMessage={actorEmptyMessage}
-                      inactiveValue={ALL_VALUE}
-                    />
-                  ),
-                },
-              ]
-            : []),
-        ]}
-      >
-        <SearchInput
-          isLoading={isFetching}
-          objectNamePlural="audit events"
-          searchFields={["actor", "path", "resource"]}
-          paramName="search"
-          className={filterSearchClass}
-        />
-        <FilterSelect
-          value={action ?? ALL_VALUE}
-          onValueChange={handleActionChange}
-          placeholder="Filter by action"
-          items={actionOptions}
-          inactiveValue={ALL_VALUE}
-        />
-        <FilterSelect
-          value={outcome ?? ALL_VALUE}
-          onValueChange={handleOutcomeChange}
-          placeholder="Filter by outcome"
-          items={outcomeOptions}
-          inactiveValue={ALL_VALUE}
-        />
-        <DateTimeRangePicker
-          startDate={dateTimePicker.startDate}
-          endDate={dateTimePicker.endDate}
-          isDialogOpen={dateTimePicker.isDateDialogOpen}
-          tempStartDate={dateTimePicker.tempStartDate}
-          tempEndDate={dateTimePicker.tempEndDate}
-          displayText={dateTimePicker.getDateRangeDisplay()}
-          onDialogOpenChange={dateTimePicker.setIsDateDialogOpen}
-          onTempStartDateChange={dateTimePicker.setTempStartDate}
-          onTempEndDateChange={dateTimePicker.setTempEndDate}
-          onOpenDialog={dateTimePicker.openDateDialog}
-          onApply={dateTimePicker.handleApplyDateRange}
-          className={filterControlClass({
-            active: dateTimePicker.startDate !== undefined,
-          })}
-        />
-      </FilterBar>
+    <div>
+      <CollectionFilters>
+        <FilterBar
+          leading
+          onClearFilters={hasFilters ? clearFilters : undefined}
+          // Action, outcome and the date range are what people reach for on this
+          // trail day to day; the four identity/resource pickers only matter once
+          // you are chasing a specific thing, so they start tucked away.
+          moreFilters={[
+            {
+              key: "actorType",
+              label: "Actor type",
+              active: !!actorType,
+              control: (
+                <FilterSelect
+                  value={actorType ?? ALL_VALUE}
+                  onValueChange={handleActorTypeChange}
+                  placeholder="Filter by actor type"
+                  items={actorTypeOptions}
+                  inactiveValue={ALL_VALUE}
+                />
+              ),
+            },
+            {
+              key: "resourceType",
+              label: "Resource type",
+              active: !!resourceType,
+              control: (
+                <FilterSelect
+                  value={resourceType ?? ALL_VALUE}
+                  onValueChange={handleResourceChange}
+                  placeholder="Filter by resource type"
+                  items={resourceOptions}
+                  inactiveValue={ALL_VALUE}
+                />
+              ),
+            },
+            {
+              key: "resourceId",
+              label: "Resource",
+              active: !!resourceId,
+              control: (
+                <FilterSelect
+                  value={resourceId ?? ALL_VALUE}
+                  onValueChange={handleEntityChange}
+                  placeholder="Filter by resource"
+                  items={entityOptions}
+                  inactiveValue={ALL_VALUE}
+                />
+              ),
+            },
+            // Without auditLog:admin the server scopes the trail to the caller's
+            // own actions, so an actor filter would be pointless.
+            ...(canSeeAllAuditLogs
+              ? [
+                  {
+                    key: "actorId",
+                    label: "Actor",
+                    active: !!actorId,
+                    control: (
+                      <FilterSelect
+                        value={actorId ?? ALL_VALUE}
+                        onValueChange={handleActorChange}
+                        placeholder="Filter by actor"
+                        items={memberOptions}
+                        pinnedItems={[
+                          { value: ALL_VALUE, label: "All actors" },
+                        ]}
+                        onSearchQueryChange={onActorSearchChange}
+                        emptyMessage={actorEmptyMessage}
+                        inactiveValue={ALL_VALUE}
+                      />
+                    ),
+                  },
+                ]
+              : []),
+          ]}
+        >
+          <SearchInput
+            isLoading={isFetching}
+            objectNamePlural="audit events"
+            searchFields={["actor", "path", "resource"]}
+            paramName="search"
+            className={filterSearchClass}
+          />
+          <FilterSelect
+            value={action ?? ALL_VALUE}
+            onValueChange={handleActionChange}
+            placeholder="Filter by action"
+            items={actionOptions}
+            inactiveValue={ALL_VALUE}
+          />
+          <FilterSelect
+            value={outcome ?? ALL_VALUE}
+            onValueChange={handleOutcomeChange}
+            placeholder="Filter by outcome"
+            items={outcomeOptions}
+            inactiveValue={ALL_VALUE}
+          />
+          <DateTimeRangePicker
+            startDate={dateTimePicker.startDate}
+            endDate={dateTimePicker.endDate}
+            isDialogOpen={dateTimePicker.isDateDialogOpen}
+            tempStartDate={dateTimePicker.tempStartDate}
+            tempEndDate={dateTimePicker.tempEndDate}
+            displayText={dateTimePicker.getDateRangeDisplay()}
+            onDialogOpenChange={dateTimePicker.setIsDateDialogOpen}
+            onTempStartDateChange={dateTimePicker.setTempStartDate}
+            onTempEndDateChange={dateTimePicker.setTempEndDate}
+            onOpenDialog={dateTimePicker.openDateDialog}
+            onApply={dateTimePicker.handleApplyDateRange}
+            className={filterControlClass({
+              active: dateTimePicker.startDate !== undefined,
+            })}
+          />
+        </FilterBar>
+      </CollectionFilters>
 
       <DataTable<AuditLogRow, unknown>
         columns={columns}

--- a/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
@@ -45,7 +45,11 @@ import { EditConnectorDialog } from "@/app/knowledge/knowledge-bases/_parts/edit
 import { BackLink } from "@/components/agent-pages/agent-page-shell";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { type DetailFact, DetailFacts } from "@/components/detail-facts";
-import { FilterBar, filterControlClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterControlClass,
+} from "@/components/filter-bar";
 import { FormDialog } from "@/components/form-dialog";
 import { LoadingState, LoadingWrapper } from "@/components/loading";
 import { PageLayout } from "@/components/page-layout";
@@ -740,84 +744,86 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
           />
         ) : (
           <div>
-            <FilterBar className="mb-3">
-              {isAutoSync && (
+            <CollectionFilters>
+              <FilterBar>
+                {isAutoSync && (
+                  <Select
+                    value={runTypeFilter}
+                    onValueChange={(value) => {
+                      setRunTypeFilter(value as typeof runTypeFilter);
+                      setPageIndex(0);
+                    }}
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      className={filterControlClass({
+                        active: runTypeFilter !== "all",
+                      })}
+                      aria-label="Filter runs"
+                    >
+                      <SelectValue placeholder="All runs" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All runs</SelectItem>
+                      <SelectItem value="content">Documents</SelectItem>
+                      <SelectItem value="permission">Permissions</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
                 <Select
-                  value={runTypeFilter}
+                  value={runStatusFilter}
                   onValueChange={(value) => {
-                    setRunTypeFilter(value as typeof runTypeFilter);
+                    setRunStatusFilter(value as typeof runStatusFilter);
                     setPageIndex(0);
                   }}
                 >
                   <SelectTrigger
                     size="sm"
                     className={filterControlClass({
-                      active: runTypeFilter !== "all",
+                      active: runStatusFilter !== "all",
                     })}
-                    aria-label="Filter runs"
+                    aria-label="Filter by status"
                   >
-                    <SelectValue placeholder="All runs" />
+                    <SelectValue placeholder="All statuses" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">All runs</SelectItem>
-                    <SelectItem value="content">Documents</SelectItem>
-                    <SelectItem value="permission">Permissions</SelectItem>
+                    <SelectItem value="all">All statuses</SelectItem>
+                    <SelectItem value="running">Running</SelectItem>
+                    <SelectItem value="success">Success</SelectItem>
+                    <SelectItem value="completed_with_errors">
+                      Completed with errors
+                    </SelectItem>
+                    <SelectItem value="no_documents">No documents</SelectItem>
+                    <SelectItem value="failed">Failed</SelectItem>
+                    <SelectItem value="partial">Partial</SelectItem>
+                    <SelectItem value="cancelled">Cancelled</SelectItem>
+                    <SelectItem value="superseded">Superseded</SelectItem>
                   </SelectContent>
                 </Select>
-              )}
-              <Select
-                value={runStatusFilter}
-                onValueChange={(value) => {
-                  setRunStatusFilter(value as typeof runStatusFilter);
-                  setPageIndex(0);
-                }}
-              >
-                <SelectTrigger
-                  size="sm"
-                  className={filterControlClass({
-                    active: runStatusFilter !== "all",
-                  })}
-                  aria-label="Filter by status"
+                <Select
+                  value={runResultFilter}
+                  onValueChange={(value) => {
+                    setRunResultFilter(value as typeof runResultFilter);
+                    setPageIndex(0);
+                  }}
                 >
-                  <SelectValue placeholder="All statuses" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All statuses</SelectItem>
-                  <SelectItem value="running">Running</SelectItem>
-                  <SelectItem value="success">Success</SelectItem>
-                  <SelectItem value="completed_with_errors">
-                    Completed with errors
-                  </SelectItem>
-                  <SelectItem value="no_documents">No documents</SelectItem>
-                  <SelectItem value="failed">Failed</SelectItem>
-                  <SelectItem value="partial">Partial</SelectItem>
-                  <SelectItem value="cancelled">Cancelled</SelectItem>
-                  <SelectItem value="superseded">Superseded</SelectItem>
-                </SelectContent>
-              </Select>
-              <Select
-                value={runResultFilter}
-                onValueChange={(value) => {
-                  setRunResultFilter(value as typeof runResultFilter);
-                  setPageIndex(0);
-                }}
-              >
-                <SelectTrigger
-                  size="sm"
-                  className={filterControlClass({
-                    active: runResultFilter !== "all",
-                  })}
-                  aria-label="Filter by result"
-                >
-                  <SelectValue placeholder="All results" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All results</SelectItem>
-                  <SelectItem value="changes">With changes</SelectItem>
-                  <SelectItem value="no-changes">No changes</SelectItem>
-                </SelectContent>
-              </Select>
-            </FilterBar>
+                  <SelectTrigger
+                    size="sm"
+                    className={filterControlClass({
+                      active: runResultFilter !== "all",
+                    })}
+                    aria-label="Filter by result"
+                  >
+                    <SelectValue placeholder="All results" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All results</SelectItem>
+                    <SelectItem value="changes">With changes</SelectItem>
+                    <SelectItem value="no-changes">No changes</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FilterBar>
+            </CollectionFilters>
             <LoadingWrapper
               isPending={
                 (isRunsPending || isRunsFetching) && runRows.length === 0

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
@@ -7,6 +7,7 @@ import { useCallback, useMemo, useState } from "react";
 import { AclBadges } from "@/app/knowledge/connectors/_parts/acl-badges";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -281,49 +282,51 @@ export function ConnectorDocumentsTable({
   );
 
   return (
-    <BulkActionsScope className="space-y-3">
-      <FilterBar>
-        <SearchInput
-          isLoading={isFetching}
-          value={search}
-          syncQueryParams={false}
-          placeholder="Search documents by title"
-          className={filterSearchClass}
-          onSearchChange={(nextValue) =>
-            updateQueryParams({
-              search: nextValue || null,
-              page: "1",
-            })
-          }
-        />
-        {showGroupFilter && (
-          <Select
-            value={group || "all"}
-            onValueChange={(value) =>
+    <BulkActionsScope>
+      <CollectionFilters>
+        <FilterBar>
+          <SearchInput
+            isLoading={isFetching}
+            value={search}
+            syncQueryParams={false}
+            placeholder="Search documents by title"
+            className={filterSearchClass}
+            onSearchChange={(nextValue) =>
               updateQueryParams({
-                group: value === "all" ? null : value,
+                search: nextValue || null,
                 page: "1",
               })
             }
-          >
-            <SelectTrigger
-              size="sm"
-              className={filterControlClass({ active: Boolean(group) })}
-              aria-label={`Filter by ${noun.singular}`}
+          />
+          {showGroupFilter && (
+            <Select
+              value={group || "all"}
+              onValueChange={(value) =>
+                updateQueryParams({
+                  group: value === "all" ? null : value,
+                  page: "1",
+                })
+              }
             >
-              <SelectValue placeholder={`All ${noun.plural}`} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{`All ${noun.plural}`}</SelectItem>
-              {groupOptions.map(({ groupId, label }) => (
-                <SelectItem key={groupId} value={groupId}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-      </FilterBar>
+              <SelectTrigger
+                size="sm"
+                className={filterControlClass({ active: Boolean(group) })}
+                aria-label={`Filter by ${noun.singular}`}
+              >
+                <SelectValue placeholder={`All ${noun.plural}`} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{`All ${noun.plural}`}</SelectItem>
+                {groupOptions.map(({ groupId, label }) => (
+                  <SelectItem key={groupId} value={groupId}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </FilterBar>
+      </CollectionFilters>
 
       <BulkActions
         count={selectedCount}

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-members-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-members-table.tsx
@@ -8,6 +8,7 @@ import { UserCog } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -300,50 +301,56 @@ export function ConnectorMembersTable({
   return (
     <div>
       {members.length > 0 && (
-        <FilterBar className="mb-3">
-          <SearchInput
-            value={search}
-            syncQueryParams={false}
-            placeholder={`Search by ID, email, name, or ${noun.singular}`}
-            className={filterSearchClass}
-            onSearchChange={setSearch}
-          />
-          <Select
-            value={filter}
-            onValueChange={(value) => setFilter(value as MemberFilter)}
-          >
-            <SelectTrigger
-              size="sm"
-              className={filterControlClass({ active: filter !== "all" })}
-              aria-label="Filter users"
+        <CollectionFilters>
+          <FilterBar>
+            <SearchInput
+              value={search}
+              syncQueryParams={false}
+              placeholder={`Search by ID, email, name, or ${noun.singular}`}
+              className={filterSearchClass}
+              onSearchChange={setSearch}
+            />
+            <Select
+              value={filter}
+              onValueChange={(value) => setFilter(value as MemberFilter)}
             >
-              <SelectValue placeholder="All users" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All users</SelectItem>
-              <SelectItem value="automatic">Automatically assigned</SelectItem>
-              <SelectItem value="manual">Manually assigned</SelectItem>
-              <SelectItem value="unassigned">Unassigned</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select value={groupFilter} onValueChange={setGroupFilter}>
-            <SelectTrigger
-              size="sm"
-              className={filterControlClass({ active: groupFilter !== "all" })}
-              aria-label={`Filter by ${noun.singular}`}
-            >
-              <SelectValue placeholder={`All ${noun.plural}`} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{`All ${noun.plural}`}</SelectItem>
-              {groupIds.map((groupId) => (
-                <SelectItem key={groupId} value={groupId}>
-                  {groupLabel(groupId)}
+              <SelectTrigger
+                size="sm"
+                className={filterControlClass({ active: filter !== "all" })}
+                aria-label="Filter users"
+              >
+                <SelectValue placeholder="All users" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All users</SelectItem>
+                <SelectItem value="automatic">
+                  Automatically assigned
                 </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </FilterBar>
+                <SelectItem value="manual">Manually assigned</SelectItem>
+                <SelectItem value="unassigned">Unassigned</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={groupFilter} onValueChange={setGroupFilter}>
+              <SelectTrigger
+                size="sm"
+                className={filterControlClass({
+                  active: groupFilter !== "all",
+                })}
+                aria-label={`Filter by ${noun.singular}`}
+              >
+                <SelectValue placeholder={`All ${noun.plural}`} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{`All ${noun.plural}`}</SelectItem>
+                {groupIds.map((groupId) => (
+                  <SelectItem key={groupId} value={groupId}>
+                    {groupLabel(groupId)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FilterBar>
+        </CollectionFilters>
       )}
 
       {userGroups?.truncated && (

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.tsx
@@ -7,6 +7,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { Users } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -211,51 +212,55 @@ export function ConnectorUserGroupsTable({
   return (
     <div>
       {groups.length > 0 && (
-        <FilterBar className="mb-3">
-          <SearchInput
-            value={search}
-            syncQueryParams={false}
-            placeholder={`Search by ${noun.singular} or member name`}
-            className={filterSearchClass}
-            onSearchChange={setSearch}
-          />
-          <Select
-            value={filter}
-            onValueChange={(value) => setFilter(value as GroupFilter)}
-          >
-            <SelectTrigger
-              size="sm"
-              className={filterControlClass({ active: filter !== "all" })}
-              aria-label={`Filter ${noun.plural}`}
+        <CollectionFilters>
+          <FilterBar>
+            <SearchInput
+              value={search}
+              syncQueryParams={false}
+              placeholder={`Search by ${noun.singular} or member name`}
+              className={filterSearchClass}
+              onSearchChange={setSearch}
+            />
+            <Select
+              value={filter}
+              onValueChange={(value) => setFilter(value as GroupFilter)}
             >
-              <SelectValue placeholder={`All ${noun.plural}`} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{`All ${noun.plural}`}</SelectItem>
-              <SelectItem value="fully-assigned">Fully assigned</SelectItem>
-              <SelectItem value="not-fully-assigned">
-                Not fully assigned
-              </SelectItem>
-            </SelectContent>
-          </Select>
-          <Select value={memberFilter} onValueChange={setMemberFilter}>
-            <SelectTrigger
-              size="sm"
-              className={filterControlClass({ active: memberFilter !== "all" })}
-              aria-label="Filter by member"
-            >
-              <SelectValue placeholder="All members" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All members</SelectItem>
-              {memberOptions.map((member) => (
-                <SelectItem key={member.value} value={member.value}>
-                  {member.label}
+              <SelectTrigger
+                size="sm"
+                className={filterControlClass({ active: filter !== "all" })}
+                aria-label={`Filter ${noun.plural}`}
+              >
+                <SelectValue placeholder={`All ${noun.plural}`} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{`All ${noun.plural}`}</SelectItem>
+                <SelectItem value="fully-assigned">Fully assigned</SelectItem>
+                <SelectItem value="not-fully-assigned">
+                  Not fully assigned
                 </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </FilterBar>
+              </SelectContent>
+            </Select>
+            <Select value={memberFilter} onValueChange={setMemberFilter}>
+              <SelectTrigger
+                size="sm"
+                className={filterControlClass({
+                  active: memberFilter !== "all",
+                })}
+                aria-label="Filter by member"
+              >
+                <SelectValue placeholder="All members" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All members</SelectItem>
+                {memberOptions.map((member) => (
+                  <SelectItem key={member.value} value={member.value}>
+                    {member.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FilterBar>
+        </CollectionFilters>
       )}
 
       {userGroups?.truncated && (

--- a/platform/frontend/src/app/knowledge/connectors/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/page.client.tsx
@@ -21,6 +21,7 @@ import { CreateConnectorDialog } from "@/app/knowledge/knowledge-bases/_parts/cr
 import { EditConnectorDialog } from "@/app/knowledge/knowledge-bases/_parts/edit-connector-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -427,7 +428,7 @@ function ConnectorsList() {
     >
       <TableCardView storageKey="archestra-connectors-view">
         <div>
-          <div className="mb-3 flex flex-col gap-2">
+          <CollectionFilters>
             <FilterBar
               leading
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
@@ -466,7 +467,7 @@ function ConnectorsList() {
                 deletePermission={{ knowledgeSource: ["delete"] }}
               />
             </FilterBar>
-          </div>
+          </CollectionFilters>
 
           {isConnectorsLoadError ? (
             <QueryLoadError

--- a/platform/frontend/src/app/knowledge/files/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/files/page.client.tsx
@@ -22,7 +22,11 @@ import {
   FilePreviewDialog,
   type PreviewableDocument,
 } from "@/components/files/file-preview-dialog";
-import { FilterBar, filterSearchClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { QueryLoadError } from "@/components/query-load-error";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { SearchInput } from "@/components/search-input";
@@ -504,52 +508,54 @@ export default function KnowledgeFilesPage() {
       }
       isPending={isLoading && files.length === 0}
     >
-      <BulkActionsScope className="space-y-3">
-        <FilterBar
-          leading
-          onClearFilters={
-            search
-              ? () => {
-                  setSearch("");
+      <BulkActionsScope>
+        <CollectionFilters>
+          <FilterBar
+            leading
+            onClearFilters={
+              search
+                ? () => {
+                    setSearch("");
+                    updateQueryParams({ page: "1" });
+                  }
+                : undefined
+            }
+          >
+            {openDirectory ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="-ml-2"
+                onClick={() => {
+                  setOpenDirectoryId(null);
+                  clearSelection();
                   updateQueryParams({ page: "1" });
-                }
-              : undefined
-          }
-        >
-          {openDirectory ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="-ml-2"
-              onClick={() => {
-                setOpenDirectoryId(null);
-                clearSelection();
+                }}
+              >
+                <ChevronLeft className="mr-1 h-4 w-4" />
+                <span>All files</span>
+              </Button>
+            ) : null}
+            {openDirectory && (
+              <span className="font-medium text-sm">{openDirectory.name}</span>
+            )}
+
+            <SearchInput
+              isLoading={isLoading}
+              value={search}
+              onSearchChange={(value) => {
+                setSearch(value);
                 updateQueryParams({ page: "1" });
               }}
-            >
-              <ChevronLeft className="mr-1 h-4 w-4" />
-              <span>All files</span>
-            </Button>
-          ) : null}
-          {openDirectory && (
-            <span className="font-medium text-sm">{openDirectory.name}</span>
-          )}
-
-          <SearchInput
-            isLoading={isLoading}
-            value={search}
-            onSearchChange={(value) => {
-              setSearch(value);
-              updateQueryParams({ page: "1" });
-            }}
-            // The term lives in local state and the page reset is handled just
-            // above, so the component's own query-param sync would only add a
-            // second router push per keystroke.
-            syncQueryParams={false}
-            placeholder="Search documents…"
-            className={filterSearchClass}
-          />
-        </FilterBar>
+              // The term lives in local state and the page reset is handled just
+              // above, so the component's own query-param sync would only add a
+              // second router push per keystroke.
+              syncQueryParams={false}
+              placeholder="Search documents…"
+              className={filterSearchClass}
+            />
+          </FilterBar>
+        </CollectionFilters>
 
         {/* Visibility follows the ticked rows, not the document count: picking
             an empty directory selects something the bar has to be able to

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -20,7 +20,11 @@ import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { KnowledgePageLayout } from "@/app/knowledge/_parts/knowledge-page-layout";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
-import { FilterBar, filterSearchClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { LoadingState } from "@/components/loading";
 import {
   PERMANENT_DELETE_LABEL,
@@ -450,7 +454,7 @@ function KnowledgeBasesList() {
     >
       <TableCardView storageKey="knowledge-bases-view">
         <div>
-          <div className="mb-3 flex flex-col gap-2">
+          <CollectionFilters>
             <FilterBar
               leading
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
@@ -464,7 +468,7 @@ function KnowledgeBasesList() {
                 deletePermission={{ knowledgeSource: ["delete"] }}
               />
             </FilterBar>
-          </div>
+          </CollectionFilters>
 
           {!isDeletedView && (
             <BulkActions

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -22,6 +22,12 @@ import { AgentIcon } from "@/components/agent-icon";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EnvironmentScopeSelect } from "@/components/environment-scope-select";
 import { ExternalDocsLink } from "@/components/external-docs-link";
+import {
+  CollectionFilters,
+  FilterBar,
+  FilterSelect,
+  filterControlClass,
+} from "@/components/filter-bar";
 import { FormDialog } from "@/components/form-dialog";
 import {
   CLEANUP_INTERVAL_LABELS,
@@ -38,6 +44,7 @@ import { TableRowActions } from "@/components/table-row-actions";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -51,13 +58,6 @@ import { Label } from "@/components/ui/label";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { Progress } from "@/components/ui/progress";
 import { SearchableSelect } from "@/components/ui/searchable-select";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import {
   Tooltip,
   TooltipContent,
@@ -614,7 +614,7 @@ export default function LimitsPage() {
         cell: ({ row }) => {
           const usage = getUsageStatus(row.original);
           return (
-            <div className="w-[180px]">
+            <div className="min-w-0 w-full overflow-hidden">
               <Progress
                 value={Math.min(usage.percentage, 100)}
                 className={
@@ -625,7 +625,7 @@ export default function LimitsPage() {
                       : undefined
                 }
               />
-              <p className="mt-1 text-left text-xs text-muted-foreground">
+              <p className="mt-1 truncate text-left text-xs text-muted-foreground">
                 {`${formatCurrencyWhole(usage.actualUsage)} / ${formatCurrencyWhole(usage.actualLimit)} (${usage.percentage.toFixed(1)}%)`}
               </p>
             </div>
@@ -741,12 +741,12 @@ export default function LimitsPage() {
   }
 
   return (
-    <div className="space-y-4">
+    <div>
       <WithPermissions
         permissions={{ llmLimit: ["read"] }}
         noPermissionHandle="hide"
       >
-        <Alert variant="info">
+        <Alert variant="info" className="mb-4">
           <AlertDescription className="block">
             {defaultUserLimits.length > 0
               ? "A default user limit applies to every user. Custom per-user limits override it. Configure it in "
@@ -762,99 +762,108 @@ export default function LimitsPage() {
         </Alert>
       </WithPermissions>
 
-      <div
-        className={`flex flex-wrap gap-3 ${(isPending || isFetching) && limits.length === 0 ? "" : "!mb-3"}`}
-      >
-        <Select
-          value={statusFilter}
-          onValueChange={(value) =>
-            updateQueryParams({ status: value === "all" ? null : value })
-          }
-        >
-          <SelectTrigger className="w-full sm:w-[220px]">
-            <SelectValue placeholder="All statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All statuses</SelectItem>
-            <SelectItem value="safe">Safe</SelectItem>
-            <SelectItem value="warning">Near limit</SelectItem>
-            <SelectItem value="danger">Exceeded</SelectItem>
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={appliedToFilter}
-          onValueChange={(value) =>
-            updateQueryParams({ appliedTo: value === "all" ? null : value })
-          }
-        >
-          <SelectTrigger className="w-full sm:w-[220px]">
-            <SelectValue placeholder="All scopes" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All applied to</SelectItem>
-            <SelectItem value="organization">Organization</SelectItem>
-            <SelectItem value="team">Team</SelectItem>
-            <SelectItem value="agent">Agent</SelectItem>
-            <SelectItem value="llm_proxy">LLM Proxy</SelectItem>
-            <SelectItem value="user">User</SelectItem>
-            <SelectItem value="virtual_key">Virtual Key</SelectItem>
-            <SelectItem value="environment">Environment</SelectItem>
-          </SelectContent>
-        </Select>
-
-        <LlmModelSearchableSelect
-          value={modelFilter}
-          onValueChange={(value) =>
-            updateQueryParams({ model: value === "all" ? null : value })
-          }
-          options={modelOptions}
-          placeholder="All models"
-          className="sm:max-w-[320px]"
-          showPricing={false}
-          includeAllOption
-          allLabel="All models"
-        />
-      </div>
-
-      <LoadingWrapper
-        isPending={(isPending || isFetching) && limits.length === 0}
-        loadingFallback={<LoadingState variant="page" />}
-      >
-        <BulkActions
-          count={selectedLimits.length}
-          noun="limit"
-          onClear={clearSelection}
-          busy={bulkDeleteLimits.isPending}
-          selectAllMatching={selectAllMatching}
-        >
-          <PermissionButton
-            permissions={{ llmLimit: ["delete"] }}
-            variant="destructive"
-            size="sm"
-            onClick={() => setIsBulkDeleteDialogOpen(true)}
+      <BulkActionsScope>
+        <CollectionFilters>
+          <FilterBar
+            onClearFilters={
+              hasActiveFilters
+                ? () =>
+                    updateQueryParams({
+                      status: null,
+                      appliedTo: null,
+                      model: null,
+                    })
+                : undefined
+            }
           >
-            <Trash2 className="h-4 w-4" />
-            <span>Delete</span>
-          </PermissionButton>
-        </BulkActions>
-        <DataTable
-          columns={columns}
-          data={filteredLimits}
-          getRowId={(limit) => limit.id}
-          rowSelection={rowSelection}
-          onRowSelectionChange={setRowSelection}
-          onPageRowIdsChange={onPageRowIdsChange}
-          hideSelectedCount
-          emptyIcon={CircleDollarSign}
-          emptyMessage="No limits configured"
-          hasActiveFilters={hasActiveFilters}
-          filteredEmptyMessage="No limits match your filters"
-          onClearFilters={() => {
-            updateQueryParams({ status: null, appliedTo: null, model: null });
-          }}
-        />
-      </LoadingWrapper>
+            <FilterSelect
+              value={statusFilter}
+              onValueChange={(value) =>
+                updateQueryParams({ status: value === "all" ? null : value })
+              }
+              placeholder="All statuses"
+              showSearch={false}
+              items={[
+                { value: "all", label: "All statuses" },
+                { value: "safe", label: "Safe" },
+                { value: "warning", label: "Near limit" },
+                { value: "danger", label: "Exceeded" },
+              ]}
+            />
+            <FilterSelect
+              value={appliedToFilter}
+              onValueChange={(value) =>
+                updateQueryParams({ appliedTo: value === "all" ? null : value })
+              }
+              placeholder="All applied to"
+              showSearch={false}
+              items={[
+                { value: "all", label: "All applied to" },
+                { value: "organization", label: "Organization" },
+                { value: "team", label: "Team" },
+                { value: "agent", label: "Agent" },
+                { value: "llm_proxy", label: "LLM Proxy" },
+                { value: "user", label: "User" },
+                { value: "virtual_key", label: "Virtual Key" },
+                { value: "environment", label: "Environment" },
+              ]}
+            />
+            <LlmModelSearchableSelect
+              value={modelFilter}
+              onValueChange={(value) =>
+                updateQueryParams({ model: value === "all" ? null : value })
+              }
+              options={modelOptions}
+              placeholder="All models"
+              className={filterControlClass({
+                active: modelFilter !== "all",
+              })}
+              showPricing={false}
+              includeAllOption
+              allLabel="All models"
+            />
+          </FilterBar>
+        </CollectionFilters>
+
+        <LoadingWrapper
+          isPending={(isPending || isFetching) && limits.length === 0}
+          loadingFallback={<LoadingState variant="page" />}
+        >
+          <BulkActions
+            count={selectedLimits.length}
+            noun="limit"
+            onClear={clearSelection}
+            busy={bulkDeleteLimits.isPending}
+            selectAllMatching={selectAllMatching}
+          >
+            <PermissionButton
+              permissions={{ llmLimit: ["delete"] }}
+              variant="destructive"
+              size="sm"
+              onClick={() => setIsBulkDeleteDialogOpen(true)}
+            >
+              <Trash2 className="h-4 w-4" />
+              <span>Delete</span>
+            </PermissionButton>
+          </BulkActions>
+          <DataTable
+            columns={columns}
+            data={filteredLimits}
+            getRowId={(limit) => limit.id}
+            rowSelection={rowSelection}
+            onRowSelectionChange={setRowSelection}
+            onPageRowIdsChange={onPageRowIdsChange}
+            hideSelectedCount
+            emptyIcon={CircleDollarSign}
+            emptyMessage="No limits configured"
+            hasActiveFilters={hasActiveFilters}
+            filteredEmptyMessage="No limits match your filters"
+            onClearFilters={() => {
+              updateQueryParams({ status: null, appliedTo: null, model: null });
+            }}
+          />
+        </LoadingWrapper>
+      </BulkActionsScope>
 
       <FormDialog
         open={isCreateDialogOpen || !!editingLimit}

--- a/platform/frontend/src/app/llm/logs/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.tsx
@@ -16,6 +16,7 @@ import { AgentSelector } from "@/components/agent-selector";
 import { BilledCost } from "@/components/billed-cost";
 import { ClientSourceBadge } from "@/components/client-source-badge";
 import {
+  CollectionFilters,
   FilterBar,
   FilterSelect,
   filterControlClass,
@@ -491,101 +492,106 @@ function SessionsTable() {
   }
 
   return (
-    <div className="space-y-3">
-      <FilterBar leading onClearFilters={hasFilters ? clearFilters : undefined}>
-        {/* Anchor the "not a session ID" hint as a floating overlay under the
+    <div>
+      <CollectionFilters>
+        <FilterBar
+          leading
+          onClearFilters={hasFilters ? clearFilters : undefined}
+        >
+          {/* Anchor the "not a session ID" hint as a floating overlay under the
             input so toggling it never reflows the filter bar or the table. */}
-        <div className={filterSearchClass}>
-          <SearchInput
-            isLoading={isFetching}
-            objectNamePlural="logs"
-            searchFields={["session ID"]}
-            paramName="search"
-            className="relative w-full"
-          />
-          {searchIsNotSessionId && (
-            <output className="absolute left-0 top-full z-20 mt-1 w-full rounded-md border bg-popover px-2 py-1 text-xs text-muted-foreground shadow-md">
-              Enter a valid session UUID
-            </output>
-          )}
-        </div>
+          <div className={filterSearchClass}>
+            <SearchInput
+              isLoading={isFetching}
+              objectNamePlural="logs"
+              searchFields={["session ID"]}
+              paramName="search"
+              className="relative w-full"
+            />
+            {searchIsNotSessionId && (
+              <output className="absolute left-0 top-full z-20 mt-1 w-full rounded-md border bg-popover px-2 py-1 text-xs text-muted-foreground shadow-md">
+                Enter a valid session UUID
+              </output>
+            )}
+          </div>
 
-        {/* Two people's personal agents can both be called "My Agent", so the
+          {/* Two people's personal agents can both be called "My Agent", so the
             picker carries each one's scope and owner email rather than a bare
             name. */}
-        <AgentSelector
-          mode="single"
-          flat
-          compactTrigger
-          agents={agents ?? []}
-          value={profileFilter}
-          onValueChange={handleProfileFilterChange}
-          sentinelOption={{
-            value: "all",
-            label: "All Agents",
-          }}
-          // Only reached when the URL pins an id that no longer resolves to an
-          // agent (e.g. a bookmarked filter whose target was deleted); the
-          // sentinel label covers the ordinary unfiltered state.
-          placeholder="Filter by Agent"
-          searchPlaceholder="Search agents…"
-          emptyMessage="No agents found."
-          className={filterControlClass({ active: profileFilter !== "all" })}
-        />
-
-        {canSeeAllLogs ? (
-          // Without log:admin the server scopes every listing to the caller's
-          // own rows, so a user filter would be a one-entry dropdown.
-          <UserFilterSelect
-            value={userFilter}
-            onValueChange={handleUserFilterChange}
-            users={uniqueUsers}
+          <AgentSelector
+            mode="single"
+            flat
+            compactTrigger
+            agents={agents ?? []}
+            value={profileFilter}
+            onValueChange={handleProfileFilterChange}
+            sentinelOption={{
+              value: "all",
+              label: "All Agents",
+            }}
+            // Only reached when the URL pins an id that no longer resolves to an
+            // agent (e.g. a bookmarked filter whose target was deleted); the
+            // sentinel label covers the ordinary unfiltered state.
+            placeholder="Filter by Agent"
+            searchPlaceholder="Search agents…"
+            emptyMessage="No agents found."
+            className={filterControlClass({ active: profileFilter !== "all" })}
           />
-        ) : null}
 
-        <FilterSelect
-          value={sourceFilter}
-          onValueChange={handleSourceFilterChange}
-          placeholder="Filter by Source"
-          items={[
-            { value: "all", label: "All Sources" },
-            ...Object.entries(INTERACTION_SOURCE_DISPLAY).map(
-              ([value, { label }]) => ({
-                value,
-                label,
-                content: (
-                  <SourceFilterOption source={value as InteractionSource} />
-                ),
-                selectedContent: (
-                  <SourceFilterOption source={value as InteractionSource} />
-                ),
-              }),
-            ),
-          ]}
-        />
+          {canSeeAllLogs ? (
+            // Without log:admin the server scopes every listing to the caller's
+            // own rows, so a user filter would be a one-entry dropdown.
+            <UserFilterSelect
+              value={userFilter}
+              onValueChange={handleUserFilterChange}
+              users={uniqueUsers}
+            />
+          ) : null}
 
-        <ClientFilterSelect
-          value={clientFilter}
-          onValueChange={handleClientFilterChange}
-        />
+          <FilterSelect
+            value={sourceFilter}
+            onValueChange={handleSourceFilterChange}
+            placeholder="Filter by Source"
+            items={[
+              { value: "all", label: "All Sources" },
+              ...Object.entries(INTERACTION_SOURCE_DISPLAY).map(
+                ([value, { label }]) => ({
+                  value,
+                  label,
+                  content: (
+                    <SourceFilterOption source={value as InteractionSource} />
+                  ),
+                  selectedContent: (
+                    <SourceFilterOption source={value as InteractionSource} />
+                  ),
+                }),
+              ),
+            ]}
+          />
 
-        <DateTimeRangePicker
-          startDate={dateTimePicker.startDate}
-          endDate={dateTimePicker.endDate}
-          isDialogOpen={dateTimePicker.isDateDialogOpen}
-          tempStartDate={dateTimePicker.tempStartDate}
-          tempEndDate={dateTimePicker.tempEndDate}
-          displayText={dateTimePicker.getDateRangeDisplay()}
-          onDialogOpenChange={dateTimePicker.setIsDateDialogOpen}
-          onTempStartDateChange={dateTimePicker.setTempStartDate}
-          onTempEndDateChange={dateTimePicker.setTempEndDate}
-          onOpenDialog={dateTimePicker.openDateDialog}
-          onApply={dateTimePicker.handleApplyDateRange}
-          className={filterControlClass({
-            active: dateTimePicker.startDate !== undefined,
-          })}
-        />
-      </FilterBar>
+          <ClientFilterSelect
+            value={clientFilter}
+            onValueChange={handleClientFilterChange}
+          />
+
+          <DateTimeRangePicker
+            startDate={dateTimePicker.startDate}
+            endDate={dateTimePicker.endDate}
+            isDialogOpen={dateTimePicker.isDateDialogOpen}
+            tempStartDate={dateTimePicker.tempStartDate}
+            tempEndDate={dateTimePicker.tempEndDate}
+            displayText={dateTimePicker.getDateRangeDisplay()}
+            onDialogOpenChange={dateTimePicker.setIsDateDialogOpen}
+            onTempStartDateChange={dateTimePicker.setTempStartDate}
+            onTempEndDateChange={dateTimePicker.setTempEndDate}
+            onOpenDialog={dateTimePicker.openDateDialog}
+            onApply={dateTimePicker.handleApplyDateRange}
+            className={filterControlClass({
+              active: dateTimePicker.startDate !== undefined,
+            })}
+          />
+        </FilterBar>
+      </CollectionFilters>
 
       <DataTable
         columns={columns}

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -26,6 +26,7 @@ import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -714,38 +715,40 @@ export default function ApiKeysPage() {
           </p>
         </div>
 
-        <BulkActionsScope className="space-y-3">
-          <FilterBar>
-            <SearchInput
-              isLoading={isFetching}
-              objectNamePlural="credentials"
-              searchFields={["name"]}
-              paramName="search"
-              className={filterSearchClass}
-            />
-            <Select
-              value={providerFilter}
-              onValueChange={(value) =>
-                updateQueryParams({
-                  provider: value === "all" ? null : value,
-                })
-              }
-            >
-              <SelectTrigger
-                size="sm"
-                aria-label="Filter by provider"
-                className={filterControlClass({
-                  active: providerFilter !== "all",
-                })}
+        <BulkActionsScope>
+          <CollectionFilters>
+            <FilterBar>
+              <SearchInput
+                isLoading={isFetching}
+                objectNamePlural="credentials"
+                searchFields={["name"]}
+                paramName="search"
+                className={filterSearchClass}
+              />
+              <Select
+                value={providerFilter}
+                onValueChange={(value) =>
+                  updateQueryParams({
+                    provider: value === "all" ? null : value,
+                  })
+                }
               >
-                <SelectValue placeholder="All providers" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All providers</SelectItem>
-                <LlmProviderSelectItems options={providerOptions} />
-              </SelectContent>
-            </Select>
-          </FilterBar>
+                <SelectTrigger
+                  size="sm"
+                  aria-label="Filter by provider"
+                  className={filterControlClass({
+                    active: providerFilter !== "all",
+                  })}
+                >
+                  <SelectValue placeholder="All providers" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All providers</SelectItem>
+                  <LlmProviderSelectItems options={providerOptions} />
+                </SelectContent>
+              </Select>
+            </FilterBar>
+          </CollectionFilters>
 
           {byosEnabled &&
             apiKeys.some((key) => key.secretStorageType === "database") && (

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -24,6 +24,7 @@ import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
 import {
+  CollectionFilters,
   FilterBar,
   FilterSelect,
   filterControlClass,
@@ -521,111 +522,113 @@ export default function ModelsPage() {
       description='Models available from your configured providers. Use "Refresh Models" to re-fetch models and capabilities from providers.'
       actionButton={refreshModelsButton}
     >
-      <BulkActionsScope className="space-y-3">
+      <BulkActionsScope>
         {models.length > 0 && (
-          <FilterBar leading>
-            <SearchInput
-              objectNamePlural="models"
-              searchFields={["model ID"]}
-              value={search}
-              onSearchChange={setSearch}
-              syncQueryParams={false}
-              className={filterSearchClass}
-            />
-            <LlmProviderApiKeyDropdown
-              availableKeys={apiKeys}
-              selectedApiKeyId={apiKeyFilter === "all" ? null : apiKeyFilter}
-              open={apiKeyFilterOpen}
-              onOpenChange={setApiKeyFilterOpen}
-              onSelectKey={(value) => {
-                setApiKeyFilter(value);
-                setApiKeyFilterOpen(false);
-              }}
-              triggerVariant="select"
-              triggerClassName={filterControlClass({
-                active: apiKeyFilter !== "all",
-              })}
-              popoverClassName="w-[min(20rem,calc(100vw-2rem))]"
-              allOptionLabel="All provider API keys"
-              allOptionSelected={apiKeyFilter === "all"}
-              onSelectAllOption={() => {
-                setApiKeyFilter("all");
-                setApiKeyFilterOpen(false);
-              }}
-            />
-            <FilterSelect
-              value={modelTypeFilter}
-              onValueChange={(v) =>
-                setModelTypeFilter(v as "all" | "chat" | "embedding")
-              }
-              placeholder="Model type"
-              items={[
-                {
-                  value: "all",
-                  label: "All models",
-                  content: (
-                    <span className="flex items-center gap-2">
-                      <Boxes className="h-4 w-4 text-muted-foreground" />
-                      <span>All models</span>
-                    </span>
-                  ),
-                  selectedContent: (
-                    <span className="flex items-center gap-2">
-                      <Boxes className="h-4 w-4 text-muted-foreground" />
-                      <span>All models</span>
-                    </span>
-                  ),
-                },
-                {
-                  value: "chat",
-                  label: "Chat / generation",
-                  content: (
-                    <span className="flex items-center gap-2">
-                      <Brain className="h-4 w-4 text-muted-foreground" />
-                      <span>Chat / generation</span>
-                    </span>
-                  ),
-                  selectedContent: (
-                    <span className="flex items-center gap-2">
-                      <Brain className="h-4 w-4 text-muted-foreground" />
-                      <span>Chat / generation</span>
-                    </span>
-                  ),
-                },
-                {
-                  value: "embedding",
-                  label: "Embedding",
-                  content: (
-                    <span className="flex items-center gap-2">
-                      <Fingerprint className="h-4 w-4 text-muted-foreground" />
-                      <span>Embedding</span>
-                    </span>
-                  ),
-                  selectedContent: (
-                    <span className="flex items-center gap-2">
-                      <Fingerprint className="h-4 w-4 text-muted-foreground" />
-                      <span>Embedding</span>
-                    </span>
-                  ),
-                },
-              ]}
-            />
-            {canFilterFreeModels && (
-              <div className="flex items-center gap-2">
-                <Switch
-                  id="models-free-only"
-                  checked={freeOnly}
-                  onCheckedChange={setFreeOnly}
-                />
-                <Label
-                  htmlFor="models-free-only"
-                  className="text-sm text-muted-foreground"
-                >
-                  Free only
-                </Label>
-              </div>
-            )}
-          </FilterBar>
+          <CollectionFilters>
+            <FilterBar leading>
+              <SearchInput
+                objectNamePlural="models"
+                searchFields={["model ID"]}
+                value={search}
+                onSearchChange={setSearch}
+                syncQueryParams={false}
+                className={filterSearchClass}
+              />
+              <LlmProviderApiKeyDropdown
+                availableKeys={apiKeys}
+                selectedApiKeyId={apiKeyFilter === "all" ? null : apiKeyFilter}
+                open={apiKeyFilterOpen}
+                onOpenChange={setApiKeyFilterOpen}
+                onSelectKey={(value) => {
+                  setApiKeyFilter(value);
+                  setApiKeyFilterOpen(false);
+                }}
+                triggerVariant="select"
+                triggerClassName={filterControlClass({
+                  active: apiKeyFilter !== "all",
+                })}
+                popoverClassName="w-[min(20rem,calc(100vw-2rem))]"
+                allOptionLabel="All provider API keys"
+                allOptionSelected={apiKeyFilter === "all"}
+                onSelectAllOption={() => {
+                  setApiKeyFilter("all");
+                  setApiKeyFilterOpen(false);
+                }}
+              />
+              <FilterSelect
+                value={modelTypeFilter}
+                onValueChange={(v) =>
+                  setModelTypeFilter(v as "all" | "chat" | "embedding")
+                }
+                placeholder="Model type"
+                items={[
+                  {
+                    value: "all",
+                    label: "All models",
+                    content: (
+                      <span className="flex items-center gap-2">
+                        <Boxes className="h-4 w-4 text-muted-foreground" />
+                        <span>All models</span>
+                      </span>
+                    ),
+                    selectedContent: (
+                      <span className="flex items-center gap-2">
+                        <Boxes className="h-4 w-4 text-muted-foreground" />
+                        <span>All models</span>
+                      </span>
+                    ),
+                  },
+                  {
+                    value: "chat",
+                    label: "Chat / generation",
+                    content: (
+                      <span className="flex items-center gap-2">
+                        <Brain className="h-4 w-4 text-muted-foreground" />
+                        <span>Chat / generation</span>
+                      </span>
+                    ),
+                    selectedContent: (
+                      <span className="flex items-center gap-2">
+                        <Brain className="h-4 w-4 text-muted-foreground" />
+                        <span>Chat / generation</span>
+                      </span>
+                    ),
+                  },
+                  {
+                    value: "embedding",
+                    label: "Embedding",
+                    content: (
+                      <span className="flex items-center gap-2">
+                        <Fingerprint className="h-4 w-4 text-muted-foreground" />
+                        <span>Embedding</span>
+                      </span>
+                    ),
+                    selectedContent: (
+                      <span className="flex items-center gap-2">
+                        <Fingerprint className="h-4 w-4 text-muted-foreground" />
+                        <span>Embedding</span>
+                      </span>
+                    ),
+                  },
+                ]}
+              />
+              {canFilterFreeModels && (
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id="models-free-only"
+                    checked={freeOnly}
+                    onCheckedChange={setFreeOnly}
+                  />
+                  <Label
+                    htmlFor="models-free-only"
+                    className="text-sm text-muted-foreground"
+                  >
+                    Free only
+                  </Label>
+                </div>
+              )}
+            </FilterBar>
+          </CollectionFilters>
         )}
         <BulkActions
           count={selectedModels.length}

--- a/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
@@ -23,6 +23,7 @@ import {
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EditVirtualKeyDialog } from "@/components/edit-virtual-key-dialog";
 import {
+  CollectionFilters,
   FilterBar,
   FilterSelect,
   filterSearchClass,
@@ -341,7 +342,7 @@ function VirtualKeysTable() {
   return (
     <TableCardView storageKey="archestra-llm-virtual-keys-view">
       <div>
-        <div className="mb-3">
+        <CollectionFilters>
           <FilterBar leading actions={<TableCardViewToggle />}>
             <SearchInput
               isLoading={query.isFetching}
@@ -388,7 +389,7 @@ function VirtualKeysTable() {
               }
             />
           </FilterBar>
-        </div>
+        </CollectionFilters>
 
         <BulkActions
           count={selectedKeys.length}

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -42,7 +42,11 @@ import { BulkVisibilityDialog } from "@/components/bulk-visibility-dialog";
 import { CloneAgentDialog } from "@/components/clone-agent-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { ExternalDocsLink } from "@/components/external-docs-link";
-import { FilterBar, filterSearchClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { PageLayout } from "@/components/page-layout";
 import { PERMANENT_DELETE_LABEL } from "@/components/permanent-delete";
 import { PermissionRequirementHint } from "@/components/permission-requirement-hint";
@@ -686,7 +690,7 @@ function McpGateways({
       <TableCardView storageKey="archestra-mcp-gateways-view">
         <div>
           <div>
-            <div className="mb-3 flex flex-col gap-2">
+            <CollectionFilters>
               <FilterBar
                 leading
                 actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
@@ -714,7 +718,7 @@ function McpGateways({
                 />
               )}
               <ActiveFilterBadges adminPermission={{ mcpGateway: ["admin"] }} />
-            </div>
+            </CollectionFilters>
 
             <div data-testid={E2eTestId.AgentsTable}>
               <BulkActions

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { AgentSelector } from "@/components/agent-selector";
 import { ExecutedAsBadge } from "@/components/executed-as-badge";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -502,33 +503,38 @@ function McpToolCallsTable({
   }
 
   return (
-    <div className="space-y-3">
-      <FilterBar leading onClearFilters={hasFilters ? clearFilters : undefined}>
-        {searchInputComponent}
-        {/* Two people's personal gateways can both be called "My Gateway", so
+    <div>
+      <CollectionFilters>
+        <FilterBar
+          leading
+          onClearFilters={hasFilters ? clearFilters : undefined}
+        >
+          {searchInputComponent}
+          {/* Two people's personal gateways can both be called "My Gateway", so
             the picker carries each one's scope and owner email rather than a
             bare name. */}
-        <AgentSelector
-          mode="single"
-          flat
-          compactTrigger
-          agents={agents ?? []}
-          value={profileFilter}
-          onValueChange={handleProfileFilterChange}
-          sentinelOption={{
-            value: "all",
-            label: "All Agents & MCP Gateways",
-          }}
-          // Only reached when the URL pins an id that no longer resolves to an
-          // agent (e.g. a bookmarked filter whose target was deleted); the
-          // sentinel label covers the ordinary unfiltered state.
-          placeholder="Filter by Agent"
-          searchPlaceholder="Search agents and MCP gateways…"
-          emptyMessage="No agents or MCP gateways found."
-          className={filterControlClass({ active: profileFilter !== "all" })}
-        />
-        {datePickerComponent}
-      </FilterBar>
+          <AgentSelector
+            mode="single"
+            flat
+            compactTrigger
+            agents={agents ?? []}
+            value={profileFilter}
+            onValueChange={handleProfileFilterChange}
+            sentinelOption={{
+              value: "all",
+              label: "All Agents & MCP Gateways",
+            }}
+            // Only reached when the URL pins an id that no longer resolves to an
+            // agent (e.g. a bookmarked filter whose target was deleted); the
+            // sentinel label covers the ordinary unfiltered state.
+            placeholder="Filter by Agent"
+            searchPlaceholder="Search agents and MCP gateways…"
+            emptyMessage="No agents or MCP gateways found."
+            className={filterControlClass({ active: profileFilter !== "all" })}
+          />
+          {datePickerComponent}
+        </FilterBar>
+      </CollectionFilters>
 
       <DataTable
         columns={columns}

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -1126,12 +1127,6 @@ export function InternalMCPCatalog({
     filters.author.size > 0 ||
     filters.status.has(INSTALLED_STATUS_VALUE) ||
     filters.status.has(NOT_INSTALLED_STATUS_VALUE);
-  const hasFilterChips =
-    filters.issue.size > 0 ||
-    filters.environment.size > 0 ||
-    filters.author.size > 0 ||
-    filters.status.has(INSTALLED_STATUS_VALUE) ||
-    filters.status.has(NOT_INSTALLED_STATUS_VALUE);
   const handleClearAllFilters = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString());
     params.delete("search");
@@ -1165,14 +1160,8 @@ export function InternalMCPCatalog({
 
   return (
     <TableCardView storageKey="archestra-mcp-registry-view" defaultMode="table">
-      <div className="space-y-4">
-        <div
-          className={
-            !hasLabelFilters && !hasFilterChips
-              ? "space-y-3 !mb-3"
-              : "space-y-3"
-          }
-        >
+      <div>
+        <CollectionFilters>
           <FilterBar
             leading
             onClearFilters={
@@ -1257,18 +1246,15 @@ export function InternalMCPCatalog({
               />
             )}
           </FilterBar>
-        </div>
-        {hasLabelFilters && (
-          <div className={!hasFilterChips ? "!mb-3" : undefined}>
+          {hasLabelFilters && (
             <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
-          </div>
-        )}
-        <RegistryFilterChips
-          className="!mb-3"
-          selected={filters}
-          onRemove={removeFilter}
-          onClearAll={clearAdvancedFilters}
-        />
+          )}
+          <RegistryFilterChips
+            selected={filters}
+            onRemove={removeFilter}
+            onClearAll={clearAdvancedFilters}
+          />
+        </CollectionFilters>
         {selectedFacet ? (
           allFilteredItems.length === 0 ? (
             // A clean fleet is only claimable when the facet itself is empty.

--- a/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -146,72 +147,74 @@ export function ArchestraCatalogTab({
   );
 
   return (
-    <div className="w-full space-y-3">
-      <FilterBar
-        className="ml-1"
-        onClearFilters={
-          searchQuery || filters.type !== "all" || filters.category !== "all"
-            ? () => {
-                setSearchQuery("");
-                setFilters({ type: "all", category: "all" });
-              }
-            : undefined
-        }
-      >
-        <SearchInput
-          placeholder="Search servers by name..."
-          value={searchQuery}
-          onSearchChange={setSearchQuery}
-          syncQueryParams={false}
-          className={filterSearchClass}
-        />
-        <Select
-          value={filters.type}
-          onValueChange={(value) =>
-            setFilters({ ...filters, type: value as ServerType })
+    <div className="w-full">
+      <CollectionFilters>
+        <FilterBar
+          className="ml-1"
+          onClearFilters={
+            searchQuery || filters.type !== "all" || filters.category !== "all"
+              ? () => {
+                  setSearchQuery("");
+                  setFilters({ type: "all", category: "all" });
+                }
+              : undefined
           }
         >
-          <SelectTrigger
-            size="sm"
-            aria-label="Filter by server type"
-            className={filterControlClass({
-              active: filters.type !== "all",
-            })}
+          <SearchInput
+            placeholder="Search servers by name..."
+            value={searchQuery}
+            onSearchChange={setSearchQuery}
+            syncQueryParams={false}
+            className={filterSearchClass}
+          />
+          <Select
+            value={filters.type}
+            onValueChange={(value) =>
+              setFilters({ ...filters, type: value as ServerType })
+            }
           >
-            <SelectValue placeholder="All types" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All types</SelectItem>
-            <SelectItem value="remote">Remote</SelectItem>
-            <SelectItem value="local">Local</SelectItem>
-            <SelectItem value="mcp-apps-demo">MCP Apps Demo</SelectItem>
-          </SelectContent>
-        </Select>
-        <Select
-          value={filters.category}
-          onValueChange={(value) =>
-            setFilters({ ...filters, category: value as SelectedCategory })
-          }
-        >
-          <SelectTrigger
-            size="sm"
-            aria-label="Filter by category"
-            className={filterControlClass({
-              active: filters.category !== "all",
-            })}
+            <SelectTrigger
+              size="sm"
+              aria-label="Filter by server type"
+              className={filterControlClass({
+                active: filters.type !== "all",
+              })}
+            >
+              <SelectValue placeholder="All types" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All types</SelectItem>
+              <SelectItem value="remote">Remote</SelectItem>
+              <SelectItem value="local">Local</SelectItem>
+              <SelectItem value="mcp-apps-demo">MCP Apps Demo</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select
+            value={filters.category}
+            onValueChange={(value) =>
+              setFilters({ ...filters, category: value as SelectedCategory })
+            }
           >
-            <SelectValue placeholder="All categories" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All categories</SelectItem>
-            {visibleCategories.map((category) => (
-              <SelectItem key={category} value={category}>
-                {category}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </FilterBar>
+            <SelectTrigger
+              size="sm"
+              aria-label="Filter by category"
+              className={filterControlClass({
+                active: filters.category !== "all",
+              })}
+            >
+              <SelectValue placeholder="All categories" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All categories</SelectItem>
+              {visibleCategories.map((category) => (
+                <SelectItem key={category} value={category}>
+                  {category}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </FilterBar>
+      </CollectionFilters>
 
       {isLoading && (
         <div className="grid gap-4 md:grid-cols-3">

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.test.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.test.tsx
@@ -9,6 +9,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/components/filter-bar", () => ({
+  CollectionFilters: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
   FilterBar: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   FilterSelect: () => <button type="button">All Sources</button>,
   filterSearchClass: "",

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
@@ -24,6 +24,7 @@ import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { RowClickShield } from "@/components/agent-pages/row-click-shield";
 import { CallPolicyToggle } from "@/components/call-policy-toggle";
 import {
+  CollectionFilters,
   FilterBar,
   FilterSelect,
   filterSearchClass,
@@ -632,127 +633,134 @@ export function AssignedToolsTable({
   );
 
   return (
-    <BulkActionsScope className="space-y-3">
-      <FilterBar leading>
-        <SearchInput
-          isLoading={isLoading}
-          objectNamePlural="tools"
-          searchFields={["name"]}
-          paramName="search"
-          onSearchChange={handleSearchChange}
-          className={filterSearchClass}
-        />
+    <BulkActionsScope>
+      <CollectionFilters>
+        <FilterBar leading>
+          <SearchInput
+            isLoading={isLoading}
+            objectNamePlural="tools"
+            searchFields={["name"]}
+            paramName="search"
+            onSearchChange={handleSearchChange}
+            className={filterSearchClass}
+          />
 
-        <FilterSelect
-          value={originFilter}
-          onValueChange={handleOriginFilterChange}
-          placeholder="Filter by Source"
-          items={[
-            { value: "all", label: "All Sources" },
-            {
-              value: "agent",
-              label: "Agent",
-              content: (
-                <div className="flex items-center gap-2 min-w-0">
-                  <Bot className="h-4 w-4 shrink-0" />
-                  <span className="truncate">Agent</span>
-                </div>
-              ),
-              selectedContent: (
-                <div className="flex items-center gap-2 min-w-0">
-                  <Bot className="h-4 w-4 shrink-0" />
-                  <span className="truncate">Agent</span>
-                </div>
-              ),
-            },
-            ...(hasAppSources
-              ? [
-                  {
-                    value: APP_ORIGIN_FILTER_VALUE,
-                    label: APP_TOOL_SOURCE_LABEL,
-                    content: (
-                      <div className="flex items-center gap-2 min-w-0">
-                        <AppWindow className="h-4 w-4 shrink-0" />
-                        <span className="truncate">
-                          {APP_TOOL_SOURCE_LABEL}
-                        </span>
-                      </div>
-                    ),
-                    selectedContent: (
-                      <div className="flex items-center gap-2 min-w-0">
-                        <AppWindow className="h-4 w-4 shrink-0" />
-                        <span className="truncate">
-                          {APP_TOOL_SOURCE_LABEL}
-                        </span>
-                      </div>
-                    ),
-                  },
-                ]
-              : []),
-            {
-              value: "llm-proxy",
-              label: OBSERVED_TOOL_SOURCE_LABEL,
-              content: (
-                <div className="flex items-center gap-2 min-w-0">
-                  <Network className="h-4 w-4 shrink-0" />
-                  <span className="truncate">{OBSERVED_TOOL_SOURCE_LABEL}</span>
-                </div>
-              ),
-              selectedContent: (
-                <div className="flex items-center gap-2 min-w-0">
-                  <Network className="h-4 w-4 shrink-0" />
-                  <span className="truncate">{OBSERVED_TOOL_SOURCE_LABEL}</span>
-                </div>
-              ),
-            },
-            ...visibleCatalogSources.map((source) => ({
-              value: source.id,
-              label: source.name,
-              content: (
-                <div className="flex items-center gap-2 min-w-0">
-                  <McpCatalogIcon
-                    icon={source.icon}
-                    catalogId={source.id}
-                    size={16}
-                  />
-                  <span className="truncate">{source.name}</span>
-                </div>
-              ),
-              selectedContent: (
-                <div className="flex items-center gap-2 min-w-0">
-                  <McpCatalogIcon
-                    icon={source.icon}
-                    catalogId={source.id}
-                    size={16}
-                  />
-                  <span className="truncate">{source.name}</span>
-                </div>
-              ),
-            })),
-          ]}
-        />
+          <FilterSelect
+            value={originFilter}
+            onValueChange={handleOriginFilterChange}
+            placeholder="Filter by Source"
+            items={[
+              { value: "all", label: "All Sources" },
+              {
+                value: "agent",
+                label: "Agent",
+                content: (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Bot className="h-4 w-4 shrink-0" />
+                    <span className="truncate">Agent</span>
+                  </div>
+                ),
+                selectedContent: (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Bot className="h-4 w-4 shrink-0" />
+                    <span className="truncate">Agent</span>
+                  </div>
+                ),
+              },
+              ...(hasAppSources
+                ? [
+                    {
+                      value: APP_ORIGIN_FILTER_VALUE,
+                      label: APP_TOOL_SOURCE_LABEL,
+                      content: (
+                        <div className="flex items-center gap-2 min-w-0">
+                          <AppWindow className="h-4 w-4 shrink-0" />
+                          <span className="truncate">
+                            {APP_TOOL_SOURCE_LABEL}
+                          </span>
+                        </div>
+                      ),
+                      selectedContent: (
+                        <div className="flex items-center gap-2 min-w-0">
+                          <AppWindow className="h-4 w-4 shrink-0" />
+                          <span className="truncate">
+                            {APP_TOOL_SOURCE_LABEL}
+                          </span>
+                        </div>
+                      ),
+                    },
+                  ]
+                : []),
+              {
+                value: "llm-proxy",
+                label: OBSERVED_TOOL_SOURCE_LABEL,
+                content: (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Network className="h-4 w-4 shrink-0" />
+                    <span className="truncate">
+                      {OBSERVED_TOOL_SOURCE_LABEL}
+                    </span>
+                  </div>
+                ),
+                selectedContent: (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Network className="h-4 w-4 shrink-0" />
+                    <span className="truncate">
+                      {OBSERVED_TOOL_SOURCE_LABEL}
+                    </span>
+                  </div>
+                ),
+              },
+              ...visibleCatalogSources.map((source) => ({
+                value: source.id,
+                label: source.name,
+                content: (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <McpCatalogIcon
+                      icon={source.icon}
+                      catalogId={source.id}
+                      size={16}
+                    />
+                    <span className="truncate">{source.name}</span>
+                  </div>
+                ),
+                selectedContent: (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <McpCatalogIcon
+                      icon={source.icon}
+                      catalogId={source.id}
+                      size={16}
+                    />
+                    <span className="truncate">{source.name}</span>
+                  </div>
+                ),
+              })),
+            ]}
+          />
 
-        {/* Observed-tool attribution filters: narrow the list to tools seen in
+          {/* Observed-tool attribution filters: narrow the list to tools seen in
             one user's LLM proxy traffic, from one client app family. Only
             shown while the source filter is "Observed tools" — MCP-sourced
             tools carry no observations — and once someone has observed tools. */}
-        {observationFiltersActive && (toolObservers?.users.length ?? 0) > 0 && (
-          <UserFilterSelect
-            value={observedByFilter}
-            onValueChange={handleObservedByFilterChange}
-            users={toolObservers?.users}
-          />
-        )}
+          {observationFiltersActive &&
+            (toolObservers?.users.length ?? 0) > 0 && (
+              <UserFilterSelect
+                value={observedByFilter}
+                onValueChange={handleObservedByFilterChange}
+                users={toolObservers?.users}
+              />
+            )}
 
-        {observationFiltersActive &&
-          (toolObservers?.clients.length ?? 0) > 0 && (
-            <ClientFilterSelect
-              value={clientFilter}
-              onValueChange={handleClientFilterChange}
-              clients={toolObservers?.clients}
-            />
-          )}
-      </FilterBar>
+          {observationFiltersActive &&
+            (toolObservers?.clients.length ?? 0) > 0 && (
+              <ClientFilterSelect
+                value={clientFilter}
+                onValueChange={handleClientFilterChange}
+                clients={toolObservers?.clients}
+              />
+            )}
+        </FilterBar>
+      </CollectionFilters>
 
       <ToolPolicyBulkActionsBar
         selectedToolIds={bulkTools.map((tool) => tool.id)}

--- a/platform/frontend/src/app/plugins/page.client.tsx
+++ b/platform/frontend/src/app/plugins/page.client.tsx
@@ -20,6 +20,7 @@ import { BulkVisibilityDialog } from "@/components/bulk-visibility-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -616,7 +617,7 @@ function PluginsList() {
             <PluginsEmptyState />
           ) : (
             <>
-              <div className="mb-3 flex flex-col gap-2">
+              <CollectionFilters>
                 <FilterBar
                   leading
                   onClearFilters={hasActiveFilters ? clearFilters : undefined}
@@ -748,7 +749,7 @@ function PluginsList() {
                   />
                 </FilterBar>
                 <ActiveFilterBadges adminPermission={{ plugin: ["admin"] }} />
-              </div>
+              </CollectionFilters>
 
               <BulkActions
                 count={bulkSelection.selected.length}

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -17,7 +17,11 @@ import { ApiKeyLoadError } from "@/components/api-key-load-error";
 import { BulkVisibilityDialog } from "@/components/bulk-visibility-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
-import { FilterBar, filterSearchClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { IdentityFields } from "@/components/identity-fields";
 import { LoadingState } from "@/components/loading";
 import { NoApiKeySetup } from "@/components/no-api-key-setup";
@@ -251,35 +255,36 @@ function ProjectsList() {
             confirmLabel={PERMANENT_DELETE_LABEL}
           />
         )}
-        <div className="space-y-6">
-          <FilterBar
-            leading
-            className={projects.length > 0 ? "!mb-3" : undefined}
-            actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
-          >
-            {/* Hidden in the trash: the backend serves that slice whole, ignoring
+        <div>
+          <CollectionFilters>
+            <FilterBar
+              leading
+              actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
+            >
+              {/* Hidden in the trash: the backend serves that slice whole, ignoring
               search and scope, so live controls would read as broken filters. */}
-            {!isDeletedView && (
-              <>
-                <SearchInput
-                  isLoading={isFetching}
-                  placeholder="Search projects"
-                  paramName="search"
-                  className={filterSearchClass}
-                />
-                <ResourceScopeFilter
-                  ownerLabelPlural="projects"
-                  allLabel="All projects"
-                  adminPermission={{ project: ["admin"] }}
-                />
-              </>
-            )}
-            {/* Gated on `project:admin`, matching the slice the backend serves:
+              {!isDeletedView && (
+                <>
+                  <SearchInput
+                    isLoading={isFetching}
+                    placeholder="Search projects"
+                    paramName="search"
+                    className={filterSearchClass}
+                  />
+                  <ResourceScopeFilter
+                    ownerLabelPlural="projects"
+                    allLabel="All projects"
+                    adminPermission={{ project: ["admin"] }}
+                  />
+                </>
+              )}
+              {/* Gated on `project:admin`, matching the slice the backend serves:
               anyone else switching to Deleted would get an empty table. */}
-            <ResourceDeletedStatusFilter
-              deletePermission={{ project: ["admin"] }}
-            />
-          </FilterBar>
+              <ResourceDeletedStatusFilter
+                deletePermission={{ project: ["admin"] }}
+              />
+            </FilterBar>
+          </CollectionFilters>
           {(isPending || isFetching) && projects.length === 0 ? (
             <LoadingState label="Loading projects…" variant="page" />
           ) : isDeletedView ? (

--- a/platform/frontend/src/app/settings/llm/_parts/model-providers-section.tsx
+++ b/platform/frontend/src/app/settings/llm/_parts/model-providers-section.tsx
@@ -9,7 +9,11 @@ import {
   SupportedProviders,
 } from "@archestra/shared";
 import { useEffect, useRef, useState } from "react";
-import { FilterBar, filterSearchClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { ProviderIcon } from "@/components/provider-icon";
 import { WithPermissions } from "@/components/roles/with-permissions";
 import { SearchInput } from "@/components/search-input";
@@ -111,18 +115,20 @@ export function ModelProvidersSection() {
           {({ hasPermission }) => {
             const locked = updateMutation.isPending || !hasPermission;
             return (
-              <div className="flex flex-col gap-3">
-                <FilterBar
-                  onClearFilters={search ? () => setSearch("") : undefined}
-                >
-                  <SearchInput
-                    value={search}
-                    onSearchChange={setSearch}
-                    syncQueryParams={false}
-                    placeholder="Search providers…"
-                    className={filterSearchClass}
-                  />
-                </FilterBar>
+              <div>
+                <CollectionFilters>
+                  <FilterBar
+                    onClearFilters={search ? () => setSearch("") : undefined}
+                  >
+                    <SearchInput
+                      value={search}
+                      onSearchChange={setSearch}
+                      syncQueryParams={false}
+                      placeholder="Search providers…"
+                      className={filterSearchClass}
+                    />
+                  </FilterBar>
+                </CollectionFilters>
 
                 {visible.length === 0 ? (
                   <p className="py-6 text-center text-sm text-muted-foreground">

--- a/platform/frontend/src/app/settings/messaging-channels/_components/channels-section.tsx
+++ b/platform/frontend/src/app/settings/messaging-channels/_components/channels-section.tsx
@@ -19,7 +19,11 @@ import { type MouseEvent, useCallback, useMemo, useRef, useState } from "react";
 import { AgentBadge } from "@/components/agent-badge";
 import Divider from "@/components/divider";
 import { EmptyState } from "@/components/empty-state";
-import { FilterBar, filterSearchClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { LoadingState } from "@/components/loading";
 import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
@@ -427,100 +431,102 @@ export function ChannelsSection({
           onRetry={() => refetchBindings()}
         />
       ) : hasAnyChannels ? (
-        <div className="space-y-3">
+        <div>
           {/* Search + filters + bulk assign */}
-          <FilterBar
-            onClearFilters={hasActiveFilters ? clearFilters : undefined}
-            actions={
-              <BulkAssignButton
-                agents={channelAgentList}
-                selectedCount={selectedIds.size}
-                isUpdating={bulkMutation.isPending}
-                onAssign={handleBulkAssign}
+          <CollectionFilters>
+            <FilterBar
+              onClearFilters={hasActiveFilters ? clearFilters : undefined}
+              actions={
+                <BulkAssignButton
+                  agents={channelAgentList}
+                  selectedCount={selectedIds.size}
+                  isUpdating={bulkMutation.isPending}
+                  onAssign={handleBulkAssign}
+                />
+              }
+            >
+              <SearchInput
+                isLoading={isFetching}
+                placeholder="Search channels..."
+                paramName="search"
+                className={filterSearchClass}
+                debounceMs={300}
+                onSearchChange={handleSearchChange}
               />
-            }
-          >
-            <SearchInput
-              isLoading={isFetching}
-              placeholder="Search channels..."
-              paramName="search"
-              className={filterSearchClass}
-              debounceMs={300}
-              onSearchChange={handleSearchChange}
-            />
 
-            <Button
-              variant="ghost"
-              size="sm"
-              className={cn(
-                "h-8 rounded-full text-xs gap-1.5",
-                statusFromUrl === "all" && "bg-primary/10 text-primary",
-              )}
-              onClick={() => handleStatusChange("all")}
-            >
-              <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />
-              All{counts ? <span> ({totalCount})</span> : null}
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className={cn(
-                "h-8 rounded-full text-xs gap-1.5",
-                statusFromUrl === "configured"
-                  ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                  : "text-muted-foreground",
-              )}
-              onClick={() => handleStatusChange("configured")}
-            >
-              <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
-              Configured{counts ? <span> ({counts.configured})</span> : null}
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className={cn(
-                "h-8 rounded-full text-xs gap-1.5",
-                statusFromUrl === "unassigned"
-                  ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
-                  : "text-muted-foreground",
-              )}
-              onClick={() => handleStatusChange("unassigned")}
-            >
-              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
-              Unassigned{counts ? <span> ({counts.unassigned})</span> : null}
-            </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "h-8 rounded-full text-xs gap-1.5",
+                  statusFromUrl === "all" && "bg-primary/10 text-primary",
+                )}
+                onClick={() => handleStatusChange("all")}
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />
+                All{counts ? <span> ({totalCount})</span> : null}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "h-8 rounded-full text-xs gap-1.5",
+                  statusFromUrl === "configured"
+                    ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                    : "text-muted-foreground",
+                )}
+                onClick={() => handleStatusChange("configured")}
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                Configured{counts ? <span> ({counts.configured})</span> : null}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "h-8 rounded-full text-xs gap-1.5",
+                  statusFromUrl === "unassigned"
+                    ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                    : "text-muted-foreground",
+                )}
+                onClick={() => handleStatusChange("unassigned")}
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+                Unassigned{counts ? <span> ({counts.unassigned})</span> : null}
+              </Button>
 
-            {hasMultipleWorkspaces && (
-              <>
-                <span className="mx-1 hidden self-stretch border-l border-border sm:block" />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "h-8 rounded-full text-xs",
-                    !workspaceIdFromUrl && "bg-muted",
-                  )}
-                  onClick={() => handleWorkspaceChange(null)}
-                >
-                  All workspaces
-                </Button>
-                {workspaces.map((ws) => (
+              {hasMultipleWorkspaces && (
+                <>
+                  <span className="mx-1 hidden self-stretch border-l border-border sm:block" />
                   <Button
-                    key={ws.id}
                     variant="ghost"
                     size="sm"
                     className={cn(
                       "h-8 rounded-full text-xs",
-                      workspaceIdFromUrl === ws.id && "bg-muted",
+                      !workspaceIdFromUrl && "bg-muted",
                     )}
-                    onClick={() => handleWorkspaceChange(ws.id)}
+                    onClick={() => handleWorkspaceChange(null)}
                   >
-                    {ws.name}
+                    All workspaces
                   </Button>
-                ))}
-              </>
-            )}
-          </FilterBar>
+                  {workspaces.map((ws) => (
+                    <Button
+                      key={ws.id}
+                      variant="ghost"
+                      size="sm"
+                      className={cn(
+                        "h-8 rounded-full text-xs",
+                        workspaceIdFromUrl === ws.id && "bg-muted",
+                      )}
+                      onClick={() => handleWorkspaceChange(ws.id)}
+                    >
+                      {ws.name}
+                    </Button>
+                  ))}
+                </>
+              )}
+            </FilterBar>
+          </CollectionFilters>
 
           {/* Table */}
           <div className="overflow-hidden rounded-md border">

--- a/platform/frontend/src/app/settings/oauth-clients/page.tsx
+++ b/platform/frontend/src/app/settings/oauth-clients/page.tsx
@@ -14,6 +14,7 @@ import { useSetSettingsAction } from "@/app/settings/layout";
 import { CreateOAuthClientDialog } from "@/components/create-oauth-client-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import {
+  CollectionFilters,
   FilterBar,
   FilterSelect,
   filterSearchClass,
@@ -349,7 +350,7 @@ function OauthClientsTable() {
 
   return (
     <div>
-      <div className="mb-3">
+      <CollectionFilters>
         <FilterBar>
           <SearchInput
             isLoading={llmQuery.isFetching || mcpQuery.isFetching}
@@ -391,7 +392,7 @@ function OauthClientsTable() {
             ]}
           />
         </FilterBar>
-      </div>
+      </CollectionFilters>
 
       <DataTable
         columns={columns}

--- a/platform/frontend/src/app/settings/service-accounts/page.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/page.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import {
+  CollectionFilters,
   FilterBar,
   FilterSelect,
   filterSearchClass,
@@ -358,44 +359,45 @@ export default function ServiceAccountsSettingsPage() {
         >
           <TableCardView storageKey="archestra-service-accounts-view">
             <div>
-              <FilterBar
-                className="mb-3"
-                actions={<TableCardViewToggle />}
-                onClearFilters={hasActiveFilters ? clearFilters : undefined}
-              >
-                <SearchInput
-                  objectNamePlural="service accounts"
-                  searchFields={["name"]}
-                  className={filterSearchClass}
-                />
-                <RoleFilterSelect
-                  value={roleFilter}
-                  onValueChange={(value) =>
-                    updateQueryParams({
-                      role: value === ALL ? null : value,
-                      page: "1",
-                    })
-                  }
-                  allOptionValue={ALL}
-                />
-                <FilterSelect
-                  value={statusFilter}
-                  onValueChange={(value) =>
-                    updateQueryParams({
-                      status: value === ALL ? null : value,
-                      page: "1",
-                    })
-                  }
-                  placeholder="Filter by status"
-                  items={[
-                    { value: ALL, label: "All statuses" },
-                    ...STATUS_FILTERS.map((health) => ({
-                      value: health,
-                      label: ACCOUNT_HEALTH_LABELS[health],
-                    })),
-                  ]}
-                />
-              </FilterBar>
+              <CollectionFilters>
+                <FilterBar
+                  actions={<TableCardViewToggle />}
+                  onClearFilters={hasActiveFilters ? clearFilters : undefined}
+                >
+                  <SearchInput
+                    objectNamePlural="service accounts"
+                    searchFields={["name"]}
+                    className={filterSearchClass}
+                  />
+                  <RoleFilterSelect
+                    value={roleFilter}
+                    onValueChange={(value) =>
+                      updateQueryParams({
+                        role: value === ALL ? null : value,
+                        page: "1",
+                      })
+                    }
+                    allOptionValue={ALL}
+                  />
+                  <FilterSelect
+                    value={statusFilter}
+                    onValueChange={(value) =>
+                      updateQueryParams({
+                        status: value === ALL ? null : value,
+                        page: "1",
+                      })
+                    }
+                    placeholder="Filter by status"
+                    items={[
+                      { value: ALL, label: "All statuses" },
+                      ...STATUS_FILTERS.map((health) => ({
+                        value: health,
+                        label: ACCOUNT_HEALTH_LABELS[health],
+                      })),
+                    ]}
+                  />
+                </FilterBar>
+              </CollectionFilters>
               {isServiceAccountsLoadError ? (
                 <QueryLoadError
                   title="Couldn't load your service accounts"

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -20,6 +20,7 @@ import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { AuthProviderIcon } from "@/components/auth-provider-icon";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -607,19 +608,23 @@ function MembersTab({
   ];
 
   return (
-    <BulkActionsScope className="space-y-3">
-      <FilterBar
-        actions={<TabButtons activeTab={activeTab} onTabChange={onTabChange} />}
-      >
-        <SearchInput
-          isLoading={isFetching}
-          objectNamePlural="users"
-          searchFields={["name", "email"]}
-          paramName="name"
-          className={filterSearchClass}
-        />
-        <RoleFilterDropdown />
-      </FilterBar>
+    <BulkActionsScope>
+      <CollectionFilters>
+        <FilterBar
+          actions={
+            <TabButtons activeTab={activeTab} onTabChange={onTabChange} />
+          }
+        >
+          <SearchInput
+            isLoading={isFetching}
+            objectNamePlural="users"
+            searchFields={["name", "email"]}
+            paramName="name"
+            className={filterSearchClass}
+          />
+          <RoleFilterDropdown />
+        </FilterBar>
+      </CollectionFilters>
 
       <LoadingWrapper isPending={isPending} loadingFallback={<LoadingState />}>
         <BulkActions
@@ -999,12 +1004,14 @@ function InvitationsTab({
   ];
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-4">
-        <div className="ml-auto">
-          <TabButtons activeTab={activeTab} onTabChange={onTabChange} />
-        </div>
-      </div>
+    <div>
+      <CollectionFilters>
+        <FilterBar
+          actions={
+            <TabButtons activeTab={activeTab} onTabChange={onTabChange} />
+          }
+        />
+      </CollectionFilters>
 
       <LoadingWrapper isPending={isPending} loadingFallback={<LoadingState />}>
         <DataTable

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -25,6 +25,7 @@ import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -792,7 +793,7 @@ function SkillsList() {
             <SkillsEmptyState />
           ) : (
             <>
-              <div className="mb-3 flex flex-col gap-2">
+              <CollectionFilters>
                 <FilterBar
                   leading
                   onClearFilters={hasActiveFilters ? clearFilters : undefined}
@@ -895,7 +896,7 @@ function SkillsList() {
                   )}
                 </FilterBar>
                 <ActiveFilterBadges adminPermission={{ skill: ["admin"] }} />
-              </div>
+              </CollectionFilters>
 
               <section className="space-y-3" aria-label="Skills">
                 <BulkActions

--- a/platform/frontend/src/components/filter-bar.test.tsx
+++ b/platform/frontend/src/components/filter-bar.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import {
+  CollectionFilters,
   FilterBar,
   FilterBarContextualActions,
   FilterSelect,
@@ -11,6 +12,21 @@ const ITEMS = [
   { value: "all", label: "All actions" },
   { value: "create", label: "Create" },
 ];
+
+describe("CollectionFilters", () => {
+  it("owns the 12px gap to the next sibling even inside a space-y stack", () => {
+    const { container } = render(
+      <div className="space-y-6">
+        <CollectionFilters>filters</CollectionFilters>
+        <div>table</div>
+      </div>,
+    );
+
+    const slot = container.querySelector('[data-slot="collection-filters"]');
+    expect(slot?.className).toContain("mb-3");
+    expect(slot?.className).toContain("[&+*]:!mt-0");
+  });
+});
 
 describe("FilterBar", () => {
   it("renders a Clear control only while filters are applied", async () => {

--- a/platform/frontend/src/components/filter-bar.tsx
+++ b/platform/frontend/src/components/filter-bar.tsx
@@ -37,6 +37,32 @@ export type OverflowFilter = {
 };
 
 /**
+ * Owns the 12px gap between a collection's filters and the table or cards
+ * below. Agents and Skills are the reference: wrap the {@link FilterBar} plus
+ * any badges, chips, or hints, then render the collection as the next sibling.
+ *
+ * `[&+*]:!mt-0` cancels a parent `space-y-*` margin on the collection so the
+ * gap stays 12px even when the page still uses a vertical stack. Bordered
+ * tables read as 13px because of the table's top border.
+ */
+export function CollectionFilters({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      data-slot="collection-filters"
+      className={cn("mb-3 flex flex-col gap-2 [&+*]:!mt-0", className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
  * One compact row of table filters: search, then the filter controls, then any
  * trailing view/sort actions. Every filtered list page uses this so the bars
  * read the same everywhere.
@@ -65,13 +91,11 @@ export type OverflowFilter = {
  * @param leading - Pulls the first control strip below a page header into the
  * surrounding vertical rhythm. Nested bars leave this disabled.
  *
- * The bar carries no outer margin: the surrounding stack owns the gap between
- * it and the table. It used to default to `mb-4`, which made "let my parent
- * space this" and "have no spacing at all" the same string — callers wrote
- * `className="mb-0"` meaning the former and silently got the latter, because
- * tailwind's `space-y-*` spaces a stack via margin-bottom on every child but
- * the last, which `mb-0` then cancelled. Six pages had a collapsed gap this
- * way. Pass an explicit margin here only when there is no stack to own it.
+ * The bar carries no outer margin. Wrap it — and any badges or chips that
+ * belong with the filters — in {@link CollectionFilters}, which owns the 12px
+ * gap to the table or cards. Putting `mb-*` on the bar itself fights parent
+ * `space-y-*` stacks (those space via margin-top on the next sibling) and is
+ * how collection pages ended up with collapsed or doubled gaps.
  */
 export function FilterBar({
   children,
@@ -84,7 +108,7 @@ export function FilterBar({
   actions,
   leading = false,
 }: {
-  children: ReactNode;
+  children?: ReactNode;
   className?: string;
   contextualActions?: ReactNode;
   contextualActionsClassName?: string;

--- a/platform/frontend/src/components/roles/roles-list.ee.tsx
+++ b/platform/frontend/src/components/roles/roles-list.ee.tsx
@@ -14,7 +14,11 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useSetSettingsAction } from "@/app/settings/layout";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
-import { FilterBar, filterSearchClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { FormDialog } from "@/components/form-dialog";
 import { QueryLoadError } from "@/components/query-load-error";
 import { RoleTypeIcon } from "@/components/role-type-icon";
@@ -420,23 +424,25 @@ export function RolesList({ headerAction }: { headerAction?: ReactNode }) {
 
   return (
     <>
-      <BulkActionsScope className="space-y-3">
-        <FilterBar
-          onClearFilters={
-            nameFilter
-              ? () => updateQueryParams({ name: null, page: "1" })
-              : undefined
-          }
-          actions={headerAction}
-        >
-          <SearchInput
-            isLoading={isLoading}
-            objectNamePlural="roles"
-            searchFields={["name"]}
-            paramName="name"
-            className={filterSearchClass}
-          />
-        </FilterBar>
+      <BulkActionsScope>
+        <CollectionFilters>
+          <FilterBar
+            onClearFilters={
+              nameFilter
+                ? () => updateQueryParams({ name: null, page: "1" })
+                : undefined
+            }
+            actions={headerAction}
+          >
+            <SearchInput
+              isLoading={isLoading}
+              objectNamePlural="roles"
+              searchFields={["name"]}
+              paramName="name"
+              className={filterSearchClass}
+            />
+          </FilterBar>
+        </CollectionFilters>
 
         {isLoadingError ? (
           <QueryLoadError

--- a/platform/frontend/src/components/settings/api-keys-card.tsx
+++ b/platform/frontend/src/components/settings/api-keys-card.tsx
@@ -11,7 +11,11 @@ import { CopyButton } from "@/components/copy-button";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { ExpirationDateTimeField } from "@/components/expiration-date-time-field";
 import { ExternalDocsLink } from "@/components/external-docs-link";
-import { FilterBar, filterSearchClass } from "@/components/filter-bar";
+import {
+  CollectionFilters,
+  FilterBar,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { FormDialog } from "@/components/form-dialog";
 import { LoadingState, LoadingWrapper } from "@/components/loading";
 import { QueryLoadError } from "@/components/query-load-error";
@@ -320,20 +324,22 @@ function ApiKeysCardContent() {
           isPending={(isPending || isFetching) && apiKeys.length === 0}
           loadingFallback={<LoadingState variant="page" />}
         >
-          <BulkActionsScope className="space-y-3">
-            <FilterBar
-              onClearFilters={
-                search
-                  ? () => updateQueryParams({ search: null, page: "1" })
-                  : undefined
-              }
-            >
-              <SearchInput
-                objectNamePlural="API keys"
-                searchFields={["key name"]}
-                className={filterSearchClass}
-              />
-            </FilterBar>
+          <BulkActionsScope>
+            <CollectionFilters>
+              <FilterBar
+                onClearFilters={
+                  search
+                    ? () => updateQueryParams({ search: null, page: "1" })
+                    : undefined
+                }
+              >
+                <SearchInput
+                  objectNamePlural="API keys"
+                  searchFields={["key name"]}
+                  className={filterSearchClass}
+                />
+              </FilterBar>
+            </CollectionFilters>
             {isApiKeysLoadError ? (
               <QueryLoadError
                 title="Couldn't load your API keys"

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 import { useSetSettingsAction } from "@/app/settings/layout";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import {
+  CollectionFilters,
   FilterBar,
   filterControlClass,
   filterSearchClass,
@@ -296,24 +297,26 @@ export function TeamsList() {
 
   return (
     <>
-      <BulkActionsScope className="space-y-3">
-        <FilterBar>
-          <SearchInput
-            isLoading={isLoading}
-            objectNamePlural="teams"
-            searchFields={["name"]}
-            className={filterSearchClass}
-          />
-          <LabelSelect
-            labelKeys={labelKeys}
-            LabelKeyRowComponent={TeamLabelKeyRow}
-            className={filterControlClass({ active: hasLabelFilters })}
-          />
-        </FilterBar>
+      <BulkActionsScope>
+        <CollectionFilters>
+          <FilterBar>
+            <SearchInput
+              isLoading={isLoading}
+              objectNamePlural="teams"
+              searchFields={["name"]}
+              className={filterSearchClass}
+            />
+            <LabelSelect
+              labelKeys={labelKeys}
+              LabelKeyRowComponent={TeamLabelKeyRow}
+              className={filterControlClass({ active: hasLabelFilters })}
+            />
+          </FilterBar>
 
-        {hasLabelFilters && (
-          <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
-        )}
+          {hasLabelFilters && (
+            <LabelFilterBadges onRemoveLabel={handleRemoveLabel} />
+          )}
+        </CollectionFilters>
 
         <BulkActions
           count={selectedTeams.length}


### PR DESCRIPTION
## Summary
- give every filtered collection page the same 12px filter-to-table/cards gap via a shared `CollectionFilters` wrapper (Agents and Skills as the reference)
- contain the Limits usage cell so the progress label cannot overflow the column
- portal Limits bulk actions into the filter bar so the 42px empty selection rail does not inflate the gap

## Validation
- biome check on all 33 changed files
- `pnpm type-check`
- 28 targeted frontend tests (`filter-bar`, limits page, users page)

Task: [T-1237](https://slack.com/archives/C0B2AGC0AFQ/p1788003462649779?thread_ts=1788003431.173339&cid=C0B2AGC0AFQ)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>