### PR TITLE
fix(costs): keep statistics tables readable on narrow viewports

### DIFF
--- a/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
@@ -421,14 +421,19 @@ describe("OrganizationCostsPage", () => {
 
     // `table-fixed` splits width equally without explicit widths, which left
     // the Models and Cost columns narrower than their badges — the badges then
-    // overflowed onto the neighbouring column.
-    const peopleTable = container.querySelector("table.min-w-\\[900px\\]");
-    expect(peopleTable).not.toBeNull();
+    // overflowed onto the neighbouring column. The same floor is on every
+    // statistics table so phone viewports scroll instead of wrapping cells.
+    const peopleTable = Array.from(
+      container.querySelectorAll("table.min-w-\\[70rem\\]"),
+    ).find((table) => table.textContent?.includes("Example User C"));
+    expect(peopleTable).toBeDefined();
 
     const headers = Array.from(peopleTable?.querySelectorAll("thead th") ?? []);
     expect(headers).toHaveLength(7);
     for (const header of headers) {
       expect(header.className).toMatch(/w-\[\d+%\]/);
+      expect(header.className).toMatch(/min-w-\[/);
+      expect(header.className).toMatch(/max-w-\[/);
     }
   });
 
@@ -559,6 +564,9 @@ describe("OrganizationCostsPage", () => {
     for (const tablePanel of tablePanels) {
       expect(tablePanel.className).toContain("max-h-[280px]");
       expect(tablePanel.className).toContain("overflow-auto");
+      const table = tablePanel.querySelector("table.min-w-\\[70rem\\]");
+      expect(table).not.toBeNull();
+      expect(table?.className).toContain("table-auto");
     }
   });
   it("reports LLM Proxy usage as one total rather than a table of proxies", () => {

--- a/platform/frontend/src/app/llm/(costs)/costs/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.tsx
@@ -203,6 +203,22 @@ function StatisticsSkeletonRows({
 const TIMEFRAME_STORAGE_KEY = "cost-statistics-timeframe";
 const STATISTICS_TABLE_MAX_HEIGHT_CLASS = "max-h-[280px]";
 /**
+ * `table-fixed` plus `wrap-break-word` (the shared Table) shrinks every
+ * column to the panel width, so on a phone headers and figures wrap into
+ * neighbouring cells. The floor is the sum of the column mins so the panel
+ * scrolls instead of crushing nowrap headers into the next cell.
+ */
+const STATISTICS_TABLE_MIN_WIDTH_CLASS = "min-w-[70rem] table-auto";
+const HEAD_STICKY = "bg-card sticky top-0 z-10 whitespace-nowrap";
+const COL_NAME = "min-w-[12rem] max-w-[20rem]";
+const COL_TEAM = "min-w-[8rem] max-w-[14rem]";
+const COL_MODEL = "min-w-[14rem] max-w-[24rem]";
+const COL_METRIC = "min-w-[7rem] max-w-[10rem]";
+const COL_TOKENS = "min-w-[8rem] max-w-[12rem]";
+const COL_COST = "min-w-[8rem] max-w-[12rem]";
+const COL_COST_BADGE = "min-w-[10rem] max-w-[16rem]";
+const COL_LONG = "min-w-[11rem] max-w-[16rem]";
+/**
  * The per-user endpoint is paginated because user cardinality is unbounded;
  * this page renders a leaderboard rather than the full roster.
  */
@@ -695,7 +711,7 @@ export default function StatisticsPage() {
   }, [getTimeframeDisplay, handleTimeframeChange, setActionButton, timeframe]);
 
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6 [&_[data-slot=card]]:min-w-0 [&_[data-slot=card-content]]:min-w-0">
       <CustomDateTimeRangeDialog
         open={isCustomDialogOpen}
         onOpenChange={setIsCustomDialogOpen}
@@ -717,7 +733,7 @@ export default function StatisticsPage() {
         isUsagePending={isModelStatisticsPending}
       />
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid min-w-0 grid-cols-1 gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
             <CardTitle>Costs</CardTitle>
@@ -910,25 +926,27 @@ export default function StatisticsPage() {
             </div>
 
             <StatisticsTablePanel>
-              <Table>
+              <Table className={STATISTICS_TABLE_MIN_WIDTH_CLASS}>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_NAME}`}>
                       Team Name
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_METRIC}`}>
                       Members
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_METRIC}`}>
                       Profiles
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_METRIC}`}>
                       Requests
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_TOKENS}`}>
                       Tokens
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10 text-right">
+                    <TableHead
+                      className={`${HEAD_STICKY} ${COL_COST} text-right`}
+                    >
                       Cost
                     </TableHead>
                   </TableRow>
@@ -948,18 +966,29 @@ export default function StatisticsPage() {
                   ) : (
                     sortedTeamStatistics.map((team) => (
                       <TableRow key={team.teamId}>
-                        <TableCell className="font-medium">
-                          {team.teamName}
+                        <TableCell className={`font-medium ${COL_NAME}`}>
+                          <span
+                            className="block truncate"
+                            title={team.teamName}
+                          >
+                            {team.teamName}
+                          </span>
                         </TableCell>
-                        <TableCell>{team.members}</TableCell>
-                        <TableCell>{team.agents}</TableCell>
-                        <TableCell>{team.requests.toLocaleString()}</TableCell>
-                        <TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
+                          {team.members}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
+                          {team.agents}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
+                          {team.requests.toLocaleString()}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
                           {(
                             team.inputTokens + team.outputTokens
                           ).toLocaleString()}
                         </TableCell>
-                        <TableCell className="text-right">
+                        <TableCell className="whitespace-nowrap text-right tabular-nums">
                           ${team.cost.toFixed(2)}
                         </TableCell>
                       </TableRow>
@@ -1030,25 +1059,27 @@ export default function StatisticsPage() {
             </div>
 
             <StatisticsTablePanel>
-              <Table>
+              <Table className={STATISTICS_TABLE_MIN_WIDTH_CLASS}>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_NAME}`}>
                       Name
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_TEAM}`}>
                       Team
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_METRIC}`}>
                       Requests
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_TOKENS}`}>
                       Tokens
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_TOKENS}`}>
                       Cache read
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10 text-right">
+                    <TableHead
+                      className={`${HEAD_STICKY} ${COL_COST} text-right`}
+                    >
                       Cost
                     </TableHead>
                   </TableRow>
@@ -1068,20 +1099,34 @@ export default function StatisticsPage() {
                   ) : (
                     sortedChatAgentStatistics.map((agent) => (
                       <TableRow key={agent.agentId}>
-                        <TableCell className="font-medium">
-                          {agent.agentName}
+                        <TableCell className={`font-medium ${COL_NAME}`}>
+                          <span
+                            className="block truncate"
+                            title={agent.agentName}
+                          >
+                            {agent.agentName}
+                          </span>
                         </TableCell>
-                        <TableCell>{agent.teamName}</TableCell>
-                        <TableCell>{agent.requests.toLocaleString()}</TableCell>
-                        <TableCell>
+                        <TableCell className={COL_TEAM}>
+                          <span
+                            className="block truncate"
+                            title={agent.teamName}
+                          >
+                            {agent.teamName}
+                          </span>
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
+                          {agent.requests.toLocaleString()}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
                           {(
                             agent.inputTokens + agent.outputTokens
                           ).toLocaleString()}
                         </TableCell>
-                        <TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
                           {(agent.cacheReadTokens ?? 0).toLocaleString()}
                         </TableCell>
-                        <TableCell className="text-right">
+                        <TableCell className="whitespace-nowrap text-right tabular-nums">
                           ${agent.cost.toFixed(2)}
                         </TableCell>
                       </TableRow>
@@ -1136,7 +1181,7 @@ export default function StatisticsPage() {
               </LineChart>
             </ChartContainerWrapper>
 
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className="grid min-w-0 grid-cols-1 gap-4 sm:grid-cols-3">
               <StatisticsFigure
                 label="Requests"
                 value={llmProxyTotals.requests.toLocaleString()}
@@ -1215,25 +1260,27 @@ export default function StatisticsPage() {
             </div>
 
             <StatisticsTablePanel>
-              <Table>
+              <Table className={STATISTICS_TABLE_MIN_WIDTH_CLASS}>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_MODEL}`}>
                       Model
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_METRIC}`}>
                       Requests
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_TOKENS}`}>
                       Tokens Used
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_TOKENS}`}>
                       Cache read
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10">
+                    <TableHead className={`${HEAD_STICKY} ${COL_COST}`}>
                       Cost
                     </TableHead>
-                    <TableHead className="bg-card sticky top-0 z-10 text-right">
+                    <TableHead
+                      className={`${HEAD_STICKY} ${COL_METRIC} text-right`}
+                    >
                       % of Total
                     </TableHead>
                   </TableRow>
@@ -1253,20 +1300,26 @@ export default function StatisticsPage() {
                   ) : (
                     sortedModelStatistics.map((model) => (
                       <TableRow key={model.model}>
-                        <TableCell className="font-medium">
-                          {model.model}
+                        <TableCell className={`font-medium ${COL_MODEL}`}>
+                          <span className="block truncate" title={model.model}>
+                            {model.model}
+                          </span>
                         </TableCell>
-                        <TableCell>{model.requests.toLocaleString()}</TableCell>
-                        <TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
+                          {model.requests.toLocaleString()}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
                           {(
                             model.inputTokens + model.outputTokens
                           ).toLocaleString()}
                         </TableCell>
-                        <TableCell>
+                        <TableCell className="whitespace-nowrap tabular-nums">
                           {(model.cacheReadTokens ?? 0).toLocaleString()}
                         </TableCell>
-                        <TableCell>${model.cost.toFixed(2)}</TableCell>
-                        <TableCell className="text-right">
+                        <TableCell className="whitespace-nowrap tabular-nums">
+                          ${model.cost.toFixed(2)}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap text-right tabular-nums">
                           {model.percentage.toFixed(1)}%
                         </TableCell>
                       </TableRow>
@@ -1296,28 +1349,32 @@ export default function StatisticsPage() {
                 overflow their cell onto the next column. The floor width makes
                 the panel scroll rather than crush the columns.
               */}
-            <Table className="min-w-[900px]">
+            <Table className={STATISTICS_TABLE_MIN_WIDTH_CLASS}>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="bg-card sticky top-0 z-10 w-[18%]">
+                  <TableHead className={`${HEAD_STICKY} ${COL_NAME} w-[18%]`}>
                     User
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 w-[10%]">
+                  <TableHead className={`${HEAD_STICKY} ${COL_METRIC} w-[10%]`}>
                     Requests
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 w-[13%]">
+                  <TableHead className={`${HEAD_STICKY} ${COL_TOKENS} w-[13%]`}>
                     Tokens Used
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 w-[21%]">
+                  <TableHead className={`${HEAD_STICKY} ${COL_MODEL} w-[21%]`}>
                     Models
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 w-[11%]">
+                  <TableHead className={`${HEAD_STICKY} ${COL_METRIC} w-[11%]`}>
                     Active Days
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 w-[16%]">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_COST_BADGE} w-[16%]`}
+                  >
                     Cost
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 w-[11%] text-right">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_LONG} w-[11%] text-right`}
+                  >
                     Last Active
                   </TableHead>
                 </TableRow>
@@ -1337,7 +1394,7 @@ export default function StatisticsPage() {
                 ) : (
                   userStatistics.map((user) => (
                     <TableRow key={user.userId}>
-                      <TableCell>
+                      <TableCell className={COL_NAME}>
                         <div
                           className="font-medium truncate"
                           title={user.userName}
@@ -1351,12 +1408,18 @@ export default function StatisticsPage() {
                           {user.userEmail}
                         </div>
                       </TableCell>
-                      <TableCell>{user.requests.toLocaleString()}</TableCell>
-                      <TableCell>{user.totalTokens.toLocaleString()}</TableCell>
+                      <TableCell className="whitespace-nowrap tabular-nums">
+                        {user.requests.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap tabular-nums">
+                        {user.totalTokens.toLocaleString()}
+                      </TableCell>
                       <TableCell>
                         <UserModelBadges models={user.models} />
                       </TableCell>
-                      <TableCell>{user.activeDays}</TableCell>
+                      <TableCell className="whitespace-nowrap tabular-nums">
+                        {user.activeDays}
+                      </TableCell>
                       <TableCell>
                         <BilledCost
                           cost={String(user.billedCost + user.subscriptionCost)}
@@ -1367,7 +1430,7 @@ export default function StatisticsPage() {
                           className="flex-wrap"
                         />
                       </TableCell>
-                      <TableCell className="text-right text-muted-foreground">
+                      <TableCell className="whitespace-nowrap text-right text-muted-foreground tabular-nums">
                         {user.lastActiveAt
                           ? format(new Date(user.lastActiveAt), "MMM d, HH:mm")
                           : "—"}
@@ -1414,28 +1477,36 @@ export default function StatisticsPage() {
         </CardHeader>
         <CardContent>
           <StatisticsTablePanel>
-            <Table>
+            <Table className={STATISTICS_TABLE_MIN_WIDTH_CLASS}>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className={`${HEAD_STICKY} ${COL_NAME}`}>
                     App
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className={`${HEAD_STICKY} ${COL_METRIC}`}>
                     Runs
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className={`${HEAD_STICKY} ${COL_METRIC}`}>
                     Tool calls
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_COST} text-right`}
+                  >
                     Build cost
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_COST} text-right`}
+                  >
                     Runtime cost
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_LONG} text-right`}
+                  >
                     As chat (est.)
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_LONG} text-right`}
+                  >
                     Net saving (est.)
                   </TableHead>
                 </TableRow>
@@ -1458,25 +1529,37 @@ export default function StatisticsPage() {
                 ) : (
                   appStatistics.map((app) => (
                     <TableRow key={app.appId}>
-                      <TableCell>
-                        <div className="font-medium">{app.appName}</div>
-                        <div className="text-xs text-muted-foreground">
+                      <TableCell className={COL_NAME}>
+                        <div
+                          className="truncate font-medium"
+                          title={app.appName}
+                        >
+                          {app.appName}
+                        </div>
+                        <div
+                          className="truncate text-xs text-muted-foreground"
+                          title={app.authorName ?? "Unknown author"}
+                        >
                           {app.authorName ?? "Unknown author"}
                         </div>
                       </TableCell>
-                      <TableCell>{app.runs.toLocaleString()}</TableCell>
-                      <TableCell>{app.toolCalls.toLocaleString()}</TableCell>
-                      <TableCell className="text-right">
+                      <TableCell className="whitespace-nowrap tabular-nums">
+                        {app.runs.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap tabular-nums">
+                        {app.toolCalls.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap text-right">
                         <AppBuildCostCell app={app} />
                       </TableCell>
-                      <TableCell className="text-right">
+                      <TableCell className="whitespace-nowrap text-right tabular-nums">
                         ${app.runtimeCost.toFixed(2)}
                       </TableCell>
-                      <TableCell className="text-right text-muted-foreground">
+                      <TableCell className="whitespace-nowrap text-right text-muted-foreground tabular-nums">
                         ${app.estimatedChatEquivalentCost.toFixed(2)}
                       </TableCell>
                       <TableCell
-                        className={`text-right ${
+                        className={`whitespace-nowrap text-right tabular-nums ${
                           app.estimatedNetSavings < 0 ? "text-destructive" : ""
                         }`}
                       >
@@ -1511,28 +1594,36 @@ export default function StatisticsPage() {
         </CardHeader>
         <CardContent>
           <StatisticsTablePanel>
-            <Table>
+            <Table className={STATISTICS_TABLE_MIN_WIDTH_CLASS}>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className={`${HEAD_STICKY} ${COL_NAME}`}>
                     Skill
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className={`${HEAD_STICKY} ${COL_METRIC}`}>
                     Activations
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className={`${HEAD_STICKY} ${COL_METRIC}`}>
                     People
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_TOKENS} text-right`}
+                  >
                     Context tokens
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_LONG} text-right`}
+                  >
                     Turns that used it
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_LONG} text-right`}
+                  >
                     Cost on those turns
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead
+                    className={`${HEAD_STICKY} ${COL_LONG} text-right`}
+                  >
                     Last used
                   </TableHead>
                 </TableRow>
@@ -1552,25 +1643,30 @@ export default function StatisticsPage() {
                 ) : (
                   skillStatistics.map((skill) => (
                     <TableRow key={skill.skillId}>
-                      <TableCell className="font-medium">
-                        {skill.skillName}
+                      <TableCell className={`font-medium ${COL_NAME}`}>
+                        <span
+                          className="block truncate"
+                          title={skill.skillName}
+                        >
+                          {skill.skillName}
+                        </span>
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="whitespace-nowrap tabular-nums">
                         {skill.activations.toLocaleString()}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="whitespace-nowrap tabular-nums">
                         {skill.distinctUsers.toLocaleString()}
                       </TableCell>
-                      <TableCell className="text-right">
+                      <TableCell className="whitespace-nowrap text-right">
                         <SkillContextTokensCell skill={skill} />
                       </TableCell>
-                      <TableCell className="text-right">
+                      <TableCell className="whitespace-nowrap text-right tabular-nums">
                         {skill.attributedRequests.toLocaleString()}
                       </TableCell>
-                      <TableCell className="text-right">
+                      <TableCell className="whitespace-nowrap text-right tabular-nums">
                         ${skill.attributedCost.toFixed(2)}
                       </TableCell>
-                      <TableCell className="text-right text-muted-foreground">
+                      <TableCell className="whitespace-nowrap text-right text-muted-foreground tabular-nums">
                         {skill.lastActivatedAt
                           ? format(
                               new Date(skill.lastActivatedAt),
@@ -1798,7 +1894,7 @@ function UserModelBadges({
 function StatisticsTablePanel({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className={`${STATISTICS_TABLE_MAX_HEIGHT_CLASS} overflow-auto rounded-md border`}
+      className={`${STATISTICS_TABLE_MAX_HEIGHT_CLASS} min-w-0 overflow-auto rounded-md border`}
     >
       {children}
     </div>

--- a/platform/frontend/src/app/llm/(costs)/layout.tsx
+++ b/platform/frontend/src/app/llm/(costs)/layout.tsx
@@ -81,6 +81,7 @@ export default function CostsLayout({
   return (
     <CostsLayoutContext.Provider value={contextValue}>
       <PageLayout
+        minWidth="phone"
         title={config.title}
         description={
           pathname === "/llm/costs" && prometheusDocsUrl ? (

--- a/platform/frontend/src/app/llm/usage/_parts/top-sessions-card.tsx
+++ b/platform/frontend/src/app/llm/usage/_parts/top-sessions-card.tsx
@@ -76,16 +76,30 @@ export function TopSessionsCard({
           </p>
         ) : (
           <div className="overflow-x-auto">
-            <Table>
+            <Table className="min-w-[70rem] table-auto">
               <TableHeader>
                 <TableRow>
-                  <TableHead>Started</TableHead>
-                  <TableHead>Client</TableHead>
-                  <TableHead>Model</TableHead>
-                  <TableHead className="text-right">Requests</TableHead>
-                  <TableHead className="text-right">Duration</TableHead>
-                  <TableHead className="text-right">Tokens</TableHead>
-                  <TableHead className="text-right">Spend</TableHead>
+                  <TableHead className="min-w-[9rem] max-w-[12rem] whitespace-nowrap">
+                    Started
+                  </TableHead>
+                  <TableHead className="min-w-[8rem] max-w-[14rem] whitespace-nowrap">
+                    Client
+                  </TableHead>
+                  <TableHead className="min-w-[14rem] max-w-[24rem] whitespace-nowrap">
+                    Model
+                  </TableHead>
+                  <TableHead className="min-w-[7rem] max-w-[10rem] whitespace-nowrap text-right">
+                    Requests
+                  </TableHead>
+                  <TableHead className="min-w-[7rem] max-w-[10rem] whitespace-nowrap text-right">
+                    Duration
+                  </TableHead>
+                  <TableHead className="min-w-[8rem] max-w-[12rem] whitespace-nowrap text-right">
+                    Tokens
+                  </TableHead>
+                  <TableHead className="min-w-[10rem] max-w-[16rem] whitespace-nowrap text-right">
+                    Spend
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -102,26 +116,26 @@ export function TopSessionsCard({
                         {session.sessionId}
                       </span>
                     </TableCell>
-                    <TableCell className="max-w-[14ch] truncate">
+                    <TableCell className="max-w-[14rem] truncate">
                       <span title={session.client ?? undefined}>
                         {session.client ?? "Not reported"}
                       </span>
                     </TableCell>
-                    <TableCell className="max-w-[18ch] truncate">
+                    <TableCell className="max-w-[24rem] truncate">
                       <span title={session.model ?? undefined}>
                         {session.model ?? "Not reported"}
                       </span>
                     </TableCell>
-                    <TableCell className="text-right tabular-nums">
+                    <TableCell className="whitespace-nowrap text-right tabular-nums">
                       {session.requests.toLocaleString()}
                     </TableCell>
-                    <TableCell className="text-right tabular-nums">
+                    <TableCell className="whitespace-nowrap text-right tabular-nums">
                       {formatDuration(session.durationMinutes)}
                     </TableCell>
-                    <TableCell className="text-right tabular-nums">
+                    <TableCell className="whitespace-nowrap text-right tabular-nums">
                       {formatTokens(session.tokens)}
                     </TableCell>
-                    <TableCell className="text-right tabular-nums">
+                    <TableCell className="whitespace-nowrap text-right tabular-nums">
                       <BilledCost
                         cost={String(session.cost)}
                         billedCost={String(session.billedCost)}

--- a/platform/frontend/src/app/llm/usage/_parts/usage-dimension-cards.test.tsx
+++ b/platform/frontend/src/app/llm/usage/_parts/usage-dimension-cards.test.tsx
@@ -30,6 +30,10 @@ describe("usage dimension cards", () => {
     expect(
       screen.getByRole("img", { name: /62\.5% of tokens/i }),
     ).toBeInTheDocument();
+    // Phone viewports must scroll the table rather than wrap figures into
+    // neighbouring columns (`table-fixed` + wrap-break-word otherwise crush it).
+    expect(screen.getByRole("table").className).toContain("min-w-[70rem]");
+    expect(screen.getByRole("table").className).toContain("table-auto");
   });
 
   it("groups client usage and keeps subscription-covered value out of spend", () => {

--- a/platform/frontend/src/app/llm/usage/_parts/usage-dimension-cards.tsx
+++ b/platform/frontend/src/app/llm/usage/_parts/usage-dimension-cards.tsx
@@ -95,23 +95,28 @@ function UsageDimensionCard({
             {emptyMessage}
           </p>
         ) : (
-          <div className="max-h-[360px] overflow-auto rounded-md border">
-            <Table>
+          <div className="max-h-[360px] min-w-0 overflow-auto rounded-md border">
+            {/*
+              Shared Table is `table-fixed` + wrap-break-word; without a floor
+              width, phone viewports crush headers and figures into neighbouring
+              columns. Scroll horizontally instead.
+            */}
+            <Table className="min-w-[70rem] table-auto">
               <TableHeader>
                 <TableRow>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className="bg-card sticky top-0 z-10 min-w-[12rem] max-w-[20rem] whitespace-nowrap">
                     {dimensionLabel}
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10">
+                  <TableHead className="bg-card sticky top-0 z-10 min-w-28 max-w-[12rem] whitespace-nowrap">
                     Share
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead className="bg-card sticky top-0 z-10 min-w-[7rem] max-w-[10rem] whitespace-nowrap text-right">
                     Requests
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead className="bg-card sticky top-0 z-10 min-w-[8rem] max-w-[12rem] whitespace-nowrap text-right">
                     Tokens
                   </TableHead>
-                  <TableHead className="bg-card sticky top-0 z-10 text-right">
+                  <TableHead className="bg-card sticky top-0 z-10 min-w-[10rem] max-w-[16rem] whitespace-nowrap text-right">
                     Spend
                   </TableHead>
                 </TableRow>
@@ -119,7 +124,7 @@ function UsageDimensionCard({
               <TableBody>
                 {rows.map((row) => (
                   <TableRow key={row.label}>
-                    <TableCell className="max-w-[20ch] font-medium">
+                    <TableCell className="max-w-[20rem] font-medium">
                       <span className="block truncate" title={row.label}>
                         {row.label}
                       </span>
@@ -143,10 +148,10 @@ function UsageDimensionCard({
                         </span>
                       </div>
                     </TableCell>
-                    <TableCell className="text-right tabular-nums">
+                    <TableCell className="whitespace-nowrap text-right tabular-nums">
                       {row.requests.toLocaleString()}
                     </TableCell>
-                    <TableCell className="text-right tabular-nums">
+                    <TableCell className="whitespace-nowrap text-right tabular-nums">
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span className="cursor-default underline decoration-dotted underline-offset-4">
@@ -167,7 +172,7 @@ function UsageDimensionCard({
                         </TooltipContent>
                       </Tooltip>
                     </TableCell>
-                    <TableCell className="text-right">
+                    <TableCell className="whitespace-nowrap text-right">
                       <BilledCost
                         cost={String(row.billedCost + row.subscriptionCost)}
                         billedCost={String(row.billedCost)}

--- a/platform/frontend/src/app/llm/usage/page.tsx
+++ b/platform/frontend/src/app/llm/usage/page.tsx
@@ -77,6 +77,7 @@ export default function MyUsagePage() {
 
   return (
     <PageLayout
+      minWidth="phone"
       title="My Usage"
       description="Review your own LLM activity, token mix, clients, models, sessions, and billed spend."
       actionButton={
@@ -94,11 +95,11 @@ export default function MyUsagePage() {
         </Select>
       }
     >
-      <div className="space-y-6">
+      <div className="min-w-0 space-y-6">
         <MyUsageSummary timeframe={timeframe} enabled={isTimeframeResolved} />
 
         {statisticsQuery.isPending || breakdownQuery.isPending ? (
-          <div className="grid gap-6 xl:grid-cols-2">
+          <div className="grid min-w-0 gap-6 xl:grid-cols-2">
             <Skeleton className="h-72 w-full" />
             <Skeleton className="h-72 w-full" />
             <Skeleton className="h-72 w-full" />
@@ -114,12 +115,12 @@ export default function MyUsagePage() {
           </p>
         ) : (
           <>
-            <div className="grid gap-6 xl:grid-cols-2">
+            <div className="grid min-w-0 gap-6 xl:grid-cols-2">
               <ModelUsageCard models={statisticsQuery.data.models} />
               <ClientUsageCard clients={breakdownQuery.data.clients} />
             </div>
 
-            <div className="grid gap-6 xl:grid-cols-2">
+            <div className="grid min-w-0 gap-6 xl:grid-cols-2">
               <TokenMixCard mix={breakdownQuery.data.tokenMix} />
               <ContextSizeCard buckets={breakdownQuery.data.contextBuckets} />
             </div>

--- a/platform/frontend/src/components/page-layout.test.tsx
+++ b/platform/frontend/src/components/page-layout.test.tsx
@@ -340,6 +340,18 @@ describe("PageLayout header", () => {
 
     expect(screen.getByRole("heading", { level: 1 })).toHaveClass("min-w-0");
   });
+
+  it("floors table pages at phone width so copy does not collapse to a sliver", () => {
+    const { container } = render(
+      <PageLayout minWidth="phone" title="Costs">
+        <div>tables</div>
+      </PageLayout>,
+    );
+
+    expect(
+      container.querySelectorAll(".min-w-\\[20rem\\]").length,
+    ).toBeGreaterThan(0);
+  });
 });
 
 const FIVE_TABS = [

--- a/platform/frontend/src/components/page-layout.tsx
+++ b/platform/frontend/src/components/page-layout.tsx
@@ -51,6 +51,7 @@ export function PageLayout({
   actionButton,
   mobileVisibleCount = 3,
   maxWidth: maxWidthKey = "wide",
+  minWidth: minWidthKey = "none",
 }: {
   children: React.ReactNode;
   /**
@@ -111,6 +112,12 @@ export function PageLayout({
    * opens into one — the column then stays put between reading and editing.
    */
   maxWidth?: keyof typeof MAX_WIDTH_CLASSES;
+  /**
+   * Floor for the shared header/content column. `phone` is 20rem — wide
+   * enough to read body copy, narrow enough that a phone does not
+   * horizontally scroll the whole page. Tables inside still scroll.
+   */
+  minWidth?: keyof typeof MIN_WIDTH_CLASSES;
 }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -128,6 +135,7 @@ export function PageLayout({
     ? `${pathname}?${searchParams.toString()}`
     : pathname;
   const maxWidth = MAX_WIDTH_CLASSES[maxWidthKey];
+  const minWidth = MIN_WIDTH_CLASSES[minWidthKey];
   const [overflowOpen, setOverflowOpen] = useState(false);
 
   // Split tabs for mobile: visible vs overflow
@@ -147,9 +155,14 @@ export function PageLayout({
       : undefined;
 
   return (
-    <div className="flex h-full w-full flex-col">
+    <div
+      className={cn(
+        "flex h-full w-full flex-col",
+        minWidth && "min-w-0 overflow-x-auto",
+      )}
+    >
       <div className="border-b border-border bg-card/30">
-        <div className={cn("mx-auto", maxWidth, "px-6 pt-6 md:px-6")}>
+        <div className={cn("mx-auto", minWidth, maxWidth, "px-6 pt-6 md:px-6")}>
           {backLink && <div className="mb-2">{backLink}</div>}
           {/* Below sm the action buttons drop under the title/description
               instead of squeezing them into a sliver beside the buttons. */}
@@ -303,13 +316,25 @@ export function PageLayout({
         </div>
       </div>
       <div className="w-full h-full">
-        <div className={cn("mx-auto w-full", maxWidth, "px-6 py-6 md:px-6")}>
+        <div
+          className={cn(
+            "mx-auto w-full",
+            minWidth || "min-w-0",
+            maxWidth,
+            "px-6 py-6 md:px-6",
+          )}
+        >
           {children}
         </div>
       </div>
     </div>
   );
 }
+
+const MIN_WIDTH_CLASSES = {
+  none: "",
+  phone: "min-w-[20rem]",
+} as const;
 
 const MAX_WIDTH_CLASSES = {
   wide: "max-w-[1680px]",


### PR DESCRIPTION
## Summary

Costs and My Usage statistics tables wrap cell text into neighbouring columns on phones because the shared `Table` is `table-fixed` + `wrap-break-word`. Pin a 70rem table floor with column min/max widths so those tables scroll inside the card instead. Floor the page column at 20rem so copy stays readable when the sidebar leaves a sliver, without making a phone scroll the whole page.

T-1239

## Validation

- biome check on touched files
- frontend vitest: page-layout, costs layout/page, usage page/dimension cards (37 tests)
- `pnpm type-check` in frontend

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>