### PR TITLE
fix(frontend): remove redundant subagent helper copy

### DIFF
--- a/platform/frontend/src/components/agent-form.tsx
+++ b/platform/frontend/src/components/agent-form.tsx
@@ -3418,35 +3418,19 @@ export function AgentForm({
                         </TabsList>
                       </Tabs>
                       {accessAllSubagents ? (
-                        <div className="space-y-2">
-                          <ul className="space-y-1.5 pt-1 text-xs text-muted-foreground">
-                            <li className="flex gap-2">
-                              <CheckIcon className="mt-px size-3.5 shrink-0" />
-                              Can delegate to any agent the calling user can
-                              access, in this{" "}
-                              {agentTypeDisplayName[agentType] || "agent"}'s
-                              environment — new agents included automatically
-                            </li>
-                            <li className="flex gap-2">
-                              <CheckIcon className="mt-px size-3.5 shrink-0" />
-                              Disable specific agents below to keep them off the
-                              delegation surface
-                            </li>
-                          </ul>
-                          <div className="space-y-1.5">
-                            <p className="text-sm text-muted-foreground">
-                              All subagents except ({disabledSubagentCount})
-                            </p>
-                            <SubagentsEditor
-                              availableAgents={allInternalAgents}
-                              selectedAgentIds={disabledSubagentIds}
-                              onSelectionChange={setDisabledSubagentIds}
-                              currentAgentId={agent?.id}
-                              placeholder="Search agents to disable..."
-                              showCreateAction={false}
-                              tone="exclude"
-                            />
-                          </div>
+                        <div className="space-y-1.5">
+                          <p className="text-sm text-muted-foreground">
+                            All subagents except ({disabledSubagentCount})
+                          </p>
+                          <SubagentsEditor
+                            availableAgents={allInternalAgents}
+                            selectedAgentIds={disabledSubagentIds}
+                            onSelectionChange={setDisabledSubagentIds}
+                            currentAgentId={agent?.id}
+                            placeholder="Search agents to disable..."
+                            showCreateAction={false}
+                            tone="exclude"
+                          />
                         </div>
                       ) : (
                         <div className="space-y-1.5">


### PR DESCRIPTION
Removes duplicated Auto-mode helper text from the Subagents configuration so the functional exclusion label and editor remain clear.

Preserves Auto/Custom mode behavior and the existing subagent selection controls.

Task: https://slack.com/archives/C0B2AGC0AFQ/p1787844775294179

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>