### PR TITLE
fix(logs): rank user filter by activity

### DIFF
--- a/platform/backend/src/models/interaction.test.ts
+++ b/platform/backend/src/models/interaction.test.ts
@@ -2947,13 +2947,13 @@ describe("InteractionModel", () => {
   });
 
   describe("getUniqueUserIds", () => {
-    test("returns unique user IDs with names", async ({
+    test("returns unique users ordered by activity", async ({
       makeAdmin,
       makeUser,
     }) => {
       const admin = await makeAdmin();
-      const user1 = await makeUser({ name: "User One" });
-      const user2 = await makeUser({ name: "User Two" });
+      const user1 = await makeUser({ name: "Zulu Most Active" });
+      const user2 = await makeUser({ name: "Alpha Less Active" });
 
       const agent = await AgentModel.create({
         name: "Agent",
@@ -3008,9 +3008,10 @@ describe("InteractionModel", () => {
       const userIds = await InteractionModel.getUniqueUserIds(admin.id, true);
 
       expect(userIds).toHaveLength(2);
-      // Results should be sorted by name
-      expect(userIds.map((u) => u.name)).toContain("User One");
-      expect(userIds.map((u) => u.name)).toContain("User Two");
+      expect(userIds.map((u) => u.name)).toEqual([
+        "Zulu Most Active",
+        "Alpha Less Active",
+      ]);
       expect(userIds.every((u) => u.id && u.name)).toBe(true);
     });
 

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -925,9 +925,12 @@ class InteractionModel {
       );
     }
 
-    // Get distinct user IDs from interactions and join with users table to get names
+    // Put the most active users first so a large organization's filter surfaces
+    // likely choices before its alphabetical tail. Names and ids close ties to
+    // keep the order stable between requests.
+    const activityCount = count();
     const result = await db
-      .selectDistinct({
+      .select({
         userId: schema.interactionsTable.userId,
         userName: schema.usersTable.name,
       })
@@ -937,7 +940,12 @@ class InteractionModel {
         eq(schema.interactionsTable.userId, schema.usersTable.id),
       )
       .where(and(...conditions))
-      .orderBy(asc(schema.usersTable.name));
+      .groupBy(schema.interactionsTable.userId, schema.usersTable.name)
+      .orderBy(
+        desc(activityCount),
+        asc(schema.usersTable.name),
+        asc(schema.interactionsTable.userId),
+      );
 
     return result
       .filter(


### PR DESCRIPTION
## Summary

- rank the LLM Logs user filter by interaction count
- keep alphabetical and ID tie-breakers for deterministic ordering
- cover the ordering against an intentionally opposite alphabetical order

Origin: [T-1230](https://slack.com/archives/C0B2AGC0AFQ/p1787927677146609?thread_ts=1787927649.374999&cid=C0B2AGC0AFQ)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>