### PR TITLE
fix(agents): edit system prompt from overview

### DIFF
--- a/platform/frontend/src/components/a2a-connection-instructions.test.tsx
+++ b/platform/frontend/src/components/a2a-connection-instructions.test.tsx
@@ -1,5 +1,6 @@
 import type { archestraApiTypes } from "@archestra/shared";
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useAgentEmailAddress } from "@/lib/chatops/incoming-email.query";
@@ -98,6 +99,24 @@ beforeEach(() => {
 });
 
 describe("A2AConnectionInstructions — Other ways to reach this agent", () => {
+  it("puts raw API examples after user-facing channels and keeps them collapsed", async () => {
+    const user = userEvent.setup();
+    renderChannels();
+
+    const channelsHeading = screen.getByRole("heading", {
+      name: "Other ways to reach this agent",
+    });
+    const apiTrigger = screen.getByRole("button", { name: /Call via API/ });
+    expect(
+      channelsHeading.compareDocumentPosition(apiTrigger) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.queryByText("Continue the conversation")).toBeNull();
+
+    await user.click(apiTrigger);
+    expect(screen.getByText("Continue the conversation")).toBeVisible();
+  });
+
   // Email invocation used to render its guidance inside a bg-muted/50 panel at
   // text-sm, so the channel that most often has nothing to copy shouted over
   // the two above it. Every channel now gets the same one line of prose.

--- a/platform/frontend/src/components/a2a-connection-instructions.tsx
+++ b/platform/frontend/src/components/a2a-connection-instructions.tsx
@@ -531,7 +531,7 @@ curl -X POST "${a2aEndpoint}" \\
           className="space-y-4 rounded-lg border bg-card p-4"
         >
           <h3 id={endpointHeadingId} className="text-sm font-semibold">
-            Endpoint
+            Agent Endpoint
           </h3>
           <ConnectionUrlStep
             bare
@@ -573,8 +573,9 @@ curl -X POST "${a2aEndpoint}" \\
               Authentication
             </h3>
             <p className="text-sm text-muted-foreground">
-              Use a platform token for A2A. OAuth access tokens and configured
-              identity-provider JWTs also work; LLM API keys do not.
+              Use a platform token for A2A calls. OAuth access tokens and
+              configured identity-provider JWTs also work. LLM API keys do not
+              work.
             </p>
           </div>
           <div className="space-y-3">
@@ -661,109 +662,6 @@ curl -X POST "${a2aEndpoint}" \\
           </div>
         </section>
 
-        <section
-          aria-labelledby={examplesHeadingId}
-          className="space-y-4 rounded-lg border bg-card p-4"
-        >
-          <h3 id={examplesHeadingId} className="text-sm font-semibold">
-            Call the agent
-          </h3>
-          <div className="space-y-3">
-            <CurlExampleSection
-              key={`card-${effectiveTokenId}`}
-              code={agentCardCurlCode}
-              {...curlExampleProps}
-            />
-            <CurlExampleSection
-              key={`send-${effectiveTokenId}`}
-              code={curlCode}
-              {...curlExampleProps}
-            />
-            <CurlExampleSection
-              key={`stream-${effectiveTokenId}`}
-              code={streamingCurlCode}
-              {...curlExampleProps}
-            />
-            <Collapsible className="rounded-lg border">
-              <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
-                Continue the conversation
-                <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-              </CollapsibleTrigger>
-              <CollapsibleContent className="px-4 pb-4">
-                <CurlExampleSection
-                  key={`reply-${effectiveTokenId}`}
-                  code={replyCurlCode}
-                  {...curlExampleProps}
-                />
-              </CollapsibleContent>
-            </Collapsible>
-            <Collapsible className="rounded-lg border">
-              <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
-                Approve or deny tool calls
-                <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-              </CollapsibleTrigger>
-              <CollapsibleContent className="px-4 pb-4">
-                <CurlExampleSection
-                  key={`approval-${effectiveTokenId}`}
-                  code={approvalCurlCode}
-                  {...curlExampleProps}
-                />
-              </CollapsibleContent>
-            </Collapsible>
-            <Collapsible className="rounded-lg border">
-              <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
-                Run in the background
-                <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-              </CollapsibleTrigger>
-              <CollapsibleContent className="px-4 pb-4">
-                <CurlExampleSection
-                  key={`background-${effectiveTokenId}`}
-                  code={backgroundTaskCurlCode}
-                  {...curlExampleProps}
-                />
-              </CollapsibleContent>
-            </Collapsible>
-            <Collapsible className="rounded-lg border">
-              <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
-                Reconnect to a running task
-                <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-              </CollapsibleTrigger>
-              <CollapsibleContent className="px-4 pb-4">
-                <CurlExampleSection
-                  key={`subscribe-${effectiveTokenId}`}
-                  code={subscribeCurlCode}
-                  {...curlExampleProps}
-                />
-              </CollapsibleContent>
-            </Collapsible>
-            <Collapsible className="rounded-lg border">
-              <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
-                List and cancel tasks
-                <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-              </CollapsibleTrigger>
-              <CollapsibleContent className="px-4 pb-4">
-                <CurlExampleSection
-                  key={`manage-${effectiveTokenId}`}
-                  code={manageTasksCurlCode}
-                  {...curlExampleProps}
-                />
-              </CollapsibleContent>
-            </Collapsible>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Every method is covered in the{" "}
-            <a
-              href={getDocsUrl(DocsPage.PlatformAgentTriggersWebhookA2a)}
-              target="_blank"
-              rel="noreferrer"
-              className="underline hover:text-foreground"
-            >
-              A2A docs
-            </a>
-            .
-          </p>
-        </section>
-
         <section className="space-y-4 rounded-lg border bg-card p-4">
           <h3 className="text-sm font-semibold">
             Other ways to reach this agent
@@ -782,13 +680,130 @@ curl -X POST "${a2aEndpoint}" \\
             />
           </div>
         </section>
+
+        <Collapsible className="rounded-lg border bg-card">
+          <CollapsibleTrigger className="group flex w-full items-center justify-between gap-4 rounded-lg p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+            <span className="space-y-1">
+              <span
+                id={examplesHeadingId}
+                className="block text-sm font-semibold"
+              >
+                Call via API
+              </span>
+              <span className="block text-xs font-normal text-muted-foreground">
+                View A2A request examples for a custom integration.
+              </span>
+            </span>
+            <ChevronDown className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+          </CollapsibleTrigger>
+          <CollapsibleContent
+            aria-labelledby={examplesHeadingId}
+            role="region"
+            className="space-y-4 border-t px-4 pb-4 pt-4"
+          >
+            <div className="space-y-3">
+              <CurlExampleSection
+                key={`card-${effectiveTokenId}`}
+                code={agentCardCurlCode}
+                {...curlExampleProps}
+              />
+              <CurlExampleSection
+                key={`send-${effectiveTokenId}`}
+                code={curlCode}
+                {...curlExampleProps}
+              />
+              <CurlExampleSection
+                key={`stream-${effectiveTokenId}`}
+                code={streamingCurlCode}
+                {...curlExampleProps}
+              />
+              <Collapsible className="rounded-lg border">
+                <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
+                  Continue the conversation
+                  <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="px-4 pb-4">
+                  <CurlExampleSection
+                    key={`reply-${effectiveTokenId}`}
+                    code={replyCurlCode}
+                    {...curlExampleProps}
+                  />
+                </CollapsibleContent>
+              </Collapsible>
+              <Collapsible className="rounded-lg border">
+                <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
+                  Approve or deny tool calls
+                  <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="px-4 pb-4">
+                  <CurlExampleSection
+                    key={`approval-${effectiveTokenId}`}
+                    code={approvalCurlCode}
+                    {...curlExampleProps}
+                  />
+                </CollapsibleContent>
+              </Collapsible>
+              <Collapsible className="rounded-lg border">
+                <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
+                  Run in the background
+                  <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="px-4 pb-4">
+                  <CurlExampleSection
+                    key={`background-${effectiveTokenId}`}
+                    code={backgroundTaskCurlCode}
+                    {...curlExampleProps}
+                  />
+                </CollapsibleContent>
+              </Collapsible>
+              <Collapsible className="rounded-lg border">
+                <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
+                  Reconnect to a running task
+                  <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="px-4 pb-4">
+                  <CurlExampleSection
+                    key={`subscribe-${effectiveTokenId}`}
+                    code={subscribeCurlCode}
+                    {...curlExampleProps}
+                  />
+                </CollapsibleContent>
+              </Collapsible>
+              <Collapsible className="rounded-lg border">
+                <CollapsibleTrigger className="group flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium">
+                  List and cancel tasks
+                  <ChevronDown className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="px-4 pb-4">
+                  <CurlExampleSection
+                    key={`manage-${effectiveTokenId}`}
+                    code={manageTasksCurlCode}
+                    {...curlExampleProps}
+                  />
+                </CollapsibleContent>
+              </Collapsible>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              The{" "}
+              <a
+                href={getDocsUrl(DocsPage.PlatformAgentTriggersWebhookA2a)}
+                target="_blank"
+                rel="noreferrer"
+                className="underline hover:text-foreground"
+              >
+                A2A docs
+              </a>
+              <span> cover every method.</span>
+            </p>
+          </CollapsibleContent>
+        </Collapsible>
       </div>
     );
   }
 
   return (
     <div>
-      <WizardStep n={1} title="Endpoint">
+      <WizardStep n={1} title="Agent Endpoint">
         <div className="space-y-3">
           <ConnectionUrlStep
             bare

--- a/platform/frontend/src/components/agent-pages/agent-detail-page.test.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-detail-page.test.tsx
@@ -38,6 +38,9 @@ vi.mock("./agent-connect-content", () => ({
 vi.mock("./agent-background-execution-card", () => ({
   AgentBackgroundExecutionCard: () => <div>background execution</div>,
 }));
+vi.mock("./agent-system-prompt-card", () => ({
+  AgentSystemPromptCard: () => <div>system prompt editor</div>,
+}));
 vi.mock("./agent-executions", () => ({
   AgentExecutions: () => <div>execution history</div>,
 }));
@@ -174,22 +177,24 @@ describe("AgentDetailPage", () => {
     expect(screen.queryByRole("link", { name: "Connect" })).toBeNull();
   });
 
-  it("shows the overview without a click, above the connection instructions, and links to the full configuration", () => {
+  it("shows overview and system prompt editing before connection instructions", () => {
     render(<AgentDetailPage kind="agent" id="a1" />);
 
     expect(screen.getByRole("heading", { name: "Overview" })).toBeVisible();
     const overview = screen.getByText("overview");
+    const systemPrompt = screen.getByText("system prompt editor");
     const connect = screen.getByText("connect content");
     expect(
-      overview.compareDocumentPosition(connect) &
+      overview.compareDocumentPosition(systemPrompt) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    // Same destination as the header's Edit, so Overview is a way in rather
-    // than a second, shorter copy of the form.
-    expect(screen.getByRole("link", { name: /Configuration/ })).toHaveAttribute(
-      "href",
-      "/agents/a1/edit",
-    );
+    expect(
+      systemPrompt.compareDocumentPosition(connect) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: /Full configuration/i }),
+    ).toHaveAttribute("href", "/agents/a1/edit");
   });
 
   it("keeps the MCP Gateway Overview but moves its environment into the header", () => {

--- a/platform/frontend/src/components/agent-pages/agent-detail-page.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-detail-page.tsx
@@ -76,6 +76,7 @@ import {
   isAgentTypeAllowedOnPage,
 } from "./agent-page-config";
 import { BackLink } from "./agent-page-shell";
+import { AgentSystemPromptCard } from "./agent-system-prompt-card";
 import { useAgentAccess } from "./use-agent-access";
 
 /**
@@ -477,7 +478,17 @@ function AgentDetails({
             headingId="agent-overview-heading"
             facts={overviewFacts}
             configHref={canEdit ? agentActionHref(editAction) : undefined}
+            configLabel="Full configuration"
           />
+
+          {kind === "agent" && (
+            <AgentSystemPromptCard
+              key={agent.id}
+              agent={agent}
+              readOnly={!canEdit}
+              builtInAgentName={agent.builtInAgentConfig?.name}
+            />
+          )}
 
           {hasBackgroundExecution && (
             <AgentBackgroundExecutionCard

--- a/platform/frontend/src/components/agent-pages/agent-system-prompt-card.test.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-system-prompt-card.test.tsx
@@ -1,0 +1,211 @@
+import {
+  BUILT_IN_AGENT_DEFAULT_SYSTEM_PROMPTS,
+  BUILT_IN_AGENT_IDS,
+} from "@archestra/shared";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "next/navigation";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUpdateProfile } from "@/lib/agent.query";
+import { AgentSystemPromptCard } from "./agent-system-prompt-card";
+
+vi.mock("@/lib/agent.query", () => ({ useUpdateProfile: vi.fn() }));
+vi.mock("next/navigation");
+vi.mock("@/components/system-prompt-editor", () => ({
+  SystemPromptEditor: ({
+    title,
+    value,
+    onChange,
+    readOnly,
+    headerExtra,
+  }: {
+    title: string;
+    value: string;
+    onChange: (value: string) => void;
+    readOnly: boolean;
+    headerExtra?: ReactNode;
+  }) => (
+    <div>
+      <span>{title}</span>
+      {headerExtra}
+      <textarea
+        aria-label={title}
+        value={value}
+        readOnly={readOnly}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </div>
+  ),
+}));
+
+const mutate = vi.fn();
+const push = vi.fn();
+
+describe("AgentSystemPromptCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({ push } as never);
+    vi.mocked(useUpdateProfile).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateProfile>);
+  });
+
+  it("saves an edited system prompt directly from the overview", async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentSystemPromptCard
+        agent={{ id: "agent-1", systemPrompt: "Old prompt" }}
+        readOnly={false}
+      />,
+    );
+
+    const editor = screen.getByRole("textbox", { name: "System prompt" });
+    fireEvent.change(editor, { target: { value: "  New prompt  " } });
+    await user.click(
+      screen.getByRole("button", { name: "Save system prompt" }),
+    );
+
+    expect(mutate).toHaveBeenCalledWith({
+      id: "agent-1",
+      data: { systemPrompt: "New prompt" },
+    });
+  });
+
+  it("shows the prompt without edit controls to a read-only viewer", () => {
+    render(
+      <AgentSystemPromptCard
+        agent={{ id: "agent-1", systemPrompt: "Read me" }}
+        readOnly
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "System prompt" })).toHaveValue(
+      "Read me",
+    );
+    expect(screen.getByRole("form", { name: "System prompt" })).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Save system prompt" }),
+    ).toBeNull();
+  });
+
+  it("resets local prompt state when the agent changes", () => {
+    const { rerender } = render(
+      <AgentSystemPromptCard
+        key="agent-1"
+        agent={{ id: "agent-1", systemPrompt: "First prompt" }}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "System prompt" }), {
+      target: { value: "Unsaved first prompt" },
+    });
+
+    rerender(
+      <AgentSystemPromptCard
+        key="agent-2"
+        agent={{ id: "agent-2", systemPrompt: "Second prompt" }}
+        readOnly={false}
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "System prompt" })).toHaveValue(
+      "Second prompt",
+    );
+  });
+
+  it("syncs a clean editor when the same agent receives a newer prompt", async () => {
+    const { rerender } = render(
+      <AgentSystemPromptCard
+        agent={{ id: "agent-1", systemPrompt: "First prompt" }}
+        readOnly={false}
+      />,
+    );
+
+    rerender(
+      <AgentSystemPromptCard
+        agent={{ id: "agent-1", systemPrompt: "Updated elsewhere" }}
+        readOnly={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("textbox", { name: "System prompt" }),
+      ).toHaveValue("Updated elsewhere"),
+    );
+  });
+
+  it("guards in-app navigation while the prompt has unsaved changes", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <AgentSystemPromptCard
+          agent={{ id: "agent-1", systemPrompt: "Old prompt" }}
+          readOnly={false}
+        />
+        <a href="/agents/agent-2">Another agent</a>
+      </>,
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "System prompt" }), {
+      target: { value: "Unsaved prompt" },
+    });
+
+    await user.click(screen.getByRole("link", { name: "Another agent" }));
+    expect(push).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Discard unsaved changes?",
+    });
+    await user.click(
+      within(dialog).getByRole("button", { name: "Discard changes" }),
+    );
+    expect(push).toHaveBeenCalledWith("/agents/agent-2");
+  });
+
+  it("does not guard a same-page skip link", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <AgentSystemPromptCard
+          agent={{ id: "agent-1", systemPrompt: "Old prompt" }}
+          readOnly={false}
+        />
+        <a href="#main-content">Skip to content</a>
+      </>,
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "System prompt" }), {
+      target: { value: "Unsaved prompt" },
+    });
+
+    await user.click(screen.getByRole("link", { name: "Skip to content" }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeNull();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("restores a built-in agent's default prompt", async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentSystemPromptCard
+        agent={{ id: "agent-1", systemPrompt: "Customized" }}
+        readOnly={false}
+        builtInAgentName={BUILT_IN_AGENT_IDS.POLICY_CONFIG}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reset to Default" }));
+    expect(screen.getByRole("textbox", { name: "System prompt" })).toHaveValue(
+      BUILT_IN_AGENT_DEFAULT_SYSTEM_PROMPTS[BUILT_IN_AGENT_IDS.POLICY_CONFIG],
+    );
+  });
+});

--- a/platform/frontend/src/components/agent-pages/agent-system-prompt-card.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-system-prompt-card.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { BUILT_IN_AGENT_DEFAULT_SYSTEM_PROMPTS } from "@archestra/shared";
+import { Loader2, RotateCcw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { SystemPromptEditor } from "@/components/system-prompt-editor";
+import { Button } from "@/components/ui/button";
+import {
+  UnsavedChangesDialog,
+  useBeforeUnloadWhileDirty,
+  useUnsavedChangesGuard,
+} from "@/components/unsaved-changes-guard";
+import { useUpdateProfile } from "@/lib/agent.query";
+
+export function AgentSystemPromptCard({
+  agent,
+  readOnly,
+  builtInAgentName,
+}: {
+  agent: { id: string; systemPrompt?: string | null };
+  readOnly: boolean;
+  builtInAgentName?: keyof typeof BUILT_IN_AGENT_DEFAULT_SYSTEM_PROMPTS;
+}) {
+  const router = useRouter();
+  const savedPrompt = agent.systemPrompt ?? "";
+  const [systemPrompt, setSystemPrompt] = useState(savedPrompt);
+  const previousSavedPromptRef = useRef(savedPrompt);
+  const pendingHrefRef = useRef<string | null>(null);
+  const updateAgent = useUpdateProfile({
+    successMessage: "System prompt saved",
+  });
+  const isDirty = systemPrompt.trim() !== savedPrompt.trim();
+  const defaultSystemPrompt = builtInAgentName
+    ? (BUILT_IN_AGENT_DEFAULT_SYSTEM_PROMPTS[builtInAgentName] ?? "")
+    : undefined;
+
+  useBeforeUnloadWhileDirty(isDirty);
+
+  useEffect(() => {
+    const previousSavedPrompt = previousSavedPromptRef.current;
+    previousSavedPromptRef.current = savedPrompt;
+    setSystemPrompt((currentPrompt) =>
+      currentPrompt.trim() === previousSavedPrompt.trim()
+        ? savedPrompt
+        : currentPrompt,
+    );
+  }, [savedPrompt]);
+
+  const guard = useUnsavedChangesGuard({
+    isDirty,
+    onOpenChange: (open) => {
+      if (open) return;
+      const href = pendingHrefRef.current;
+      pendingHrefRef.current = null;
+      if (href) router.push(href);
+    },
+  });
+
+  useEffect(() => {
+    if (!isDirty) return;
+
+    const guardNavigation = (event: MouseEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      const target = event.target;
+      const anchor =
+        target instanceof Element
+          ? target.closest<HTMLAnchorElement>("a[href]")
+          : null;
+      if (
+        !anchor ||
+        anchor.target === "_blank" ||
+        anchor.hasAttribute("download")
+      ) {
+        return;
+      }
+      const url = new URL(anchor.href, window.location.href);
+      if (url.origin !== window.location.origin) return;
+      if (
+        url.pathname === window.location.pathname &&
+        url.search === window.location.search &&
+        url.hash
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      pendingHrefRef.current = `${url.pathname}${url.search}${url.hash}`;
+      guard.requestClose();
+    };
+
+    document.addEventListener("click", guardNavigation, true);
+    return () => document.removeEventListener("click", guardNavigation, true);
+  }, [guard.requestClose, isDirty]);
+
+  return (
+    <>
+      <form
+        aria-label="System prompt"
+        className="space-y-4 rounded-lg border bg-card p-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!isDirty || readOnly || updateAgent.isPending) return;
+          updateAgent.mutate({
+            id: agent.id,
+            data: { systemPrompt: systemPrompt.trim() || null },
+          });
+        }}
+      >
+        <SystemPromptEditor
+          title="System prompt"
+          value={systemPrompt}
+          onChange={setSystemPrompt}
+          readOnly={readOnly}
+          variant="section"
+          builtInAgentId={builtInAgentName}
+          headerExtra={
+            !readOnly && builtInAgentName ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                disabled={systemPrompt === defaultSystemPrompt}
+                onClick={() => setSystemPrompt(defaultSystemPrompt ?? "")}
+              >
+                <RotateCcw className="size-4" />
+                <span>Reset to Default</span>
+              </Button>
+            ) : undefined
+          }
+        />
+        {!readOnly && (
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!isDirty || updateAgent.isPending}
+              onClick={() => setSystemPrompt(savedPrompt)}
+            >
+              Discard changes
+            </Button>
+            <Button type="submit" disabled={!isDirty || updateAgent.isPending}>
+              {updateAgent.isPending ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  <span>Saving...</span>
+                </>
+              ) : (
+                <span>Save system prompt</span>
+              )}
+            </Button>
+          </div>
+        )}
+      </form>
+      <UnsavedChangesDialog
+        open={guard.confirmOpen}
+        onKeepEditing={() => {
+          pendingHrefRef.current = null;
+          guard.keepEditing();
+        }}
+        onDiscard={guard.discardChanges}
+      />
+    </>
+  );
+}

--- a/platform/frontend/src/components/system-prompt-editor.test.tsx
+++ b/platform/frontend/src/components/system-prompt-editor.test.tsx
@@ -75,6 +75,7 @@ describe("SystemPromptEditor", () => {
 
     render(
       <SystemPromptEditor
+        title="System prompt"
         value="Hello {{user.name}}"
         onChange={onChange}
         height="120px"
@@ -84,7 +85,7 @@ describe("SystemPromptEditor", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
 
     await user.click(screen.getByRole("button", { name: /full screen/i }));
-    const dialog = screen.getByRole("dialog", { name: "Instruction" });
+    const dialog = screen.getByRole("dialog", { name: "System prompt" });
     // The whole viewport: a second editor on the same value, the header's
     // extra action alongside the way back.
     const editors = within(dialog).getAllByTestId("editor");

--- a/platform/frontend/src/components/system-prompt-editor.tsx
+++ b/platform/frontend/src/components/system-prompt-editor.tsx
@@ -26,6 +26,7 @@ import {
 import { useUnparseableExpressions } from "@/lib/utils/handlebars-validation";
 
 export function SystemPromptEditor({
+  title = "Instruction",
   value,
   onChange,
   readOnly,
@@ -34,6 +35,7 @@ export function SystemPromptEditor({
   headerExtra,
   builtInAgentId,
 }: {
+  title?: string;
   value: string;
   onChange: (value: string) => void;
   readOnly?: boolean;
@@ -56,7 +58,7 @@ export function SystemPromptEditor({
   });
   const description = (
     <>
-      System prompt used by the agent. Supports{" "}
+      <span>Defines the agent&apos;s behavior. Supports </span>
       <a
         href="https://handlebarsjs.com/"
         target="_blank"
@@ -64,11 +66,11 @@ export function SystemPromptEditor({
         className="underline hover:text-foreground"
       >
         Handlebars
-      </a>{" "}
-      templating
-      {docsUrl ? (
+      </a>
+      <span> templating.</span>
+      {docsUrl && (
         <>
-          <span>{" — see "}</span>
+          <span> See </span>
           <ExternalDocsLink
             href={docsUrl}
             className="underline hover:text-foreground"
@@ -76,10 +78,8 @@ export function SystemPromptEditor({
           >
             docs
           </ExternalDocsLink>
-          <span>{" for available variables."}</span>
+          <span> for available variables.</span>
         </>
-      ) : (
-        <span>.</span>
       )}
     </>
   );
@@ -89,9 +89,9 @@ export function SystemPromptEditor({
       <div className="flex items-start justify-between gap-3">
         <div>
           {variant === "section" ? (
-            <h3 className="text-base font-semibold">Instruction</h3>
+            <h3 className="text-base font-semibold">{title}</h3>
           ) : (
-            <p className="text-sm font-medium">Instruction</p>
+            <p className="text-sm font-medium">{title}</p>
           )}
           <p className="text-xs text-muted-foreground">{description}</p>
         </div>
@@ -122,6 +122,7 @@ export function SystemPromptEditor({
       </div>
       <UnparseableExpressionsWarning expressions={unparseableExpressions} />
       <SystemPromptFullScreenDialog
+        title={title}
         open={isFullScreen}
         onOpenChange={setIsFullScreen}
         value={value}
@@ -184,6 +185,7 @@ const UNPARSEABLE_SHOWN_MAX = 5;
  * suggestion list, the find box), which keeps it.
  */
 function SystemPromptFullScreenDialog({
+  title,
   open,
   onOpenChange,
   value,
@@ -194,6 +196,7 @@ function SystemPromptFullScreenDialog({
   templateExpressions,
   unparseableExpressions,
 }: {
+  title: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   value: string;
@@ -220,7 +223,7 @@ function SystemPromptFullScreenDialog({
       >
         <div className="flex items-start justify-between gap-3 border-b px-4 py-3">
           <div className="space-y-1">
-            <DialogTitle className="text-base">Instruction</DialogTitle>
+            <DialogTitle className="text-base">{title}</DialogTitle>
             <DialogDescription className="text-xs">
               {description}
             </DialogDescription>

--- a/platform/frontend/src/lib/agent.query.test.ts
+++ b/platform/frontend/src/lib/agent.query.test.ts
@@ -2,6 +2,7 @@ import { archestraApiSdk } from "@archestra/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCreateProfile, useUpdateProfile } from "@/lib/agent.query";
 import { isReportedApiError } from "@/lib/utils";
@@ -100,5 +101,23 @@ describe("agent write mutations", () => {
     await expect(
       result.current.mutateAsync({ name: "New", agentType: "agent" } as never),
     ).resolves.toMatchObject({ id: "agent-1" });
+  });
+
+  it("shows a caller-specific message after an update succeeds", async () => {
+    sdk.updateAgent.mockResolvedValue({
+      data: { id: "agent-1", systemPrompt: "New prompt" },
+      error: undefined,
+    } as never);
+
+    const { result } = setup(() =>
+      useUpdateProfile({ successMessage: "System prompt saved" }),
+    );
+
+    await result.current.mutateAsync({
+      id: "agent-1",
+      data: { systemPrompt: "New prompt" },
+    });
+
+    expect(toast.success).toHaveBeenCalledWith("System prompt saved");
   });
 });

--- a/platform/frontend/src/lib/agent.query.ts
+++ b/platform/frontend/src/lib/agent.query.ts
@@ -336,7 +336,7 @@ export function useCreateProfile() {
   });
 }
 
-export function useUpdateProfile() {
+export function useUpdateProfile(options?: { successMessage?: string }) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({
@@ -361,6 +361,9 @@ export function useUpdateProfile() {
       // chat (or any other page using useProfile) shows fresh data
       queryClient.setQueryData(["agents", variables.id], data);
       queryClient.invalidateQueries({ queryKey: ["agents"] });
+      if (options?.successMessage) {
+        toast.success(options.successMessage);
+      }
       // Invalidate profile tokens when teams change (tokens are auto-created/deleted)
       queryClient.invalidateQueries({
         queryKey: ["profileTokens", variables.id],


### PR DESCRIPTION
## Summary
- let users edit an agent system prompt from its overview
- preserve built-in prompt tools and guard unsaved edits
- move raw A2A examples below user-facing connection options

## Testing
- 36 focused frontend tests
- frontend type-check
- Biome checks
- desktop and mobile live verification

Task: https://slack.com/archives/C0B2AGC0AFQ/p1787916291762869?thread_ts=1787916274.188199&cid=C0B2AGC0AFQ

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>