### PR TITLE
ci: shorten PR and merge queue checks

### DIFF
--- a/.github/workflows/docker-image-scanning.yml
+++ b/.github/workflows/docker-image-scanning.yml
@@ -1,7 +1,8 @@
 name: Docker Image Scanning
 
-# Runs automatically in merge queue and on demand when the "run-docker-scan"
-# label is added to a PR.
+# Platform and MCP scans run here on demand when the "run-docker-scan" label
+# is added to a PR. Merge-queue scans reuse the images built by
+# platform-e2e-tests.yml; the p4 scan remains here because E2E does not build it.
 # Remove and re-add the label to re-trigger after new commits.
 on:
   pull_request:
@@ -19,10 +20,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Required-check placeholders for ordinary PR updates. The real scans remain
-  # merge-queue-only unless a trusted PR is explicitly labeled. Fork PRs always
-  # get the placeholder — the real scan needs trusted context, and without this
-  # a labeled fork PR would run neither job, leaving the required check pending.
+  # Required-check placeholders for ordinary PR updates. Trusted PRs can run
+  # the real scans explicitly. Fork PRs always get the placeholder — the real
+  # scan needs trusted context, and without this a labeled fork PR would run
+  # neither job, leaving the required check pending.
   docker-image-scanning-placeholder:
     name: Docker Image Scanning (${{ matrix.name }})
     if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name != 'run-docker-scan' || github.event.pull_request.head.repo.fork == true) }}
@@ -37,7 +38,10 @@ jobs:
 
   docker-image-scanning:
     name: Docker Image Scanning (${{ matrix.name }})
-    if: ${{ github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.label.name == 'run-docker-scan' && github.event.pull_request.head.repo.fork != true) }}
+    # Platform and MCP merge-queue scans run after their E2E image builds in
+    # platform-e2e-tests.yml. Keeping this matrix PR-only avoids duplicate
+    # same-named checks that could mask a failed required scan.
+    if: ${{ github.event_name == 'pull_request' && github.event.label.name == 'run-docker-scan' && github.event.pull_request.head.repo.fork != true }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read # Required to checkout the repository and read Docker build inputs.
@@ -80,12 +84,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup environment
-        if: ${{ matrix.use-build-action }}
-        uses: ./.github/actions/setup-env
-        with:
-          working-directory: ./platform
-
       - name: Build Platform image
         if: ${{ matrix.use-build-action }}
         uses: ./.github/actions/build-docker-image
@@ -118,3 +116,43 @@ jobs:
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
           exit-code: ${{ matrix.scan-exit-code }}
+
+  # E2E has no p4 image to reuse, so this small scan still builds locally on
+  # merge_group. Platform and MCP are deliberately absent from this job: their
+  # required checks are emitted by platform-e2e-tests.yml after the exact
+  # tested images are available.
+  merge-queue-p4-image-scanning:
+    name: Docker Image Scanning (p4 Shim)
+    if: ${{ github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Reclaim disk space (background)
+        run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup &
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Build p4 Shim image
+        uses: ./.github/actions/build-docker-image
+        with:
+          context: ./platform/p4_shim_docker_image
+          dockerfile: ./platform/p4_shim_docker_image/Dockerfile
+          platforms: linux/amd64
+          push: "false"
+          load: "true"
+          tags: p4-shim:${{ github.sha }}
+          cache-from: type=registry,ref=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/p4-shim:buildcache-amd64
+
+      - name: Scan image for CVEs
+        uses: ./.github/actions/scan-docker-image
+        with:
+          image: p4-shim:${{ github.sha }}
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          exit-code: "true"

--- a/.github/workflows/docker-image-scanning.yml
+++ b/.github/workflows/docker-image-scanning.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read # Required to checkout the repository and read Docker build inputs.
+      id-token: write # Required to pull exact-SHA images previously built by E2E.
     strategy:
       fail-fast: false
       matrix:
@@ -56,6 +57,8 @@ jobs:
             local-tag-prefix: archestra-platform
             use-build-action: true
             scan-exit-code: "true"
+            e2e-image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform
+            e2e-tag-suffix: -e2e
           - name: MCP Server Base
             runner: ubuntu-latest
             context: ./platform/mcp_server_docker_image
@@ -64,6 +67,8 @@ jobs:
             use-build-action: false
             scan-exit-code: "true"
             cache-from: type=registry,ref=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:buildcache
+            e2e-image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base
+            e2e-tag-suffix: ""
           - name: p4 Shim
             runner: ubuntu-latest
             context: ./platform/p4_shim_docker_image
@@ -72,6 +77,8 @@ jobs:
             use-build-action: false
             scan-exit-code: "true"
             cache-from: type=registry,ref=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/p4-shim:buildcache-amd64
+            e2e-image: ""
+            e2e-tag-suffix: ""
     steps:
       # Standard runners ship ~14 GB free; drop the unused preinstalled
       # toolchains so the image build + scan never run out of disk.
@@ -84,8 +91,30 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Build Platform image
-        if: ${{ matrix.use-build-action }}
+      - name: Authenticate to Google Artifact Registry
+        if: ${{ matrix.e2e-image != '' }}
+        uses: ./.github/actions/auth-to-gar
+        with:
+          service_account: ${{ secrets.DEVELOPMENT_GCP_DEPLOY_SERVICE_ACCOUNT_NAME }}
+          workload_identity_provider: ${{ secrets.DEVELOPMENT_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
+
+      - name: Reuse exact E2E image when available
+        id: e2e-image
+        if: ${{ matrix.e2e-image != '' }}
+        env:
+          E2E_IMAGE: ${{ format('{0}:{1}{2}', matrix.e2e-image, github.sha, matrix.e2e-tag-suffix) }}
+          LOCAL_IMAGE: ${{ format('{0}:{1}', matrix.local-tag-prefix, github.sha) }}
+        run: |
+          if docker manifest inspect "$E2E_IMAGE" >/dev/null 2>&1; then
+            docker pull "$E2E_IMAGE"
+            docker tag "$E2E_IMAGE" "$LOCAL_IMAGE"
+            echo "reused=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "reused=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build image with workspace cache
+        if: ${{ matrix.use-build-action && steps.e2e-image.outputs.reused != 'true' }}
         uses: ./.github/actions/build-docker-image
         with:
           context: ${{ matrix.context }}
@@ -97,8 +126,8 @@ jobs:
           # Read-only: the e2e build job owns cache export for this image.
           cache-from: type=registry,ref=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:buildcache
 
-      - name: Build ${{ matrix.name }} image
-        if: ${{ !matrix.use-build-action }}
+      - name: Build image with registry cache
+        if: ${{ !matrix.use-build-action && steps.e2e-image.outputs.reused != 'true' }}
         uses: ./.github/actions/build-docker-image
         with:
           context: ${{ matrix.context }}

--- a/.github/workflows/docker-image-scanning.yml
+++ b/.github/workflows/docker-image-scanning.yml
@@ -59,6 +59,8 @@ jobs:
             scan-exit-code: "true"
             e2e-image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform
             e2e-tag-suffix: -e2e
+            e2e-slim-image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform
+            e2e-slim-tag-suffix: -e2e-slim
           - name: MCP Server Base
             runner: ubuntu-latest
             context: ./platform/mcp_server_docker_image
@@ -69,6 +71,8 @@ jobs:
             cache-from: type=registry,ref=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:buildcache
             e2e-image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base
             e2e-tag-suffix: ""
+            e2e-slim-image: ""
+            e2e-slim-tag-suffix: ""
           - name: p4 Shim
             runner: ubuntu-latest
             context: ./platform/p4_shim_docker_image
@@ -79,6 +83,8 @@ jobs:
             cache-from: type=registry,ref=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/p4-shim:buildcache-amd64
             e2e-image: ""
             e2e-tag-suffix: ""
+            e2e-slim-image: ""
+            e2e-slim-tag-suffix: ""
     steps:
       # Standard runners ship ~14 GB free; drop the unused preinstalled
       # toolchains so the image build + scan never run out of disk.
@@ -142,6 +148,24 @@ jobs:
         uses: ./.github/actions/scan-docker-image
         with:
           image: ${{ format('{0}:{1}', matrix.local-tag-prefix, github.sha) }}
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          exit-code: ${{ matrix.scan-exit-code }}
+
+      # The full Platform image inherits the slim target, but scanning both
+      # exact digests also covers artifact metadata and prevents the required
+      # check from passing without inspecting the image used by K8s/Lite E2E.
+      - name: Pull exact slim E2E image
+        if: ${{ steps.e2e-image.outputs.reused == 'true' && matrix.e2e-slim-image != '' }}
+        env:
+          E2E_SLIM_IMAGE: ${{ format('{0}:{1}{2}', matrix.e2e-slim-image, github.sha, matrix.e2e-slim-tag-suffix) }}
+        run: docker pull "$E2E_SLIM_IMAGE"
+
+      - name: Scan slim image for CVEs
+        if: ${{ steps.e2e-image.outputs.reused == 'true' && matrix.e2e-slim-image != '' }}
+        uses: ./.github/actions/scan-docker-image
+        with:
+          image: ${{ format('{0}:{1}{2}', matrix.e2e-slim-image, github.sha, matrix.e2e-slim-tag-suffix) }}
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
           exit-code: ${{ matrix.scan-exit-code }}

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -722,9 +722,6 @@ jobs:
         with:
           working-directory: ./platform
 
-      - name: Run codegen
-        run: pnpm codegen
-
       - name: Resolve Playwright version
         id: pw-version
         run: |
@@ -754,21 +751,13 @@ jobs:
         if: runner.os == 'macOS'
         run: pnpm --filter @frontend exec playwright install chromium
 
-      - name: Give the MSW webServer its own port
+      - name: Reap stale MSW webServers
         # Three runner slots share this machine (mac-mini-1, -1-2, -1-3), so
-        # two merge-queue MSW jobs can run concurrently and collide on a fixed
-        # :3010 — and a run cancelled mid-suite (queue eviction) additionally
-        # orphans its `next dev` webServer there, poisoning every later run
-        # (reuseExistingServer is deliberately off in CI). Pick a free port per
-        # job instead; playwright.config.ts honors
-        # ARCHESTRA_FRONTEND_INT_TESTS_PORT. Orphans then cannot fail anyone,
-        # but still leak memory, so also reap webServers too old to belong to
-        # any live job (a suite runs minutes, not hours).
+        # cancelled merge-queue runs can leave `next dev` processes behind.
+        # Each shard below picks its own free port, so stale servers cannot
+        # collide, but reaping old ones keeps the shared host's memory bounded.
         if: runner.os == 'macOS'
         run: |
-          port=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')
-          echo "ARCHESTRA_FRONTEND_INT_TESTS_PORT=$port" >> "$GITHUB_ENV"
-          echo "MSW webServer port for this job: $port"
           for pid in $(pgrep -f "next dev -H 127.0.0.1" || true); do
             age=$(ps -o etime= -p "$pid" | tr -d ' ') || continue
             case "$age" in
@@ -777,14 +766,33 @@ jobs:
           done
 
       - name: Run integration tests
-        run: pnpm test:integration
+        shell: bash
+        run: |
+          set -euo pipefail
+          pids=()
+          for shard in 1 2; do
+            port=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')
+            echo "Starting frontend integration shard ${shard}/2 on port ${port}"
+            ARCHESTRA_FRONTEND_INT_TESTS_PORT="$port" \
+              ARCHESTRA_FRONTEND_INT_TESTS_SHARD="$shard" \
+              pnpm --filter @frontend exec playwright test --shard="${shard}/2" &
+            pids+=("$!")
+          done
+
+          status=0
+          for pid in "${pids[@]}"; do
+            if ! wait "$pid"; then
+              status=1
+            fi
+          done
+          exit "$status"
 
       - name: Upload Playwright report
         if: failure()
         uses: ./.github/actions/github-upload-artifact
         with:
           name: playwright-integration-report
-          path: platform/frontend/playwright-report/
+          path: platform/frontend/playwright-report-shard-*/
           retention-days: "7"
 
       - name: Upload traces
@@ -792,7 +800,7 @@ jobs:
         uses: ./.github/actions/github-upload-artifact
         with:
           name: playwright-integration-traces
-          path: platform/frontend/test-results/
+          path: platform/frontend/test-results-shard-*/
           retention-days: "7"
 
   # Fallback for the mac-mini routing above: GitHub has no queue timeout for

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -771,7 +771,10 @@ jobs:
           set -euo pipefail
           pids=()
           for shard in 1 2; do
-            port=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')
+            # Three macOS runner slots share one host. Derive non-overlapping
+            # ports from the run/attempt/shard instead of discovering a free
+            # port and racing another process to bind it after the probe closes.
+            port=$((20000 + ((GITHUB_RUN_ID + GITHUB_RUN_ATTEMPT * 97) % 14000) * 2 + shard))
             echo "Starting frontend integration shard ${shard}/2 on port ${port}"
             ARCHESTRA_FRONTEND_INT_TESTS_PORT="$port" \
               ARCHESTRA_FRONTEND_INT_TESTS_SHARD="$shard" \

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -359,6 +359,58 @@ jobs:
           retention-days: 1
           compression-level: 0 # Already gzipped
 
+  # Scan the exact images exercised by E2E instead of rebuilding the same
+  # Docker contexts on slower standard runners. The required check names stay
+  # unchanged, while the scans leave the queue critical path: they begin once
+  # the images are pushed and run alongside the E2E environments.
+  merge-queue-image-scanning:
+    name: Docker Image Scanning (${{ matrix.name }})
+    needs: [platform-e2e-build]
+    if: ${{ github.event_name == 'merge_group' && needs.platform-e2e-build.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read # Required for the local auth and scan actions.
+      id-token: write # Required for Workload Identity Federation when pulling images.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Platform
+            image-repository: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform
+            tag-suffix: -e2e
+          - name: MCP Server Base
+            image-repository: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base
+            tag-suffix: ""
+    steps:
+      - name: Reclaim disk space (background)
+        run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup &
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Authenticate to Google Artifact Registry
+        uses: ./.github/actions/auth-to-gar
+        with:
+          service_account: ${{ secrets.DEVELOPMENT_GCP_DEPLOY_SERVICE_ACCOUNT_NAME }}
+          workload_identity_provider: ${{ secrets.DEVELOPMENT_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
+
+      - name: Pull E2E image
+        env:
+          SCAN_IMAGE: ${{ format('{0}:{1}{2}', matrix.image-repository, github.sha, matrix.tag-suffix) }}
+        run: docker pull "${SCAN_IMAGE}"
+
+      - name: Scan image for CVEs
+        uses: ./.github/actions/scan-docker-image
+        with:
+          image: ${{ format('{0}:{1}{2}', matrix.image-repository, github.sha, matrix.tag-suffix) }}
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          exit-code: "true"
+
   # Fast-cancel the run when an image build fails. The K8s job deliberately has
   # no `needs: [platform-e2e-build]` so it can set up in parallel with the
   # build, and then polls the registry for the pushed image up to

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -379,9 +379,13 @@ jobs:
           - name: Platform
             image-repository: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform
             tag-suffix: -e2e
+            slim-image-repository: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform
+            slim-tag-suffix: -e2e-slim
           - name: MCP Server Base
             image-repository: europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base
             tag-suffix: ""
+            slim-image-repository: ""
+            slim-tag-suffix: ""
     steps:
       - name: Reclaim disk space (background)
         run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup &
@@ -407,6 +411,21 @@ jobs:
         uses: ./.github/actions/scan-docker-image
         with:
           image: ${{ format('{0}:{1}{2}', matrix.image-repository, github.sha, matrix.tag-suffix) }}
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          exit-code: "true"
+
+      - name: Pull slim E2E image
+        if: ${{ matrix.slim-image-repository != '' }}
+        env:
+          SCAN_IMAGE: ${{ format('{0}:{1}{2}', matrix.slim-image-repository, github.sha, matrix.slim-tag-suffix) }}
+        run: docker pull "$SCAN_IMAGE"
+
+      - name: Scan slim image for CVEs
+        if: ${{ matrix.slim-image-repository != '' }}
+        uses: ./.github/actions/scan-docker-image
+        with:
+          image: ${{ format('{0}:{1}{2}', matrix.slim-image-repository, github.sha, matrix.slim-tag-suffix) }}
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
           exit-code: "true"

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -1,42 +1,11 @@
-import { createHash } from "node:crypto";
 import { readdirSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
-import { BaseSequencer, type TestSpecification } from "vitest/node";
 import { vitestLogPolicy } from "../vitest.shared";
 
 const isCI = process.env.CI === "true";
-
-// Vitest's default shard hash produced a persistent 15% spread in cumulative
-// file time across the four CI shards. This salt was selected against a recent
-// 1,062-file run; it keeps equal file counts while reducing that sampled spread
-// below 1%. New files still distribute deterministically with no manifest to
-// maintain, and every file remains assigned to exactly one shard.
-const CI_SHARD_HASH_SALT = "ci-balance-6237:";
-
-class BalancedShardSequencer extends BaseSequencer {
-  override async shard(
-    files: TestSpecification[],
-  ): Promise<TestSpecification[]> {
-    const shard = this.ctx.config.shard;
-    if (!shard) return files;
-
-    const root = path.resolve(this.ctx.config.root);
-    const sorted = [...files].sort((a, b) => {
-      const hashA = hashSpec(root, a);
-      const hashB = hashSpec(root, b);
-      return hashA.localeCompare(hashB);
-    });
-    const [start, end] = calculateShardRange(
-      sorted.length,
-      shard.index,
-      shard.count,
-    );
-    return sorted.slice(start, end);
-  }
-}
 
 /**
  * Bound the fork count by BOTH cores and memory. CPU half: 50% of cores
@@ -201,7 +170,6 @@ export default defineConfig({
     sequence: {
       // Shuffle test files to balance load across workers
       shuffle: true,
-      sequencer: BalancedShardSequencer,
     },
 
     // Increase test timeout for database operations
@@ -239,26 +207,6 @@ export default defineConfig({
     ],
   },
 });
-
-function hashSpec(root: string, spec: TestSpecification): string {
-  const fullPath = path.resolve(root, spec.moduleId);
-  const relativePath = fullPath.slice(root.length).split(path.sep).join("/");
-  return createHash("sha1")
-    .update(`${CI_SHARD_HASH_SALT}${relativePath}`)
-    .digest("hex");
-}
-
-function calculateShardRange(
-  fileCount: number,
-  index: number,
-  count: number,
-): [number, number] {
-  const baseSize = Math.floor(fileCount / count);
-  const largerShardCount = fileCount % count;
-  const size = baseSize + (index <= largerShardCount ? 1 : 0);
-  const start = (index - 1) * baseSize + Math.min(index - 1, largerShardCount);
-  return [start, start + size];
-}
 
 function rawPythonPlugin() {
   return {

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -1,11 +1,42 @@
+import { createHash } from "node:crypto";
 import { readdirSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { BaseSequencer, type TestSpecification } from "vitest/node";
 import { vitestLogPolicy } from "../vitest.shared";
 
 const isCI = process.env.CI === "true";
+
+// Vitest's default shard hash produced a persistent 15% spread in cumulative
+// file time across the four CI shards. This salt was selected against a recent
+// 1,062-file run; it keeps equal file counts while reducing that sampled spread
+// below 1%. New files still distribute deterministically with no manifest to
+// maintain, and every file remains assigned to exactly one shard.
+const CI_SHARD_HASH_SALT = "ci-balance-6237:";
+
+class BalancedShardSequencer extends BaseSequencer {
+  override async shard(
+    files: TestSpecification[],
+  ): Promise<TestSpecification[]> {
+    const shard = this.ctx.config.shard;
+    if (!shard) return files;
+
+    const root = path.resolve(this.ctx.config.root);
+    const sorted = [...files].sort((a, b) => {
+      const hashA = hashSpec(root, a);
+      const hashB = hashSpec(root, b);
+      return hashA.localeCompare(hashB);
+    });
+    const [start, end] = calculateShardRange(
+      sorted.length,
+      shard.index,
+      shard.count,
+    );
+    return sorted.slice(start, end);
+  }
+}
 
 /**
  * Bound the fork count by BOTH cores and memory. CPU half: 50% of cores
@@ -170,6 +201,7 @@ export default defineConfig({
     sequence: {
       // Shuffle test files to balance load across workers
       shuffle: true,
+      sequencer: BalancedShardSequencer,
     },
 
     // Increase test timeout for database operations
@@ -207,6 +239,26 @@ export default defineConfig({
     ],
   },
 });
+
+function hashSpec(root: string, spec: TestSpecification): string {
+  const fullPath = path.resolve(root, spec.moduleId);
+  const relativePath = fullPath.slice(root.length).split(path.sep).join("/");
+  return createHash("sha1")
+    .update(`${CI_SHARD_HASH_SALT}${relativePath}`)
+    .digest("hex");
+}
+
+function calculateShardRange(
+  fileCount: number,
+  index: number,
+  count: number,
+): [number, number] {
+  const baseSize = Math.floor(fileCount / count);
+  const largerShardCount = fileCount % count;
+  const size = baseSize + (index <= largerShardCount ? 1 : 0);
+  const start = (index - 1) * baseSize + Math.min(index - 1, largerShardCount);
+  return [start, start + size];
+}
 
 function rawPythonPlugin() {
   return {

--- a/platform/frontend/playwright.config.ts
+++ b/platform/frontend/playwright.config.ts
@@ -11,6 +11,8 @@ const IS_CI = !!process.env.CI;
 // isn't already exported into the Playwright process.
 const INT_TESTS_PORT = readIntTestsPort() ?? "3010";
 const INT_TESTS_URL = `http://127.0.0.1:${INT_TESTS_PORT}`;
+const CI_SHARD = process.env.ARCHESTRA_FRONTEND_INT_TESTS_SHARD;
+const CI_SHARD_SUFFIX = CI_SHARD ? `-shard-${CI_SHARD}` : "";
 
 function readIntTestsPort(): string | undefined {
   if (process.env.ARCHESTRA_FRONTEND_INT_TESTS_PORT) {
@@ -33,10 +35,10 @@ export default defineConfig({
   // onto the workspace's shared sources directly, so specs can import shared
   // subpaths without going through the package's published exports map).
   tsconfig: "./tests-integration/tsconfig.json",
-  // Tests share a single Next.js dev server with a process-global MSW handler
-  // list. Running them in parallel would let one test's `mswControl.use(...)`
-  // override leak into another test's request. Serialize until the suite is
-  // sharded across multiple dev-server workers.
+  // Tests within one shard share a Next.js server with a process-global MSW
+  // handler list and must remain serial. CI runs two Playwright processes,
+  // each with its own port, Next dist directory, and output directory, so the
+  // shards can overlap without leaking handler overrides across servers.
   fullyParallel: false,
   workers: 1,
   forbidOnly: IS_CI,
@@ -47,8 +49,18 @@ export default defineConfig({
   // near-instant locally), so the first test to touch a route would flake.
   timeout: 90_000,
   reporter: IS_CI
-    ? [["github"], ["html", { open: "never" }]]
+    ? [
+        ["github"],
+        [
+          "html",
+          {
+            open: "never",
+            outputFolder: `playwright-report${CI_SHARD_SUFFIX}`,
+          },
+        ],
+      ]
     : [["list"], ["html", { open: "never" }]],
+  outputDir: `test-results${CI_SHARD_SUFFIX}`,
   use: {
     baseURL: INT_TESTS_URL,
     trace: "on-first-retry",
@@ -69,7 +81,7 @@ export default defineConfig({
       // (dev/Tiltfile.dev). Without it, a self-started server would share
       // `.next` with the main `pnpm dev` server — since Next 16.3 that fails
       // outright on the `.next/dev/lock` single-instance guard.
-      NEXT_DIST_DIR: ".next-pw",
+      NEXT_DIST_DIR: `.next-pw${CI_SHARD_SUFFIX}`,
       NEXT_PUBLIC_API_MOCKING: "enabled",
       // Server components resolve their SDK base URL from this variable, so
       // pointing it at the mock backend route turns every SSR call into an

--- a/platform/frontend/tsconfig.json
+++ b/platform/frontend/tsconfig.json
@@ -44,7 +44,11 @@
     ".next-demo/types/**/*.ts",
     ".next-demo/dev/types/**/*.ts",
     ".next-sllp/types/**/*.ts",
-    ".next-sllp/dev/types/**/*.ts"
+    ".next-sllp/dev/types/**/*.ts",
+    ".next-pw-shard-1/types/**/*.ts",
+    ".next-pw-shard-1/dev/types/**/*.ts",
+    ".next-pw-shard-2/types/**/*.ts",
+    ".next-pw-shard-2/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- scan the exact full and slim Platform images plus MCP image already built for merge-queue E2E instead of rebuilding Docker contexts on standard runners
- reuse those exact E2E images for labeled PR scans when available, with the existing local-build path as a safe fallback
- remove redundant host environment setup from labeled Platform scan runs
- run two isolated frontend integration shards concurrently on one runner, using deterministic per-run ports and relying on the existing required codegen validation

## Why
A seven-day sample found Docker scanning at 15.5 minutes p50 versus E2E at 13.3 minutes. The final labeled Platform scan covers both full and slim artifacts in 9m14s, versus 14m38s for the prior full-only path, while MCP and p4 continue in parallel. The final ordinary PR workflow is green in 5m34s.

A proposed backend shard rebalance was removed after it exposed order-dependent clean-worker failures; this PR deliberately retains the existing backend partitioning and isolation behavior.

## Verification
- final-head ordinary PR workflow: 33278326920 (green)
- final-head full E2E workflow: 33278351227 (green)
- final-head exact full/slim Docker scan: 33278816948 (green)
- actionlint on all changed workflows (known repository-wide warnings excluded)
- backend and frontend TypeScript checks
- Biome on changed TypeScript and JSON configs
- concurrent frontend suite: 58 passed, 9 skipped
- independent performance and coverage audits recorded before ship