### PR TITLE
fix(llm): reconnect ChatGPT subscriptions

### DIFF
--- a/platform/backend/src/routes/chat/model-fetchers/openai.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openai.ts
@@ -73,6 +73,8 @@ export async function fetchOpenAiModels(
     // predecessor, so a discarded rotation leaves the stored token dead.
     await openAiCodexTokenManager.getAccessToken({
       refreshToken: codexCredential.refreshToken,
+      accessToken: codexCredential.accessToken,
+      accessTokenExpiresAtMs: codexCredential.accessTokenExpiresAtMs,
       providerApiKeyId: opts?.providerApiKeyId,
       accountId: codexCredential.accountId,
     });

--- a/platform/backend/src/routes/openai-codex-auth/openai-codex-auth.routes.ts
+++ b/platform/backend/src/routes/openai-codex-auth/openai-codex-auth.routes.ts
@@ -261,11 +261,12 @@ const openaiCodexAuthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         return { status: "pending" as const };
       }
 
-      const { refreshToken, idToken } = await exchangeOpenAiCodexAuthCode({
-        code: payload.authorization_code,
-        codeVerifier: payload.code_verifier,
-        redirectUri: `${issuer}/deviceauth/callback`,
-      });
+      const { refreshToken, idToken, accessToken, accessTokenExpiresAtMs } =
+        await exchangeOpenAiCodexAuthCode({
+          code: payload.authorization_code,
+          codeVerifier: payload.code_verifier,
+          redirectUri: `${issuer}/deviceauth/callback`,
+        });
 
       const accountId = extractChatgptAccountId(idToken);
       if (!accountId) {
@@ -279,7 +280,12 @@ const openaiCodexAuthRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
       return {
         status: "complete" as const,
-        credential: encodeOpenAiCodexCredential({ refreshToken, accountId }),
+        credential: encodeOpenAiCodexCredential({
+          refreshToken,
+          accountId,
+          accessToken,
+          accessTokenExpiresAtMs,
+        }),
       };
     },
   );

--- a/platform/backend/src/routes/openai-codex-auth/poll.openai-codex-auth.route.test.ts
+++ b/platform/backend/src/routes/openai-codex-auth/poll.openai-codex-auth.route.test.ts
@@ -103,10 +103,14 @@ describe("POST /api/openai-codex-auth/device/poll", () => {
     expect(response.statusCode).toBe(200);
     const body = response.json();
     expect(body.status).toBe("complete");
-    expect(decodeOpenAiCodexCredential(body.credential)).toEqual({
+    expect(decodeOpenAiCodexCredential(body.credential)).toMatchObject({
       refreshToken: "rt_1",
       accountId: "acc_xyz",
+      accessToken: "at_1",
     });
+    expect(
+      decodeOpenAiCodexCredential(body.credential)?.accessTokenExpiresAtMs,
+    ).toBeGreaterThan(Date.now());
 
     // First call polls deviceauth/token with { device_auth_id, user_code } —
     // and no client_id, matching the Codex CLI's poll request.

--- a/platform/backend/src/services/openai-codex-credentials.ts
+++ b/platform/backend/src/services/openai-codex-credentials.ts
@@ -31,6 +31,14 @@ export interface OpenAiCodexCredential {
   /** Long-lived ChatGPT OAuth refresh token (rotates on redemption). */
   refreshToken: string;
   /**
+   * Short-lived access token returned by the sign-in exchange. Keeping it with
+   * the refresh token mirrors Codex's own auth store and avoids immediately
+   * refreshing a credential that OpenAI has only just issued.
+   */
+  accessToken?: string;
+  /** Absolute expiry for `accessToken`, in Unix milliseconds. */
+  accessTokenExpiresAtMs?: number;
+  /**
    * The ChatGPT `account_id` (a.k.a. `chatgpt_account_id`), read from the
    * id_token JWT at connect time and sent as the `chatgpt-account-id` header on
    * every Codex request. Required — the Codex backend rejects requests without it.
@@ -77,6 +85,12 @@ export function decodeOpenAiCodexCredential(
     return {
       refreshToken: parsed.refreshToken,
       accountId: parsed.accountId,
+      accessToken:
+        typeof parsed.accessToken === "string" ? parsed.accessToken : undefined,
+      accessTokenExpiresAtMs:
+        typeof parsed.accessTokenExpiresAtMs === "number"
+          ? parsed.accessTokenExpiresAtMs
+          : undefined,
     };
   } catch {
     return null;

--- a/platform/backend/src/services/openai-codex-token.test.ts
+++ b/platform/backend/src/services/openai-codex-token.test.ts
@@ -47,6 +47,21 @@ describe("openAiCodexTokenManager.getAccessToken (uncached, no key id)", () => {
       refresh_token: CREDENTIAL.refreshToken,
       client_id: expect.any(String),
     });
+    const headers = new Headers(init?.headers);
+    expect(headers.get("originator")).toBe("archestra");
+    expect(headers.get("user-agent")).toMatch(/^archestra\//);
+  });
+
+  it("uses the access token from sign-in without immediately refreshing it", async () => {
+    const fetchMock = vi.mocked(fetch);
+    const token = await openAiCodexTokenManager.getAccessToken({
+      refreshToken: CREDENTIAL.refreshToken,
+      accessToken: "at_from_sign_in",
+      accessTokenExpiresAtMs: Date.now() + 60 * 60 * 1000,
+    });
+
+    expect(token).toBe("at_from_sign_in");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("surfaces a 401 when OpenAI rejects the refresh token", async () => {
@@ -120,6 +135,40 @@ describe("createOpenAiCodexFetch", () => {
     );
 
     expect(innerFetch).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(200);
+  });
+
+  it("refreshes instead of replaying a sign-in token rejected before expiry", async () => {
+    const authorizationHeaders: string[] = [];
+    const innerFetch = vi.fn(async (_input, init?: RequestInit) => {
+      authorizationHeaders.push(
+        new Headers(init?.headers).get("authorization") ?? "",
+      );
+      return authorizationHeaders.length === 1
+        ? new Response("nope", { status: 401 })
+        : new Response("{}", { status: 200 });
+    });
+
+    const codexFetch = createOpenAiCodexFetch({
+      credential: {
+        ...CREDENTIAL,
+        accessToken: "at_from_sign_in",
+        accessTokenExpiresAtMs: Date.now() + 60 * 60 * 1000,
+      },
+      providerApiKeyId: "key-early-revocation",
+      sessionId: "sess_1",
+      innerFetch,
+    });
+    const response = await codexFetch(
+      "https://chatgpt.com/backend-api/codex/responses",
+      { method: "POST", body: "{}" },
+    );
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+    expect(authorizationHeaders).toEqual([
+      "Bearer at_from_sign_in",
+      "Bearer at_fresh",
+    ]);
     expect(response.status).toBe(200);
   });
 });

--- a/platform/backend/src/services/openai-codex-token.test.ts
+++ b/platform/backend/src/services/openai-codex-token.test.ts
@@ -36,6 +36,17 @@ describe("openAiCodexTokenManager.getAccessToken (uncached, no key id)", () => {
       refreshToken: CREDENTIAL.refreshToken,
     });
     expect(token).toBe("at_1");
+
+    const fetchMock = vi.mocked(fetch);
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(new Headers(init?.headers).get("content-type")).toBe(
+      "application/json",
+    );
+    expect(JSON.parse(String(init?.body))).toEqual({
+      grant_type: "refresh_token",
+      refresh_token: CREDENTIAL.refreshToken,
+      client_id: expect.any(String),
+    });
   });
 
   it("surfaces a 401 when OpenAI rejects the refresh token", async () => {
@@ -136,8 +147,10 @@ function stubTokenEndpoint(
   rotations: Record<string, { accessToken: string; rotatedTo?: string }>,
 ) {
   const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
-    const params = new URLSearchParams(String(init?.body));
-    const presented = params.get("refresh_token") ?? "";
+    const payload = JSON.parse(String(init?.body)) as {
+      refresh_token?: string;
+    };
+    const presented = payload.refresh_token ?? "";
     const entry = rotations[presented];
     if (!entry) {
       return tokenResponse({ error: "invalid_grant" }, 400);
@@ -200,7 +213,8 @@ describe("in-flight redemption lineage isolation", () => {
       (_input: unknown, init?: RequestInit) =>
         new Promise<Response>((resolve) => {
           presentedTokens.push(
-            new URLSearchParams(String(init?.body)).get("refresh_token"),
+            (JSON.parse(String(init?.body)) as { refresh_token?: string })
+              .refresh_token ?? null,
           );
           resolvers.push(resolve);
         }),

--- a/platform/backend/src/services/openai-codex-token.ts
+++ b/platform/backend/src/services/openai-codex-token.ts
@@ -640,8 +640,8 @@ async function redeemWithOpenAi(refreshToken: string): Promise<{
 
   const response = await fetch(`${issuer}/oauth/token`, {
     method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
       grant_type: "refresh_token",
       refresh_token: refreshToken,
       client_id: clientId,

--- a/platform/backend/src/services/openai-codex-token.ts
+++ b/platform/backend/src/services/openai-codex-token.ts
@@ -74,6 +74,8 @@ class OpenAiCodexTokenManager {
    */
   async getAccessToken(params: {
     refreshToken: string;
+    accessToken?: string;
+    accessTokenExpiresAtMs?: number;
     providerApiKeyId?: string;
     /**
      * The account id of the credential being redeemed. Used to guard rotated-
@@ -82,16 +84,30 @@ class OpenAiCodexTokenManager {
      */
     accountId?: string;
   }): Promise<string> {
-    const { refreshToken, providerApiKeyId, accountId } = params;
+    const {
+      refreshToken,
+      accessToken,
+      accessTokenExpiresAtMs,
+      providerApiKeyId,
+      accountId,
+    } = params;
+
+    const suppliedAccessTokenIsFresh =
+      accessToken !== undefined &&
+      accessTokenExpiresAtMs !== undefined &&
+      accessTokenExpiresAtMs - REFRESH_BUFFER_MS > Date.now();
 
     if (!providerApiKeyId) {
+      if (suppliedAccessTokenIsFresh) {
+        return accessToken;
+      }
       // Follow any rotation already observed for this token, so validating the
       // same credential twice in one process doesn't redeem a dead predecessor.
       const latestToken = this.latestKnownRefreshToken(refreshToken);
-      const { accessToken, rotatedRefreshToken } =
+      const { accessToken: redeemedAccessToken, rotatedRefreshToken } =
         await redeemWithOpenAi(latestToken);
       this.recordValidationRotation(latestToken, rotatedRefreshToken);
-      return accessToken;
+      return redeemedAccessToken;
     }
 
     const callerDigest = hashToken(refreshToken);
@@ -105,6 +121,19 @@ class OpenAiCodexTokenManager {
     }
     if (cached && cached.expiresAtMs - REFRESH_BUFFER_MS > Date.now()) {
       return cached.accessToken;
+    }
+
+    if (!cached && suppliedAccessTokenIsFresh) {
+      this.tokenCache.set(
+        providerApiKeyId,
+        {
+          accessToken,
+          expiresAtMs: accessTokenExpiresAtMs,
+          knownRefreshTokenDigests: [callerDigest],
+        },
+        Math.max(accessTokenExpiresAtMs - Date.now(), 0),
+      );
+      return accessToken;
     }
 
     // Join an in-flight redemption only when the caller's token belongs to the
@@ -244,6 +273,8 @@ class OpenAiCodexTokenManager {
     if (rotatedRefreshToken && rotatedRefreshToken !== refreshToken) {
       this.queuePersist(providerApiKeyId, {
         newRefreshToken: rotatedRefreshToken,
+        newAccessToken: accessToken,
+        newAccessTokenExpiresAtMs: expiresAtMs,
         predecessorRefreshToken: redeemedToken,
         lineageDigests: updatedDigests,
         expectedAccountId: accountId,
@@ -369,6 +400,8 @@ class OpenAiCodexTokenManager {
       apiKey: encodeOpenAiCodexCredential({
         refreshToken: newRefreshToken,
         accountId: existing.accountId,
+        accessToken: params.newAccessToken,
+        accessTokenExpiresAtMs: params.newAccessTokenExpiresAtMs,
       }),
     });
   }
@@ -420,6 +453,8 @@ export function createOpenAiCodexFetch(params: {
     try {
       accessToken = await openAiCodexTokenManager.getAccessToken({
         refreshToken: credential.refreshToken,
+        accessToken: credential.accessToken,
+        accessTokenExpiresAtMs: credential.accessTokenExpiresAtMs,
         providerApiKeyId,
         accountId: credential.accountId,
       });
@@ -439,6 +474,8 @@ export function createOpenAiCodexFetch(params: {
       try {
         freshAccessToken = await openAiCodexTokenManager.getAccessToken({
           refreshToken: credential.refreshToken,
+          accessToken: credential.accessToken,
+          accessTokenExpiresAtMs: credential.accessTokenExpiresAtMs,
           providerApiKeyId,
           accountId: credential.accountId,
         });
@@ -460,7 +497,12 @@ export async function exchangeOpenAiCodexAuthCode(params: {
   code: string;
   codeVerifier: string;
   redirectUri: string;
-}): Promise<{ refreshToken: string; idToken: string }> {
+}): Promise<{
+  refreshToken: string;
+  idToken: string;
+  accessToken: string;
+  accessTokenExpiresAtMs: number;
+}> {
   const { code, codeVerifier, redirectUri } = params;
   const { issuer, clientId } = config.llm.openai.codex;
 
@@ -492,14 +534,23 @@ export async function exchangeOpenAiCodexAuthCode(params: {
     access_token?: string;
     refresh_token?: string;
     id_token?: string;
+    expires_in?: number;
   };
-  if (!payload.refresh_token || !payload.id_token) {
+  if (!payload.refresh_token || !payload.id_token || !payload.access_token) {
     throw new ApiError(
       502,
       "ChatGPT sign-in returned an unexpected token payload",
     );
   }
-  return { refreshToken: payload.refresh_token, idToken: payload.id_token };
+  return {
+    refreshToken: payload.refresh_token,
+    idToken: payload.id_token,
+    accessToken: payload.access_token,
+    accessTokenExpiresAtMs: accessTokenExpiryMs(
+      payload.access_token,
+      payload.expires_in,
+    ),
+  };
 }
 
 /**
@@ -549,6 +600,8 @@ interface InFlightRedemption {
 
 interface PersistRotationParams {
   newRefreshToken: string;
+  newAccessToken: string;
+  newAccessTokenExpiresAtMs: number;
   /** The exact token whose redemption produced `newRefreshToken`. */
   predecessorRefreshToken: string;
   /** Lineage digests known when the rotation happened, for the persist CAS. */
@@ -640,7 +693,12 @@ async function redeemWithOpenAi(refreshToken: string): Promise<{
 
   const response = await fetch(`${issuer}/oauth/token`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      originator: config.llm.openai.codex.originator,
+      "user-agent": CODEX_USER_AGENT,
+    },
     body: JSON.stringify({
       grant_type: "refresh_token",
       refresh_token: refreshToken,

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.test.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.test.tsx
@@ -20,13 +20,16 @@ vi.mock("@/components/llm-provider-api-key-form", () => ({
   }: {
     form: { register: (name: string) => Record<string, unknown> };
     credentialMode?: "api-key" | "subscription";
-    onSubscriptionCredential?: (credential: string) => void;
+    onSubscriptionCredential?: (credential: string) => void | Promise<void>;
   }) => (
     <div>
       {credentialMode === "subscription" ? (
         <button
           type="button"
-          onClick={() => onSubscriptionCredential?.("subscription-token")}
+          onClick={() => {
+            const result = onSubscriptionCredential?.("subscription-token");
+            if (result instanceof Promise) void result.catch(() => undefined);
+          }}
         >
           Sign in
         </button>
@@ -260,5 +263,38 @@ describe("CreateLlmProviderApiKeyDialog", () => {
     expect(mutateAsync).not.toHaveBeenCalled();
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(onSuccess).toHaveBeenCalledWith("existing-key-id");
+  });
+
+  it("closes a failed subscription sign-in without an unsaved-changes prompt", async () => {
+    mutateAsync.mockRejectedValueOnce(new Error("credential rejected"));
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <CreateLlmProviderApiKeyDialog
+        open
+        onOpenChange={onOpenChange}
+        title="Sign in with ChatGPT"
+        description="Connect your ChatGPT account"
+        credentialMode="subscription"
+        allowedProviders={["openai"]}
+        defaultValues={{
+          name: "ChatGPT Subscription",
+          provider: "openai",
+          scope: "personal",
+          authMethod: "subscription",
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(mutateAsync).toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).not.toBeInTheDocument();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
@@ -194,7 +194,7 @@ export function CreateLlmProviderApiKeyDialog({
       description={description}
       size="small"
       className="sm:max-w-xl"
-      isDirty={form.formState.isDirty}
+      isDirty={credentialMode === "api-key" && form.formState.isDirty}
     >
       <DialogForm
         onSubmit={handleCreate}

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -1365,11 +1365,14 @@ export function LlmProviderApiKeyForm({
                       <SubscriptionSignIn
                         kind={activeSubscriptionKind}
                         disabled={isPending}
-                        onSecret={(secret) => {
+                        onSecret={async (secret) => {
+                          if (onSubscriptionCredential) {
+                            await onSubscriptionCredential(secret);
+                            return;
+                          }
                           form.setValue("apiKey", secret, {
                             shouldDirty: true,
                           });
-                          return onSubscriptionCredential?.(secret);
                         }}
                       />
                     </>

--- a/platform/frontend/src/components/openai-codex-sign-in.test.tsx
+++ b/platform/frontend/src/components/openai-codex-sign-in.test.tsx
@@ -1,0 +1,92 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { startDeviceFlow, pollDeviceFlow } = vi.hoisted(() => ({
+  startDeviceFlow: vi.fn(),
+  pollDeviceFlow: vi.fn(),
+}));
+
+vi.mock("@/lib/openai-codex-auth.query", () => ({
+  useStartOpenaiCodexDeviceFlow: () => ({
+    isPending: false,
+    mutateAsync: startDeviceFlow,
+  }),
+  usePollOpenaiCodexDeviceFlow: () => ({
+    mutateAsync: pollDeviceFlow,
+  }),
+}));
+
+import { OpenaiCodexSignIn } from "./openai-codex-sign-in";
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("OpenaiCodexSignIn persistence handoff", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    startDeviceFlow.mockReset().mockResolvedValue({
+      deviceAuthId: "device-1",
+      userCode: "CODE-1",
+      verificationUri: "https://auth.openai.com/codex/device",
+      interval: 5,
+      expiresIn: 900,
+    });
+    pollDeviceFlow.mockReset().mockResolvedValue({
+      status: "complete",
+      credential: "chatgpt-oauth:encoded",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not show linked until credential persistence resolves", async () => {
+    let resolveSave: (() => void) | undefined;
+    const onCredential = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    render(<OpenaiCodexSignIn onCredential={onCredential} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sign in with ChatGPT" }),
+    );
+    await flushMicrotasks();
+    act(() => vi.advanceTimersByTime(5_000));
+    await flushMicrotasks();
+
+    expect(onCredential).toHaveBeenCalledWith("chatgpt-oauth:encoded");
+    expect(
+      screen.queryByText(/ChatGPT account linked/),
+    ).not.toBeInTheDocument();
+
+    await act(async () => resolveSave?.());
+    expect(screen.getByText(/ChatGPT account linked/)).toBeInTheDocument();
+  });
+
+  it("returns to a retryable sign-in when credential persistence fails", async () => {
+    const onCredential = vi.fn().mockRejectedValue(new Error("save failed"));
+    render(<OpenaiCodexSignIn onCredential={onCredential} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sign in with ChatGPT" }),
+    );
+    await flushMicrotasks();
+    act(() => vi.advanceTimersByTime(5_000));
+    await flushMicrotasks();
+
+    expect(
+      screen.queryByText(/ChatGPT account linked/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sign in with ChatGPT" }),
+    ).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Summary

Fix ChatGPT subscription connection and reconnection across the complete Codex OAuth lifecycle.

- Preserve the fresh access token returned by device authorization and use it until expiry instead of immediately redeeming the newly issued refresh token.
- Match the Codex refresh-token endpoint contract with JSON payloads and the expected request identity headers.
- Continue persisting rotated refresh and access tokens, including early-revocation recovery after a 401.
- Show the connected state only after Archestra successfully persists the credential.
- Let subscription dialogs close directly without an irrelevant unsaved-changes confirmation.

## Test

- Completed a real local ChatGPT device authorization and persisted the subscription successfully.
- Backend focused tests: 15 passed across token lifecycle and device-auth polling coverage.
- Frontend focused tests: 9 passed across subscription persistence and dialog behavior.
- Backend and frontend type checks passed.
- Pre-commit checks passed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>