### PR TITLE
fix(agents): harden background execution UX

### DIFF
--- a/docs/pages/platform-agent-background-execution.md
+++ b/docs/pages/platform-agent-background-execution.md
@@ -359,6 +359,12 @@ An Agent with Background execution configured has an **Executions** tab. Use it 
 - read live or retained container logs
 - attach to the live shell for troubleshooting or interactive work
 
+Runner Jobs provide `/var/run/archestra/attach` for direct Kubernetes access.
+Interactive `bash` and `sh` sessions opened through `kubectl exec` or k9s join
+the Agent session automatically. Press `Ctrl-b`, then `d`, to detach without
+stopping the execution. For a raw diagnostic shell, set
+`ARCHESTRA_AGENT_BACKGROUND_EXECUTION_AUTO_ATTACH=0` on the exec command.
+
 Archestra retains up to 1 MB of container output after the pod is removed. Only the user whose credentials started an execution can attach to its live shell. Agent administrators cannot enter another user's shell. There is no separate Background execution permission or sidebar resource.
 
 ## Example Architecture

--- a/platform/backend/src/k8s/runner-runtime/manager.ts
+++ b/platform/backend/src/k8s/runner-runtime/manager.ts
@@ -779,14 +779,14 @@ const RUNNER_ATTACH_TIMEOUT_MS = 60_000;
 
 function runnerTerminalAttachCommand(): string[] {
   return [
-    "env",
-    "LANG=C.UTF-8",
-    "LC_ALL=C.UTF-8",
-    "TERM=xterm-256color",
-    "tmux",
-    "attach",
-    "-t",
-    RUNNER_TMUX_SESSION,
+    "/bin/sh",
+    "-c",
+    [
+      // Apply this at attach time as well as bootstrap time so sessions that
+      // predate an upgrade immediately gain working browser scrollback.
+      `tmux set-option -t ${RUNNER_TMUX_SESSION} mouse on`,
+      `exec env LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=xterm-256color tmux attach -t ${RUNNER_TMUX_SESSION}`,
+    ].join(" && "),
   ];
 }
 

--- a/platform/backend/src/k8s/runner-runtime/manager.ts
+++ b/platform/backend/src/k8s/runner-runtime/manager.ts
@@ -23,6 +23,7 @@ import McpDeploymentLeaseModel, {
 import { reportRunnerSteer } from "@/observability/metrics/runner";
 import type { RunnerLaunchSpec } from "@/services/runners/backends";
 import {
+  RUNNER_ATTACH_SCRIPT,
   RUNNER_ATTACHMENTS_DIR,
   RUNNER_ATTACHMENTS_MANIFEST,
   RUNNER_INPUTS_READY_FILE,
@@ -36,6 +37,7 @@ import {
   buildRunnerJob,
   buildRunnerPlatformEgressPolicy,
   buildRunnerSecret,
+  buildRunnerTerminalIntegrationScript,
   type KubernetesRunnerLaunchSpec,
   RUNNER_CONTAINER_NAME,
   RUNNER_TMUX_SESSION,
@@ -296,6 +298,13 @@ class RunnerRuntimeManager {
       throw new Error("This session has no running pod to attach to");
     }
     await this.waitForTmuxSession({ session: params.session, podName });
+    // Live pods created before an upgrade do not have the stable helper yet.
+    // Installing it here keeps the displayed command truthful for them too.
+    await this.execInPod({
+      session: params.session,
+      podName,
+      command: ["/bin/sh", "-c", buildRunnerTerminalIntegrationScript()],
+    });
     const namespace = params.session.runtimeScope;
     const socket = await clients.exec.exec(
       namespace,
@@ -778,16 +787,7 @@ const RUNNER_INPUT_STAGING_TIMEOUT_MS = 5 * 60_000;
 const RUNNER_ATTACH_TIMEOUT_MS = 60_000;
 
 function runnerTerminalAttachCommand(): string[] {
-  return [
-    "/bin/sh",
-    "-c",
-    [
-      // Apply this at attach time as well as bootstrap time so sessions that
-      // predate an upgrade immediately gain working browser scrollback.
-      `tmux set-option -t ${RUNNER_TMUX_SESSION} mouse on`,
-      `exec env LANG=C.UTF-8 LC_ALL=C.UTF-8 TERM=xterm-256color tmux attach -t ${RUNNER_TMUX_SESSION}`,
-    ].join(" && "),
-  ];
+  return [RUNNER_ATTACH_SCRIPT];
 }
 
 /** Sleep that wakes early on abort, so cancellation is not delayed a full poll. */

--- a/platform/backend/src/k8s/runner-runtime/manifests.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.test.ts
@@ -93,6 +93,22 @@ describe("buildRunnerJob", () => {
         },
       ]),
     );
+    expect(
+      buildRunnerJob({
+        ...SPEC,
+        env: {
+          ...SPEC.env,
+          ARCHESTRA_AGENT_BACKGROUND_EXECUTION_AUTO_ATTACH: "0",
+        },
+      }).spec?.template.spec?.containers[0]?.env,
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          name: "ARCHESTRA_AGENT_BACKGROUND_EXECUTION_AUTO_ATTACH",
+          value: "0",
+        },
+      ]),
+    );
   });
 
   it("holds the entrypoint until declared input files are staged", () => {

--- a/platform/backend/src/k8s/runner-runtime/manifests.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.test.ts
@@ -198,6 +198,13 @@ describe("the container bootstrap", () => {
     );
     expect(script()).not.toContain("sleep 10");
   });
+
+  it("lets terminal wheel events scroll tmux history", () => {
+    expect(script()).toContain("tmux set-option -t agent mouse on");
+    expect(script().indexOf("mouse on")).toBeLessThan(
+      script().indexOf("tmux respawn-pane"),
+    );
+  });
 });
 
 describe("buildRunnerSecret", () => {

--- a/platform/backend/src/k8s/runner-runtime/manifests.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.test.ts
@@ -77,6 +77,24 @@ describe("buildRunnerJob", () => {
     );
   });
 
+  it("makes direct interactive shells join the agent session", () => {
+    const env = buildRunnerJob(SPEC).spec?.template.spec?.containers[0]?.env;
+
+    expect(env).toEqual(
+      expect.arrayContaining([
+        { name: "ENV", value: "/var/run/archestra/shell-init" },
+        {
+          name: "PROMPT_COMMAND",
+          value: ". /var/run/archestra/shell-init",
+        },
+        {
+          name: "ARCHESTRA_AGENT_BACKGROUND_EXECUTION_AUTO_ATTACH",
+          value: "1",
+        },
+      ]),
+    );
+  });
+
   it("holds the entrypoint until declared input files are staged", () => {
     const container = buildRunnerJob({ ...SPEC, inputFileCount: 2 }).spec
       ?.template.spec?.containers[0];
@@ -203,6 +221,15 @@ describe("the container bootstrap", () => {
     expect(script()).toContain("tmux set-option -t agent mouse on");
     expect(script().indexOf("mouse on")).toBeLessThan(
       script().indexOf("tmux respawn-pane"),
+    );
+  });
+
+  it("installs a portable attach command for exec clients", () => {
+    expect(script()).toContain("> /var/run/archestra/attach");
+    expect(script()).toContain("chmod 755 /var/run/archestra/attach");
+    expect(script()).toContain("exec /var/run/archestra/attach");
+    expect(script().indexOf("/var/run/archestra/attach")).toBeLessThan(
+      script().indexOf("tmux new-session"),
     );
   });
 });

--- a/platform/backend/src/k8s/runner-runtime/manifests.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.ts
@@ -65,20 +65,20 @@ function buildRunnerBootstrapScript(): string {
     `mkdir -p ${RUNNER_RUNTIME_DIR}`,
     `mkdir -p ${RUNNER_ATTACHMENTS_DIR}`,
     'if [ "$ARCHESTRA_AGENT_BACKGROUND_EXECUTION_INPUT_FILE_COUNT" -gt 0 ]; then',
-    `  echo "[archestra] staging $ARCHESTRA_AGENT_BACKGROUND_EXECUTION_INPUT_FILE_COUNT input file(s)"`,
+    `  echo "[runner] staging $ARCHESTRA_AGENT_BACKGROUND_EXECUTION_INPUT_FILE_COUNT input file(s)"`,
     `  attempts=0; while [ ! -f ${RUNNER_INPUTS_READY_FILE} ]; do`,
     "    attempts=$((attempts + 1))",
-    '    if [ "$attempts" -gt 300 ]; then echo "archestra: timed out while staging execution inputs" >&2; exit 74; fi',
+    '    if [ "$attempts" -gt 300 ]; then echo "runner: timed out while staging execution inputs" >&2; exit 74; fi',
     "    sleep 1",
     "  done",
     "fi",
     `[ -p "${RUNNER_STEER_FIFO}" ] || mkfifo -m 600 "${RUNNER_STEER_FIFO}"`,
     "if ! command -v tmux >/dev/null 2>&1; then",
-    '  echo "archestra: this image has no tmux, which runners require for attach and steering" >&2',
+    '  echo "runner: this image has no tmux, which runners require for attach and steering" >&2',
     `  exit ${RUNNER_UNUSABLE_IMAGE_EXIT_CODE}`,
     "fi",
     `printf '%s\\n' "$ARCHESTRA_AGENT_BACKGROUND_EXECUTION_ENTRYPOINT" > ${RUNNER_RUNTIME_DIR}/entry.sh`,
-    `printf '%s\n' '/bin/sh ${RUNNER_RUNTIME_DIR}/entry.sh; status=$?; printf "%s\\n" "$status" > ${exitCodeFile}; echo; echo "[archestra] agent session exited"; exit "$status"' > ${RUNNER_RUNTIME_DIR}/session.sh`,
+    `printf '%s\n' '/bin/sh ${RUNNER_RUNTIME_DIR}/entry.sh; status=$?; printf "%s\\n" "$status" > ${exitCodeFile}; echo; echo "[runner] agent session exited"; exit "$status"' > ${RUNNER_RUNTIME_DIR}/session.sh`,
     // Create the pane before starting the Agent so its output cannot race the
     // pipe setup. A fast one-shot client used to finish before pipe-pane was
     // attached, leaving its durable transcript empty.
@@ -92,7 +92,7 @@ function buildRunnerBootstrapScript(): string {
     // completes when the agent is done rather than when tmux forks away.
     `while tmux has-session -t ${RUNNER_TMUX_SESSION} 2>/dev/null; do sleep 5; done`,
     `if [ ! -f ${exitCodeFile} ]; then`,
-    '  echo "archestra: agent session ended without an exit status" >&2',
+    '  echo "runner: agent session ended without an exit status" >&2',
     "  exit 1",
     "fi",
     `exit "$(cat ${exitCodeFile})"`,

--- a/platform/backend/src/k8s/runner-runtime/manifests.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.ts
@@ -1,10 +1,12 @@
 import type * as k8s from "@kubernetes/client-node";
 import type { RunnerLaunchSpec } from "@/services/runners/backends";
 import {
+  RUNNER_ATTACH_SCRIPT,
   RUNNER_ATTACHMENTS_DIR,
   RUNNER_ATTACHMENTS_MANIFEST,
   RUNNER_INPUTS_READY_FILE,
   RUNNER_RUNTIME_DIR,
+  RUNNER_SHELL_INIT_SCRIPT,
   RUNNER_STEER_FIFO,
 } from "@/services/runners/runtime-contract";
 import type { AgentDeploymentResources } from "@/types";
@@ -20,6 +22,20 @@ export const RUNNER_TMUX_SESSION = "agent";
 
 /** Container name in the Job spec; exec and log reads both address it. */
 export const RUNNER_CONTAINER_NAME = "runner";
+
+/**
+ * Install the stable attach command and the hook used by kubectl/k9s shells.
+ * Kept as a script so the manager can repair live pods created before an
+ * upgrade without relying on anything beyond the image's required /bin/sh.
+ */
+export function buildRunnerTerminalIntegrationScript(): string {
+  return [
+    `printf '%s\\n' '#!/bin/sh' 'tmux set-option -t ${RUNNER_TMUX_SESSION} mouse on' 'exec tmux attach -t ${RUNNER_TMUX_SESSION}' > ${RUNNER_ATTACH_SCRIPT}`,
+    `chmod 755 ${RUNNER_ATTACH_SCRIPT}`,
+    `printf '%s\\n' 'if [ "\${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_AUTO_ATTACH:-1}" = "1" ] && [ -t 0 ] && [ -t 1 ] && [ -z "\${TMUX:-}" ] && tmux has-session -t ${RUNNER_TMUX_SESSION} 2>/dev/null; then exec ${RUNNER_ATTACH_SCRIPT}; fi' > ${RUNNER_SHELL_INIT_SCRIPT}`,
+    `chmod 644 ${RUNNER_SHELL_INIT_SCRIPT}`,
+  ].join("\n");
+}
 
 /**
  * Exit code the bootstrap uses when the image cannot host a runner. Distinct
@@ -63,6 +79,7 @@ function buildRunnerBootstrapScript(): string {
   return [
     "set -eu",
     `mkdir -p ${RUNNER_RUNTIME_DIR}`,
+    buildRunnerTerminalIntegrationScript(),
     `mkdir -p ${RUNNER_ATTACHMENTS_DIR}`,
     'if [ "$ARCHESTRA_AGENT_BACKGROUND_EXECUTION_INPUT_FILE_COUNT" -gt 0 ]; then',
     `  echo "[runner] staging $ARCHESTRA_AGENT_BACKGROUND_EXECUTION_INPUT_FILE_COUNT input file(s)"`,
@@ -163,6 +180,11 @@ export function buildRunnerJob(spec: KubernetesRunnerLaunchSpec): k8s.V1Job {
                   LANG: "C.UTF-8",
                   LC_ALL: "C.UTF-8",
                   TERM: "xterm-256color",
+                  // k9s opens `bash` or `sh` directly. These standard shell
+                  // hooks join the already-running tmux pane on first prompt.
+                  ENV: RUNNER_SHELL_INIT_SCRIPT,
+                  PROMPT_COMMAND: `. ${RUNNER_SHELL_INIT_SCRIPT}`,
+                  ARCHESTRA_AGENT_BACKGROUND_EXECUTION_AUTO_ATTACH: "1",
                   ...spec.env,
                 }).map(([name, value]) => ({ name, value })),
                 {

--- a/platform/backend/src/k8s/runner-runtime/manifests.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.ts
@@ -83,6 +83,10 @@ function buildRunnerBootstrapScript(): string {
     // pipe setup. A fast one-shot client used to finish before pipe-pane was
     // attached, leaving its durable transcript empty.
     `tmux new-session -d -s ${RUNNER_TMUX_SESSION} 'while :; do sleep 1; done'`,
+    // Let browser terminals send wheel events to tmux. Its WheelUpPane binding
+    // enters copy mode and scrolls tmux's own history; without mouse mode,
+    // xterm falls back to cursor-key sequences that get typed into the pane.
+    `tmux set-option -t ${RUNNER_TMUX_SESSION} mouse on`,
     // Mirror the pane to the container's stdout. tmux gives the agent a pty,
     // so without this its output exists only inside the pane: kubectl logs
     // shows nothing, and the platform's log-follower streams an empty task.

--- a/platform/backend/src/services/runners/launch-spec.test.ts
+++ b/platform/backend/src/services/runners/launch-spec.test.ts
@@ -61,7 +61,7 @@ describe("buildRunnerLaunchSpec", () => {
       organizationId: setup.agent.organizationId,
       runtimeScope: "agent-tests",
       effectiveNetworkPolicy: { source: "built_in", policy: null },
-      appName: "Archestra",
+      appName: "Example AI",
       executionMode: "one_shot",
       task: "Inspect the repository and report the result.",
     });
@@ -75,7 +75,12 @@ describe("buildRunnerLaunchSpec", () => {
       ARCHESTRA_LLM_PROXY_URL: `https://platform.example.test/v1/model-router/${setup.agent.id}`,
       OPENAI_BASE_URL: `https://platform.example.test/v1/model-router/${setup.agent.id}`,
       ARCHESTRA_MCP_GATEWAY_URL: `https://platform.example.test/v1/mcp/${setup.agent.id}`,
+      ARCHESTRA_AGENT_BACKGROUND_EXECUTION_BANNER:
+        "Example AI\nSecure access to your AI tools",
     });
+    expect(spec.env.ARCHESTRA_AGENT_BACKGROUND_EXECUTION_BANNER).not.toContain(
+      "⣾⣿",
+    );
     expect(spec.secretEnv.OPENAI_API_KEY).toMatch(/^arch_/);
     expect(spec.secretEnv.OPENAI_API_KEY).not.toBe("upstream-secret");
     expect(spec.env.OPENAI_BASE_URL).not.toBe("https://bypass.invalid");
@@ -129,6 +134,14 @@ describe("buildRunnerLaunchSpec", () => {
     expect(spec.secretEnv.ARCHESTRA_MCP_GATEWAY_TOKEN).toEqual(
       expect.any(String),
     );
+    // SPDX-SnippetBegin
+    // SPDX-SnippetCopyrightText: 2026 Archestra Inc.
+    // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+    expect(config.enterpriseFeatures.fullWhiteLabeling).toBe(true);
+    expect(spec.env.ARCHESTRA_AGENT_BACKGROUND_EXECUTION_BANNER).toBe(
+      "Archestra\nSecure access to your AI tools",
+    );
+    // SPDX-SnippetEnd
     const virtualKey = await VirtualApiKeyModel.findById(virtualApiKeyId);
     expect(virtualKey).toMatchObject({ scope: "org", authorId: null });
   });

--- a/platform/backend/src/services/runners/launch-spec.ts
+++ b/platform/backend/src/services/runners/launch-spec.ts
@@ -339,6 +339,14 @@ export async function buildRunnerLaunchSpec(params: {
 }
 
 function executionBanner(appName: string): string {
+  // SPDX-SnippetBegin
+  // SPDX-SnippetCopyrightText: 2026 Archestra Inc.
+  // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+  if (config.enterpriseFeatures.fullWhiteLabeling) {
+    return `${appName}\nSecure access to your AI tools`;
+  }
+  // SPDX-SnippetEnd
+
   return isDefaultBrandedAppName(appName)
     ? archestraMarkWithText({ appName }).join("\n")
     : `${appName}\nSecure access to your AI tools`;

--- a/platform/backend/src/services/runners/runtime-contract.ts
+++ b/platform/backend/src/services/runners/runtime-contract.ts
@@ -1,6 +1,10 @@
 /** Filesystem contract shared by maintained execution images and backends. */
 export const RUNNER_RUNTIME_DIR = "/var/run/archestra";
 export const RUNNER_STEER_FIFO = `${RUNNER_RUNTIME_DIR}/steer`;
+/** Stable command that joins the interactive session from any exec client. */
+export const RUNNER_ATTACH_SCRIPT = `${RUNNER_RUNTIME_DIR}/attach`;
+/** Startup hook used by interactive shells opened directly in a runner pod. */
+export const RUNNER_SHELL_INIT_SCRIPT = `${RUNNER_RUNTIME_DIR}/shell-init`;
 /** Stable input location shared by every execution backend and Agent image. */
 export const RUNNER_ATTACHMENTS_DIR = `${RUNNER_RUNTIME_DIR}/attachments`;
 export const RUNNER_ATTACHMENTS_MANIFEST = `${RUNNER_RUNTIME_DIR}/attachments.json`;

--- a/platform/frontend/src/app/chat/executions/page.client.test.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.test.tsx
@@ -6,6 +6,7 @@ const queryState = vi.hoisted(() => ({
     data: undefined as Record<string, unknown> | undefined,
     isPending: false,
     isError: false,
+    error: undefined as Error | undefined,
     refetch: vi.fn(),
   },
 }));
@@ -40,6 +41,7 @@ describe("BackgroundExecutionChatSession", () => {
       data: undefined,
       isPending: false,
       isError: false,
+      error: undefined,
       refetch: vi.fn(),
     };
   });
@@ -53,6 +55,37 @@ describe("BackgroundExecutionChatSession", () => {
     expect(
       screen.getByText(
         "Scheduling the workload and preparing its terminal. You can leave this page and come back.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the last execution visible when a background refresh fails", () => {
+    queryState.value.data = execution({
+      state: "TASK_STATE_SUBMITTED",
+      endedAt: null,
+    });
+    queryState.value.isError = true;
+
+    render(<BackgroundExecutionChatSession taskId="task-1" />);
+
+    expect(screen.getByText("Starting Codex…")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Couldn't load this execution"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("explains when the requested execution cannot be found", () => {
+    queryState.value.isError = true;
+    queryState.value.error = new Error("Execution not found");
+
+    render(<BackgroundExecutionChatSession taskId="task-1" />);
+
+    expect(
+      screen.getByText("Couldn't load this execution"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This execution no longer exists, or you no longer have access to it.",
       ),
     ).toBeInTheDocument();
   });

--- a/platform/frontend/src/app/chat/executions/page.client.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.tsx
@@ -54,7 +54,11 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
               <h1 className="truncate text-sm font-medium">
                 {execution.title}
               </h1>
-              <AgentExecutionState state={execution.state} compact />
+              <AgentExecutionState
+                state={execution.state}
+                statusReason={execution.statusReason}
+                compact
+              />
             </div>
             <p className="truncate text-xs text-muted-foreground">
               {execution.agent.name}

--- a/platform/frontend/src/app/chat/executions/page.client.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.tsx
@@ -21,15 +21,16 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
   const [stopDialogOpen, setStopDialogOpen] = useState(false);
   const execution = query.data;
 
-  if (query.isPending) {
+  if (query.isPending && !execution) {
     return <ExecutionBooting />;
   }
-  if (query.isError || !execution) {
+  if (!execution) {
     return (
       <div className="flex h-full items-center justify-center p-6">
         <QueryLoadError
           className="max-w-lg border"
           title="Couldn't load this execution"
+          description={executionLoadErrorDescription(query.error)}
           onRetry={() => query.refetch()}
         />
       </div>
@@ -114,6 +115,13 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
       />
     </main>
   );
+}
+
+function executionLoadErrorDescription(error: unknown): string | undefined {
+  if (error instanceof Error && error.message === "Execution not found") {
+    return "This execution no longer exists, or you no longer have access to it.";
+  }
+  return undefined;
 }
 
 function ExecutionBooting({

--- a/platform/frontend/src/components/agent-execution-state.test.tsx
+++ b/platform/frontend/src/components/agent-execution-state.test.tsx
@@ -18,7 +18,7 @@ describe("AgentExecutionState", () => {
       />,
     );
 
-    expect(screen.getByText("View details")).toBeVisible();
+    expect(screen.getByText("Details")).toBeVisible();
     await user.click(
       screen.getByRole("button", { name: "View failed details" }),
     );

--- a/platform/frontend/src/components/agent-execution-state.test.tsx
+++ b/platform/frontend/src/components/agent-execution-state.test.tsx
@@ -18,6 +18,7 @@ describe("AgentExecutionState", () => {
       />,
     );
 
+    expect(screen.getByText("View details")).toBeVisible();
     await user.click(
       screen.getByRole("button", { name: "View failed details" }),
     );
@@ -38,5 +39,18 @@ describe("AgentExecutionState", () => {
     expect(
       screen.queryByRole("button", { name: /view failed details/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps an icon-only history status accessible", () => {
+    render(
+      <AgentExecutionState
+        state="TASK_STATE_INPUT_REQUIRED"
+        compact
+        iconOnly
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Needs input" })).toBeVisible();
+    expect(screen.queryByText("Needs input")).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/agent-execution-state.test.tsx
+++ b/platform/frontend/src/components/agent-execution-state.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AgentExecutionState } from "@/components/agent-execution-state";
+
+vi.mock("@/lib/clipboard", () => ({ copyToClipboard: vi.fn() }));
+
+describe("AgentExecutionState", () => {
+  it("opens copyable failure details from the compact status", async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentExecutionState
+        state="TASK_STATE_FAILED"
+        statusReason={
+          'HTTP-Code: 403 Message: Access denied Body: "{\\"kind\\":\\"Status\\",\\"code\\":403}"'
+        }
+        compact
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "View failed details" }),
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveTextContent("Execution failed");
+    expect(dialog).toHaveTextContent("HTTP-Code: 403 Message: Access denied");
+    expect(dialog.querySelector("pre")).toHaveTextContent(
+      /"kind": "Status"[\s\S]*"code": 403/,
+    );
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeEnabled();
+  });
+
+  it("renders a non-interactive status when no details were recorded", () => {
+    render(<AgentExecutionState state="TASK_STATE_FAILED" compact />);
+
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /view failed details/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/agent-execution-state.tsx
+++ b/platform/frontend/src/components/agent-execution-state.tsx
@@ -5,37 +5,65 @@ import { useState } from "react";
 import { LogConsole } from "@/components/log-console";
 import { StandardDialog } from "@/components/standard-dialog";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { AgentExecution } from "@/lib/agent-background-execution.query";
 import { cn } from "@/lib/utils";
 
 export function AgentExecutionState({
   state,
   compact = false,
+  iconOnly = false,
   statusReason,
 }: {
   state: AgentExecution["state"];
   compact?: boolean;
+  iconOnly?: boolean;
   statusReason?: string | null;
 }) {
   const presentation = executionStatePresentation(state);
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const dot = (
+    <span
+      className={cn(
+        "size-1.5 rounded-full",
+        presentation.pulse && "animate-pulse",
+        presentation.dotClassName,
+      )}
+    />
+  );
   const status = (
     <span
       className={cn(
         "inline-flex shrink-0 items-center gap-1.5 font-medium text-muted-foreground",
         compact ? "text-[11px]" : "text-xs",
+        statusReason && "text-foreground",
       )}
     >
-      <span
-        className={cn(
-          "size-1.5 rounded-full",
-          presentation.pulse && "animate-pulse",
-          presentation.dotClassName,
-        )}
-      />
+      {dot}
       <span>{presentation.label}</span>
     </span>
   );
+
+  if (iconOnly) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            role="img"
+            aria-label={presentation.label}
+            className="inline-flex size-5 shrink-0 items-center justify-center"
+          >
+            {dot}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="right">{presentation.label}</TooltipContent>
+      </Tooltip>
+    );
+  }
 
   if (!statusReason) return status;
 
@@ -43,13 +71,17 @@ export function AgentExecutionState({
     <>
       <Button
         type="button"
-        variant="ghost"
+        variant="outline"
         size="sm"
-        className="-mx-1.5 h-6 gap-0.5 rounded-md px-1.5 hover:bg-muted"
+        className="-mx-1 h-7 gap-1.5 rounded-full border-destructive/20 bg-destructive/5 px-2 hover:border-destructive/30 hover:bg-destructive/10"
         aria-label={`View ${presentation.label.toLowerCase()} details`}
         onClick={() => setDetailsOpen(true)}
       >
         {status}
+        <span aria-hidden className="h-3 w-px bg-border" />
+        <span className="text-[10px] font-normal text-muted-foreground">
+          View details
+        </span>
         <ChevronRight className="size-3 text-muted-foreground/70" />
       </Button>
       <StandardDialog

--- a/platform/frontend/src/components/agent-execution-state.tsx
+++ b/platform/frontend/src/components/agent-execution-state.tsx
@@ -40,7 +40,7 @@ export function AgentExecutionState({
       className={cn(
         "inline-flex shrink-0 items-center gap-1.5 font-medium text-muted-foreground",
         compact ? "text-[11px]" : "text-xs",
-        statusReason && "text-foreground",
+        statusReason && "gap-1 text-[10px] text-foreground",
       )}
     >
       {dot}
@@ -73,16 +73,16 @@ export function AgentExecutionState({
         type="button"
         variant="outline"
         size="sm"
-        className="-mx-1 h-7 gap-1.5 rounded-full border-destructive/20 bg-destructive/5 px-2 hover:border-destructive/30 hover:bg-destructive/10"
+        className="-mx-0.5 h-5 gap-1 rounded-md border-destructive/15 bg-destructive/5 px-1.5 hover:border-destructive/25 hover:bg-destructive/10"
         aria-label={`View ${presentation.label.toLowerCase()} details`}
         onClick={() => setDetailsOpen(true)}
       >
         {status}
-        <span aria-hidden className="h-3 w-px bg-border" />
-        <span className="text-[10px] font-normal text-muted-foreground">
-          View details
+        <span aria-hidden className="h-2.5 w-px bg-border" />
+        <span className="text-[9px] font-normal text-muted-foreground">
+          Details
         </span>
-        <ChevronRight className="size-3 text-muted-foreground/70" />
+        <ChevronRight className="size-2.5 text-muted-foreground/70" />
       </Button>
       <StandardDialog
         open={detailsOpen}

--- a/platform/frontend/src/components/agent-execution-state.tsx
+++ b/platform/frontend/src/components/agent-execution-state.tsx
@@ -1,15 +1,25 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import { useState } from "react";
+import { LogConsole } from "@/components/log-console";
+import { StandardDialog } from "@/components/standard-dialog";
+import { Button } from "@/components/ui/button";
 import type { AgentExecution } from "@/lib/agent-background-execution.query";
 import { cn } from "@/lib/utils";
 
 export function AgentExecutionState({
   state,
   compact = false,
+  statusReason,
 }: {
   state: AgentExecution["state"];
   compact?: boolean;
+  statusReason?: string | null;
 }) {
   const presentation = executionStatePresentation(state);
-  return (
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const status = (
     <span
       className={cn(
         "inline-flex shrink-0 items-center gap-1.5 font-medium text-muted-foreground",
@@ -23,8 +33,40 @@ export function AgentExecutionState({
           presentation.dotClassName,
         )}
       />
-      {presentation.label}
+      <span>{presentation.label}</span>
     </span>
+  );
+
+  if (!statusReason) return status;
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="-mx-1.5 h-6 gap-0.5 rounded-md px-1.5 hover:bg-muted"
+        aria-label={`View ${presentation.label.toLowerCase()} details`}
+        onClick={() => setDetailsOpen(true)}
+      >
+        {status}
+        <ChevronRight className="size-3 text-muted-foreground/70" />
+      </Button>
+      <StandardDialog
+        open={detailsOpen}
+        onOpenChange={setDetailsOpen}
+        title={`Execution ${presentation.label.toLowerCase()}`}
+        description="The execution reported this reason when it stopped."
+        size="medium"
+      >
+        <LogConsole
+          content={formatExecutionStatusReason(statusReason)}
+          contentTone="error"
+          copySuccessMessage="Execution details copied to clipboard"
+          className="h-64"
+        />
+      </StandardDialog>
+    </>
   );
 }
 
@@ -52,5 +94,28 @@ function executionStatePresentation(state: AgentExecution["state"]): {
       return { label: "Starting", dotClassName: "bg-sky-500", pulse: true };
     default:
       return { label: "Pending", dotClassName: "bg-sky-500", pulse: true };
+  }
+}
+
+function formatExecutionStatusReason(reason: string): string {
+  const bodyMarker = "Body: ";
+  const bodyStart = reason.indexOf(bodyMarker);
+  if (bodyStart === -1) return reason;
+
+  const parsedBody = parseEmbeddedJson(
+    reason.slice(bodyStart + bodyMarker.length),
+  );
+  if (parsedBody === null) return reason;
+
+  const summary = reason.slice(0, bodyStart).trimEnd();
+  return `${summary}\n\nBody:\n${JSON.stringify(parsedBody, null, 2)}`;
+}
+
+function parseEmbeddedJson(value: string): unknown | null {
+  try {
+    const parsed: unknown = JSON.parse(value.trim());
+    return typeof parsed === "string" ? JSON.parse(parsed) : parsed;
+  } catch {
+    return null;
   }
 }

--- a/platform/frontend/src/components/agent-pages/agent-catalog.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-catalog.tsx
@@ -5,14 +5,19 @@ import type { AgentFormInitialValues } from "@/components/agent-form";
 import { CatalogSourceCard } from "@/components/catalog-source-card";
 import { ProviderIcon } from "@/components/provider-icon";
 import { Badge } from "@/components/ui/badge";
+import appConfig from "@/lib/config/config";
 import { useFeature } from "@/lib/config/config.query";
-import { useAppIconLogo, useAppName } from "@/lib/hooks/use-app-name";
+import {
+  DEFAULT_APP_LOGO,
+  useAppIconLogo,
+  useAppName,
+} from "@/lib/hooks/use-app-name";
 
 export interface AgentCatalogTemplate {
   id: "archestra" | "claude-code" | "codex" | "hermes" | "openclaw";
   name: string;
   description: string;
-  icon: string;
+  icon: string | null;
   initialValues: AgentFormInitialValues;
 }
 
@@ -20,7 +25,7 @@ export function getAgentCatalogTemplates(
   archestraImage: string,
   // white-label-ok: test/helper fallback only; shipped UI always passes useAppName().
   appName = "Archestra",
-  appIconLogo = "/logo-icon.svg",
+  appIconLogo: string | null = "/logo-icon.svg",
 ): readonly AgentCatalogTemplate[] {
   return [
     template({
@@ -101,7 +106,16 @@ export function AgentCatalog({
 }) {
   const configuredImage = useFeature("agentBackgroundExecutionBaseImage");
   const appName = useAppName();
-  const appIconLogo = useAppIconLogo();
+  const resolvedAppIconLogo = useAppIconLogo();
+  // SPDX-SnippetBegin
+  // SPDX-SnippetCopyrightText: 2026 Archestra Inc.
+  // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+  const appIconLogo =
+    appConfig.enterpriseFeatures.fullWhiteLabeling &&
+    resolvedAppIconLogo === DEFAULT_APP_LOGO
+      ? null
+      : resolvedAppIconLogo;
+  // SPDX-SnippetEnd
   const templates = getAgentCatalogTemplates(
     typeof configuredImage === "string"
       ? configuredImage
@@ -151,11 +165,11 @@ function CatalogAgentIcon({
   appIconLogo,
 }: {
   id: AgentCatalogTemplate["id"];
-  appIconLogo: string;
+  appIconLogo: string | null;
 }) {
   switch (id) {
     case "archestra":
-      return (
+      return appIconLogo ? (
         <Image
           src={appIconLogo}
           alt=""
@@ -163,6 +177,8 @@ function CatalogAgentIcon({
           height={22}
           className="size-[22px] rounded-sm object-contain"
         />
+      ) : (
+        <Bot className="size-5" />
       );
     case "claude-code":
       return <ProviderIcon provider="anthropic" size={22} />;
@@ -197,7 +213,7 @@ function template(params: {
   id: AgentCatalogTemplate["id"];
   name: string;
   description: string;
-  icon: string;
+  icon: string | null;
   platformName: string;
   image: string;
   command: string[] | null;

--- a/platform/frontend/src/components/agent-pages/agent-create-page.test.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-create-page.test.tsx
@@ -9,10 +9,21 @@ import { useFeature } from "@/lib/config/config.query";
 import { useAppIconLogo, useAppName } from "@/lib/hooks/use-app-name";
 import { AgentCreatePage } from "./agent-create-page";
 
+const { mockConfig } = vi.hoisted(() => ({
+  mockConfig: {
+    enterpriseFeatures: {
+      fullWhiteLabeling: false,
+    },
+  },
+}));
+
 vi.mock("next/navigation");
 vi.mock("@/lib/auth/auth.query");
 vi.mock("@/lib/config/config.query");
 vi.mock("@/lib/hooks/use-app-name");
+vi.mock("@/lib/config/config", () => ({
+  default: mockConfig,
+}));
 
 // The form itself is covered by agent-form.test.tsx; here it is a stub whose
 // props are what the page is expected to hand it, plus a way to fire
@@ -61,6 +72,7 @@ function mockPermissions({
 describe("AgentCreatePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockConfig.enterpriseFeatures.fullWhiteLabeling = false;
     mockPermissions({ canRead: true });
     vi.mocked(useFeature).mockReturnValue(false);
     vi.mocked(useAppName).mockReturnValue("Archestra");
@@ -152,6 +164,37 @@ describe("AgentCreatePage", () => {
       }),
     );
   });
+
+  // SPDX-SnippetBegin
+  // SPDX-SnippetCopyrightText: 2026 Archestra Inc.
+  // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+  it("uses a neutral built-in Agent icon when full white-labeling has no custom icon", async () => {
+    const user = userEvent.setup();
+    mockConfig.enterpriseFeatures.fullWhiteLabeling = true;
+    vi.mocked(useFeature).mockImplementation((feature) =>
+      feature === "agentBackgroundExecution" ? true : undefined,
+    );
+    vi.mocked(useAppName).mockReturnValue("Example AI");
+    vi.mocked(useAppIconLogo).mockReturnValue("/logo-icon.svg");
+
+    render(<AgentCreatePage kind="agent" />);
+
+    const template = screen.getByRole("button", {
+      name: /example ai agent/i,
+    });
+    expect(template.querySelector("img")).toBeNull();
+
+    await user.click(template);
+    expect(formProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        initialValues: expect.objectContaining({
+          name: "Example AI Agent",
+          icon: null,
+        }),
+      }),
+    );
+  });
+  // SPDX-SnippetEnd
 
   it("prefills Claude Code with its runtime-scoped personal subscription token", async () => {
     const user = userEvent.setup();

--- a/platform/frontend/src/components/agent-pages/agent-executions.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-executions.tsx
@@ -98,16 +98,22 @@ export function AgentExecutions({ agentId }: { agentId: string }) {
                       <span className="min-w-0 flex-1 truncate text-sm font-medium">
                         {execution.title}
                       </span>
-                      <AgentExecutionState state={execution.state} compact />
+                      <AgentExecutionState
+                        state={execution.state}
+                        compact
+                        iconOnly
+                      />
                     </span>
                     <span className="flex items-center gap-1.5 text-[11px] font-normal text-muted-foreground">
                       <span className="font-mono">
                         {shortTaskId(execution.taskId)}
                       </span>
                       <span aria-hidden>·</span>
-                      {formatDistanceToNow(new Date(execution.startedAt), {
-                        addSuffix: true,
-                      })}
+                      <span className="min-w-0 truncate">
+                        {formatDistanceToNow(new Date(execution.startedAt), {
+                          addSuffix: true,
+                        })}
+                      </span>
                     </span>
                   </span>
                 </Button>

--- a/platform/frontend/src/components/agent-pages/agent-executions.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-executions.tsx
@@ -152,18 +152,17 @@ function ExecutionDetails({
               <h2 className="truncate text-sm font-medium">
                 {execution.title}
               </h2>
-              <AgentExecutionState state={execution.state} compact />
+              <AgentExecutionState
+                state={execution.state}
+                statusReason={execution.statusReason}
+                compact
+              />
             </div>
             <p className="mt-1 flex flex-wrap items-center gap-x-1.5 text-[11px] text-muted-foreground">
               <span className="font-mono">{shortTaskId(execution.taskId)}</span>
               <span aria-hidden>·</span>
               <span>{new Date(execution.startedAt).toLocaleString()}</span>
             </p>
-            {execution.statusReason && (
-              <p className="mt-2 text-xs text-destructive">
-                {execution.statusReason}
-              </p>
-            )}
           </div>
           <DeploymentConsoleTabList
             variant="compact"

--- a/platform/frontend/src/components/agent-pages/agent-executions.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-executions.tsx
@@ -87,15 +87,18 @@ export function AgentExecutions({ agentId }: { agentId: string }) {
                   type="button"
                   variant="ghost"
                   className={cn(
-                    "h-auto w-full justify-start rounded-lg px-3 py-2.5 text-left hover:bg-muted/70",
+                    "h-auto w-full min-w-0 justify-start overflow-hidden rounded-lg px-3 py-2.5 text-left hover:bg-muted/70",
                     isSelected &&
                       "bg-muted text-foreground ring-1 ring-inset ring-border hover:bg-muted",
                   )}
                   onClick={() => setSelectedTaskId(execution.taskId)}
                 >
-                  <span className="min-w-0 flex-1 space-y-1">
-                    <span className="flex min-w-0 items-center gap-2">
-                      <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                  <span className="flex min-w-0 flex-1 flex-col gap-1 overflow-hidden">
+                    <span className="grid min-w-0 grid-cols-[minmax(0,1fr)_1.25rem] items-center gap-1.5">
+                      <span
+                        className="truncate text-sm font-medium"
+                        title={execution.title}
+                      >
                         {execution.title}
                       </span>
                       <AgentExecutionState

--- a/platform/frontend/src/components/exec/exec-terminal.test.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.test.tsx
@@ -6,8 +6,12 @@ const terminalHarness = vi.hoisted(() => {
     resizeHandler: null as
       | ((dimensions: { cols: number; rows: number }) => void)
       | null,
+    wheelHandler: null as (() => boolean) | null,
     emitResize(cols: number, rows: number) {
       this.resizeHandler?.({ cols, rows });
+    },
+    processWheel() {
+      return this.wheelHandler?.();
     },
   };
 });
@@ -15,11 +19,15 @@ const terminalHarness = vi.hoisted(() => {
 vi.mock("@xterm/xterm", () => ({
   Terminal: class Terminal {
     rows = 24;
+    buffer = { active: { type: "alternate" } };
     loadAddon() {}
     open() {}
     dispose() {}
     write() {}
     onData() {}
+    attachCustomWheelEventHandler(handler: () => boolean) {
+      terminalHarness.wheelHandler = handler;
+    }
     onResize(handler: (dimensions: { cols: number; rows: number }) => void) {
       terminalHarness.resizeHandler = handler;
     }
@@ -47,6 +55,7 @@ describe("ExecTerminal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalHarness.resizeHandler = null;
+    terminalHarness.wheelHandler = null;
   });
 
   it("keeps the remote PTY synchronized with xterm dimension changes", async () => {
@@ -69,5 +78,21 @@ describe("ExecTerminal", () => {
     await waitFor(() => {
       expect(transport.sendResize).toHaveBeenCalledWith(164, 52);
     });
+  });
+
+  it("does not turn wheel motion over tmux into remote terminal input", async () => {
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        handlers.onStarted(null);
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(<ExecTerminal sessionKey="task-1" transport={transport} isActive />);
+
+    await screen.findByText("Connected");
+    expect(terminalHarness.processWheel()).toBe(false);
   });
 });

--- a/platform/frontend/src/components/exec/exec-terminal.test.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.test.tsx
@@ -7,6 +7,9 @@ const terminalHarness = vi.hoisted(() => {
       | ((dimensions: { cols: number; rows: number }) => void)
       | null,
     wheelHandler: null as (() => boolean) | null,
+    openedElement: null as HTMLDivElement | null,
+    buffer: { active: { type: "normal", baseY: 100, viewportY: 100 } },
+    scrollLines: vi.fn(),
     emitResize(cols: number, rows: number) {
       this.resizeHandler?.({ cols, rows });
     },
@@ -19,9 +22,12 @@ const terminalHarness = vi.hoisted(() => {
 vi.mock("@xterm/xterm", () => ({
   Terminal: class Terminal {
     rows = 24;
-    buffer = { active: { type: "alternate" } };
+    buffer = terminalHarness.buffer;
+    scrollLines = terminalHarness.scrollLines;
     loadAddon() {}
-    open() {}
+    open(element: HTMLDivElement) {
+      terminalHarness.openedElement = element;
+    }
     dispose() {}
     write() {}
     onData() {}
@@ -56,6 +62,10 @@ describe("ExecTerminal", () => {
     vi.clearAllMocks();
     terminalHarness.resizeHandler = null;
     terminalHarness.wheelHandler = null;
+    terminalHarness.openedElement = null;
+    terminalHarness.buffer.active.baseY = 100;
+    terminalHarness.buffer.active.viewportY = 100;
+    terminalHarness.scrollLines.mockReset();
   });
 
   it("keeps the remote PTY synchronized with xterm dimension changes", async () => {
@@ -94,5 +104,57 @@ describe("ExecTerminal", () => {
 
     await screen.findByText("Connected");
     expect(terminalHarness.processWheel()).toBe(false);
+  });
+
+  it("scrolls the local transcript without sending wheel input remotely", async () => {
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        handlers.onStarted(null);
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(<ExecTerminal sessionKey="task-1" transport={transport} isActive />);
+
+    await screen.findByText("Connected");
+    const wheel = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: -32,
+    });
+    terminalHarness.openedElement?.dispatchEvent(wheel);
+
+    expect(terminalHarness.scrollLines).toHaveBeenCalledWith(-2);
+    expect(wheel.defaultPrevented).toBe(true);
+    expect(transport.sendInput).not.toHaveBeenCalled();
+  });
+
+  it("hands wheel motion to the page at the transcript boundary", async () => {
+    terminalHarness.buffer.active.baseY = 0;
+    terminalHarness.buffer.active.viewportY = 0;
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        handlers.onStarted(null);
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(<ExecTerminal sessionKey="task-1" transport={transport} isActive />);
+
+    await screen.findByText("Connected");
+    const wheel = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 32,
+    });
+    terminalHarness.openedElement?.dispatchEvent(wheel);
+
+    expect(terminalHarness.scrollLines).not.toHaveBeenCalled();
+    expect(wheel.defaultPrevented).toBe(false);
+    expect(transport.sendInput).not.toHaveBeenCalled();
   });
 });

--- a/platform/frontend/src/components/exec/exec-terminal.test.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.test.tsx
@@ -6,15 +6,8 @@ const terminalHarness = vi.hoisted(() => {
     resizeHandler: null as
       | ((dimensions: { cols: number; rows: number }) => void)
       | null,
-    wheelHandler: null as (() => boolean) | null,
-    openedElement: null as HTMLDivElement | null,
-    buffer: { active: { type: "normal", baseY: 100, viewportY: 100 } },
-    scrollLines: vi.fn(),
     emitResize(cols: number, rows: number) {
       this.resizeHandler?.({ cols, rows });
-    },
-    processWheel() {
-      return this.wheelHandler?.();
     },
   };
 });
@@ -22,18 +15,11 @@ const terminalHarness = vi.hoisted(() => {
 vi.mock("@xterm/xterm", () => ({
   Terminal: class Terminal {
     rows = 24;
-    buffer = terminalHarness.buffer;
-    scrollLines = terminalHarness.scrollLines;
     loadAddon() {}
-    open(element: HTMLDivElement) {
-      terminalHarness.openedElement = element;
-    }
+    open() {}
     dispose() {}
     write() {}
     onData() {}
-    attachCustomWheelEventHandler(handler: () => boolean) {
-      terminalHarness.wheelHandler = handler;
-    }
     onResize(handler: (dimensions: { cols: number; rows: number }) => void) {
       terminalHarness.resizeHandler = handler;
     }
@@ -61,11 +47,6 @@ describe("ExecTerminal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalHarness.resizeHandler = null;
-    terminalHarness.wheelHandler = null;
-    terminalHarness.openedElement = null;
-    terminalHarness.buffer.active.baseY = 100;
-    terminalHarness.buffer.active.viewportY = 100;
-    terminalHarness.scrollLines.mockReset();
   });
 
   it("keeps the remote PTY synchronized with xterm dimension changes", async () => {
@@ -88,73 +69,5 @@ describe("ExecTerminal", () => {
     await waitFor(() => {
       expect(transport.sendResize).toHaveBeenCalledWith(164, 52);
     });
-  });
-
-  it("does not turn wheel motion over tmux into remote terminal input", async () => {
-    const transport: ExecSessionTransport = {
-      open: (handlers) => {
-        handlers.onStarted(null);
-        return vi.fn();
-      },
-      sendInput: vi.fn(),
-      sendResize: vi.fn(),
-    };
-
-    render(<ExecTerminal sessionKey="task-1" transport={transport} isActive />);
-
-    await screen.findByText("Connected");
-    expect(terminalHarness.processWheel()).toBe(false);
-  });
-
-  it("scrolls the local transcript without sending wheel input remotely", async () => {
-    const transport: ExecSessionTransport = {
-      open: (handlers) => {
-        handlers.onStarted(null);
-        return vi.fn();
-      },
-      sendInput: vi.fn(),
-      sendResize: vi.fn(),
-    };
-
-    render(<ExecTerminal sessionKey="task-1" transport={transport} isActive />);
-
-    await screen.findByText("Connected");
-    const wheel = new WheelEvent("wheel", {
-      bubbles: true,
-      cancelable: true,
-      deltaY: -32,
-    });
-    terminalHarness.openedElement?.dispatchEvent(wheel);
-
-    expect(terminalHarness.scrollLines).toHaveBeenCalledWith(-2);
-    expect(wheel.defaultPrevented).toBe(true);
-    expect(transport.sendInput).not.toHaveBeenCalled();
-  });
-
-  it("hands wheel motion to the page at the transcript boundary", async () => {
-    terminalHarness.buffer.active.baseY = 0;
-    terminalHarness.buffer.active.viewportY = 0;
-    const transport: ExecSessionTransport = {
-      open: (handlers) => {
-        handlers.onStarted(null);
-        return vi.fn();
-      },
-      sendInput: vi.fn(),
-      sendResize: vi.fn(),
-    };
-
-    render(<ExecTerminal sessionKey="task-1" transport={transport} isActive />);
-
-    await screen.findByText("Connected");
-    const wheel = new WheelEvent("wheel", {
-      bubbles: true,
-      cancelable: true,
-      deltaY: 32,
-    });
-    terminalHarness.openedElement?.dispatchEvent(wheel);
-
-    expect(terminalHarness.scrollLines).not.toHaveBeenCalled();
-    expect(wheel.defaultPrevented).toBe(false);
-    expect(transport.sendInput).not.toHaveBeenCalled();
   });
 });

--- a/platform/frontend/src/components/exec/exec-terminal.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.tsx
@@ -143,12 +143,31 @@ export function ExecTerminal({
       terminal.loadAddon(fitAddon);
       terminal.open(terminalRef.current);
       terminal.attachCustomWheelEventHandler(
-        // xterm turns wheel motion into Up/Down input when an alternate-screen
-        // app such as tmux has no browser scrollback. That types escape
-        // sequences into the remote TUI. Leave normal-buffer scrollback to
-        // xterm, but let the surrounding page consume alternate-screen wheels.
-        () => terminal.buffer.active.type === "normal",
+        // xterm can forward a wheel as mouse input or synthesize Up/Down input
+        // when it thinks an application such as tmux should own scrolling.
+        // Browser wheel motion must never become remote terminal input.
+        () => false,
       );
+      const wheelContainer = terminalRef.current;
+      const handleWheel = (event: WheelEvent) => {
+        const buffer = terminal.buffer.active;
+        const atLocalBoundary =
+          event.deltaY < 0
+            ? buffer.viewportY <= 0
+            : buffer.viewportY >= buffer.baseY;
+
+        // Keep xterm from seeing the event in both cases. At a local scrollback
+        // boundary, leaving the default action intact lets the page scroll.
+        event.stopPropagation();
+        if (event.deltaY === 0 || atLocalBoundary) return;
+
+        event.preventDefault();
+        terminal.scrollLines(wheelDeltaInLines(event, terminal.rows));
+      };
+      wheelContainer.addEventListener("wheel", handleWheel, {
+        capture: true,
+        passive: false,
+      });
 
       // FitAddon can resize xterm for reasons other than an element resize
       // (font metrics settling is the common one). Drive the remote PTY from
@@ -224,6 +243,7 @@ export function ExecTerminal({
       }
 
       return () => {
+        wheelContainer.removeEventListener("wheel", handleWheel, true);
         resizeObserver.disconnect();
         closeSession();
       };
@@ -326,4 +346,14 @@ export function ExecTerminal({
       )}
     </div>
   );
+}
+
+function wheelDeltaInLines(event: WheelEvent, pageSize: number): number {
+  const lines =
+    event.deltaMode === WheelEvent.DOM_DELTA_LINE
+      ? event.deltaY
+      : event.deltaMode === WheelEvent.DOM_DELTA_PAGE
+        ? event.deltaY * pageSize
+        : event.deltaY / 16;
+  return Math.sign(lines) * Math.max(1, Math.round(Math.abs(lines)));
 }

--- a/platform/frontend/src/components/exec/exec-terminal.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.tsx
@@ -142,6 +142,13 @@ export function ExecTerminal({
 
       terminal.loadAddon(fitAddon);
       terminal.open(terminalRef.current);
+      terminal.attachCustomWheelEventHandler(
+        // xterm turns wheel motion into Up/Down input when an alternate-screen
+        // app such as tmux has no browser scrollback. That types escape
+        // sequences into the remote TUI. Leave normal-buffer scrollback to
+        // xterm, but let the surrounding page consume alternate-screen wheels.
+        () => terminal.buffer.active.type === "normal",
+      );
 
       // FitAddon can resize xterm for reasons other than an element resize
       // (font metrics settling is the common one). Drive the remote PTY from

--- a/platform/frontend/src/components/exec/exec-terminal.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.tsx
@@ -142,32 +142,6 @@ export function ExecTerminal({
 
       terminal.loadAddon(fitAddon);
       terminal.open(terminalRef.current);
-      terminal.attachCustomWheelEventHandler(
-        // xterm can forward a wheel as mouse input or synthesize Up/Down input
-        // when it thinks an application such as tmux should own scrolling.
-        // Browser wheel motion must never become remote terminal input.
-        () => false,
-      );
-      const wheelContainer = terminalRef.current;
-      const handleWheel = (event: WheelEvent) => {
-        const buffer = terminal.buffer.active;
-        const atLocalBoundary =
-          event.deltaY < 0
-            ? buffer.viewportY <= 0
-            : buffer.viewportY >= buffer.baseY;
-
-        // Keep xterm from seeing the event in both cases. At a local scrollback
-        // boundary, leaving the default action intact lets the page scroll.
-        event.stopPropagation();
-        if (event.deltaY === 0 || atLocalBoundary) return;
-
-        event.preventDefault();
-        terminal.scrollLines(wheelDeltaInLines(event, terminal.rows));
-      };
-      wheelContainer.addEventListener("wheel", handleWheel, {
-        capture: true,
-        passive: false,
-      });
 
       // FitAddon can resize xterm for reasons other than an element resize
       // (font metrics settling is the common one). Drive the remote PTY from
@@ -243,7 +217,6 @@ export function ExecTerminal({
       }
 
       return () => {
-        wheelContainer.removeEventListener("wheel", handleWheel, true);
         resizeObserver.disconnect();
         closeSession();
       };
@@ -346,14 +319,4 @@ export function ExecTerminal({
       )}
     </div>
   );
-}
-
-function wheelDeltaInLines(event: WheelEvent, pageSize: number): number {
-  const lines =
-    event.deltaMode === WheelEvent.DOM_DELTA_LINE
-      ? event.deltaY
-      : event.deltaMode === WheelEvent.DOM_DELTA_PAGE
-        ? event.deltaY * pageSize
-        : event.deltaY / 16;
-  return Math.sign(lines) * Math.max(1, Math.round(Math.abs(lines)));
 }

--- a/platform/frontend/src/components/log-console.tsx
+++ b/platform/frontend/src/components/log-console.tsx
@@ -23,6 +23,8 @@ export function LogConsole({
   emptyMessage = "No logs available",
   placeholder,
   error,
+  contentTone = "logs",
+  copySuccessMessage = "Logs copied to clipboard",
   status,
   scrollAreaRef,
   onScroll,
@@ -41,6 +43,9 @@ export function LogConsole({
   placeholder?: React.ReactNode;
   /** Shown instead of the content — the logs could not be loaded at all. */
   error?: string | null;
+  /** Visual tone for copyable content. Transport errors use the `error` prop. */
+  contentTone?: "logs" | "error";
+  copySuccessMessage?: string;
   /** Footer content on the left of the copy button (streaming indicator, …). */
   status?: React.ReactNode;
   scrollAreaRef?: React.Ref<HTMLDivElement>;
@@ -57,12 +62,12 @@ export function LogConsole({
     try {
       await copyToClipboard(content);
       setCopied(true);
-      toast.success("Logs copied to clipboard");
+      toast.success(copySuccessMessage);
       setTimeout(() => setCopied(false), 2000);
     } catch (_error) {
       toast.error("Failed to copy logs");
     }
-  }, [content]);
+  }, [content, copySuccessMessage]);
 
   return (
     <div
@@ -89,7 +94,10 @@ export function LogConsole({
             </div>
           ) : content ? (
             <pre
-              className="font-mono text-xs whitespace-pre-wrap break-words text-emerald-400"
+              className={cn(
+                "font-mono text-xs whitespace-pre-wrap break-words",
+                contentTone === "error" ? "text-red-400" : "text-emerald-400",
+              )}
               data-testid={contentTestId}
             >
               {content}

--- a/platform/frontend/src/lib/agent-background-execution.query.test.tsx
+++ b/platform/frontend/src/lib/agent-background-execution.query.test.tsx
@@ -1,0 +1,53 @@
+import { archestraApiSdk } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useMyAgentExecution } from "./agent-background-execution.query";
+
+vi.mock("@archestra/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@archestra/shared")>();
+  return {
+    ...actual,
+    archestraApiSdk: {
+      ...actual.archestraApiSdk,
+      getMyAgentExecution: vi.fn(),
+    },
+  };
+});
+
+const sdk = vi.mocked(archestraApiSdk);
+
+describe("useMyAgentExecution", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("stops polling after an execution load exhausts its retries", async () => {
+    vi.useFakeTimers();
+    sdk.getMyAgentExecution.mockResolvedValue({
+      data: undefined,
+      error: {
+        error: {
+          message: "Execution not found",
+          type: "api_not_found_error",
+        },
+      },
+    } as never);
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useMyAgentExecution("task-1"), {
+      wrapper,
+    });
+
+    await act(() => vi.advanceTimersByTimeAsync(10_000));
+    expect(result.current.isError).toBe(true);
+    const callsAfterRetries = sdk.getMyAgentExecution.mock.calls.length;
+
+    await act(() => vi.advanceTimersByTimeAsync(10_000));
+    expect(sdk.getMyAgentExecution).toHaveBeenCalledTimes(callsAfterRetries);
+  });
+});

--- a/platform/frontend/src/lib/agent-background-execution.query.ts
+++ b/platform/frontend/src/lib/agent-background-execution.query.ts
@@ -75,7 +75,10 @@ export function useMyAgentExecution(taskId: string, enabled = true) {
       return data;
     },
     enabled: enabled && !!taskId,
-    refetchInterval: (query) => (query.state.data?.endedAt ? false : 2_000),
+    refetchInterval: (query) =>
+      query.state.status === "error" || query.state.data?.endedAt
+        ? false
+        : 2_000,
     retry: (failureCount) => failureCount < 8,
     retryDelay: 500,
   });

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -499,6 +499,14 @@ rbac.environmentNamespaces, so both grant exactly the same access (no drift).
 - apiGroups: ["apps"]
   resources: ["deployments", "statefulsets"]
   verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+# Jobs run Agent background executions. The control plane only needs to create,
+# inspect, and remove them; it never mutates an existing Job or manages CronJobs.
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "create", "delete"]
+- apiGroups: ["batch"]
+  resources: ["jobs/status"]
+  verbs: ["get"]
 # DaemonSet for the MCP image pre-puller, which keeps every node's image cache
 # warm so a hibernated MCP server wakes without reaching the registry. Narrower
 # than the rule above on purpose: the reconciler only reads and rewrites its own

--- a/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_service_account_test.yaml
@@ -177,7 +177,7 @@ tests:
     asserts:
       - lengthEqual:
           path: rules
-          count: 13
+          count: 15
       - notContains:
           path: rules
           content:
@@ -301,14 +301,26 @@ tests:
             resources: ["applicationnetworkpolicies"]
             verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
 
-  - it: should NOT have batch/cronjobs permissions in MCP Manager Role
+  - it: should grant narrow Agent background execution Job permissions in MCP Manager Role
     documentIndex: 1
     asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["batch"]
+            resources: ["jobs"]
+            verbs: ["get", "create", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["batch"]
+            resources: ["jobs/status"]
+            verbs: ["get"]
       - notContains:
           path: rules
           content:
             apiGroups: ["batch"]
-            resources: ["cronjobs", "jobs"]
+            resources: ["cronjobs"]
             verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
 
   # MCP Manager RoleBinding tests

--- a/platform/runner-agent/src/index.ts
+++ b/platform/runner-agent/src/index.ts
@@ -29,7 +29,7 @@ async function main(): Promise<number> {
     config = readConfig(process.env);
   } catch (error: unknown) {
     if (error instanceof BackgroundExecutionAgentConfigError) {
-      write(`archestra: ${error.message}`);
+      write(`runner: ${error.message}`);
       return 78;
     }
     throw error;
@@ -38,7 +38,7 @@ async function main(): Promise<number> {
   renderHeader(config);
 
   const steerQueue = new SteerQueue(config.steerFifo, (error: unknown) => {
-    write(`archestra: could not read the steer channel: ${describe(error)}`);
+    write(`runner: could not read the steer channel: ${describe(error)}`);
   });
   steerQueue.start();
   const terminalInput =
@@ -92,9 +92,7 @@ async function main(): Promise<number> {
         const incoming = await steerQueue.waitForMessage(config.idleTimeoutMs);
         if (incoming.length === 0) {
           if (config.idleTimeoutMs !== null) {
-            write(
-              "[archestra] no further direction — session complete, exiting",
-            );
+            write("[runner] no further direction — session complete, exiting");
           }
           break;
         }
@@ -148,7 +146,7 @@ async function main(): Promise<number> {
       // SDK/provider exceptions can carry raw HTTP response bodies. Keep the
       // user-visible terminal generic rather than persisting those details in
       // the run's scrollback and logs.
-      write("\narchestra: the session failed.");
+      write("\nrunner: the session failed.");
       exitCode = 1;
     }
   } finally {
@@ -285,7 +283,7 @@ main()
     process.exit(code);
   })
   .catch(() => {
-    write("archestra: the session could not start.");
+    write("runner: the session could not start.");
     // An MCP transport may retain internal fetch handles after a failed
     // handshake. This is a task process, so a startup failure is terminal: do
     // not leave the execution pod looking alive after surfacing the error.


### PR DESCRIPTION
## Summary

- grant the platform service account least-privilege Kubernetes Job access for background Agent executions
- replace raw inline failure text with a compact clickable status and a copyable, formatted terminal-style dialog
- respect full white-label configuration in the built-in Agent catalog and runner banner, and keep runtime diagnostics neutral
- enable tmux-owned wheel scrollback in the shared execution terminal without sending cursor garbage to the Agent
- bake locale, terminal, tmux mouse mode, and a stable attach helper into every runner Job; direct kubectl and k9s shells auto-attach
- keep execution loading errors stable after retries and preserve the last loaded execution during transient refresh failures

## Verification

- targeted backend manifest and frontend execution tests
- backend and frontend type checks
- backend development and production knip checks
- Helm tests
- live Chrome verification on both execution terminal routes and the execution-not-found state
- live throwaway Kubernetes Job verification using the same shell command as k9s