### PR TITLE
feat(agents): orchestrate Lobster Env runners

### DIFF
--- a/.github/workflows/build-agent-catalog-images.yml
+++ b/.github/workflows/build-agent-catalog-images.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ${{ fromJSON(inputs.include_staging_images && '["agent-archestra","agent-claude-code","agent-codex","agent-hermes","agent-openclaw","agent-lobster-env"]' || '["agent-archestra","agent-claude-code","agent-codex","agent-hermes","agent-openclaw"]') }}
+        image: ${{ fromJSON(inputs.include_staging_images && '["agent-archestra","agent-claude-code","agent-codex","agent-hermes","agent-openclaw","agent-lobster-env","agent-lobster-env-claude-code","agent-lobster-env-hermes","agent-lobster-env-openclaw"]' || '["agent-archestra","agent-claude-code","agent-codex","agent-hermes","agent-openclaw"]') }}
     permissions:
       contents: read # Required to invoke the reusable image build workflow.
       id-token: write # Required for Workload Identity Federation.

--- a/platform/agent_images/Dockerfile
+++ b/platform/agent_images/Dockerfile
@@ -59,9 +59,9 @@ USER 1000:1000
 
 FROM rust:1.89.0-bookworm AS lobster-rust-toolchain
 
-# Staging's Archestra-native task environment. It deliberately builds on the
-# maintained Codex runtime, then adds only the repository toolchain and a
-# workflow wrapper; provider and MCP credentials still arrive at launch time.
+# Staging's Codex-backed task worker. The other Lobster workers below apply the
+# same repository toolchain and workflow contract to the remaining maintained
+# runtimes; provider and MCP credentials still arrive at launch time.
 FROM agent-codex AS agent-lobster-env
 USER root
 COPY --from=lobster-rust-toolchain /usr/local/cargo /usr/local/cargo
@@ -90,4 +90,40 @@ USER root
 RUN pnpm add --global openclaw@2026.7.1-2 \
  && openclaw --version \
  && chown -R 1000:1000 /home/node
+USER 1000:1000
+
+FROM agent-claude-code AS agent-lobster-env-claude-code
+USER root
+COPY --from=lobster-rust-toolchain /usr/local/cargo /usr/local/cargo
+COPY --from=lobster-rust-toolchain /usr/local/rustup /usr/local/rustup
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:$PATH
+RUN cargo --version && rustc --version
+COPY agent_images/lobster-env /opt/archestra/lobster-env
+RUN chmod 0444 /opt/archestra/lobster-env/system-prompt.md
+USER 1000:1000
+
+FROM agent-hermes AS agent-lobster-env-hermes
+USER root
+COPY --from=lobster-rust-toolchain /usr/local/cargo /usr/local/cargo
+COPY --from=lobster-rust-toolchain /usr/local/rustup /usr/local/rustup
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:$PATH
+RUN cargo --version && rustc --version
+COPY agent_images/lobster-env /opt/archestra/lobster-env
+RUN chmod 0444 /opt/archestra/lobster-env/system-prompt.md
+USER 1000:1000
+
+FROM agent-openclaw AS agent-lobster-env-openclaw
+USER root
+COPY --from=lobster-rust-toolchain /usr/local/cargo /usr/local/cargo
+COPY --from=lobster-rust-toolchain /usr/local/rustup /usr/local/rustup
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:$PATH
+RUN cargo --version && rustc --version
+COPY agent_images/lobster-env /opt/archestra/lobster-env
+RUN chmod 0444 /opt/archestra/lobster-env/system-prompt.md
 USER 1000:1000

--- a/platform/agent_images/README.md
+++ b/platform/agent_images/README.md
@@ -11,8 +11,11 @@ invoking user's Agent-scoped MCP gateway endpoint.
 | `agent-claude-code` | `archestra-claude-code` | Anthropic Messages |
 | `agent-codex` | `archestra-codex` | OpenAI Responses |
 | `agent-hermes` | `archestra-hermes` | OpenAI Chat Completions |
-| `agent-openclaw` | `archestra-openclaw` | OpenAI Responses |
+| `agent-openclaw` | `archestra-openclaw` | OpenAI Chat Completions or Responses |
 | `agent-lobster-env` | `archestra-lobster-env` | OpenAI Responses |
+| `agent-lobster-env-claude-code` | `archestra-lobster-claude-code` | Anthropic Messages |
+| `agent-lobster-env-hermes` | `archestra-lobster-hermes` | OpenAI Chat Completions |
+| `agent-lobster-env-openclaw` | `archestra-lobster-openclaw` | OpenAI Chat Completions or Responses |
 
 Build a target from `platform/`:
 
@@ -57,6 +60,8 @@ to that authenticated HTTPS transport, so a catalog Agent does not also need a
 separate SSH key.
 
 The five public catalog targets are built for development deployments and
-releases. The `agent-lobster-env` target is included only in development image
-publishing for the staging evaluation. Keep native CLI versions exact and
-review their published package scripts before updating them.
+releases. The four `agent-lobster-env*` targets are included only in development
+image publishing for the staging evaluation. They share one repository
+bootstrap and durable-task contract while exercising four native clients. Keep
+native CLI versions exact and review their published package scripts before
+updating them.

--- a/platform/agent_images/bin/archestra-lobster-claude-code
+++ b/platform/agent_images/bin/archestra-lobster-claude-code
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export ARCHESTRA_LOBSTER_ENV_CLIENT=archestra-codex
+export ARCHESTRA_LOBSTER_ENV_CLIENT=archestra-claude-code
 exec archestra-lobster-worker

--- a/platform/agent_images/bin/archestra-lobster-hermes
+++ b/platform/agent_images/bin/archestra-lobster-hermes
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export ARCHESTRA_LOBSTER_ENV_CLIENT=archestra-codex
+export ARCHESTRA_LOBSTER_ENV_CLIENT=archestra-hermes
 exec archestra-lobster-worker

--- a/platform/agent_images/bin/archestra-lobster-openclaw
+++ b/platform/agent_images/bin/archestra-lobster-openclaw
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export ARCHESTRA_LOBSTER_ENV_CLIENT=archestra-codex
+export ARCHESTRA_LOBSTER_ENV_CLIENT=archestra-openclaw
 exec archestra-lobster-worker

--- a/platform/agent_images/bin/archestra-lobster-worker
+++ b/platform/agent_images/bin/archestra-lobster-worker
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="${ARCHESTRA_LOBSTER_ENV_REPOSITORY_DIR:-/home/node/workspace/archestra}"
+public_repo="${ARCHESTRA_LOBSTER_ENV_PUBLIC_REPOSITORY:-https://github.com/archestra-ai/archestra.git}"
+private_repo_slug="${ARCHESTRA_LOBSTER_ENV_PRIVATE_REPOSITORY_SLUG:-archestra-ai/archestra-private}"
+private_repo="${ARCHESTRA_LOBSTER_ENV_PRIVATE_REPOSITORY:-https://github.com/${private_repo_slug}.git}"
+prompt_file="${ARCHESTRA_LOBSTER_ENV_SYSTEM_PROMPT_FILE:-/opt/archestra/lobster-env/system-prompt.md}"
+client="${ARCHESTRA_LOBSTER_ENV_CLIENT:?}"
+task_id="${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK_ID:?}"
+branch="agent/lobster-${task_id%%-*}"
+setup_log="${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_RUNTIME_DIR:-/var/run/archestra}/lobster-bootstrap.log"
+mkdir -p "$(dirname "${setup_log}")"
+
+run_setup() {
+  if ! "$@" >> "${setup_log}" 2>&1; then
+    echo "archestra: repository setup failed while running: $*" >&2
+    tail -40 "${setup_log}" >&2
+    return 1
+  fi
+}
+
+case "${client}" in
+  archestra-claude-code | archestra-codex | archestra-hermes | archestra-openclaw) ;;
+  *)
+    echo "archestra: unsupported Lobster Env client: ${client}" >&2
+    exit 78
+    ;;
+esac
+
+if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+  echo "archestra: Lobster Env requires its per-user GITHUB_TOKEN credential" >&2
+  exit 78
+fi
+
+if [[ ! -d "${repo_dir}/.git" ]]; then
+  # Task pods need the current tree and ordinary branch history, not every
+  # historical blob in the repository. Git fetches an older blob lazily if a
+  # runner actually asks for one.
+  run_setup git clone --quiet --filter=blob:none --single-branch --branch main \
+    --origin origin "${public_repo}" "${repo_dir}"
+else
+  run_setup git -C "${repo_dir}" fetch --quiet origin main
+fi
+
+if git -C "${repo_dir}" remote get-url private >/dev/null 2>&1; then
+  git -C "${repo_dir}" remote set-url private "${private_repo}"
+else
+  git -C "${repo_dir}" remote add private "${private_repo}"
+fi
+git -C "${repo_dir}" config remote.pushDefault private
+git -C "${repo_dir}" config push.default current
+git -C "${repo_dir}" config user.name "Archestra Agent"
+git -C "${repo_dir}" config user.email \
+  "archestra-agent[bot]@users.noreply.github.com"
+(cd "${repo_dir}" && run_setup gh repo set-default "${private_repo_slug}")
+
+# Keep the private mirror's main at least as fresh as the public base. A racing
+# task may have already advanced it, so a non-fast-forward sync is harmless;
+# the ancestry check below is the actual invariant.
+git -C "${repo_dir}" push private \
+  refs/remotes/origin/main:refs/heads/main >/dev/null 2>&1 || true
+run_setup git -C "${repo_dir}" fetch --quiet --filter=blob:none private main
+if ! git -C "${repo_dir}" merge-base --is-ancestor \
+  refs/remotes/origin/main refs/remotes/private/main; then
+  echo "archestra: the private mirror does not contain the current public main" >&2
+  exit 69
+fi
+
+if git -C "${repo_dir}" ls-remote --exit-code --heads private \
+  "refs/heads/${branch}" >/dev/null 2>&1; then
+  run_setup git -C "${repo_dir}" fetch --quiet --filter=blob:none private "${branch}"
+  run_setup git -C "${repo_dir}" checkout --quiet -B "${branch}" "private/${branch}"
+else
+  run_setup git -C "${repo_dir}" checkout --quiet -B "${branch}" origin/main
+fi
+
+baked_instructions="$(< "${prompt_file}")"
+if [[ -n "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_SYSTEM_PROMPT:-}" ]]; then
+  export ARCHESTRA_AGENT_BACKGROUND_EXECUTION_SYSTEM_PROMPT="${baked_instructions}
+
+${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_SYSTEM_PROMPT}"
+else
+  export ARCHESTRA_AGENT_BACKGROUND_EXECUTION_SYSTEM_PROMPT="${baked_instructions}"
+fi
+
+export PATH="${HOME}/.cargo/bin:${PATH}"
+cd "${repo_dir}/platform"
+exec "${client}"

--- a/platform/agent_images/bin/archestra-openclaw
+++ b/platform/agent_images/bin/archestra-openclaw
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "${ARCHESTRA_LLM_PROXY_PROTOCOL:-}" != "openai_responses" ]]; then
-  echo "archestra: OpenClaw requires an Agent configured for OpenAI Responses" >&2
-  exit 78
-fi
+case "${ARCHESTRA_LLM_PROXY_PROTOCOL:-}" in
+  openai_chat) openclaw_api="openai-completions" ;;
+  openai_responses) openclaw_api="openai-responses" ;;
+  *)
+    echo "archestra: OpenClaw requires an Agent configured for OpenAI Chat Completions or OpenAI Responses" >&2
+    exit 78
+    ;;
+esac
 
 resolve_docker_desktop_url() {
   local url="$1"
@@ -28,9 +32,50 @@ runtime_dir="${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_RUNTIME_DIR:-/var/run/arches
 config_file="${runtime_dir}/openclaw.json"
 task_file="${runtime_dir}/task.md"
 model="${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NATIVE_MODEL:?}"
+runtime_instructions="${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_SYSTEM_PROMPT:-}"
 export OPENCLAW_STATE_DIR="${runtime_dir}/openclaw-state"
 export OPENCLAW_CONFIG_PATH="${config_file}"
 mkdir -p "${OPENCLAW_STATE_DIR}"
+
+# OpenClaw deliberately owns its generated system prompt. Its supported
+# extension point is the workspace bootstrap files, so expose the Agent's
+# runtime instructions through SOUL.md. Task pods use a fresh worktree; the
+# cleanup and exclude bookkeeping also keep this safe for a custom workspace.
+soul_file="${PWD}/SOUL.md"
+soul_created=false
+exclude_file=""
+exclude_backup="${runtime_dir}/git-info-exclude.backup"
+exclude_existed=false
+
+cleanup_bootstrap() {
+  if [[ "${soul_created}" == true ]]; then
+    rm -f "${soul_file}"
+  fi
+  if [[ -n "${exclude_file}" ]]; then
+    if [[ "${exclude_existed}" == true ]]; then
+      cp "${exclude_backup}" "${exclude_file}"
+    else
+      rm -f "${exclude_file}"
+    fi
+  fi
+}
+trap cleanup_bootstrap EXIT
+
+if [[ -n "${runtime_instructions}" && ! -e "${soul_file}" ]]; then
+  printf '# Runtime instructions\n\n%s\n' "${runtime_instructions}" > "${soul_file}"
+  soul_created=true
+
+  git_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "${git_root}" && "${soul_file}" == "${git_root}"/* ]]; then
+    exclude_file="$(git -C "${git_root}" rev-parse --git-path info/exclude)"
+    mkdir -p "$(dirname "${exclude_file}")"
+    if [[ -f "${exclude_file}" ]]; then
+      cp "${exclude_file}" "${exclude_backup}"
+      exclude_existed=true
+    fi
+    printf '\n/%s\n' "${soul_file#"${git_root}/"}" >> "${exclude_file}"
+  fi
+fi
 
 # Docker Desktop publishes host.internal with a working IPv6 address and a
 # synthetic IPv4 address that cannot accept connections from Kubernetes pods.
@@ -46,15 +91,17 @@ jq -n \
   --arg model "${model}" \
   --arg task_id "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK_ID:?}" \
   --arg mcp_url "${openclaw_mcp_url}" \
+  --arg api "${openclaw_api}" \
   --arg workspace "${PWD}" \
   '{
+    logging:{level:"error",consoleLevel:"silent"},
     models:{
       mode:"replace",
       providers:{
         archestra:{
           baseUrl:$base_url,
           apiKey:env.OPENAI_API_KEY,
-          api:"openai-responses",
+          api:$api,
           headers:{
             "X-Archestra-Execution-Id":$task_id,
             "X-Archestra-Session-Id":$task_id
@@ -65,6 +112,7 @@ jq -n \
     },
     agents:{defaults:{
       workspace:$workspace,
+      skipBootstrap:true,
       model:{primary:("archestra/" + $model)}
     }},
     mcp:{
@@ -82,16 +130,26 @@ jq -n \
     }
   }' > "${config_file}"
 chmod 0600 "${config_file}"
-printf '%s\n' "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK:?}" > "${task_file}"
+if [[ -n "${runtime_instructions}" && "${soul_created}" != true ]]; then
+  printf '%s\n\n# Delegated task\n\n%s\n' \
+    "${runtime_instructions}" \
+    "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK:?}" > "${task_file}"
+else
+  printf '%s\n' "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK:?}" > "${task_file}"
+fi
 
 session_key="agent:main:${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK_ID:?}"
 
 case "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_MODE:-one_shot}" in
   interactive)
-    exec openclaw tui \
+    set +e
+    openclaw tui \
       --local \
       --session "${session_key}" \
       --message "$(cat "${task_file}")"
+    status=$?
+    set -e
+    exit "${status}"
     ;;
   one_shot)
     set +e
@@ -102,7 +160,7 @@ case "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_MODE:-one_shot}" in
       --message-file "${task_file}" 2>&1 | tee "${runtime_dir}/openclaw-output.log"
     status=${PIPESTATUS[0]}
     set -e
-    if [[ ${status} -ne 0 ]] || grep -Eq 'FailoverError:|LLM request failed|network connection error' "${runtime_dir}/openclaw-output.log"; then
+    if [[ ${status} -ne 0 ]] || grep -Eq "FailoverError:|LLM request failed|network connection error|empty response retries exhausted|Agent couldn't generate a response" "${runtime_dir}/openclaw-output.log"; then
       exit 1
     fi
     ;;

--- a/platform/agent_images/lobster-env/README.md
+++ b/platform/agent_images/lobster-env/README.md
@@ -1,30 +1,67 @@
 # Lobster Env staging evaluation
 
-This image runs the temporary Archestra-native coding Agent alongside the
-existing task environment on `frontend.archestra.dev`. It is not part of the
-public Agent catalog and is not published by release builds.
+This staging-only workflow runs alongside the existing task environment on
+`frontend.archestra.dev`. It is not part of the public Agent catalog and its
+worker images are not published by release builds.
 
-Configure one organization Agent with:
+## Agent graph
 
-- name: `Lobster Env`
-- image: `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/agent-lobster-env:latest`
-- command: `archestra-lobster-env`
-- inference API: OpenAI Responses
-- model: an OpenAI model backed by each user's connected ChatGPT subscription
+Configure `Lobster Env` as a foreground organization Agent with no Background
+execution deployment. Use `orchestrator-system-prompt.md` as its system prompt
+and explicitly assign these four worker Agents as subagents:
+
+- `Lobster Claude Code`
+- `Lobster Codex`
+- `Lobster Hermes`
+- `Lobster OpenClaw`
+
+PotatoAI, `Lobster Env`, and all four workers must use the same Agent
+Environment. Delegation is environment-isolated, so moving only part of this
+graph to another Environment intentionally makes those targets unavailable.
+For the first staging evaluation, keep the complete graph in PotatoAI's current
+Environment and apply the repository/package-registry egress policy there.
+
+The channel coordinator delegates an explicitly requested coding task to
+`Lobster Env`. Lobster asks which runner to use unless the request already
+names one, then delegates to that worker. Nested delegation is intentional:
+the foreground router keeps the Slack conversation interactive while the
+selected worker's deployment turns the second delegation into a durable task.
+
+Configure each worker as an organization Agent with Background execution:
+
+| Worker | Image | Command | Inference API |
+| --- | --- | --- | --- |
+| Lobster Claude Code | `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/agent-lobster-env-claude-code:latest` | `archestra-lobster-claude-code` | Anthropic Messages |
+| Lobster Codex | `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/agent-lobster-env:latest` | `archestra-lobster-env` | OpenAI Responses |
+| Lobster Hermes | `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/agent-lobster-env-hermes:latest` | `archestra-lobster-hermes` | OpenAI Chat Completions |
+| Lobster OpenClaw | `europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/agent-lobster-env-openclaw:latest` | `archestra-lobster-openclaw` | OpenAI Chat Completions |
+
+Every worker uses:
+
 - tool access: all tools, so the runtime receives the Agent-scoped MCP gateway
 - required per-user deployment credential: `GITHUB_TOKEN`
-- Environment: the staging coding Environment, with GitHub and any package
-  registries needed by repository checks allowed by its egress policy
+- Environment: the same Environment as PotatoAI and the Lobster router, with
+  GitHub and any package registries needed by repository checks allowed by its
+  egress policy
 
-Give the Slack channel's foreground coordinator access to this Agent as a
-subagent. The staging deployment maps `:lobster:` reactions to explicit durable
-delegation requests. A channel instruction can pin the temporary evaluation:
+Claude Code additionally declares the per-user `CLAUDE_CODE_OAUTH_TOKEN`
+credential and must select an Anthropic model. Codex must explicitly select an
+OpenAI model backed by the initiating user's connected ChatGPT subscription;
+do not leave its model blank, because the maintained runtime refuses to fall
+back to a metered organization key. Hermes and OpenClaw use the provider
+key/model configured on their Agent.
+
+Give the Slack channel's foreground coordinator access only to `Lobster Env`
+for this workflow. The staging deployment maps `:lobster:` reactions to
+explicit delegation requests. The coordinator instructions should include:
 
 > When a message says the user explicitly requested isolated Background
-> execution, delegate it to Lobster Env as a durable task. Acknowledge only
-> after the task starts; do not implement it in the foreground.
+> execution, delegate the full task and Slack context to Lobster Env. Lobster
+> may ask which runner to use. Relay that question, and on the requester's next
+> reply delegate the full thread back to Lobster Env. Do not choose a runner or
+> implement the task yourself.
 
-The image clones public main, configures the private mirror as its push target,
-creates one branch per execution, and appends `system-prompt.md` to Codex's
-developer instructions. The existing task environment remains independent and
-can be removed only after the staging evaluation is approved.
+All four worker images clone public main, configure the private mirror as their
+push target, create one branch per execution, and append `system-prompt.md` to
+the native client's instructions. The existing task environment remains
+independent and can be removed only after the staging evaluation is approved.

--- a/platform/agent_images/lobster-env/orchestrator-system-prompt.md
+++ b/platform/agent_images/lobster-env/orchestrator-system-prompt.md
@@ -1,0 +1,27 @@
+You are Lobster Env, the coding-task router for this Slack workspace. You do
+not implement tasks yourself. You help the requester choose a runner, then
+delegate the complete task to exactly one of your assigned Background
+execution Agents.
+
+Your available runners are Claude Code, Codex, Hermes, and OpenClaw.
+
+When a new task does not explicitly name one of those runners, reply with only
+this concise question and do not delegate yet:
+
+Which runner should take this: Claude Code, Codex, Hermes, or OpenClaw?
+
+When the triggering message already names a runner, or a later message in the
+same Slack thread selects one, delegate immediately to that runner. Pass the
+complete original task, the selected runner, all concrete requirements, Slack
+channel/thread/message identifiers, relevant permalinks, and attachment
+details. Treat a runner name by itself as the answer to your pending question,
+not as a new task.
+
+After delegation starts, reply in one short sentence naming the runner. The
+execution reports its result back to the originating Slack thread. Never claim
+that a task started unless the delegation tool confirmed it. If the selected
+runner is unavailable or its required personal credential is missing, explain
+that specific problem briefly and let the requester choose another runner.
+
+Never select a runner silently, start more than one runner for the same task,
+write code in the foreground, or delegate back to the channel coordinator.

--- a/platform/backend/src/archestra-mcp-server/delegation.test.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.test.ts
@@ -162,6 +162,104 @@ describe("delegation tool execution", () => {
     }
   });
 
+  test("lets a foreground router hand a nested delegation to a Background execution worker", async ({
+    makeAgent,
+    makeAgentTool,
+  }) => {
+    const previous = config.agentBackgroundExecution.enabled;
+    config.agentBackgroundExecution.enabled = true;
+    const router = await makeAgent({ name: "Coding Task Router" });
+    const worker = await makeAgent({
+      name: "Selected Coding Worker",
+      backgroundExecution: {
+        image: "example.invalid/coding-worker:test",
+        command: ["coding-worker"],
+        inferenceProtocol: "openai_responses",
+        backend: "kubernetes",
+        steerMode: "pipe",
+        privileged: false,
+        resources: null,
+        environment: null,
+        credentials: null,
+        ttlHours: null,
+        idleTimeoutMinutes: null,
+      },
+    });
+    const routerTool = await ToolModel.findOrCreateDelegationTool(router.id);
+    const workerTool = await ToolModel.findOrCreateDelegationTool(worker.id);
+    await makeAgentTool(testAgent.id, routerTool.id);
+    await makeAgentTool(router.id, workerTool.id);
+
+    const rootContext = {
+      ...mockContext,
+      userId: "user-1",
+      sessionId: "chatops:slack:thread-1",
+      chatOpsBindingId: "binding-1",
+      chatOpsThreadId: "thread-1",
+    };
+    mockStartDelegatedTask.mockResolvedValue({
+      content: [{ type: "text", text: "Task task-1 started" }],
+      isError: false,
+    });
+    mockExecuteA2AMessage.mockImplementationOnce(async (params) => {
+      const nestedContext: ArchestraContext = {
+        agent: { id: router.id, name: router.name },
+        agentId: router.id,
+        organizationId: params.organizationId,
+        userId: params.userId,
+        sessionId: params.sessionId,
+        delegationChain: `${params.parentDelegationChain}:${router.id}`,
+        chatOpsBindingId: params.chatOpsBindingId,
+        chatOpsThreadId: params.chatOpsThreadId,
+      };
+      const nestedResult = await executeArchestraTool(
+        `${AGENT_TOOL_PREFIX}${slugify(worker.name)}`,
+        { message: "Run the complete original task." },
+        nestedContext,
+      );
+      expect(nestedResult.isError).toBe(false);
+      return {
+        messageId: "router-message-1",
+        text: "The selected worker has started.",
+        finishReason: "stop",
+      };
+    });
+
+    try {
+      const result = await executeArchestraTool(
+        `${AGENT_TOOL_PREFIX}${slugify(router.name)}`,
+        { message: "Ask which coding worker to use." },
+        rootContext,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(mockExecuteA2AMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: router.id,
+          parentDelegationChain: testAgent.id,
+          userId: rootContext.userId,
+          sessionId: rootContext.sessionId,
+          chatOpsBindingId: rootContext.chatOpsBindingId,
+          chatOpsThreadId: rootContext.chatOpsThreadId,
+        }),
+      );
+      expect(mockStartDelegatedTask).toHaveBeenCalledWith({
+        agentId: worker.id,
+        message: "Run the complete original task.",
+        context: expect.objectContaining({
+          agentId: router.id,
+          delegationChain: `${testAgent.id}:${router.id}`,
+          userId: rootContext.userId,
+          sessionId: rootContext.sessionId,
+          chatOpsBindingId: rootContext.chatOpsBindingId,
+          chatOpsThreadId: rootContext.chatOpsThreadId,
+        }),
+      });
+    } finally {
+      config.agentBackgroundExecution.enabled = previous;
+    }
+  });
+
   test("propagates the current trust state to delegated subagents", async ({
     makeAgent,
     makeAgentTool,

--- a/platform/backend/src/routes/proxy/adapters/gemini-schema.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-schema.test.ts
@@ -54,6 +54,53 @@ describe("sanitizeGeminiToolSchema", () => {
     });
   });
 
+  it("converts exclusive numeric bounds into Gemini-compatible constraints", () => {
+    expect(
+      sanitizeGeminiToolSchema({
+        type: "object",
+        properties: {
+          count: { type: "integer", exclusiveMinimum: 0 },
+          ratio: {
+            type: "number",
+            exclusiveMaximum: 1,
+            description: "Normalized ratio.",
+          },
+        },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        count: {
+          type: "integer",
+          minimum: 0,
+          description: "Value must be greater than `0`.",
+        },
+        ratio: {
+          type: "number",
+          maximum: 1,
+          description: "Normalized ratio. Value must be less than `1`.",
+        },
+      },
+    });
+  });
+
+  it("removes OpenAPI boolean exclusive bounds while preserving their hint", () => {
+    expect(
+      sanitizeGeminiToolSchema({
+        type: "number",
+        minimum: 0,
+        exclusiveMinimum: true,
+        maximum: 10,
+        exclusiveMaximum: false,
+      }),
+    ).toEqual({
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description: "Value must be greater than `0`.",
+    });
+  });
+
   it("infers the type from the first value when none is declared", () => {
     expect(sanitizeGeminiToolSchema({ enum: [true] })).toEqual({
       type: "boolean",

--- a/platform/backend/src/routes/proxy/adapters/gemini-schema.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-schema.ts
@@ -56,6 +56,7 @@ export function sanitizeGeminiToolSchema(schema: unknown): unknown {
 
   const result: SchemaObject = { ...(schema as SchemaObject) };
   normalizeEnum(result);
+  normalizeExclusiveBounds(result);
   recurseSubschemas(result);
   ensureNodeType(result);
   return result;
@@ -119,6 +120,48 @@ function normalizeEnum(node: SchemaObject): void {
   }
 }
 
+function normalizeExclusiveBounds(node: SchemaObject): void {
+  normalizeExclusiveBound({
+    node,
+    exclusiveKey: "exclusiveMinimum",
+    inclusiveKey: "minimum",
+    comparison: "greater than",
+  });
+  normalizeExclusiveBound({
+    node,
+    exclusiveKey: "exclusiveMaximum",
+    inclusiveKey: "maximum",
+    comparison: "less than",
+  });
+}
+
+function normalizeExclusiveBound(params: {
+  node: SchemaObject;
+  exclusiveKey: "exclusiveMinimum" | "exclusiveMaximum";
+  inclusiveKey: "minimum" | "maximum";
+  comparison: "greater than" | "less than";
+}): void {
+  const { node, exclusiveKey, inclusiveKey, comparison } = params;
+  const exclusiveValue = node[exclusiveKey];
+  const bound =
+    typeof exclusiveValue === "number"
+      ? exclusiveValue
+      : exclusiveValue === true && typeof node[inclusiveKey] === "number"
+        ? node[inclusiveKey]
+        : undefined;
+
+  delete node[exclusiveKey];
+  if (typeof bound !== "number") return;
+
+  if (node[inclusiveKey] === undefined) {
+    node[inclusiveKey] = bound;
+  }
+  node.description = appendDescription(
+    node.description,
+    `Value must be ${comparison} \`${bound}\`.`,
+  );
+}
+
 function recurseSubschemas(node: SchemaObject): void {
   for (const key of SUBSCHEMA_MAP_KEYS) {
     const map = node[key];
@@ -179,6 +222,10 @@ function appendConstraint(description: unknown, values: unknown[]): string {
     rendered.length === 1
       ? `Value must be ${rendered[0]}.`
       : `Value must be one of: ${rendered.join(", ")}.`;
+  return appendDescription(description, note);
+}
+
+function appendDescription(description: unknown, note: string): string {
   return typeof description === "string" && description.length > 0
     ? `${description} ${note}`
     : note;

--- a/platform/backend/src/services/runners/launch-spec.test.ts
+++ b/platform/backend/src/services/runners/launch-spec.test.ts
@@ -324,7 +324,7 @@ describe("buildRunnerLaunchSpec", () => {
     expect(spec.secretEnv.GH_TOKEN).toBe("github-token");
   });
 
-  test("scopes a personal Claude subscription token to the Claude Code runtime", async ({
+  test("scopes a personal Claude subscription token to maintained Claude Code runtimes", async ({
     makeOrganization,
     makeAdmin,
     makeMember,
@@ -341,16 +341,14 @@ describe("buildRunnerLaunchSpec", () => {
       makeLlmProviderApiKey,
       makeAgent,
     });
-    const configuredDeployment = deployment(setup.agent, "anthropic");
-    configuredDeployment.command = ["archestra-claude-code"];
-    configuredDeployment.credentials = [
+    const credentials = [
       {
         key: "CLAUDE_CODE_OAUTH_TOKEN",
         scope: "per_user",
         label: "Claude Code subscription token",
         required: false,
       },
-    ];
+    ] as const;
     await UserCredentialModel.upsert({
       organizationId: setup.agent.organizationId,
       userId: setup.user.id,
@@ -358,44 +356,52 @@ describe("buildRunnerLaunchSpec", () => {
       key: "CLAUDE_CODE_OAUTH_TOKEN",
       value: "claude-subscription-token",
     });
-    const taskId = crypto.randomUUID();
+    for (const command of [
+      "archestra-claude-code",
+      "archestra-lobster-claude-code",
+    ]) {
+      const configuredDeployment = deployment(setup.agent, "anthropic");
+      configuredDeployment.command = [command];
+      configuredDeployment.credentials = [...credentials];
+      const taskId = crypto.randomUUID();
 
-    const { spec, virtualApiKeyId } = await buildRunnerLaunchSpec({
-      deployment: configuredDeployment,
-      taskId,
-      agentId: setup.agent.id,
-      actor: {
-        id: setup.user.id,
-        kind: "user",
+      const { spec, virtualApiKeyId } = await buildRunnerLaunchSpec({
+        deployment: configuredDeployment,
+        taskId,
+        agentId: setup.agent.id,
+        actor: {
+          id: setup.user.id,
+          kind: "user",
+          organizationId: setup.agent.organizationId,
+        },
         organizationId: setup.agent.organizationId,
-      },
-      organizationId: setup.agent.organizationId,
-      runtimeScope: "agent-tests",
-      effectiveNetworkPolicy: { source: "built_in", policy: null },
-      appName: "Archestra",
-      executionMode: "one_shot",
-    });
+        runtimeScope: "agent-tests",
+        effectiveNetworkPolicy: { source: "built_in", policy: null },
+        appName: "Archestra",
+        executionMode: "one_shot",
+      });
 
-    expect(spec.secretEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe(
-      "claude-subscription-token",
-    );
-    expect(spec.secretEnv).not.toHaveProperty("ANTHROPIC_API_KEY");
-    expect(spec.secretEnv).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
-    expect(spec.secretEnv).not.toHaveProperty("OPENAI_API_KEY");
-    expect(spec.secretEnv.ANTHROPIC_CUSTOM_HEADERS).toContain(
-      `X-Archestra-Execution-Id: ${taskId}`,
-    );
-    expect(spec.secretEnv.ANTHROPIC_CUSTOM_HEADERS).toContain(
-      `X-Archestra-Session-Id: ${taskId}`,
-    );
-    expect(spec.secretEnv.ANTHROPIC_CUSTOM_HEADERS).toMatch(
-      /X-Archestra-Virtual-Key: arch_/,
-    );
+      expect(spec.secretEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+        "claude-subscription-token",
+      );
+      expect(spec.secretEnv).not.toHaveProperty("ANTHROPIC_API_KEY");
+      expect(spec.secretEnv).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
+      expect(spec.secretEnv).not.toHaveProperty("OPENAI_API_KEY");
+      expect(spec.secretEnv.ANTHROPIC_CUSTOM_HEADERS).toContain(
+        `X-Archestra-Execution-Id: ${taskId}`,
+      );
+      expect(spec.secretEnv.ANTHROPIC_CUSTOM_HEADERS).toContain(
+        `X-Archestra-Session-Id: ${taskId}`,
+      );
+      expect(spec.secretEnv.ANTHROPIC_CUSTOM_HEADERS).toMatch(
+        /X-Archestra-Virtual-Key: arch_/,
+      );
 
-    const virtualKey = await VirtualApiKeyModel.findById(virtualApiKeyId);
-    expect(virtualKey?.keyType).toBe("passthrough");
-    expect(virtualKey?.scope).toBe("personal");
-    expect(virtualKey?.authorId).toBe(setup.user.id);
+      const virtualKey = await VirtualApiKeyModel.findById(virtualApiKeyId);
+      expect(virtualKey?.keyType).toBe("passthrough");
+      expect(virtualKey?.scope).toBe("personal");
+      expect(virtualKey?.authorId).toBe(setup.user.id);
+    }
   });
 
   test("never falls back to Anthropic API billing for Claude Code", async ({
@@ -415,29 +421,34 @@ describe("buildRunnerLaunchSpec", () => {
       makeLlmProviderApiKey,
       makeAgent,
     });
-    const configuredDeployment = deployment(setup.agent, "anthropic");
-    configuredDeployment.command = ["archestra-claude-code"];
+    for (const command of [
+      "archestra-claude-code",
+      "archestra-lobster-claude-code",
+    ]) {
+      const configuredDeployment = deployment(setup.agent, "anthropic");
+      configuredDeployment.command = [command];
 
-    await expect(
-      buildRunnerLaunchSpec({
-        deployment: configuredDeployment,
-        taskId: crypto.randomUUID(),
-        agentId: setup.agent.id,
-        actor: {
-          id: setup.user.id,
-          kind: "user",
+      await expect(
+        buildRunnerLaunchSpec({
+          deployment: configuredDeployment,
+          taskId: crypto.randomUUID(),
+          agentId: setup.agent.id,
+          actor: {
+            id: setup.user.id,
+            kind: "user",
+            organizationId: setup.agent.organizationId,
+          },
           organizationId: setup.agent.organizationId,
-        },
-        organizationId: setup.agent.organizationId,
-        runtimeScope: "agent-tests",
-        effectiveNetworkPolicy: { source: "built_in", policy: null },
-        appName: "Archestra",
-        executionMode: "interactive",
-      }),
-    ).rejects.toMatchObject({
-      statusCode: 409,
-      message: expect.stringContaining("never falls back"),
-    });
+          runtimeScope: "agent-tests",
+          effectiveNetworkPolicy: { source: "built_in", policy: null },
+          appName: "Archestra",
+          executionMode: "interactive",
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: expect.stringContaining("never falls back"),
+      });
+    }
   });
 
   test("uses the acting user's ChatGPT subscription for maintained Codex runtimes", async ({
@@ -514,29 +525,31 @@ describe("buildRunnerLaunchSpec", () => {
       makeLlmProviderApiKey,
       makeAgent,
     });
-    const configuredDeployment = deployment(setup.agent, "openai_responses");
-    configuredDeployment.command = ["archestra-codex"];
+    for (const command of ["archestra-codex", "archestra-lobster-env"]) {
+      const configuredDeployment = deployment(setup.agent, "openai_responses");
+      configuredDeployment.command = [command];
 
-    await expect(
-      buildRunnerLaunchSpec({
-        deployment: configuredDeployment,
-        taskId: crypto.randomUUID(),
-        agentId: setup.agent.id,
-        actor: {
-          id: setup.user.id,
-          kind: "user",
+      await expect(
+        buildRunnerLaunchSpec({
+          deployment: configuredDeployment,
+          taskId: crypto.randomUUID(),
+          agentId: setup.agent.id,
+          actor: {
+            id: setup.user.id,
+            kind: "user",
+            organizationId: setup.agent.organizationId,
+          },
           organizationId: setup.agent.organizationId,
-        },
-        organizationId: setup.agent.organizationId,
-        runtimeScope: "agent-tests",
-        effectiveNetworkPolicy: { source: "built_in", policy: null },
-        appName: "Archestra",
-        executionMode: "interactive",
-      }),
-    ).rejects.toMatchObject({
-      statusCode: 409,
-      message: expect.stringContaining("never falls back"),
-    });
+          runtimeScope: "agent-tests",
+          effectiveNetworkPolicy: { source: "built_in", policy: null },
+          appName: "Archestra",
+          executionMode: "interactive",
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: expect.stringContaining("never falls back"),
+      });
+    }
   });
 
   test("does not inject a Claude subscription token into a custom runtime", async ({

--- a/platform/backend/src/services/runners/launch-spec.ts
+++ b/platform/backend/src/services/runners/launch-spec.ts
@@ -155,8 +155,9 @@ export async function buildRunnerLaunchSpec(params: {
   const claudeCodeSubscriptionToken =
     credentials.env.CLAUDE_CODE_OAUTH_TOKEN?.trim();
   const usesClaudeCodeSubscription = Boolean(claudeCodeSubscriptionToken);
-  const isClaudeCodeRuntime =
-    params.deployment.command?.[0] === "archestra-claude-code";
+  const isClaudeCodeRuntime = CLAUDE_CODE_RUNTIME_COMMANDS.has(
+    params.deployment.command?.[0] ?? "",
+  );
   const isCodexRuntime = CODEX_RUNTIME_COMMANDS.has(
     params.deployment.command?.[0] ?? "",
   );
@@ -292,7 +293,7 @@ export async function buildRunnerLaunchSpec(params: {
       : {}),
     ...(task ? { ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK: task } : {}),
     ...withNativeClientCredentialAliases(credentials.env),
-    ...(params.deployment.command?.[0] === "archestra-claude-code"
+    ...(isClaudeCodeRuntime
       ? {
           // Claude Code accepts only one custom-header variable. Keep run
           // correlation on both auth paths, and add the passthrough identity
@@ -378,6 +379,11 @@ const RESERVED_RUNTIME_ENV_KEYS = new Set([
 const CODEX_RUNTIME_COMMANDS = new Set([
   "archestra-codex",
   "archestra-lobster-env",
+]);
+
+const CLAUDE_CODE_RUNTIME_COMMANDS = new Set([
+  "archestra-claude-code",
+  "archestra-lobster-claude-code",
 ]);
 
 function claudeCodeCustomHeaders(params: {

--- a/platform/backend/src/services/runners/lobster-env-worker.test.ts
+++ b/platform/backend/src/services/runners/lobster-env-worker.test.ts
@@ -1,0 +1,290 @@
+import { execFile } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const BIN_DIR = path.resolve(
+  import.meta.dirname,
+  "../../../../agent_images/bin",
+);
+
+describe("Lobster Env worker bootstrap", () => {
+  test("prepares the private-mirror branch and hands the combined task contract to the selected client", async () => {
+    const fixture = await makeFixture();
+    try {
+      await execFileAsync(
+        "bash",
+        [path.join(BIN_DIR, "archestra-lobster-worker")],
+        {
+          env: {
+            ...process.env,
+            HOME: fixture.home,
+            PATH: `${fixture.bin}:${process.env.PATH}`,
+            LOBSTER_TEST_GIT_LOG: fixture.gitLog,
+            LOBSTER_TEST_OUTPUT_DIR: fixture.output,
+            ARCHESTRA_AGENT_BACKGROUND_EXECUTION_RUNTIME_DIR: fixture.runtime,
+            ARCHESTRA_LOBSTER_ENV_CLIENT: "archestra-hermes",
+            ARCHESTRA_LOBSTER_ENV_REPOSITORY_DIR: fixture.repository,
+            ARCHESTRA_LOBSTER_ENV_SYSTEM_PROMPT_FILE: fixture.prompt,
+            ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK_ID:
+              "12345678-abcd-4000-8000-123456789abc",
+            ARCHESTRA_AGENT_BACKGROUND_EXECUTION_SYSTEM_PROMPT:
+              "Operator-specific constraints.",
+          },
+        },
+      );
+
+      expect(await readFile(path.join(fixture.output, "client"), "utf8")).toBe(
+        "archestra-hermes",
+      );
+      expect(await readFile(path.join(fixture.output, "cwd"), "utf8")).toBe(
+        path.join(fixture.repository, "platform"),
+      );
+      expect(
+        await readFile(path.join(fixture.output, "system-prompt"), "utf8"),
+      ).toBe("Baked worker contract.\n\nOperator-specific constraints.");
+
+      const gitLog = await readFile(fixture.gitLog, "utf8");
+      expect(gitLog).toContain("fetch --quiet origin main");
+      expect(gitLog).toContain("fetch --quiet --filter=blob:none private main");
+      expect(gitLog).toContain(
+        "checkout --quiet -B agent/lobster-12345678 origin/main",
+      );
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ["archestra-lobster-env", "archestra-codex"],
+    ["archestra-lobster-claude-code", "archestra-claude-code"],
+    ["archestra-lobster-hermes", "archestra-hermes"],
+    ["archestra-lobster-openclaw", "archestra-openclaw"],
+  ])("%s dispatches to %s", async (entrypoint, expectedClient) => {
+    const root = await mkdtemp(path.join(tmpdir(), "archestra-lobster-entry-"));
+    try {
+      const bin = path.join(root, "bin");
+      const output = path.join(root, "selected-client");
+      await mkdir(bin);
+      await writeExecutable(
+        path.join(bin, "archestra-lobster-worker"),
+        `#!/bin/sh\nprintf '%s' "$ARCHESTRA_LOBSTER_ENV_CLIENT" > "$LOBSTER_TEST_SELECTED_CLIENT"\n`,
+      );
+
+      await execFileAsync("bash", [path.join(BIN_DIR, entrypoint)], {
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          LOBSTER_TEST_SELECTED_CLIENT: output,
+        },
+      });
+
+      expect(await readFile(output, "utf8")).toBe(expectedClient);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("uses a blob-filtered main-branch clone in a fresh task pod", async () => {
+    const fixture = await makeFixture({ existingRepository: false });
+    try {
+      await execFileAsync(
+        "bash",
+        [path.join(BIN_DIR, "archestra-lobster-worker")],
+        {
+          env: {
+            ...process.env,
+            HOME: fixture.home,
+            PATH: `${fixture.bin}:${process.env.PATH}`,
+            LOBSTER_TEST_GIT_LOG: fixture.gitLog,
+            LOBSTER_TEST_OUTPUT_DIR: fixture.output,
+            ARCHESTRA_AGENT_BACKGROUND_EXECUTION_RUNTIME_DIR: fixture.runtime,
+            ARCHESTRA_LOBSTER_ENV_CLIENT: "archestra-hermes",
+            ARCHESTRA_LOBSTER_ENV_REPOSITORY_DIR: fixture.repository,
+            ARCHESTRA_LOBSTER_ENV_SYSTEM_PROMPT_FILE: fixture.prompt,
+            ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK_ID:
+              "12345678-abcd-4000-8000-123456789abc",
+          },
+        },
+      );
+
+      const gitLog = await readFile(fixture.gitLog, "utf8");
+      expect(gitLog).toContain(
+        `clone --quiet --filter=blob:none --single-branch --branch main --origin origin https://github.com/archestra-ai/archestra.git ${fixture.repository}`,
+      );
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses an unknown native client before touching the repository", async () => {
+    const fixture = await makeFixture();
+    try {
+      await expect(
+        execFileAsync(
+          "bash",
+          [path.join(BIN_DIR, "archestra-lobster-worker")],
+          {
+            env: {
+              ...process.env,
+              HOME: fixture.home,
+              PATH: `${fixture.bin}:${process.env.PATH}`,
+              LOBSTER_TEST_GIT_LOG: fixture.gitLog,
+              LOBSTER_TEST_OUTPUT_DIR: fixture.output,
+              ARCHESTRA_AGENT_BACKGROUND_EXECUTION_RUNTIME_DIR: fixture.runtime,
+              ARCHESTRA_LOBSTER_ENV_CLIENT: "arbitrary-command",
+              ARCHESTRA_LOBSTER_ENV_REPOSITORY_DIR: fixture.repository,
+              ARCHESTRA_LOBSTER_ENV_SYSTEM_PROMPT_FILE: fixture.prompt,
+              ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK_ID:
+                "12345678-abcd-4000-8000-123456789abc",
+            },
+          },
+        ),
+      ).rejects.toMatchObject({
+        code: 78,
+        stderr: expect.stringContaining("unsupported Lobster Env client"),
+      });
+      await expect(readFile(fixture.gitLog, "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ["openai_chat", "openai-completions"],
+    ["openai_responses", "openai-responses"],
+  ])("configures OpenClaw's %s transport as %s", async (protocol, expectedApi) => {
+    const root = await mkdtemp(path.join(tmpdir(), "archestra-openclaw-"));
+    try {
+      const bin = path.join(root, "bin");
+      const runtime = path.join(root, "runtime");
+      const workspace = path.join(root, "workspace");
+      await Promise.all([
+        mkdir(bin, { recursive: true }),
+        mkdir(workspace, { recursive: true }),
+      ]);
+      await writeExecutable(
+        path.join(bin, "openclaw"),
+        `#!/bin/sh
+cp "$PWD/SOUL.md" "$ARCHESTRA_AGENT_BACKGROUND_EXECUTION_RUNTIME_DIR/captured-soul.md"
+printf 'OpenClaw test response\\n'
+`,
+      );
+
+      await execFileAsync("bash", [path.join(BIN_DIR, "archestra-openclaw")], {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          ARCHESTRA_LLM_PROXY_PROTOCOL: protocol,
+          ARCHESTRA_AGENT_BACKGROUND_EXECUTION_RUNTIME_DIR: runtime,
+          ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NATIVE_MODEL: "test-model",
+          ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK_ID:
+            "12345678-abcd-4000-8000-123456789abc",
+          ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK: "Run the task.",
+          ARCHESTRA_AGENT_BACKGROUND_EXECUTION_SYSTEM_PROMPT:
+            "Follow the Lobster worker contract.",
+          ARCHESTRA_AGENT_BACKGROUND_EXECUTION_MODE: "one_shot",
+          ARCHESTRA_MCP_GATEWAY_URL: "http://localhost:9000/v1/mcp/test",
+          ARCHESTRA_MCP_GATEWAY_TOKEN: "test-token",
+          OPENAI_API_KEY: "test-key",
+          OPENAI_BASE_URL: "http://localhost:9000/v1/model-router/test",
+        },
+      });
+
+      const config = JSON.parse(
+        await readFile(path.join(runtime, "openclaw.json"), "utf8"),
+      );
+      expect(config.models.providers.archestra.api).toBe(expectedApi);
+      expect(config.logging.level).toBe("error");
+      expect(config.logging.consoleLevel).toBe("silent");
+      expect(config.agents.defaults.skipBootstrap).toBe(true);
+      expect(
+        await readFile(path.join(runtime, "captured-soul.md"), "utf8"),
+      ).toContain("Follow the Lobster worker contract.");
+      await expect(
+        readFile(path.join(workspace, "SOUL.md"), "utf8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+async function makeFixture(
+  params: { existingRepository?: boolean } = {},
+): Promise<{
+  root: string;
+  home: string;
+  bin: string;
+  repository: string;
+  runtime: string;
+  prompt: string;
+  gitLog: string;
+  output: string;
+}> {
+  const root = await mkdtemp(path.join(tmpdir(), "archestra-lobster-worker-"));
+  const home = path.join(root, "home");
+  const bin = path.join(root, "bin");
+  const repository = path.join(root, "repository");
+  const runtime = path.join(root, "runtime");
+  const prompt = path.join(root, "system-prompt.md");
+  const gitLog = path.join(root, "git.log");
+  const output = path.join(root, "output");
+  await Promise.all([
+    mkdir(home, { recursive: true }),
+    mkdir(bin, { recursive: true }),
+    mkdir(output, { recursive: true }),
+    mkdir(runtime, { recursive: true }),
+    writeFile(prompt, "Baked worker contract.", "utf8"),
+  ]);
+  if (params.existingRepository !== false) {
+    await Promise.all([
+      mkdir(path.join(repository, ".git"), { recursive: true }),
+      mkdir(path.join(repository, "platform"), { recursive: true }),
+    ]);
+  }
+
+  await writeExecutable(path.join(bin, "gh"), "#!/bin/sh\nexit 0\n");
+  await writeExecutable(
+    path.join(bin, "git"),
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$LOBSTER_TEST_GIT_LOG"
+case "$*" in
+  clone*)
+    destination="\${!#}"
+    mkdir -p "$destination/.git" "$destination/platform"
+    ;;
+  *"remote get-url private"* | *"ls-remote --exit-code --heads private"*) exit 1 ;;
+esac
+exit 0
+`,
+  );
+  await writeExecutable(
+    path.join(bin, "archestra-hermes"),
+    `#!/bin/sh
+printf '%s' "$ARCHESTRA_LOBSTER_ENV_CLIENT" > "$LOBSTER_TEST_OUTPUT_DIR/client"
+pwd | tr -d '\n' > "$LOBSTER_TEST_OUTPUT_DIR/cwd"
+printf '%s' "$ARCHESTRA_AGENT_BACKGROUND_EXECUTION_SYSTEM_PROMPT" > "$LOBSTER_TEST_OUTPUT_DIR/system-prompt"
+`,
+  );
+
+  return { root, home, bin, repository, runtime, prompt, gitLog, output };
+}
+
+async function writeExecutable(file: string, contents: string): Promise<void> {
+  await writeFile(file, contents, "utf8");
+  await chmod(file, 0o755);
+}

--- a/platform/frontend/src/components/agent-pages/agent-catalog.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-catalog.tsx
@@ -91,7 +91,7 @@ export function getAgentCatalogTemplates(
       platformName: appName,
       image: image(archestraImage, "openclaw"),
       command: ["archestra-openclaw"],
-      inferenceProtocol: "openai_responses",
+      inferenceProtocol: "openai_chat",
       steerMode: "tmux_keys",
     }),
   ] as const;

--- a/platform/frontend/src/components/agent-pages/agent-create-page.test.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-create-page.test.tsx
@@ -136,6 +136,32 @@ describe("AgentCreatePage", () => {
     expect(screen.getByRole("button", { name: "Catalog" })).toBeInTheDocument();
   });
 
+  it("prefills OpenClaw with its compatible Chat Completions transport", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useFeature).mockImplementation((feature) =>
+      feature === "agentBackgroundExecution"
+        ? true
+        : feature === "agentBackgroundExecutionBaseImage"
+          ? "agent-archestra:dev"
+          : undefined,
+    );
+
+    render(<AgentCreatePage kind="agent" />);
+    await user.click(screen.getByRole("button", { name: /openclaw/i }));
+
+    expect(formProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        initialValues: expect.objectContaining({
+          name: "OpenClaw",
+          backgroundExecution: expect.objectContaining({
+            command: ["archestra-openclaw"],
+            inferenceProtocol: "openai_chat",
+          }),
+        }),
+      }),
+    );
+  });
+
   it("uses the configured product name and sidebar icon for the built-in Agent", async () => {
     const user = userEvent.setup();
     vi.mocked(useFeature).mockImplementation((feature) =>


### PR DESCRIPTION
## Summary

- turn Lobster Env into a foreground routing agent that asks users to choose Claude Code, Codex, Hermes, or OpenClaw before delegating
- add four staging worker images that bootstrap the Archestra repository and run the selected native agent harness
- preserve nested delegation context across messaging threads and enforce personal subscription credentials for Claude Code and Codex
- make OpenClaw delegation non-interactive and compatible with Archestra proxy schemas, including Gemini schema sanitization

## Validation

- nested foreground to foreground to background delegation tested through the live local stack
- Codex, Hermes, and OpenClaw workers completed live tasks; Claude Code correctly failed preflight when its required personal subscription token was absent
- backend focused suite: 68 tests passed
- frontend focused suite: 12 tests passed
- workspace type-check: 9 tasks passed
- all four Lobster worker images built locally

## Documentation

- added an internal operator README describing the PotatoAI to Lobster Env to worker graph, shared Environment requirement, credentials, protocols, and deployment setup
- no public docs change because these Lobster images and prompts are staging-only

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>