### PR TITLE
fix(shared): correct hasNext/hasPrev when offset not aligned to limit

### DIFF
--- a/platform/shared/pagination.ts
+++ b/platform/shared/pagination.ts
@@ -57,7 +57,7 @@ export function calculatePaginationMeta(
     limit: params.limit,
     total,
     totalPages,
-    hasNext: currentPage < totalPages,
-    hasPrev: currentPage > 1,
+    hasNext: params.offset + params.limit < total,
+    hasPrev: params.offset > 0,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #7563 — `calculatePaginationMeta` derived `hasNext`/`hasPrev` from `currentPage` rather than from `offset`, so non-aligned offsets produced wrong navigation flags.

- `hasNext` now `offset + limit < total` instead of `currentPage < totalPages`
- `hasPrev` now `offset > 0` instead of `currentPage > 1`
- retains `currentPage = floor(offset/limit)+1` and `totalPages` for display; only the navigation booleans change

Minimal diff: single file `platform/shared/pagination.ts:60-61`, two lines.

## Why

`PaginationQuerySchema` allows any `offset >= 0` (not just multiples of `limit`). Virtual scroll, DataTable page-size switches, and manual `?offset=5` queries all hit the gap:

- `total=15, limit=10, offset=5` previously returned `hasNext:true, hasPrev:false` — the UI showed a next button that fetched an empty page. Now correctly `hasNext:false, hasPrev:true` because `5+10 >= 15`.
- `total=100, limit=20, offset=5` previously hid the prev button (`hasPrev:false`). Now correctly `hasPrev:true` because `offset>0`.

Every list endpoint flows through `shared/pagination.ts` → `backend/src/database/utils/pagination.ts:44`, so the fix propagates to agents, interactions, knowledge-bases, teams, skills, etc.

## How tested

- Repro script `repro_pagination.mjs` before/after: buggy fails 2/6 cases (`15/10/5` and `100/20/5`), fixed passes 6/6.
- Existing aligned-offset cases remain green: `calculatePaginationMeta(100,{limit:20,offset:0})` → `hasNext:true`, `offset:80` → `hasNext:false`, empty `total=0` → both false, etc. (matches `platform/shared/pagination.test.ts:5` expectations).
- `git diff` shows only the two boolean lines changed; no API surface change besides corrected booleans.

Fixes #7563
