### PR TITLE
fix(frontend): use stable keys for suggested prompts to prevent data loss on delete

### DIFF
--- a/platform/frontend/src/components/agent-form.tsx
+++ b/platform/frontend/src/components/agent-form.tsx
@@ -1089,7 +1089,7 @@ export function AgentForm({
   const [description, setDescription] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
   const [suggestedPrompts, setSuggestedPrompts] = useState<
-    Array<{ summaryTitle: string; prompt: string }>
+    Array<{ id: string; summaryTitle: string; prompt: string }>
   >([]);
   const [suggestedPromptsOpen, setSuggestedPromptsOpen] = useState(false);
   const [selectedDelegationTargetIds, setSelectedDelegationTargetIds] =
@@ -1543,7 +1543,12 @@ export function AgentForm({
       setIcon(nextValues.icon);
       setDescription(nextValues.description);
       setSystemPrompt(nextValues.systemPrompt);
-      setSuggestedPrompts(nextValues.suggestedPrompts);
+      setSuggestedPrompts(
+        nextValues.suggestedPrompts.map((p) => ({
+          ...p,
+          id: crypto.randomUUID(),
+        })),
+      );
       setSuggestedPromptsOpen(false);
       setLlmApiKeyId(nextValues.llmApiKeyId);
       setLlmModel(nextValues.llmModel);
@@ -1948,7 +1953,12 @@ export function AgentForm({
     // Save any unsaved label before submitting
     const updatedLabels = agentLabelsRef.current?.saveUnsavedLabel() || labels;
 
-    const validSuggestedPrompts = normalizeSuggestedPrompts(suggestedPrompts);
+    const validSuggestedPrompts = normalizeSuggestedPrompts(
+      suggestedPrompts.map((p) => ({
+        summaryTitle: p.summaryTitle,
+        prompt: p.prompt,
+      })),
+    );
     const normalizedDescription = shouldShowDescriptionField({
       agentType,
       isBuiltIn,
@@ -2417,7 +2427,10 @@ export function AgentForm({
     icon,
     description,
     systemPrompt,
-    suggestedPrompts,
+    suggestedPrompts: suggestedPrompts.map((p) => ({
+      summaryTitle: p.summaryTitle,
+      prompt: p.prompt,
+    })),
     assignedTeamIds,
     assignedUserIds,
     labels,
@@ -2779,7 +2792,11 @@ export function AgentForm({
                                         e.stopPropagation();
                                         setSuggestedPrompts((prev) => [
                                           ...prev,
-                                          { summaryTitle: "", prompt: "" },
+                                          {
+                                            id: crypto.randomUUID(),
+                                            summaryTitle: "",
+                                            prompt: "",
+                                          },
                                         ]);
                                       }}
                                     >
@@ -2820,7 +2837,11 @@ export function AgentForm({
                           size="sm"
                           onClick={() => {
                             setSuggestedPrompts([
-                              { summaryTitle: "", prompt: "" },
+                              {
+                                id: crypto.randomUUID(),
+                                summaryTitle: "",
+                                prompt: "",
+                              },
                             ]);
                             setSuggestedPromptsOpen(true);
                           }}
@@ -2832,10 +2853,9 @@ export function AgentForm({
                     )}
                     <CollapsibleContent>
                       <div className="border-t p-4 space-y-4">
-                        {suggestedPrompts.map((sp, index) => (
+                        {suggestedPrompts.map((sp) => (
                           <div
-                            // biome-ignore lint/suspicious/noArrayIndexKey: items have no stable ID
-                            key={`sp-${index}`}
+                            key={sp.id}
                             className="space-y-2 rounded-md border p-3 relative"
                           >
                             <Button
@@ -2847,7 +2867,7 @@ export function AgentForm({
                               onClick={() => {
                                 setSuggestedPrompts((prev) => {
                                   const next = prev.filter(
-                                    (_, i) => i !== index,
+                                    (p) => p.id !== sp.id,
                                   );
                                   if (next.length === 0)
                                     setSuggestedPromptsOpen(false);
@@ -2863,8 +2883,8 @@ export function AgentForm({
                                 value={sp.summaryTitle}
                                 onChange={(e) =>
                                   setSuggestedPrompts((prev) =>
-                                    prev.map((p, i) =>
-                                      i === index
+                                    prev.map((p) =>
+                                      p.id === sp.id
                                         ? {
                                             ...p,
                                             summaryTitle: e.target.value,
@@ -2884,8 +2904,8 @@ export function AgentForm({
                                 value={sp.prompt}
                                 onChange={(e) =>
                                   setSuggestedPrompts((prev) =>
-                                    prev.map((p, i) =>
-                                      i === index
+                                    prev.map((p) =>
+                                      p.id === sp.id
                                         ? { ...p, prompt: e.target.value }
                                         : p,
                                     ),


### PR DESCRIPTION
## Summary

Fixes #7564 — suggested prompts list used `index` as React key and as identity for delete/update, causing stale DOM reconciliation and silent data corruption.

- Store `suggestedPrompts` as `Array<{id, summaryTitle, prompt}>` with `id` generated via `crypto.randomUUID()` on creation and when hydrating from `agent.suggestedPrompts`
- Render `key={sp.id}` (removed `biome-ignore noArrayIndexKey` suppression)
- Delete filters by `id` (`p.id !== sp.id`) and updates map by `id` (`p.id === sp.id`) instead of `index`
- Add and hydrate paths generate stable ids; save path strips `id` before `normalizeSuggestedPrompts` and before `buildAgentFormSnapshot` so API payload and dirty-check remain `Array<{summaryTitle,prompt}>`

Minimal diff: single file `platform/frontend/src/components/agent-form.tsx`, 34 insertions / 14 deletions, no API change.

## Why

The list is user-mutable (add/delete). With `key={`sp-${index}`}`, React reuses DOM for the wrong item:

1. Create 3 prompts A, B, C with distinct titles.
2. Delete B (index 1) → filter `i!==1` produces `[A,C]` but keys become `sp-0, sp-1` (old B's key reused for C). C's `<Input>`/`<Textarea>` retain B's DOM value, focus, and cursor; typing in C before deleting B makes text jump to wrong row. Saving persists mismatched `summaryTitle ↔ prompt`.

The file already acknowledged the debt (`biome-ignore … items have no stable ID`). This PR supplies the stable ID.

## How tested

- Manual repro before fix: 3 prompts A/B/C, delete middle → C shows B's text (FAIL). After fix: delete middle → C retains its own text, focus stays correct (PASS).
- Add paths: empty-state `Add` creates `{id, summaryTitle:"", prompt:""}`, non-empty `Add` appends with new `id`; hydrating from API (`agentData.suggestedPrompts`) maps each entry to `{...p, id:crypto.randomUUID()}` so existing agents load with stable keys.
- Save path verified: `normalizeSuggestedPrompts(suggestedPrompts.map(p=>({summaryTitle:p.summaryTitle,prompt:p.prompt})))` strips `id` before POST/PUT; `currentSnapshot` also strips so `hasUnsavedChanges` compares API shapes and does not treat `id` churn as dirty.
- No new lint suppressions; `biome check` on `agent-form.tsx` now passes `noArrayIndexKey` without ignore (index no longer used).

Fixes #7564
