### PR TITLE
ci: accelerate platform image builds

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -72,6 +72,10 @@ inputs:
     description: "Sentry auth token for source map uploads (optional)"
     required: false
     default: ""
+  setup-builder:
+    description: "Set up a new Buildx builder; disable to reuse the current job builder"
+    required: false
+    default: "true"
 
 outputs:
   digest:
@@ -111,6 +115,7 @@ runs:
         INPUT_PREVIOUS_IMAGE: ${{ inputs.previous-image }}
 
     - name: Setup Docker Builder
+      if: ${{ inputs.setup-builder == 'true' }}
       uses: ./.github/actions/setup-docker-builder
 
     - name: Build Docker image

--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -52,7 +52,7 @@ inputs:
     required: false
     default: ""
   cache-from:
-    description: "External cache sources (e.g. type=registry,ref=...)"
+    description: "External cache sources, one per line (e.g. type=registry,ref=...)"
     required: false
     default: ""
   cache-to:
@@ -146,7 +146,12 @@ runs:
 
         [ -n "${INPUT_PLATFORMS}" ] && ARGS+=( --platform "${INPUT_PLATFORMS}" )
         [ -n "${INPUT_TARGET}" ] && ARGS+=( --target "${INPUT_TARGET}" )
-        [ -n "${INPUT_CACHE_FROM}" ] && ARGS+=( --cache-from "${INPUT_CACHE_FROM}" )
+        # Cache specs contain commas, so unlike tags they must split on newlines only.
+        while IFS= read -r cache_from; do
+          cache_from="${cache_from#"${cache_from%%[![:space:]]*}"}"
+          cache_from="${cache_from%"${cache_from##*[![:space:]]}"}"
+          [ -n "${cache_from}" ] && ARGS+=( --cache-from "${cache_from}" )
+        done <<< "${INPUT_CACHE_FROM}"
         [ -n "${INPUT_CACHE_TO}" ] && ARGS+=( --cache-to "${INPUT_CACHE_TO}" )
         [ -n "${INPUT_PROVENANCE}" ] && ARGS+=( --provenance "${INPUT_PROVENANCE}" )
         [ -n "${INPUT_VERSION}" ] && ARGS+=( --build-arg "VERSION=${INPUT_VERSION}" )

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -63,7 +63,7 @@ jobs:
       # This reusable workflow currently publishes the compile-bound Platform
       # image; keep release builds on the same measured native runners as dev.
       amd64_runner: blacksmith-16vcpu-ubuntu-2404
-      arm64_runner: blacksmith-16vcpu-ubuntu-2404-arm
+      arm64_runner: blacksmith-32vcpu-ubuntu-2404-arm
       # supply-chain-policy: allow-latest internal release channel
       previous_image: docker.io/archestra/${{ inputs.image_name }}:latest
     secrets:

--- a/.github/workflows/build-dockerhub-image.yml
+++ b/.github/workflows/build-dockerhub-image.yml
@@ -60,6 +60,10 @@ jobs:
       include_latest_tag: ${{ inputs.version != 'dev' }}
       checkout_fetch_depth: 0
       checkout_ref: ${{ inputs.checkout_ref }}
+      # This reusable workflow currently publishes the compile-bound Platform
+      # image; keep release builds on the same measured native runners as dev.
+      amd64_runner: blacksmith-16vcpu-ubuntu-2404
+      arm64_runner: blacksmith-16vcpu-ubuntu-2404-arm
       # supply-chain-policy: allow-latest internal release channel
       previous_image: docker.io/archestra/${{ inputs.image_name }}:latest
     secrets:

--- a/.github/workflows/build-native-multi-arch-image.yml
+++ b/.github/workflows/build-native-multi-arch-image.yml
@@ -62,6 +62,11 @@ on:
         required: false
         type: boolean
         default: false
+      amd64_runner:
+        description: "Runner label for the linux/amd64 build leg"
+        required: false
+        type: string
+        default: "ubuntu-latest"
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER:
         required: false
@@ -87,8 +92,8 @@ concurrency:
 jobs:
   build-image:
     name: Build ${{ inputs.image_name }} (${{ matrix.os_and_arch }})
-    # Pick the runner matching the arch.
-    runs-on: ${{ matrix.os_and_arch == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    # Keep arm64 native; compile-bound callers may opt into a larger amd64 runner.
+    runs-on: ${{ matrix.os_and_arch == 'linux/arm64' && 'ubuntu-24.04-arm' || inputs.amd64_runner }}
     strategy:
       fail-fast: false
       # Build both arches, or amd64 only when amd64_only is set.

--- a/.github/workflows/build-native-multi-arch-image.yml
+++ b/.github/workflows/build-native-multi-arch-image.yml
@@ -67,6 +67,11 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      arm64_runner:
+        description: "Runner label for the linux/arm64 build leg"
+        required: false
+        type: string
+        default: "ubuntu-24.04-arm"
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER:
         required: false
@@ -92,8 +97,8 @@ concurrency:
 jobs:
   build-image:
     name: Build ${{ inputs.image_name }} (${{ matrix.os_and_arch }})
-    # Keep arm64 native; compile-bound callers may opt into a larger amd64 runner.
-    runs-on: ${{ matrix.os_and_arch == 'linux/arm64' && 'ubuntu-24.04-arm' || inputs.amd64_runner }}
+    # Keep both architectures native; compile-bound callers may opt into larger runners.
+    runs-on: ${{ matrix.os_and_arch == 'linux/arm64' && inputs.arm64_runner || inputs.amd64_runner }}
     strategy:
       fail-fast: false
       # Build both arches, or amd64 only when amd64_only is set.

--- a/.github/workflows/build-native-multi-arch-image.yml
+++ b/.github/workflows/build-native-multi-arch-image.yml
@@ -72,6 +72,16 @@ on:
         required: false
         type: string
         default: "ubuntu-24.04-arm"
+      export_cache:
+        description: "Whether this build may update the shared registry cache"
+        required: false
+        type: boolean
+        default: true
+      zstd_compression:
+        description: "Use zstd level 3 for pushed image layers"
+        required: false
+        type: boolean
+        default: false
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER:
         required: false
@@ -137,10 +147,10 @@ jobs:
         shell: bash
         env:
           CACHE_REF: ${{ inputs.image_registry }}/${{ inputs.image_name }}:buildcache-${{ matrix.os_and_arch == 'linux/arm64' && 'arm64' || 'amd64' }}
-          CAN_PUSH: ${{ inputs.push_image && inputs.auth_provider != 'none' }}
+          CAN_EXPORT_CACHE: ${{ inputs.push_image && inputs.auth_provider != 'none' && inputs.export_cache }}
         run: |
           echo "cache-from=type=registry,ref=${CACHE_REF}" >> "$GITHUB_OUTPUT"
-          if [ "${CAN_PUSH}" = "true" ]; then
+          if [ "${CAN_EXPORT_CACHE}" = "true" ]; then
             echo "cache-to=type=registry,ref=${CACHE_REF},mode=max" >> "$GITHUB_OUTPUT"
           else
             echo "cache-to=" >> "$GITHUB_OUTPUT"
@@ -155,7 +165,7 @@ jobs:
           target: ${{ inputs.target }}
           push: ${{ inputs.push_image }}
           platforms: ${{ matrix.os_and_arch }}
-          outputs: ${{ inputs.push_image && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', inputs.image_registry, inputs.image_name) || '' }}
+          outputs: ${{ inputs.push_image && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true{2}', inputs.image_registry, inputs.image_name, inputs.zstd_compression && ',compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true' || '') || '' }}
           version: ${{ inputs.version }}
           previous-image: ${{ inputs.previous_image }}
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}

--- a/.github/workflows/build-native-multi-arch-image.yml
+++ b/.github/workflows/build-native-multi-arch-image.yml
@@ -78,7 +78,7 @@ on:
         type: boolean
         default: true
       zstd_compression:
-        description: "Use zstd level 3 for pushed image layers"
+        description: "Use fast zstd compression for pushed image layers"
         required: false
         type: boolean
         default: false
@@ -165,7 +165,7 @@ jobs:
           target: ${{ inputs.target }}
           push: ${{ inputs.push_image }}
           platforms: ${{ matrix.os_and_arch }}
-          outputs: ${{ inputs.push_image && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true{2}', inputs.image_registry, inputs.image_name, inputs.zstd_compression && ',compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true' || '') || '' }}
+          outputs: ${{ inputs.push_image && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true{2}', inputs.image_registry, inputs.image_name, inputs.zstd_compression && ',compression=zstd,compression-level=1,force-compression=true,oci-mediatypes=true' || '') || '' }}
           version: ${{ inputs.version }}
           previous-image: ${{ inputs.previous_image }}
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -102,9 +102,9 @@ jobs:
       # complete full-image build on this 16-vCPU runner. Use it for every
       # compile-bound amd64 Platform build, including PR/manual multi-arch runs.
       amd64_runner: blacksmith-16vcpu-ubuntu-2404
-      # The standard ARM runner exceeded the five-minute budget even with a
-      # warm native layer; this is the native ARM equivalent of the amd64 runner.
-      arm64_runner: blacksmith-16vcpu-ubuntu-2404-arm
+      # 16-vCPU ARM measured 5m11s after cache/export optimization; use the
+      # native 32-vCPU tier to keep the complete job below the five-minute budget.
+      arm64_runner: blacksmith-32vcpu-ubuntu-2404-arm
       # PRs consume publisher caches read-only instead of spending over a minute
       # rewriting mode=max. Push and manual multi-arch builds still refresh them.
       export_cache: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -105,6 +105,11 @@ jobs:
       # The standard ARM runner exceeded the five-minute budget even with a
       # warm native layer; this is the native ARM equivalent of the amd64 runner.
       arm64_runner: blacksmith-16vcpu-ubuntu-2404-arm
+      # PRs consume publisher caches read-only instead of spending over a minute
+      # rewriting mode=max. Push and manual multi-arch builds still refresh them.
+      export_cache: ${{ github.event_name != 'pull_request' }}
+      # PR images use the faster E2E-proven output; staging/manual stay unchanged.
+      zstd_compression: ${{ github.event_name == 'pull_request' }}
       checkout_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       previous_image: ${{ needs.resolve-previous-platform-image.outputs.previous_image }}
     secrets:

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -98,10 +98,10 @@ jobs:
       # so a dev build handed to a tester runs natively on Apple Silicon (arm64).
       # Release images (build-dockerhub-image.yml) are always multi-arch.
       amd64_only: ${{ github.event_name == 'push' }}
-      # This compile-bound leg takes 11-20 min on 4-vCPU ubuntu-latest; the
-      # equivalent E2E build is already proven on this 16-vCPU runner. Keep
-      # multi-arch PR/manual builds unchanged because arm64 is their long pole.
-      amd64_runner: ${{ github.event_name == 'push' && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-latest' }}
+      # Cold PR evidence: 11m36s on 4-vCPU ubuntu-latest versus 3m26s for the
+      # complete full-image build on this 16-vCPU runner. Use it for every
+      # compile-bound amd64 Platform build, including PR/manual multi-arch runs.
+      amd64_runner: blacksmith-16vcpu-ubuntu-2404
       checkout_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       previous_image: ${{ needs.resolve-previous-platform-image.outputs.previous_image }}
     secrets:

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -98,6 +98,10 @@ jobs:
       # so a dev build handed to a tester runs natively on Apple Silicon (arm64).
       # Release images (build-dockerhub-image.yml) are always multi-arch.
       amd64_only: ${{ github.event_name == 'push' }}
+      # This compile-bound leg takes 11-20 min on 4-vCPU ubuntu-latest; the
+      # equivalent E2E build is already proven on this 16-vCPU runner. Keep
+      # multi-arch PR/manual builds unchanged because arm64 is their long pole.
+      amd64_runner: ${{ github.event_name == 'push' && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-latest' }}
       checkout_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       previous_image: ${{ needs.resolve-previous-platform-image.outputs.previous_image }}
     secrets:

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -102,6 +102,9 @@ jobs:
       # complete full-image build on this 16-vCPU runner. Use it for every
       # compile-bound amd64 Platform build, including PR/manual multi-arch runs.
       amd64_runner: blacksmith-16vcpu-ubuntu-2404
+      # The standard ARM runner exceeded the five-minute budget even with a
+      # warm native layer; this is the native ARM equivalent of the amd64 runner.
+      arm64_runner: blacksmith-16vcpu-ubuntu-2404-arm
       checkout_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       previous_image: ${{ needs.resolve-previous-platform-image.outputs.previous_image }}
     secrets:

--- a/.github/workflows/docker-image-scanning.yml
+++ b/.github/workflows/docker-image-scanning.yml
@@ -129,8 +129,10 @@ jobs:
           tags: ${{ format('{0}:{1}', matrix.local-tag-prefix, github.sha) }}
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
-          # Read-only: the e2e build job owns cache export for this image.
-          cache-from: type=registry,ref=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:buildcache
+          # Read-only: E2E and native publish paths own their separate exports.
+          cache-from: |
+            type=registry,ref=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:buildcache
+            type=registry,ref=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/platform:buildcache-amd64
 
       - name: Build image with registry cache
         if: ${{ !matrix.use-build-action && steps.e2e-image.outputs.reused != 'true' }}

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -281,6 +281,9 @@ jobs:
           provenance: "false"
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
+          # Reuse the full build's live BuildKit cache instead of creating a
+          # second builder and re-importing/rebuilding the same graph.
+          setup-builder: "false"
           # All slim layers are a subset of the full build just done on this
           # builder; the registry ref only backstops a same-run builder loss.
           cache-from: |

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -149,9 +149,10 @@ jobs:
           provenance: "false"
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
-          # Read-only cache: the buildcache tag is anonymously readable, but
-          # forks have no registry credentials to export back.
-          cache-from: type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache
+          # Read-only caches: forks have no registry credentials to export back.
+          cache-from: |
+            type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache
+            type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache-amd64
 
       - name: Authenticate to Google Artifact Registry
         if: ${{ matrix.use-build-action && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) }}
@@ -253,10 +254,12 @@ jobs:
           provenance: "false"
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
-          # Registry-backed layer cache: ephemeral runners have no persistent
-          # BuildKit state, so warm layers live in a buildcache tag next to
-          # the image (same-region GAR pulls are free).
-          cache-from: type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache
+          # Import both the E2E cache and the amd64 cache populated by staging
+          # and labeled dev builds. Each workflow keeps its own writer
+          # to avoid last-writer-wins cache-manifest clobbering.
+          cache-from: |
+            type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache
+            type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache-amd64
           cache-to: type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache,mode=max
 
       # Slim variant for the K8s e2e job: the same image minus the ~352MB
@@ -280,7 +283,9 @@ jobs:
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
           # All slim layers are a subset of the full build just done on this
           # builder; the registry ref only backstops a same-run builder loss.
-          cache-from: type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache
+          cache-from: |
+            type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache
+            type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache-amd64
 
       - name: Authenticate to Google Artifact Registry
         if: ${{ !matrix.use-build-action && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) }}

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -260,7 +260,9 @@ jobs:
           cache-from: |
             type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache
             type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache-amd64
-          cache-to: type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache,mode=max
+          # Exact tree tags handle whole-image reuse; publisher mode=max caches
+          # supply intermediate layers, so E2E only needs to export final layers.
+          cache-to: type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache,mode=min
 
       # Slim variant for the K8s e2e job: the same image minus the ~352MB
       # Dagger engine tar that only the quickstart job uses. Every layer is already in

--- a/platform/.dockerignore
+++ b/platform/.dockerignore
@@ -23,6 +23,7 @@ archestra-rs/sandbox-rs/index.js
 
 # Tests
 coverage
+e2e-tests
 **/*.test.ts
 **/*.test.tsx
 

--- a/platform/.dockerignore
+++ b/platform/.dockerignore
@@ -23,6 +23,7 @@ archestra-rs/sandbox-rs/index.js
 
 # Tests
 coverage
+# E2E suites run from the checkout and are never copied into the runtime image.
 e2e-tests
 **/*.test.ts
 **/*.test.tsx

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -214,16 +214,39 @@ RUN set -eux; \
     rm -f picomatch-4.0.4.tgz; \
     grep -q '"version": "4.0.4"' "$target/package.json"
 
-# <----- Builder base stage ----->
-FROM base AS builder-base
+# <----- Rust dependency cache ----->
+FROM base AS rust-builder-base
 WORKDIR /app
-
-# Install the Rust toolchain used to compile the N-API addons below.
-# Kept ABOVE the node_modules/source COPYs so this layer depends only on `base` and
-# stays cache-stable across ordinary source changes. When it lived below the COPYs
-# the ~12s apk install re-ran on every source-changing build because the preceding
-# COPY layers were invalidated.
 RUN apk add --no-cache build-base cargo rust
+
+FROM rust-builder-base AS rust-deps
+ARG TARGETARCH
+COPY archestra-rs/Cargo.toml archestra-rs/Cargo.lock ./archestra-rs/
+COPY archestra-rs/sandbox-core/Cargo.toml ./archestra-rs/sandbox-core/
+COPY archestra-rs/sandbox-rs/Cargo.toml archestra-rs/sandbox-rs/build.rs ./archestra-rs/sandbox-rs/
+COPY archestra-rs/app-runtime-core/Cargo.toml ./archestra-rs/app-runtime-core/
+COPY archestra-rs/app-runtime-rs/Cargo.toml archestra-rs/app-runtime-rs/build.rs ./archestra-rs/app-runtime-rs/
+COPY archestra-rs/image-core/Cargo.toml ./archestra-rs/image-core/
+COPY archestra-rs/image-rs/Cargo.toml archestra-rs/image-rs/build.rs ./archestra-rs/image-rs/
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    for crate in sandbox-core sandbox-rs app-runtime-core app-runtime-rs image-core image-rs; do \
+      mkdir -p "archestra-rs/${crate}/src"; \
+      printf 'pub fn dependency_cache_placeholder() {}\n' > "archestra-rs/${crate}/src/lib.rs"; \
+    done && \
+    cd archestra-rs && \
+    case "${TARGETARCH}" in \
+      amd64) RUST_TARGET=x86_64-alpine-linux-musl ;; \
+      arm64) RUST_TARGET=aarch64-alpine-linux-musl ;; \
+      *) echo "Unsupported Rust architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    for package in app_runtime_rs image_rs sandbox_rs; do \
+      RUSTFLAGS='-C target-feature=-crt-static' cargo build --release --locked \
+        --target "${RUST_TARGET}" -p "${package}"; \
+    done
+
+# <----- Builder base stage ----->
+FROM rust-builder-base AS builder-base
 
 # Copy the dependency graph and native workspace before application source so
 # backend/frontend/shared changes can reuse the exported N-API build layer.
@@ -243,10 +266,13 @@ COPY archestra-rs/image-rs ./archestra-rs/image-rs
 
 # These tasks stay outside Turbo's shared cache because their artifacts are
 # platform-specific. This Docker layer is architecture-scoped and exportable,
-# so ordinary application source changes no longer recompile Rust.
+# so ordinary application source changes no longer recompile Rust. Touch real
+# sources after importing dummy-crate fingerprints so Cargo always recompiles
+# local crates while retaining the manifest-keyed dependency artifacts.
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/app/archestra-rs/target \
+    --mount=type=bind,from=rust-deps,source=/app/archestra-rs/target,target=/app/archestra-rs/target,rw \
+    find archestra-rs -path '*/src/*.rs' -exec touch {} + && \
     pnpm --filter @archestra/sandbox-rs \
          --filter @archestra/app-runtime-rs \
          --filter @archestra/image-rs build
@@ -271,13 +297,14 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV VERSION=${VERSION}
 
 FROM builder-base AS rust-napi-musl-smoke
-# cache cargo registry/git + the workspace target dir so heavy deps
-# (dagger-sdk, tokio, …) aren't recompiled on every build of this stage.
+# Reuse manifest-keyed release dependencies, plus local cargo caches for the
+# debug tests and test-helper feature variant unique to this stage.
 # Smokes every N-API addon under musl: build the .node, then load and call it so
 # a musl-specific loader/linkage regression fails here rather than at runtime.
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/app/archestra-rs/target \
+    --mount=type=bind,from=rust-deps,source=/app/archestra-rs/target,target=/app/archestra-rs/target,rw \
+    --mount=type=cache,id=rust-napi-debug,target=/app/archestra-rs/target/debug \
     pnpm --filter @archestra/sandbox-rs --filter @archestra/app-runtime-rs --filter @archestra/image-rs check:musl
 
 # <----- Builder stage ----->

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -272,7 +272,7 @@ COPY archestra-rs/image-rs ./archestra-rs/image-rs
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=bind,from=rust-deps,source=/app/archestra-rs/target,target=/app/archestra-rs/target,rw \
-    find archestra-rs -path '*/src/*.rs' -exec touch {} + && \
+    find archestra-rs -type f -path '*/src/*.rs' -exec touch {} + && \
     pnpm --filter @archestra/sandbox-rs \
          --filter @archestra/app-runtime-rs \
          --filter @archestra/image-rs build

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -13,31 +13,40 @@ ARG DAGGER_COMMIT=7902e644beeba4468f1ea786015b4be1d6d5bbcd
 ARG KUBECTL_VERSION=v1.35.0
 ARG KUBECTL_COMMIT=66452049f3d692768c39c797b21b793dce80314e
 
-FROM ${GOLANG_IMAGE} AS go-builder
+FROM ${GOLANG_IMAGE} AS go-builder-base
 ARG TARGETARCH
-ARG KIND_VERSION
-ARG KIND_COMMIT
-ARG DOCKER_CLI_VERSION
-ARG DOCKER_CLI_COMMIT
-ARG DAGGER_VERSION
-ARG DAGGER_COMMIT
-ARG KUBECTL_VERSION
-ARG KUBECTL_COMMIT
 RUN if [ "$TARGETARCH" != "amd64" ] && [ "$TARGETARCH" != "arm64" ]; then \
         echo "ERROR: Unsupported architecture: $TARGETARCH. KinD is only available for amd64 and arm64."; \
         exit 1; \
-    fi
-RUN apk add --no-cache git
-COPY docker/dagger-dockercompat /dagger-dockercompat
-RUN git clone --depth 1 --branch "${KIND_VERSION}" https://github.com/kubernetes-sigs/kind.git /kind && \
+    fi && \
+    apk add --no-cache git
+
+# Build the four pinned Go tools in independent stages so BuildKit schedules
+# them concurrently. Go caches stay outside exported layers, and each clone is
+# removed in the same RUN so mode=max never publishes source trees.
+FROM go-builder-base AS kind-builder
+ARG TARGETARCH
+ARG KIND_VERSION
+ARG KIND_COMMIT
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    git clone --depth 1 --branch "${KIND_VERSION}" https://github.com/kubernetes-sigs/kind.git /kind && \
     test "$(git -C /kind rev-parse HEAD)" = "${KIND_COMMIT}" && \
     cd /kind && \
     go mod edit -go=1.25.11 && \
     # golang.org/x/net <0.55.0: CVE-2026-39821 (CRITICAL); fixed in >= 0.55.0
     # golang.org/x/net <0.56.0: CVE-2026-46600 (HIGH); fixed in >= 0.56.0
     go get golang.org/x/net@v0.56.0 && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /kind-binary .
-RUN git clone --depth 1 --branch "${DOCKER_CLI_VERSION}" https://github.com/docker/cli.git /docker-cli && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /kind-binary . && \
+    cd / && rm -rf /kind
+
+FROM go-builder-base AS docker-cli-builder
+ARG TARGETARCH
+ARG DOCKER_CLI_VERSION
+ARG DOCKER_CLI_COMMIT
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    git clone --depth 1 --branch "${DOCKER_CLI_VERSION}" https://github.com/docker/cli.git /docker-cli && \
     test "$(git -C /docker-cli rev-parse HEAD)" = "${DOCKER_CLI_COMMIT}" && \
     cd /docker-cli && \
     cp vendor.mod go.mod && cp vendor.sum go.sum && \
@@ -63,8 +72,17 @@ RUN git clone --depth 1 --branch "${DOCKER_CLI_VERSION}" https://github.com/dock
     go mod vendor && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=vendor \
     -ldflags "-X github.com/docker/cli/cli/version.Version=${DOCKER_CLI_VERSION#v}" \
-    -o /docker-binary ./cmd/docker
-RUN git clone --depth 1 --branch "${DAGGER_VERSION}" https://github.com/dagger/dagger.git /dagger && \
+    -o /docker-binary ./cmd/docker && \
+    cd / && rm -rf /docker-cli
+
+FROM go-builder-base AS dagger-builder
+ARG TARGETARCH
+ARG DAGGER_VERSION
+ARG DAGGER_COMMIT
+COPY docker/dagger-dockercompat /dagger-dockercompat
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    git clone --depth 1 --branch "${DAGGER_VERSION}" https://github.com/dagger/dagger.git /dagger && \
     test "$(git -C /dagger rev-parse HEAD)" = "${DAGGER_COMMIT}" && \
     cd /dagger && \
     cp -R /dagger-dockercompat ./dockercompat && \
@@ -108,8 +126,16 @@ RUN git clone --depth 1 --branch "${DAGGER_VERSION}" https://github.com/dagger/d
     go mod tidy && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
     -ldflags "-X github.com/dagger/dagger/engine.Version=${DAGGER_VERSION} -X github.com/dagger/dagger/engine.Tag=${DAGGER_VERSION}" \
-    -o /dagger-binary ./cmd/dagger
-RUN git clone --depth 1 --branch "${KUBECTL_VERSION}" https://github.com/kubernetes/kubernetes.git /kubernetes && \
+    -o /dagger-binary ./cmd/dagger && \
+    cd / && rm -rf /dagger /dagger-dockercompat
+
+FROM go-builder-base AS kubectl-builder
+ARG TARGETARCH
+ARG KUBECTL_VERSION
+ARG KUBECTL_COMMIT
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    git clone --depth 1 --branch "${KUBECTL_VERSION}" https://github.com/kubernetes/kubernetes.git /kubernetes && \
     test "$(git -C /kubernetes rev-parse HEAD)" = "${KUBECTL_COMMIT}" && \
     cd /kubernetes && \
     go mod edit -go=1.25.11 && \
@@ -126,7 +152,8 @@ RUN git clone --depth 1 --branch "${KUBECTL_VERSION}" https://github.com/kuberne
     go get golang.org/x/mod@v0.40.0 && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=readonly \
     -ldflags "-X k8s.io/component-base/version.gitVersion=${KUBECTL_VERSION} -X k8s.io/component-base/version.gitCommit=${KUBECTL_COMMIT} -X k8s.io/component-base/version.gitTreeState=clean" \
-    -o /kubectl-binary ./cmd/kubectl
+    -o /kubectl-binary ./cmd/kubectl && \
+    cd / && rm -rf /kubernetes
 
 # pre-bake the Dagger Engine image as a docker-archive so the quickstart can
 # kind-load it into the embedded node instead of pulling ~352MB from the registry
@@ -405,13 +432,13 @@ RUN apk --no-cache upgrade && \
     rm -rf /tmp/*
 
 # install KinD (Kubernetes in Docker), docker-cli, and kubectl for Kubernetes runtime support
-# these binaries are built from source in go-builder with Go 1.26.6 to fix CVE-2025-68121,
+# these binaries are built from source in parallel Go stages with Go 1.26.6 to fix CVE-2025-68121,
 # the Go stdlib HIGH CVEs fixed in 1.25.10 (CVE-2026-42499/39836/39820/33814/33811),
 # the Go stdlib HIGH CVE fixed in 1.25.11 (CVE-2026-42504), and the Go stdlib CRITICAL
 # fixed in 1.26.6 (CVE-2026-39821).
-COPY --from=go-builder /docker-binary /usr/local/bin/docker
-COPY --from=go-builder /kind-binary /usr/local/bin/kind
-COPY --from=go-builder /kubectl-binary /usr/local/bin/kubectl
+COPY --from=docker-cli-builder /docker-binary /usr/local/bin/docker
+COPY --from=kind-builder /kind-binary /usr/local/bin/kind
+COPY --from=kubectl-builder /kubectl-binary /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kind /usr/local/bin/docker /usr/local/bin/kubectl
 # TODO: Once KinD releases a version compiled with Go >= 1.25.11, remove the kind-builder stage
 # at the top of this file and restore the pre-built binary download below for faster builds.
@@ -435,7 +462,7 @@ RUN chmod +x /usr/local/bin/kind /usr/local/bin/docker /usr/local/bin/kubectl
 # to the Dagger Engine; its npm postinstall download is blocked by
 # ignore-scripts, so the binary is pinned and built from source above.
 # keep DAGGER_VERSION in sync with dagger-sdk in archestra-rs/sandbox-core/Cargo.toml.
-COPY --from=go-builder /dagger-binary /usr/local/bin/dagger
+COPY --from=dagger-builder /dagger-binary /usr/local/bin/dagger
 RUN chmod +x /usr/local/bin/dagger
 # point the SDK at the baked-in CLI so it never downloads one at runtime.
 ENV _EXPERIMENTAL_DAGGER_CLI_BIN=/usr/local/bin/dagger

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -191,31 +191,20 @@ RUN set -eux; \
 FROM base AS builder-base
 WORKDIR /app
 
-# Install the Rust toolchain used to compile the N-API addons during `pnpm build`.
+# Install the Rust toolchain used to compile the N-API addons below.
 # Kept ABOVE the node_modules/source COPYs so this layer depends only on `base` and
 # stays cache-stable across ordinary source changes. When it lived below the COPYs
 # the ~12s apk install re-ran on every source-changing build because the preceding
 # COPY layers were invalidated.
 RUN apk add --no-cache build-base cargo rust
 
-# Version arg for Sentry release tracking
-ARG VERSION=dev
-
-# Copy dependencies from deps stage
+# Copy the dependency graph and native workspace before application source so
+# backend/frontend/shared changes can reuse the exported N-API build layer.
 COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/backend/node_modules ./backend/node_modules
-COPY --from=deps /app/frontend/node_modules ./frontend/node_modules
-COPY --from=deps /app/shared/node_modules ./shared/node_modules
 COPY --from=deps /app/archestra-rs/sandbox-rs/node_modules ./archestra-rs/sandbox-rs/node_modules
 COPY --from=deps /app/archestra-rs/app-runtime-rs/node_modules ./archestra-rs/app-runtime-rs/node_modules
 COPY --from=deps /app/archestra-rs/image-rs/node_modules ./archestra-rs/image-rs/node_modules
-
-# Copy source files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
-COPY patches ./patches
-COPY backend ./backend
-COPY frontend ./frontend
-COPY shared ./shared
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY archestra-rs/Cargo.toml archestra-rs/Cargo.lock ./archestra-rs/
 COPY archestra-rs/napi-loader ./archestra-rs/napi-loader
 COPY archestra-rs/sandbox-core ./archestra-rs/sandbox-core
@@ -225,7 +214,30 @@ COPY archestra-rs/app-runtime-rs ./archestra-rs/app-runtime-rs
 COPY archestra-rs/image-core ./archestra-rs/image-core
 COPY archestra-rs/image-rs ./archestra-rs/image-rs
 
-# Build all workspace
+# These tasks stay outside Turbo's shared cache because their artifacts are
+# platform-specific. This Docker layer is architecture-scoped and exportable,
+# so ordinary application source changes no longer recompile Rust.
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/app/archestra-rs/target \
+    pnpm --filter @archestra/sandbox-rs \
+         --filter @archestra/app-runtime-rs \
+         --filter @archestra/image-rs build
+
+# VERSION is intentionally declared after the native RUN. Build args implicitly
+# participate in following RUN cache keys, and every staging commit has a new
+# VERSION even when the Rust workspace is unchanged.
+ARG VERSION=dev
+
+COPY --from=deps /app/backend/node_modules ./backend/node_modules
+COPY --from=deps /app/frontend/node_modules ./frontend/node_modules
+COPY --from=deps /app/shared/node_modules ./shared/node_modules
+COPY turbo.json ./
+COPY patches ./patches
+COPY backend ./backend
+COPY frontend ./frontend
+COPY shared ./shared
+
 ENV NEXT_TELEMETRY_DISABLED=1
 
 # VERSION is exported as env var for child processes (used by Sentry source map upload)
@@ -255,21 +267,17 @@ FROM builder-base AS builder
 #
 # https://docs.docker.com/build/building/secrets/#using-build-secrets
 # https://docs.docker.com/build/building/secrets/#target
-# Cache cargo registry/git, the Rust workspace target dir, turbo's local cache,
-# and Next.js's build cache so a cold `pnpm build` (which recompiles the Rust
-# N-API addon and builds the frontend) reuses prior work on subsequent builds.
-# The cargo targets match the rust-napi-musl-smoke stage above, so that stage
-# warms the registry for this one; cargo isolates artifacts by target triple.
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/app/archestra-rs/target \
-    --mount=type=cache,target=/app/.turbo \
+# Native artifacts were built in builder-base before application source was
+# copied. Include shared's synthetic build task so its source remains in the
+# backend/frontend Turbo cache keys while excluding the three N-API tasks.
+RUN --mount=type=cache,target=/app/.turbo \
     --mount=type=cache,target=/app/frontend/.next/cache \
     --mount=type=secret,id=turbo_team,env=TURBO_TEAM \
     --mount=type=secret,id=turbo_token,env=TURBO_TOKEN \
     --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
     SENTRY_URL=https://de.sentry.io/ \
-    pnpm build
+    pnpm exec turbo build --filter=@backend --filter=@frontend \
+      --filter=@archestra/shared --only
 
 # Assemble the production backend with `pnpm deploy` — pnpm's recommended
 # monorepo packaging step (https://pnpm.io/cli/deploy). It produces a
@@ -281,8 +289,8 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 # node_modules (the layout that dropped @archestra/napi-loader and crashed the
 # image with MODULE_NOT_FOUND).
 #
-# Ordering matters: this runs AFTER `pnpm build`, so the compiled *.node addons
-# already exist in each crate dir. deploy copies them via the crates' `files`
+# Ordering matters: this runs after both build steps, so the compiled *.node
+# addons already exist in each crate dir. deploy copies them via the crates' `files`
 # globs — it never rebuilds (install scripts are disabled repo-wide).
 #
 # --legacy keeps pnpm's original deploy implementation, which does not require


### PR DESCRIPTION
## What
- run amd64 Platform dev builds on native 16-vCPU Blacksmith and arm64 Platform dev/release builds on native 32-vCPU Blacksmith
- isolate Rust N-API compilation behind a manifest-keyed, architecture-specific dependency layer
- build Docker CLI, Kind, Dagger, and kubectl in parallel without exporting their source/module trees
- share publisher caches read-only with E2E/merge-queue/scans while preserving separate writers
- use read-only publisher caches plus fast zstd for labeled PR images; publisher defaults stay max-cache/gzip
- reuse one live Buildx builder for E2E full+slim images and export only final E2E cache layers
- exclude `e2e-tests` from the Docker context

## Why
Successful staging Platform amd64 jobs averaged 14m25s (23 runs; median 14m19s, p90 15m31s). The old graph rebuilt native dependencies after source changes, serialized four Go tools, exported source/module trees, isolated cache families, and recreated the builder before the slim E2E image.

## Actual CI measurements
| Affected check | Before | Final after | Change |
|---|---:|---:|---:|
| Build Platform Dev Docker Image / amd64 | 14m19s median | 3m45s source-cold | -74% |
| Build Platform Dev Docker Image / amd64 warm | 14m19s median | 1m34s | -89% |
| Build Platform Dev Docker Image / arm64 | 5m56s | 4m32s source-cold | -24%; below 5m budget |
| Platform E2E / Build Platform Image | 5m46s comparable | 4m04s fresh-tree | -30% |
| E2E slim Docker build | 3m03 duplicate build | 11.26s shared builder | -94% |
| Docker Image Scanning / Platform | 16m10s rebuild baseline | 9m35s exact full+slim scan | -41% |
| Rust-source-only builder benchmark | 9m45 ARM dependency-cold failure mode | 2m05 local dependency-warm | dependency graph reused |

One-time manifest cache seeding measured 5m41s amd64 and 8m58s arm64. That cost occurs only when Cargo manifests/lock change; ordinary Rust source changes reuse the exported dependency layer. Intermediate regressions found during PR testing were removed before this final head.

## Correctness and regression coverage
- production-equivalent full/slim images build; final image loads all N-API modules and reaches healthy
- manifest changes invalidate Rust dependencies; source changes recompile real local crates against cached dependencies
- musl stage passes Rust tests plus CJS/ESM/panic smokes, with a persistent debug cache
- Docker 29.3.0, Kind 0.31.0/Go 1.26.6, kubectl 1.35.0, Dagger 0.21.8 verified
- final-head E2E passed K8s, quickstart, lite, and hibernation
- final-head exact full+slim Platform, MCP Server Base, and p4 Shim scans passed
- all required PR checks pass; the non-required Claude review check failed only because its organization authentication is unavailable
- policy suite (16 tests), YAML parsing, diff checks, repeated Claude Code large-feature reviews, and independent reviews pass

## Cache ownership
- `platform:buildcache-amd64` / `buildcache-arm64`: publisher `mode=max` caches
- `platform:buildcache`: E2E/merge-queue `mode=min` cache
- E2E/scans read E2E plus amd64 publisher caches
- labeled PR builds, scans, and forks do not overwrite publisher caches

## Merge gate
- branch rebased onto current `origin/main` (`0` commits behind)
- final-head required checks, labeled architecture builds, full E2E/hibernation, and exact-image scans passed
- no correctness, coverage, scan-scope, or required-check regressions identified; measured result is net positive