### PR TITLE
feat: support CIDR exceptions for public egress

### DIFF
--- a/docs/pages/platform-agent-background-execution.md
+++ b/docs/pages/platform-agent-background-execution.md
@@ -3,7 +3,7 @@ title: Background Execution
 category: Agents
 order: 7
 description: Run delegated Agent tasks in an isolated deployment
-lastUpdated: 2026-08-29
+lastUpdated: 2026-08-30
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -85,13 +85,13 @@ The deployment uses the same Agent system prompt and tool access as foreground e
 Each execution Job uses the Agent's [Environment](/docs/platform-environments),
 including its Kubernetes namespace and network egress policy. If the Agent has
 no Environment policy override, Archestra uses the organization default policy,
-then the built-in **Allow all** policy.
+then the built-in **Public internet** policy.
 
 The policy is applied before Kubernetes creates the Job. Archestra emits the
 policy type supported by the cluster: standard Kubernetes `NetworkPolicy`,
 Cilium `CiliumNetworkPolicy`, GKE `FQDNNetworkPolicy`, or AWS
 `ApplicationNetworkPolicy`. This gives executions the same IP, domain, and
-Allow-all floor behavior as MCP server pods and code sandboxes. DNS and the
+Public internet floor behavior as MCP server pods and code sandboxes. DNS and the
 Archestra control plane remain reachable so the execution can use the LLM
 proxy and MCP gateway.
 

--- a/docs/pages/platform-agent-background-execution.md
+++ b/docs/pages/platform-agent-background-execution.md
@@ -90,8 +90,8 @@ then the built-in **Public internet** policy.
 The policy is applied before Kubernetes creates the Job. Archestra emits the
 policy type supported by the cluster: standard Kubernetes `NetworkPolicy`,
 Cilium `CiliumNetworkPolicy`, GKE `FQDNNetworkPolicy`, or AWS
-`ApplicationNetworkPolicy`. This gives executions the same IP, domain, and
-Public internet floor behavior as MCP server pods and code sandboxes. DNS and the
+`ApplicationNetworkPolicy`. This gives executions the same IP, domain, Public
+internet CIDR-exception, and floor behavior as MCP server pods and code sandboxes. DNS and the
 Archestra control plane remain reachable so the execution can use the LLM
 proxy and MCP gateway.
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -519,7 +519,7 @@ Archestra protects every MCP server pod from Server-Side Request Forgery (SSRF) 
 
 Each pod gets one policy, chosen by its environment's egress mode:
 
-- **Public internet** (`unrestricted`, the default) — DNS and public egress are allowed; private, link-local, metadata, and other reserved ranges are blocked.
+- **Public internet** (`unrestricted`, the default) — DNS and public egress are allowed. Explicit CIDRs can open selected private ranges; other private, link-local, metadata, and reserved ranges remain blocked.
 - **Allowlist** (`restricted`) — only the CIDRs and domains the environment allow-lists, plus DNS.
 - **Block all** (`off`) — all egress is denied.
 
@@ -537,7 +537,7 @@ A namespace-wide default-deny baseline also selects every MCP pod, so a pod that
 
 **Prerequisite**: your cluster must use a CNI that enforces network policies. Calico, Cilium, and GKE Dataplane V2 enforce standard `NetworkPolicy` objects; on EKS Auto Mode, where `ApplicationNetworkPolicy` is the enforcement mechanism, the policy is emitted as an `ApplicationNetworkPolicy` instead. Where no enforcing dataplane is present, the policies are created but not enforced.
 
-To let a server reach a specific internal service — a Grafana instance in the `monitoring` namespace, for example — set its environment's egress mode to **Allowlist** (`restricted`) and add that CIDR or domain to the allow-list. See [Network Policies](/docs/platform-private-registry#network-policies).
+To let a server reach a private service while retaining public internet access, add its range under **Additional allowed CIDRs**. Use **Allowlist** instead when the server should reach only selected destinations. See [Network Policies](/docs/platform-private-registry#network-policies).
 
 ### Accessing the Platform
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -2,7 +2,7 @@
 title: Deployment
 category: Archestra Platform
 order: 3
-lastUpdated: 2026-08-29
+lastUpdated: 2026-08-30
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -519,13 +519,13 @@ Archestra protects every MCP server pod from Server-Side Request Forgery (SSRF) 
 
 Each pod gets one policy, chosen by its environment's egress mode:
 
-- **Allow all** (`unrestricted`, the default) — a reserved-range floor: DNS and the public internet are allowed; private, link-local, and metadata ranges are blocked.
+- **Public internet** (`unrestricted`, the default) — DNS and public egress are allowed; private, link-local, metadata, and other reserved ranges are blocked.
 - **Allowlist** (`restricted`) — only the CIDRs and domains the environment allow-lists, plus DNS.
 - **Block all** (`off`) — all egress is denied.
 
 A namespace-wide default-deny baseline also selects every MCP pod, so a pod that is still starting up is denied by default rather than left open.
 
-**Blocked reserved ranges** (the Allow all floor):
+**Blocked reserved ranges** (the Public internet floor):
 
 - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` - RFC 1918 private ranges (cluster pods, services, nodes)
 - `169.254.0.0/16` - Link-local / cloud metadata endpoints (AWS IMDSv1, GCP, Azure)

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -525,19 +525,9 @@ Each pod gets one policy, chosen by its environment's egress mode:
 
 A namespace-wide default-deny baseline also selects every MCP pod, so a pod that is still starting up is denied by default rather than left open.
 
-**Blocked reserved ranges** (the Public internet floor):
-
-- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` - RFC 1918 private ranges (cluster pods, services, nodes)
-- `169.254.0.0/16` - Link-local / cloud metadata endpoints (AWS IMDSv1, GCP, Azure)
-- `168.63.129.16/32` - Azure platform metadata (a public IP outside the private ranges)
-- `100.64.0.0/10` - Carrier-grade NAT (RFC 6598)
-- `127.0.0.0/8`, `0.0.0.0/8` - Loopback and unspecified addresses
-- `::1/128`, `fc00::/7`, `fe80::/10` - The IPv6 equivalents
-- `64:ff9b::/96` - NAT64 (blocks reaching the IPv4 ranges via IPv6; IPv4-mapped IPv6 is already covered by the IPv4 rules)
+Public internet uses a maintained floor for private, metadata, and reserved destinations. See [The Public Internet Floor](/docs/platform-environments#the-public-internet-floor) for the exact ranges and CIDR exception behavior.
 
 **Prerequisite**: your cluster must use a CNI that enforces network policies. Calico, Cilium, and GKE Dataplane V2 enforce standard `NetworkPolicy` objects; on EKS Auto Mode, where `ApplicationNetworkPolicy` is the enforcement mechanism, the policy is emitted as an `ApplicationNetworkPolicy` instead. Where no enforcing dataplane is present, the policies are created but not enforced.
-
-To let a server reach a private service while retaining public internet access, add its range under **Additional allowed CIDRs**. Use **Allowlist** instead when the server should reach only selected destinations. See [Network Policies](/docs/platform-private-registry#network-policies).
 
 ### Accessing the Platform
 

--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -82,7 +82,7 @@ This applies to both explicitly assigned resources and the implicit **Auto** acc
 
 ## Network egress policies
 
-An environment can define a Kubernetes **namespace** and a **network egress policy**. Self-hosted MCP server pods, agent [code sandboxes](/docs/platform-code-sandbox), and Agent [Background execution Jobs](/docs/platform-agent-background-execution#environments-and-network-egress) run in that namespace and inherit the policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Block all** (`off`) denies all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Public internet** (`unrestricted`) permits public egress — pods in your cluster still get a [fixed floor](#the-public-internet-floor) of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
+An environment can define a Kubernetes **namespace** and a **network egress policy**. Self-hosted MCP server pods, agent [code sandboxes](/docs/platform-code-sandbox), and Agent [Background execution Jobs](/docs/platform-agent-background-execution#environments-and-network-egress) run in that namespace and inherit the policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Block all** (`off`) denies all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Public internet** (`unrestricted`) permits public egress and any additional CIDRs you list. Pods in your cluster still get a [fixed floor](#the-public-internet-floor) of blocked reserved ranges outside those explicit exceptions. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
 
 When a workload runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in Public internet policy (`unrestricted`).
 
@@ -91,6 +91,7 @@ When a workload runs in an environment, Archestra uses the environment's network
 | No outbound access                    | **Block all**                                  |
 | Selected internal or public endpoints | **Allowlist**, with those domains or CIDRs     |
 | Public internet without private ranges | **Public internet**                            |
+| Public internet plus a private range   | **Public internet**, with an additional CIDR   |
 
 An environment applies one policy to all of its workloads. Use separate environments when MCP servers need different policies. The environments can share a Kubernetes namespace, but the usual [environment isolation](#tool-knowledge-skill-and-subagent-isolation) still applies.
 
@@ -121,9 +122,11 @@ Public internet mode blocks a fixed set of destinations for pods in your cluster
 - `127.0.0.0/8` and `0.0.0.0/8` — loopback
 - `::1/128`, `fc00::/7`, `fe80::/10`, `64:ff9b::/96` — the IPv6 equivalents
 
-The floor stops a server that fetches a URL from reaching your internal network or a cloud metadata endpoint. It is not configurable, and no environment setting turns it off. DNS to the cluster resolver stays allowed.
+The floor stops a server that fetches a URL from reaching your internal network or a cloud metadata endpoint. DNS to the cluster resolver stays allowed.
 
-To let a workload reach a private address, use Allowlist mode and list the range. Allowlist entries are not checked against the floor.
+To retain public internet access and reach one private range, add that range under **Additional allowed CIDRs**. The explicit CIDR becomes an exception to the floor. Other private and reserved ranges stay blocked. For example, adding `10.20.0.0/16` does not open the rest of `10.0.0.0/8`.
+
+Use **Allowlist** instead when the workload should reach only selected destinations. CIDRs in either mode are explicit network-policy allow rules.
 
 ### Domain Presets
 

--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -3,7 +3,7 @@ title: "Environments"
 category: Administration
 description: "Isolate tools, knowledge, skills, subagents, runtimes, and cost limits across deployment environments"
 order: 3
-lastUpdated: 2026-08-29
+lastUpdated: 2026-08-30
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -21,7 +21,7 @@ This document is the canonical reference for deployment Environments. Include:
   are exempt)
 - Network egress policies (namespace + egress policy applied to MCP server pods,
   agent code sandboxes, and Agent Background execution Jobs), the always-on
-  Allow all floor, provider support matrix, and domain presets
+  Public internet floor, provider support matrix, and domain presets
 - How environments scope per-environment cost limits
 - Link out to: agents, mcp gateway, knowledge connectors, costs & limits
 -->
@@ -82,9 +82,17 @@ This applies to both explicitly assigned resources and the implicit **Auto** acc
 
 ## Network egress policies
 
-An environment can define a Kubernetes **namespace** and a **network egress policy**. Self-hosted MCP server pods, agent [code sandboxes](/docs/platform-code-sandbox), and Agent [Background execution Jobs](/docs/platform-agent-background-execution#environments-and-network-egress) run in that namespace and inherit the policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Block all** (`off`) denies all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Allow all** (`unrestricted`) permits egress to the public internet — pods in your cluster still get a [fixed floor](#the-allow-all-floor) of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
+An environment can define a Kubernetes **namespace** and a **network egress policy**. Self-hosted MCP server pods, agent [code sandboxes](/docs/platform-code-sandbox), and Agent [Background execution Jobs](/docs/platform-agent-background-execution#environments-and-network-egress) run in that namespace and inherit the policy, so their outbound network reach is contained. A policy sets one of three egress modes. **Block all** (`off`) denies all egress. **Allowlist** (`restricted`) permits only selected IP/CIDR ranges and domains. **Public internet** (`unrestricted`) permits public egress — pods in your cluster still get a [fixed floor](#the-public-internet-floor) of blocked reserved ranges. Domain presets and custom domains require a supported FQDN policy provider; Kubernetes `NetworkPolicy` alone only enforces IP/CIDR rules.
 
-When a workload runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in Allow all policy (`unrestricted`).
+When a workload runs in an environment, Archestra uses the environment's network policy, then the organization default network policy, then the built-in Public internet policy (`unrestricted`).
+
+| Workload requirement                  | Egress mode                                    |
+| ------------------------------------- | ---------------------------------------------- |
+| No outbound access                    | **Block all**                                  |
+| Selected internal or public endpoints | **Allowlist**, with those domains or CIDRs     |
+| Public internet without private ranges | **Public internet**                            |
+
+An environment applies one policy to all of its workloads. Use separate environments when MCP servers need different policies. The environments can share a Kubernetes namespace, but the usual [environment isolation](#tool-knowledge-skill-and-subagent-isolation) still applies.
 
 How a policy applies depends on the workload. A **self-hosted MCP server**, agent code sandbox, or Agent Background execution runs in your cluster, so the policy is enforced continuously at the network layer. Archestra selects the cluster's supported policy type before creating the workload. A workload that needs broad outbound access (for example one that visits arbitrary sites) fails under a restrictive policy unless its destinations are allowlisted.
 
@@ -102,9 +110,9 @@ See Kubernetes [NetworkPolicy](https://kubernetes.io/docs/concepts/services-netw
 
 On EKS Auto Mode, `ApplicationNetworkPolicy` only supports IP and domain egress peers, so Archestra automatically adds a DNS bootstrap rule allowing port 53 to the cluster DNS service IP (recorded in the `archestra.io/network-policy-cluster-dns` annotation).
 
-### The Allow All Floor
+### The Public Internet Floor
 
-Allow all blocks a fixed set of destinations for pods in your cluster:
+Public internet mode blocks a fixed set of destinations for pods in your cluster:
 
 - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` — private ranges, where your other pods, services, and nodes live
 - `169.254.0.0/16` — link-local, including the AWS, GCP, and Azure metadata endpoints

--- a/platform/backend/src/k8s/dagger-environment-runtime/network-policy.test.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/network-policy.test.ts
@@ -135,6 +135,23 @@ describe("buildDaggerEgressPolicies (reuses MCP machinery for the dagger engine)
     expect(except).toContain("34.118.224.0/20");
   });
 
+  it("adds explicit CIDR exceptions to Public internet", () => {
+    const policies = buildDaggerEgressPolicies({
+      environmentId: ENV_ID,
+      effectivePolicy: effective({
+        egressMode: "unrestricted",
+        domainPreset: "none",
+        allowedDomains: [],
+        allowedCidrs: ["10.20.0.0/16"],
+      }),
+      capabilities: caps({}),
+    });
+    const np = policies[0].object as unknown as PolicyManifest;
+    expect(np.spec.egress).toEqual(
+      expect.arrayContaining([{ to: [{ ipBlock: { cidr: "10.20.0.0/16" } }] }]),
+    );
+  });
+
   it("applies the open-egress floor when the environment has no policy (built-in)", () => {
     const policies = buildDaggerEgressPolicies({
       environmentId: ENV_ID,

--- a/platform/backend/src/k8s/dagger-environment-runtime/network-policy.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/network-policy.ts
@@ -101,6 +101,7 @@ export function buildDaggerEgressPolicies(params: {
 
   if (!shouldManageK8sNetworkPolicy(effectivePolicy)) {
     // unrestricted / built-in default: open public egress, private ranges blocked.
+    const allowedCidrs = effectivePolicy.policy?.allowedCidrs ?? [];
     return [
       {
         kind: "NetworkPolicy",
@@ -117,6 +118,7 @@ export function buildDaggerEgressPolicies(params: {
           // range such a resolver usually lives in.
           clusterDnsIps,
           additionalDeniedCidrs: params.additionalDeniedCidrs ?? [],
+          allowedCidrs,
         }),
       },
     ];

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -5282,6 +5282,27 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     expect(policy?.spec?.egress).toEqual(PLAIN_FLOOR_EGRESS);
   });
 
+  test("applies explicit CIDR exceptions on top of the unrestricted floor", async () => {
+    const { api, policies } = makeStatefulNetworkingApi();
+    await makeNetworkPolicyDeployment({
+      networkingApi: api,
+      effectiveNetworkPolicy: makeNetworkPolicy({
+        egressMode: "unrestricted",
+        allowedCidrs: ["10.20.0.0/16"],
+      }),
+      networkPolicyCapabilities: PLAIN_CAPS,
+    }).applyK8sNetworkPolicy();
+
+    const egress = policies.get(POLICY_NAME)?.spec?.egress ?? [];
+    const publicRule = egress.find(
+      (rule) => rule.to?.[0]?.ipBlock?.cidr === "0.0.0.0/0",
+    );
+    expect(publicRule?.to?.[0]?.ipBlock?.except).toContain("10.0.0.0/8");
+    expect(egress).toContainEqual({
+      to: [{ ipBlock: { cidr: "10.20.0.0/16" } }],
+    });
+  });
+
   test("per-pod policy selector keys on app + mcp-server-id only, never the per-install name", async () => {
     const { api, policies } = makeStatefulNetworkingApi();
     await makeNetworkPolicyDeployment({

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -771,6 +771,8 @@ export default class K8sDeployment {
   private async applyUnrestrictedFloorNetworkPolicy(
     policyName: string,
   ): Promise<void> {
+    const allowedCidrs =
+      this.effectiveNetworkPolicy?.policy?.allowedCidrs ?? [];
     const labels = {
       app: "mcp-server",
       "app.kubernetes.io/managed-by": "archestra",
@@ -810,6 +812,7 @@ export default class K8sDeployment {
           podSelectorLabels: this.getPodSelectorLabels(),
           labels,
           clusterDnsIps,
+          allowedCidrs,
         }),
       });
       await Promise.all([
@@ -831,6 +834,7 @@ export default class K8sDeployment {
         podSelectorLabels: this.getPodSelectorLabels(),
         labels,
         clusterDnsIps,
+        allowedCidrs,
       }),
     );
     await Promise.all([

--- a/platform/backend/src/k8s/mcp-server-runtime/network-policy.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/network-policy.test.ts
@@ -1,3 +1,4 @@
+import type * as k8s from "@kubernetes/client-node";
 import { sanitizeMetadataLabels } from "@/k8s/shared";
 import { describe, expect, test } from "@/test";
 import type { EffectiveNetworkPolicy } from "@/types";
@@ -649,6 +650,40 @@ describe("MCP egress floor and default-deny baseline builders", () => {
 
     // Both variants share the identical public-egress rules.
     expect(anpEgress.slice(1)).toEqual(plain.spec?.egress?.slice(1));
+  });
+
+  test("public internet keeps its floor while allowing explicit CIDR exceptions", () => {
+    const allowedCidrs = ["10.20.0.0/16", "fd00:1234::/64"];
+    const plain = buildUnrestrictedFloorPolicy({
+      name: "mcp-egress-test",
+      podSelectorLabels,
+      labels: MANAGED_LABELS,
+      allowedCidrs,
+    });
+    const aws = buildUnrestrictedFloorAwsApplicationNetworkPolicy({
+      name: "mcp-egress-test",
+      podSelectorLabels,
+      labels: MANAGED_LABELS,
+      allowedCidrs,
+    });
+
+    for (const egress of [
+      plain.spec?.egress ?? [],
+      (aws.spec as { egress: k8s.V1NetworkPolicyEgressRule[] }).egress,
+    ]) {
+      const publicRule = egress.find(
+        (rule) =>
+          rule.to?.[0]?.ipBlock?.cidr === "0.0.0.0/0" &&
+          rule.ports === undefined,
+      );
+      expect(publicRule?.to?.[0]?.ipBlock?.except).toContain("10.0.0.0/8");
+      expect(egress).toEqual(
+        expect.arrayContaining([
+          { to: [{ ipBlock: { cidr: "10.20.0.0/16" } }] },
+          { to: [{ ipBlock: { cidr: "fd00:1234::/64" } }] },
+        ]),
+      );
+    }
   });
 
   test("plain floor adds a resolver-IP DNS allow alongside the selector rule (NodeLocal DNSCache / custom DNS)", () => {

--- a/platform/backend/src/k8s/mcp-server-runtime/network-policy.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/network-policy.ts
@@ -253,6 +253,8 @@ export function buildUnrestrictedFloorPolicy(params: {
    * set it (MCP pods), so their floor is unchanged.
    */
   additionalDeniedCidrs?: string[];
+  /** CIDRs explicitly allowed in addition to the public-egress floor. */
+  allowedCidrs?: string[];
 }): k8s.V1NetworkPolicy {
   return {
     apiVersion: "networking.k8s.io/v1",
@@ -278,7 +280,10 @@ export function buildUnrestrictedFloorPolicy(params: {
         // public rule below blocks. Empty when the resolver is unknown; the
         // selector rule above still covers the standard kube-dns case.
         ...buildResolverIpDnsEgressRules(params.clusterDnsIps ?? []),
-        ...floorPublicEgressRules(params.additionalDeniedCidrs ?? []),
+        ...floorPublicEgressRules({
+          additionalDeniedCidrs: params.additionalDeniedCidrs ?? [],
+          allowedCidrs: params.allowedCidrs ?? [],
+        }),
       ],
     },
   };
@@ -289,6 +294,7 @@ export function buildUnrestrictedFloorAwsApplicationNetworkPolicy(params: {
   podSelectorLabels: Record<string, string>;
   labels: Record<string, string>;
   clusterDnsIps?: string[];
+  allowedCidrs?: string[];
 }): Record<string, unknown> {
   return {
     apiVersion: "networking.k8s.aws/v1alpha1",
@@ -302,7 +308,7 @@ export function buildUnrestrictedFloorAwsApplicationNetworkPolicy(params: {
       policyTypes: ["Egress"],
       egress: [
         buildAwsDnsBootstrapEgressRule(params.clusterDnsIps ?? []),
-        ...floorPublicEgressRules(),
+        ...floorPublicEgressRules({ allowedCidrs: params.allowedCidrs ?? [] }),
       ],
     },
   };
@@ -399,9 +405,12 @@ const FLOOR_DENIED_IPV6_CIDRS = [
 // private, and cloud-metadata ranges above. Each floor variant prepends its own
 // provider-appropriate DNS rule (selector-based for the plain NetworkPolicy, the
 // cluster resolver ipBlock for the AWS ApplicationNetworkPolicy).
-function floorPublicEgressRules(
-  additionalDeniedCidrs: string[] = [],
-): k8s.V1NetworkPolicyEgressRule[] {
+function floorPublicEgressRules(params: {
+  additionalDeniedCidrs?: string[];
+  allowedCidrs?: string[];
+}): k8s.V1NetworkPolicyEgressRule[] {
+  const additionalDeniedCidrs = params.additionalDeniedCidrs ?? [];
+  const allowedCidrs = params.allowedCidrs ?? [];
   return [
     {
       to: [
@@ -416,6 +425,7 @@ function floorPublicEgressRules(
     {
       to: [{ ipBlock: { cidr: "::/0", except: FLOOR_DENIED_IPV6_CIDRS } }],
     },
+    ...allowedCidrs.map((cidr) => ({ to: [{ ipBlock: { cidr } }] })),
   ];
 }
 

--- a/platform/backend/src/k8s/runner-runtime/network-policy.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/network-policy.test.ts
@@ -65,6 +65,28 @@ describe("buildRunnerEnvironmentEgressPolicies", () => {
     ).toBe(true);
   });
 
+  it("adds explicit CIDR exceptions to Public internet", () => {
+    const [policy] = buildRunnerEnvironmentEgressPolicies({
+      spec: {
+        ...SPEC,
+        effectiveNetworkPolicy: {
+          source: "environment",
+          policy: {
+            egressMode: "unrestricted",
+            domainPreset: "none",
+            allowedDomains: [],
+            allowedCidrs: ["10.20.0.0/16"],
+          },
+        },
+      },
+      capabilities: CAPABILITIES,
+    });
+    const egress = (policy?.object as k8s.V1NetworkPolicy).spec?.egress ?? [];
+    expect(egress).toContainEqual({
+      to: [{ ipBlock: { cidr: "10.20.0.0/16" } }],
+    });
+  });
+
   it("uses Cilium for a domain allowlist when the cluster supports it", () => {
     const policies = buildRunnerEnvironmentEgressPolicies({
       spec: restrictedSpec(),

--- a/platform/backend/src/k8s/runner-runtime/network-policy.ts
+++ b/platform/backend/src/k8s/runner-runtime/network-policy.ts
@@ -70,18 +70,21 @@ export function buildRunnerEnvironmentEgressPolicies(params: {
     !spec.effectiveNetworkPolicy.policy ||
     spec.effectiveNetworkPolicy.policy.egressMode === "unrestricted"
   ) {
+    const allowedCidrs = spec.effectiveNetworkPolicy.policy?.allowedCidrs ?? [];
     const object = isAwsApplicationNetworkPolicyProvider(capabilities)
       ? buildUnrestrictedFloorAwsApplicationNetworkPolicy({
           name: names.environmentNetworkPolicy,
           podSelectorLabels,
           labels: metadata.labels,
           clusterDnsIps,
+          allowedCidrs,
         })
       : buildUnrestrictedFloorPolicy({
           name: names.environmentNetworkPolicy,
           podSelectorLabels,
           labels: metadata.labels,
           clusterDnsIps,
+          allowedCidrs,
         });
     return [
       withRunnerMetadata({

--- a/platform/backend/src/routes/environment.test.ts
+++ b/platform/backend/src/routes/environment.test.ts
@@ -232,6 +232,20 @@ describe("environment routes", () => {
     expect(created.statusCode).toBe(200);
     expect(created.json().networkPolicy).toEqual(policy);
 
+    const publicWithPrivateException = {
+      egressMode: "unrestricted",
+      domainPreset: "none",
+      allowedDomains: [],
+      allowedCidrs: ["10.20.0.0/16"],
+    };
+    const madePublic = await app.inject({
+      method: "PATCH",
+      url: `/api/environments/${created.json().id}`,
+      payload: { networkPolicy: publicWithPrivateException },
+    });
+    expect(madePublic.statusCode).toBe(200);
+    expect(madePublic.json().networkPolicy).toEqual(publicWithPrivateException);
+
     const updated = await app.inject({
       method: "PATCH",
       url: `/api/environments/${created.json().id}`,

--- a/platform/backend/src/types/environment.ts
+++ b/platform/backend/src/types/environment.ts
@@ -307,7 +307,7 @@ function normalizeNetworkPolicy(value: {
       egressMode === "restricted" ? (value.domainPreset ?? "none") : "none",
     allowedDomains:
       egressMode === "restricted" ? (value.allowedDomains ?? []) : [],
-    allowedCidrs: egressMode === "restricted" ? (value.allowedCidrs ?? []) : [],
+    allowedCidrs: egressMode === "off" ? [] : (value.allowedCidrs ?? []),
   };
 }
 

--- a/platform/frontend/AGENTS.md
+++ b/platform/frontend/AGENTS.md
@@ -1,7 +1,9 @@
 <!-- BEGIN:nextjs-agent-rules -->
+
 # This is NOT the Next.js you know
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 
-**Keep this block, including in commits.** It is part of the project's agent setup, maintained by `next dev` for every agent that works here. If it appears as an uncommitted change, that is intentional — commit it as-is. Do not remove it to clean up a diff; it will be regenerated.
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
 <!-- END:nextjs-agent-rules -->

--- a/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.test.ts
@@ -114,22 +114,36 @@ describe("buildEditorNetworkPolicy", () => {
     });
   });
 
-  test("off/unrestricted modes drop all allowlists", () => {
-    for (const egressMode of ["off", "unrestricted"] as const) {
-      expect(
-        buildEditorNetworkPolicy({
-          ...base,
-          egressMode,
-          allowedCidrsText: "203.0.113.0/24",
-          allowedDomainsText: "api.example.com",
-        }),
-      ).toEqual({
-        egressMode,
-        domainPreset: "none",
-        allowedDomains: [],
-        allowedCidrs: [],
-      });
-    }
+  test("public internet keeps CIDR exceptions but drops domain allowlists", () => {
+    expect(
+      buildEditorNetworkPolicy({
+        ...base,
+        egressMode: "unrestricted",
+        allowedCidrsText: "10.20.0.0/16",
+        allowedDomainsText: "api.example.com",
+      }),
+    ).toEqual({
+      egressMode: "unrestricted",
+      domainPreset: "none",
+      allowedDomains: [],
+      allowedCidrs: ["10.20.0.0/16"],
+    });
+  });
+
+  test("block all drops every allowlist", () => {
+    expect(
+      buildEditorNetworkPolicy({
+        ...base,
+        egressMode: "off",
+        allowedCidrsText: "10.20.0.0/16",
+        allowedDomainsText: "api.example.com",
+      }),
+    ).toEqual({
+      egressMode: "off",
+      domainPreset: "none",
+      allowedDomains: [],
+      allowedCidrs: [],
+    });
   });
 
   test("a CIDR-only edit keeps the seeded (inherited) domain allowlist even when the env has no policy of its own", () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.ts
@@ -113,7 +113,10 @@ export function buildEditorNetworkPolicy(params: {
     allowedDomains: restricted
       ? splitPolicyList(params.allowedDomainsText)
       : [],
-    allowedCidrs: restricted ? splitPolicyList(params.allowedCidrsText) : [],
+    allowedCidrs:
+      params.egressMode === "off"
+        ? []
+        : splitPolicyList(params.allowedCidrsText),
   };
 }
 

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
@@ -289,6 +289,12 @@ describe("EnvironmentsSection filters", () => {
         name: /Learn more/,
       }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/IPv4 or IPv6 CIDR ranges that workloads/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Allowed CIDRs help" }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Validation rule")).not.toBeInTheDocument();
     expect(
       screen.queryByLabelText("Trusted image registries"),

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
@@ -117,7 +117,25 @@ vi.mock("@/components/ui/bulk-actions-context", () => ({
     <>{children}</>
   ),
 }));
-vi.mock("@/components/form-dialog", () => ({ FormDialog: () => null }));
+vi.mock("@/components/form-dialog", () => ({
+  FormDialog: ({
+    open,
+    title,
+    description,
+    children,
+  }: {
+    open: boolean;
+    title: React.ReactNode;
+    description?: React.ReactNode;
+    children: React.ReactNode;
+  }) =>
+    open ? (
+      <section role="dialog" aria-label={String(title)}>
+        <div data-testid="dialog-description">{description}</div>
+        {children}
+      </section>
+    ) : null,
+}));
 vi.mock("@/components/delete-confirm-dialog", () => ({
   DeleteConfirmDialog: () => null,
 }));
@@ -250,6 +268,38 @@ describe("EnvironmentsSection filters", () => {
     expect(table.getByText("Inherited policy")).toBeInTheDocument();
     expect(table.queryByText("Internal tools")).not.toBeInTheDocument();
     expect(table.queryByText("Offline")).not.toBeInTheDocument();
+  });
+
+  test("keeps infrequently used environment controls collapsed", () => {
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("create=1") as unknown as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+    vi.mocked(useFeature).mockImplementation((feature) => {
+      if (feature === "environmentNamespaces") return [];
+      if (feature === "orchestratorK8sRuntime") return true;
+      return false;
+    });
+
+    render(<EnvironmentsSection canEdit />);
+
+    expect(
+      within(screen.getByTestId("dialog-description")).getByRole("link", {
+        name: /Learn more/,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Validation rule")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Trusted image registries"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
+
+    expect(screen.getByLabelText("Validation rule")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Trusted image registries"),
+    ).toBeInTheDocument();
   });
 });
 

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
@@ -1,0 +1,272 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { useFeature } from "@/lib/config/config.query";
+import {
+  useBulkDeleteEnvironments,
+  useCreateEnvironment,
+  useDeleteEnvironment,
+  useEnvironments,
+  useK8sCapabilities,
+  useUpdateEnvironment,
+} from "@/lib/environment.query";
+import {
+  useDefaultEnvironment,
+  useOrganization,
+  useUpdateDefaultEnvironment,
+} from "@/lib/organization.query";
+import { EnvironmentsSection } from "./environments-section";
+
+vi.mock("next/navigation");
+vi.mock("@/lib/config/config.query");
+vi.mock("@/lib/organization.query");
+vi.mock("@/lib/environment.query", () => ({
+  useBulkDeleteEnvironments: vi.fn(),
+  useCreateEnvironment: vi.fn(),
+  useDeleteEnvironment: vi.fn(),
+  useEnvironments: vi.fn(),
+  useK8sCapabilities: vi.fn(),
+  useUpdateEnvironment: vi.fn(),
+}));
+
+vi.mock("@/components/search-input", () => ({
+  SearchInput: ({
+    value,
+    onSearchChange,
+  }: {
+    value: string;
+    onSearchChange: (value: string) => void;
+  }) => (
+    <input
+      aria-label="Search environments by name and namespace"
+      value={value}
+      onChange={(event) => onSearchChange(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock("@/components/filter-bar", () => ({
+  CollectionFilters: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  FilterBar: ({
+    children,
+    onClearFilters,
+  }: {
+    children: React.ReactNode;
+    onClearFilters?: () => void;
+  }) => (
+    <div>
+      {children}
+      {onClearFilters ? (
+        <button type="button" onClick={onClearFilters}>
+          Clear filters
+        </button>
+      ) : null}
+    </div>
+  ),
+  FilterSelect: ({
+    value,
+    onValueChange,
+    placeholder,
+    items,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    placeholder: string;
+    items: Array<{ value: string; label: string }>;
+  }) => (
+    <select
+      aria-label={placeholder}
+      value={value}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      {items.map((item) => (
+        <option key={item.value} value={item.value}>
+          {item.label}
+        </option>
+      ))}
+    </select>
+  ),
+  filterSearchClass: "",
+}));
+
+vi.mock("@/components/ui/data-table", () => ({
+  DataTable: ({
+    data,
+    filteredEmptyMessage,
+  }: {
+    data: Array<{ id: string; name: string }>;
+    filteredEmptyMessage: string;
+  }) => (
+    <div data-testid="environment-table">
+      {data.length > 0
+        ? data.map((row) => <div key={row.id}>{row.name}</div>)
+        : filteredEmptyMessage}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/bulk-actions-bar", () => ({
+  BulkActions: () => null,
+}));
+vi.mock("@/components/ui/bulk-actions-context", () => ({
+  BulkActionsScope: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+vi.mock("@/components/form-dialog", () => ({ FormDialog: () => null }));
+vi.mock("@/components/delete-confirm-dialog", () => ({
+  DeleteConfirmDialog: () => null,
+}));
+vi.mock("./environment-resource-defaults-dialog", () => ({
+  EnvironmentResourceDefaultsDialog: () => null,
+}));
+
+const mutation = { mutate: vi.fn(), isPending: false };
+const publicInternetPolicy = {
+  egressMode: "unrestricted" as const,
+  domainPreset: "none" as const,
+  allowedDomains: [],
+  allowedCidrs: [],
+};
+
+describe("EnvironmentsSection filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({
+      replace: vi.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(usePathname).mockReturnValue("/settings/environments");
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
+    );
+    vi.mocked(useFeature).mockImplementation((feature) =>
+      feature === "environmentNamespaces" ? [] : false,
+    );
+    vi.mocked(useOrganization).mockReturnValue({
+      isSuccess: true,
+    } as ReturnType<typeof useOrganization>);
+    vi.mocked(useDefaultEnvironment).mockReturnValue({
+      name: "Default",
+      namespace: "archestra",
+      description: null,
+      networkPolicy: publicInternetPolicy,
+      restricted: false,
+      validationRegex: null,
+      trustedImageRegistries: null,
+    });
+    vi.mocked(useEnvironments).mockReturnValue({
+      data: {
+        environments: [
+          makeEnvironment({
+            id: "internal",
+            name: "Internal tools",
+            namespace: "private-services",
+            networkPolicy: {
+              egressMode: "restricted",
+              domainPreset: "none",
+              allowedDomains: [],
+              allowedCidrs: ["10.0.0.0/8"],
+            },
+          }),
+          makeEnvironment({
+            id: "public",
+            name: "Public tools",
+            namespace: "internet-services",
+            networkPolicy: publicInternetPolicy,
+          }),
+          makeEnvironment({
+            id: "inherited",
+            name: "Inherited policy",
+            namespace: "shared-services",
+            networkPolicy: null,
+          }),
+          makeEnvironment({
+            id: "offline",
+            name: "Offline",
+            namespace: "isolated",
+            networkPolicy: {
+              egressMode: "off",
+              domainPreset: "none",
+              allowedDomains: [],
+              allowedCidrs: [],
+            },
+          }),
+        ],
+        defaultAssignedCatalogCount: 0,
+      },
+      isFetching: false,
+    } as unknown as ReturnType<typeof useEnvironments>);
+    vi.mocked(useK8sCapabilities).mockReturnValue({
+      data: undefined,
+    } as ReturnType<typeof useK8sCapabilities>);
+    vi.mocked(useBulkDeleteEnvironments).mockReturnValue(
+      mutation as unknown as ReturnType<typeof useBulkDeleteEnvironments>,
+    );
+    vi.mocked(useCreateEnvironment).mockReturnValue(
+      mutation as unknown as ReturnType<typeof useCreateEnvironment>,
+    );
+    vi.mocked(useUpdateEnvironment).mockReturnValue(
+      mutation as unknown as ReturnType<typeof useUpdateEnvironment>,
+    );
+    vi.mocked(useDeleteEnvironment).mockReturnValue(
+      mutation as unknown as ReturnType<typeof useDeleteEnvironment>,
+    );
+    vi.mocked(useUpdateDefaultEnvironment).mockReturnValue(
+      mutation as unknown as ReturnType<typeof useUpdateDefaultEnvironment>,
+    );
+  });
+
+  test("searches the visible name and namespace fields", () => {
+    render(<EnvironmentsSection canEdit />);
+
+    fireEvent.change(
+      screen.getByRole("textbox", {
+        name: "Search environments by name and namespace",
+      }),
+      { target: { value: "private-services" } },
+    );
+
+    const table = within(screen.getByTestId("environment-table"));
+    expect(table.getByText("Internal tools")).toBeInTheDocument();
+    expect(table.queryByText("Default")).not.toBeInTheDocument();
+    expect(table.queryByText("Public tools")).not.toBeInTheDocument();
+  });
+
+  test("filters inherited policies by their effective egress mode", () => {
+    render(<EnvironmentsSection canEdit />);
+
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Filter by network egress" }),
+      { target: { value: "unrestricted" } },
+    );
+
+    const table = within(screen.getByTestId("environment-table"));
+    expect(table.getByText("Default")).toBeInTheDocument();
+    expect(table.getByText("Public tools")).toBeInTheDocument();
+    expect(table.getByText("Inherited policy")).toBeInTheDocument();
+    expect(table.queryByText("Internal tools")).not.toBeInTheDocument();
+    expect(table.queryByText("Offline")).not.toBeInTheDocument();
+  });
+});
+
+function makeEnvironment(overrides: {
+  id: string;
+  name: string;
+  namespace: string;
+  networkPolicy: ReturnType<typeof useDefaultEnvironment>["networkPolicy"];
+}) {
+  return {
+    organizationId: "organization-id",
+    description: null,
+    restricted: false,
+    validationRegex: null,
+    trustedImageRegistries: null,
+    sortOrder: 0,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    assignedCatalogCount: 0,
+    ...overrides,
+  };
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
@@ -31,14 +31,16 @@ vi.mock("@/lib/environment.query", () => ({
 
 vi.mock("@/components/search-input", () => ({
   SearchInput: ({
+    placeholder,
     value,
     onSearchChange,
   }: {
+    placeholder?: string;
     value: string;
     onSearchChange: (value: string) => void;
   }) => (
     <input
-      aria-label="Search environments by name and namespace"
+      aria-label={placeholder}
       value={value}
       onChange={(event) => onSearchChange(event.target.value)}
     />
@@ -223,7 +225,7 @@ describe("EnvironmentsSection filters", () => {
 
     fireEvent.change(
       screen.getByRole("textbox", {
-        name: "Search environments by name and namespace",
+        name: "Search by name or namespace",
       }),
       { target: { value: "private-services" } },
     );

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
@@ -15,7 +15,10 @@ import {
   useOrganization,
   useUpdateDefaultEnvironment,
 } from "@/lib/organization.query";
-import { EnvironmentsSection } from "./environments-section";
+import {
+  EnvironmentsSection,
+  NetworkPolicyFields,
+} from "./environments-section";
 
 vi.mock("next/navigation");
 vi.mock("@/lib/config/config.query");
@@ -306,6 +309,42 @@ describe("EnvironmentsSection filters", () => {
     expect(
       screen.getByLabelText("Trusted image registries"),
     ).toBeInTheDocument();
+  });
+});
+
+describe("NetworkPolicyFields", () => {
+  test("guides Public internet CIDR exceptions at the point of configuration", () => {
+    render(
+      <NetworkPolicyFields
+        egressMode="unrestricted"
+        setEgressMode={vi.fn()}
+        domainPreset="none"
+        setDomainPreset={vi.fn()}
+        allowedDomainsText=""
+        setAllowedDomainsText={vi.fn()}
+        allowedCidrsText="10.20.0.0/16"
+        setAllowedCidrsText={vi.fn()}
+        supportsFqdn={false}
+        enforcementStatus="verified-enforced"
+        baselineLoaded
+        disabled={false}
+      />,
+    );
+
+    expect(screen.getByLabelText("Additional allowed CIDRs")).toBeEnabled();
+    expect(
+      screen.getByText(/allow in addition to public internet/),
+    ).toBeInTheDocument();
+    const floorLinks = screen.getAllByRole("link", {
+      name: /View blocked ranges/,
+    });
+    expect(floorLinks).toHaveLength(2);
+    for (const link of floorLinks) {
+      expect(link).toHaveAttribute(
+        "href",
+        expect.stringContaining("#the-public-internet-floor"),
+      );
+    }
   });
 });
 

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -81,6 +81,10 @@ const NETWORK_POLICY_DOCS_URL = getDocsUrl(
   DocsPage.PlatformEnvironments,
   "network-egress-policies",
 );
+const PUBLIC_INTERNET_FLOOR_DOCS_URL = getDocsUrl(
+  DocsPage.PlatformEnvironments,
+  "the-public-internet-floor",
+);
 const DOMAIN_PRESETS_DOCS_URL = getDocsUrl(
   DocsPage.PlatformEnvironments,
   "domain-presets",
@@ -1135,7 +1139,11 @@ export function NetworkPolicyFields({
           <AlertDescription className="block leading-6">
             Egress rules would be accepted and then ignored, so these controls
             stay disabled until the cluster enforces NetworkPolicy.{" "}
-            <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
+            <ExternalDocsLink
+              href={NETWORK_POLICY_DOCS_URL}
+              className="underline"
+              showIcon={false}
+            >
               View docs
             </ExternalDocsLink>
           </AlertDescription>
@@ -1148,7 +1156,11 @@ export function NetworkPolicyFields({
             Nothing has confirmed this cluster acts on NetworkPolicy, so the
             rules below may be accepted and then ignored. They are still
             applied, and the enforcement check runs on the next upgrade.{" "}
-            <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
+            <ExternalDocsLink
+              href={NETWORK_POLICY_DOCS_URL}
+              className="underline"
+              showIcon={false}
+            >
               View docs
             </ExternalDocsLink>
           </AlertDescription>
@@ -1174,7 +1186,11 @@ export function NetworkPolicyFields({
             </code>{" "}
             supports IP/CIDR rules only. Domain allowlists require a supported
             FQDN policy provider.{" "}
-            <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
+            <ExternalDocsLink
+              href={NETWORK_POLICY_DOCS_URL}
+              className="underline"
+              showIcon={false}
+            >
               View docs
             </ExternalDocsLink>
           </AlertDescription>
@@ -1182,7 +1198,21 @@ export function NetworkPolicyFields({
       ) : null}
 
       <div className="space-y-2">
-        <Label htmlFor="network-policy-egress">Egress</Label>
+        <div className="space-y-1">
+          <Label htmlFor="network-policy-egress">Egress</Label>
+          <p className="text-xs text-muted-foreground">
+            Choose whether workloads can reach nothing, only approved
+            destinations, or the public internet. Public internet keeps private
+            and reserved ranges blocked.{" "}
+            <ExternalDocsLink
+              href={PUBLIC_INTERNET_FLOOR_DOCS_URL}
+              className="underline"
+              showIcon={false}
+            >
+              View blocked ranges
+            </ExternalDocsLink>
+          </p>
+        </div>
         <Select
           value={egressMode}
           onValueChange={(value) => setEgressMode(value as EgressMode)}
@@ -1214,18 +1244,38 @@ export function NetworkPolicyFields({
       <div className="space-y-2">
         <FieldLabel
           htmlFor="network-policy-cidrs"
-          label="Allowed CIDRs"
-          description="IPv4 or IPv6 CIDR ranges that workloads in Allowlist mode may reach. These rules are enforced by standard Kubernetes NetworkPolicy."
+          label={
+            egressMode === "unrestricted"
+              ? "Additional allowed CIDRs"
+              : "Allowed CIDRs"
+          }
+          description={
+            egressMode === "unrestricted" ? (
+              <>
+                Optional IPv4 or IPv6 CIDR ranges to allow in addition to public
+                internet. Other private and reserved ranges remain blocked.{" "}
+                <ExternalDocsLink
+                  href={PUBLIC_INTERNET_FLOOR_DOCS_URL}
+                  className="underline"
+                  showIcon={false}
+                >
+                  View blocked ranges
+                </ExternalDocsLink>
+              </>
+            ) : egressMode === "off" ? (
+              "CIDR exceptions are unavailable while all egress is blocked."
+            ) : (
+              "IPv4 or IPv6 CIDR ranges that workloads in Allowlist mode may reach."
+            )
+          }
         />
         <Textarea
           id="network-policy-cidrs"
           value={allowedCidrsText}
           onChange={(e) => setAllowedCidrsText(e.target.value)}
-          placeholder={"203.0.113.0/24\n2001:db8::/32"}
+          placeholder={"10.20.0.0/16\nfd00:1234::/64"}
           className="min-h-20 font-mono text-sm"
-          disabled={
-            disabled || enforcementUnavailable || egressMode !== "restricted"
-          }
+          disabled={disabled || enforcementUnavailable || egressMode === "off"}
         />
       </div>
 
@@ -1238,7 +1288,11 @@ export function NetworkPolicyFields({
               Adds a maintained domain allowlist for common dependency or
               package manager traffic. Requires a supported FQDN policy
               provider.{" "}
-              <ExternalDocsLink href={DOMAIN_PRESETS_DOCS_URL}>
+              <ExternalDocsLink
+                href={DOMAIN_PRESETS_DOCS_URL}
+                className="underline"
+                showIcon={false}
+              >
                 View presets
               </ExternalDocsLink>
             </>
@@ -1308,7 +1362,7 @@ const EGRESS_MODE_DESCRIPTIONS: Record<EgressMode, string> = {
   off: "Block all outbound traffic.",
   restricted: "Allow only the CIDRs and domains configured below.",
   unrestricted:
-    "Allow public destinations; private and reserved ranges stay blocked.",
+    "Allow public destinations plus any additional CIDRs configured below.",
 };
 
 function formatEgressMode(mode: EgressMode) {
@@ -1318,7 +1372,9 @@ function formatEgressMode(mode: EgressMode) {
 function formatPolicySummary(policy: NetworkPolicy) {
   if (policy.egressMode === "off") return "No outbound egress";
   if (policy.egressMode === "unrestricted")
-    return "Private ranges blocked in-cluster";
+    return policy.allowedCidrs.length > 0
+      ? `${policy.allowedCidrs.length} CIDR exception${policy.allowedCidrs.length === 1 ? "" : "s"}`
+      : "Private ranges blocked in-cluster";
 
   const parts: string[] = [];
   if (policy.domainPreset !== "none") {

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -17,6 +17,12 @@ import { FormDialog } from "@/components/form-dialog";
 import { ReinstallConfirmBar } from "@/components/reinstall-confirm-bar";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
@@ -75,6 +81,7 @@ import {
 import { EnvironmentResourceDefaultsDialog } from "./environment-resource-defaults-dialog";
 import { compileValidationRegex } from "./environment-validation-helpers";
 
+const ENVIRONMENTS_DOCS_URL = getDocsUrl(DocsPage.PlatformEnvironments);
 const NETWORK_POLICY_DOCS_URL = getDocsUrl(
   DocsPage.PlatformEnvironments,
   "network-egress-policies",
@@ -805,12 +812,24 @@ function EnvironmentEditorDialog({
       : mode === "default"
         ? "Edit default environment"
         : "Edit environment";
-  const dialogDescription =
-    mode === "create"
-      ? "Create an org-level deployment environment."
-      : mode === "default"
-        ? "Update the default environment."
-        : "Update this environment.";
+  const dialogDescription = (
+    <>
+      <span>
+        {mode === "create"
+          ? "Create an org-level deployment environment."
+          : mode === "default"
+            ? "Update the default environment."
+            : "Update this environment."}
+      </span>{" "}
+      <ExternalDocsLink
+        href={ENVIRONMENTS_DOCS_URL}
+        className="underline"
+        showIcon={false}
+      >
+        Learn more
+      </ExternalDocsLink>
+    </>
+  );
 
   return (
     <FormDialog
@@ -903,104 +922,9 @@ function EnvironmentEditorDialog({
             disabled={isPending}
           />
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="environment-validation-regex">Validation rule</Label>
-          <p className="text-xs text-muted-foreground">
-            Allowlist regular expression: config values entered when installing
-            into this environment are accepted only if they match. Leave empty
-            to disable. To block a substring (e.g. <code>prod</code>), use a
-            negative lookahead like{" "}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono">
-              ^(?!.*(prod|production)).*$
-            </code>
-            .
-          </p>
-          <Input
-            id="environment-validation-regex"
-            value={validationRegex}
-            onChange={(e) => setValidationRegex(e.target.value)}
-            placeholder="^(?!.*(prod|production)).*$"
-            className="font-mono"
-            disabled={isPending}
-            aria-invalid={validationRegexError ? true : undefined}
-          />
-          {validationRegexError && (
-            <p className="text-xs text-destructive">{validationRegexError}</p>
-          )}
-        </div>
-        {runtimeEnabled && (
-          <div className="space-y-2">
-            <Label htmlFor="environment-trusted-registries">
-              Trusted image registries
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              List of trusted Docker image registries. Any MCP server whose
-              image isn't on this list is held for admin approval before it can
-              be installed. Leave empty to allow any image.
-            </p>
-            <div className="flex gap-2">
-              <Input
-                id="environment-trusted-registries"
-                value={registryDraft}
-                onChange={(e) => {
-                  setRegistryDraft(e.target.value);
-                  setRegistryError(null);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    addTrustedRegistry();
-                  }
-                }}
-                placeholder="ghcr.io/acme"
-                className="font-mono"
-                disabled={isPending}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                onClick={addTrustedRegistry}
-                disabled={isPending || registryDraft.trim() === ""}
-              >
-                <Plus className="h-4 w-4" />
-                Add
-              </Button>
-            </div>
-            {registryError && (
-              <p className="text-xs text-destructive">{registryError}</p>
-            )}
-            {trustedImageRegistries.length > 0 && (
-              <div className="flex flex-wrap gap-1.5">
-                {trustedImageRegistries.map((registry) => (
-                  <Badge
-                    key={registry}
-                    variant="secondary"
-                    className="gap-1 font-mono"
-                  >
-                    {registry}
-                    <button
-                      type="button"
-                      onClick={() => removeTrustedRegistry(registry)}
-                      disabled={isPending}
-                      aria-label={`Remove ${registry}`}
-                      className="rounded-full text-muted-foreground hover:text-foreground"
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </Badge>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
         <section className="space-y-4 border-t pt-4">
           <div className="space-y-1">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <h3 className="font-medium text-sm">Network Egress Policy</h3>
-              <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
-                Network egress docs
-              </ExternalDocsLink>
-            </div>
+            <h3 className="font-medium text-sm">Network Egress Policy</h3>
             <p className="text-xs text-muted-foreground">
               Configure outbound network access for workloads in this
               environment.
@@ -1036,6 +960,109 @@ function EnvironmentEditorDialog({
             disabled={isPending || !egressBaselineLoaded}
           />
         </section>
+        <Accordion type="single" collapsible>
+          <AccordionItem value="advanced" className="rounded-md border px-4">
+            <AccordionTrigger className="py-3 hover:no-underline">
+              Advanced
+            </AccordionTrigger>
+            <AccordionContent className="space-y-4 pb-4">
+              <div className="space-y-2">
+                <Label htmlFor="environment-validation-regex">
+                  Validation rule
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Allowlist regular expression: config values entered when
+                  installing into this environment are accepted only if they
+                  match. Leave empty to disable. To block a substring (e.g.{" "}
+                  <code>prod</code>), use a negative lookahead like{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono">
+                    ^(?!.*(prod|production)).*$
+                  </code>
+                  .
+                </p>
+                <Input
+                  id="environment-validation-regex"
+                  value={validationRegex}
+                  onChange={(e) => setValidationRegex(e.target.value)}
+                  placeholder="^(?!.*(prod|production)).*$"
+                  className="font-mono"
+                  disabled={isPending}
+                  aria-invalid={validationRegexError ? true : undefined}
+                />
+                {validationRegexError && (
+                  <p className="text-xs text-destructive">
+                    {validationRegexError}
+                  </p>
+                )}
+              </div>
+              {runtimeEnabled && (
+                <div className="space-y-2">
+                  <Label htmlFor="environment-trusted-registries">
+                    Trusted image registries
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    List of trusted Docker image registries. Any MCP server
+                    whose image isn't on this list is held for admin approval
+                    before it can be installed. Leave empty to allow any image.
+                  </p>
+                  <div className="flex gap-2">
+                    <Input
+                      id="environment-trusted-registries"
+                      value={registryDraft}
+                      onChange={(e) => {
+                        setRegistryDraft(e.target.value);
+                        setRegistryError(null);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          addTrustedRegistry();
+                        }
+                      }}
+                      placeholder="ghcr.io/acme"
+                      className="font-mono"
+                      disabled={isPending}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={addTrustedRegistry}
+                      disabled={isPending || registryDraft.trim() === ""}
+                    >
+                      <Plus className="h-4 w-4" />
+                      Add
+                    </Button>
+                  </div>
+                  {registryError && (
+                    <p className="text-xs text-destructive">{registryError}</p>
+                  )}
+                  {trustedImageRegistries.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5">
+                      {trustedImageRegistries.map((registry) => (
+                        <Badge
+                          key={registry}
+                          variant="secondary"
+                          className="gap-1 font-mono"
+                        >
+                          {registry}
+                          <button
+                            type="button"
+                            onClick={() => removeTrustedRegistry(registry)}
+                            disabled={isPending}
+                            aria-label={`Remove ${registry}`}
+                            className="rounded-full text-muted-foreground hover:text-foreground"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </DialogBody>
       {showConfirm ? (
         <ReinstallConfirmBar

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -35,11 +35,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PermissionButton } from "@/components/ui/permission-button";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import {
   Select,
   SelectContent,
   SelectItem,
@@ -960,9 +955,9 @@ function EnvironmentEditorDialog({
             disabled={isPending || !egressBaselineLoaded}
           />
         </section>
-        <Accordion type="single" collapsible>
-          <AccordionItem value="advanced" className="rounded-md border px-4">
-            <AccordionTrigger className="py-3 hover:no-underline">
+        <Accordion type="single" collapsible className="border-t">
+          <AccordionItem value="advanced">
+            <AccordionTrigger className="hover:no-underline">
               Advanced
             </AccordionTrigger>
             <AccordionContent className="space-y-4 pb-4">
@@ -1186,41 +1181,29 @@ export function NetworkPolicyFields({
       ) : null}
 
       <div className="space-y-2">
-        <FieldLabel
-          label="Egress"
-          description={
-            <>
-              Controls outbound internet access. Block all (
-              <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
-                off
-              </code>{" "}
-              in the API) denies all egress, Allowlist (
-              <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
-                restricted
-              </code>
-              ) permits only the CIDR/domain rules below, and Public internet (
-              <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
-                unrestricted
-              </code>
-              ) permits public egress. Workloads hosted in your cluster still
-              block private, link-local, metadata, and other reserved ranges.
-            </>
-          }
-        />
+        <Label htmlFor="network-policy-egress">Egress</Label>
         <Select
           value={egressMode}
           onValueChange={(value) => setEgressMode(value as EgressMode)}
           disabled={disabled || enforcementUnavailable}
         >
-          <SelectTrigger className="w-full">
+          <SelectTrigger id="network-policy-egress" className="w-full">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="off">{EGRESS_MODE_LABELS.off}</SelectItem>
-            <SelectItem value="restricted">
+            <SelectItem value="off" description={EGRESS_MODE_DESCRIPTIONS.off}>
+              {EGRESS_MODE_LABELS.off}
+            </SelectItem>
+            <SelectItem
+              value="restricted"
+              description={EGRESS_MODE_DESCRIPTIONS.restricted}
+            >
               {EGRESS_MODE_LABELS.restricted}
             </SelectItem>
-            <SelectItem value="unrestricted">
+            <SelectItem
+              value="unrestricted"
+              description={EGRESS_MODE_DESCRIPTIONS.unrestricted}
+            >
               {EGRESS_MODE_LABELS.unrestricted}
             </SelectItem>
           </SelectContent>
@@ -1247,6 +1230,7 @@ export function NetworkPolicyFields({
 
       <div className="space-y-2">
         <FieldLabel
+          htmlFor="network-policy-domain-preset"
           label="Domain preset"
           description={
             <>
@@ -1264,7 +1248,7 @@ export function NetworkPolicyFields({
           onValueChange={(value) => setDomainPreset(value as DomainPreset)}
           disabled={disabled || egressMode !== "restricted" || !supportsFqdn}
         >
-          <SelectTrigger className="w-full">
+          <SelectTrigger id="network-policy-domain-preset" className="w-full">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -1306,24 +1290,9 @@ function FieldLabel({
   description: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="space-y-1">
       <Label htmlFor={htmlFor}>{label}</Label>
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            className="h-5 w-5 text-muted-foreground hover:text-foreground"
-            aria-label={`${label} help`}
-          >
-            <Info className="h-3.5 w-3.5" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-80 text-sm">
-          {description}
-        </PopoverContent>
-      </Popover>
+      <div className="text-xs text-muted-foreground">{description}</div>
     </div>
   );
 }
@@ -1332,6 +1301,13 @@ const EGRESS_MODE_LABELS: Record<EgressMode, string> = {
   off: "Block all",
   restricted: "Allowlist",
   unrestricted: "Public internet",
+};
+
+const EGRESS_MODE_DESCRIPTIONS: Record<EgressMode, string> = {
+  off: "Block all outbound traffic.",
+  restricted: "Allow only the CIDRs and domains configured below.",
+  unrestricted:
+    "Allow public destinations; private and reserved ranges stay blocked.",
 };
 
 function formatEgressMode(mode: EgressMode) {

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -1062,13 +1062,14 @@ function EnvironmentEditorDialog({
       {showConfirm ? (
         <ReinstallConfirmBar
           mode="auto"
+          className="mt-0"
           affectedServerCount={environment?.assignedCatalogCount ?? 0}
           isSubmitting={isPending}
           onCancel={() => setShowConfirm(false)}
           onConfirm={doSave}
         />
       ) : (
-        <DialogStickyFooter>
+        <DialogStickyFooter className="mt-0">
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -7,12 +7,20 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { ExternalDocsLink } from "@/components/external-docs-link";
+import {
+  CollectionFilters,
+  FilterBar,
+  FilterSelect,
+  filterSearchClass,
+} from "@/components/filter-bar";
 import { FormDialog } from "@/components/form-dialog";
 import { ReinstallConfirmBar } from "@/components/reinstall-confirm-bar";
+import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { BulkActions } from "@/components/ui/bulk-actions-bar";
+import { BulkActionsScope } from "@/components/ui/bulk-actions-context";
 import { createSelectColumn } from "@/components/ui/bulk-select-column";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -78,6 +86,7 @@ const DOMAIN_PRESETS_DOCS_URL = getDocsUrl(
 
 type NetworkPolicy = NonNullable<EnvironmentWithAssignedCount["networkPolicy"]>;
 type EgressMode = NetworkPolicy["egressMode"];
+type EgressModeFilter = EgressMode | "all";
 type DomainPreset = NetworkPolicy["domainPreset"];
 
 type EnvironmentTableRow =
@@ -102,6 +111,9 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
   const defaultEnvironment = useDefaultEnvironment();
   const [deleteTarget, setDeleteTarget] =
     useState<EnvironmentWithAssignedCount | null>(null);
+  const [search, setSearch] = useState("");
+  const [egressModeFilter, setEgressModeFilter] =
+    useState<EgressModeFilter>("all");
 
   // Which editor is open is derived from the URL (`?edit=<id|default>` /
   // `?create`) so the form survives a reload and is shareable. Only admins
@@ -185,6 +197,33 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
     ],
     [defaultAssignedCatalogCount, defaultEnvironment, environments],
   );
+  const normalizedSearch = search.trim().toLowerCase();
+  const filteredRows = useMemo(
+    () =>
+      rows.filter((row) => {
+        const matchesSearch =
+          normalizedSearch === "" ||
+          row.name.toLowerCase().includes(normalizedSearch) ||
+          row.namespace?.toLowerCase().includes(normalizedSearch);
+        const effectiveEgressMode =
+          row.networkPolicy?.egressMode ??
+          defaultEnvironment.networkPolicy?.egressMode ??
+          "unrestricted";
+        const matchesEgressMode =
+          egressModeFilter === "all" ||
+          effectiveEgressMode === egressModeFilter;
+
+        return matchesSearch && matchesEgressMode;
+      }),
+    [
+      defaultEnvironment.networkPolicy?.egressMode,
+      egressModeFilter,
+      normalizedSearch,
+      rows,
+    ],
+  );
+  const hasActiveFilters =
+    normalizedSearch !== "" || egressModeFilter !== "all";
 
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const bulkDelete = useBulkDeleteEnvironments();
@@ -197,13 +236,13 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
     selected: selectedEnvironments,
     selectAllMatching,
   } = useBulkSelection({
-    rows,
+    rows: filteredRows,
     getId: (row) => row.id,
     // The Default row is synthetic — it stands for "no environment" — and the
     // delete route refuses one that still has catalog items assigned.
     canSelect: (row) =>
       row.kind === "environment" && row.assignedCatalogCount === 0,
-    filterSignature: "environments",
+    filterSignature: `environments:${normalizedSearch}:${egressModeFilter}`,
     matchDescription: "can be deleted",
   });
 
@@ -302,7 +341,44 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
   );
 
   return (
-    <div className="space-y-4">
+    <BulkActionsScope className="space-y-4">
+      <CollectionFilters>
+        <FilterBar
+          leading
+          onClearFilters={
+            hasActiveFilters
+              ? () => {
+                  setSearch("");
+                  setEgressModeFilter("all");
+                }
+              : undefined
+          }
+        >
+          <SearchInput
+            objectNamePlural="environments"
+            searchFields={["name", "namespace"]}
+            value={search}
+            onSearchChange={setSearch}
+            syncQueryParams={false}
+            className={filterSearchClass}
+          />
+          <FilterSelect
+            value={egressModeFilter}
+            onValueChange={(value) =>
+              setEgressModeFilter(value as EgressModeFilter)
+            }
+            placeholder="Filter by network egress"
+            items={[
+              { value: "all", label: "All network egress" },
+              { value: "unrestricted", label: "Public internet" },
+              { value: "restricted", label: "Allowlist" },
+              { value: "off", label: "Block all" },
+            ]}
+            inactiveValue="all"
+          />
+        </FilterBar>
+      </CollectionFilters>
+
       <BulkActions
         count={selectedEnvironments.length}
         noun="environment"
@@ -323,7 +399,7 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
 
       <DataTable
         columns={columns}
-        data={rows}
+        data={filteredRows}
         getRowId={(row) => row.id}
         rowSelection={rowSelection}
         onRowSelectionChange={setRowSelection}
@@ -331,6 +407,12 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
         hideSelectedCount
         isLoading={isLoading}
         emptyMessage="No environments"
+        hasActiveFilters={hasActiveFilters}
+        filteredEmptyMessage="No environments match your filters"
+        onClearFilters={() => {
+          setSearch("");
+          setEgressModeFilter("all");
+        }}
       />
 
       {bulkDeleteOpen && (
@@ -397,7 +479,7 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
         onOpenChange={(open) => !open && closeEditor()}
         canEdit={canEdit}
       />
-    </div>
+    </BulkActionsScope>
   );
 }
 
@@ -914,13 +996,15 @@ function EnvironmentEditorDialog({
         )}
         <section className="space-y-4 border-t pt-4">
           <div className="space-y-1">
-            <h3 className="font-medium text-sm">Network Egress Policy</h3>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h3 className="font-medium text-sm">Network Egress Policy</h3>
+              <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
+                Network egress docs
+              </ExternalDocsLink>
+            </div>
             <p className="text-xs text-muted-foreground">
               Configure outbound network access for workloads in this
-              environment.{" "}
-              <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
-                View docs
-              </ExternalDocsLink>
+              environment.
             </p>
           </div>
 
@@ -1088,12 +1172,12 @@ export function NetworkPolicyFields({
               <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
                 restricted
               </code>
-              ) permits only the CIDR/domain rules below, and Allow all (
+              ) permits only the CIDR/domain rules below, and Public internet (
               <code className="inline rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">
                 unrestricted
               </code>
-              ) permits everything — workloads hosted in your cluster still get
-              a fixed floor of blocked reserved ranges.
+              ) permits public egress. Workloads hosted in your cluster still
+              block private, link-local, metadata, and other reserved ranges.
             </>
           }
         />
@@ -1221,7 +1305,7 @@ function FieldLabel({
 const EGRESS_MODE_LABELS: Record<EgressMode, string> = {
   off: "Block all",
   restricted: "Allowlist",
-  unrestricted: "Allow all",
+  unrestricted: "Public internet",
 };
 
 function formatEgressMode(mode: EgressMode) {
@@ -1230,7 +1314,8 @@ function formatEgressMode(mode: EgressMode) {
 
 function formatPolicySummary(policy: NetworkPolicy) {
   if (policy.egressMode === "off") return "No outbound egress";
-  if (policy.egressMode === "unrestricted") return "All outbound egress";
+  if (policy.egressMode === "unrestricted")
+    return "Private ranges blocked in-cluster";
 
   const parts: string[] = [];
   if (policy.domainPreset !== "none") {

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -355,8 +355,7 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
           }
         >
           <SearchInput
-            objectNamePlural="environments"
-            searchFields={["name", "namespace"]}
+            placeholder="Search by name or namespace"
             value={search}
             onSearchChange={setSearch}
             syncQueryParams={false}

--- a/platform/frontend/src/components/reinstall-confirm-bar.tsx
+++ b/platform/frontend/src/components/reinstall-confirm-bar.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Loader2 } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { DialogStickyFooter } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
 
 /**
  * Inline confirm surface that replaces the host form's footer when a
@@ -25,6 +26,7 @@ export function ReinstallConfirmBar({
   isSubmitting,
   onCancel,
   onConfirm,
+  className,
 }: {
   mode: "manual" | "auto" | "rename";
   /** A name change rides along with a manual/auto cascade — append the
@@ -37,6 +39,7 @@ export function ReinstallConfirmBar({
   isSubmitting: boolean;
   onCancel: () => void;
   onConfirm: () => void | Promise<void>;
+  className?: string;
 }) {
   // If Save was clicked while scrolled mid-form, the new footer would
   // sit off-screen — user would read it as "nothing happened".
@@ -153,7 +156,10 @@ export function ReinstallConfirmBar({
       // above its opaque backdrop. A plain `bg-amber-…/40` here would be
       // merged *in place of* that backdrop instead, leaving the bar
       // translucent and its warning unreadable against the form underneath.
-      className="flex-col items-stretch gap-3 border-t-2 border-amber-500/40 after:bg-amber-100/60 sm:flex-col dark:after:bg-amber-950/40"
+      className={cn(
+        "flex-col items-stretch gap-3 border-t-2 border-amber-500/40 after:bg-amber-100/60 sm:flex-col dark:after:bg-amber-950/40",
+        className,
+      )}
     >
       <div className="flex items-start gap-3 pr-2 text-sm">
         <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-500" />


### PR DESCRIPTION
## Summary

- allow **Public internet** egress policies to add explicit CIDR exceptions while preserving the default private and reserved-range floor
- clarify each egress mode, link directly to the blocked-ranges documentation, and use the canonical white-label-aware docs link component
- add a compact search and egress filter toolbar to the environments table
- simplify the create/edit dialog by moving less-common controls into a collapsed Advanced section
- align the environment, deployment, and background-execution documentation with the updated behavior and terminology