### PR TITLE
fix(knowledge): tolerate persisted connector config drift

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -239920,822 +239920,830 @@
                       ]
                     },
                     "config": {
-                      "oneOf": [
+                      "anyOf": [
                         {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "jira"
-                              ]
-                            },
-                            "jiraBaseUrl": {},
-                            "isCloud": {
-                              "type": "boolean"
-                            },
-                            "projectKey": {
-                              "type": "string"
-                            },
-                            "jqlQuery": {
-                              "type": "string"
-                            },
-                            "commentEmailBlacklist": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "labelsToSkip": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "jiraBaseUrl",
-                            "isCloud"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "confluence"
-                              ]
-                            },
-                            "confluenceUrl": {},
-                            "isCloud": {
-                              "type": "boolean"
-                            },
-                            "spaceKeys": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "pageIds": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "cqlQuery": {
-                              "type": "string"
-                            },
-                            "labelsToSkip": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "batchSize": {
-                              "type": "number"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "confluenceUrl",
-                            "isCloud"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "github"
-                              ]
-                            },
-                            "githubUrl": {},
-                            "owner": {
-                              "type": "string"
-                            },
-                            "authMethod": {
-                              "type": "string",
-                              "enum": [
-                                "pat",
-                                "github_app"
-                              ]
-                            },
-                            "githubAppConfigId": {
-                              "anyOf": [
-                                {
-                                  "type": "string",
-                                  "format": "uuid",
-                                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
-                                },
-                                {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
                                   "type": "string",
                                   "enum": [
-                                    ""
+                                    "jira"
                                   ]
+                                },
+                                "jiraBaseUrl": {},
+                                "isCloud": {
+                                  "type": "boolean"
+                                },
+                                "projectKey": {
+                                  "type": "string"
+                                },
+                                "jqlQuery": {
+                                  "type": "string"
+                                },
+                                "commentEmailBlacklist": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "labelsToSkip": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 }
-                              ]
+                              },
+                              "required": [
+                                "type",
+                                "jiraBaseUrl",
+                                "isCloud"
+                              ],
+                              "additionalProperties": false
                             },
-                            "repos": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "includeIssues": {
-                              "type": "boolean"
-                            },
-                            "includePullRequests": {
-                              "type": "boolean"
-                            },
-                            "includeRepositoryFiles": {
-                              "type": "boolean"
-                            },
-                            "fileTypes": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "includePaths": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "labelsToSkip": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "githubUrl",
-                            "owner"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "gitlab"
-                              ]
-                            },
-                            "gitlabUrl": {},
-                            "projectIds": {
-                              "type": "array",
-                              "items": {
-                                "type": "number"
-                              }
-                            },
-                            "groupId": {
-                              "type": "string"
-                            },
-                            "includeIssues": {
-                              "type": "boolean"
-                            },
-                            "includeMergeRequests": {
-                              "type": "boolean"
-                            },
-                            "includeMarkdownFiles": {
-                              "type": "boolean"
-                            },
-                            "labelsToSkip": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "gitlabUrl"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "servicenow"
-                              ]
-                            },
-                            "instanceUrl": {},
-                            "includeIncidents": {
-                              "type": "boolean"
-                            },
-                            "includeChanges": {
-                              "type": "boolean"
-                            },
-                            "includeChangeRequests": {
-                              "type": "boolean"
-                            },
-                            "includeProblems": {
-                              "type": "boolean"
-                            },
-                            "includeBusinessApps": {
-                              "type": "boolean"
-                            },
-                            "includeKnowledgeArticles": {
-                              "type": "boolean"
-                            },
-                            "states": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "assignmentGroups": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "roleAudiences": {
+                            {
                               "type": "object",
-                              "additionalProperties": {
-                                "type": "array",
-                                "items": {
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "confluence"
+                                  ]
+                                },
+                                "confluenceUrl": {},
+                                "isCloud": {
+                                  "type": "boolean"
+                                },
+                                "spaceKeys": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "pageIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "cqlQuery": {
+                                  "type": "string"
+                                },
+                                "labelsToSkip": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "batchSize": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "confluenceUrl",
+                                "isCloud"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "github"
+                                  ]
+                                },
+                                "githubUrl": {},
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "authMethod": {
+                                  "type": "string",
+                                  "enum": [
+                                    "pat",
+                                    "github_app"
+                                  ]
+                                },
+                                "githubAppConfigId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        ""
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "repos": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "includeIssues": {
+                                  "type": "boolean"
+                                },
+                                "includePullRequests": {
+                                  "type": "boolean"
+                                },
+                                "includeRepositoryFiles": {
+                                  "type": "boolean"
+                                },
+                                "fileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "includePaths": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "labelsToSkip": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "githubUrl",
+                                "owner"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "gitlab"
+                                  ]
+                                },
+                                "gitlabUrl": {},
+                                "projectIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                },
+                                "groupId": {
+                                  "type": "string"
+                                },
+                                "includeIssues": {
+                                  "type": "boolean"
+                                },
+                                "includeMergeRequests": {
+                                  "type": "boolean"
+                                },
+                                "includeMarkdownFiles": {
+                                  "type": "boolean"
+                                },
+                                "labelsToSkip": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "gitlabUrl"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "servicenow"
+                                  ]
+                                },
+                                "instanceUrl": {},
+                                "includeIncidents": {
+                                  "type": "boolean"
+                                },
+                                "includeChanges": {
+                                  "type": "boolean"
+                                },
+                                "includeChangeRequests": {
+                                  "type": "boolean"
+                                },
+                                "includeProblems": {
+                                  "type": "boolean"
+                                },
+                                "includeBusinessApps": {
+                                  "type": "boolean"
+                                },
+                                "includeKnowledgeArticles": {
+                                  "type": "boolean"
+                                },
+                                "states": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "assignmentGroups": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "roleAudiences": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "batchSize": {
+                                  "type": "number"
+                                },
+                                "syncDataForLastMonths": {
+                                  "type": "number",
+                                  "minimum": 1,
+                                  "maximum": 12
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "instanceUrl"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "notion"
+                                  ]
+                                },
+                                "databaseIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "pageIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "batchSize": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "sharepoint"
+                                  ]
+                                },
+                                "tenantId": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "siteUrl": {},
+                                "driveIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "folderPath": {
+                                  "type": "string"
+                                },
+                                "recursive": {
+                                  "type": "boolean"
+                                },
+                                "maxDepth": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 100
+                                },
+                                "includePages": {
+                                  "type": "boolean"
+                                },
+                                "batchSize": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "tenantId",
+                                "siteUrl"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "gdrive"
+                                  ]
+                                },
+                                "authMode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "service_account",
+                                    "service_account_delegated",
+                                    "oauth"
+                                  ]
+                                },
+                                "delegatedAdminEmail": {
+                                  "type": "string"
+                                },
+                                "connectedAccountEmail": {
+                                  "type": "string"
+                                },
+                                "driveId": {
+                                  "type": "string"
+                                },
+                                "driveIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "folderId": {
+                                  "type": "string"
+                                },
+                                "recursive": {
+                                  "type": "boolean"
+                                },
+                                "maxDepth": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 100
+                                },
+                                "fileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "batchSize": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "dropbox"
+                                  ]
+                                },
+                                "rootPath": {
+                                  "type": "string"
+                                },
+                                "fileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "batchSize": {
+                                  "type": "number"
+                                },
+                                "recursive": {
+                                  "type": "boolean"
+                                },
+                                "maxDepth": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "onedrive"
+                                  ]
+                                },
+                                "tenantId": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "userIds": {
+                                  "minItems": 1,
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "folderId": {
+                                  "type": "string"
+                                },
+                                "recursive": {
+                                  "type": "boolean"
+                                },
+                                "maxDepth": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 100
+                                },
+                                "fileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "batchSize": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "tenantId",
+                                "userIds"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "asana"
+                                  ]
+                                },
+                                "workspaceGid": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "projectGids": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "tagsToSkip": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "workspaceGid"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "linear"
+                                  ]
+                                },
+                                "linearApiUrl": {
+                                  "default": "https://api.linear.app"
+                                },
+                                "teamIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "projectIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "states": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "includeComments": {
+                                  "type": "boolean"
+                                },
+                                "includeProjects": {
+                                  "type": "boolean"
+                                },
+                                "includeCycles": {
+                                  "type": "boolean"
+                                },
+                                "batchSize": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "linearApiUrl"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "outline"
+                                  ]
+                                },
+                                "outlineUrl": {},
+                                "collectionIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "batchSize": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "outlineUrl"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "salesforce"
+                                  ]
+                                },
+                                "loginUrl": {
+                                  "default": "https://login.salesforce.com"
+                                },
+                                "objects": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "advancedObjectConfigJson": {
                                   "type": "string"
                                 }
-                              }
+                              },
+                              "required": [
+                                "type",
+                                "loginUrl"
+                              ],
+                              "additionalProperties": false
                             },
-                            "batchSize": {
-                              "type": "number"
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "web_crawler"
+                                  ]
+                                },
+                                "startUrl": {},
+                                "includePathPrefixes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "excludePathPatterns": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "contentSelector": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 500
+                                },
+                                "excludeSelectors": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 500
+                                  }
+                                },
+                                "maxPages": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 10000
+                                },
+                                "maxDepth": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 50
+                                },
+                                "batchSize": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 100
+                                },
+                                "requestDelayMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 10000
+                                },
+                                "userAgent": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "allowPrivateNetwork": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "startUrl"
+                              ],
+                              "additionalProperties": false
                             },
-                            "syncDataForLastMonths": {
-                              "type": "number",
-                              "minimum": 1,
-                              "maximum": 12
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "perforce"
+                                  ]
+                                },
+                                "serverUrl": {},
+                                "depotPaths": {
+                                  "minItems": 1,
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "excludePaths": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "fileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "pattern": "^\\.?[A-Za-z0-9_-]+$"
+                                  }
+                                },
+                                "p4Port": {
+                                  "type": "string",
+                                  "pattern": "^(ssl:)?[A-Za-z0-9_.[\\]-]+:\\d{1,5}$"
+                                },
+                                "adminUsername": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 256
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "serverUrl",
+                                "depotPaths"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "mfiles"
+                                  ]
+                                },
+                                "baseUrl": {},
+                                "vaultGuid": {
+                                  "type": "string",
+                                  "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+                                },
+                                "authMethod": {
+                                  "type": "string",
+                                  "enum": [
+                                    "oauth_client_credentials",
+                                    "mfiles_password_token"
+                                  ]
+                                },
+                                "oauthTokenEndpoint": {},
+                                "oauthScope": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "oauthResource": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "oauthAuthConfig": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "oauthAuthConfigScope": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "oauthAccountName": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "oauthUseIdToken": {
+                                  "type": "boolean"
+                                },
+                                "oauthClientAuthMethod": {
+                                  "type": "string",
+                                  "enum": [
+                                    "client_secret_post",
+                                    "client_secret_basic"
+                                  ]
+                                },
+                                "domain": {
+                                  "type": "string"
+                                },
+                                "objectTypeIds": {
+                                  "minItems": 1,
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 9007199254740991
+                                  }
+                                },
+                                "batchSize": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 500
+                                },
+                                "permissionExtensionMethod": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "baseUrl",
+                                "vaultGuid"
+                              ],
+                              "additionalProperties": false
                             }
-                          },
-                          "required": [
-                            "type",
-                            "instanceUrl"
-                          ],
-                          "additionalProperties": false
+                          ]
                         },
                         {
                           "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "notion"
-                              ]
-                            },
-                            "databaseIds": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "pageIds": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "batchSize": {
-                              "type": "number"
-                            }
-                          },
-                          "required": [
-                            "type"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "sharepoint"
-                              ]
-                            },
-                            "tenantId": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "siteUrl": {},
-                            "driveIds": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "folderPath": {
-                              "type": "string"
-                            },
-                            "recursive": {
-                              "type": "boolean"
-                            },
-                            "maxDepth": {
-                              "type": "integer",
-                              "minimum": 1,
-                              "maximum": 100
-                            },
-                            "includePages": {
-                              "type": "boolean"
-                            },
-                            "batchSize": {
-                              "type": "number"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "tenantId",
-                            "siteUrl"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "gdrive"
-                              ]
-                            },
-                            "authMode": {
-                              "type": "string",
-                              "enum": [
-                                "service_account",
-                                "service_account_delegated",
-                                "oauth"
-                              ]
-                            },
-                            "delegatedAdminEmail": {
-                              "type": "string"
-                            },
-                            "connectedAccountEmail": {
-                              "type": "string"
-                            },
-                            "driveId": {
-                              "type": "string"
-                            },
-                            "driveIds": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "folderId": {
-                              "type": "string"
-                            },
-                            "recursive": {
-                              "type": "boolean"
-                            },
-                            "maxDepth": {
-                              "type": "integer",
-                              "minimum": 1,
-                              "maximum": 100
-                            },
-                            "fileTypes": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "batchSize": {
-                              "type": "number"
-                            }
-                          },
-                          "required": [
-                            "type"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "dropbox"
-                              ]
-                            },
-                            "rootPath": {
-                              "type": "string"
-                            },
-                            "fileTypes": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "batchSize": {
-                              "type": "number"
-                            },
-                            "recursive": {
-                              "type": "boolean"
-                            },
-                            "maxDepth": {
-                              "type": "number"
-                            }
-                          },
-                          "required": [
-                            "type"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "onedrive"
-                              ]
-                            },
-                            "tenantId": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "userIds": {
-                              "minItems": 1,
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "folderId": {
-                              "type": "string"
-                            },
-                            "recursive": {
-                              "type": "boolean"
-                            },
-                            "maxDepth": {
-                              "type": "integer",
-                              "minimum": 1,
-                              "maximum": 100
-                            },
-                            "fileTypes": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "batchSize": {
-                              "type": "number"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "tenantId",
-                            "userIds"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "asana"
-                              ]
-                            },
-                            "workspaceGid": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "projectGids": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "tagsToSkip": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "workspaceGid"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "linear"
-                              ]
-                            },
-                            "linearApiUrl": {
-                              "default": "https://api.linear.app"
-                            },
-                            "teamIds": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "projectIds": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "states": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "includeComments": {
-                              "type": "boolean"
-                            },
-                            "includeProjects": {
-                              "type": "boolean"
-                            },
-                            "includeCycles": {
-                              "type": "boolean"
-                            },
-                            "batchSize": {
-                              "type": "integer",
-                              "exclusiveMinimum": true,
-                              "maximum": 9007199254740991
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "linearApiUrl"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "outline"
-                              ]
-                            },
-                            "outlineUrl": {},
-                            "collectionIds": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "batchSize": {
-                              "type": "number"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "outlineUrl"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "salesforce"
-                              ]
-                            },
-                            "loginUrl": {
-                              "default": "https://login.salesforce.com"
-                            },
-                            "objects": {
-                              "type": "array",
-                              "items": {
-                                "type": "string",
-                                "minLength": 1
-                              }
-                            },
-                            "advancedObjectConfigJson": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "loginUrl"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "web_crawler"
-                              ]
-                            },
-                            "startUrl": {},
-                            "includePathPrefixes": {
-                              "type": "array",
-                              "items": {
-                                "type": "string",
-                                "minLength": 1
-                              }
-                            },
-                            "excludePathPatterns": {
-                              "type": "array",
-                              "items": {
-                                "type": "string",
-                                "minLength": 1
-                              }
-                            },
-                            "contentSelector": {
-                              "type": "string",
-                              "minLength": 1,
-                              "maxLength": 500
-                            },
-                            "excludeSelectors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 500
-                              }
-                            },
-                            "maxPages": {
-                              "type": "integer",
-                              "minimum": 1,
-                              "maximum": 10000
-                            },
-                            "maxDepth": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 50
-                            },
-                            "batchSize": {
-                              "type": "integer",
-                              "minimum": 1,
-                              "maximum": 100
-                            },
-                            "requestDelayMs": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 10000
-                            },
-                            "userAgent": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "allowPrivateNetwork": {
-                              "type": "boolean"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "startUrl"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "perforce"
-                              ]
-                            },
-                            "serverUrl": {},
-                            "depotPaths": {
-                              "minItems": 1,
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "excludePaths": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "fileTypes": {
-                              "type": "array",
-                              "items": {
-                                "type": "string",
-                                "pattern": "^\\.?[A-Za-z0-9_-]+$"
-                              }
-                            },
-                            "p4Port": {
-                              "type": "string",
-                              "pattern": "^(ssl:)?[A-Za-z0-9_.[\\]-]+:\\d{1,5}$"
-                            },
-                            "adminUsername": {
-                              "type": "string",
-                              "minLength": 1,
-                              "maxLength": 256
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "serverUrl",
-                            "depotPaths"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "mfiles"
-                              ]
-                            },
-                            "baseUrl": {},
-                            "vaultGuid": {
-                              "type": "string",
-                              "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
-                            },
-                            "authMethod": {
-                              "type": "string",
-                              "enum": [
-                                "oauth_client_credentials",
-                                "mfiles_password_token"
-                              ]
-                            },
-                            "oauthTokenEndpoint": {},
-                            "oauthScope": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "oauthResource": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "oauthAuthConfig": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "oauthAuthConfigScope": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "oauthAccountName": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "oauthUseIdToken": {
-                              "type": "boolean"
-                            },
-                            "oauthClientAuthMethod": {
-                              "type": "string",
-                              "enum": [
-                                "client_secret_post",
-                                "client_secret_basic"
-                              ]
-                            },
-                            "domain": {
-                              "type": "string"
-                            },
-                            "objectTypeIds": {
-                              "minItems": 1,
-                              "type": "array",
-                              "items": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 9007199254740991
-                              }
-                            },
-                            "batchSize": {
-                              "type": "integer",
-                              "minimum": 1,
-                              "maximum": 500
-                            },
-                            "permissionExtensionMethod": {
-                              "type": "string",
-                              "minLength": 1
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "baseUrl",
-                            "vaultGuid"
-                          ],
-                          "additionalProperties": false
+                          "additionalProperties": {}
                         }
                       ]
                     },

--- a/platform/backend/src/routes/knowledge-base.test.ts
+++ b/platform/backend/src/routes/knowledge-base.test.ts
@@ -30,7 +30,7 @@ import { secretManager } from "@/secrets-manager";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test, vi } from "@/test";
-import type { User } from "@/types";
+import type { ConnectorConfig, User } from "@/types";
 
 describe("knowledge base routes", () => {
   let app: FastifyInstanceWithZod;
@@ -770,6 +770,30 @@ describe("knowledge base routes", () => {
       expect(body.name).toBe("Get Connector");
       expect(body.connectorType).toBe("jira");
       expect(body).toHaveProperty("totalDocsIngested");
+    });
+
+    test("returns a connector whose persisted config predates the current schema", async () => {
+      const persistedConfig = {
+        type: "retired_connector",
+        endpoint: "https://connector.example.test",
+      } as unknown as ConnectorConfig;
+      const connector = await KnowledgeBaseConnectorModel.create({
+        organizationId,
+        name: "Connector with legacy config",
+        connectorType: "jira",
+        config: persistedConfig,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/connectors/${connector.id}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        id: connector.id,
+        config: persistedConfig,
+      });
     });
 
     test("returns 404 for non-existent connector", async () => {

--- a/platform/backend/src/routes/knowledge-base.ts
+++ b/platform/backend/src/routes/knowledge-base.ts
@@ -141,25 +141,27 @@ const KnowledgeBaseWithConnectorsSchema = SelectKnowledgeBaseSchema.extend({
   assignedAgents: z.array(AssignedAgentSummarySchema),
 });
 
-// `permissionSyncState` (probe cursors/fingerprints) is internal permission-
-// sync bookkeeping — never part of the API surface.
+/**
+ * `permissionSyncState` (probe cursors/fingerprints) is internal permission-
+ * sync bookkeeping and never part of the API surface.
+ */
 const KnowledgeBaseConnectorResponseSchema =
   SelectKnowledgeBaseConnectorSchema.omit({ permissionSyncState: true });
 
 /**
- * The connector LIST response. Identical to the detail response except that
- * `config` also accepts a shape the current `ConnectorConfigSchema` no longer
- * recognizes — a config persisted by an older version and since drifted.
- *
- * The active list drops such rows (they still have a detail page, an edit form
- * and a delete button to reach them by id), but the trash cannot: it is the
- * only surface offering restore and permanent delete, so a row it refuses to
- * render is a row nobody can ever recover or purge. Valid configs still match
- * the discriminated union first and keep their precise shape.
+ * Connector rows can outlive the config schema that created them. Read
+ * responses therefore accept an opaque object after trying the current,
+ * precisely typed config union first. Create and update inputs remain strict,
+ * so this only keeps existing rows reachable for inspection, repair, or
+ * deletion instead of turning schema drift into a 500.
  */
-const KnowledgeBaseConnectorListItemSchema =
+const KnowledgeBaseConnectorReadResponseSchema =
   KnowledgeBaseConnectorResponseSchema.extend({
     config: z.union([ConnectorConfigSchema, z.record(z.string(), z.unknown())]),
+  });
+
+const KnowledgeBaseConnectorListItemSchema =
+  KnowledgeBaseConnectorReadResponseSchema.extend({
     assignedAgents: z.array(AssignedAgentSummarySchema),
   });
 
@@ -1081,7 +1083,7 @@ const knowledgeBaseRoutes: FastifyPluginAsyncZod = async (fastify) => {
         tags: ["Connectors"],
         params: z.object({ id: z.uuid() }),
         response: constructResponseSchema(
-          KnowledgeBaseConnectorResponseSchema.extend({
+          KnowledgeBaseConnectorReadResponseSchema.extend({
             totalDocsIngested: z.number(),
           }),
         ),

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -60918,6 +60918,8 @@ export type GetConnectorResponses = {
             objectTypeIds?: Array<number>;
             batchSize?: number;
             permissionExtensionMethod?: string;
+        } | {
+            [key: string]: unknown;
         };
         secretId: string | null;
         environmentId: string | null;


### PR DESCRIPTION
## Problem

Connector records persisted by an earlier schema can contain config shapes that the current discriminated union no longer recognizes. The connector detail endpoint applied that strict union during response serialization, turning an otherwise-readable record into a 500 response.

## Change

Connector read schemas now prefer the precise current config union and fall back to an opaque object for persisted schema drift. Create and update request validation remains strict. The OpenAPI specification and generated client type reflect the read-only fallback.

## Verification

A route-level regression test persists a connector with an unsupported historical config shape and verifies that the detail endpoint returns 200 with the stored config intact. The complete knowledge-base route suite passes, including the existing recoverability case for drifted connector configs.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>