### PR TITLE
fix(bench): alert on pre-publish runner failures

### DIFF
--- a/.github/bench/job.yaml
+++ b/.github/bench/job.yaml
@@ -31,6 +31,10 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       restartPolicy: Never
+      # A pre-publication failure sends a small Slack alert from the shell's EXIT trap. Leave enough
+      # time for that network call after Kubernetes sends SIGTERM (the default 30s is too tight when
+      # the benchmark child is still draining).
+      terminationGracePeriodSeconds: 120
       serviceAccountName: ${PLATFORM_SA}
       initContainers:
         - name: postgres

--- a/.github/bench/runner-entrypoint.sh
+++ b/.github/bench/runner-entrypoint.sh
@@ -11,10 +11,55 @@ umask 077
 BENCH_ENVS="${BENCH_ENVS:-basic}"
 BENCH_LANES="${BENCH_LANES:-glm}"
 service_account_dir=/var/run/secrets/kubernetes.io/serviceaccount
+run_dir=/work/run
+bench_phase=bootstrap
+publish_finished=0
+failure_notified=0
+bench_pid=
+log_tail_pid=
+
+# The normal publisher uploads the full run and posts its own summary. A hard failure before that
+# point used to leave no signal at all: the Job's one-hour TTL deletes the only copy of stderr. Keep
+# this deliberately dependency-free so it can report an RBAC/bootstrap/archive failure too.
+notify_early_failure() {
+  [ "${publish_finished}" -eq 0 ] || return 0
+  [ "${failure_notified}" -eq 0 ] || return 0
+  failure_notified=1
+
+  webhook="${SLACK_BENCH_WEBHOOK_URL:-}"
+  [ -n "${webhook}" ] || return 0
+
+  export BENCH_FAILURE_PHASE="${bench_phase}"
+  export BENCH_FAILURE_RUN="${GITHUB_RUN_NUMBER:-unknown}-${GITHUB_RUN_ATTEMPT:-unknown}"
+  export BENCH_FAILURE_URL="${RUN_URL:-}"
+  if ! python3 - <<'PY'
+import json
+import os
+import urllib.request
+
+text = (
+    f"❌ benchmark runner stopped before publishing "
+    f"(run {os.environ['BENCH_FAILURE_RUN']}, phase {os.environ['BENCH_FAILURE_PHASE']})"
+)
+if url := os.environ.get("BENCH_FAILURE_URL"):
+    text += f"\n<{url}|run>"
+request = urllib.request.Request(
+    os.environ["SLACK_BENCH_WEBHOOK_URL"],
+    data=json.dumps({"text": text}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+with urllib.request.urlopen(request, timeout=15) as response:
+    print(f"posted early benchmark failure summary ({response.status})", flush=True)
+PY
+  then
+    printf 'warning: could not post early benchmark failure summary\n' >&2
+  fi
+}
 
 cleanup_dagger() {
   status=$?
   trap - EXIT
+  notify_early_failure
   if [ -n "${DAGGER_ENGINE_POD:-}" ]; then
     # Never let cleanup decide the exit code: under `set -e` a failed read here would replace the
     # publish status, and that status is the run-health signal CI reads off the pod's terminal phase.
@@ -30,7 +75,7 @@ cleanup_dagger() {
   exit "${status}"
 }
 trap cleanup_dagger EXIT
-trap 'exit 143' HUP INT TERM
+trap 'bench_phase=terminated; [ -z "${bench_pid}" ] || kill "${bench_pid}" 2>/dev/null || true; [ -z "${log_tail_pid}" ] || kill "${log_tail_pid}" 2>/dev/null || true; exit 143' HUP INT TERM
 
 # Check with the pod's actual identity; the CI deploy identity deliberately cannot impersonate it.
 namespace=$(cat "${service_account_dir}/namespace")
@@ -89,39 +134,59 @@ EOF
 # from the process env, so exporting it here is enough.
 export ARCHESTRA_AUTH_SECRET="$(head -c 32 /dev/urandom | base64 | tr -d '\n')"
 
-mkdir -p /work/run
+mkdir -p "${run_dir}"
 
 # The bench exits non-zero whenever any rollout fails, which is normal for a model benchmark — so its
-# exit code is not the health signal. Health is read from aggregate.json by the publish step. tee keeps
-# progress visible in `kubectl logs` and captures it for upload.
+# exit code is not the health signal. Health is read from aggregate.json by the publish step. A
+# background tail keeps progress visible in `kubectl logs` while the file is captured for upload.
 set +e
+bench_phase=benchmark
 archestra-bench benchmark \
   --platform-dir /app \
   --bench-dir /bench \
   --env "${BENCH_ENVS}" \
   --lanes "${BENCH_LANES}" \
-  --run-dir /work/run \
-  --out /work/run/report.md 2>&1 | tee /work/run/bench.log
+  --run-dir "${run_dir}" \
+  --out "${run_dir}/report.md" > "${run_dir}/bench.log" 2>&1 &
+bench_pid=$!
+# Keep rollout progress in the container logs without putting the benchmark pipeline in the shell's
+# foreground. That lets SIGTERM interrupt `wait`, run the failure notifier, and use the grace period.
+tail -n +1 -f "${run_dir}/bench.log" &
+log_tail_pid=$!
+wait "${bench_pid}"
+kill "${log_tail_pid}" 2>/dev/null || true
+wait "${log_tail_pid}" 2>/dev/null || true
+bench_pid=
+log_tail_pid=
 set -e
 
 # Package the run dir (report, aggregate, per-rollout JSON, backend + bench logs) so the GCS upload
 # carries one verifiable archive alongside the unpacked aggregate/report.
+bench_phase=archive
 tar czf /work/run.tgz -C /work run
 
 # Reporting deps are baked into the image venv, so these run with plain python3 (no runtime fetch).
 # Best-effort export: a missing aggregate (hard bench crash) must still reach the publish step so it
 # reports a failure rather than the pod dying silently here; the export outcome is passed on so publish
 # can flag a lost TensorBoard history.
-if python3 /bench/scripts/export_tensorboard.py --run-dir /work/run --out /work/tb; then
+bench_phase=tensorboard_export
+if python3 /bench/scripts/export_tensorboard.py --run-dir "${run_dir}" --out /work/tb; then
   export BENCH_TB_EXPORT_OK=1
 else
   export BENCH_TB_EXPORT_OK=0
 fi
 
 # Final step: uploads to GCS, posts Slack, and exits non-zero on a broken harness so the pod's terminal
-# phase reflects run health. Not `exec`ed, so the EXIT trap runs after publishing and removes the
-# separate Dagger pod. That covers a normal exit only: a SIGTERM (pod deleted, activeDeadlineSeconds)
-# reaches this shell, but sh defers the handler until the foreground command returns, so the bench
-# outlives the grace period and is SIGKILLed with the trap still pending. CI's label sweep on the next
-# run is what actually reaps an engine orphaned that way.
-python3 /bench/scripts/publish_run.py --tb /work/tb --run-dir /work/run --tarball /work/run.tgz
+# phase reflects run health. Capture the code explicitly: `set -e` would otherwise invoke the early
+# failure notifier after a normal (but unhealthy) publisher result, duplicating its Slack message.
+# Not `exec`ed, so the EXIT trap runs after publishing and removes the
+# separate Dagger pod. The benchmark runs in the background specifically so SIGTERM interrupts the
+# shell's `wait`, posts the early failure notice, and then tears down the Dagger engine before the
+# termination grace period expires.
+bench_phase=publish
+set +e
+python3 /bench/scripts/publish_run.py --tb /work/tb --run-dir "${run_dir}" --tarball /work/run.tgz
+publish_status=$?
+set -e
+publish_finished=1
+exit "${publish_status}"


### PR DESCRIPTION
## Summary

The benchmark runner could terminate before its normal publisher ran, leaving neither a Slack alert nor a GCS artifact before the Job TTL removed the pod.

- send a direct Slack failure notice from the EXIT path until normal publishing completes
- run the benchmark as a background process so SIGTERM can interrupt the shell and trigger that notice
- allow 120 seconds of termination grace for the alert and Dagger cleanup
- preserve a single final Slack report for runs that reach `publish_run.py`

## Validation

- shell syntax and ShellCheck pass
- rendered Job manifest parses as YAML
- `git diff --check` passes

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>