### PR TITLE
fix(llm): allow keyless Vertex AI/Bedrock credentials for background executions

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -75,6 +75,10 @@ archestra:
     # Background execution is intentionally independent of ARCHESTRA_BETA.
     # Enable it only on staging while the capability is being rolled out.
     ARCHESTRA_AGENT_BACKGROUND_EXECUTION_ENABLED: "true"
+    # Execution Jobs run in separate pods, so the API's ordinary loopback URL
+    # cannot reach the platform from a runner. Use the in-cluster Service that
+    # the runner NetworkPolicy already permits on port 9000.
+    ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLATFORM_BASE_URL: "http://archestra-platform.archestra.svc.cluster.local:9000"
     # BETA: auto-sync-permissions connectors (off by default everywhere else).
     # Explicit so staging keeps the feature even if ARCHESTRA_BETA is ever
     # flipped off.

--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -79,6 +79,14 @@ archestra:
     # cannot reach the platform from a runner. Use the in-cluster Service that
     # the runner NetworkPolicy already permits on port 9000.
     ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLATFORM_BASE_URL: "http://archestra-platform.archestra.svc.cluster.local:9000"
+    # Lobster Env workers run dockerd + kind + tilt inside their pods, which
+    # needs the privileged opt-in, and land on the dedicated autoscaled
+    # runners pool (tainted archestra-runners=true) so heavy sessions never
+    # pressure the platform's own nodes. The storage cap covers the in-pod
+    # /var/lib/docker emptyDir on that pool's 200GB disks.
+    ARCHESTRA_AGENT_BACKGROUND_EXECUTION_ALLOW_PRIVILEGED: "true"
+    ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR: "archestra-runners=true"
+    ARCHESTRA_AGENT_BACKGROUND_EXECUTION_EPHEMERAL_STORAGE_LIMIT: "60Gi"
     # BETA: auto-sync-permissions connectors (off by default everywhere else).
     # Explicit so staging keeps the feature even if ARCHESTRA_BETA is ever
     # flipped off.

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -2,7 +2,7 @@
 title: Deployment
 category: Archestra Platform
 order: 3
-lastUpdated: 2026-08-30
+lastUpdated: 2026-08-31
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -856,6 +856,9 @@ Background execution runs delegated Agent tasks in dedicated Kubernetes pods. Yo
 
 - **`ARCHESTRA_AGENT_BACKGROUND_EXECUTION_EPHEMERAL_STORAGE_LIMIT`** - Maximum writable scratch space for one execution. Kubernetes enforces the limit on the run's `emptyDir` volume.
   - Default: `10Gi`
+
+- **`ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR`** - Steers background pods onto a dedicated node pool, written as `key=value` pairs. The pairs become each pod's node selector, with a matching `NoSchedule` toleration per pair. Empty schedules background pods like any other workload. Use it when heavy runs should not share nodes with the platform.
+  - Default: unset
 
 - **`ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLATFORM_POD_SELECTOR`** - Label selector matching the platform's own API pods, written as `key=value` pairs. Background pods get an egress policy allowing exactly that destination. Override it when your deployment labels the platform differently.
   - Default: `archestra.io/p4-shim-client=true`

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -596,6 +596,10 @@ ARCHESTRA_AGENT_BACKGROUND_EXECUTION_ENABLED=false
 # ARCHESTRA_AGENT_BACKGROUND_EXECUTION_MEMORY_LIMIT=4Gi
 # Maximum writable emptyDir storage available to one execution.
 # ARCHESTRA_AGENT_BACKGROUND_EXECUTION_EPHEMERAL_STORAGE_LIMIT=10Gi
+# Steer runner pods onto a dedicated node pool: key=value list applied as the
+# pods' nodeSelector, with a matching NoSchedule toleration per entry. Empty
+# schedules runners like any other pod.
+# ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR=archestra-runners=true
 # Base URL a background pod uses to reach the LLM proxy and MCP gateway. Must be
 # reachable from inside the cluster; defaults to ARCHESTRA_INTERNAL_API_BASE_URL.
 # With neither set, starting a run fails loudly rather than letting an agent

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -1848,6 +1848,7 @@ export const parseSandboxMemoryMaxBytes = (
 export function parseLabelSelector(
   value: string | undefined,
   defaultValue: Record<string, string>,
+  envName = "ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLATFORM_POD_SELECTOR",
 ): Record<string, string> {
   const raw = value?.trim();
   if (!raw) return defaultValue;
@@ -1858,7 +1859,7 @@ export function parseLabelSelector(
     const labelValue = rest.join("=").trim();
     if (!label || !labelValue) {
       logger.error(
-        `ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLATFORM_POD_SELECTOR is not a key=value list (${raw}); using the default`,
+        `${envName} is not a key=value list (${raw}); using the default`,
       );
       return defaultValue;
     }
@@ -2311,6 +2312,19 @@ const config = {
     platformPodSelector: parseLabelSelector(
       process.env.ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLATFORM_POD_SELECTOR,
       { "archestra.io/p4-shim-client": "true" },
+    ),
+    /**
+     * Steers runner pods onto a dedicated node pool: a key=value list that
+     * becomes each runner pod's nodeSelector, plus one matching NoSchedule
+     * toleration per entry so a pool tainted with the same pairs admits them.
+     * Empty (the default) schedules runners like any other pod. Heavy
+     * privileged runners sharing nodes with the platform can evict it under
+     * memory or disk pressure; a dedicated autoscaled pool contains that.
+     */
+    nodeSelector: parseLabelSelector(
+      process.env.ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR,
+      {},
+      "ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR",
     ),
     /** How often the reconciler syncs runner state and applies TTL/idle stops. */
     reconcileIntervalSeconds: parsePositiveInt(

--- a/platform/backend/src/k8s/runner-runtime/manifests.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.test.ts
@@ -15,6 +15,7 @@ const SPEC: KubernetesRunnerLaunchSpec = {
   image: "registry.example.test/agent-archestra:latest",
   command: null,
   privileged: false,
+  nodeSelector: {},
   resources: { cpuRequest: "500m", memoryRequest: "1Gi", memoryLimit: "4Gi" },
   env: {
     ARCHESTRA_AGENT_BACKGROUND_EXECUTION_AGENT_ID:
@@ -163,6 +164,26 @@ describe("buildRunnerJob", () => {
       buildRunnerJob(SPEC).spec?.template.spec?.volumes?.[0]?.emptyDir
         ?.sizeLimit,
     ).toBe("10Gi");
+  });
+
+  it("steers pods onto a dedicated pool only when a selector is configured", () => {
+    const plain = buildRunnerJob(SPEC).spec?.template.spec;
+    expect(plain?.nodeSelector).toBeUndefined();
+    expect(plain?.tolerations).toBeUndefined();
+
+    const steered = buildRunnerJob({
+      ...SPEC,
+      nodeSelector: { "archestra-runners": "true" },
+    }).spec?.template.spec;
+    expect(steered?.nodeSelector).toEqual({ "archestra-runners": "true" });
+    expect(steered?.tolerations).toEqual([
+      {
+        key: "archestra-runners",
+        operator: "Equal",
+        value: "true",
+        effect: "NoSchedule",
+      },
+    ]);
   });
 
   it("gives a privileged runner a real filesystem for /var/lib/docker", () => {

--- a/platform/backend/src/k8s/runner-runtime/manifests.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.test.ts
@@ -165,6 +165,24 @@ describe("buildRunnerJob", () => {
     ).toBe("10Gi");
   });
 
+  it("gives a privileged runner a real filesystem for /var/lib/docker", () => {
+    const unprivileged = buildRunnerJob(SPEC).spec?.template.spec;
+    expect(unprivileged?.volumes?.map((volume) => volume.name)).toEqual([
+      "archestra-run",
+    ]);
+
+    const privileged = buildRunnerJob({ ...SPEC, privileged: true }).spec
+      ?.template.spec;
+    expect(privileged?.volumes).toContainEqual({
+      name: "docker-lib",
+      emptyDir: { sizeLimit: "10Gi" },
+    });
+    expect(privileged?.containers[0]?.volumeMounts).toContainEqual({
+      name: "docker-lib",
+      mountPath: "/var/lib/docker",
+    });
+  });
+
   it("quotes a configured command so arguments cannot break out", () => {
     const job = buildRunnerJob({
       ...SPEC,

--- a/platform/backend/src/k8s/runner-runtime/manifests.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.ts
@@ -165,6 +165,19 @@ export function buildRunnerJob(spec: KubernetesRunnerLaunchSpec): k8s.V1Job {
               name: "archestra-run",
               emptyDir: { sizeLimit: spec.ephemeralStorageLimit },
             },
+            // A privileged runner is expected to run its own dockerd (kind,
+            // tilt, testcontainers). Docker's overlay2 storage driver cannot
+            // stack on the container's own overlayfs root, and its silent
+            // fallback is vfs — full copies per layer, unusably slow. An
+            // emptyDir gives /var/lib/docker a real (non-overlay) filesystem.
+            ...(spec.privileged
+              ? [
+                  {
+                    name: "docker-lib",
+                    emptyDir: { sizeLimit: spec.ephemeralStorageLimit },
+                  },
+                ]
+              : []),
           ],
           containers: [
             {
@@ -212,6 +225,9 @@ export function buildRunnerJob(spec: KubernetesRunnerLaunchSpec): k8s.V1Job {
               resources: buildResourceRequirements(spec.resources),
               volumeMounts: [
                 { name: "archestra-run", mountPath: RUNNER_RUNTIME_DIR },
+                ...(spec.privileged
+                  ? [{ name: "docker-lib", mountPath: "/var/lib/docker" }]
+                  : []),
               ],
               ...(spec.privileged
                 ? { securityContext: { privileged: true } }

--- a/platform/backend/src/k8s/runner-runtime/manifests.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.ts
@@ -150,6 +150,23 @@ export function buildRunnerJob(spec: KubernetesRunnerLaunchSpec): k8s.V1Job {
         metadata: { labels },
         spec: {
           restartPolicy: "Never",
+          // A dedicated runner pool keeps heavy privileged sessions from
+          // pressuring the platform's own nodes. The selector's pairs double
+          // as tolerations so a pool tainted with the same key=value admits
+          // exactly these pods.
+          ...(Object.keys(spec.nodeSelector).length > 0
+            ? {
+                nodeSelector: spec.nodeSelector,
+                tolerations: Object.entries(spec.nodeSelector).map(
+                  ([key, value]) => ({
+                    key,
+                    operator: "Equal",
+                    value,
+                    effect: "NoSchedule",
+                  }),
+                ),
+              }
+            : {}),
           ...(spec.imagePullSecrets.length > 0
             ? {
                 imagePullSecrets: spec.imagePullSecrets.map((name) => ({

--- a/platform/backend/src/k8s/runner-runtime/network-policy.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/network-policy.test.ts
@@ -13,6 +13,7 @@ const SPEC: KubernetesRunnerLaunchSpec = {
   image: "registry.example.test/agent-archestra:latest",
   command: null,
   privileged: false,
+  nodeSelector: {},
   resources: null,
   env: {},
   secretEnv: {},

--- a/platform/backend/src/models/llm-provider-api-key.ts
+++ b/platform/backend/src/models/llm-provider-api-key.ts
@@ -12,6 +12,7 @@ import {
 import { and, asc, desc, eq, ilike, inArray, ne, or, sql } from "drizzle-orm";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
+import config from "@/config";
 import db, { schema, type Transaction } from "@/database";
 import logger from "@/logging";
 import { getSecretValueForLlmProviderApiKey } from "@/secrets-manager";
@@ -338,10 +339,7 @@ class LlmProviderApiKeyModel {
       eq(schema.llmProviderApiKeysTable.isSystem, true),
       inArray(
         schema.llmProviderApiKeysTable.provider,
-        getProvidersWithOptionalApiKey({
-          azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
-        }),
+        getConfiguredProvidersWithOptionalApiKey(),
       ),
     );
     if (secretOrSystemCondition) {
@@ -492,10 +490,7 @@ class LlmProviderApiKeyModel {
       sql`${schema.llmProviderApiKeysTable.secretId} IS NOT NULL`,
       inArray(
         schema.llmProviderApiKeysTable.provider,
-        getProvidersWithOptionalApiKey({
-          azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
-        }),
+        getConfiguredProvidersWithOptionalApiKey(),
       ),
     );
 
@@ -608,10 +603,7 @@ class LlmProviderApiKeyModel {
             sql`${schema.llmProviderApiKeysTable.secretId} IS NOT NULL`,
             inArray(
               schema.llmProviderApiKeysTable.provider,
-              getProvidersWithOptionalApiKey({
-                azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-                anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
-              }),
+              getConfiguredProvidersWithOptionalApiKey(),
             ),
           ),
         ),
@@ -735,10 +727,7 @@ class LlmProviderApiKeyModel {
       sql`${schema.llmProviderApiKeysTable.secretId} IS NOT NULL`,
       inArray(
         schema.llmProviderApiKeysTable.provider,
-        getProvidersWithOptionalApiKey({
-          azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
-        }),
+        getConfiguredProvidersWithOptionalApiKey(),
       ),
     );
 
@@ -1224,10 +1213,21 @@ function canUseProviderApiKey(
     return true;
   }
 
-  return getProvidersWithOptionalApiKey({
+  return getConfiguredProvidersWithOptionalApiKey().includes(apiKey.provider);
+}
+
+function getConfiguredProvidersWithOptionalApiKey(): SupportedProvider[] {
+  const providers = getProvidersWithOptionalApiKey({
     azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
     anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
-  }).includes(apiKey.provider);
+  });
+  if (config.llm.gemini.vertexAi.enabled) {
+    providers.push("gemini");
+  }
+  if (config.llm.bedrock.iamAuthEnabled) {
+    providers.push("bedrock");
+  }
+  return providers;
 }
 
 export default LlmProviderApiKeyModel;

--- a/platform/backend/src/services/runners/backends/types.ts
+++ b/platform/backend/src/services/runners/backends/types.ts
@@ -32,6 +32,12 @@ export type RunnerLaunchSpec = {
   activeDeadlineSeconds: number | null;
   /** Writable scratch-space ceiling enforced by the execution backend. */
   ephemeralStorageLimit: string;
+  /**
+   * Steers the pod onto a dedicated node pool: applied verbatim as the pod's
+   * nodeSelector, with one matching NoSchedule toleration per entry. Empty
+   * means no steering.
+   */
+  nodeSelector: Record<string, string>;
   imagePullSecrets: string[];
   effectiveNetworkPolicy: EffectiveNetworkPolicy;
   /** Number of durable input files the backend must stage before entrypoint. */

--- a/platform/backend/src/services/runners/launch-spec.test.ts
+++ b/platform/backend/src/services/runners/launch-spec.test.ts
@@ -1,6 +1,7 @@
 import type { SupportedProvider } from "@archestra/shared";
 import config from "@/config";
 import {
+  LlmProviderApiKeyModel,
   LlmProviderApiKeyModelLinkModel,
   ModelModel,
   TeamTokenModel,
@@ -89,6 +90,72 @@ describe("buildRunnerLaunchSpec", () => {
     const virtualKey = await VirtualApiKeyModel.findById(virtualApiKeyId);
     expect(virtualKey?.scope).toBe("personal");
     expect(virtualKey?.authorId).toBe(setup.user.id);
+  });
+
+  test("routes a Gemini Vertex AI execution through its keyless stored credential", async ({
+    makeOrganization,
+    makeAdmin,
+    makeMember,
+    makeAgent,
+  }) => {
+    config.llm.gemini.vertexAi.enabled = true;
+    config.llm.gemini.vertexAi.project = "test-project";
+
+    const organization = await makeOrganization();
+    const user = await makeAdmin();
+    await makeMember(user.id, organization.id, { role: "admin" });
+    const providerKey = await LlmProviderApiKeyModel.create({
+      organizationId: organization.id,
+      secretId: null,
+      name: "Vertex AI workload identity",
+      provider: "gemini",
+      scope: "org",
+      userId: null,
+      teamId: null,
+      baseUrl: null,
+      inferenceBaseUrl: null,
+    });
+    const model = await ModelModel.create({
+      externalId: "gemini/keyless-model",
+      provider: "gemini",
+      modelId: "keyless-model",
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      lastSyncedAt: new Date(),
+    });
+    await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(providerKey.id, [
+      model.id,
+    ]);
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      authorId: user.id,
+      agentType: "agent",
+      modelId: model.id,
+      llmApiKeyId: providerKey.id,
+    });
+
+    const { spec, virtualApiKeyId } = await buildRunnerLaunchSpec({
+      deployment: deployment(agent, "openai_responses"),
+      taskId: crypto.randomUUID(),
+      agentId: agent.id,
+      actor: {
+        id: user.id,
+        kind: "user",
+        organizationId: organization.id,
+      },
+      organizationId: organization.id,
+      runtimeScope: "agent-tests",
+      effectiveNetworkPolicy: { source: "built_in", policy: null },
+      appName: "Archestra",
+      executionMode: "one_shot",
+    });
+
+    expect(spec.secretEnv.OPENAI_API_KEY).toMatch(/^arch_/);
+    const providerVirtualKeys = await VirtualApiKeyModel.findByProviderApiKeyId(
+      providerKey.id,
+    );
+    expect(providerVirtualKeys.map(({ id }) => id)).toContain(virtualApiKeyId);
   });
 
   test("uses organization-scoped access for a system execution actor", async ({

--- a/platform/backend/src/services/runners/launch-spec.ts
+++ b/platform/backend/src/services/runners/launch-spec.ts
@@ -329,6 +329,7 @@ export async function buildRunnerLaunchSpec(params: {
         60,
       ephemeralStorageLimit:
         config.agentBackgroundExecution.ephemeralStorageLimit,
+      nodeSelector: config.agentBackgroundExecution.nodeSelector,
       imagePullSecrets: params.imagePullSecrets ?? [],
       effectiveNetworkPolicy: params.effectiveNetworkPolicy,
       inputFileCount: params.inputFiles?.length ?? 0,

--- a/platform/backend/src/utils/llm-api-key-resolution.ts
+++ b/platform/backend/src/utils/llm-api-key-resolution.ts
@@ -11,7 +11,7 @@ import {
 } from "@archestra/shared";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
-import { getProviderEnvApiKey } from "@/config";
+import config, { getProviderEnvApiKey } from "@/config";
 import logger from "@/logging";
 import { LlmProviderApiKeyModel, ModelModel, TeamModel } from "@/models";
 import { getSecretValueForLlmProviderApiKey } from "@/secrets-manager";
@@ -183,7 +183,9 @@ export async function resolveProviderApiKey(params: {
         provider,
         azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
         anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
-      })
+      }) ||
+      (provider === "gemini" && config.llm.gemini.vertexAi.enabled) ||
+      (provider === "bedrock" && config.llm.bedrock.iamAuthEnabled)
     ) {
       return {
         apiKey: undefined,

--- a/platform/frontend/src/mocks/handlers.ts
+++ b/platform/frontend/src/mocks/handlers.ts
@@ -162,6 +162,21 @@ export const handlers: HttpHandler[] = [
     environments: [],
     defaultAssignedCatalogCount: 0,
   }),
+  // Fetched by the agent settings page's messaging-channels section. No
+  // configured providers and no bindings keep the strict unhandled-request
+  // guard satisfied.
+  ...getJson("/api/chatops/status", { providers: [] }),
+  ...getJson("/api/chatops/bindings", {
+    data: [],
+    pagination: {
+      currentPage: 1,
+      limit: 100,
+      total: 0,
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    },
+  }),
   ...getJson("/api/teams", teamsSeed),
   ...getJson("/api/members", {
     data: [],


### PR DESCRIPTION
## What

Four pieces needed for Lobster Env (in-Archestra task runtime, Crab Env replacement) — see infra#178 for the image/terraform half:

1. **Staging values**: background execution pods inherited a loopback platform URL, which is invalid from a separate Kubernetes pod. Adds `ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLATFORM_BASE_URL` (already applied live to staging).

2. **Keyless execution credentials**: background execution launch rejected stored Gemini credentials with no secret even when Vertex AI/ADC mode is enabled, and would do the same for Bedrock IAM auth. Normal chat already worked through these keyless modes — only the runner launch path discarded them. Blocks Hermes/OpenClaw runtime validation on staging.

3. **Privileged runner DinD mount**: when a runner deployment is `privileged`, mount an emptyDir at `/var/lib/docker` — docker's overlay2 cannot stack on the container's overlayfs root and silently falls back to vfs. Enables in-pod dockerd + kind + tilt (the Crab VM dev-stack parity).

4. **Dedicated runner node pool steering**: new `ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR` env applies a nodeSelector + matching NoSchedule tolerations to runner pods, so heavy privileged sessions land on a dedicated autoscaled pool instead of pressuring the platform's own nodes (staging default pool is ~90% memory-requested with 50GB boot disks). Staging values opt in (`archestra-runners=true`, privileged allowed, 60Gi storage cap).

## Testing

- New behavior test: a Gemini Vertex AI background execution maps through its keyless stored credential (the test reproduced the failure before the fix).
- Manifest tests pin the privileged `/var/lib/docker` emptyDir and the nodeSelector→tolerations behavior; unprivileged/unset behavior unchanged.
- Backend type-check, biome, knip dev+production clean.
- Runtime validated on staging via `#test-joey-slackbot`: Lobster Claude Code completed a full diagnostic (pnpm install, focused tests 29/29, private checkpoint push, MCP call, clean Job completion); Codex validated earlier. Hermes/OpenClaw need this PR deployed (keyless Gemini).
- Env var documented in `platform-deployment.md` + `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)