### PR TITLE
fix(llm): round-trip Gemini 3 thought signatures through the OpenAI chat surface

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
@@ -239,3 +239,105 @@ describe("geminiResponseToOpenai — blocked replies", () => {
     expect(result.choices[0].message.content).toBe("hi");
   });
 });
+
+describe("Gemini 3 thought signature round-trip", () => {
+  const ctx = {
+    chatcmplId: "chatcmpl-test",
+    createdUnix: 1,
+    requestedModel: "gemini-3.7-flash",
+  };
+
+  test("a functionCall's thoughtSignature survives the OpenAI wire format", () => {
+    const response = geminiResponseToOpenai(
+      {
+        candidates: [
+          {
+            finishReason: "STOP",
+            content: {
+              role: "model",
+              parts: [
+                {
+                  functionCall: { name: "run_command", args: { cmd: "ls" } },
+                  thoughtSignature: "sig-abc/123==",
+                },
+              ],
+            },
+          },
+        ],
+      } as Gemini.Types.GenerateContentResponse,
+      ctx,
+    );
+
+    const toolCall = firstToolCall(response);
+    // The wire id carries the signature; the client just echoes it.
+    expect(toolCall.id).toMatch(/^gemsig-/);
+
+    const { geminiBody } = openaiToGemini({
+      model: "gemini-3.7-flash",
+      messages: [
+        { role: "user", content: "list files" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [toolCall],
+        },
+        {
+          role: "tool",
+          tool_call_id: toolCall.id,
+          content: "ok",
+        },
+      ],
+    } as unknown as Parameters<typeof openaiToGemini>[0]);
+
+    const modelTurn = geminiBody.contents[1];
+    expect(modelTurn.role).toBe("model");
+    expect(modelTurn.parts[0]).toMatchObject({
+      functionCall: { name: "run_command", args: { cmd: "ls" } },
+      thoughtSignature: "sig-abc/123==",
+    });
+    // The marker never reaches Gemini: functionCall/functionResponse ids match
+    // and are free of the encoding.
+    const functionCallId = (
+      modelTurn.parts[0] as { functionCall: { id?: string } }
+    ).functionCall.id;
+    const toolTurn = geminiBody.contents[2];
+    const functionResponseId = (
+      toolTurn.parts[0] as { functionResponse: { id?: string } }
+    ).functionResponse.id;
+    expect(functionCallId).not.toMatch(/gemsig-/);
+    expect(functionResponseId).toBe(functionCallId);
+  });
+
+  test("unsigned tool calls keep plain ids in both directions", () => {
+    const response = geminiResponseToOpenai(
+      {
+        candidates: [
+          {
+            finishReason: "STOP",
+            content: {
+              role: "model",
+              parts: [{ functionCall: { id: "call-1", name: "fn", args: {} } }],
+            },
+          },
+        ],
+      } as Gemini.Types.GenerateContentResponse,
+      ctx,
+    );
+    const toolCall = firstToolCall(response);
+    expect(toolCall.id).toBe("call-1");
+
+    const { geminiBody } = openaiToGemini({
+      model: "gemini-3.7-flash",
+      messages: [{ role: "assistant", content: null, tool_calls: [toolCall] }],
+    } as unknown as Parameters<typeof openaiToGemini>[0]);
+    expect(geminiBody.contents[0].parts[0]).toEqual({
+      functionCall: { id: "call-1", name: "fn", args: {} },
+    });
+  });
+});
+
+function firstToolCall(response: ReturnType<typeof geminiResponseToOpenai>) {
+  const toolCall = response.choices[0].message.tool_calls?.[0];
+  if (!toolCall) throw new Error("expected a tool call");
+  return toolCall;
+}

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
@@ -73,12 +73,16 @@ export function openaiToGemini(req: OpenAiRequest): {
       }
       for (const toolCall of message.tool_calls ?? []) {
         if (toolCall.type !== "function") continue;
+        const signed = decodeSignedToolCallId(toolCall.id);
         parts.push({
           functionCall: {
-            id: toolCall.id,
+            id: signed.id,
             name: toolCall.function.name,
             args: parseJsonObject(toolCall.function.arguments),
           },
+          ...(signed.thoughtSignature
+            ? { thoughtSignature: signed.thoughtSignature }
+            : {}),
         });
       }
       if (parts.length > 0) {
@@ -97,7 +101,7 @@ export function openaiToGemini(req: OpenAiRequest): {
         parts: [
           {
             functionResponse: {
-              id: message.tool_call_id,
+              id: decodeSignedToolCallId(message.tool_call_id).id,
               // OpenAI tool result messages only include tool_call_id, not the
               // original function name. Use a stable synthetic name for Gemini.
               name: "tool_result",
@@ -256,9 +260,12 @@ export function geminiResponseToOpenai(
     }
     if ("functionCall" in part && part.functionCall) {
       toolCalls.push({
-        id:
-          part.functionCall.id ??
-          `gemini-call-${part.functionCall.name}-${Date.now()}`,
+        id: encodeSignedToolCallId({
+          id: part.functionCall.id,
+          name: part.functionCall.name,
+          thoughtSignature:
+            "thoughtSignature" in part ? part.thoughtSignature : undefined,
+        }),
         type: "function",
         function: {
           name: part.functionCall.name,
@@ -321,6 +328,54 @@ export function mapGeminiFinishReason(
   if (reason && reason !== "STOP") return "content_filter";
   return "stop";
 }
+
+/**
+ * Gemini 3 rejects conversation history whose functionCall parts lack the
+ * thoughtSignature they were produced with. The OpenAI chat wire format has
+ * no field to carry one, but clients echo tool-call ids verbatim — so the
+ * signature rides inside the id on the way to the client and is unpacked
+ * (and stripped) on the way back upstream.
+ */
+export function encodeSignedToolCallId(params: {
+  id: string | undefined;
+  name: string | undefined;
+  thoughtSignature: string | undefined;
+}): string {
+  const base = params.id ?? `gemini-call-${params.name ?? "fn"}-${Date.now()}`;
+  if (!params.thoughtSignature) {
+    return base;
+  }
+  const encoded = Buffer.from(params.thoughtSignature, "utf8").toString(
+    "base64url",
+  );
+  return `${SIGNED_TOOL_CALL_ID_PREFIX}${encoded}.${base}`;
+}
+
+export function decodeSignedToolCallId(id: string | undefined): {
+  id: string | undefined;
+  thoughtSignature: string | undefined;
+} {
+  if (!id?.startsWith(SIGNED_TOOL_CALL_ID_PREFIX)) {
+    return { id, thoughtSignature: undefined };
+  }
+  const rest = id.slice(SIGNED_TOOL_CALL_ID_PREFIX.length);
+  const dot = rest.indexOf(".");
+  if (dot < 0) {
+    return { id, thoughtSignature: undefined };
+  }
+  try {
+    return {
+      id: rest.slice(dot + 1),
+      thoughtSignature: Buffer.from(rest.slice(0, dot), "base64url").toString(
+        "utf8",
+      ),
+    };
+  } catch {
+    return { id, thoughtSignature: undefined };
+  }
+}
+
+const SIGNED_TOOL_CALL_ID_PREFIX = "gemsig-";
 
 function toGeminiToolChoice(
   toolChoice: OpenAiRequest["tool_choice"],

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
@@ -10,6 +10,7 @@ import type {
 } from "@/types";
 import { geminiAdapterFactory } from "./gemini";
 import {
+  encodeSignedToolCallId,
   type GeminiOpenaiContext,
   geminiResponseToOpenai,
   geminiUsageViewToOpenai,
@@ -138,6 +139,10 @@ class GeminiOpenaiStreamAdapter
   private ctx: GeminiOpenaiContext;
   private toolNameCodec: GeminiToolNameCodec;
   private pendingToolCallEvents: string[] = [];
+  // Gemini 3 thought signatures per tool-call index, mirrored from the chunks
+  // so both SSE emission paths can encode them into the wire tool-call ids.
+  private toolCallSignatures: Map<number, string> = new Map();
+  private seenToolCalls = 0;
 
   constructor(ctx: GeminiOpenaiContext, request?: GeminiRequest) {
     this.inner = geminiAdapterFactory.createStreamAdapter();
@@ -151,6 +156,17 @@ class GeminiOpenaiStreamAdapter
 
   processChunk(chunk: GeminiStreamChunk) {
     const decodedChunk = this.toolNameCodec.decodeResponse(chunk);
+    for (const part of decodedChunk.candidates?.[0]?.content?.parts ?? []) {
+      if ("functionCall" in part && part.functionCall) {
+        if (part.thoughtSignature) {
+          this.toolCallSignatures.set(
+            this.seenToolCalls,
+            part.thoughtSignature,
+          );
+        }
+        this.seenToolCalls += 1;
+      }
+    }
     const innerResult = this.inner.processChunk(decodedChunk);
     const sseData = this.toOpenaiSse(decodedChunk);
 
@@ -197,7 +213,11 @@ class GeminiOpenaiStreamAdapter
         delta: {
           tool_calls: toolCalls.map((toolCall, index) => ({
             index,
-            id: toolCall.id,
+            id: encodeSignedToolCallId({
+              id: toolCall.id,
+              name: toolCall.name,
+              thoughtSignature: this.toolCallSignatures.get(index),
+            }),
             type: "function" as const,
             function: { name: toolCall.name, arguments: toolCall.arguments },
           })),
@@ -251,7 +271,11 @@ class GeminiOpenaiStreamAdapter
             tool_calls: [
               {
                 index: Math.max(this.state.toolCalls.length - 1, 0),
-                id: part.functionCall.id,
+                id: encodeSignedToolCallId({
+                  id: part.functionCall.id,
+                  name: part.functionCall.name,
+                  thoughtSignature: part.thoughtSignature,
+                }),
                 type: "function",
                 function: {
                   name: part.functionCall.name,


### PR DESCRIPTION
## What

Vertex Gemini 3 returns HTTP 400 when conversation history contains functionCall parts without the `thoughtSignature` they were produced with. The native Gemini adapter already preserves signatures (clients echo raw Gemini parts), but the model-router's OpenAI chat translation dropped them — the OpenAI wire format has no field for one — so any `openai_chat` client using tools against a Gemini 3 model died on its second turn.

Observed live: a Lobster Env Hermes background execution on staging made its first call fine, then every tool-history echo 400'd with *"Function call is missing a thought_signature in functionCall parts"*, retried 3×, and the Job failed. OpenClaw (`openai_responses` + Gemini) is expected to share the underlying gap.

## How

Clients echo tool-call ids verbatim, so the signature rides inside the id:

- **Out** (streaming per-chunk SSE, buffered post-policy tool-call SSE, and the non-streaming response): ids become `gemsig-<base64url(signature)>.<original-id>` when a signature is present; unsigned calls keep plain ids.
- **In** (`openaiToGemini`): the marker is decoded back into `part.thoughtSignature` and stripped from the `functionCall`/`functionResponse` ids Gemini sees, keeping them consistent.

Stateless by design: survives multiple proxy replicas and client-side conversation persistence (an in-memory signature cache would break on both).

## Testing

- New behavior tests: full round-trip (signature emitted in the wire id → reattached as `thoughtSignature`, marker stripped from both ids Gemini sees) and the unsigned-id no-op path.
- Full gemini adapter + model-router suites: 153/153 passing; backend type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>