### PR TITLE
feat(chat): list background executions in the search palette and fix locked-chat icons

### DIFF
--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -15,7 +15,6 @@ import {
   PinOff,
   Sparkles,
   Square,
-  TerminalSquare,
   Trash2,
   UsersRound,
 } from "lucide-react";
@@ -26,6 +25,7 @@ import { ConversationProjectActions } from "@/app/_parts/conversation-project-ac
 import { CreateProjectFromChatDialog } from "@/app/_parts/create-project-from-chat-dialog";
 import { isScheduledRunConversation } from "@/app/_parts/scheduled-run-sidebar.utils";
 import { AgentIcon } from "@/components/agent-icon";
+import { ExecutionStateIcon } from "@/components/chat/execution-state-icon";
 import { LockedChatIcon } from "@/components/chat/locked-chat-icon";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
@@ -685,7 +685,6 @@ export function ChatSidebarSection({
     execution: (typeof executionSessions)[number],
   ) => {
     const active = currentExecutionTaskId === execution.taskId;
-    const terminalState = executionStateIcon(execution.state);
     const menuKey = `execution:${execution.taskId}`;
     const isMenuOpen = openMenuId === menuKey;
     const isEditing = editingExecutionId === execution.taskId;
@@ -720,20 +719,10 @@ export function ChatSidebarSection({
               className="cursor-pointer flex-1"
             >
               <span className="flex min-w-0 flex-1 items-center gap-2">
-                {terminalState.spinning ? (
-                  <Loader2
-                    aria-label={terminalState.label}
-                    className={cn(
-                      "size-3.5 shrink-0 animate-spin",
-                      terminalState.className,
-                    )}
-                  />
-                ) : (
-                  <TerminalSquare
-                    aria-label={terminalState.label}
-                    className={cn("size-3.5 shrink-0", terminalState.className)}
-                  />
-                )}
+                <ExecutionStateIcon
+                  state={execution.state}
+                  className="size-3.5"
+                />
                 <TruncatedText
                   message={execution.title}
                   maxLength={MAX_TITLE_LENGTH}
@@ -962,9 +951,9 @@ export function ChatSidebarSection({
     (left, right) =>
       new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime(),
   );
-  // Executions are operational sessions, so do not hide them behind the
-  // conversation-only search palette. Keep the usual number of chat rows and
-  // add every execution row, still sorted as one timeline.
+  // Executions are operational sessions, so keep every one of them visible
+  // instead of counting them against the chat slots — the rows still sort
+  // into the same timeline.
   const visibleSlots = slots + executionSessions.length;
   const showMore = recentUnpinnedChats.length > slots;
 
@@ -1096,39 +1085,4 @@ export function ChatSidebarSection({
       />
     </>
   );
-}
-
-function executionStateIcon(state: string): {
-  label: string;
-  className: string;
-  spinning: boolean;
-} {
-  switch (state) {
-    case "TASK_STATE_SUBMITTED":
-      return {
-        label: "Execution starting",
-        className: "text-amber-500",
-        spinning: true,
-      };
-    case "TASK_STATE_WORKING":
-    case "TASK_STATE_INPUT_REQUIRED":
-      return {
-        label: "Execution running",
-        className: "text-emerald-500",
-        spinning: false,
-      };
-    case "TASK_STATE_FAILED":
-    case "TASK_STATE_REJECTED":
-      return {
-        label: "Execution failed",
-        className: "text-destructive",
-        spinning: false,
-      };
-    default:
-      return {
-        label: "Execution finished",
-        className: "text-muted-foreground",
-        spinning: false,
-      };
-  }
 }

--- a/platform/frontend/src/components/agent-execution-credential-prompt.tsx
+++ b/platform/frontend/src/components/agent-execution-credential-prompt.tsx
@@ -4,7 +4,6 @@ import { KeyRound } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { ExecutionCredentialConnectionDialog } from "@/components/execution-credential-connection-dialog";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { useFeature } from "@/lib/config/config.query";
 import {
@@ -62,27 +61,37 @@ export function AgentExecutionCredentialPrompt({
       : "Add this personal secret from the Agent details page.";
 
   return (
-    <Alert variant="warning" className="mt-3">
-      <KeyRound />
-      <AlertTitle>
-        {missing.length === 1
-          ? `${missing[0].label} is required`
-          : `${missing.length} connections are required`}
-      </AlertTitle>
-      <AlertDescription className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
-        <p>{helperText}</p>
+    <>
+      {/* Deliberately slimmer than an <Alert>: this sits directly under the
+          composer, where a full padded alert block dwarfs the input row. */}
+      <div
+        role="alert"
+        className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-amber-500/50 bg-amber-50 px-2.5 py-1.5 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-950/50 dark:text-amber-200"
+      >
+        <KeyRound className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+        <span className="font-medium">
+          {missing.length === 1
+            ? `${missing[0].label} is required`
+            : `${missing.length} connections are required`}
+        </span>
+        <span className="text-amber-800 dark:text-amber-300">{helperText}</span>
         {definition ? (
           <Button
             type="button"
             size="sm"
             variant="outline"
-            className="h-8 shrink-0 bg-background"
+            className="ml-auto h-6 shrink-0 bg-background px-2 text-xs"
             onClick={() => setConnecting(definition)}
           >
             Connect
           </Button>
         ) : (
-          <Button asChild size="sm" variant="outline" className="h-8 shrink-0">
+          <Button
+            asChild
+            size="sm"
+            variant="outline"
+            className="ml-auto h-6 shrink-0 px-2 text-xs"
+          >
             <Link
               href={`/agents/${agentId}?tab=overview#background-execution-credentials`}
             >
@@ -90,7 +99,7 @@ export function AgentExecutionCredentialPrompt({
             </Link>
           </Button>
         )}
-      </AlertDescription>
+      </div>
       {connecting && (
         <ExecutionCredentialConnectionDialog
           definition={connecting}
@@ -100,6 +109,6 @@ export function AgentExecutionCredentialPrompt({
           onClose={() => setConnecting(null)}
         />
       )}
-    </Alert>
+    </>
   );
 }

--- a/platform/frontend/src/components/chat/execution-state-icon.tsx
+++ b/platform/frontend/src/components/chat/execution-state-icon.tsx
@@ -1,0 +1,70 @@
+import { Loader2, TerminalSquare } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The background-execution mark: a terminal glyph colored by the session's
+ * state (spinner while starting). The single source for every execution-row
+ * affordance (sidebar rows, search palette) so the visual stays consistent.
+ */
+export function ExecutionStateIcon({
+  state,
+  className,
+}: {
+  state: string;
+  className?: string;
+}) {
+  const visual = executionStateVisual(state);
+  if (visual.spinning) {
+    return (
+      <Loader2
+        aria-label={visual.label}
+        className={cn(
+          "shrink-0 animate-spin",
+          visual.colorClassName,
+          className,
+        )}
+      />
+    );
+  }
+  return (
+    <TerminalSquare
+      aria-label={visual.label}
+      className={cn("shrink-0", visual.colorClassName, className)}
+    />
+  );
+}
+
+function executionStateVisual(state: string): {
+  label: string;
+  colorClassName: string;
+  spinning: boolean;
+} {
+  switch (state) {
+    case "TASK_STATE_SUBMITTED":
+      return {
+        label: "Execution starting",
+        colorClassName: "text-amber-500",
+        spinning: true,
+      };
+    case "TASK_STATE_WORKING":
+    case "TASK_STATE_INPUT_REQUIRED":
+      return {
+        label: "Execution running",
+        colorClassName: "text-emerald-500",
+        spinning: false,
+      };
+    case "TASK_STATE_FAILED":
+    case "TASK_STATE_REJECTED":
+      return {
+        label: "Execution failed",
+        colorClassName: "text-destructive",
+        spinning: false,
+      };
+    default:
+      return {
+        label: "Execution finished",
+        colorClassName: "text-muted-foreground",
+        spinning: false,
+      };
+  }
+}

--- a/platform/frontend/src/components/chat/locked-chat-icon.tsx
+++ b/platform/frontend/src/components/chat/locked-chat-icon.tsx
@@ -5,11 +5,18 @@ import { cn } from "@/lib/utils";
  * The locked-chat mark: a lock. The single source for every locked-chat
  * affordance (sidebar rows, composer toggle, search palette) so the visual
  * stays consistent. Inherits currentColor, so it needs no per-theme variants.
+ *
+ * Renders the bare svg (no wrapper element): container rules that size row
+ * icons — e.g. cmdk's `[&_svg]` selectors — must see this icon exactly like
+ * its lucide siblings, or it ends up a different size than the icons beside
+ * it. A wrapper whose inner svg was sized with `size-full` did exactly that.
  */
 export function LockedChatIcon({ className }: { className?: string }) {
   return (
-    <span className={cn("relative inline-block shrink-0", className)}>
-      <Lock role="img" aria-label="Locked chat" className="block size-full" />
-    </span>
+    <Lock
+      role="img"
+      aria-label="Locked chat"
+      className={cn("shrink-0", className)}
+    />
   );
 }

--- a/platform/frontend/src/components/conversation-search-palette.test.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.test.tsx
@@ -8,13 +8,17 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }));
 
-const { mockRouterPush, mockDeleteMutate, mockUseConversations } = vi.hoisted(
-  () => ({
-    mockRouterPush: vi.fn(),
-    mockDeleteMutate: vi.fn(),
-    mockUseConversations: vi.fn(),
-  }),
-);
+const {
+  mockRouterPush,
+  mockDeleteMutate,
+  mockUseConversations,
+  mockUseMyAgentExecutions,
+} = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+  mockDeleteMutate: vi.fn(),
+  mockUseConversations: vi.fn(),
+  mockUseMyAgentExecutions: vi.fn(),
+}));
 
 vi.mock("next/navigation");
 
@@ -47,6 +51,10 @@ vi.mock("@/lib/chat/chat.query", () => ({
   usePinConversation: () => ({
     mutate: vi.fn(),
   }),
+}));
+
+vi.mock("@/lib/agent-background-execution.query", () => ({
+  useMyAgentExecutions: mockUseMyAgentExecutions,
 }));
 
 // Store the onValueChange callback so tests can control selectedValue
@@ -176,6 +184,10 @@ describe("ConversationSearchPalette", () => {
       isLoading: false,
       isFetching: false,
     });
+    mockUseMyAgentExecutions.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
     capturedOnValueChange = null;
   });
 
@@ -263,6 +275,89 @@ describe("ConversationSearchPalette", () => {
     expect(screen.getByText("Pinned conversation")).toBeInTheDocument();
     // Pinned rows show their date bucket too.
     expect(screen.getByText("Today")).toBeInTheDocument();
+  });
+
+  it("shows the lock as the only leading icon on locked chat rows", () => {
+    mockUseConversations.mockReturnValue({
+      data: [
+        {
+          id: "conv-locked",
+          title: "Locked conversation",
+          updatedAt: new Date().toISOString(),
+          lastMessageAt: new Date().toISOString(),
+          lockedChat: true,
+          messages: [],
+        },
+      ],
+      isLoading: false,
+      isFetching: false,
+    });
+
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    const row = screen.getByTestId("cmd-item-conv-conv-locked");
+    expect(screen.getByLabelText("Locked chat")).toBeInTheDocument();
+    // The lock replaces the chat-bubble glyph rather than sitting next to it.
+    expect(row.querySelector(".lucide-message-circle")).toBeNull();
+  });
+
+  it("lists background execution sessions in the browse view and opens one", () => {
+    mockUseMyAgentExecutions.mockReturnValue({
+      data: [
+        {
+          taskId: "task-1",
+          title: "Nightly report run",
+          state: "TASK_STATE_WORKING",
+          startedAt: new Date().toISOString(),
+          stateChangedAt: new Date().toISOString(),
+          endedAt: null,
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    expect(screen.getByText("Nightly report run")).toBeInTheDocument();
+    // The row carries the same state-colored execution mark as the sidebar.
+    expect(screen.getByLabelText("Execution running")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("cmd-item-exec-task-1"));
+    expect(mockRouterPush).toHaveBeenCalledWith("/chat/executions/task-1");
+  });
+
+  it("matches execution sessions by title during search", () => {
+    mockUseConversations.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+    });
+    mockUseMyAgentExecutions.mockReturnValue({
+      data: [
+        {
+          taskId: "task-1",
+          title: "Nightly report run",
+          state: "TASK_STATE_COMPLETED",
+          startedAt: new Date().toISOString(),
+          stateChangedAt: new Date().toISOString(),
+          endedAt: new Date().toISOString(),
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    fireEvent.change(screen.getByTestId("command-input"), {
+      target: { value: "nightly" },
+    });
+    expect(screen.getByText("Nightly report run")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("command-input"), {
+      target: { value: "does-not-match" },
+    });
+    expect(screen.queryByText("Nightly report run")).not.toBeInTheDocument();
+    expect(screen.getByText("No chats or pages found.")).toBeInTheDocument();
   });
 
   it("routes Connect to the connection page", () => {

--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -10,6 +10,7 @@ import {
   isNavItemPermitted,
 } from "@/app/_parts/studio-nav";
 import { AgentIcon } from "@/components/agent-icon";
+import { ExecutionStateIcon } from "@/components/chat/execution-state-icon";
 import { LockedChatIcon } from "@/components/chat/locked-chat-icon";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -36,6 +37,7 @@ import {
   SHORTCUT_SEARCH,
   SHORTCUT_SIDEBAR,
 } from "@/consts";
+import { useMyAgentExecutions } from "@/lib/agent-background-execution.query";
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
 import { useHasPermissions, usePermissionMap } from "@/lib/auth/auth.query";
 import {
@@ -190,6 +192,18 @@ export function ConversationSearchPalette({
     search: debouncedSearch,
   });
 
+  // Background execution sessions live in the same sidebar timeline as chats,
+  // so the palette lists them too (searched client-side by title — they have
+  // no message bodies for the backend conversation search to match).
+  const backgroundExecutionEnabled =
+    useFeature("agentBackgroundExecution") === true;
+  const { data: executionSessions = [] } = useMyAgentExecutions(
+    open &&
+      isAuthenticated &&
+      canReadConversation === true &&
+      backgroundExecutionEnabled,
+  );
+
   const navigationDestinations = useNavigationDestinations();
 
   // Show skeleton during typing or initial fetch
@@ -210,15 +224,44 @@ export function ConversationSearchPalette({
     );
   }, [recentChatsView, searchQuery, navigationDestinations]);
 
-  const browseConversations = useMemo(() => {
+  // The conversation search runs on the backend; execution sessions carry no
+  // message bodies, so their titles are matched here instead.
+  const matchingExecutions = useMemo(() => {
+    const normalizedQuery = debouncedSearch.trim().toLocaleLowerCase();
+    if (!normalizedQuery) return [];
+    return executionSessions.filter((execution) =>
+      execution.title.toLocaleLowerCase().includes(normalizedQuery),
+    );
+  }, [executionSessions, debouncedSearch]);
+
+  const browseItems = useMemo(() => {
     if (debouncedSearch.trim()) {
       return null;
     }
     return {
       pinned: conversations.filter((c) => c.pinnedAt),
-      unpinned: conversations.filter((c) => !c.pinnedAt),
+      // Executions sort into the same timeline as chats, mirroring the
+      // sidebar's merged recents list.
+      recent: [
+        ...conversations
+          .filter((c) => !c.pinnedAt)
+          .map((item) => ({
+            kind: "conversation" as const,
+            item,
+            timestamp: item.lastMessageAt,
+          })),
+        ...executionSessions.map((item) => ({
+          kind: "execution" as const,
+          item,
+          timestamp: item.stateChangedAt ?? item.startedAt,
+        })),
+      ].sort(
+        (left, right) =>
+          new Date(right.timestamp).getTime() -
+          new Date(left.timestamp).getTime(),
+      ),
     };
-  }, [conversations, debouncedSearch]);
+  }, [conversations, executionSessions, debouncedSearch]);
 
   // Reset state on every open/close transition.
   // Clearing on open handles stale chars from macOS dead keys (e.g. Option+N inserts ˜
@@ -452,16 +495,20 @@ export function ConversationSearchPalette({
         className="flex flex-col items-start gap-1.5 px-3 py-2.5 cursor-pointer aria-selected:bg-accent rounded-sm w-full relative"
       >
         <div className="flex items-start gap-2 w-full min-w-0">
-          <IconComponent className="h-4 w-4 shrink-0 text-muted-foreground" />
-          {conv.lockedChat && (
+          {/* One leading icon per row: the lock replaces the chat/pin glyph
+              for locked chats (same size and color, so the column of icons
+              stays aligned). */}
+          {conv.lockedChat ? (
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <LockedChatIcon className="mt-0.5 h-3.5 w-3.5" />
+                  <LockedChatIcon className="h-4 w-4 text-muted-foreground" />
                 </TooltipTrigger>
                 <TooltipContent side="top">Locked chat</TooltipContent>
               </Tooltip>
             </TooltipProvider>
+          ) : (
+            <IconComponent className="h-4 w-4 shrink-0 text-muted-foreground" />
           )}
           {conv.share && (
             <TooltipProvider>
@@ -514,6 +561,31 @@ export function ConversationSearchPalette({
       </CommandItem>
     );
   };
+
+  const renderExecutionItem = (
+    execution: (typeof executionSessions)[number],
+    opts?: { dateLabel?: string },
+  ) => (
+    <CommandItem
+      key={`exec-${execution.taskId}`}
+      value={`exec-${execution.taskId}`}
+      onSelect={() => {
+        router.push(`/chat/executions/${execution.taskId}`);
+        onOpenChange(false);
+      }}
+      className="flex items-center gap-2 px-3 py-2.5 cursor-pointer aria-selected:bg-accent rounded-sm w-full"
+    >
+      <ExecutionStateIcon state={execution.state} className="h-4 w-4" />
+      <span className="text-sm flex-1 min-w-0 truncate leading-snug">
+        {execution.title}
+      </span>
+      {opts?.dateLabel && (
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {opts.dateLabel}
+        </span>
+      )}
+    </CommandItem>
+  );
 
   const renderNavigationItems = () =>
     matchingNavigationItems.map((item) => {
@@ -578,9 +650,12 @@ export function ConversationSearchPalette({
               <CommandGroup heading="Chats">
                 <SearchSkeleton />
               </CommandGroup>
-            ) : conversations.length > 0 ? (
+            ) : conversations.length > 0 || matchingExecutions.length > 0 ? (
               <CommandGroup heading="Chats">
                 {conversations.map((conv) => renderConversationItem(conv))}
+                {matchingExecutions.map((execution) =>
+                  renderExecutionItem(execution),
+                )}
               </CommandGroup>
             ) : matchingNavigationItems.length === 0 ? (
               <CommandEmpty>
@@ -616,25 +691,26 @@ export function ConversationSearchPalette({
             {/* Only when there is something under it. A reader who has never
                 started a chat was shown the heading over empty space, between
                 the New chat row and Pages. */}
-            {!recentChatsView && conversations.length > 0 && (
-              <>
-                <CommandSeparator className="my-2" />
+            {!recentChatsView &&
+              (conversations.length > 0 || executionSessions.length > 0) && (
+                <>
+                  <CommandSeparator className="my-2" />
 
-                <div className="px-2 pb-1.5">
-                  <div className="flex items-center justify-between px-1">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      Chats
-                    </span>
+                  <div className="px-2 pb-1.5">
+                    <div className="flex items-center justify-between px-1">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        Chats
+                      </span>
+                    </div>
                   </div>
-                </div>
-              </>
-            )}
+                </>
+              )}
 
-            {browseConversations ? (
+            {browseItems ? (
               <>
-                {browseConversations.pinned.length > 0 && (
+                {browseItems.pinned.length > 0 && (
                   <CommandGroup heading="Pinned">
-                    {browseConversations.pinned.map((conv) =>
+                    {browseItems.pinned.map((conv) =>
                       renderConversationItem(conv, {
                         showPinIcon: true,
                         dateLabel: getDateBucketLabel(conv.lastMessageAt),
@@ -642,20 +718,26 @@ export function ConversationSearchPalette({
                     )}
                   </CommandGroup>
                 )}
-                {browseConversations.unpinned.length > 0 && (
+                {browseItems.recent.length > 0 && (
                   <CommandGroup>
-                    {browseConversations.unpinned.map((conv) =>
-                      renderConversationItem(conv, {
-                        dateLabel: getDateBucketLabel(conv.lastMessageAt),
-                      }),
+                    {browseItems.recent.map((entry) =>
+                      entry.kind === "conversation"
+                        ? renderConversationItem(entry.item, {
+                            dateLabel: getDateBucketLabel(entry.timestamp),
+                          })
+                        : renderExecutionItem(entry.item, {
+                            dateLabel: getDateBucketLabel(entry.timestamp),
+                          }),
                     )}
                   </CommandGroup>
                 )}
-                {recentChatsView && conversations.length === 0 && (
-                  <div className="py-4 text-center text-sm text-muted-foreground">
-                    No recent chats
-                  </div>
-                )}
+                {recentChatsView &&
+                  conversations.length === 0 &&
+                  executionSessions.length === 0 && (
+                    <div className="py-4 text-center text-sm text-muted-foreground">
+                      No recent chats
+                    </div>
+                  )}
               </>
             ) : null}
 

--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -496,8 +496,8 @@ export function ConversationSearchPalette({
       >
         <div className="flex items-start gap-2 w-full min-w-0">
           {/* One leading icon per row: the lock replaces the chat/pin glyph
-              for locked chats (same size and color, so the column of icons
-              stays aligned). */}
+              for locked chats, at the same size and color, so the icon
+              column stays aligned. */}
           {conv.lockedChat ? (
             <TooltipProvider>
               <Tooltip>
@@ -689,21 +689,13 @@ export function ConversationSearchPalette({
             </CommandGroup>
 
             {/* Only when there is something under it. A reader who has never
-                started a chat was shown the heading over empty space, between
-                the New chat row and Pages. */}
+                started a chat was shown a separator over empty space, between
+                the New chat row and Pages. The groups below carry their own
+                headings (Pinned / Recent), so no standalone label here — a
+                "Chats" label stacked on "Pinned" read as a double heading. */}
             {!recentChatsView &&
               (conversations.length > 0 || executionSessions.length > 0) && (
-                <>
-                  <CommandSeparator className="my-2" />
-
-                  <div className="px-2 pb-1.5">
-                    <div className="flex items-center justify-between px-1">
-                      <span className="text-xs font-medium text-muted-foreground">
-                        Chats
-                      </span>
-                    </div>
-                  </div>
-                </>
+                <CommandSeparator className="my-2" />
               )}
 
             {browseItems ? (
@@ -719,7 +711,7 @@ export function ConversationSearchPalette({
                   </CommandGroup>
                 )}
                 {browseItems.recent.length > 0 && (
-                  <CommandGroup>
+                  <CommandGroup heading="Recent">
                     {browseItems.recent.map((entry) =>
                       entry.kind === "conversation"
                         ? renderConversationItem(entry.item, {


### PR DESCRIPTION
## Problem

Three issues around the conversation search palette (Cmd+K), plus one regression next to it:

1. Locked-chat rows rendered **two** leading icons — the chat bubble *and* a smaller lock nudged down with an `mt-0.5` hack — so the icon column looked misaligned.
2. The lock icon itself rendered at 20×20 while every sibling icon is 16×16. `LockedChatIcon` wrapped its svg in a span and sized the glyph with `size-full`; the `size-` substring escaped `CommandItem`'s `[&_svg:not([class*='size-'])]:size-4` rule, so `CommandDialog`'s `[&_[cmdk-item]_svg]:h-5` inflated it.
3. Background execution sessions appeared in the sidebar's recents timeline but not in the palette at all.
4. (Adjacent regression from #7561) the missing-execution-credential prompt under the chat composer grew into a full padded Alert block, dwarfing the composer row.

## Changes

- **One leading icon per row**: the lock replaces the bubble/pin glyph for locked chats, at the same size and color. `LockedChatIcon` now renders the bare lucide svg so container `[&_svg]` sizing rules treat it exactly like its siblings (all callers pass size classes that land on the svg unchanged).
- **Background executions in the palette**: merged into the browse view's recents timeline exactly like the sidebar (sorted by `stateChangedAt`/`startedAt`), and matched client-side by title during search (executions have no message bodies for the backend conversation search). Selecting one opens `/chat/executions/:taskId`.
- **Shared `ExecutionStateIcon` component** (`components/chat/execution-state-icon.tsx`): the state-colored terminal glyph / starting spinner previously private to the sidebar now backs both surfaces, so the palette shows the same amber/green/red/muted state colors.
- **Cleaner headings**: the browse view's standalone "Chats" label stacked directly on the "Pinned" group heading and read as a double header; the groups now carry their own **Pinned** / **Recent** headings.
- **Slim credential prompt**: the execution-credential notice is a single-row, `text-xs` banner again instead of a full `Alert`, restoring the tighter footprint it had before the reusable-credentials rework.

## Verification

- Unit tests: locked rows render the lock as the only leading icon; execution rows render with the shared state icon and navigate to the execution session on select; title search matches and excludes executions.
- Verified live in Chrome against a dev stack: sidebar and palette show identical state-colored execution icons; all leading icons measure exactly 16×16 (was 20×20 for locks); search "nightly" surfaces a background session and Enter navigates to its execution page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>