### PR TITLE
fix(llm): resolve real function names for Gemini functionResponse parts

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
@@ -306,6 +306,12 @@ describe("Gemini 3 thought signature round-trip", () => {
     ).functionResponse.id;
     expect(functionCallId).not.toMatch(/gemsig-/);
     expect(functionResponseId).toBe(functionCallId);
+    // Gemini 3 also rejects a functionResponse whose name does not match the
+    // function that was called; the name is resolved from the assistant turn.
+    expect(
+      (toolTurn.parts[0] as { functionResponse: { name: string } })
+        .functionResponse.name,
+    ).toBe("run_command");
   });
 
   test("unsigned tool calls keep plain ids in both directions", () => {

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
@@ -239,3 +239,105 @@ describe("geminiResponseToOpenai — blocked replies", () => {
     expect(result.choices[0].message.content).toBe("hi");
   });
 });
+
+describe("Gemini 3 thought signature round-trip", () => {
+  const ctx = {
+    chatcmplId: "chatcmpl-test",
+    createdUnix: 1,
+    requestedModel: "gemini-3.7-flash",
+  };
+
+  test("a functionCall's thoughtSignature survives the OpenAI wire format", () => {
+    const response = geminiResponseToOpenai(
+      {
+        candidates: [
+          {
+            finishReason: "STOP",
+            content: {
+              role: "model",
+              parts: [
+                {
+                  functionCall: { name: "run_command", args: { cmd: "ls" } },
+                  thoughtSignature: "sig-abc/123==",
+                },
+              ],
+            },
+          },
+        ],
+      } as Gemini.Types.GenerateContentResponse,
+      ctx,
+    );
+
+    const toolCall = firstToolCall(response);
+    // The wire id carries the signature; the client just echoes it.
+    expect(toolCall.id).toMatch(/^gemsig-/);
+
+    const { geminiBody } = openaiToGemini({
+      model: "gemini-3.7-flash",
+      messages: [
+        { role: "user", content: "list files" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [toolCall],
+        },
+        {
+          role: "tool",
+          tool_call_id: toolCall.id,
+          content: "ok",
+        },
+      ],
+    } as unknown as Parameters<typeof openaiToGemini>[0]);
+
+    const modelTurn = geminiBody.contents[1];
+    expect(modelTurn.role).toBe("model");
+    expect(modelTurn.parts[0]).toMatchObject({
+      functionCall: { name: "run_command", args: { cmd: "ls" } },
+      thoughtSignature: "sig-abc/123==",
+    });
+    // The marker never reaches Gemini: functionCall/functionResponse ids match
+    // and are free of the encoding.
+    const functionCallId = (
+      modelTurn.parts[0] as { functionCall: { id?: string } }
+    ).functionCall.id;
+    const toolTurn = geminiBody.contents[2];
+    const functionResponseId = (
+      toolTurn.parts[0] as { functionResponse: { id?: string } }
+    ).functionResponse.id;
+    expect(functionCallId).not.toMatch(/gemsig-/);
+    expect(functionResponseId).toBe(functionCallId);
+  });
+
+  test("unsigned tool calls keep plain ids in both directions", () => {
+    const response = geminiResponseToOpenai(
+      {
+        candidates: [
+          {
+            finishReason: "STOP",
+            content: {
+              role: "model",
+              parts: [{ functionCall: { id: "call-1", name: "fn", args: {} } }],
+            },
+          },
+        ],
+      } as Gemini.Types.GenerateContentResponse,
+      ctx,
+    );
+    const toolCall = firstToolCall(response);
+    expect(toolCall.id).toBe("call-1");
+
+    const { geminiBody } = openaiToGemini({
+      model: "gemini-3.7-flash",
+      messages: [{ role: "assistant", content: null, tool_calls: [toolCall] }],
+    } as unknown as Parameters<typeof openaiToGemini>[0]);
+    expect(geminiBody.contents[0].parts[0]).toEqual({
+      functionCall: { id: "call-1", name: "fn", args: {} },
+    });
+  });
+});
+
+function firstToolCall(response: ReturnType<typeof geminiResponseToOpenai>) {
+  const toolCall = response.choices[0].message.tool_calls?.[0];
+  if (!toolCall) throw new Error("expected a tool call");
+  return toolCall;
+}

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
@@ -48,6 +48,18 @@ export function openaiToGemini(req: OpenAiRequest): {
   const systemParts: Array<{ text: string }> = [];
   const contents: GeminiRequest["contents"] = [];
 
+  // Gemini 3 validates that a functionResponse's name matches the function
+  // that was called; OpenAI tool messages carry only tool_call_id, so the
+  // names are resolved from the assistant messages' tool_calls.
+  const toolCallNames = new Map<string, string>();
+  for (const message of req.messages as LooseMessage[]) {
+    for (const toolCall of message.tool_calls ?? []) {
+      if (toolCall.type === "function" && toolCall.id) {
+        toolCallNames.set(toolCall.id, toolCall.function.name);
+      }
+    }
+  }
+
   for (const message of req.messages as LooseMessage[]) {
     if (message.role === "system" || message.role === "developer") {
       systemParts.push({ text: stringifyTextContent(message.content) });
@@ -102,9 +114,13 @@ export function openaiToGemini(req: OpenAiRequest): {
           {
             functionResponse: {
               id: decodeSignedToolCallId(message.tool_call_id).id,
-              // OpenAI tool result messages only include tool_call_id, not the
-              // original function name. Use a stable synthetic name for Gemini.
-              name: "tool_result",
+              // Resolved from the assistant turn that made the call; Gemini 3
+              // rejects a functionResponse whose name does not match it. The
+              // synthetic fallback only covers a result with no visible call.
+              name:
+                (message.tool_call_id
+                  ? toolCallNames.get(message.tool_call_id)
+                  : undefined) ?? "tool_result",
               response: { content: stringifyTextContent(message.content) },
             },
           },

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
@@ -73,12 +73,16 @@ export function openaiToGemini(req: OpenAiRequest): {
       }
       for (const toolCall of message.tool_calls ?? []) {
         if (toolCall.type !== "function") continue;
+        const signed = decodeSignedToolCallId(toolCall.id);
         parts.push({
           functionCall: {
-            id: toolCall.id,
+            id: signed.id,
             name: toolCall.function.name,
             args: parseJsonObject(toolCall.function.arguments),
           },
+          ...(signed.thoughtSignature
+            ? { thoughtSignature: signed.thoughtSignature }
+            : {}),
         });
       }
       if (parts.length > 0) {
@@ -97,7 +101,7 @@ export function openaiToGemini(req: OpenAiRequest): {
         parts: [
           {
             functionResponse: {
-              id: message.tool_call_id,
+              id: decodeSignedToolCallId(message.tool_call_id).id,
               // OpenAI tool result messages only include tool_call_id, not the
               // original function name. Use a stable synthetic name for Gemini.
               name: "tool_result",
@@ -256,9 +260,12 @@ export function geminiResponseToOpenai(
     }
     if ("functionCall" in part && part.functionCall) {
       toolCalls.push({
-        id:
-          part.functionCall.id ??
-          `gemini-call-${part.functionCall.name}-${Date.now()}`,
+        id: encodeSignedToolCallId({
+          id: part.functionCall.id,
+          name: part.functionCall.name,
+          thoughtSignature:
+            "thoughtSignature" in part ? part.thoughtSignature : undefined,
+        }),
         type: "function",
         function: {
           name: part.functionCall.name,
@@ -321,6 +328,54 @@ export function mapGeminiFinishReason(
   if (reason && reason !== "STOP") return "content_filter";
   return "stop";
 }
+
+/**
+ * Gemini 3 rejects conversation history whose functionCall parts lack the
+ * thoughtSignature they were produced with. The OpenAI chat wire format has
+ * no field to carry one, but clients echo tool-call ids verbatim — so the
+ * signature rides inside the id on the way to the client and is unpacked
+ * (and stripped) on the way back upstream.
+ */
+export function encodeSignedToolCallId(params: {
+  id: string | undefined;
+  name: string | undefined;
+  thoughtSignature: string | undefined;
+}): string {
+  const base = params.id ?? `gemini-call-${params.name ?? "fn"}-${Date.now()}`;
+  if (!params.thoughtSignature) {
+    return base;
+  }
+  const encoded = Buffer.from(params.thoughtSignature, "utf8").toString(
+    "base64url",
+  );
+  return `${SIGNED_TOOL_CALL_ID_PREFIX}${encoded}.${base}`;
+}
+
+export function decodeSignedToolCallId(id: string | undefined): {
+  id: string | undefined;
+  thoughtSignature: string | undefined;
+} {
+  if (!id?.startsWith(SIGNED_TOOL_CALL_ID_PREFIX)) {
+    return { id, thoughtSignature: undefined };
+  }
+  const rest = id.slice(SIGNED_TOOL_CALL_ID_PREFIX.length);
+  const dot = rest.indexOf(".");
+  if (dot < 0) {
+    return { id, thoughtSignature: undefined };
+  }
+  try {
+    return {
+      id: rest.slice(dot + 1),
+      thoughtSignature: Buffer.from(rest.slice(0, dot), "base64url").toString(
+        "utf8",
+      ),
+    };
+  } catch {
+    return { id, thoughtSignature: undefined };
+  }
+}
+
+const SIGNED_TOOL_CALL_ID_PREFIX = "gemsig-";
 
 function toGeminiToolChoice(
   toolChoice: OpenAiRequest["tool_choice"],

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai.ts
@@ -10,6 +10,7 @@ import type {
 } from "@/types";
 import { geminiAdapterFactory } from "./gemini";
 import {
+  encodeSignedToolCallId,
   type GeminiOpenaiContext,
   geminiResponseToOpenai,
   geminiUsageViewToOpenai,
@@ -138,6 +139,10 @@ class GeminiOpenaiStreamAdapter
   private ctx: GeminiOpenaiContext;
   private toolNameCodec: GeminiToolNameCodec;
   private pendingToolCallEvents: string[] = [];
+  // Gemini 3 thought signatures per tool-call index, mirrored from the chunks
+  // so both SSE emission paths can encode them into the wire tool-call ids.
+  private toolCallSignatures: Map<number, string> = new Map();
+  private seenToolCalls = 0;
 
   constructor(ctx: GeminiOpenaiContext, request?: GeminiRequest) {
     this.inner = geminiAdapterFactory.createStreamAdapter();
@@ -151,6 +156,17 @@ class GeminiOpenaiStreamAdapter
 
   processChunk(chunk: GeminiStreamChunk) {
     const decodedChunk = this.toolNameCodec.decodeResponse(chunk);
+    for (const part of decodedChunk.candidates?.[0]?.content?.parts ?? []) {
+      if ("functionCall" in part && part.functionCall) {
+        if (part.thoughtSignature) {
+          this.toolCallSignatures.set(
+            this.seenToolCalls,
+            part.thoughtSignature,
+          );
+        }
+        this.seenToolCalls += 1;
+      }
+    }
     const innerResult = this.inner.processChunk(decodedChunk);
     const sseData = this.toOpenaiSse(decodedChunk);
 
@@ -197,7 +213,11 @@ class GeminiOpenaiStreamAdapter
         delta: {
           tool_calls: toolCalls.map((toolCall, index) => ({
             index,
-            id: toolCall.id,
+            id: encodeSignedToolCallId({
+              id: toolCall.id,
+              name: toolCall.name,
+              thoughtSignature: this.toolCallSignatures.get(index),
+            }),
             type: "function" as const,
             function: { name: toolCall.name, arguments: toolCall.arguments },
           })),
@@ -251,7 +271,11 @@ class GeminiOpenaiStreamAdapter
             tool_calls: [
               {
                 index: Math.max(this.state.toolCalls.length - 1, 0),
-                id: part.functionCall.id,
+                id: encodeSignedToolCallId({
+                  id: part.functionCall.id,
+                  name: part.functionCall.name,
+                  thoughtSignature: part.thoughtSignature,
+                }),
                 type: "function",
                 function: {
                   name: part.functionCall.name,


### PR DESCRIPTION
## What

Follow-up to #7581. With thought signatures now round-tripping, Vertex Gemini 3's next history validation fires: a `functionResponse` whose `name` does not match the function that was called returns a bare `INVALID_ARGUMENT` 400 (observed on the second Lobster Hermes staging run — first call fine, tool-history echo 400s).

The OpenAI chat translation used a synthetic `"tool_result"` name because OpenAI tool messages carry only `tool_call_id`. Resolve the real name from the assistant turns' `tool_calls` (id → name map over the request history); the synthetic name remains only for a result with no visible call.

## Verification

Bisected against **live Vertex `gemini-3.7-flash`** (global endpoint) using a captured real thought signature:
- our exact previous shape (`name: "tool_result"`) → `400 INVALID_ARGUMENT`
- identical request with the matching name → success

Round-trip behavior test extended to pin the resolved name; translator suite 12/12; backend type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)