### PR TITLE
Add Plyo MCP servers to the catalog

### DIFF
--- a/mcp-catalog/data/mcp-servers.json
+++ b/mcp-catalog/data/mcp-servers.json
@@ -888,5 +888,7 @@
   "https://agenttools.wolfram.com/mcp",
   "https://mcp.notion.com/mcp",
   "https://github.com/moorcheh-ai/memanto/tree/main/integrations/mcp",
-  "https://mcp.circleci.com/v1/mcp"
+  "https://mcp.circleci.com/v1/mcp",
+  "https://github.com/plyo-dev/plyo-mcp",
+  "https://api.plyo.dev/mcp"
 ]


### PR DESCRIPTION
Adds two entries for [Plyo](https://plyo.dev), a hosting and versioning service for AI-built projects aimed at people who don't code:

- `https://github.com/plyo-dev/plyo-mcp` — stdio server on npm (`npx plyo-mcp`), MIT
- `https://api.plyo.dev/mcp` — remote streamable-http endpoint

Both are published on the official MCP registry (`io.github.plyo-dev/plyo-mcp` and `dev.plyo/plyo`). Tools cover saving restorable checkpoints of a project, publishing it to a live URL with a pre-publish secret scan, drafts with preview links, agent-readable build errors, and database backups.

Added URLs only so your evaluation pipeline can generate the manifests — happy to add the evaluation JSON files directly if you'd prefer that.