### PR TITLE
fix(agents): configurable pod start timeout for scale-from-zero pools

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -87,6 +87,9 @@ archestra:
     ARCHESTRA_AGENT_BACKGROUND_EXECUTION_ALLOW_PRIVILEGED: "true"
     ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR: "archestra-runners=true"
     ARCHESTRA_AGENT_BACKGROUND_EXECUTION_EPHEMERAL_STORAGE_LIMIT: "60Gi"
+    # Scale-from-zero on the runners pool plus a cold multi-GB image pull can
+    # take 6+ minutes before the container starts.
+    ARCHESTRA_AGENT_BACKGROUND_EXECUTION_POD_START_TIMEOUT_SECONDS: "900"
     # BETA: auto-sync-permissions connectors (off by default everywhere else).
     # Explicit so staging keeps the feature even if ARCHESTRA_BETA is ever
     # flipped off.

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -857,6 +857,9 @@ Background execution runs delegated Agent tasks in dedicated Kubernetes pods. Yo
 - **`ARCHESTRA_AGENT_BACKGROUND_EXECUTION_EPHEMERAL_STORAGE_LIMIT`** - Maximum writable scratch space for one execution. Kubernetes enforces the limit on the run's `emptyDir` volume.
   - Default: `10Gi`
 
+- **`ARCHESTRA_AGENT_BACKGROUND_EXECUTION_POD_START_TIMEOUT_SECONDS`** - How long a launched run may stay pending before it is declared failed. Raise it when runs land on an autoscaled node pool — node creation plus a large image pull can pass the default.
+  - Default: `600`
+
 - **`ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR`** - Steers background pods onto a dedicated node pool, written as `key=value` pairs. The pairs become each pod's node selector, with a matching `NoSchedule` toleration per pair. Empty schedules background pods like any other workload. Use it when heavy runs should not share nodes with the platform.
   - Default: unset
 

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -600,6 +600,9 @@ ARCHESTRA_AGENT_BACKGROUND_EXECUTION_ENABLED=false
 # pods' nodeSelector, with a matching NoSchedule toleration per entry. Empty
 # schedules runners like any other pod.
 # ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR=archestra-runners=true
+# How long a launched run may stay Pending (node scale-up + image pull)
+# before it is declared failed.
+# ARCHESTRA_AGENT_BACKGROUND_EXECUTION_POD_START_TIMEOUT_SECONDS=600
 # Base URL a background pod uses to reach the LLM proxy and MCP gateway. Must be
 # reachable from inside the cluster; defaults to ARCHESTRA_INTERNAL_API_BASE_URL.
 # With neither set, starting a run fails loudly rather than letting an agent

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2348,6 +2348,17 @@ const config = {
       {},
       "ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NODE_SELECTOR",
     ),
+    /**
+     * How long a launched run may stay Pending before it is declared failed.
+     * Covers node scale-up of a dedicated (scale-to-zero) runner pool plus a
+     * cold multi-GB image pull, which together overran the old fixed 5-minute
+     * limit; a genuinely unavailable image just takes this long to surface.
+     */
+    podStartTimeoutSeconds: parsePositiveInt(
+      process.env
+        .ARCHESTRA_AGENT_BACKGROUND_EXECUTION_POD_START_TIMEOUT_SECONDS,
+      600,
+    ),
     /** How often the reconciler syncs runner state and applies TTL/idle stops. */
     reconcileIntervalSeconds: parsePositiveInt(
       process.env

--- a/platform/backend/src/services/runners/backends/kubernetes.ts
+++ b/platform/backend/src/services/runners/backends/kubernetes.ts
@@ -56,7 +56,9 @@ class KubernetesRunnerBackend implements RunnerBackend {
     session: AgentRun;
     abortSignal?: AbortSignal;
   }): Promise<void> {
-    const deadline = Date.now() + POD_START_TIMEOUT_MS;
+    const deadline =
+      Date.now() +
+      config.agentBackgroundExecution.podStartTimeoutSeconds * 1000;
 
     while (!params.abortSignal?.aborted) {
       const pod = await runnerRuntimeManager.findPodPhase(params.session);
@@ -145,7 +147,6 @@ export const kubernetesRunnerBackend = new KubernetesRunnerBackend();
 
 const POD_START_POLL_MS = 1_000;
 /** An image pull on a cold node is the slow case this has to tolerate. */
-const POD_START_TIMEOUT_MS = 5 * 60_000;
 /** From the start of the session: a task's own output is the whole transcript. */
 const RUNNER_LOG_TAIL_LINES = Number.MAX_SAFE_INTEGER;
 


### PR DESCRIPTION
## What

A background run launched onto the dedicated (scale-to-zero) runners pool can spend ~4 minutes on node scale-up plus ~2 minutes pulling a multi-GB image. The pod start deadline was a fixed `POD_START_TIMEOUT_MS = 5min`, so the reconciler declared the run failed — and deleted its env Secret — at the exact moment the container was starting (observed live: an OpenClaw Lobster run on staging died with `secret "runner-…-env" not found` right after a successful 2.9GB pull at t+6:15).

The limit becomes `ARCHESTRA_AGENT_BACKGROUND_EXECUTION_POD_START_TIMEOUT_SECONDS` (default raised to 600); staging values set 900. A genuinely unavailable image just takes correspondingly longer to surface.

## Testing

- Runner suites 19/19; backend type-check clean.
- Env var documented in `platform-deployment.md` + `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>