### PR TITLE
fix(agents): drain the runner stdout mirror before the pane exits

### DIFF
--- a/platform/backend/src/k8s/runner-runtime/manifests.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.test.ts
@@ -272,6 +272,13 @@ describe("the container bootstrap", () => {
     expect(script()).not.toContain("sleep 10");
   });
 
+  it("drains the stdout mirror before the pane exits", () => {
+    // A one-shot agent writes its whole answer in its final instant; without
+    // the drain the pane exit tears down pipe-pane first and the transcript
+    // ends up empty.
+    expect(script()).toContain('agent session exited"; sleep 2; exit');
+  });
+
   it("lets terminal wheel events scroll tmux history", () => {
     expect(script()).toContain("tmux set-option -t agent mouse on");
     expect(script().indexOf("mouse on")).toBeLessThan(

--- a/platform/backend/src/k8s/runner-runtime/manifests.ts
+++ b/platform/backend/src/k8s/runner-runtime/manifests.ts
@@ -95,7 +95,13 @@ function buildRunnerBootstrapScript(): string {
     `  exit ${RUNNER_UNUSABLE_IMAGE_EXIT_CODE}`,
     "fi",
     `printf '%s\\n' "$ARCHESTRA_AGENT_BACKGROUND_EXECUTION_ENTRYPOINT" > ${RUNNER_RUNTIME_DIR}/entry.sh`,
-    `printf '%s\n' '/bin/sh ${RUNNER_RUNTIME_DIR}/entry.sh; status=$?; printf "%s\\n" "$status" > ${exitCodeFile}; echo; echo "[runner] agent session exited"; exit "$status"' > ${RUNNER_RUNTIME_DIR}/session.sh`,
+    // The sleep before the pane exits is the drain for the pipe-pane mirror
+    // below: a one-shot CLI writes its entire result in its final instant, and
+    // a pane that exits with that burst still in the pty buffer takes the
+    // mirror down before it is copied out — the durable transcript (and the
+    // completion message built from it) arrives empty while the pane showed a
+    // full answer.
+    `printf '%s\n' '/bin/sh ${RUNNER_RUNTIME_DIR}/entry.sh; status=$?; printf "%s\\n" "$status" > ${exitCodeFile}; echo; echo "[runner] agent session exited"; sleep 2; exit "$status"' > ${RUNNER_RUNTIME_DIR}/session.sh`,
     // Create the pane before starting the Agent so its output cannot race the
     // pipe setup. A fast one-shot client used to finish before pipe-pane was
     // attached, leaving its durable transcript empty.


### PR DESCRIPTION
## Problem

Every Claude Code background run's completion message was an empty string — Slack threads got a bare **"Task finished."** with no report, and `agent_runs.logs` was 0 bytes for every run (while Hermes/Codex runs, which stream progressively, had full transcripts).

## Cause

The runner mirrors the tmux pane to container stdout via `tmux pipe-pane`. A one-shot CLI (`claude --print`) writes its **entire** answer in its final instant and exits; the pane exit tears the mirror down before the burst is copied out, so the pod log — the source of the task's final answer text — stays empty. Streaming runtimes only ever risked losing a trailing line, which is why the bug looked runtime-specific.

## Fix

`session.sh` sleeps 2s after the agent exits, before the pane exits, giving the mirror time to drain. Test pins the drain between the exit marker and the pane exit.

## Validation

- `manifests.test.ts` 26/26 (new: "drains the stdout mirror before the pane exits")
- Observed on staging: runs `runner-lobster-claude-code-{46fce2b1,591d9df6,25b7e0e4}` all logs_len=0; hermes runs 4-14KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>