### PR TITLE
fix(a2a): keep file parts when building the response artifact

### DIFF
--- a/platform/backend/src/agents/a2a/a2a-manager.tasks.test.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.tasks.test.ts
@@ -83,6 +83,28 @@ async function sendMessage(params: {
   });
 }
 
+function mockExecutorTextAndFile(
+  text: string,
+  file: { url: string; mediaType: string; filename?: string },
+) {
+  executeA2AMessage.mockImplementation(
+    async (args: { onTextDelta?: (d: string) => void }) => {
+      const messageId = crypto.randomUUID();
+      args.onTextDelta?.(text);
+      return {
+        messageId,
+        text,
+        finishReason: "stop",
+        responseUiMessage: {
+          id: messageId,
+          role: "assistant",
+          parts: [{ type: "text", text }, { type: "file", ...file }],
+        },
+      };
+    },
+  );
+}
+
 function mockExecutorText(text: string) {
   executeA2AMessage.mockImplementation(
     async (args: { onTextDelta?: (d: string) => void }) => {
@@ -341,6 +363,43 @@ describe("A2AManager full task mode", () => {
     expect(seal?.artifactUpdate?.lastChunk).toBe(true);
     expect(seal?.artifactUpdate?.artifact.parts).toEqual([
       { text: "The answer" },
+    ]);
+  });
+
+  test("a file the agent produced is delivered as an artifact part", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "agent1", teams: [] });
+    const manager = fullManager();
+    mockExecutorTextAndFile("Here is the chart", {
+      url: "https://files.example.com/chart.pdf",
+      mediaType: "application/pdf",
+      filename: "chart.pdf",
+    });
+
+    const response = await sendMessage({
+      manager,
+      agentId: agent.id,
+      taskRun: { createTask: true, detached: false },
+    });
+
+    if (!response.task) throw new Error("expected a task response");
+    // The text is coalesced into one part; the file survives beside it, so a
+    // caller reading the task gets something it can actually fetch instead of
+    // a filename mentioned in prose.
+    expect(response.task.artifacts).toEqual([
+      {
+        artifactId: expect.any(String),
+        name: "agent-response",
+        parts: [
+          { text: "Here is the chart" },
+          {
+            url: "https://files.example.com/chart.pdf",
+            mediaType: "application/pdf",
+            filename: "chart.pdf",
+          },
+        ],
+      },
     ]);
   });
 

--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -624,6 +624,12 @@ export class A2AManager {
               messages: requestMessages,
               organizationId: actor.organizationId,
               userId: actor.kind === "user" ? actor.id : "system",
+              // Scope per-execution state to the A2A context. Without a key the
+              // executor treats this as a direct execution outside a
+              // conversation, generates a throwaway one and cleans the state up
+              // when the run ends — which orphans anything the agent produced.
+              // Stateless mode has no context and keeps that behaviour.
+              isolationKey: context?.id,
               sessionId,
               source: systemParams?.source,
               parentDelegationChain: undefined, // This is the root call, chain starts with agentId

--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -624,12 +624,6 @@ export class A2AManager {
               messages: requestMessages,
               organizationId: actor.organizationId,
               userId: actor.kind === "user" ? actor.id : "system",
-              // Scope per-execution state to the A2A context. Without a key the
-              // executor treats this as a direct execution outside a
-              // conversation, generates a throwaway one and cleans the state up
-              // when the run ends — which orphans anything the agent produced.
-              // Stateless mode has no context and keeps that behaviour.
-              isolationKey: context?.id,
               sessionId,
               source: systemParams?.source,
               parentDelegationChain: undefined, // This is the root call, chain starts with agentId

--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -999,8 +999,15 @@ export class A2AManager {
           },
         },
       };
-      const finalParts: { text: string }[] = [
+      // Text is coalesced into one part (the stream appended it in chunks),
+      // but a file part is a distinct result and survives the seal —
+      // flattening it into the joined text would drop the very thing the
+      // caller asked for.
+      const finalParts: A2AProtocolPart[] = [
         { text: parts.map((part) => part.text ?? "").join("") },
+        ...parts.filter(
+          (part) => part.url !== undefined || part.raw !== undefined,
+        ),
       ];
       await A2ATaskModel.completeRun({
         taskId,
@@ -1814,6 +1821,18 @@ function extractProtocolPartsFromUIMessage(
   for (const part of parts) {
     if (part.type === "text") {
       protocolParts.push({ text: part.text });
+      continue;
+    }
+    // A file the agent produced is a result, and results are delivered as
+    // artifacts (A2A v1.0 §3.7). Dropping it here leaves the caller with the
+    // filename in prose and no way to reach the bytes. Mirrors the inbound
+    // direction, which already reconstructs file parts.
+    if (part.type === "file") {
+      protocolParts.push({
+        url: part.url,
+        mediaType: part.mediaType,
+        ...(part.filename ? { filename: part.filename } : {}),
+      });
     }
   }
   return protocolParts;


### PR DESCRIPTION
Closes #7594.

An agent that produces a file cannot send it over A2A. The caller receives the
filename in the reply text and nothing else.

Two lines drop it, both in `a2a-manager.ts`.

**1. The UI-message mapping keeps only text.**

```ts
if (part.type === "text") {
  protocolParts.push({ text: part.text });
}
// a `file` part falls through the loop and is lost
```

**2. `completeRun`'s artifact is built as a single text part.**

```ts
const finalParts: { text: string }[] = [
  { text: parts.map((part) => part.text ?? "").join("") },
];
// a file part has no .text, so it contributes "" and disappears
```

This PR keeps file parts in both places, carrying `url` + `mediaType` +
`filename`.

**What does not change:** a text-only run is identical — the added filter matches
nothing and the artifact still seals as one text part. The existing assertions in
`a2a-manager.tasks.test.ts` pass unchanged; one new test covers the file case.
`A2ATaskModel.completeRun` already accepted `A2AProtocolPart[]`, so no signature
changed.

Inbound file parts are already handled (`a2a-manager.ts:415`) — this makes the
outbound direction match.
