### PR TITLE
feat(agents): render the native TUI for delegated Claude Code runs

### DIFF
--- a/platform/agent_images/bin/archestra-claude-code
+++ b/platform/agent_images/bin/archestra-claude-code
@@ -48,10 +48,84 @@ case "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_MODE:-one_shot}" in
     exec claude "${args[@]}" "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK:?}"
     ;;
   one_shot)
-    # Delegation surfaces have nobody attached to exit the TUI. Print mode
-    # produces one terminal result and exits so the task can settle and report
-    # back to Slack, MCP, schedules, or an A2A caller.
-    exec claude --print "${args[@]}" "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK:?}"
+    # Delegation has nobody attached to exit a TUI, which is why this mode
+    # exists — but `--print` draws NOTHING until the final answer, so the
+    # execution's live terminal sits blank for the whole run and a person who
+    # attaches cannot tell a working session from a wedged one.
+    #
+    # Run the real TUI instead, and give it the completion contract print mode
+    # provided for free: a Stop hook fires when the turn ends, writes the final
+    # assistant message out of the transcript, and drops a marker. A watchdog
+    # sees the marker, ends the session, and prints the answer behind the
+    # platform's fence — so the task still settles on one clean terminal
+    # result while the pane shows the native interface throughout.
+    #
+    # ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLAIN=1 forces the old print mode.
+    if [[ "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLAIN:-0}" == "1" ]] \
+      || ! command -v jq >/dev/null 2>&1; then
+      exec claude --print "${args[@]}" "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK:?}"
+    fi
+
+    answer_file="${runtime_dir}/final-answer.txt"
+    done_marker="${runtime_dir}/turn-complete"
+    hook_script="${runtime_dir}/stop-hook.sh"
+    settings_file="${runtime_dir}/claude-settings.json"
+    rm -f "${answer_file}" "${done_marker}"
+
+    # The hook is handed the session JSON on stdin, including the transcript
+    # path. The last assistant text in that JSONL is the final answer —
+    # written before the marker so the watchdog never sees a marker without
+    # an answer beside it.
+    cat > "${hook_script}" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+runtime_dir="${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_RUNTIME_DIR:-/var/run/archestra}"
+payload="$(cat)"
+transcript="$(jq -r '.transcript_path // empty' <<<"${payload}")"
+if [[ -n "${transcript}" && -r "${transcript}" ]]; then
+  jq -rs '[.[]
+      | select(.type == "assistant")
+      | .message.content
+      | if type == "array" then (map(select(.type == "text") | .text) | join("")) else . end
+      | select(. != null and . != "")
+    ] | last // ""' "${transcript}" > "${runtime_dir}/final-answer.txt" 2>/dev/null || true
+fi
+touch "${runtime_dir}/turn-complete"
+HOOK
+    chmod 0700 "${hook_script}"
+    jq -n --arg cmd "${hook_script}" \
+      '{hooks:{Stop:[{matcher:"",hooks:[{type:"command",command:$cmd}]}]}}' \
+      > "${settings_file}"
+    args+=(--settings "${settings_file}")
+
+    claude "${args[@]}" "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_TASK:?}" &
+    claude_pid=$!
+
+    # Bounded by the run's own lifetime: the pod's TTL and the platform's
+    # cancellation both outrank this loop, so it never becomes the reason a
+    # session hangs. A vanished process without a marker means Claude Code
+    # exited on its own — normal for an error path.
+    while kill -0 "${claude_pid}" 2>/dev/null; do
+      if [[ -f "${done_marker}" ]]; then
+        # Let the pane settle on the finished frame before tearing it down,
+        # then end the session the way a person would.
+        sleep 2
+        kill -TERM "${claude_pid}" 2>/dev/null || true
+        break
+      fi
+      sleep 2
+    done
+    wait "${claude_pid}" 2>/dev/null || true
+
+    # The fence tells the platform where the prose starts; without it the
+    # "answer" would be a recording of the TUI redrawing itself.
+    printf '\n===ARCHESTRA-FINAL-ANSWER===\n'
+    if [[ -s "${answer_file}" ]]; then
+      cat "${answer_file}"
+    else
+      echo "The session ended without producing a final message."
+    fi
+    printf '\n'
     ;;
   *)
     echo "archestra: unknown Background execution mode" >&2

--- a/platform/backend/src/services/runners/pod-execution.test.ts
+++ b/platform/backend/src/services/runners/pod-execution.test.ts
@@ -1,7 +1,7 @@
 import config from "@/config";
 import { afterEach, describe, expect, test } from "@/test";
 import type { AgentBackgroundExecution } from "@/types";
-import { resolveAgentDeployment } from "./pod-execution";
+import { extractFinalAnswer, resolveAgentDeployment } from "./pod-execution";
 
 const originalEnabled = config.agentBackgroundExecution.enabled;
 
@@ -50,3 +50,35 @@ const agentWithDeployment = {
   backgroundExecution,
   backgroundExecutionSecretId: "secret-1",
 };
+
+describe("extractFinalAnswer", () => {
+  test("returns the whole transcript when no runtime fenced an answer", () => {
+    // Every one-shot runtime, and any image predating the fence.
+    expect(extractFinalAnswer("the whole answer\n")).toBe("the whole answer\n");
+  });
+
+  test("keeps only what the runtime fenced, dropping the TUI recording", () => {
+    const transcript = [
+      "\u001b[2J\u001b[H╭─ Claude Code ─╮",
+      "│ working...    │",
+      "",
+      "===ARCHESTRA-FINAL-ANSWER===",
+      "Fixed the divider and opened PR #7.",
+    ].join("\n");
+    expect(extractFinalAnswer(transcript)).toBe(
+      "Fixed the divider and opened PR #7.",
+    );
+  });
+
+  test("takes the last fence when a TUI scrolled an earlier one back", () => {
+    const transcript =
+      "===ARCHESTRA-FINAL-ANSWER===\nstale redraw\n===ARCHESTRA-FINAL-ANSWER===\nthe real answer";
+    expect(extractFinalAnswer(transcript)).toBe("the real answer");
+  });
+
+  test("falls back to the transcript when the fence has nothing after it", () => {
+    // The runtime died mid-write; a partial recording beats an empty answer.
+    const transcript = "some output\n===ARCHESTRA-FINAL-ANSWER===\n";
+    expect(extractFinalAnswer(transcript)).toBe(transcript);
+  });
+});

--- a/platform/backend/src/services/runners/pod-execution.ts
+++ b/platform/backend/src/services/runners/pod-execution.ts
@@ -297,7 +297,7 @@ async function followBackgroundTask(params: {
     // the answer at exactly the point the reader cares about.
     await Promise.race([streaming, delayMs(LOG_DRAIN_GRACE_MS)]);
 
-    const text = transcript.join("");
+    const text = extractFinalAnswer(transcript.join(""));
 
     if (completion.outcome === "failed") {
       throw new ApiError(
@@ -394,6 +394,33 @@ function delayMs(ms: number, signal?: AbortSignal): Promise<void> {
     }
     signal?.addEventListener("abort", finish, { once: true });
   });
+}
+
+/**
+ * Fence a maintained image writes its final answer between when the agent
+ * ran under a full-screen TUI. The pane transcript is then a screen
+ * recording — cursor moves, redraws, box glyphs — and joining it produces
+ * an unreadable "answer". A runtime that renders a TUI prints the fence and
+ * the answer once, after the session ends, so the reader gets prose.
+ *
+ * Absent (every one-shot runtime, and any image that predates this), the
+ * whole transcript is the answer, exactly as before.
+ */
+const FINAL_ANSWER_FENCE = "===ARCHESTRA-FINAL-ANSWER===";
+
+/**
+ * Take what a runtime fenced as its final answer, else the whole transcript.
+ * The LAST fence wins: a TUI can scroll an earlier one back into view, and
+ * the runtime prints the real one after the session is over.
+ */
+/** @public — exercised through pod-execution.test.ts */
+export function extractFinalAnswer(transcript: string): string {
+  const start = transcript.lastIndexOf(FINAL_ANSWER_FENCE);
+  if (start === -1) return transcript;
+  const answer = transcript.slice(start + FINAL_ANSWER_FENCE.length);
+  // A fence with nothing after it means the runtime died mid-write; the
+  // transcript is worth more than an empty string.
+  return answer.trim() === "" ? transcript : answer.replace(/^\r?\n/, "");
 }
 
 const LOG_DRAIN_GRACE_MS = 2_000;


### PR DESCRIPTION
Closes the first half of #7580.

## Problem
Delegated runs use `claude --print`, which emits nothing until the final answer — the execution page's live terminal stays blank for the entire run (observed repeatedly while dogfooding: a session with 400+ proxy calls in flight showed an empty pane), and the native TUI only ever appears in Chat.

## Why print mode existed
Not for its output — for its **completion contract**: one terminal result, then exit. An unattended TUI has nobody to close it.

## Fix
Claude Code's `Stop` hook supplies that contract for the real TUI: it fires at end of turn with the transcript path. The runtime installs a hook that writes the final assistant message out of the transcript and drops a marker; a watchdog sees the marker, lets the pane settle, and ends the session. The pane shows the native interface the whole time.

Since the transcript is then a screen recording (redraws, cursor moves, box glyphs), it cannot double as the answer — so the runtime prints the answer once, after the session ends, behind `===ARCHESTRA-FINAL-ANSWER===`, and `pod-execution` takes what follows the **last** fence. **No fence → the whole transcript is the answer, exactly as today**, so Codex/Hermes/OpenClaw and any image predating this are unaffected. `ARCHESTRA_AGENT_BACKGROUND_EXECUTION_PLAIN=1` restores print mode.

## Validation
- `pod-execution.test.ts` 6/6 — fence absent, fence present (TUI recording dropped), last-fence-wins, and empty-fence falls back to the transcript rather than an empty answer.
- `pnpm knip` (dev+production), `pnpm type-check` clean.
- Verified out-of-band that the native TUI renders correctly inside a tmux pane and that the Stop hook fires with a usable `transcript_path`.

Follow-up: the same contract for the other three runtimes needs a per-runtime end-of-turn signal; tracked in #7580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>