### PR TITLE
fix(mcp-base): raise expat to 2.8.4-r0 for CVE-2026-76641/66046

### DIFF
--- a/platform/mcp_server_docker_image/Dockerfile
+++ b/platform/mcp_server_docker_image/Dockerfile
@@ -155,7 +155,12 @@ RUN apk add --no-cache \
    # four installed openssl-origin packages both guarantee the fixed version and bust the
    # stale cache.
    apk add --no-cache --upgrade "openssl>=3.5.8-r0" "openssl-dev>=3.5.8-r0" \
-       "libcrypto3>=3.5.8-r0" "libssl3>=3.5.8-r0"
+       "libcrypto3>=3.5.8-r0" "libssl3>=3.5.8-r0" && \
+   # CVE-2026-76641, CVE-2026-66046: expat vulnerabilities (HIGH) fixed in 2.8.4-r0.
+   # expat is pulled in transitively (python), never named in an `apk add` here, so it
+   # needs its own floor for the same reason the openssl ones above do: the cached layer
+   # never re-runs against a newer index on its own.
+   apk add --no-cache --upgrade "expat>=2.8.4-r0"
 
 # Go toolchain sourced from upstream Alpine-based image (Alpine apk currently ships go-1.25.9-r0)
 COPY --from=go-bin /usr/local/go /usr/local/go


### PR DESCRIPTION
The MCP Server Base Docker Scout scan fails on `expat 2.8.3-r0` — two HIGH CVEs (CVE-2026-76641, CVE-2026-66046), both fixed in `2.8.4-r0`, which I confirmed exists in the Alpine v3.23 main index before pinning. Scout has no suppression mechanism, so this blocks **every** PR in the merge queue (it kicked #7596 out).

`expat` comes in transitively via python and is never named in an `apk add`, so it needed its own floor for the same reason the openssl floors directly above it did: the `RUN` layer is Docker-cached on its instruction text and never re-runs against a newer index on its own. Adding the floor both guarantees the fixed version and busts the stale cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>