### PR TITLE
fix(mcp): hold tool calls through retryable wake races with a configurable wait budget

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1416,8 +1416,8 @@ A2A task streams work across replicas. A client can subscribe on one replica whi
   - Raise it for tools that take a long time to run — a slow scraper or report builder, for example — that otherwise fail with a request-timeout error.
 - The MCP Tasks threshold — how long a call from a Tasks-capable client runs synchronously before becoming a background task — derives from this value: half of it, capped at 10 seconds. Task executions themselves are bounded by the 30-minute task retention window, not this timeout.
 - **`ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS`** - How long, in milliseconds, a tool call is held open while the MCP server behind it wakes from idle hibernation, before being answered with a retryable "still starting, retry shortly" result.
-  - Default: unset — the budget derives from the tool-call timeout above (half of it, capped at 30 seconds), which is 30 seconds under the default timeout.
-  - An explicit value is honored verbatim. Keep it below your clients' own request timeouts, or a client aborts the call first and sees a transport error instead of the retryable answer.
+  - Default: `30000` (30 seconds)
+  - Independent of the tool-call timeout above: that timeout governs the dispatched call and only starts counting once the woken server has accepted it. Keep this value below your clients' own request timeouts, or a client aborts the call first and sees a transport error instead of the retryable answer.
 - **`ARCHESTRA_MCP_SKILLS_ENABLED`** - Beta gate for both directions of the draft MCP Skills extension (SEP-2640): publishing local Skills through gateways and projecting Skills discovered from installed MCP servers.
   - Default: unset (falls back to `ARCHESTRA_BETA`)
   - An explicit `false` keeps both directions off even when the master beta switch is enabled.

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1415,6 +1415,9 @@ A2A task streams work across replicas. A client can subscribe on one replica whi
   - Default: `60000` (60 seconds)
   - Raise it for tools that take a long time to run — a slow scraper or report builder, for example — that otherwise fail with a request-timeout error.
 - The MCP Tasks threshold — how long a call from a Tasks-capable client runs synchronously before becoming a background task — derives from this value: half of it, capped at 10 seconds. Task executions themselves are bounded by the 30-minute task retention window, not this timeout.
+- **`ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS`** - How long, in milliseconds, a tool call is held open while the MCP server behind it wakes from idle hibernation, before being answered with a retryable "still starting, retry shortly" result.
+  - Default: unset — the budget derives from the tool-call timeout above (half of it, capped at 30 seconds), which is 30 seconds under the default timeout.
+  - An explicit value is honored verbatim. Keep it below your clients' own request timeouts, or a client aborts the call first and sees a transport error instead of the retryable answer.
 - **`ARCHESTRA_MCP_SKILLS_ENABLED`** - Beta gate for both directions of the draft MCP Skills extension (SEP-2640): publishing local Skills through gateways and projecting Skills discovered from installed MCP servers.
   - Default: unset (falls back to `ARCHESTRA_BETA`)
   - An explicit `false` keeps both directions off even when the master beta switch is enabled.

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -155,6 +155,12 @@ ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai
 # Defaults to 60000 (60s); raise it for tools that take a long time to execute.
 # ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS=60000
 
+# How long (ms) a tool call is held open while its MCP server wakes from idle
+# hibernation before being answered with a retryable "still starting" result.
+# Unset/0 derives the budget from the tool-call timeout (half of it, max 30s).
+# Keep an explicit value under your clients' own request timeouts.
+# ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS=30000
+
 # Opt-in periodic re-discovery of installed MCP servers' tools: every N minutes each
 # installed server's tool list is re-synced from the live server (add/update/remove,
 # no restart). Unset or 0 disables it (the default).

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -157,8 +157,9 @@ ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai
 
 # How long (ms) a tool call is held open while its MCP server wakes from idle
 # hibernation before being answered with a retryable "still starting" result.
-# Unset/0 derives the budget from the tool-call timeout (half of it, max 30s).
-# Keep an explicit value under your clients' own request timeouts.
+# Defaults to 30000 (30s). Independent of the tool-call timeout, which only
+# starts counting once the woken server accepts the call. Keep it under your
+# clients' own request timeouts.
 # ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS=30000
 
 # Opt-in periodic re-discovery of installed MCP servers' tools: every N minutes each

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -126,9 +126,14 @@ const {
 // SPDX-SnippetBegin
 // SPDX-SnippetCopyrightText: 2026 Archestra Inc.
 // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
-/** The wake response budget the mocked runtime reports, in ms. */
-const { WAKE_RESPONSE_BUDGET_TEST_MS } = vi.hoisted(() => ({
-  WAKE_RESPONSE_BUDGET_TEST_MS: 50,
+/**
+ * The wake response budget the mocked runtime reports, in ms. A mutable
+ * holder rather than a const: the default 50 ms is deliberately below the
+ * funnel's retry beat so wake failures surface immediately, and the tests of
+ * the within-budget retry raise it per test (reset in beforeEach).
+ */
+const { WAKE_BUDGET } = vi.hoisted(() => ({
+  WAKE_BUDGET: { ms: 50 },
 }));
 // SPDX-SnippetEnd
 
@@ -214,7 +219,7 @@ vi.mock("@/k8s/mcp-server-runtime", () => {
       }),
     // Short enough to keep the test fast; the production value is derived from
     // the tool-call timeout and is exercised in hibernation.ee.test.ts.
-    wakeResponseBudgetMs: () => WAKE_RESPONSE_BUDGET_TEST_MS,
+    wakeResponseBudgetMs: () => WAKE_BUDGET.ms,
     // SPDX-SnippetEnd
   };
 });
@@ -287,6 +292,7 @@ describe("McpClient", () => {
     // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
     mockEnsureAwake.mockReset();
     mockEnsureAwake.mockResolvedValue(undefined);
+    WAKE_BUDGET.ms = 50;
     mockIsDeploymentDormant.mockReset();
     mockIsDeploymentDormant.mockReturnValue(false);
     mockRunIfDeploymentServing.mockReset();
@@ -2496,6 +2502,141 @@ describe("McpClient", () => {
         // The failed wake short-circuits before any transport work.
         expect(mockUsesStreamableHttp).not.toHaveBeenCalled();
         expect(mockConnect).not.toHaveBeenCalled();
+      });
+
+      test("a wake that loses a retryable race is re-entered within the reply budget and the call completes", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "local-streamable-http-server__test_tool",
+          description: "Test tool",
+          parameters: {},
+          catalogId: localCatalogId,
+        });
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: localMcpServerId,
+        });
+
+        // Enough budget for the funnel's retry beat; the first attempt loses
+        // the mid-transition race the way a wake superseded by a concurrent
+        // hibernation transition does, and the second finds the server up.
+        WAKE_BUDGET.ms = 5_000;
+        const { McpServerWakeError } = await import("@/k8s/mcp-server-runtime");
+        mockEnsureAwake
+          .mockRejectedValueOnce(
+            new McpServerWakeError("local-streamable-http-server", {
+              detail:
+                "its wake was superseded by a concurrent transition (the deployment is now waking)",
+            }),
+          )
+          .mockResolvedValue(undefined);
+        mockUsesStreamableHttp.mockResolvedValue(true);
+        mockGetHttpEndpointUrl.mockReturnValue("http://localhost:30123/mcp");
+        mockCallTool.mockResolvedValue({
+          content: [{ type: "text", text: "served after the race" }],
+          isError: false,
+        });
+
+        const result = await mcpClient.executeToolCallForOwner(
+          {
+            id: "call_wake_race_retry",
+            name: "local-streamable-http-server__test_tool",
+            arguments: {},
+          },
+          agentOwner(agentId),
+        );
+
+        // The race never reaches the caller: the funnel re-entered the wake
+        // and the call went through to the tool.
+        expect(result.isError).toBe(false);
+        expect(result.content).toEqual([
+          { type: "text", text: "served after the race" },
+        ]);
+        expect(mockEnsureAwake).toHaveBeenCalledTimes(2);
+      });
+
+      test("with too little budget left for another attempt, the race's own retryable reason is the answer", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "local-streamable-http-server__test_tool",
+          description: "Test tool",
+          parameters: {},
+          catalogId: localCatalogId,
+        });
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: localMcpServerId,
+        });
+
+        // Default 50 ms budget: below the retry beat, so the funnel must not
+        // spin — it answers with the race's own reason, still retryable.
+        const { McpServerWakeError } = await import("@/k8s/mcp-server-runtime");
+        mockEnsureAwake.mockRejectedValue(
+          new McpServerWakeError("local-streamable-http-server", {
+            detail:
+              "its wake was superseded by a concurrent transition (the deployment is now waking)",
+          }),
+        );
+
+        const result = await mcpClient.executeToolCallForOwner(
+          {
+            id: "call_wake_race_exhausted",
+            name: "local-streamable-http-server__test_tool",
+            arguments: {},
+          },
+          agentOwner(agentId),
+        );
+
+        expect(result.isError).toBe(true);
+        expect(result.error).toContain("retry shortly");
+        expect(result.error).not.toContain("retrying will not help");
+        expect(mockEnsureAwake).toHaveBeenCalledTimes(1);
+        expect(mockConnect).not.toHaveBeenCalled();
+      });
+
+      test("a stop during the between-attempts pause persists the cancelled marker, not a wake failure", async () => {
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "local-streamable-http-server__test_tool",
+          description: "Test tool",
+          parameters: {},
+          catalogId: localCatalogId,
+        });
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: localMcpServerId,
+        });
+
+        WAKE_BUDGET.ms = 30_000;
+        const controller = new AbortController();
+        const { McpServerWakeError } = await import("@/k8s/mcp-server-runtime");
+        // The first attempt loses a retryable race; the abort lands while the
+        // funnel is pausing before its next attempt, so the pause — not a
+        // second wake or the budget — must end the wait.
+        mockEnsureAwake.mockImplementationOnce(async () => {
+          queueMicrotask(() => controller.abort());
+          throw new McpServerWakeError("local-streamable-http-server");
+        });
+
+        await expect(
+          mcpClient.executeToolCallForOwner(
+            {
+              id: "call_stop_between_wake_attempts",
+              name: "local-streamable-http-server__test_tool",
+              arguments: {},
+            },
+            agentOwner(agentId),
+            undefined,
+            { abortSignal: controller.signal },
+          ),
+        ).rejects.toThrow();
+
+        expect(mockEnsureAwake).toHaveBeenCalledTimes(1);
+        const [logged] = await db
+          .select()
+          .from(schema.mcpToolCallsTable)
+          .where(eq(schema.mcpToolCallsTable.agentId, agentId));
+        expect(logged).toBeDefined();
+        const loggedResult = logged.toolResult as {
+          isError?: boolean;
+          _meta?: { archestraError?: { type?: string } };
+        };
+        expect(loggedResult.isError).toBe(false);
+        expect(loggedResult._meta?.archestraError?.type).toBe("cancelled");
       });
 
       test("a terminally broken deployment surfaces as a do-not-retry error naming the fix", async () => {

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -5218,28 +5218,87 @@ function makeSyntheticResourceToolName(uri: string): string {
 // SPDX-SnippetBegin
 // SPDX-SnippetCopyrightText: 2026 Archestra Inc.
 // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+/**
+ * Pause between wake attempts. The wake's own readiness polls run on a 2 s
+ * cadence, so a shorter beat here only re-reads cluster truth and the lease
+ * table; 1 s keeps a raced attempt from spinning while still resolving the
+ * common "the other transition just finished" case on the next beat.
+ */
+const WAKE_RETRY_DELAY_MS = 1_000;
+
+/**
+ * Hold the tool call while the MCP server behind it wakes, up to the reply
+ * budget ({@link wakeResponseBudgetMs}).
+ *
+ * A single `ensureAwake` can lose a race it is allowed to lose — its
+ * completeWake superseded by a concurrent transition, a hibernating sweep
+ * still holding the transition gate — and reports that as a retryable
+ * `McpServerWakeError`. Those races settle in seconds. Handing them straight
+ * to the caller as "retry shortly" answers turned an in-progress hibernation
+ * into a failed tool call for any client that does not retry, so this loop IS
+ * that retry: it re-enters the wake until the server is up or the budget is
+ * spent, and only then answers. What still surfaces immediately: an abort,
+ * and failures a retry cannot help (a deployment that cannot start).
+ */
 async function waitForMcpServerWake(params: {
   mcpServerId: string;
   mcpServerName: string;
   abortSignal?: AbortSignal;
 }): Promise<void> {
-  if (params.abortSignal?.aborted) {
-    throw params.abortSignal.reason instanceof Error
-      ? params.abortSignal.reason
+  const { abortSignal } = params;
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
       : new Error("The tool call was aborted before the wake");
   }
   const budgetMs = wakeResponseBudgetMs();
-  const wake = withDeadline(
-    McpServerRuntimeManager.ensureAwake(params.mcpServerId),
-    budgetMs,
-    () => new McpServerWakePendingError(params.mcpServerName, budgetMs),
-  );
-  if (!params.abortSignal) {
-    await wake;
-    return;
-  }
+  const deadlineAt = Date.now() + budgetMs;
 
-  const { abortSignal } = params;
+  for (;;) {
+    const attempt = withDeadline(
+      McpServerRuntimeManager.ensureAwake(params.mcpServerId),
+      Math.max(1, deadlineAt - Date.now()),
+      () => new McpServerWakePendingError(params.mcpServerName, budgetMs),
+    );
+    try {
+      await raceWithAbort(attempt, abortSignal);
+      return;
+    } catch (error) {
+      // McpServerWakePendingError is the budget itself running out — it is a
+      // McpServerWakeError subclass, so it must be excluded before the
+      // retryable check or exhaustion would loop one extra beat.
+      if (
+        abortSignal?.aborted ||
+        error instanceof McpServerWakePendingError ||
+        !(error instanceof McpServerWakeError)
+      ) {
+        throw error;
+      }
+      // Too little budget left for another attempt to observe anything new:
+      // answer with the race's own reason, which is already retryable-shaped
+      // and names more than a generic "still pending" would.
+      if (deadlineAt - Date.now() <= WAKE_RETRY_DELAY_MS) {
+        throw error;
+      }
+      logger.debug(
+        { err: error, mcpServerId: params.mcpServerId },
+        "MCP server wake attempt lost a retryable race; re-entering the wake within the reply budget",
+      );
+      await raceWithAbort(
+        new Promise((resolve) => setTimeout(resolve, WAKE_RETRY_DELAY_MS)),
+        abortSignal,
+      );
+    }
+  }
+}
+
+/** Race `work` against the tool call's abort signal, if there is one. */
+async function raceWithAbort<T>(
+  work: Promise<T>,
+  abortSignal: AbortSignal | undefined,
+): Promise<T> {
+  if (!abortSignal) return work;
+
   let onAbort: (() => void) | undefined;
   const aborted = new Promise<never>((_, reject) => {
     onAbort = () => {
@@ -5257,7 +5316,7 @@ async function waitForMcpServerWake(params: {
   });
 
   try {
-    await Promise.race([wake, aborted]);
+    return await Promise.race([work, aborted]);
   } finally {
     if (onAbort) abortSignal.removeEventListener("abort", onAbort);
   }

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2214,16 +2214,16 @@ const config = {
     /**
      * How long (ms) a tool call holds its reply open while the MCP server
      * behind it wakes from idle hibernation, before being answered with the
-     * retryable "still starting, retry shortly" result. 0 (the default)
-     * derives the budget from the tool-call timeout — half of it, at most
-     * 30 s — so the wake can never eat the whole call. An explicit value is
-     * honored verbatim; keep it under the calling client's own request
-     * timeout, or the client aborts first and sees a transport error instead
-     * of the retryable answer.
+     * retryable "still starting, retry shortly" result. Deliberately
+     * independent of `toolCallTimeoutMs`, which governs the dispatched call
+     * and only starts counting once the woken server has accepted it. Keep
+     * this under the calling clients' own request timeouts, or the client
+     * aborts first and sees a transport error instead of the retryable
+     * answer.
      */
     wakeWaitTimeoutMs: parsePositiveInt(
       process.env.ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS,
-      0,
+      30_000,
     ),
     // SPDX-SnippetEnd
     /**

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2208,6 +2208,24 @@ const config = {
       process.env.ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS,
       60000,
     ),
+    // SPDX-SnippetBegin
+    // SPDX-SnippetCopyrightText: 2026 Archestra Inc.
+    // SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+    /**
+     * How long (ms) a tool call holds its reply open while the MCP server
+     * behind it wakes from idle hibernation, before being answered with the
+     * retryable "still starting, retry shortly" result. 0 (the default)
+     * derives the budget from the tool-call timeout — half of it, at most
+     * 30 s — so the wake can never eat the whole call. An explicit value is
+     * honored verbatim; keep it under the calling client's own request
+     * timeout, or the client aborts first and sees a transport error instead
+     * of the retryable answer.
+     */
+    wakeWaitTimeoutMs: parsePositiveInt(
+      process.env.ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS,
+      0,
+    ),
+    // SPDX-SnippetEnd
     /**
      * Both directions of the draft MCP Skills extension: publishing local
      * Skills through gateways and projecting external Skills from installed

--- a/platform/backend/src/k8s/mcp-server-runtime/hibernation.ee.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/hibernation.ee.test.ts
@@ -14,15 +14,37 @@
  * a fleet awake (a silent cost regression nobody notices) or scales away a
  * server an administrator explicitly pinned up.
  */
+import config from "@/config";
 import { describe, expect, test, vi } from "@/test";
 import type { McpServerHibernationMode } from "@/types";
-import { isGroupHibernationAllowed, withDeadline } from "./hibernation.ee";
+import {
+  isGroupHibernationAllowed,
+  wakeResponseBudgetMs,
+  withDeadline,
+} from "./hibernation.ee";
 
 const ALL_MODES: McpServerHibernationMode[] = [
   "inherit",
   "enabled",
   "disabled",
 ];
+
+describe("wakeResponseBudgetMs", () => {
+  // Config mutations here are restored by the shared per-test setup.
+  test("unconfigured: half the tool-call timeout, capped at 30s", () => {
+    config.mcpGateway.wakeWaitTimeoutMs = 0;
+    config.mcpGateway.toolCallTimeoutMs = 40_000;
+    expect(wakeResponseBudgetMs()).toBe(20_000);
+    config.mcpGateway.toolCallTimeoutMs = 600_000;
+    expect(wakeResponseBudgetMs()).toBe(30_000);
+  });
+
+  test("an explicit wake wait timeout is honored verbatim, even past the derived cap", () => {
+    config.mcpGateway.toolCallTimeoutMs = 60_000;
+    config.mcpGateway.wakeWaitTimeoutMs = 45_000;
+    expect(wakeResponseBudgetMs()).toBe(45_000);
+  });
+});
 
 describe("isGroupHibernationAllowed", () => {
   test("the organization toggle is the master switch: off means nothing sleeps", () => {

--- a/platform/backend/src/k8s/mcp-server-runtime/hibernation.ee.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/hibernation.ee.test.ts
@@ -31,16 +31,16 @@ const ALL_MODES: McpServerHibernationMode[] = [
 
 describe("wakeResponseBudgetMs", () => {
   // Config mutations here are restored by the shared per-test setup.
-  test("unconfigured: half the tool-call timeout, capped at 30s", () => {
-    config.mcpGateway.wakeWaitTimeoutMs = 0;
-    config.mcpGateway.toolCallTimeoutMs = 40_000;
-    expect(wakeResponseBudgetMs()).toBe(20_000);
-    config.mcpGateway.toolCallTimeoutMs = 600_000;
+  test("ships a plain 30s default", () => {
+    expect(config.mcpGateway.wakeWaitTimeoutMs).toBe(30_000);
     expect(wakeResponseBudgetMs()).toBe(30_000);
   });
 
-  test("an explicit wake wait timeout is honored verbatim, even past the derived cap", () => {
-    config.mcpGateway.toolCallTimeoutMs = 60_000;
+  test("the configured value is honored verbatim and never derived from the tool-call timeout", () => {
+    // The tool-call timeout governs the dispatched call, which only starts
+    // once the woken server has accepted it — a deliberately tiny value here
+    // must not drag the wake budget down with it.
+    config.mcpGateway.toolCallTimeoutMs = 10_000;
     config.mcpGateway.wakeWaitTimeoutMs = 45_000;
     expect(wakeResponseBudgetMs()).toBe(45_000);
   });

--- a/platform/backend/src/k8s/mcp-server-runtime/hibernation.ee.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/hibernation.ee.ts
@@ -78,10 +78,13 @@ export class McpServerWakeError extends Error {
  * about what happened and nothing about what to do, which is exactly the failure
  * an agent cannot act on.
  *
- * Derived from the existing tool-call knob rather than adding a second one,
- * the same way `taskSyncThresholdMs` is: the wake is only the prologue to the
- * call, so it may claim at most half of what the whole call is allowed, and
- * never more than 30 s. Whatever is left belongs to the tool itself.
+ * An operator who knows their clients' timeouts can pin the budget with
+ * `ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS`, and that value is honored
+ * verbatim. Left unset, the budget is derived from the existing tool-call
+ * knob rather than a second default, the same way `taskSyncThresholdMs` is:
+ * the wake is only the prologue to the call, so it may claim at most half of
+ * what the whole call is allowed, and never more than 30 s. Whatever is left
+ * belongs to the tool itself.
  *
  * Answering early does not abandon the wake. It keeps running under the
  * manager's single-flight entry, so the retry this reply asks for joins the
@@ -89,6 +92,8 @@ export class McpServerWakeError extends Error {
  * the server is usually up.
  */
 export function wakeResponseBudgetMs(): number {
+  const configured = config.mcpGateway.wakeWaitTimeoutMs;
+  if (configured > 0) return configured;
   return Math.min(30_000, Math.floor(config.mcpGateway.toolCallTimeoutMs / 2));
 }
 

--- a/platform/backend/src/k8s/mcp-server-runtime/hibernation.ee.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/hibernation.ee.ts
@@ -78,13 +78,11 @@ export class McpServerWakeError extends Error {
  * about what happened and nothing about what to do, which is exactly the failure
  * an agent cannot act on.
  *
- * An operator who knows their clients' timeouts can pin the budget with
- * `ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS`, and that value is honored
- * verbatim. Left unset, the budget is derived from the existing tool-call
- * knob rather than a second default, the same way `taskSyncThresholdMs` is:
- * the wake is only the prologue to the call, so it may claim at most half of
- * what the whole call is allowed, and never more than 30 s. Whatever is left
- * belongs to the tool itself.
+ * `ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS` (default 30 s) is that budget,
+ * verbatim — deliberately NOT derived from the tool-call timeout, which
+ * governs the dispatched call and only starts counting once the woken server
+ * has accepted it. The number an operator must keep this under is their
+ * CLIENTS' request timeouts, which nothing here can see.
  *
  * Answering early does not abandon the wake. It keeps running under the
  * manager's single-flight entry, so the retry this reply asks for joins the
@@ -92,9 +90,7 @@ export class McpServerWakeError extends Error {
  * the server is usually up.
  */
 export function wakeResponseBudgetMs(): number {
-  const configured = config.mcpGateway.wakeWaitTimeoutMs;
-  if (configured > 0) return configured;
-  return Math.min(30_000, Math.floor(config.mcpGateway.toolCallTimeoutMs / 2));
+  return config.mcpGateway.wakeWaitTimeoutMs;
 }
 
 /**

--- a/platform/backend/src/k8s/mcp-server-runtime/manager-deployment-integration.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager-deployment-integration.test.ts
@@ -27,6 +27,8 @@ import {
   MCP_PRE_HIBERNATION_REPLICAS_ANNOTATION,
 } from "@/k8s/shared";
 import { MCP_SERVER_LAST_USED_REFRESH_INTERVAL_MS } from "@/models/mcp-server";
+// biome-ignore lint/style/noRestrictedImports: runtime-gated EE service import
+import { mcpActiveUseTracker } from "@/services/mcp-active-use.ee";
 import { describe, expect, test } from "@/test";
 import type K8sDeployment from "./k8s-deployment";
 import { McpServerDeploymentFailedError } from "./k8s-deployment";
@@ -812,6 +814,207 @@ describe("McpServerRuntimeManager ↔ K8sDeployment hibernation seam", () => {
       expect(cluster.replicas).toBe(5);
       expect(cluster.annotations).toEqual({});
       expect(deployment.statusSummary.state).not.toBe("hibernated");
+    });
+
+    test("a demand caller racing an armed sweep never ends with a sleeping deployment", async ({
+      makeOrganization,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      // The full demand entry path — active-use registration around the wake,
+      // exactly as the gateway funnel holds it from before the wake through
+      // dispatch — against a sweeper that has every reason to hibernate (the
+      // persisted stamp is stale past the window). Whichever way the
+      // interleaving falls (the sweep hibernates first and the wake brings it
+      // back, or the active-use guard vetoes the sweep), the invariant is the
+      // same: a deployment with a live caller ends awake and unmarked.
+      const cluster = new FakeK8sCluster({ replicas: 1 });
+      const fixtures = {
+        makeOrganization,
+        makeInternalMcpCatalog,
+        makeMcpServer,
+      };
+      const sweeper = await makeIdleCandidate(cluster, fixtures);
+      const demand = await makeIdleCandidate(
+        cluster,
+        fixtures,
+        sweeper.mcpServer.id,
+      );
+
+      config.orchestrator.mcpIdleHibernation.windowSeconds =
+        IDLE_WINDOW_SECONDS;
+      await db
+        .update(schema.mcpServersTable)
+        .set({ lastUsedAt: new Date(Date.now() - IDLE_CUTOFF_MS - 60_000) })
+        .where(eq(schema.mcpServersTable.id, sweeper.mcpServer.id));
+
+      // The caller's demand outlives the sweep tick, the way a dispatched
+      // tool call outlives the wake that preceded it.
+      let releaseCall: () => void = () => {};
+      const callStillRunning = new Promise<void>((resolve) => {
+        releaseCall = resolve;
+      });
+      const demandPath = mcpActiveUseTracker.trackActiveUse(
+        sweeper.mcpServer.id,
+        async () => {
+          await demand.manager.ensureAwake(sweeper.mcpServer.id);
+          await callStillRunning;
+        },
+      );
+      const sweep = sweeper.internals
+        .sweepIdleDeployments()
+        .finally(releaseCall);
+
+      await expect(Promise.all([demandPath, sweep])).resolves.toBeDefined();
+
+      // Awake and unmarked, whoever won each step.
+      expect(cluster.annotations).toEqual({});
+      expect(cluster.replicas).toBeGreaterThanOrEqual(1);
+      expect(sweeper.deployment.statusSummary.state).not.toBe("failed");
+      expect(demand.deployment.statusSummary.state).not.toBe("failed");
+    });
+
+    test("a wake arriving while the hibernate still holds the transition gate waits it out and completes", async ({
+      makeOrganization,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      // The T-1265 interleaving, pinned deterministically: the sweep has
+      // patched the deployment asleep and is still inside its post-hibernate
+      // cleanup (the transition lease is held while the hibernation listeners
+      // run), when demand lands on another replica. The wake must queue
+      // behind the gate — not error, not skip — and finish the full
+      // hibernate → scale-up → annotation-drop sequence.
+      const cluster = new FakeK8sCluster({ replicas: 1 });
+      const fixtures = {
+        makeOrganization,
+        makeInternalMcpCatalog,
+        makeMcpServer,
+      };
+      const sweeper = await makeIdleCandidate(cluster, fixtures);
+      const demand = await makeIdleCandidate(
+        cluster,
+        fixtures,
+        sweeper.mcpServer.id,
+      );
+
+      config.orchestrator.mcpIdleHibernation.windowSeconds =
+        IDLE_WINDOW_SECONDS;
+      await db
+        .update(schema.mcpServersTable)
+        .set({ lastUsedAt: new Date(Date.now() - IDLE_CUTOFF_MS - 60_000) })
+        .where(eq(schema.mcpServersTable.id, sweeper.mcpServer.id));
+
+      // The listener runs under the lease. It fires the demand wake and holds
+      // the gate long enough that the wake verifiably arrives while the
+      // hibernate transition is still in flight.
+      let wake: Promise<void> | undefined;
+      sweeper.manager.registerHibernationListener(async () => {
+        wake = demand.manager.ensureAwake(sweeper.mcpServer.id);
+        await new Promise((resolve) => setTimeout(resolve, 150));
+      });
+
+      await sweeper.internals.sweepIdleDeployments();
+      expect(
+        wake,
+        "the hibernate never ran, so the race was never staged",
+      ).toBeDefined();
+      await expect(wake).resolves.toBeUndefined();
+
+      // The whole story in the API server's own write log: put to sleep,
+      // scaled back up, annotations dropped — in that order, once each.
+      expect(cluster.patchedIntents).toEqual([
+        hibernatePatchBody(1),
+        { spec: { replicas: 1 } },
+        COMPLETE_WAKE_PATCH_BODY,
+      ]);
+      expect(cluster.annotations).toEqual({});
+      expect(cluster.replicas).toBe(1);
+      expect(demand.deployment.statusSummary.state).toBe("running");
+    });
+
+    test("two replicas waking one hibernated deployment: exactly one scale-up and one annotation drop land", async ({
+      makeOrganization,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      // In-process simultaneous demand shares one wake by the single-flight
+      // map; ACROSS replicas the only protection is the transition lease and
+      // the cluster CAS. Both callers must resolve, and the API server must
+      // see exactly one wake's writes — a doubled scale-up or a second
+      // annotation drop is how replica counts and ownership markers get lost.
+      const cluster = new FakeK8sCluster({
+        replicas: 0,
+        annotations: {
+          [MCP_HIBERNATED_ANNOTATION]: "true",
+          [MCP_PRE_HIBERNATION_REPLICAS_ANNOTATION]: "2",
+        },
+      });
+      const fixtures = {
+        makeOrganization,
+        makeInternalMcpCatalog,
+        makeMcpServer,
+      };
+      const first = await makeIdleCandidate(cluster, fixtures);
+      const second = await makeIdleCandidate(
+        cluster,
+        fixtures,
+        first.mcpServer.id,
+      );
+
+      await expect(
+        Promise.all([
+          first.manager.ensureAwake(first.mcpServer.id),
+          second.manager.ensureAwake(first.mcpServer.id),
+        ]),
+      ).resolves.toBeDefined();
+
+      expect(cluster.patchedIntents).toEqual([
+        { spec: { replicas: 2 } },
+        COMPLETE_WAKE_PATCH_BODY,
+      ]);
+      expect(cluster.annotations).toEqual({});
+      expect(cluster.replicas).toBe(2);
+    });
+
+    test("the sweeper never claims a deployment that is mid-wake", async ({
+      makeOrganization,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      // Annotation still on, replicas restored, pod not yet ready: the shape
+      // every deployment passes through while a wake is in flight. A sweep
+      // tick landing exactly here must leave it alone — hibernating it would
+      // scale away the pod the waiting caller's wake just paid for.
+      const cluster = new FakeK8sCluster({
+        replicas: 1,
+        annotations: {
+          [MCP_HIBERNATED_ANNOTATION]: "true",
+          [MCP_PRE_HIBERNATION_REPLICAS_ANNOTATION]: "1",
+        },
+        podComesUp: false,
+      });
+      const { internals, deployment, mcpServer } = await makeIdleCandidate(
+        cluster,
+        { makeOrganization, makeInternalMcpCatalog, makeMcpServer },
+      );
+      expect(deployment.statusSummary.state).toBe("waking");
+
+      config.orchestrator.mcpIdleHibernation.windowSeconds =
+        IDLE_WINDOW_SECONDS;
+      await db
+        .update(schema.mcpServersTable)
+        .set({ lastUsedAt: new Date(Date.now() - IDLE_CUTOFF_MS - 60_000) })
+        .where(eq(schema.mcpServersTable.id, mcpServer.id));
+
+      await expect(internals.sweepIdleDeployments()).resolves.toBeUndefined();
+
+      expect(cluster.patches).toEqual([]);
+      expect(cluster.replicas).toBe(1);
+      expect(cluster.annotations).toEqual({
+        [MCP_HIBERNATED_ANNOTATION]: "true",
+        [MCP_PRE_HIBERNATION_REPLICAS_ANNOTATION]: "1",
+      });
     });
   });
 });

--- a/platform/backend/src/k8s/mcp-server-runtime/manager-deployment-integration.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager-deployment-integration.test.ts
@@ -681,6 +681,40 @@ describe("McpServerRuntimeManager ↔ K8sDeployment hibernation seam", () => {
     expect(deployment.statusSummary.state).toBe("running");
   });
 
+  /**
+   * Race-freedom coverage matrix — every entry path that can move a
+   * deployment through the hibernation states, raced against the others.
+   * "Entry path" means what actually reaches the state machine; callers that
+   * merely wrap one of these inherit its coverage.
+   *
+   * Raced HERE (real manager + real K8sDeployment + real transition-lease
+   * rows + a CAS-enforcing fake API server):
+   *   - sweep × sweep (two replicas) — one scale-to-zero lands
+   *   - sweep × operator write — hibernate aborts cleanly
+   *   - demand (trackActiveUse + ensureAwake, the gateway funnel's shape,
+   *     also reinstall's and the restart route's) × armed sweep
+   *   - demand × the hibernate's still-held transition gate
+   *   - demand × demand (two replicas) — one scale-up + one annotation drop
+   *   - sweep × a mid-wake deployment — never claimed
+   *   - passive refresh (refreshAllStates, the state watch's worker) ×
+   *     demand wake — hibernated and finish-wake shapes
+   *
+   * Pinned elsewhere, cited rather than duplicated:
+   *   - hard reset × demand wake, × queued wake, × concurrent resets —
+   *     routes/mcp-server.hard-reset.test.ts
+   *   - external/foreign replica controllers × sweep —
+   *     hibernation-foreign-scaler.ee.test.ts
+   *   - cross-replica cache divergence and wake-vs-re-zero —
+   *     hibernation-multi-replica.ee.test.ts
+   *   - passive discovery paths that must never wake —
+   *     manager.dormancy.test.ts
+   *   - the action-transition table itself —
+   *     hibernation-state-machine{,.ee}.test.ts
+   *   - the caller-facing funnel's retry-within-budget contract —
+   *     clients/mcp-client.test.ts
+   *   - real-cluster transitions end to end, including "no illegal
+   *     transition was ever refused" — e2e mcp-hibernation*.spec.ts
+   */
   describe("cross-replica concurrency (resourceVersion compare-and-swap)", () => {
     /** One idle, running install ready for a sweep, in its own manager. */
     async function makeIdleCandidate(
@@ -975,6 +1009,90 @@ describe("McpServerRuntimeManager ↔ K8sDeployment hibernation seam", () => {
       ]);
       expect(cluster.annotations).toEqual({});
       expect(cluster.replicas).toBe(2);
+    });
+
+    test("the passive refresh contributes no writes while a wake runs beside it", async ({
+      makeOrganization,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      // The status refresh may FINISH a wake it observes, but it must never
+      // start one: on a hibernated deployment it is read-only, whatever else
+      // is happening. Raced against a demand wake on another replica, the API
+      // server must see exactly the wake's own two writes.
+      const cluster = new FakeK8sCluster({
+        replicas: 0,
+        annotations: {
+          [MCP_HIBERNATED_ANNOTATION]: "true",
+          [MCP_PRE_HIBERNATION_REPLICAS_ANNOTATION]: "1",
+        },
+      });
+      const fixtures = {
+        makeOrganization,
+        makeInternalMcpCatalog,
+        makeMcpServer,
+      };
+      const refresher = await makeIdleCandidate(cluster, fixtures);
+      const waker = await makeIdleCandidate(
+        cluster,
+        fixtures,
+        refresher.mcpServer.id,
+      );
+
+      await expect(
+        Promise.all([
+          refresher.manager.refreshAllStates(),
+          waker.manager.ensureAwake(refresher.mcpServer.id),
+        ]),
+      ).resolves.toBeDefined();
+
+      expect(cluster.patchedIntents).toEqual([
+        { spec: { replicas: 1 } },
+        COMPLETE_WAKE_PATCH_BODY,
+      ]);
+      expect(cluster.annotations).toEqual({});
+      expect(cluster.replicas).toBe(1);
+    });
+
+    test("finish-wake claimed by the refresh and a demand wake at once lands exactly one annotation drop", async ({
+      makeOrganization,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      // Ready pod, annotations still on: both the self-heal refresh and a
+      // demand wake want to write the same completeWake. The cluster CAS
+      // must let exactly one land; the loser converges without erroring and
+      // without a second write.
+      const cluster = new FakeK8sCluster({
+        replicas: 1,
+        annotations: {
+          [MCP_HIBERNATED_ANNOTATION]: "true",
+          [MCP_PRE_HIBERNATION_REPLICAS_ANNOTATION]: "1",
+        },
+      });
+      const fixtures = {
+        makeOrganization,
+        makeInternalMcpCatalog,
+        makeMcpServer,
+      };
+      const refresher = await makeIdleCandidate(cluster, fixtures);
+      const waker = await makeIdleCandidate(
+        cluster,
+        fixtures,
+        refresher.mcpServer.id,
+      );
+
+      await expect(
+        Promise.all([
+          refresher.manager.refreshAllStates(),
+          waker.manager.ensureAwake(refresher.mcpServer.id),
+        ]),
+      ).resolves.toBeDefined();
+
+      expect(cluster.patchedIntents).toEqual([COMPLETE_WAKE_PATCH_BODY]);
+      expect(cluster.annotations).toEqual({});
+      expect(cluster.replicas).toBe(1);
+      expect(waker.deployment.statusSummary.state).toBe("running");
     });
 
     test("the sweeper never claims a deployment that is mid-wake", async ({

--- a/platform/e2e-tests/tests/mcp-hibernation.spec.ts
+++ b/platform/e2e-tests/tests/mcp-hibernation.spec.ts
@@ -60,6 +60,17 @@ const TOOL_CALL_TIMEOUT_MS = 120_000;
 const NOT_RUNNING_ERROR_PATTERN = /not running yet|not ready/i;
 const HIBERNATION_WORDING_PATTERN = /hibernat|waking/i;
 
+/**
+ * Internal wake races (a completeWake superseded by a concurrent transition,
+ * a transition gate another replica held). The demand funnel re-enters the
+ * wake within its reply budget when an attempt loses one of these, so no
+ * caller-facing answer may ever carry this wording — a caller can act on
+ * "still starting, retry" and on a terminal failure, but not on a race it
+ * cannot see.
+ */
+const WAKE_RACE_WORDING_PATTERN =
+  /superseded|concurrent transition|did not finish the deployment's lifecycle transition/i;
+
 /** Callers fired simultaneously at one sleeping deployment. */
 const CONCURRENT_WAKE_CALLERS = 4;
 
@@ -116,6 +127,14 @@ const EARLY_AWAKE_CHECK_MS = hibernationTiming.earlyAwakeCheckMs;
 const PLATFORM_HIBERNATION_TIMEOUT_MS = hibernationTiming.hibernationDeadlineMs;
 
 /**
+ * Cadence of the tight loop that watches for the sweeper's hibernation patch
+ * to land, in the one test that races the transition itself. Small enough
+ * that the first observation is well inside the pod teardown that follows the
+ * patch; large enough not to lean on the API server.
+ */
+const TRANSITION_POLL_MS = 200;
+
+/**
  * A Kubernetes merge patch, which deletes a key by sending null — something
  * the generated `V1Deployment` type cannot express.
  */
@@ -143,15 +162,18 @@ type InstallRow = {
  * being switched on: a deployment that is already asleep must always be
  * wakeable.
  *
- * The last test is the exception, and the reason the rest can take that
- * shortcut safely: with the organization toggle on for the whole file, it
- * lifts this install's own hibernation veto, leaves it genuinely idle, and
- * watches the PLATFORM write the sleeping state itself — the sweep, the window
- * arithmetic and the annotation writing that every injected state above stands
- * in for. Until then the veto is what keeps the armed sweeper out of the other
- * tests' way, which makes it load-bearing rather than decorative. Paying for
- * an idle window in wall-clock time is also why that one test carries
- * `@slow-window`, and why it is last: nothing here may depend on it.
+ * The last three tests are the exception, and the reason the rest can take
+ * that shortcut safely: with the organization toggle on for the whole file,
+ * each lifts this install's own hibernation veto, leaves it genuinely idle,
+ * and watches the PLATFORM write the sleeping state itself — the sweep, the
+ * window arithmetic and the annotation writing that every injected state
+ * above stands in for (the first waits for the sleeping shape to settle
+ * before knocking; the second knocks DURING the transition; the third keeps
+ * knocking throughout it). Until then the veto is what keeps the armed
+ * sweeper out of the other tests' way, which makes it load-bearing rather
+ * than decorative. Paying for an idle window in wall-clock time is also why
+ * those tests carry `@slow-window`, and why they are last: nothing here may
+ * depend on them.
  *
  * What runs end to end against a real API server and kubelet:
  *   sweepIdleDeployments -> hibernate (replicas 0 + both annotations)
@@ -1204,6 +1226,261 @@ test.describe("MCP idle hibernation - on-demand wake", () => {
     } finally {
       // Pin it awake again the moment this test is done with it, whatever
       // happened: the organization toggle stays on until afterAll runs.
+      await makeApiRequest({
+        request,
+        method: "put",
+        urlSuffix: `/api/internal_mcp_catalog/${catalogItemId}`,
+        data: { hibernationMode: "disabled" },
+      }).catch(() => {});
+    }
+  });
+
+  test("a tool call that lands while the platform is still hibernating the deployment wakes it back @slow-window", async ({
+    request,
+    makeApiRequest,
+  }) => {
+    // The previous test races nothing: it waits for the sleeping shape to
+    // settle and only then knocks. This one is about the transition itself —
+    // the sweeper has written its patch, the pod is being torn down, the
+    // post-hibernate cleanup still holds the transition gate — and a caller
+    // shows up NOW. The demand path must queue behind the in-flight
+    // transition and wake the deployment, never disown it ("not running
+    // yet"), and never wedge: the platform put it to sleep, so the platform
+    // owns bringing it back.
+    test.setTimeout(1_140_000);
+    requireRecordedBaseline();
+
+    try {
+      // Same idle arrangement as the sweeper test above: quiet period, a
+      // provable last-used stamp, then hands off.
+      await sleepUntil(Date.now() + LAST_USED_QUIET_PERIOD_MS);
+      const lastUsedBefore = Date.parse(
+        (await readInstall({ request, makeApiRequest })).lastUsedAt ?? "",
+      );
+      expect(await callTestTool(request)).toBe(baselineToolText);
+      const idleSince = Date.now();
+      await expect
+        .poll(
+          async () =>
+            Date.parse(
+              (await readInstall({ request, makeApiRequest })).lastUsedAt ?? "",
+            ),
+          { timeout: 30_000, intervals: CLUSTER_POLL_INTERVALS },
+        )
+        .toBeGreaterThan(lastUsedBefore);
+
+      const awake = await readDeploymentFacts();
+      expect(awake.hibernated).toBeUndefined();
+      const replicasBeforeSleep = awake.replicas ?? 0;
+      expect(replicasBeforeSleep).toBeGreaterThan(0);
+
+      await setHibernationMode({ request, makeApiRequest, mode: "enabled" });
+
+      // Catch the transition the moment it lands. hibernate() writes replicas
+      // 0 and both annotations in one patch, so the first read that sees the
+      // marker is at most one poll interval behind the write — while the
+      // kubelet is still tearing the pod down and the sweeper is still inside
+      // its post-hibernate cleanup. A tight manual loop rather than
+      // expect.poll, because the poll's report formatting would spend the
+      // very window this test exists to hit.
+      const transitionDeadlineMs =
+        idleSince +
+        EARLIEST_LEGAL_HIBERNATION_MS +
+        PLATFORM_HIBERNATION_TIMEOUT_MS;
+      let slept: Awaited<ReturnType<typeof readDeploymentFacts>> | undefined;
+      while (Date.now() < transitionDeadlineMs) {
+        const facts = await readDeploymentFacts();
+        if (facts.hibernated === "true") {
+          slept = facts;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, TRANSITION_POLL_MS));
+      }
+      expect(
+        slept,
+        "the sweeper never hibernated the idle install, so there was no transition to race",
+      ).toBeDefined();
+      const observedAtMs = Date.now();
+      expect(slept?.replicas).toBe(0);
+      expect(slept?.preHibernationReplicas).toBe(String(replicasBeforeSleep));
+
+      // Knock immediately — the call is in flight before anything else runs.
+      // The pod snapshot rides alongside it as evidence of how deep into the
+      // teardown the call landed; it is recorded, not asserted, because the
+      // kubelet's pace is not this platform's contract.
+      const firstCall = callToolOutcome(request);
+      const callFiredAtMs = Date.now();
+      const podsAtCall = await listDeploymentPods().catch(() => []);
+      test.info().annotations.push({
+        type: "mid-transition evidence",
+        description:
+          `call fired ${callFiredAtMs - observedAtMs}ms after the hibernation patch was observed; ` +
+          `pods still present: ${
+            podsAtCall
+              .map(
+                (pod) =>
+                  `${pod.metadata?.name}(${pod.metadata?.deletionTimestamp ? "terminating" : pod.status?.phase})`,
+              )
+              .join(", ") || "none"
+          }`,
+      });
+      // Both timestamps are this process's own clock: the knock verifiably
+      // happened at the transition, not after the dust settled.
+      expect(callFiredAtMs - observedAtMs).toBeLessThan(1_000);
+
+      // The demand path may answer the first knock either way — with the
+      // server's real output (the wake finished inside the reply budget) or,
+      // when a cold pod genuinely outlives the budget, with the retryable
+      // still-starting answer. What it may NEVER say: that the deployment is
+      // not the platform's problem ("not running yet" here means the gateway
+      // lost track of a deployment the sweeper itself just put to sleep), or
+      // that the wake lost an internal race ("superseded by a concurrent
+      // transition") — the demand funnel re-enters the wake within its reply
+      // budget precisely so a mid-transition caller never sees those races.
+      const firstOutcome = await firstCall;
+      expect(firstOutcome.text).not.toMatch(NOT_RUNNING_ERROR_PATTERN);
+      expect(firstOutcome.text).not.toMatch(WAKE_RACE_WORDING_PATTERN);
+      if (firstOutcome.isError) {
+        expect(firstOutcome.text).toMatch(HIBERNATION_WORDING_PATTERN);
+      } else {
+        expect(firstOutcome.text).toBe(baselineToolText);
+      }
+
+      // Demand alone completes the round trip: the server answers with its
+      // real output, and the deployment ends awake, unmarked, at the replica
+      // count it slept with.
+      await callUntilServing(request);
+      await expect
+        .poll(readHibernationShape, {
+          timeout: 90_000,
+          intervals: CLUSTER_POLL_INTERVALS,
+        })
+        .toEqual({
+          replicas: replicasBeforeSleep,
+          hibernated: undefined,
+          preHibernationReplicas: undefined,
+        });
+      await waitForDeploymentAvailable();
+    } finally {
+      // Pin it awake again whatever happened, exactly like the test above.
+      await makeApiRequest({
+        request,
+        method: "put",
+        urlSuffix: `/api/internal_mcp_catalog/${catalogItemId}`,
+        data: { hibernationMode: "disabled" },
+      }).catch(() => {});
+    }
+  });
+
+  test("demand arriving throughout an in-progress hibernation converges on one wake, and every caller is answered actionably @slow-window", async ({
+    request,
+    makeApiRequest,
+  }) => {
+    // The test above knocks once, at the instant the transition lands. This
+    // one keeps knocking THROUGH it — at the patch, mid pod-teardown, and
+    // into the wake the first caller started — because that is what a busy
+    // gateway does to a server the sweeper picked a bad moment for. Every
+    // answer must be actionable (the real output, or the still-starting
+    // retry), no caller may see an internal race or a disowning error, and
+    // the whole storm must cost exactly one wake.
+    test.setTimeout(1_140_000);
+    requireRecordedBaseline();
+
+    try {
+      await sleepUntil(Date.now() + LAST_USED_QUIET_PERIOD_MS);
+      const lastUsedBefore = Date.parse(
+        (await readInstall({ request, makeApiRequest })).lastUsedAt ?? "",
+      );
+      expect(await callTestTool(request)).toBe(baselineToolText);
+      const idleSince = Date.now();
+      await expect
+        .poll(
+          async () =>
+            Date.parse(
+              (await readInstall({ request, makeApiRequest })).lastUsedAt ?? "",
+            ),
+          { timeout: 30_000, intervals: CLUSTER_POLL_INTERVALS },
+        )
+        .toBeGreaterThan(lastUsedBefore);
+
+      const awake = await readDeploymentFacts();
+      expect(awake.hibernated).toBeUndefined();
+      const replicasBeforeSleep = awake.replicas ?? 0;
+      expect(replicasBeforeSleep).toBeGreaterThan(0);
+
+      await setHibernationMode({ request, makeApiRequest, mode: "enabled" });
+
+      const transitionDeadlineMs =
+        idleSince +
+        EARLIEST_LEGAL_HIBERNATION_MS +
+        PLATFORM_HIBERNATION_TIMEOUT_MS;
+      let slept: Awaited<ReturnType<typeof readDeploymentFacts>> | undefined;
+      while (Date.now() < transitionDeadlineMs) {
+        const facts = await readDeploymentFacts();
+        if (facts.hibernated === "true") {
+          slept = facts;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, TRANSITION_POLL_MS));
+      }
+      expect(
+        slept,
+        "the sweeper never hibernated the idle install, so there was no transition to storm",
+      ).toBeDefined();
+
+      const podCreationsBefore = await podCreationEventUids();
+
+      // Three callers spread across the transition's phases. Answers are
+      // collected, never thrown: a failed MCP call is an ordinary JSON-RPC
+      // result, and what it SAYS is the contract under test.
+      const callerDelaysMs = [0, 1_000, 2_500];
+      const firstOutcomes = await Promise.all(
+        callerDelaysMs.map(async (delayMs) => {
+          if (delayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
+          return callToolOutcome(request);
+        }),
+      );
+      for (const [index, outcome] of firstOutcomes.entries()) {
+        expect
+          .soft(outcome.text, `caller ${index} was disowned`)
+          .not.toMatch(NOT_RUNNING_ERROR_PATTERN);
+        expect
+          .soft(outcome.text, `caller ${index} saw an internal wake race`)
+          .not.toMatch(WAKE_RACE_WORDING_PATTERN);
+        if (outcome.isError) {
+          expect(outcome.text).toMatch(HIBERNATION_WORDING_PATTERN);
+        } else {
+          expect(outcome.text).toBe(baselineToolText);
+        }
+      }
+
+      // Demand converges: the server answers with its real output, on the
+      // burst budget (three callers share one serialized stdio pod).
+      await callUntilServing(request, BURST_SERVING_RETRY_TIMEOUT_MS);
+
+      // The whole storm cost at most one pod creation. 0 is the platform at
+      // its best — the wake reverted the scale-down before the ReplicaSet
+      // ever acted, so the original pod simply kept serving; 1 is a single
+      // replacement pod. More than one is a doubled wake, the thing this
+      // storm exists to rule out.
+      expect(
+        await newPodCreationsSince(podCreationsBefore),
+      ).toBeLessThanOrEqual(1);
+
+      await expect
+        .poll(readHibernationShape, {
+          timeout: 90_000,
+          intervals: CLUSTER_POLL_INTERVALS,
+        })
+        .toEqual({
+          replicas: replicasBeforeSleep,
+          hibernated: undefined,
+          preHibernationReplicas: undefined,
+        });
+      await waitForDeploymentAvailable();
+    } finally {
       await makeApiRequest({
         request,
         method: "put",

--- a/platform/e2e-tests/tests/mcp-hibernation.spec.ts
+++ b/platform/e2e-tests/tests/mcp-hibernation.spec.ts
@@ -71,6 +71,18 @@ const HIBERNATION_WORDING_PATTERN = /hibernat|waking/i;
 const WAKE_RACE_WORDING_PATTERN =
   /superseded|concurrent transition|did not finish the deployment's lifecycle transition/i;
 
+/**
+ * The state machine refuses (and logs) any lifecycle move its transition
+ * table forbids rather than throwing, so a path acting from a state it
+ * should not be in fails silently and leaves only this record behind. The
+ * closing test sweeps the platform's logs for it — same pattern as the
+ * recovery spec.
+ */
+const ILLEGAL_TRANSITION_LOG_MESSAGE =
+  "Refused an illegal MCP hibernation state transition";
+const PLATFORM_POD_LABEL_SELECTOR = "app.kubernetes.io/name=archestra-platform";
+const PLATFORM_CONTAINER_NAME = "archestra-platform";
+
 /** Callers fired simultaneously at one sleeping deployment. */
 const CONCURRENT_WAKE_CALLERS = 4;
 
@@ -172,8 +184,9 @@ type InstallRow = {
  * knocking throughout it). Until then the veto is what keeps the armed
  * sweeper out of the other tests' way, which makes it load-bearing rather
  * than decorative. Paying for an idle window in wall-clock time is also why
- * those tests carry `@slow-window`, and why they are last: nothing here may
- * depend on them.
+ * those tests carry `@slow-window`, and why they are last — followed only by
+ * the closing platform-log sweep, which asserts that nothing in this file
+ * ever forced an illegal transition through the state machine.
  *
  * What runs end to end against a real API server and kubelet:
  *   sweepIdleDeployments -> hibernate (replicas 0 + both annotations)
@@ -220,6 +233,8 @@ test.describe("MCP idle hibernation - on-demand wake", () => {
    * value is changed, so `afterAll` can put it back on every path.
    */
   let organizationHibernationWasEnabled: boolean | undefined;
+  /** When this spec began, for the closing platform-log sweep's window. */
+  const specStartedAtMs = Date.now();
 
   const listDeploymentPods = async (): Promise<k8s.V1Pod[]> => {
     const pods = await coreApi.listNamespacedPod({
@@ -1013,6 +1028,18 @@ test.describe("MCP idle hibernation - on-demand wake", () => {
     expect(halfWoken.replicas).toBe(preHibernationReplicas);
     expect(halfWoken.generation).toBe((asleep.generation ?? 0) + 1);
 
+    // The first knock lands squarely in the WAKING state. Its answer must be
+    // actionable — the real output, or the still-starting retry — never a
+    // disowning "not running" and never an internal race.
+    const firstOutcome = await callToolOutcome(request);
+    expect(firstOutcome.text).not.toMatch(NOT_RUNNING_ERROR_PATTERN);
+    expect(firstOutcome.text).not.toMatch(WAKE_RACE_WORDING_PATTERN);
+    if (firstOutcome.isError) {
+      expect(firstOutcome.text).toMatch(HIBERNATION_WORDING_PATTERN);
+    } else {
+      expect(firstOutcome.text).toBe(baselineToolText);
+    }
+
     await callUntilServing(request);
 
     await expect
@@ -1032,6 +1059,62 @@ test.describe("MCP idle hibernation - on-demand wake", () => {
     // replace the pod.
     expect((await readDeploymentFacts()).generation).toBe(
       (halfWoken.generation ?? 0) + 1,
+    );
+    expect(await newPodCreationsSince(podCreationsBefore)).toBe(1);
+  });
+
+  test("a call landing between readiness and the annotation drop completes the wake without a second scale", async ({
+    request,
+  }) => {
+    // The FINISH-WAKE state: replicas restored and the pod serving again,
+    // with both annotations still on the object — a wake frozen between its
+    // readiness and its annotation drop (also exactly what a completeWake
+    // whose process died leaves behind). A call landing here must be
+    // answered actionably and drive the deployment to running with at most
+    // the annotation-drop write — never a second scale, never a new pod.
+    test.setTimeout(360_000);
+    requireRecordedBaseline();
+
+    await putToSleepOutOfBand(preHibernationReplicas);
+    const podCreationsBefore = await podCreationEventUids();
+
+    await scaleOutOfBand(preHibernationReplicas);
+    await waitForDeploymentAvailable();
+    // The platform's own periodic refresh self-heals this exact shape, so by
+    // the time the pod is available it may have dropped the annotations
+    // already. Both are legal positions inside the same transition; record
+    // which one the call actually landed on.
+    const atCall = await readDeploymentFacts();
+    const caughtAnnotated = atCall.hibernated === "true";
+    expect(atCall.replicas).toBe(preHibernationReplicas);
+
+    const firstOutcome = await callToolOutcome(request);
+    expect(firstOutcome.text).not.toMatch(NOT_RUNNING_ERROR_PATTERN);
+    expect(firstOutcome.text).not.toMatch(WAKE_RACE_WORDING_PATTERN);
+    if (firstOutcome.isError) {
+      expect(firstOutcome.text).toMatch(HIBERNATION_WORDING_PATTERN);
+    } else {
+      expect(firstOutcome.text).toBe(baselineToolText);
+    }
+
+    await callUntilServing(request);
+    await expect
+      .poll(readHibernationShape, {
+        timeout: 60_000,
+        intervals: CLUSTER_POLL_INTERVALS,
+      })
+      .toEqual({
+        replicas: preHibernationReplicas,
+        hibernated: undefined,
+        preHibernationReplicas: undefined,
+      });
+    // Finishing costs exactly the annotation drop — one write when the call
+    // caught the annotated shape, none when the refresh had already healed
+    // it — and the pod the scale-up created is the only pod that ever
+    // existed. A second wake would show up as extra generations or a
+    // replacement pod.
+    expect((await readDeploymentFacts()).generation).toBe(
+      (atCall.generation ?? 0) + (caughtAnnotated ? 1 : 0),
     );
     expect(await newPodCreationsSince(podCreationsBefore)).toBe(1);
   });
@@ -1489,4 +1572,82 @@ test.describe("MCP idle hibernation - on-demand wake", () => {
       }).catch(() => {});
     }
   });
+
+  test("no illegal lifecycle transition was refused for this deployment", async () => {
+    // Everything above drove this deployment through every in-transition
+    // state — injected sleeps, half-woken resumes, finish-wake completions,
+    // real-sweeper transitions with demand landing mid-flight. None of it
+    // may have had to punch through the state machine: a refusal means some
+    // path reasoned from a state it should not have been in.
+    const logs = await readPlatformLogs();
+    test.skip(
+      logs === null,
+      "platform logs are not observable from a test here: no readable pod matches " +
+        PLATFORM_POD_LABEL_SELECTOR,
+    );
+
+    // deploymentName appears in every refusal record and is unique to this
+    // spec's install, so specs running in parallel cannot poison the result.
+    const attributable = (logs ?? "")
+      .split("\n")
+      .filter((line) => line.includes(deploymentName));
+
+    // Positive control: the wakes and hibernates above log this deployment
+    // by name, so a window that never mentions it is not evidence about it —
+    // a truncated window or a hidden log level would otherwise read as
+    // health.
+    expect(
+      attributable.length,
+      `no platform log record in this window names ${deploymentName}, so the window is not evidence about it`,
+    ).toBeGreaterThan(0);
+
+    expect(
+      attributable.filter((line) =>
+        line.includes(ILLEGAL_TRANSITION_LOG_MESSAGE),
+      ),
+      `the platform refused an illegal hibernation transition for ${deploymentName}`,
+    ).toEqual([]);
+  });
+
+  /**
+   * The platform's own log stream for the window this spec has been running,
+   * or `null` when it cannot be observed from here (the platform does not
+   * run as a labelled pod in this cluster, or its log endpoint refused).
+   * `null` is deliberately distinct from `""`, so an unreadable stream can
+   * never be mistaken for evidence that no warning was produced.
+   */
+  async function readPlatformLogs(): Promise<string | null> {
+    const pods = await coreApi
+      .listPodForAllNamespaces({ labelSelector: PLATFORM_POD_LABEL_SELECTOR })
+      .catch(() => null);
+    if (!pods || pods.items.length === 0) return null;
+
+    const sinceSeconds = Math.ceil((Date.now() - specStartedAtMs) / 1_000) + 60;
+    const chunks: string[] = [];
+    for (const pod of pods.items) {
+      const name = pod.metadata?.name;
+      const namespace = pod.metadata?.namespace;
+      if (!name || !namespace) continue;
+      const log = await coreApi
+        .readNamespacedPodLog({
+          name,
+          namespace,
+          container: PLATFORM_CONTAINER_NAME,
+          sinceSeconds,
+        })
+        // A multi-container pod rejects a read with no container named; a pod
+        // whose container is named otherwise rejects this one. Try both before
+        // concluding the stream is unreadable.
+        .catch(() =>
+          coreApi
+            .readNamespacedPodLog({ name, namespace, sinceSeconds })
+            .catch(() => null),
+        );
+      if (log != null) chunks.push(log);
+    }
+
+    if (chunks.length === 0) return null;
+    const combined = chunks.join("\n");
+    return combined.trim().length === 0 ? null : combined;
+  }
 });


### PR DESCRIPTION
A tool call landing while an MCP server was mid-hibernation (or mid-wake) was often answered with a retryable "waking from idle hibernation … retry shortly" error seconds into a 30s reply budget, because the demand funnel surfaced the first retryable wake race — a `completeWake` superseded by a concurrent transition, a transition gate still held by the sweep — instead of waiting it out. Any client that does not retry tool errors experienced this as a failed call (T-1265, found when a task-creation call to a hibernating server never got retried).

`waitForMcpServerWake` is now a budget-bounded retry loop: a retryable `McpServerWakeError` re-enters `ensureAwake` after a 1s beat until the server is up or the budget is spent; only budget exhaustion, aborts, and terminal deployment failures surface to the caller. The budget is `ARCHESTRA_MCP_GATEWAY_WAKE_WAIT_TIMEOUT_MS`, a plain value defaulting to 30s — deliberately independent of the tool-call timeout, which governs the dispatched call and only starts counting once the woken server has accepted it. The wake machinery itself is unchanged — its internal races were already CAS/lease-safe; the fix is that the caller-facing funnel now consumes them.

Race coverage added at three levels. Funnel unit tests: race retried within budget, race surfaced verbatim only when the remaining budget cannot fit another attempt, abort during the retry pause. Deterministic integration races on the manager↔deployment seam, with an explicit entry-path coverage matrix in the file (citing where hard-reset, foreign-scaler, dormancy, multi-replica and state-machine races are already pinned): demand racing an armed sweep under real active-use tracking, a wake queued behind the held transition gate, cross-replica simultaneous wakes landing exactly one scale-up + one annotation drop, the sweeper refusing a mid-wake deployment, and the passive refresh raced against a demand wake on both the hibernated shape (refresh contributes zero writes) and the finish-wake shape (exactly one annotation drop lands). E2E: every in-transition state now carries the same answer contract — a knock the instant the hibernation patch lands, staggered demand throughout the transition, the first knock on a half-woken (waking) deployment, a call landing between readiness and the annotation drop (finish-wake, with generation/pod accounting proving no second scale) — plus a closing sweep of the platform logs asserting the state machine never refused an illegal transition during the whole spec.

Exercised live on a dev stack with the 8s e2e timing profile: across repeated runs the superseded-wake race occurred 4 times in the backend logs, reached a caller 0 times, and the full `mcp-hibernation.spec.ts` (17 tests; the log sweep self-skips where the platform is not a pod) passed in one run. One finding from that run is pinned in the tests: a wake racing a fresh scale-down can win before the ReplicaSet reconciles, costing zero pod churn — so the storm test asserts at most one pod creation, not exactly one.

Task: T-1265.
