### PR TITLE
fix(agents): pre-accept the workspace trust prompt for TUI runs

### DIFF
--- a/platform/agent_images/bin/archestra-claude-code
+++ b/platform/agent_images/bin/archestra-claude-code
@@ -30,6 +30,25 @@ jq -n \
   > "${mcp_config}"
 chmod 0600 "${mcp_config}"
 
+# Pre-accept the workspace trust prompt. Claude Code asks "is this a project
+# you trust?" the first time it opens a directory, and --dangerously-skip-
+# permissions does NOT cover it. Print mode never renders the prompt, so this
+# was invisible until delegated runs started using the TUI — and then the
+# session sat on the dialog with nobody able to answer, burning the whole run.
+# Merged rather than written, because Claude Code rewrites this file as it runs.
+claude_json="${HOME}/.claude.json"
+workspace="$(pwd)"
+trust_patch="$(jq -n --arg dir "${workspace}" \
+  '{hasCompletedOnboarding:true,bypassPermissionsModeAccepted:true,
+    projects:{($dir):{hasTrustDialogAccepted:true}}}')"
+if [[ -s "${claude_json}" ]] && jq -e . "${claude_json}" >/dev/null 2>&1; then
+  merged="$(jq --argjson patch "${trust_patch}" '. * $patch' "${claude_json}")"
+else
+  merged="${trust_patch}"
+fi
+printf '%s\n' "${merged}" > "${claude_json}"
+chmod 0600 "${claude_json}"
+
 args=(
   --model "${ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NATIVE_MODEL:?}"
   --permission-mode bypassPermissions


### PR DESCRIPTION
Follow-up to #7596, caught on the first live staging run.

The delegated run rendered the native TUI correctly — and then **stopped on Claude Code's workspace trust dialog** (*"Is this a project you created or one you trust?"*) with nobody able to press a key. The whole execution sat there.

`--dangerously-skip-permissions` does not cover that prompt, and `--print` never renders it, so it was invisible until delegated runs started using the TUI.

Fix is crab-env's: write the workspace into `~/.claude.json` with `hasTrustDialogAccepted` before launching, merged into any existing config because Claude Code rewrites that file while it runs.

Evidence from the live run's pane:
```
lobster-env: session is APPA-gated (plugin /opt/openappa/claude-code/plugin)
…
Quick safety check: Is this a project you created or one you trust?
❯ 1. Yes, I trust this folder
  2. No, exit
```

That same capture is the **first confirmation that both the TUI and the APPA gate work in a real runner pod** — the run reached the interface; it just could not get past the door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>