### PR TITLE
ci: prebuild PR images for opportunistic merge-queue reuse

### DIFF
--- a/.github/scripts/e2e-image-input-hash.sh
+++ b/.github/scripts/e2e-image-input-hash.sh
@@ -22,7 +22,7 @@ case "$kind" in
   platform)
     {
       printf 'context\n'
-      git ls-tree "HEAD:platform" | grep -v $'\te2e-tests$' || true
+      git ls-tree "HEAD:platform" | awk -F '\t' '$2 != "e2e-tests"'
       definition
     } | git hash-object --stdin
     ;;

--- a/.github/scripts/e2e-image-input-hash.sh
+++ b/.github/scripts/e2e-image-input-hash.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Content-addressed identity of an E2E image build: the Docker context plus
+# the workflow/action files that define how the image is produced. A later
+# run with the same hash can reuse the published image instead of rebuilding.
+set -euo pipefail
+
+kind="${1:-}"
+
+workflow_blob="$(git rev-parse HEAD:.github/workflows/platform-e2e-tests.yml)"
+build_action_blob="$(git rev-parse HEAD:.github/actions/build-docker-image/action.yml)"
+builder_action_blob="$(git rev-parse HEAD:.github/actions/setup-docker-builder/action.yml)"
+hash_script_blob="$(git rev-parse HEAD:.github/scripts/e2e-image-input-hash.sh)"
+
+definition() {
+  printf 'workflow %s\n' "$workflow_blob"
+  printf 'build-action %s\n' "$build_action_blob"
+  printf 'builder-action %s\n' "$builder_action_blob"
+  printf 'hash-script %s\n' "$hash_script_blob"
+}
+
+case "$kind" in
+  platform)
+    {
+      printf 'context\n'
+      git ls-tree "HEAD:platform" | grep -v $'\te2e-tests$' || true
+      definition
+    } | git hash-object --stdin
+    ;;
+  mcp-base)
+    {
+      printf 'context %s\n' "$(git rev-parse HEAD:platform/mcp_server_docker_image)"
+      definition
+    } | git hash-object --stdin
+    ;;
+  *)
+    echo "usage: $0 platform|mcp-base" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -1,8 +1,11 @@
 name: Platform E2E Tests
 
 # Runs automatically in merge queue as the required E2E gate.
-# For PRs, add the "run-e2e" label to trigger the full E2E suite on demand.
-# Remove and re-add the label to re-trigger after new commits.
+# Trusted same-repo PR updates prebuild the Platform and MCP images so a
+# later merge-group run can retag them instead of compiling on the queue
+# critical path. Fork PRs keep the placeholder checks. Add the "run-e2e"
+# label to trigger the full E2E suite on demand. Remove and re-add the
+# label to re-trigger after new commits.
 #
 # MCP idle-hibernation coverage stays OFF the merge queue: the leg is ~10
 # minutes of mostly serial waiting, which every queued merge was paying.
@@ -71,15 +74,17 @@ jobs:
     runs-on: ubuntu-latest
     # Excludes EVERY e2e-triggering label: a label event that starts the real
     # build must not also run this placeholder under the same check names (the
-    # duplicate-name masking hazard the NOTE above forbids re-adding).
-    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || (github.event.label.name != 'run-e2e' && github.event.label.name != 'run-e2e-hibernation')) }}
+    # duplicate-name masking hazard the NOTE above forbids re-adding). Every
+    # trusted same-repo PR event runs the real builder instead; this placeholder
+    # remains only for ordinary fork events that cannot access the registry.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true && (github.event.action != 'labeled' || (github.event.label.name != 'run-e2e' && github.event.label.name != 'run-e2e-hibernation')) }}
     strategy:
       fail-fast: false
       matrix:
         name: [Platform, MCP Server Base]
     steps:
       - name: Skip full image build on ordinary PR updates
-        run: echo "Full E2E image builds run on merge queue or when the run-e2e label is added."
+        run: echo "Full E2E image builds run on trusted same-repo PR updates, merge queue, or when the run-e2e label is added."
 
   # Build Docker images for e2e tests (platform and MCP server base).
   # Trusted PRs and merge queue runs push the platform image to Artifact Registry so
@@ -88,7 +93,7 @@ jobs:
   platform-e2e-build:
     name: Build ${{ matrix.name }} Image
     runs-on: ${{ matrix.runner }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' || github.event.label.name == 'run-e2e-hibernation' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' || github.event.label.name == 'run-e2e-hibernation' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) }}
     permissions:
       contents: read # Required to checkout the repository and build images for E2E jobs.
       id-token: write # Required for Workload Identity Federation when pushing trusted images.
@@ -161,16 +166,15 @@ jobs:
           service_account: ${{ secrets.DEVELOPMENT_GCP_DEPLOY_SERVICE_ACCOUNT_NAME }}
           workload_identity_provider: ${{ secrets.DEVELOPMENT_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
 
-      # Reuse a platform image already built for this exact ./platform tree — by
-      # this PR's run-e2e build, a prior merge-queue entry, or the scheduled warm
-      # build — instead of rebuilding it on the merge-queue critical path. The
-      # image is a deterministic function of the ./platform build context (base
-      # images are digest-pinned in the Dockerfile and no build arg varies here),
-      # so a matching git tree OID guarantees byte-identical build inputs. On a
-      # hit we do a registry-side manifest copy to the commit-SHA e2e tag, so the
-      # test jobs' existing `:${sha}-e2e` pull contract is unchanged and no rebuild runs.
-      # Registry path only: fork PRs have no OIDC/registry access and fall through
-      # to the artifact build below.
+      # Reuse a platform image already built for this exact image-input hash —
+      # by this PR's trusted prebuild, a labeled run-e2e build, a prior
+      # merge-queue entry, or the scheduled warm build — instead of rebuilding
+      # it on the merge-queue critical path. The hash covers the ./platform
+      # context plus the workflow/action files that define the build command.
+      # On a hit we do a registry-side manifest copy to the commit-SHA e2e
+      # tag, so the test jobs' existing `:${sha}-e2e` pull contract is
+      # unchanged and no rebuild runs. Registry path only: fork PRs have no
+      # OIDC/registry access and fall through to the artifact build below.
       - name: Resolve platform image reuse
         id: platform-reuse
         if: ${{ matrix.use-build-action && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) }}
@@ -180,22 +184,15 @@ jobs:
           GIT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # Hash of what the image build actually consumes: the ./platform
-          # tree minus e2e-tests (tests run from the checkout, never from the
-          # image; nothing in the Dockerfile references that directory — keep
-          # it that way or remove this exclusion). Merges that only touch e2e
-          # tests then reuse the existing image instead of rebuilding an
-          # identical one. The derived hash is stable: ls-tree output is
-          # sorted and includes each entry's own tree OID.
-          TREE_HASH=$(git ls-tree "HEAD:platform" | grep -v $'\te2e-tests$' | git hash-object --stdin)
-          TREE_TAG="${IMAGE_REPO}:tree-${TREE_HASH}"
-          SLIM_TREE_TAG="${TREE_TAG}-slim"
+          INPUT_HASH=$(bash .github/scripts/e2e-image-input-hash.sh platform)
+          INPUT_TAG="${IMAGE_REPO}:input-${INPUT_HASH}"
+          SLIM_INPUT_TAG="${INPUT_TAG}-slim"
           # `-e2e` suffix, NOT the bare `:${sha}` tag: the staging deploy
           # (on-commits-to-main -> deploy-dev-platform-images) publishes its
           # image — built with `--build-arg VERSION=${sha}`, which bakes
           # ARCHESTRA_VERSION and the Next.js deploymentId — under the bare
           # commit-SHA tag, and the cluster pulls that tag by name. The e2e
-          # build omits the VERSION arg (deliberately, so the tree-hash reuse
+          # build omits the VERSION arg (deliberately, so the input-hash reuse
           # above stays deterministic), so writing it to the bare tag would
           # clobber the deployed image with a `VERSION=dev` variant. The
           # nightly scheduled run does exactly that for main's HEAD — hours
@@ -203,30 +200,30 @@ jobs:
           # pulls the dev-versioned image.
           SHA_TAG="${IMAGE_REPO}:${GIT_SHA}-e2e"
           SLIM_SHA_TAG="${SHA_TAG}-slim"
-          echo "tree_tag=${TREE_TAG}" >> "${GITHUB_OUTPUT}"
-          echo "slim_tree_tag=${SLIM_TREE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "tree_tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "slim_tree_tag=${SLIM_INPUT_TAG}" >> "${GITHUB_OUTPUT}"
           # Default to a build; only skip it if we actually land the reused images
-          # on the SHA tags. A missing/just-pruned tree tag or a transient registry
+          # on the SHA tags. A missing/just-pruned input tag or a transient registry
           # error then falls back to building instead of failing the required gate.
           # BOTH variants must be present: the K8s job pulls the -slim image (no
-          # Dagger engine tar) while the quickstart job pulls the full one, so a tree
-          # cached before the slim variant existed cannot be reused.
+          # Dagger engine tar) while the quickstart job pulls the full one, so an
+          # input cached before the slim variant existed cannot be reused.
           REUSE=false
-          if FULL_TREE_REF=$(bash .github/scripts/resolve-attested-image.sh "${TREE_TAG}") \
-            && SLIM_TREE_REF=$(bash .github/scripts/resolve-attested-image.sh "${SLIM_TREE_TAG}"); then
-            echo "Found cached platform images for tree ${TREE_HASH}; copying to ${SHA_TAG} (+ -slim)"
+          if FULL_INPUT_REF=$(bash .github/scripts/resolve-attested-image.sh "${INPUT_TAG}") \
+            && SLIM_INPUT_REF=$(bash .github/scripts/resolve-attested-image.sh "${SLIM_INPUT_TAG}"); then
+            echo "Found cached platform images for input ${INPUT_HASH}; copying to ${SHA_TAG} (+ -slim)"
             # Registry-side manifest copy (no layer pull/push) onto the SHA tags
             # the test jobs pull. Seconds, versus the ~85-226s build it
             # replaces. Copy the already validated immutable digests, not the
-            # mutable tree tags, so the checked and retagged objects are equal.
-            if docker buildx imagetools create --tag "${SHA_TAG}" "${FULL_TREE_REF}" \
-              && docker buildx imagetools create --tag "${SLIM_SHA_TAG}" "${SLIM_TREE_REF}"; then
+            # mutable input tags, so the checked and retagged objects are equal.
+            if docker buildx imagetools create --tag "${SHA_TAG}" "${FULL_INPUT_REF}" \
+              && docker buildx imagetools create --tag "${SLIM_SHA_TAG}" "${SLIM_INPUT_REF}"; then
               REUSE=true
             else
-              echo "::warning::reuse retag failed (tree tag may have just been pruned); building instead"
+              echo "::warning::reuse retag failed (input tag may have just been pruned); building instead"
             fi
           else
-            echo "No cached attested image pair for platform tree ${TREE_HASH}; building."
+            echo "No cached attested image pair for platform input ${INPUT_HASH}; building."
           fi
           echo "reuse=${REUSE}" >> "${GITHUB_OUTPUT}"
 
@@ -244,8 +241,8 @@ jobs:
           # Publish under both the commit-SHA e2e tag (what the shards pull;
           # `-e2e` suffixed so it can never clobber the bare `:${sha}` tag the
           # staging deploy publishes and the cluster pulls — see the reuse step
-          # above) and the tree-OID tag, so a later run of the same ./platform
-          # tree reuses this image instead of rebuilding.
+          # above) and the input-hash tag, so a later run of the same image
+          # inputs reuses this image instead of rebuilding.
           tags: |
             ${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:${{ github.sha }}-e2e
             ${{ steps.platform-reuse.outputs.tree_tag }}
@@ -265,7 +262,7 @@ jobs:
           cache-from: |
             type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache
             type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache-amd64
-          # Exact tree tags handle whole-image reuse; publisher mode=max caches
+          # Exact input-hash tags handle whole-image reuse; publisher mode=max caches
           # supply intermediate layers, so E2E only needs to export final layers.
           cache-to: type=registry,ref=${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:buildcache,mode=min
 
@@ -281,7 +278,7 @@ jobs:
           push: "true"
           target: unified-slim
           # Same dual-tag scheme as the full image: the SHA e2e tag the K8s job
-          # pulls, plus the tree-OID tag the reuse step checks.
+          # pulls, plus the input-hash tag the reuse step checks.
           tags: |
             ${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:${{ github.sha }}-e2e-slim
             ${{ steps.platform-reuse.outputs.slim_tree_tag }}
@@ -305,7 +302,7 @@ jobs:
           service_account: ${{ secrets.DEVELOPMENT_GCP_DEPLOY_SERVICE_ACCOUNT_NAME }}
           workload_identity_provider: ${{ secrets.DEVELOPMENT_GCP_WORKLOAD_IDENTITY_PROVIDER_IDENTIFIER }}
 
-      # Same tree-based reuse as the Platform image above. This image rarely
+      # Same input-hash reuse as the Platform image above. This image rarely
       # changes, and the lite/quickstart jobs wait for this job — so on a match, a
       # seconds-long registry retag replaces the ~100s rebuild.
       - name: Resolve MCP server base image reuse
@@ -317,20 +314,20 @@ jobs:
           GIT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          TREE_HASH=$(git rev-parse "HEAD:platform/mcp_server_docker_image")
-          TREE_TAG="${IMAGE_REPO}:tree-${TREE_HASH}"
+          INPUT_HASH=$(bash .github/scripts/e2e-image-input-hash.sh mcp-base)
+          INPUT_TAG="${IMAGE_REPO}:input-${INPUT_HASH}"
           SHA_TAG="${IMAGE_REPO}:${GIT_SHA}"
-          echo "tree_tag=${TREE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "tree_tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
           REUSE=false
-          if docker buildx imagetools inspect "${TREE_TAG}" >/dev/null 2>&1; then
-            echo "Found cached MCP server base image for tree ${TREE_HASH}; copying to ${SHA_TAG}"
-            if docker buildx imagetools create --tag "${SHA_TAG}" "${TREE_TAG}"; then
+          if docker buildx imagetools inspect "${INPUT_TAG}" >/dev/null 2>&1; then
+            echo "Found cached MCP server base image for input ${INPUT_HASH}; copying to ${SHA_TAG}"
+            if docker buildx imagetools create --tag "${SHA_TAG}" "${INPUT_TAG}"; then
               REUSE=true
             else
-              echo "::warning::mcp base reuse retag failed (tree tag may have just been pruned); building instead"
+              echo "::warning::mcp base reuse retag failed (input tag may have just been pruned); building instead"
             fi
           else
-            echo "No cached MCP server base image for tree ${TREE_HASH}; building."
+            echo "No cached MCP server base image for input ${INPUT_HASH}; building."
           fi
           echo "reuse=${REUSE}" >> "${GITHUB_OUTPUT}"
 
@@ -344,7 +341,7 @@ jobs:
           push: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'true' || 'false' }}
           load: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'true' || 'false' }}
           # Non-fork pushes tag both the commit SHA (what the jobs pull) and the
-          # tree OID (what the reuse step above checks next time).
+          # input-hash tag (what the reuse step above checks next time).
           tags: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('{0}/{1}:{2},{3}', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME, github.sha, steps.mcp-base-reuse.outputs.tree_tag) || format('{0}:{1}', matrix.local-tag-prefix, github.sha) }}
           cache-from: type=registry,ref=${{ env.MCP_SERVER_BASE_IMAGE_REGISTRY }}/${{ env.MCP_SERVER_BASE_IMAGE_NAME }}:buildcache
           # Forks have no registry credentials to export the cache back.

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -200,8 +200,8 @@ jobs:
           # pulls the dev-versioned image.
           SHA_TAG="${IMAGE_REPO}:${GIT_SHA}-e2e"
           SLIM_SHA_TAG="${SHA_TAG}-slim"
-          echo "tree_tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
-          echo "slim_tree_tag=${SLIM_INPUT_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "input_tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "slim_input_tag=${SLIM_INPUT_TAG}" >> "${GITHUB_OUTPUT}"
           # Default to a build; only skip it if we actually land the reused images
           # on the SHA tags. A missing/just-pruned input tag or a transient registry
           # error then falls back to building instead of failing the required gate.
@@ -245,7 +245,7 @@ jobs:
           # inputs reuses this image instead of rebuilding.
           tags: |
             ${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:${{ github.sha }}-e2e
-            ${{ steps.platform-reuse.outputs.tree_tag }}
+            ${{ steps.platform-reuse.outputs.input_tag }}
           # E2E image consumed only by CI e2e jobs — skip SLSA provenance to
           # trim export time. The SBOM below intentionally makes this an OCI
           # index with an attestation manifest. Published release images keep
@@ -281,7 +281,7 @@ jobs:
           # pulls, plus the input-hash tag the reuse step checks.
           tags: |
             ${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:${{ github.sha }}-e2e-slim
-            ${{ steps.platform-reuse.outputs.slim_tree_tag }}
+            ${{ steps.platform-reuse.outputs.slim_input_tag }}
           provenance: "false"
           sbom: generator=docker/scout-sbom-indexer:1.24.0@sha256:4b67f29eb0d1244ab0f62de867ac5dafd7262fcd7ebbdefa6ec8aacd6b15252d
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
@@ -317,7 +317,7 @@ jobs:
           INPUT_HASH=$(bash .github/scripts/e2e-image-input-hash.sh mcp-base)
           INPUT_TAG="${IMAGE_REPO}:input-${INPUT_HASH}"
           SHA_TAG="${IMAGE_REPO}:${GIT_SHA}"
-          echo "tree_tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "input_tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
           REUSE=false
           if docker buildx imagetools inspect "${INPUT_TAG}" >/dev/null 2>&1; then
             echo "Found cached MCP server base image for input ${INPUT_HASH}; copying to ${SHA_TAG}"
@@ -342,7 +342,7 @@ jobs:
           load: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'true' || 'false' }}
           # Non-fork pushes tag both the commit SHA (what the jobs pull) and the
           # input-hash tag (what the reuse step above checks next time).
-          tags: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('{0}/{1}:{2},{3}', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME, github.sha, steps.mcp-base-reuse.outputs.tree_tag) || format('{0}:{1}', matrix.local-tag-prefix, github.sha) }}
+          tags: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('{0}/{1}:{2},{3}', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME, github.sha, steps.mcp-base-reuse.outputs.input_tag) || format('{0}:{1}', matrix.local-tag-prefix, github.sha) }}
           cache-from: type=registry,ref=${{ env.MCP_SERVER_BASE_IMAGE_REGISTRY }}/${{ env.MCP_SERVER_BASE_IMAGE_NAME }}:buildcache
           # Forks have no registry credentials to export the cache back.
           cache-to: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME) || '' }}

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -33,6 +33,7 @@ catalogs:
 
 overrides:
   '@babel/core': '>=7.29.6 <8'
+  browserslist: '>=4.28.7'
   '@fastify/reply-from': '>=12.6.2'
   '@fastify/http-proxy': '>=11.4.4'
   protobufjs: '>=8.6.0'
@@ -6682,6 +6683,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
@@ -6816,8 +6822,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -6883,6 +6889,9 @@ packages:
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -7588,8 +7597,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.340:
-    resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
+  electron-to-chromium@1.5.414:
+    resolution: {integrity: sha512-aYlviXiaXBbzvKgyALpcMmqa3Np3sDr0XnZbEG62n2UpZFbEcjQ4EEMOLGzVPhwVnwTz0lvKY+GcARbunuHekw==}
 
   elkjs@0.11.1:
     resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
@@ -9103,8 +9112,9 @@ packages:
   node-html-better-parser@1.5.9:
     resolution: {integrity: sha512-z1I5UINMezJXYL9cH3h0a9KBth2G978gSLlfkpQ+CQzzVHVQy9gpARgm9eDsz1O4gn1HtgUqjdAIYxKFZm6uHQ==}
 
-  node-releases@2.0.37:
-    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
 
   node-rsa@1.1.1:
     resolution: {integrity: sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==}
@@ -10522,11 +10532,11 @@ packages:
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: '>=4.28.7'
 
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
@@ -11930,7 +11940,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -17336,6 +17346,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.19: {}
 
+  baseline-browser-mapping@2.11.19: {}
+
   before-after-hook@4.0.0: {}
 
   better-auth@1.6.22(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(kysely@0.28.17)(pg@8.20.0))(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@25.5.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(msw@2.14.6(@types/node@25.5.0)(@typescript/typescript6@6.0.1))(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))):
@@ -17544,13 +17556,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.2:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.19
-      caniuse-lite: 1.0.30001788
-      electron-to-chromium: 1.5.340
-      node-releases: 2.0.37
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.414
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -17618,6 +17630,8 @@ snapshots:
   callsites@4.2.0: {}
 
   caniuse-lite@1.0.30001788: {}
+
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -18247,7 +18261,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.340: {}
+  electron-to-chromium@1.5.414: {}
 
   elkjs@0.11.1: {}
 
@@ -18957,7 +18971,7 @@ snapshots:
 
   header-generator@2.1.82:
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       generative-bayesian-network: 2.1.83
       ow: 0.28.2
       tslib: 2.8.1
@@ -20155,7 +20169,7 @@ snapshots:
     dependencies:
       html-entities: 2.6.0
 
-  node-releases@2.0.37: {}
+  node-releases@2.0.53: {}
 
   node-rsa@1.1.1:
     dependencies:
@@ -21798,9 +21812,9 @@ snapshots:
 
   until-async@3.0.2: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -22043,7 +22057,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.20.1
       es-module-lexer: 2.0.0

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -32,6 +32,12 @@ overrides:
   # range. Bounded to <8 so the floor can't drag the toolchain onto Babel 8 while
   # the sibling @babel/* plugins are still 7.x.
   '@babel/core': '>=7.29.6 <8'
+  # CVE-2026-73089 (uncontrolled resource consumption) and CVE-2026-73088
+  # (prototype pollution), both HIGH / CVSS 7.5, affect <=4.28.6 and are fixed
+  # in 4.28.7. Transitive-only (webpack, @babel/helper-compilation-targets and
+  # header-generator all resolve it), so an override is the only way to lift
+  # every resolution past the vulnerable range.
+  browserslist: '>=4.28.7'
   '@fastify/reply-from': '>=12.6.2'
   '@fastify/http-proxy': '>=11.4.4'
   protobufjs: '>=8.6.0'


### PR DESCRIPTION
## Why

Platform E2E timing is bimodal. Across 13 comparable Aug 30-31 runs, image reuse missed in 8/13 runs; misses had a 10m30s median workflow wall versus 6m29s for hits. Representative cold run [33412392906](https://github.com/archestra-ai/archestra/actions/runs/33412392906) spent 3m34s building the full Platform image and 47s building slim before Lite could become eligible at 5m06s.

## What

Trusted same-repository PR events now prebuild Platform and MCP E2E images without running E2E. The images are published under an input hash covering the relevant source context plus the workflow, build action, builder action, and hash implementation. A later label or merge-group event with exactly the same image inputs verifies and registry-retags those immutable images instead of rebuilding them on the queue critical path.

Fork PRs retain unprivileged placeholder checks. Missing, stale, rebased, cumulative-queue, or pruned input tags retain the existing fresh-build fallback. Required check names and the commit-SHA image contract are unchanged.

This PR is image-only after rebasing onto `6c345f31c`; test and hibernation labels were removed. It also incorporates the `browserslist` security override from #7614, preserving Joey's authorship, because the exact-image scan exposed those findings while measuring this PR.

## Before / after

Measurements use final head `8142bdba5`. The warm image-only label event exercises the same resolution and SHA-retag implementation as `merge_group`, but without cumulative queue changes.

| Targeted metric | Before | Measured reuse path | Change |
|---|---:|---:|---:|
| Platform image job | 4m50s cold reference | 41s warm reuse job | -4m09s / -86% |
| Full Platform build step | 3m34s | skipped | -3m34s |
| Slim Platform build step | 47s | skipped | -47s |
| Image dependency ready from workflow creation | 5m06s | 1m19s latest; 54s prior warm run | -3m47s to -4m12s |
| Registry resolve and retag step | 19s on fast reference | 12s | -7s |
| Cold PR prebuild workflow wall | placeholder-only before | 5m02s | cost moved before queue admission |

Evidence:

- [Final cold trusted-PR prebuild](https://github.com/archestra-ai/archestra/actions/runs/33554943016): 5m02s workflow, 4m45s Platform job, full 3m14s, slim 46s.
- [Final warm reuse](https://github.com/archestra-ai/archestra/actions/runs/33555477304): 1m19s workflow, 41s Platform job, both Platform builds skipped, 12s resolve/retag.
- [Representative previous cold merge-group run](https://github.com/archestra-ai/archestra/actions/runs/33412392906): 11m32s workflow, 4m50s Platform build job.

## Actual merge-group validation

The first production queue run, [33557605903](https://github.com/archestra-ai/archestra/actions/runs/33557605903), passed but did **not** hit reuse:

| Metric | Actual first queue run |
|---|---:|
| Workflow wall | 12m14s |
| Platform image job | 4m37s |
| Full / slim build | 2m51s / 1m07s |
| Slowest Lite shard | 5m16s |
| Required merge report gate | passed |

The PR entered at queue position 6 on top of several cumulative queue candidates. Its merge-group Platform tree was `daa35599...`, while the ordinary PR prebuild used `9f0ee106...`. The queue tree matched the preceding candidate, but that candidate was built under the old workflow recipe; this PR changes the recipe included in the hash. Therefore this first rollout had to build once and seed queue-exact `input-*` tags.

Steady-state reuse is opportunistic, not guaranteed. It hits when either the ordinary PR merge tree still matches the queue tree or an earlier queue candidate already published the same Platform tree under the current build recipe. A Platform-changing PR behind other Platform-changing queue entries can still rebuild safely.

The image path demonstrates an 86% hit-path reduction, but the first real queue run did not achieve the original 2x total-wall target. Test/runtime and queue-base drift remain follow-up work.

## Image workflow controls

| Workflow | Actual result | Interpretation |
|---|---:|---|
| Labeled Platform scan, final head | 1m02s, passed | Exact full/slim attested digests resolved; both fallback builds skipped; scan itself took 16s. |
| Labeled MCP scan, final head | 1m24s, passed | Exact E2E image reused; both fallback builds skipped. |
| Labeled p4 scan, final head | 1m08s, passed | Independent control; registry-cache build path unchanged. |
| Deploy Dev Platform Images | 7m33s, passed | Independent multi-arch workflow; not optimized here. |

- [Final successful exact-image scans](https://github.com/archestra-ai/archestra/actions/runs/33555477412)
- [Rebased dev-image control](https://github.com/archestra-ai/archestra/actions/runs/33551210232)

## Security finding resolved

The first exact-image scan found `browserslist@4.28.2`, affected by HIGH CVE-2026-73088 and CVE-2026-73089. The added `>=4.28.7` pnpm override resolves every path to 4.28.8, beyond the fixed floor and seven-day release-age window.

A frozen install passes supply-chain policy, `pnpm why browserslist -r` reports exactly one 4.28.8 resolution, frontend/backend/shared type checks pass, and Docker Scout passes on both exact full and slim Platform images.

## Validation

Supply-chain policy, its 16 unit tests, Actionlint, Zizmor, normal PR checks, all labeled image scans, and the first merge-group E2E suite pass. The automated review's `tree_tag` naming concern was addressed with `input_tag` / `slim_input_tag`; the hash pipeline uses `awk` so a `git ls-tree` failure is not hidden by `|| true`.