### PR TITLE
feat(runners): stream startup progress into the background execution terminal

### DIFF
--- a/docs/pages/platform-agent-background-execution.md
+++ b/docs/pages/platform-agent-background-execution.md
@@ -3,7 +3,7 @@ title: Background Execution
 category: Agents
 order: 7
 description: Run delegated Agent tasks in an isolated deployment
-lastUpdated: 2026-08-30
+lastUpdated: 2026-09-01
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -337,7 +337,9 @@ the system actor and can use shared credentials only. See [Incoming Email](/docs
 When a Background-enabled Agent is selected in Chat, the composer clearly
 identifies execution mode. Sending the first task creates a durable execution
 and replaces the composer with the Agent's live terminal. While Kubernetes is
-starting the pod, Chat shows the startup state instead of an empty terminal.
+starting the pod, Chat shows each startup step: scheduling, image pull, agent
+session, then the terminal. If Kubernetes reports a problem — an image that
+cannot be pulled, for example — the reason appears with the step.
 Files attached before sending are copied into the execution input directory
 before the Agent process starts.
 

--- a/platform/backend/src/k8s/runner-runtime/manager.ts
+++ b/platform/backend/src/k8s/runner-runtime/manager.ts
@@ -48,6 +48,13 @@ import {
   RUNNER_EGRESS_POLICY_CRDS,
   type RunnerEgressPolicyObject,
 } from "./network-policy";
+import {
+  attachingProgress,
+  describeRunnerStartupProgress,
+  isSameRunnerStartupProgress,
+  type RunnerStartupProgress,
+  type RunnerStartupProgressReporter,
+} from "./startup-phase";
 
 /** `K8sClients` is internal to the shared module, so it is derived here. */
 type K8sClients = ReturnType<typeof createK8sClients>;
@@ -283,6 +290,8 @@ class RunnerRuntimeManager {
     stdout: Writable;
     stderr: Writable;
     onStatus?: (status: k8s.V1Status) => void;
+    /** Called as the attach moves through its waits; see `startup-phase`. */
+    onProgress?: RunnerStartupProgressReporter;
   }): Promise<{ podName: string; command: string; socket: WebSocket }> {
     const clients = this.requireClients();
     // A2A marks the durable task working before Kubernetes necessarily has a
@@ -293,11 +302,17 @@ class RunnerRuntimeManager {
       session: params.session,
       timeoutMessage:
         "Timed out waiting for the Agent pod to accept a terminal",
+      onProgress: params.onProgress,
     });
     if (!podName) {
       throw new Error("This session has no running pod to attach to");
     }
-    await this.waitForTmuxSession({ session: params.session, podName });
+    await this.waitForTmuxSession({
+      session: params.session,
+      podName,
+      onProgress: params.onProgress,
+    });
+    params.onProgress?.({ ...attachingProgress(), resourceName: podName });
     // Live pods created before an upgrade do not have the stable helper yet.
     // Installing it here keeps the displayed command truthful for them too.
     await this.execInPod({
@@ -393,14 +408,25 @@ class RunnerRuntimeManager {
   async findPodPhase(
     session: AgentRun,
   ): Promise<{ name: string; phase: string } | null> {
+    const pod = await this.findPod(session);
+    if (!pod?.metadata?.name) return null;
+    return { name: pod.metadata.name, phase: pod.status?.phase ?? "Unknown" };
+  }
+
+  /**
+   * The whole pod object behind `findPodPhase`.
+   *
+   * A phase alone cannot say *why* a pod is Pending, and that reason — no node
+   * has room, the image will not pull — is the only thing worth telling
+   * someone watching a run start.
+   */
+  async findPod(session: AgentRun): Promise<k8s.V1Pod | null> {
     const clients = this.requireClients();
     const pods = await clients.coreApi.listNamespacedPod({
       namespace: session.runtimeScope,
       labelSelector: runnerPodSelector(session.taskId),
     });
-    const pod = pods.items.find((candidate) => candidate.metadata?.name);
-    if (!pod?.metadata?.name) return null;
-    return { name: pod.metadata.name, phase: pod.status?.phase ?? "Unknown" };
+    return pods.items.find((candidate) => candidate.metadata?.name) ?? null;
   }
 
   /**
@@ -691,13 +717,25 @@ class RunnerRuntimeManager {
   private async waitForRunningPod(params: {
     session: AgentRun;
     timeoutMessage: string;
+    onProgress?: RunnerStartupProgressReporter;
   }): Promise<string | null> {
     const deadline = Date.now() + RUNNER_INPUT_STAGING_TIMEOUT_MS;
+    let lastProgress: RunnerStartupProgress | null = null;
     while (Date.now() < deadline) {
-      const pod = await this.findPodPhase(params.session);
-      if (pod?.phase === "Running") return pod.name;
-      if (pod && (pod.phase === "Succeeded" || pod.phase === "Failed")) {
-        return null;
+      const pod = await this.findPod(params.session);
+      const phase = pod?.status?.phase;
+      if (phase === "Running" && pod?.metadata?.name) return pod.metadata.name;
+      if (phase === "Succeeded" || phase === "Failed") return null;
+
+      if (params.onProgress) {
+        const progress = describeRunnerStartupProgress(pod);
+        if (!isSameRunnerStartupProgress(lastProgress, progress)) {
+          lastProgress = progress;
+          params.onProgress({
+            ...progress,
+            resourceName: pod?.metadata?.name ?? null,
+          });
+        }
       }
       await delay(RUNNER_INPUT_STAGING_POLL_MS);
     }
@@ -712,8 +750,15 @@ class RunnerRuntimeManager {
   private async waitForTmuxSession(params: {
     session: AgentRun;
     podName: string;
+    onProgress?: RunnerStartupProgressReporter;
   }): Promise<void> {
     const deadline = Date.now() + RUNNER_ATTACH_TIMEOUT_MS;
+    params.onProgress?.({
+      phase: "starting",
+      message: "Waiting for the agent session",
+      detail: null,
+      resourceName: params.podName,
+    });
     while (Date.now() < deadline) {
       const ready = await this.execInPod({
         session: params.session,

--- a/platform/backend/src/k8s/runner-runtime/startup-phase.test.ts
+++ b/platform/backend/src/k8s/runner-runtime/startup-phase.test.ts
@@ -1,0 +1,185 @@
+import type * as k8s from "@kubernetes/client-node";
+import { describe, expect, it } from "vitest";
+import {
+  describeRunnerStartupProgress,
+  isSameRunnerStartupProgress,
+} from "./startup-phase";
+
+describe("describeRunnerStartupProgress", () => {
+  it("reports the run as queued before a pod carries it", () => {
+    expect(describeRunnerStartupProgress(null)).toEqual({
+      phase: "queued",
+      message: "Waiting for the run to be scheduled",
+      detail: null,
+    });
+  });
+
+  it("surfaces why a pending pod cannot be placed", () => {
+    const progress = describeRunnerStartupProgress(
+      pod({
+        phase: "Pending",
+        conditions: [
+          {
+            type: "PodScheduled",
+            status: "False",
+            reason: "Unschedulable",
+            message: "0/3 nodes are available: insufficient memory",
+          },
+        ],
+      }),
+    );
+
+    expect(progress.phase).toBe("scheduling");
+    expect(progress.detail).toBe(
+      "Unschedulable: 0/3 nodes are available: insufficient memory",
+    );
+  });
+
+  it("surfaces a failing image pull rather than presenting it as a normal wait", () => {
+    const progress = describeRunnerStartupProgress(
+      pod({
+        phase: "Pending",
+        conditions: [{ type: "PodScheduled", status: "True" }],
+        containerStatuses: [
+          {
+            state: {
+              waiting: {
+                reason: "ImagePullBackOff",
+                message: 'Back-off pulling image "ghcr.io/example/agent:v9"',
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(progress.phase).toBe("pulling");
+    expect(progress.detail).toBe(
+      'ImagePullBackOff: Back-off pulling image "ghcr.io/example/agent:v9"',
+    );
+  });
+
+  it("treats an ordinary container start as progress with nothing to explain", () => {
+    const progress = describeRunnerStartupProgress(
+      pod({
+        phase: "Pending",
+        conditions: [{ type: "PodScheduled", status: "True" }],
+        containerStatuses: [
+          { state: { waiting: { reason: "ContainerCreating" } } },
+        ],
+      }),
+    );
+
+    expect(progress).toEqual({
+      phase: "pulling",
+      message: "Pulling the agent image",
+      detail: null,
+    });
+  });
+
+  it("waits on the agent session once the container is running", () => {
+    const progress = describeRunnerStartupProgress(pod({ phase: "Running" }));
+
+    expect(progress).toEqual({
+      phase: "starting",
+      message: "Waiting for the agent session",
+      detail: null,
+    });
+  });
+
+  it("does not report a crash-looping container as a healthy start", () => {
+    const progress = describeRunnerStartupProgress(
+      pod({
+        phase: "Running",
+        containerStatuses: [
+          {
+            state: {
+              waiting: {
+                reason: "CrashLoopBackOff",
+                message: "back-off 40s restarting failed container",
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(progress.phase).toBe("starting");
+    expect(progress.detail).toBe(
+      "CrashLoopBackOff: back-off 40s restarting failed container",
+    );
+  });
+
+  it("reads an init container's wait, which blocks the run just as much", () => {
+    const progress = describeRunnerStartupProgress(
+      pod({
+        phase: "Pending",
+        conditions: [{ type: "PodScheduled", status: "True" }],
+        initContainerStatuses: [
+          {
+            state: {
+              waiting: { reason: "ErrImagePull", message: "manifest unknown" },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(progress.phase).toBe("pulling");
+    expect(progress.detail).toBe("ErrImagePull: manifest unknown");
+  });
+});
+
+describe("isSameRunnerStartupProgress", () => {
+  it("suppresses a repeat of the poll's previous report", () => {
+    const progress = describeRunnerStartupProgress(pod({ phase: "Running" }));
+    expect(isSameRunnerStartupProgress(progress, { ...progress })).toBe(true);
+  });
+
+  it("lets a changed reason through even when the phase has not moved", () => {
+    const creating = describeRunnerStartupProgress(
+      pod({
+        phase: "Pending",
+        conditions: [{ type: "PodScheduled", status: "True" }],
+        containerStatuses: [
+          { state: { waiting: { reason: "ContainerCreating" } } },
+        ],
+      }),
+    );
+    const backingOff = describeRunnerStartupProgress(
+      pod({
+        phase: "Pending",
+        conditions: [{ type: "PodScheduled", status: "True" }],
+        containerStatuses: [
+          { state: { waiting: { reason: "ImagePullBackOff" } } },
+        ],
+      }),
+    );
+
+    expect(creating.phase).toBe(backingOff.phase);
+    expect(isSameRunnerStartupProgress(creating, backingOff)).toBe(false);
+  });
+
+  it("always reports the first observation", () => {
+    const progress = describeRunnerStartupProgress(null);
+    expect(isSameRunnerStartupProgress(null, progress)).toBe(false);
+  });
+});
+
+function pod(status: {
+  phase?: string;
+  conditions?: k8s.V1PodCondition[];
+  containerStatuses?: Partial<k8s.V1ContainerStatus>[];
+  initContainerStatuses?: Partial<k8s.V1ContainerStatus>[];
+}): k8s.V1Pod {
+  return {
+    metadata: { name: "archestra-run-test" },
+    status: {
+      phase: status.phase,
+      conditions: status.conditions,
+      containerStatuses: status.containerStatuses as k8s.V1ContainerStatus[],
+      initContainerStatuses:
+        status.initContainerStatuses as k8s.V1ContainerStatus[],
+    },
+  } as k8s.V1Pod;
+}

--- a/platform/backend/src/k8s/runner-runtime/startup-phase.ts
+++ b/platform/backend/src/k8s/runner-runtime/startup-phase.ts
@@ -1,0 +1,193 @@
+import type { AgentRunAttachPhase } from "@archestra/shared";
+import type * as k8s from "@kubernetes/client-node";
+
+/** One reportable step of an attach, before the terminal is live. */
+export type RunnerStartupProgress = {
+  phase: AgentRunAttachPhase;
+  message: string;
+  detail: string | null;
+};
+
+/**
+ * Describe what a run's pod is currently waiting on.
+ *
+ * Kubernetes already explains itself — an unschedulable pod names the
+ * constraint it failed, a failing pull names the image — but none of that
+ * reaches the person watching a terminal that says "Connecting…". This turns
+ * the pod's own status into that sentence.
+ *
+ * `null` is the pre-pod case: the Job is accepted and nothing carries it yet.
+ */
+export function describeRunnerStartupProgress(
+  pod: k8s.V1Pod | null,
+): RunnerStartupProgress {
+  if (!pod) {
+    return {
+      phase: "queued",
+      message: "Waiting for the run to be scheduled",
+      detail: null,
+    };
+  }
+
+  const phase = pod.status?.phase;
+
+  if (phase === "Pending") {
+    const unschedulable = findUnschedulableCondition(pod);
+    if (unschedulable) {
+      return {
+        phase: "scheduling",
+        message: "Waiting for a node with room for this run",
+        detail: unschedulable,
+      };
+    }
+
+    const waiting = findWaitingContainer(pod);
+    if (waiting) return waiting;
+
+    // Scheduled, but no container has reported a state yet.
+    return isScheduled(pod)
+      ? {
+          phase: "pulling",
+          message: "Preparing the container",
+          detail: null,
+        }
+      : {
+          phase: "scheduling",
+          message: "Waiting for a node",
+          detail: null,
+        };
+  }
+
+  if (phase === "Running") {
+    // A Running pod can still hold a container that is not up: a crash loop
+    // reports here, and silently calling that "starting" is how a broken image
+    // spends the whole attach timeout looking like a slow one.
+    const waiting = findWaitingContainer(pod);
+    if (waiting?.detail) {
+      return { ...waiting, phase: "starting" };
+    }
+    return {
+      phase: "starting",
+      message: "Waiting for the agent session",
+      detail: null,
+    };
+  }
+
+  // Succeeded/Failed/Unknown: the callers that wait for a terminal treat these
+  // as the end of the road, but a phase is still reported so a run that
+  // finished mid-attach explains itself rather than timing out silently.
+  return {
+    phase: "starting",
+    message: "Waiting for the agent session",
+    detail: pod.status?.message ?? pod.status?.reason ?? null,
+  };
+}
+
+/** The attach step after the agent session exists and before output flows. */
+export function attachingProgress(): RunnerStartupProgress {
+  return {
+    phase: "attaching",
+    message: "Opening the terminal stream",
+    detail: null,
+  };
+}
+
+/**
+ * Whether two reports say the same thing.
+ *
+ * Startup is polled once a second; without this every subscriber would get a
+ * message per tick saying nothing new.
+ */
+export function isSameRunnerStartupProgress(
+  a: RunnerStartupProgress | null,
+  b: RunnerStartupProgress,
+): boolean {
+  return (
+    a !== null &&
+    a.phase === b.phase &&
+    a.message === b.message &&
+    a.detail === b.detail
+  );
+}
+
+export type RunnerStartupProgressReporter = (
+  progress: RunnerStartupProgress & { resourceName?: string | null },
+) => void;
+
+// ===================== internals =====================
+
+/**
+ * Waiting reasons that mean the image itself is the problem, not the wait.
+ * These are surfaced verbatim: "ImagePullBackOff: manifest unknown" is the
+ * whole diagnosis, and hiding it behind "Connecting…" costs an operator the
+ * trip to `kubectl describe`.
+ */
+const IMAGE_WAITING_REASONS = new Set([
+  "ErrImagePull",
+  "ImagePullBackOff",
+  "ImageInspectError",
+  "InvalidImageName",
+  "RegistryUnavailable",
+]);
+
+/** Waiting reasons that are ordinary progress, not a fault. */
+const BENIGN_WAITING_REASONS = new Set([
+  "ContainerCreating",
+  "PodInitializing",
+]);
+
+function findWaitingContainer(pod: k8s.V1Pod): RunnerStartupProgress | null {
+  const statuses = [
+    ...(pod.status?.initContainerStatuses ?? []),
+    ...(pod.status?.containerStatuses ?? []),
+  ];
+
+  for (const status of statuses) {
+    const waiting = status.state?.waiting;
+    if (!waiting?.reason) continue;
+
+    if (BENIGN_WAITING_REASONS.has(waiting.reason)) {
+      return {
+        phase: "pulling",
+        message: "Pulling the agent image",
+        detail: null,
+      };
+    }
+
+    const detail = joinReason(waiting.reason, waiting.message);
+    if (IMAGE_WAITING_REASONS.has(waiting.reason)) {
+      return { phase: "pulling", message: "Pulling the agent image", detail };
+    }
+    // Anything else (CreateContainerConfigError, CrashLoopBackOff, a reason
+    // this build has never heard of) is still worth showing rather than
+    // flattening into a generic wait.
+    return { phase: "pulling", message: "Starting the container", detail };
+  }
+
+  return null;
+}
+
+function findUnschedulableCondition(pod: k8s.V1Pod): string | null {
+  const scheduled = pod.status?.conditions?.find(
+    (condition) => condition.type === "PodScheduled",
+  );
+  if (!scheduled || scheduled.status === "True") return null;
+  return joinReason(scheduled.reason, scheduled.message) ?? "Not yet scheduled";
+}
+
+function isScheduled(pod: k8s.V1Pod): boolean {
+  return (
+    pod.status?.conditions?.some(
+      (condition) =>
+        condition.type === "PodScheduled" && condition.status === "True",
+    ) ?? false
+  );
+}
+
+function joinReason(
+  reason: string | undefined,
+  message: string | undefined,
+): string | null {
+  if (reason && message) return `${reason}: ${message}`;
+  return reason ?? message ?? null;
+}

--- a/platform/backend/src/services/runners/backends/kubernetes.ts
+++ b/platform/backend/src/services/runners/backends/kubernetes.ts
@@ -10,6 +10,7 @@ import type {
 import { ApiError } from "@/types";
 import type {
   RunnerAttachment,
+  RunnerAttachProgress,
   RunnerAttachStatus,
   RunnerBackend,
   RunnerCompletion,
@@ -103,12 +104,14 @@ class KubernetesRunnerBackend implements RunnerBackend {
     stdout: Writable;
     stderr: Writable;
     onStatus?: (status: RunnerAttachStatus) => void;
+    onProgress?: (progress: RunnerAttachProgress) => void;
   }): Promise<RunnerAttachment> {
     const attachment = await runnerRuntimeManager.attach({
       session: params.session,
       stdin: params.stdin,
       stdout: params.stdout,
       stderr: params.stderr,
+      onProgress: params.onProgress,
       onStatus: (status) =>
         params.onStatus?.({
           outcome: status.status === "Failure" ? "failure" : "success",

--- a/platform/backend/src/services/runners/backends/types.ts
+++ b/platform/backend/src/services/runners/backends/types.ts
@@ -1,4 +1,5 @@
 import type { Readable, Writable } from "node:stream";
+import type { AgentRunAttachPhase } from "@archestra/shared";
 import type WebSocket from "ws";
 import type {
   AgentDeploymentBackend,
@@ -108,13 +109,21 @@ export interface RunnerBackend {
     message: string;
   }): Promise<void>;
 
-  /** Attach an interactive terminal to the execution. */
+  /**
+   * Attach an interactive terminal to the execution.
+   *
+   * A backend that has to wait — for placement, for an image, for the agent's
+   * session — reports those waits through `onProgress` rather than leaving the
+   * caller to stare at an unresolved promise. Reporting is best-effort: a
+   * backend that knows nothing about its own startup simply never calls it.
+   */
   attach(params: {
     session: AgentRun;
     stdin: Readable;
     stdout: Writable;
     stderr: Writable;
     onStatus?: (status: RunnerAttachStatus) => void;
+    onProgress?: (progress: RunnerAttachProgress) => void;
   }): Promise<RunnerAttachment>;
 
   /**
@@ -149,6 +158,23 @@ export interface RunnerCompletion {
 export interface RunnerAttachStatus {
   outcome: "success" | "failure";
   message?: string;
+}
+
+/**
+ * One step of an attach that has not completed yet.
+ *
+ * Runtime-neutral on purpose: "waiting for a node" and "pulling the image" are
+ * true of a VM pool or a sandbox tier as much as of a pod, so the vocabulary
+ * belongs to the interface rather than to Kubernetes.
+ */
+export interface RunnerAttachProgress {
+  phase: AgentRunAttachPhase;
+  /** Short phrase naming the wait. */
+  message: string;
+  /** The runtime's own explanation, when it has one. */
+  detail?: string | null;
+  /** Backend-native resource identifier, once one exists. */
+  resourceName?: string | null;
 }
 
 export interface RunnerAttachment {

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -569,6 +569,23 @@ class WebSocketService {
         stdin,
         stdout,
         stderr,
+        // Attaching waits on scheduling, the image pull and the agent's own
+        // session — minutes, on a cold node. Relay each wait as it is entered
+        // so the terminal can name what it is waiting for instead of showing
+        // an unqualified "Connecting…" for the whole of it.
+        onProgress: (progress) => {
+          if (ws.readyState !== WS.OPEN) return;
+          this.sendToClient(ws, {
+            type: "agent_run_attach_progress",
+            payload: {
+              runId,
+              phase: progress.phase,
+              message: progress.message,
+              detail: progress.detail ?? null,
+              resourceName: progress.resourceName ?? null,
+            },
+          });
+        },
         onStatus: (status) => {
           if (status.outcome === "failure") {
             this.sendToClient(ws, {

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-run-details-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-run-details-dialog.tsx
@@ -252,7 +252,8 @@ export function ConnectorRunDetailsDialog({
                 <h4 className="text-sm font-medium">Logs</h4>
                 <LogConsole
                   content={formattedLogs}
-                  emptyMessage="This run recorded no logs."
+                  emptyMessage="No logs recorded"
+                  emptyHint="This sync run finished without writing any log output."
                   className="h-80"
                 />
               </div>

--- a/platform/frontend/src/components/agent-execution-logs.tsx
+++ b/platform/frontend/src/components/agent-execution-logs.tsx
@@ -5,6 +5,7 @@ import type {
   AgentRunLogsErrorMessage,
   AgentRunLogsMessage,
 } from "@archestra/shared";
+import { FileX2, TerminalSquare } from "lucide-react";
 import { useEffect, useState } from "react";
 import {
   DeploymentLogPanel,
@@ -87,10 +88,14 @@ export function AgentExecutionLogs({
       scrollAreaRef={scrollAreaRef}
       showScrollToBottom={showScrollToBottom}
       onScrollToBottom={scrollToBottom}
+      emptyIcon={execution.endedAt ? FileX2 : TerminalSquare}
       emptyMessage={
+        execution.endedAt ? "No output recorded" : "Waiting for output"
+      }
+      emptyHint={
         execution.endedAt
-          ? "No output was recorded for this execution."
-          : "Waiting for output…"
+          ? "This execution ended without writing anything to its log."
+          : "Output appears here as the Agent writes it."
       }
       status={
         isStreaming ? (

--- a/platform/frontend/src/components/agent-execution-terminal.tsx
+++ b/platform/frontend/src/components/agent-execution-terminal.tsx
@@ -4,6 +4,7 @@ import type {
   AgentRunAttachClosedMessage,
   AgentRunAttachErrorMessage,
   AgentRunAttachOutputMessage,
+  AgentRunAttachProgressMessage,
   AgentRunAttachStartedMessage,
 } from "@archestra/shared";
 import { useMemo } from "react";
@@ -53,6 +54,19 @@ export function createAgentExecutionTransport(
           (message: AgentRunAttachStartedMessage) => {
             if (message.payload.runId === taskId) {
               handlers.onStarted(message.payload.command);
+            }
+          },
+        ),
+        websocketService.subscribe(
+          "agent_run_attach_progress",
+          (message: AgentRunAttachProgressMessage) => {
+            if (message.payload.runId === taskId) {
+              handlers.onProgress?.({
+                phase: message.payload.phase,
+                message: message.payload.message,
+                detail: message.payload.detail ?? null,
+                resourceName: message.payload.resourceName ?? null,
+              });
             }
           },
         ),

--- a/platform/frontend/src/components/deployment-console.tsx
+++ b/platform/frontend/src/components/deployment-console.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { LucideIcon } from "lucide-react";
 import { ArrowDown } from "lucide-react";
 import {
   type ReactNode,
@@ -177,6 +178,8 @@ export function DeploymentLogPanel({
   error,
   placeholder,
   emptyMessage,
+  emptyHint,
+  emptyIcon,
   status,
   scrollAreaRef,
   showScrollToBottom = false,
@@ -192,6 +195,8 @@ export function DeploymentLogPanel({
   error?: string | null;
   placeholder?: ReactNode;
   emptyMessage?: string;
+  emptyHint?: string;
+  emptyIcon?: LucideIcon;
   status?: ReactNode;
   scrollAreaRef?: Ref<HTMLDivElement>;
   showScrollToBottom?: boolean;
@@ -240,6 +245,8 @@ export function DeploymentLogPanel({
         error={error}
         placeholder={placeholder}
         emptyMessage={emptyMessage}
+        emptyHint={emptyHint}
+        emptyIcon={emptyIcon}
         status={status}
         contentTestId={contentTestId}
         errorTestId={errorTestId}

--- a/platform/frontend/src/components/exec/exec-terminal-progress.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal-progress.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import type { AgentRunAttachPhase } from "@archestra/shared";
+import { Check, CircleAlert, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+/** What the terminal knows about an attach that has not completed yet. */
+export type ExecSessionProgress = {
+  phase: AgentRunAttachPhase;
+  message: string;
+  detail: string | null;
+  resourceName: string | null;
+};
+
+/**
+ * The waits an attach goes through, as a person would describe them.
+ *
+ * Several protocol phases collapse into one step: "queued" and "scheduling"
+ * are both "we do not have a machine yet", and splitting them would show a
+ * step that ticks over without anything having visibly happened.
+ */
+const STEPS: { label: string; phases: AgentRunAttachPhase[] }[] = [
+  { label: "Scheduling onto a node", phases: ["queued", "scheduling"] },
+  { label: "Pulling the agent image", phases: ["pulling"] },
+  { label: "Starting the agent session", phases: ["starting"] },
+  { label: "Opening the terminal", phases: ["attaching"] },
+];
+
+/**
+ * Startup progress for a background execution's terminal.
+ *
+ * Replaces an unqualified "Connecting…" that could sit for minutes while a pod
+ * was scheduled and its image pulled. Every line here comes from the run's
+ * actual runtime state, so a run that is stuck says why it is stuck.
+ */
+export function ExecTerminalProgress({
+  progress,
+  startedAt,
+}: {
+  progress: ExecSessionProgress;
+  /** When this attach began, for the elapsed counter. */
+  startedAt: number;
+}) {
+  const elapsed = useElapsedSeconds(startedAt);
+  const currentStep = STEPS.findIndex((step) =>
+    step.phases.includes(progress.phase),
+  );
+  // An unrecognized phase from a newer backend should not blank the list.
+  const activeStep = currentStep === -1 ? 0 : currentStep;
+  // Never reaches 100%: the terminal itself replaces this on success, and a
+  // full bar under a spinner reads as a stall.
+  const percent = ((activeStep + 1) / (STEPS.length + 1)) * 100;
+
+  return (
+    <div className="flex flex-1 items-center justify-center p-6">
+      <div className="w-full max-w-sm space-y-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="text-sm font-medium text-slate-100">
+            {progress.message}
+          </p>
+          <span
+            role="timer"
+            className="shrink-0 font-mono text-xs tabular-nums text-slate-500"
+            aria-label="Time spent starting"
+          >
+            {formatElapsed(elapsed)}
+          </span>
+        </div>
+
+        <div
+          className="h-1 w-full overflow-hidden rounded-full bg-slate-800"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={STEPS.length}
+          aria-valuenow={activeStep + 1}
+          aria-valuetext={progress.message}
+        >
+          <div
+            className="h-full rounded-full bg-emerald-500 transition-[width] duration-500 ease-out"
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+
+        <ol className="space-y-1.5">
+          {STEPS.map((step, index) => (
+            <li
+              key={step.label}
+              className="flex items-center gap-2 text-xs"
+              aria-current={index === activeStep ? "step" : undefined}
+            >
+              <StepIcon
+                state={
+                  index < activeStep
+                    ? "done"
+                    : index === activeStep
+                      ? "active"
+                      : "pending"
+                }
+              />
+              <span
+                className={cn(
+                  index < activeStep && "text-slate-500",
+                  index === activeStep && "text-slate-200",
+                  index > activeStep && "text-slate-600",
+                )}
+              >
+                {step.label}
+              </span>
+            </li>
+          ))}
+        </ol>
+
+        {progress.detail ? (
+          <div className="flex gap-2 rounded-md border border-amber-500/20 bg-amber-500/5 p-2.5">
+            <CircleAlert className="mt-px size-3.5 shrink-0 text-amber-400" />
+            <p className="break-words font-mono text-[11px] leading-relaxed text-amber-200/90">
+              {progress.detail}
+            </p>
+          </div>
+        ) : null}
+
+        {progress.resourceName ? (
+          <p className="truncate font-mono text-[11px] text-slate-600">
+            {progress.resourceName}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// ===================== internals =====================
+
+function StepIcon({ state }: { state: "done" | "active" | "pending" }) {
+  if (state === "done") {
+    return <Check className="size-3.5 shrink-0 text-emerald-500" />;
+  }
+  if (state === "active") {
+    return (
+      <Loader2 className="size-3.5 shrink-0 animate-spin text-emerald-400" />
+    );
+  }
+  return (
+    <span
+      className="size-3.5 shrink-0"
+      // A dot rather than an outline circle: four ringed placeholders read as
+      // checkboxes waiting to be ticked by the reader.
+    >
+      <span className="mt-[5px] ml-[3px] block size-1.5 rounded-full bg-slate-700" />
+    </span>
+  );
+}
+
+function useElapsedSeconds(startedAt: number): number {
+  const [elapsed, setElapsed] = useState(() =>
+    Math.floor((Date.now() - startedAt) / 1000),
+  );
+
+  useEffect(() => {
+    setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    const interval = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [startedAt]);
+
+  return elapsed;
+}
+
+function formatElapsed(totalSeconds: number): string {
+  const safe = Math.max(0, totalSeconds);
+  const minutes = Math.floor(safe / 60);
+  const seconds = safe % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}

--- a/platform/frontend/src/components/exec/exec-terminal-progress.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal-progress.tsx
@@ -56,12 +56,16 @@ export function ExecTerminalProgress({
     <div className="flex flex-1 items-center justify-center p-6">
       <div className="w-full max-w-sm space-y-4">
         <div className="flex items-baseline justify-between gap-3">
-          <p className="text-sm font-medium text-slate-100">
+          {/* Live region: a screen reader user gets the phase change spoken
+              rather than watching a spinner they cannot see. */}
+          <output className="text-sm font-medium text-slate-100">
             {progress.message}
-          </p>
+          </output>
+          {/* `role="timer"` is implicitly aria-live="off", so a counter that
+              ticks every second never interrupts the region above. */}
           <span
             role="timer"
-            className="shrink-0 font-mono text-xs tabular-nums text-slate-500"
+            className="shrink-0 font-mono text-xs tabular-nums text-slate-400"
             aria-label="Time spent starting"
           >
             {formatElapsed(elapsed)}
@@ -76,9 +80,11 @@ export function ExecTerminalProgress({
           aria-valuenow={activeStep + 1}
           aria-valuetext={progress.message}
         >
+          {/* Scale, not width: animating width relayouts the panel every
+              frame, while a transform stays on the compositor. */}
           <div
-            className="h-full rounded-full bg-emerald-500 transition-[width] duration-500 ease-out"
-            style={{ width: `${percent}%` }}
+            className="h-full w-full origin-left rounded-full bg-emerald-500 transition-transform duration-500 ease-out motion-reduce:transition-none"
+            style={{ transform: `scaleX(${percent / 100})` }}
           />
         </div>
 
@@ -98,11 +104,12 @@ export function ExecTerminalProgress({
                       : "pending"
                 }
               />
+              {/* Only two text tiers: slate-500/600 measure 4.2:1 and 2.7:1 on
+                  this panel, both under WCAG AA. The icon carries done vs
+                  pending, so the label does not have to dim below legibility. */}
               <span
                 className={cn(
-                  index < activeStep && "text-slate-500",
-                  index === activeStep && "text-slate-200",
-                  index > activeStep && "text-slate-600",
+                  index === activeStep ? "text-slate-100" : "text-slate-400",
                 )}
               >
                 {step.label}
@@ -121,7 +128,7 @@ export function ExecTerminalProgress({
         ) : null}
 
         {progress.resourceName ? (
-          <p className="truncate font-mono text-[11px] text-slate-600">
+          <p className="truncate font-mono text-[11px] text-slate-400">
             {progress.resourceName}
           </p>
         ) : null}
@@ -137,8 +144,10 @@ function StepIcon({ state }: { state: "done" | "active" | "pending" }) {
     return <Check className="size-3.5 shrink-0 text-emerald-500" />;
   }
   if (state === "active") {
+    // The one animation on this panel, so it is also the one that has to stop
+    // for readers who ask motion to stop (WCAG 2.3.3).
     return (
-      <Loader2 className="size-3.5 shrink-0 animate-spin text-emerald-400" />
+      <Loader2 className="size-3.5 shrink-0 animate-spin text-emerald-400 motion-reduce:animate-none" />
     );
   }
   return (
@@ -147,7 +156,7 @@ function StepIcon({ state }: { state: "done" | "active" | "pending" }) {
       // A dot rather than an outline circle: four ringed placeholders read as
       // checkboxes waiting to be ticked by the reader.
     >
-      <span className="mt-[5px] ml-[3px] block size-1.5 rounded-full bg-slate-700" />
+      <span className="mt-[5px] ml-[3px] block size-1.5 rounded-full bg-slate-500" />
     </span>
   );
 }

--- a/platform/frontend/src/components/exec/exec-terminal.test.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.test.tsx
@@ -35,7 +35,11 @@ vi.mock("@xterm/addon-fit", () => ({
 
 vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 
-import { type ExecSessionTransport, ExecTerminal } from "./exec-terminal";
+import {
+  type ExecSessionHandlers,
+  type ExecSessionTransport,
+  ExecTerminal,
+} from "./exec-terminal";
 
 global.ResizeObserver = class ResizeObserver {
   observe() {}
@@ -69,5 +73,76 @@ describe("ExecTerminal", () => {
     await waitFor(() => {
       expect(transport.sendResize).toHaveBeenCalledWith(164, 52);
     });
+  });
+
+  it("names the wait a session is in, and the runtime's reason for it", async () => {
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        handlers.onProgress?.({
+          phase: "scheduling",
+          message: "Waiting for a node with room for this run",
+          detail: "Unschedulable: 0/3 nodes are available: insufficient cpu",
+          resourceName: "archestra-run-abc123",
+        });
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(<ExecTerminal sessionKey="task-2" transport={transport} isActive />);
+
+    expect(
+      await screen.findByText("Waiting for a node with room for this run"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Unschedulable: 0/3 nodes are available: insufficient cpu",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("archestra-run-abc123")).toBeInTheDocument();
+    expect(screen.queryByText("Connecting...")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the plain connecting state for a transport that reports no progress", async () => {
+    const transport: ExecSessionTransport = {
+      open: () => vi.fn(),
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(<ExecTerminal sessionKey="task-3" transport={transport} isActive />);
+
+    expect(await screen.findByText("Connecting...")).toBeInTheDocument();
+  });
+
+  it("drops the startup progress once the session is live", async () => {
+    const session: { handlers: ExecSessionHandlers | null } = {
+      handlers: null,
+    };
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        session.handlers = handlers;
+        handlers.onProgress?.({
+          phase: "attaching",
+          message: "Opening the terminal stream",
+          detail: null,
+          resourceName: null,
+        });
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(<ExecTerminal sessionKey="task-4" transport={transport} isActive />);
+    await screen.findByText("Opening the terminal stream");
+
+    session.handlers?.onStarted(null);
+
+    await screen.findByText("Connected");
+    expect(
+      screen.queryByText("Opening the terminal stream"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/exec/exec-terminal.test.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.test.tsx
@@ -104,6 +104,61 @@ describe("ExecTerminal", () => {
     expect(screen.queryByText("Connecting...")).not.toBeInTheDocument();
   });
 
+  /**
+   * The startup phase is conveyed by a spinner moving down a list, which a
+   * screen reader user cannot see. The phase text has to be announced instead.
+   */
+  it("announces the current wait to assistive technology", async () => {
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        handlers.onProgress?.({
+          phase: "pulling",
+          message: "Pulling the agent image",
+          detail: null,
+          resourceName: null,
+        });
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(<ExecTerminal sessionKey="task-5" transport={transport} isActive />);
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Pulling the agent image",
+    );
+  });
+
+  /**
+   * The step spinner is the only animation on the panel, so it is the one that
+   * has to hold still for readers who ask motion to stop (WCAG 2.3.3).
+   */
+  it("keeps the step spinner still under prefers-reduced-motion", async () => {
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        handlers.onProgress?.({
+          phase: "starting",
+          message: "Waiting for the agent session",
+          detail: null,
+          resourceName: null,
+        });
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    const { container } = render(
+      <ExecTerminal sessionKey="task-6" transport={transport} isActive />,
+    );
+    await screen.findByText("Waiting for the agent session");
+
+    expect(
+      container.querySelector(".animate-spin.motion-reduce\\:animate-none"),
+    ).toBeInTheDocument();
+  });
+
   it("falls back to the plain connecting state for a transport that reports no progress", async () => {
     const transport: ExecSessionTransport = {
       open: () => vi.fn(),

--- a/platform/frontend/src/components/exec/exec-terminal.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.tsx
@@ -7,6 +7,10 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { copyToClipboard } from "@/lib/clipboard";
 import { isUsableTerminalDimensions } from "./exec-terminal.utils";
+import {
+  type ExecSessionProgress,
+  ExecTerminalProgress,
+} from "./exec-terminal-progress";
 
 type ConnectionStatus =
   | "idle"
@@ -24,6 +28,14 @@ export type ExecSessionHandlers = {
   onOutput: (data: string) => void;
   onError: (message: string) => void;
   onClosed: (reason: string | null) => void;
+  /**
+   * A wait the session is still in, before it is live.
+   *
+   * Optional because not every transport can see inside its own startup: one
+   * attaching to a pod that is already running has nothing to report, and gets
+   * the plain connecting state instead.
+   */
+  onProgress?: (progress: ExecSessionProgress) => void;
 };
 
 /**
@@ -88,6 +100,12 @@ export function ExecTerminal({
   );
   const fitAddonRef = useRef<import("@xterm/addon-fit").FitAddon | null>(null);
   const [status, setStatus] = useState<ConnectionStatus>("idle");
+  const [progress, setProgress] = useState<ExecSessionProgress | null>(null);
+  /**
+   * When the current attach began. Reset per attempt so a reconnect's elapsed
+   * counter starts from that attempt, not from when the page was opened.
+   */
+  const [connectingSince, setConnectingSince] = useState(() => Date.now());
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [closedReason, setClosedReason] = useState<string | null>(null);
   const [command, setCommand] = useState<string | null>(null);
@@ -169,12 +187,19 @@ export function ExecTerminal({
       initializedRef.current = true;
 
       setStatus("connecting");
+      setProgress(null);
+      setConnectingSince(Date.now());
       setErrorMessage(null);
 
       const closeSession = transportRef.current.open({
+        onProgress: (sessionProgress) => {
+          if (disposed) return;
+          setProgress(sessionProgress);
+        },
         onStarted: (startedCommand) => {
           if (disposed) return;
           setStatus("connected");
+          setProgress(null);
           setCommand(startedCommand);
           const dims = fitAddon.proposeDimensions();
           if (isUsableTerminalDimensions(dims)) {
@@ -262,11 +287,17 @@ export function ExecTerminal({
           <h3 className="text-sm font-semibold flex-shrink-0">{title}</h3>
         )}
         <div className="flex flex-col flex-1 min-h-0 rounded-md border bg-slate-950 overflow-hidden">
-          {status === "connecting" && (
-            <div className="flex items-center justify-center p-4 text-slate-400 text-sm font-mono">
-              {statusText}
-            </div>
-          )}
+          {status === "connecting" &&
+            (progress ? (
+              <ExecTerminalProgress
+                progress={progress}
+                startedAt={connectingSince}
+              />
+            ) : (
+              <div className="flex items-center justify-center p-4 text-slate-400 text-sm font-mono">
+                {statusText}
+              </div>
+            ))}
           {(status === "error" || status === "disconnected") && (
             <div
               className={`flex items-center justify-center p-4 text-sm font-mono ${status === "error" ? "text-red-400" : "text-yellow-400"}`}

--- a/platform/frontend/src/components/log-console.test.tsx
+++ b/platform/frontend/src/components/log-console.test.tsx
@@ -20,4 +20,41 @@ describe("LogConsole", () => {
     rerender(<LogConsole content={null} emptyMessage="Nothing here" />);
     expect(screen.getByText("Nothing here")).toBeInTheDocument();
   });
+
+  /**
+   * An empty console is a large dark panel. One line of mono text in its top
+   * corner reads as a rendering failure, so the empty state says what happened
+   * and why, together, in the middle of the space it is explaining.
+   */
+  it("explains an empty console rather than stranding a single line", () => {
+    render(
+      <LogConsole
+        content={null}
+        emptyMessage="No output recorded"
+        emptyHint="This execution ended without writing anything to its log."
+      />,
+    );
+
+    expect(screen.getByText("No output recorded")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This execution ended without writing anything to its log.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("lets a caller's own placeholder replace the empty state", () => {
+    render(
+      <LogConsole
+        content={null}
+        emptyMessage="No output recorded"
+        emptyHint="Should not be shown"
+        placeholder={<span>Connecting to pod logs…</span>}
+      />,
+    );
+
+    expect(screen.getByText("Connecting to pod logs…")).toBeInTheDocument();
+    expect(screen.queryByText("No output recorded")).not.toBeInTheDocument();
+    expect(screen.queryByText("Should not be shown")).not.toBeInTheDocument();
+  });
 });

--- a/platform/frontend/src/components/log-console.tsx
+++ b/platform/frontend/src/components/log-console.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Copy } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Copy, ScrollText } from "lucide-react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -21,6 +22,8 @@ import { cn } from "@/lib/utils";
 export function LogConsole({
   content,
   emptyMessage = "No logs available",
+  emptyHint,
+  emptyIcon: EmptyIcon = ScrollText,
   placeholder,
   error,
   contentTone = "logs",
@@ -35,6 +38,10 @@ export function LogConsole({
   /** The log text. Empty or absent renders `placeholder`, else `emptyMessage`. */
   content: string | null | undefined;
   emptyMessage?: string;
+  /** One short line under `emptyMessage` saying why there is nothing here. */
+  emptyHint?: string;
+  /** Glyph for the empty state, when a console has a more specific one. */
+  emptyIcon?: LucideIcon;
   /**
    * What to show in place of the empty message while there is no log text yet
    * — a "connecting…" line, an explanation of why none exist. Not copyable:
@@ -76,41 +83,60 @@ export function LogConsole({
         className,
       )}
     >
-      <ScrollArea
-        ref={scrollAreaRef}
-        onScroll={onScroll}
-        // Radix sizes the viewport's inner wrapper as a `display: table`, which
-        // makes it grow to the widest line instead of wrapping inside the
-        // panel. Logs are read wrapped, so force it back to a block.
-        className="min-h-0 flex-1 overflow-auto [&_[data-radix-scroll-area-viewport]>div]:!block"
-      >
-        <div className="p-4">
-          {error ? (
-            <div
-              className="font-mono text-sm text-red-400"
-              data-testid={errorTestId}
-            >
-              {error}
-            </div>
-          ) : content ? (
-            <pre
-              className={cn(
-                "font-mono text-xs whitespace-pre-wrap break-words",
-                contentTone === "error" ? "text-red-400" : "text-emerald-400",
-              )}
-              data-testid={contentTestId}
-            >
-              {content}
-            </pre>
-          ) : (
-            (placeholder ?? (
-              <div className="font-mono text-sm text-slate-400">
-                {emptyMessage}
+      {error || content ? (
+        <ScrollArea
+          ref={scrollAreaRef}
+          onScroll={onScroll}
+          // Radix sizes the viewport's inner wrapper as a `display: table`, which
+          // makes it grow to the widest line instead of wrapping inside the
+          // panel. Logs are read wrapped, so force it back to a block.
+          className="min-h-0 flex-1 overflow-auto [&_[data-radix-scroll-area-viewport]>div]:!block"
+        >
+          <div className="p-4">
+            {error ? (
+              <div
+                className="font-mono text-sm text-red-400"
+                data-testid={errorTestId}
+              >
+                {error}
               </div>
-            ))
+            ) : (
+              <pre
+                className={cn(
+                  "font-mono text-xs whitespace-pre-wrap break-words",
+                  contentTone === "error" ? "text-red-400" : "text-emerald-400",
+                )}
+                data-testid={contentTestId}
+              >
+                {content}
+              </pre>
+            )}
+          </div>
+        </ScrollArea>
+      ) : (
+        // Nothing to read: centre the state instead of stranding one line of
+        // mono text in the corner of a large empty panel. Callers that supply
+        // their own placeholder get the centring without losing control of it.
+        <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+          {placeholder ?? (
+            <div className="flex max-w-xs flex-col items-center gap-3 text-center">
+              <div className="flex size-9 items-center justify-center rounded-lg border border-slate-800 bg-slate-900 text-slate-400">
+                <EmptyIcon className="size-4" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-slate-300">
+                  {emptyMessage}
+                </p>
+                {emptyHint ? (
+                  <p className="text-xs leading-relaxed text-slate-400">
+                    {emptyHint}
+                  </p>
+                ) : null}
+              </div>
+            </div>
           )}
         </div>
-      </ScrollArea>
+      )}
       <div className="flex items-center justify-between border-t border-slate-800 px-3 py-2">
         {status ?? <div />}
         <Button

--- a/platform/shared/websocket.ts
+++ b/platform/shared/websocket.ts
@@ -406,6 +406,51 @@ export type McpDeploymentStatusEntry = {
 };
 
 // Agent run attach + logs, server -> client
+
+/**
+ * Where an attach has got to before the terminal is live.
+ *
+ * Attaching is not instant: the run's task is marked working as soon as the
+ * workload is accepted, so a browser can ask for the terminal while the pod is
+ * still being scheduled or its image pulled. These are the waits the backend
+ * already performs, named so the UI can say which one is happening instead of
+ * showing an unqualified "Connecting…" for what can be minutes.
+ *
+ * Ordered: a client may treat every earlier phase as complete.
+ */
+export const AGENT_RUN_ATTACH_PHASES = [
+  /** The workload is accepted but no pod carries it yet. */
+  "queued",
+  /** A pod exists and Kubernetes is placing it on a node. */
+  "scheduling",
+  /** The node is preparing the container, usually pulling its image. */
+  "pulling",
+  /** The container runs; its agent session is still coming up. */
+  "starting",
+  /** The session exists and the terminal stream is being opened. */
+  "attaching",
+] as const;
+
+export type AgentRunAttachPhase = (typeof AGENT_RUN_ATTACH_PHASES)[number];
+
+export type AgentRunAttachProgressMessage = {
+  type: "agent_run_attach_progress";
+  payload: {
+    runId: string;
+    phase: AgentRunAttachPhase;
+    /** Short phrase naming the wait, e.g. "Pulling the agent image". */
+    message: string;
+    /**
+     * The runtime's own explanation when it has one — an unschedulable pod's
+     * reason, a failing image pull. This is the part that turns a stuck run
+     * from a hang into something the person watching can act on.
+     */
+    detail?: string | null;
+    /** Named once a pod carries the run, for operators reading logs. */
+    resourceName?: string | null;
+  };
+};
+
 export type AgentRunAttachStartedMessage = {
   type: "agent_run_attach_started";
   payload: { runId: string; command: string; resourceName: string };
@@ -529,6 +574,7 @@ export type ServerWebSocketMessage =
   | McpExecOutputMessage
   | McpExecErrorMessage
   | McpExecClosedMessage
+  | AgentRunAttachProgressMessage
   | AgentRunAttachStartedMessage
   | AgentRunAttachOutputMessage
   | AgentRunAttachErrorMessage


### PR DESCRIPTION
## Problem

Opening the **Live terminal** on a background execution showed a bare `Connecting...` on a black panel, with no other signal, for as long as the attach took. That window is not short: the A2A task is marked working as soon as the workload is accepted, so the browser can ask for a terminal while the pod is still being scheduled and its image pulled — minutes on a cold node, and up to the 10-minute pod-start timeout when something is actually wrong.

The backend already knew which wait it was in at every moment (`waitForRunningPod`, then `waitForTmuxSession`), and Kubernetes already explains itself — an unschedulable pod names the constraint it failed, a failing pull names the image. None of that reached the person watching. A run stuck on a bad image tag and a run pulling a large image looked identical.

## Approach

`RunnerBackend.attach` takes an optional `onProgress` reporter. It is runtime-neutral: "waiting for a node" and "pulling the image" are true of a VM pool or a sandbox tier as much as of a pod, so the vocabulary sits on the interface rather than in the Kubernetes adapter. A backend that cannot see inside its own startup simply never calls it.

- The Kubernetes backend drives it from the two wait loops it already ran, so this adds no new polling.
- `startup-phase.ts` maps a `V1Pod` to a phase plus a human message, and — when Kubernetes has a complaint — its verbatim reason. Reports are deduped, so a 1s poll does not become one message per second, while a *changed* reason still gets through.
- A new `agent_run_attach_progress` server→client message relays each step; sends are guarded on socket state since an attach can outlive the client.
- `ExecTerminal` renders a four-step stepper, an elapsed counter, the pod name, and the runtime's reason in a callout when there is one.

Progress is optional on the transport, so the MCP exec terminal — which attaches to an already-running pod and has nothing to report — keeps the plain connecting state unchanged.

## Behavior

Two runs were driven end to end against a local cluster.

Healthy run: `Scheduling onto a node` → `Pulling the agent image` → `Starting the agent session` → `Opening the terminal`, then the live tmux terminal and its copyable `kubectl exec` command, as before.

Run pinned to a tag that does not exist: the terminal stays on `Pulling the agent image` and shows

```
ErrImagePull: Error response from daemon: manifest for …/agent-archestra:no-such-tag-9x9
not found: manifest unknown: Failed to fetch "no-such-tag-9x9"
```

updating to `ImagePullBackOff: Back-off pulling image …` as kubelet backs off. Previously this was an indefinite `Connecting...` ending in a timeout, with `kubectl describe` the only way to find out why.

## Notes

The phase vocabulary is ordered (`queued → scheduling → pulling → starting → attaching`), so a client may treat every earlier phase as complete; an unrecognized phase from a newer backend degrades to the first step rather than blanking the list. A pod that is `Running` but holds a waiting container (a crash loop) is deliberately not reported as a healthy start — that was how a broken image could spend the whole attach timeout looking like a slow one.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>