### PR TITLE
docs(plugins): shorten product copy and public docs

### DIFF
--- a/docs/pages/platform-agent-plugins.md
+++ b/docs/pages/platform-agent-plugins.md
@@ -2,97 +2,58 @@
 title: Plugins
 category: Agents
 order: 4
-description: Client-native extensions delivered to Claude Code, Codex, Copilot CLI, and Cursor
-lastUpdated: 2026-08-27
+description: Client-native extensions for Claude Code, Codex, Copilot CLI, and Cursor
+lastUpdated: 2026-09-01
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
 
-Plugins package client-native behavior for coding agents. A plugin can contain hooks, agents, commands, skills, MCP configuration, and companion scripts.
+A plugin installs client-native files on a developer machine. It can include hooks, agents, commands, skills, MCP configuration, and scripts.
 
-Plugins run on developer machines. Review every file before you approve an import or update.
+Review every file before you approve an import or update.
 
 ![The Plugins catalog with GitHub sources, sync state, supported clients, and visibility](/docs/automated_screenshots/platform-agent-plugins_catalog.webp)
 
 > **Beta feature** — set `ARCHESTRA_PLUGINS_ENABLED=true`, or enable the `ARCHESTRA_BETA` switch. See [Deployment](/docs/platform-deployment#skills-marketplace).
 
-Plugins live under **Studio** in the sidebar. The catalog shows each plugin's client, platform support, source, visibility, and sync state.
+Go to **Studio → Plugins** to create or import a plugin.
 
 ## Creating a Plugin
 
-**Add new plugin** opens a three-step wizard. Choose a source, review the files, then set visibility.
+You can start from a blank template or import a GitHub marketplace.
 
 A blank plugin starts with `hooks/hooks.json`. Hooks are optional. You can replace that file with any payload the target client supports.
 
-Every plugin targets one client:
+Every plugin targets one client: Claude Code, Codex, Copilot CLI, or Cursor. It also declares macOS/Linux, Windows, or both, so a setup command skips an incompatible payload.
 
-- Claude Code
-- Codex
-- Copilot CLI
-- Cursor
-
-It also declares support for macOS/Linux, Windows, or both. This prevents a setup command from installing an incompatible payload.
-
-Archestra stores plugin files without translating them. Imported executable modes are preserved. Files such as `.mcp.json` remain part of the plugin when the client supports them.
-
-You can also manage plugins from chat. The built-in plugin tools list and read plugins, create manual plugins, replace or edit files, and delete plugins. File replacements and edits check the plugin's content hash so a stale chat cannot overwrite a newer change. GitHub-sourced files stay read-only — review and apply those updates in the Plugins UI.
+The platform stores plugin files without translating them.
 
 ## Importing a Marketplace
 
-You can import from a popular marketplace or paste another GitHub marketplace URL. Private repositories use a saved GitHub App or personal access token from **Settings → GitHub**.
+Import from a popular marketplace, or paste a GitHub marketplace URL. Private repositories use a GitHub App or personal access token from **Settings → GitHub**.
 
-Discovery lists the marketplace entries before anything is imported. Select the plugins you want and preview their files.
-
-Each import accepts up to 10 plugins. Reopen the marketplace to import the next batch.
-
-An import pins the marketplace revision and each selected source commit. If a source moves during review, the import stops instead of substituting different files.
-
-GitHub-owned files stay read-only in Archestra. Edit them in their repository.
+Select the plugins you want and preview their files. GitHub-owned files stay read-only here. Edit them in their repository.
 
 ## Reviewing Updates
 
-GitHub checks can run manually, every 15 minutes, every hour, or once a day. A changed commit becomes an update candidate.
-
-An update never replaces approved files automatically. Open **Updates**, review the candidate, then approve and apply it.
-
-Open a GitHub plugin's edit page to change its repository, tracked ref, check schedule, or visibility. Leave the token field empty to keep its current credential. If a token expires, enter a replacement token or select a GitHub App.
-
-OpenAPPA is imported once for each organization when Plugins are enabled. It behaves like any other GitHub plugin after import. You can update or delete it.
+A changed GitHub commit becomes an update candidate. Approved files never change until you review the candidate and apply it.
 
 ## Installing Plugins
 
-You can install one plugin from its details page. Select several compatible rows to generate one command for the batch.
+Install a plugin from its details page, or select several compatible ones for one command.
 
-Bulk installation requires one client and a platform shared by every selected plugin.
-
-The [Connection page](/docs/platform-connection) can install plugins alongside the MCP gateway, LLM proxy, and shared Skills. The review step freezes the exact plugin selection into a one-time command.
+The [Connection page](/docs/platform-connection) can install plugins with the MCP gateway, LLM proxy, and shared Skills.
 
 | Client | Installation |
 | --- | --- |
 | Claude Code | Registers the marketplace and installs each selected plugin. |
 | Codex | Installs each plugin. Open `/hooks` to approve delivered hooks before they run. |
 | Copilot CLI | Registers the marketplace and installs each selected plugin. |
-| Cursor | Registers the marketplace, then lists the plugins to install from **Customize → Plugins**. |
+| Cursor | Registers the marketplace, then lists the plugins under **Customize → Plugins**. |
 
-Plugin-only commands leave MCP and proxy configuration unchanged.
+## Use Case: Block Commits on Main
 
-## Visibility And Permissions
-
-Visibility controls who can discover a plugin:
-
-- **Personal** — the owner and explicitly shared users.
-- **Team** — members of the selected teams.
-- **Organization** — everyone in the organization.
-
-Every plugin action requires `plugin:admin` plus its action-specific permission. See [Access Control](/docs/platform-access-control) for the complete reference.
-
-Disabling a plugin removes it from future setup commands and marketplace revisions. Deleting it also stops GitHub checks.
-
-Neither action removes code already installed on a developer machine. Uninstall it with the client or the [startup guard](/docs/platform-connection#startup-guard).
-
-## Use Case: Custom Hook Bundle
-
-A platform team keeps its coding-agent policy in one GitHub repository:
+A platform engineer wants every Claude Code session to reject commits on `main`. They keep the hooks in GitHub:
 
 ```text
 developer-policy/
@@ -101,18 +62,4 @@ developer-policy/
 └── scripts/check-branch.ps1
 ```
 
-The team imports the marketplace entry and reviews the pinned files. It marks both platforms as supported after testing each script.
-
-An authorized platform administrator selects the plugin and runs the setup command. A later GitHub change appears as a review candidate before it reaches another machine.
-
-## Plugins, Skills, And Hooks
-
-| Primitive | What it does |
-| --- | --- |
-| [Plugin](/docs/platform-agent-plugins) | Installs client-native files and behavior on a developer machine. |
-| [Skill](/docs/platform-agent-skills) | Gives an agent instructions and resources to load on demand. |
-| [Archestra hook](/docs/platform-agent-hooks) | Runs a script in Archestra's sandbox during an agent lifecycle event. |
-
-Use a plugin when the coding client must own the behavior. Use a Skill when the model needs reusable guidance.
-
-Skills embedded at any depth in a plugin also appear under **Skills from plugins** on the Skills page. This read-only Beta category ignores the plugin's client and platform when listing `SKILL.md` files. Every file owned by the Skill tree is shared except hooks, hook manifests, plugin or marketplace metadata, and installation files. Agents in any connected client can discover and load these Skills without creating standalone copies.
+They import the repository, review the hooks, and share the plugin with the team. Each engineer runs the setup command. The next time someone tries to commit on `main`, Claude Code blocks it deterministically.

--- a/platform/frontend/src/app/plugins/[id]/edit/page.client.tsx
+++ b/platform/frontend/src/app/plugins/[id]/edit/page.client.tsx
@@ -59,9 +59,8 @@ import type { PluginPlatform } from "../../_parts/plugin-platforms";
 import { PluginScopeSelector } from "../../_parts/plugin-scope-selector";
 
 const STEP_DESCRIPTIONS: Record<PluginEditStepId, string> = {
-  content:
-    "Edit the plugin's metadata and payload files. GitHub-sourced bytes stay read-only.",
-  access: "Choose who can discover and install the plugin.",
+  content: "Edit metadata and files. GitHub files stay read-only.",
+  access: "Choose who can discover this plugin.",
 };
 
 const GITHUB_SYNC_OPTIONS = [
@@ -338,7 +337,7 @@ function PluginEditWizard({ plugin }: { plugin: PluginDetail }) {
       documentTitle={`Edit ${plugin.displayName}`}
       description={
         isGithubPlugin
-          ? "Edit the tracked GitHub source, authentication, update schedule, and discoverability."
+          ? "Edit the GitHub source, schedule, and who can discover this plugin."
           : STEP_DESCRIPTIONS[step]
       }
       backLink={

--- a/platform/frontend/src/app/plugins/[id]/edit/page.test.tsx
+++ b/platform/frontend/src/app/plugins/[id]/edit/page.test.tsx
@@ -138,7 +138,7 @@ describe("PluginEditPage", () => {
 
     expect(
       screen.getByText(
-        "Edit the tracked GitHub source, authentication, update schedule, and discoverability.",
+        "Edit the GitHub source, schedule, and who can discover this plugin.",
       ),
     ).toBeVisible();
     expect(screen.getByLabelText("Repository URL")).toHaveValue(

--- a/platform/frontend/src/app/plugins/[id]/page.client.tsx
+++ b/platform/frontend/src/app/plugins/[id]/page.client.tsx
@@ -376,7 +376,7 @@ function PluginDetailView({
         open={deleteRequested}
         onOpenChange={setDeleteRequested}
         title="Delete plugin?"
-        description="It will disappear from future marketplace revisions. This does not uninstall code already present on developer machines; remove that plugin locally through the client or startup guard."
+        description="Installed copies stay on developer machines until you uninstall them."
         isPending={deletePlugin.isPending}
         onConfirm={handleDelete}
       />

--- a/platform/frontend/src/app/plugins/_parts/import-marketplace-dialog.tsx
+++ b/platform/frontend/src/app/plugins/_parts/import-marketplace-dialog.tsx
@@ -529,10 +529,10 @@ export function ImportMarketplaceDialog({
       }
       description={
         isAutoDiscovering
-          ? "Looking for a plugin marketplace manifest in the repository."
+          ? "Looking for a marketplace manifest."
           : isSelectStep
-            ? "Choose which plugins to add to your organization."
-            : "Point at a repository containing a plugin marketplace manifest."
+            ? "Choose which plugins to import."
+            : "Paste a GitHub marketplace URL."
       }
       size="medium"
       bodyClassName={isSelectStep ? "p-0" : undefined}

--- a/platform/frontend/src/app/plugins/_parts/plugin-content-fields.tsx
+++ b/platform/frontend/src/app/plugins/_parts/plugin-content-fields.tsx
@@ -76,7 +76,7 @@ export function PluginContentFields({
             value={description}
             readOnly={readOnly}
             onChange={(event) => onDescriptionChange(event.target.value)}
-            placeholder="What this plugin does and when an administrator should deploy it"
+            placeholder="What this plugin does."
             maxLength={1000}
             rows={3}
           />
@@ -91,7 +91,7 @@ export function PluginContentFields({
               className="font-mono text-xs"
             />
             <span className="block text-xs text-muted-foreground">
-              Frozen so renaming the plugin cannot orphan installed plugins.
+              This name stays after you rename the plugin.
             </span>
           </div>
         ) : null}

--- a/platform/frontend/src/app/plugins/_parts/plugin-github-updates-dialog.tsx
+++ b/platform/frontend/src/app/plugins/_parts/plugin-github-updates-dialog.tsx
@@ -61,7 +61,7 @@ export function PluginGithubUpdatesDialog({
       open={open}
       onOpenChange={close}
       title="GitHub updates"
-      description="Check the tracked source and approve new plugin bytes before they are delivered."
+      description="Review GitHub changes before they install."
       size="large"
       bodyClassName="space-y-5 overflow-y-auto"
       footer={

--- a/platform/frontend/src/app/plugins/_parts/plugin-install-dialog.tsx
+++ b/platform/frontend/src/app/plugins/_parts/plugin-install-dialog.tsx
@@ -139,7 +139,7 @@ export function PluginInstallDialog({
           ? `Install ${plugins[0]?.displayName}`
           : `Install ${plugins.length} plugins`
       }
-      description="Review the target, then run the generated setup command."
+      description="Review the target, then run the setup command."
       size="medium"
       className="sm:max-w-5xl"
       bodyClassName="overflow-y-auto"

--- a/platform/frontend/src/app/plugins/new/page.client.tsx
+++ b/platform/frontend/src/app/plugins/new/page.client.tsx
@@ -42,10 +42,9 @@ const CREATE_STEPS: Array<{ id: CreateStep; title: string }> = [
 ];
 
 const STEP_DESCRIPTIONS: Record<CreateStep, string> = {
-  source: "Import from a GitHub marketplace or start from a blank template.",
-  content:
-    "Author the native hook configuration and any payload files the plugin needs.",
-  access: "Choose who can discover and install the plugin.",
+  source: "Import from GitHub, or start blank.",
+  content: "Add the files this plugin installs.",
+  access: "Choose who can discover this plugin.",
 };
 
 const INITIAL_FILES: PluginFileDraft[] = [
@@ -189,13 +188,13 @@ function NewPluginWizard() {
                 <CatalogSourceCard
                   icon={<Github className="size-5" />}
                   title="Custom GitHub URL"
-                  description="Paste any repository with a plugin marketplace manifest."
+                  description="Paste a GitHub marketplace URL."
                   onClick={openImport}
                 />
                 <CatalogSourceCard
                   icon={<FileText className="size-5" />}
                   title="Blank template"
-                  description="Author native plugin files from scratch."
+                  description="Write the plugin files here."
                   onClick={() => setStep("content")}
                 />
               </div>

--- a/platform/frontend/src/app/plugins/page.client.tsx
+++ b/platform/frontend/src/app/plugins/page.client.tsx
@@ -97,7 +97,7 @@ import {
 import { PluginSourceIcon } from "./_parts/plugin-source-icon";
 
 const PLUGINS_DESCRIPTION =
-  "Plugins ship native hook configurations and companion scripts to connected coding agents, stored verbatim and approved per content hash.";
+  "Plugins install client-native files on developer machines.";
 
 export default function PluginsPage() {
   return (
@@ -948,7 +948,7 @@ function PluginsList() {
           title="Delete plugins"
           description={`Delete ${bulkSelection.selected.length} ${
             bulkSelection.selected.length === 1 ? "plugin" : "plugins"
-          }? Their payload files and client delivery will be removed.`}
+          }? Installed copies stay on developer machines.`}
           isPending={bulkDelete.isPending}
           confirmLabel="Delete plugins"
           onConfirm={async () => {
@@ -975,7 +975,7 @@ function PluginsEmptyState() {
       className="min-h-[60vh]"
       icon={Braces}
       title="No plugins yet."
-      description="A plugin packages a client's native hooks file and its companion scripts. The platform stores the payload verbatim and delivers it to connected coding agents."
+      description="Create a plugin for Claude Code, Codex, Copilot CLI, or Cursor."
       action={
         <PermissionButton permissions={{ plugin: ["create", "admin"] }} asChild>
           <Link href="/plugins/new">
@@ -1009,7 +1009,7 @@ function DeletePluginDialog({
       open={open}
       onOpenChange={onOpenChange}
       title="Delete plugin?"
-      description={`Delete "${plugin.displayName}"? It disappears from future marketplace revisions. This does not uninstall code already present on developer machines; remove that plugin locally through the client or startup guard.`}
+      description={`Delete "${plugin.displayName}"? Installed copies stay on developer machines until you uninstall them.`}
       isPending={deletePlugin.isPending}
       onConfirm={handleDelete}
     />

--- a/platform/frontend/src/app/skills/plugins/[pluginId]/page.client.test.tsx
+++ b/platform/frontend/src/app/skills/plugins/[pluginId]/page.client.test.tsx
@@ -62,11 +62,9 @@ describe("PluginSkillPage", () => {
     const sourceNotice = screen.getByText(
       (_, element) =>
         element?.tagName === "P" &&
-        element.textContent?.includes("This portable skill comes from") ===
-          true,
+        element.textContent?.includes("This skill comes from") === true,
     );
-    expect(sourceNotice).toHaveTextContent(/not copied or versioned/);
-    expect(sourceNotice).toHaveTextContent(/standalone Workspace skill/);
+    expect(sourceNotice).toHaveTextContent(/plugin still owns these files/);
     expect(screen.getByTestId("content")).toHaveAttribute(
       "data-read-only",
       "true",

--- a/platform/frontend/src/app/skills/plugins/[pluginId]/page.client.tsx
+++ b/platform/frontend/src/app/skills/plugins/[pluginId]/page.client.tsx
@@ -7,7 +7,6 @@ import { AgentBadge } from "@/components/agent-badge";
 import { PageLayout } from "@/components/page-layout";
 import { Badge } from "@/components/ui/badge";
 import { useHasPermissions } from "@/lib/auth/auth.query";
-import { useAppName } from "@/lib/hooks/use-app-name";
 import { usePluginSkill } from "@/lib/skills/skill.query";
 import { SkillContentEditor } from "../../_parts/skill-content-editor";
 import {
@@ -17,7 +16,6 @@ import {
 } from "../../_parts/skill-page-shell";
 
 export function PluginSkillPage({ pluginId }: { pluginId: string }) {
-  const appName = useAppName();
   const search = useSearchParams();
   const skillPath = search.get("skillPath") ?? "";
   const { data: canManagePlugin } = useHasPermissions({ plugin: ["admin"] });
@@ -41,7 +39,7 @@ export function PluginSkillPage({ pluginId }: { pluginId: string }) {
       <div className="mb-4 flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2.5 text-sm text-muted-foreground">
         <Puzzle className="mt-0.5 size-4 shrink-0 text-blue-600 dark:text-blue-400" />
         <p>
-          <span>This portable skill comes from </span>
+          <span>This skill comes from </span>
           {canManagePlugin ? (
             <Link
               href={`/plugins/${skill.pluginId}`}
@@ -55,9 +53,8 @@ export function PluginSkillPage({ pluginId }: { pluginId: string }) {
             </span>
           )}
           <span>
-            , a plugin for {skill.clientType}. Its source bytes remain managed
-            by the plugin and are not copied or versioned as a standalone{" "}
-            {appName} skill.
+            , a plugin for {skill.clientType}. The plugin still owns these
+            files.
           </span>
         </p>
       </div>


### PR DESCRIPTION
Plugins product copy and the public docs page were long and restated the UI.

This shortens in-app strings on the Plugins list, wizard, edit, install, and the plugin-skill notice. The docs page now states what a plugin is and how you use it, keeps the per-client install table, and tells a branch-policy use case that ends when Claude Code blocks a commit on `main`.

Tried on a live stack: Plugins list, Add new plugin wizard, and `/docs/platform-agent-plugins`.

Task: https://slack.com/archives/C0B2AGC0AFQ/p1788285516272369?thread_ts=1788285515.572779&cid=C0B2AGC0AFQ

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>