### PR TITLE
docs(platform): name the MCP gateway alongside the LLM proxy under /v1

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -317,7 +317,7 @@ Practical starting point for worker autoscaling:
 - `archestra.ingress.spec` - Complete ingress specification for advanced configurations
 - `archestra.ingress.routeBackendApisDirectly` - Route `/v1` and `/v2` to the backend port on hosts that serve the UI (default: true)
 
-`/v1` (the LLM proxy) and `/v2` (A2A) have no frontend route — the frontend only forwards them to the backend. `/v1` requests carry large bodies and stay open for the length of a completion, so forwarding them runs that traffic on the same process that answers the dashboard's API calls, and the UI slows down while an agent is working. The chart routes both prefixes to the backend port for you.
+`/v1` and `/v2` have no frontend route — the frontend only forwards them to the backend. `/v1` carries the LLM proxy and the MCP gateway, `/v2` carries A2A. That is all of your agents' traffic: completions with large request bodies held open for the length of a response, and tool calls. Forwarding it runs it on the same process that answers the dashboard's API calls, so the UI slows down while an agent is working. The chart routes both prefixes to the backend port for you.
 
 A host that declares its own `/v1` or `/v2` path keeps it. So does a host that never routes to the frontend port. Set `routeBackendApisDirectly: false` to turn the behavior off. It does not apply when you supply a complete `spec`, which replaces the generated rules.
 
@@ -586,7 +586,11 @@ If pgvector is not installed or the database user lacks permissions, the Knowled
 
 Send `/v1` and `/v2` to the backend port (9000), and everything else to the frontend port (3000).
 
-Both prefixes are backend APIs. Neither has a frontend route — the frontend receives them only to forward them on. `/v1` is the LLM proxy, and its requests carry large bodies and stay open for the length of a completion. Routed through the frontend port, that traffic runs on the same single-threaded process that answers the dashboard's own API calls, so the UI gets slow while an agent is working.
+Both prefixes are backend APIs. Neither has a frontend route — the frontend receives them only to forward them on.
+
+`/v1` is the LLM proxy and the MCP gateway. `/v2` is A2A. Together they are the traffic your agents make: completions whose request bodies are large and stay open for the length of a response, and MCP tool calls, which include a poll that runs about once a second per connected client. None of it comes from a browser.
+
+Routed through the frontend port, that traffic runs on the same single-threaded process that answers the dashboard's own API calls, so the UI gets slow while an agent is working.
 
 Keep `/` on the frontend. `/api/auth` is a real frontend route and must stay there, so route the two specific prefixes rather than all of `/api`.
 

--- a/platform/helm/archestra/templates/ingress.yaml
+++ b/platform/helm/archestra/templates/ingress.yaml
@@ -32,13 +32,15 @@ spec:
           {{- /*
             A host that serves the UI gets the backend's own API prefixes routed
             straight to the backend port, unless it already routes them itself.
-            /v1 (the LLM proxy) and /v2 (A2A) have no Next.js route — the
-            frontend only forwards them — and /v1 carries multi-megabyte request
-            bodies held open for the length of a completion. Sending that through
-            the frontend port puts it on the single-threaded Node process that
-            also answers the dashboard's API calls, so the UI slows down while an
-            agent is working. Everything else, /api/auth included, stays on the
-            frontend: that one IS a real app route.
+            Neither prefix has a Next.js route — the frontend only forwards
+            them. /v1 is the LLM proxy AND the MCP gateway, /v2 is A2A, so
+            between them they carry every request an agent makes: completions
+            whose bodies are multi-megabyte and stay open for the length of a
+            response, plus tool calls and their once-a-second poll. Sending that
+            through the frontend port puts it on the single-threaded Node
+            process that also answers the dashboard's API calls, so the UI slows
+            down while an agent is working. Everything else, /api/auth included,
+            stays on the frontend: that one IS a real app route.
           */}}
           {{- $frontendPaths := list }}
           {{- $ownsBackendApis := false }}

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -765,12 +765,13 @@ archestra:
     # port on any host that also serves the UI.
     #
     # Neither prefix has a frontend route — the frontend only forwards them to
-    # the backend — and /v1 is the LLM proxy, whose requests carry
-    # multi-megabyte bodies and stay open for the length of a completion.
-    # Forwarding that through the frontend port runs it on the same
-    # single-threaded process that answers the dashboard's API calls, so the UI
-    # gets slow while an agent is working. Routing it at the ingress removes
-    # that contention.
+    # the backend. /v1 is the LLM proxy and the MCP gateway; /v2 is A2A. That is
+    # every request an agent makes: completions whose bodies are multi-megabyte
+    # and stay open for the length of a response, plus tool calls and their
+    # once-a-second poll. Forwarding that through the frontend port runs it on
+    # the same single-threaded process that answers the dashboard's API calls,
+    # so the UI gets slow while an agent is working. Routing it at the ingress
+    # removes that contention.
     #
     # Applies to hosts declared under `hosts:` below. A host that already
     # declares its own /v1 or /v2 path is left alone, as is one that never


### PR DESCRIPTION
Follow-up to #7615.

That PR's routing guidance describes `/v1` as the LLM proxy. It is the LLM proxy **and** the MCP gateway (`PROXY_API_PREFIX = "/v1"`, `MCP_GATEWAY_PREFIX = "/v1/mcp"`), so it was describing half of what the split actually moves. Agent tool calls come off the frontend process too, along with the gateway's poll — `server.ts` notes it runs about once a second per connected client, and it was 72 requests at p50 485ms in a five-minute staging sample.

The omission matters to anyone deciding whether to apply this to an ingress they manage themselves: the change is larger than "move LLM completions". And the reasonable next question — "does this touch my dashboard?" — deserves an explicit answer, so the guidance now states plainly that none of `/v1` or `/v2` is browser traffic and that `/api/*` is unaffected.

Three places, same correction: both docs sections and the two chart comments.

Comments and prose only, no behavior change.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>