### PR TITLE
fix(agents): suppress terminal redraw completion output

### DIFF
--- a/platform/backend/src/agents/task-completion-notification.test.ts
+++ b/platform/backend/src/agents/task-completion-notification.test.ts
@@ -81,4 +81,35 @@ describe("buildTaskCompletionNotification", () => {
       }),
     ).toBe("Task finished.");
   });
+
+  test("does not post terminal control streams as completion summaries", () => {
+    expect(
+      buildTaskCompletionNotification({
+        state: "TASK_STATE_COMPLETED",
+        statusReason: null,
+        output:
+          "\u001b[20;3H\u001b[?25hWorking\u001b[14B\u001b[38;5;244mGenerating",
+      }),
+    ).toBe("Task finished.");
+  });
+
+  test("detects terminal control streams after escape bytes are stripped", () => {
+    expect(
+      buildTaskCompletionNotification({
+        state: "TASK_STATE_COMPLETED",
+        statusReason: null,
+        output: "[20;3H[?25hWorking[14B[38;5;244mGenerating",
+      }),
+    ).toBe("Task finished.");
+  });
+
+  test("keeps ordinary prose containing bracketed references", () => {
+    expect(
+      buildTaskCompletionNotification({
+        state: "TASK_STATE_COMPLETED",
+        statusReason: null,
+        output: "Finished the requested work; see notes [1] and [2].",
+      }),
+    ).toBe("Finished the requested work; see notes [1] and [2].");
+  });
 });

--- a/platform/backend/src/agents/task-completion-notification.ts
+++ b/platform/backend/src/agents/task-completion-notification.ts
@@ -43,7 +43,10 @@ function conciseOutput(output: string): string {
   // Native catalog clients write their complete interactive transcript to the
   // execution log. That belongs in the execution console, not in a completion
   // message. PR links are extracted above before this guard.
-  if (output.includes("[archestra] agent session exited")) {
+  if (
+    output.includes("[archestra] agent session exited") ||
+    looksLikeTerminalControlStream(output)
+  ) {
     return "";
   }
 
@@ -65,4 +68,23 @@ function conciseOutput(output: string): string {
     .trim();
 
   return cleaned.length > 1_000 ? `…${cleaned.slice(-1_000)}` : cleaned;
+}
+
+function looksLikeTerminalControlStream(output: string): boolean {
+  const escapeCharacter = String.fromCharCode(27);
+  const controlSequenceIntroducer = String.fromCharCode(155);
+  if (
+    output.includes(`${escapeCharacter}[`) ||
+    output.includes(controlSequenceIntroducer)
+  ) {
+    return true;
+  }
+
+  // Some transcript transports drop the escape byte while preserving the CSI
+  // payload. Repeated cursor/style commands are still enough to identify a TUI
+  // redraw, without rejecting ordinary prose containing square brackets.
+  const bareControlSequences = output.match(
+    /\[(?:\?[0-9;:]*|[0-9;:]+)[ -/]*[@-~]/g,
+  );
+  return (bareControlSequences?.length ?? 0) >= 3;
 }

--- a/platform/frontend/src/components/mcp-app/external-link.test.ts
+++ b/platform/frontend/src/components/mcp-app/external-link.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { normalizeMcpAppExternalUrl } from "./external-link";
+
+describe("normalizeMcpAppExternalUrl", () => {
+  test("allows web links", () => {
+    expect(normalizeMcpAppExternalUrl("https://example.com/path?q=1")).toBe(
+      "https://example.com/path?q=1",
+    );
+  });
+
+  test("allows canonical Slack desktop channel links", () => {
+    expect(
+      normalizeMcpAppExternalUrl(
+        "slack://channel?team=T123ABC456&id=C123ABC456",
+      ),
+    ).toBe("slack://channel?team=T123ABC456&id=C123ABC456");
+  });
+
+  test("rejects other Slack desktop actions", () => {
+    expect(
+      normalizeMcpAppExternalUrl("slack://open?team=T123ABC456"),
+    ).toBeNull();
+    expect(
+      normalizeMcpAppExternalUrl(
+        "slack://channel?team=not-a-team&id=C123ABC456",
+      ),
+    ).toBeNull();
+  });
+
+  test("rejects executable and malformed URLs", () => {
+    expect(normalizeMcpAppExternalUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeMcpAppExternalUrl("not a URL")).toBeNull();
+  });
+});

--- a/platform/frontend/src/components/mcp-app/external-link.ts
+++ b/platform/frontend/src/components/mcp-app/external-link.ts
@@ -1,0 +1,29 @@
+export function normalizeMcpAppExternalUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (WEB_PROTOCOLS.has(parsed.protocol)) {
+      return parsed.href;
+    }
+
+    if (
+      parsed.protocol !== "slack:" ||
+      parsed.hostname !== "channel" ||
+      (parsed.pathname !== "" && parsed.pathname !== "/")
+    ) {
+      return null;
+    }
+
+    const team = parsed.searchParams.get("team");
+    const channel = parsed.searchParams.get("id");
+    if (!team || !channel || !SLACK_ID.test(team) || !SLACK_ID.test(channel)) {
+      return null;
+    }
+
+    return `slack://channel?team=${encodeURIComponent(team)}&id=${encodeURIComponent(channel)}`;
+  } catch {
+    return null;
+  }
+}
+
+const WEB_PROTOCOLS = new Set(["http:", "https:"]);
+const SLACK_ID = /^[A-Z][A-Z0-9]+$/;

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -21,6 +21,7 @@ import { useTheme } from "next-themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AppSessionRecorderRuntimeHooks } from "@/components/app-session-recording/use-app-session-recorder";
 import { INITIAL_INLINE_HEIGHT } from "@/components/mcp-app/app-height";
+import { normalizeMcpAppExternalUrl } from "@/components/mcp-app/external-link";
 import { McpAppAuthBanner } from "@/components/mcp-app/mcp-app-auth-banner";
 import { Button } from "@/components/ui/button";
 import {
@@ -370,13 +371,8 @@ export const McpAppRuntime = function McpAppRuntime({
     };
 
     appBridge.onopenlink = async ({ url }) => {
-      try {
-        const parsed = new URL(url);
-        if (!["http:", "https:"].includes(parsed.protocol)) return {};
-        window.open(url, "_blank", "noopener,noreferrer");
-      } catch {
-        // malformed URL — ignore
-      }
+      const safeUrl = normalizeMcpAppExternalUrl(url);
+      if (safeUrl) window.open(safeUrl, "_blank", "noopener,noreferrer");
       return {};
     };
 


### PR DESCRIPTION
## Summary

- fail closed when a completed agent output contains terminal control streams
- detect transcripts whose transport stripped the escape byte but retained repeated CSI payloads
- allow only canonical Slack channel deep links alongside existing web links in app UI hosts
- preserve normal prose, PR-link completion behavior, and blocking of executable/custom URL schemes

## Verification

- `ARCHESTRA_DATABASE_URL=postgresql://test:test@localhost/test pnpm --dir backend exec vitest run src/agents/task-completion-notification.test.ts` (10 passed)
- `pnpm --dir frontend exec vitest run src/components/mcp-app/external-link.test.ts` (4 passed)
- `pnpm --dir backend type-check`
- `pnpm --dir frontend type-check`
- `pnpm exec biome check` on changed source and tests
- `git diff --check`

## Documentation

No documentation change: these are defensive ChatOps output sanitization and narrowly scoped app-host link handling changes with no deployment configuration.