### PR TITLE
fix(agents): stabilize execution terminal rendering

### DIFF
--- a/platform/frontend/src/app/chat/executions/page.client.test.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.test.tsx
@@ -58,17 +58,17 @@ describe("BackgroundExecutionChatSession", () => {
     };
   });
 
-  it("shows the durable startup state while the session is being created", () => {
+  it("opens the shared terminal while the session is being created", () => {
     queryState.value.isPending = true;
 
     render(<BackgroundExecutionChatSession taskId="task-1" />);
 
-    expect(screen.getByText("Starting execution…")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Scheduling the workload and preparing its terminal. You can leave this page and come back.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Live terminal task-1")).toBeInTheDocument();
+    expect(screen.queryByText("Starting execution…")).not.toBeInTheDocument();
+    expect(terminalState.props).toMatchObject({
+      showManualCommand: false,
+      showDisconnectedStatus: false,
+    });
   });
 
   it("keeps the last execution visible when a background refresh fails", () => {
@@ -80,7 +80,8 @@ describe("BackgroundExecutionChatSession", () => {
 
     render(<BackgroundExecutionChatSession taskId="task-1" />);
 
-    expect(screen.getByText("Starting Codex…")).toBeInTheDocument();
+    expect(screen.getByText("Live terminal task-1")).toBeInTheDocument();
+    expect(screen.getByText("Starting")).toBeInTheDocument();
     expect(
       screen.queryByText("Couldn't load this execution"),
     ).not.toBeInTheDocument();

--- a/platform/frontend/src/app/chat/executions/page.client.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.tsx
@@ -19,6 +19,7 @@ import { QueryLoadError } from "@/components/query-load-error";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogHeader,
@@ -173,21 +174,22 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
         open={connectionDialogOpen}
         onOpenChange={setConnectionDialogOpen}
       >
-        <DialogContent>
+        <DialogContent className="max-w-3xl">
           <DialogHeader>
             <DialogTitle>Terminal connection details</DialogTitle>
             <DialogDescription>
               Attach to this execution from a shell with access to its cluster.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-2">
+          <DialogBody className="space-y-2">
             <p className="text-sm font-medium">Manual attach command</p>
-            <div className="flex items-center gap-2 rounded-md border bg-slate-950 p-3">
+            <div className="flex flex-col gap-3 rounded-md border bg-slate-950 p-3 sm:flex-row sm:items-center">
               <code className="min-w-0 flex-1 break-all font-mono text-xs text-emerald-400">
                 {connectionCommand}
               </code>
               <Button
-                variant="ghost"
+                className="shrink-0 self-end sm:self-auto"
+                variant="outline"
                 size="sm"
                 aria-label="Copy terminal command"
                 onClick={async () => {
@@ -206,7 +208,7 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
                 <span>{commandCopied ? "Copied!" : "Copy"}</span>
               </Button>
             </div>
-          </div>
+          </DialogBody>
         </DialogContent>
       </Dialog>
     </main>

--- a/platform/frontend/src/app/chat/executions/page.client.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.tsx
@@ -3,7 +3,6 @@
 import {
   Bot,
   Copy,
-  Loader2,
   MoreHorizontal,
   Square,
   TerminalSquare,
@@ -48,10 +47,7 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
   const [commandCopied, setCommandCopied] = useState(false);
   const execution = query.data;
 
-  if (query.isPending && !execution) {
-    return <ExecutionBooting />;
-  }
-  if (!execution) {
+  if (!query.isPending && !execution) {
     return (
       <div className="flex h-full items-center justify-center p-6">
         <QueryLoadError
@@ -64,78 +60,88 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
     );
   }
 
-  const live = execution.endedAt === null;
-  const terminalReady =
-    live &&
-    (execution.state === "TASK_STATE_WORKING" ||
-      execution.state === "TASK_STATE_INPUT_REQUIRED");
+  const live = !execution || execution.endedAt === null;
 
   return (
     <main className="flex h-full min-h-0 flex-col bg-background">
-      <header className="flex shrink-0 items-center justify-between gap-4 border-b px-5 py-3">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted/40">
-            <AgentIcon icon={execution.agent.icon} size={20} />
-          </div>
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <h1 className="truncate text-sm font-medium">
-                {execution.title}
-              </h1>
-              <AgentExecutionState
-                state={execution.state}
-                statusReason={execution.statusReason}
-                compact
-              />
+      {/* Keep this slot mounted while metadata loads so inserting the header
+          cannot remount the terminal and restart its attach progress. */}
+      <header
+        className={
+          execution
+            ? "flex shrink-0 items-center justify-between gap-4 border-b px-5 py-3"
+            : "hidden"
+        }
+      >
+        {execution ? (
+          <>
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted/40">
+                <AgentIcon icon={execution.agent.icon} size={20} />
+              </div>
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <h1 className="truncate text-sm font-medium">
+                    {execution.title}
+                  </h1>
+                  <AgentExecutionState
+                    state={execution.state}
+                    statusReason={execution.statusReason}
+                    compact
+                  />
+                </div>
+                <p className="truncate text-xs text-muted-foreground">
+                  {execution.agent.name}
+                </p>
+              </div>
             </div>
-            <p className="truncate text-xs text-muted-foreground">
-              {execution.agent.name}
-            </p>
-          </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {live && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setStopDialogOpen(true)}
-            >
-              <Square className="size-3.5 fill-current" />
-              Stop
-            </Button>
-          )}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="icon"
-                className="size-8"
-                aria-label="More execution actions"
-              >
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem asChild>
-                <Link href={`/agents/${execution.agent.id}?section=executions`}>
-                  <Bot className="size-4" />
-                  <span>View Agent</span>
-                </Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                disabled={!connectionCommand}
-                onSelect={() => setConnectionDialogOpen(true)}
-              >
-                <TerminalSquare className="size-4" />
-                <span>View connection details</span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {live && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setStopDialogOpen(true)}
+                >
+                  <Square className="size-3.5 fill-current" />
+                  <span>Stop</span>
+                </Button>
+              )}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="size-8"
+                    aria-label="More execution actions"
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem asChild>
+                    <Link
+                      href={`/agents/${execution.agent.id}?section=executions`}
+                    >
+                      <Bot className="size-4" />
+                      <span>View Agent</span>
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={!connectionCommand}
+                    onSelect={() => setConnectionDialogOpen(true)}
+                  >
+                    <TerminalSquare className="size-4" />
+                    <span>View connection details</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </>
+        ) : null}
       </header>
 
       <section className="flex min-h-0 flex-1 flex-col p-4 md:p-6">
-        {terminalReady ? (
+        {live ? (
           <AgentExecutionTerminal
             taskId={taskId}
             active
@@ -145,11 +151,9 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
             onCommandChange={setConnectionCommand}
             onClosed={() => void query.refetch()}
           />
-        ) : live ? (
-          <ExecutionBooting inline agentName={execution.agent.name} />
-        ) : (
+        ) : execution ? (
           <AgentExecutionLogs execution={execution} />
-        )}
+        ) : null}
       </section>
       <DeleteConfirmDialog
         open={stopDialogOpen}
@@ -214,38 +218,4 @@ function executionLoadErrorDescription(error: unknown): string | undefined {
     return "This execution no longer exists, or you no longer have access to it.";
   }
   return undefined;
-}
-
-function ExecutionBooting({
-  inline = false,
-  agentName,
-}: {
-  inline?: boolean;
-  agentName?: string;
-}) {
-  return (
-    <div
-      className={
-        inline
-          ? "flex min-h-0 flex-1 items-center justify-center rounded-lg border bg-slate-950"
-          : "flex h-full items-center justify-center p-6"
-      }
-    >
-      <div className="flex max-w-md flex-col items-center gap-3 text-center">
-        <div className="relative flex size-12 items-center justify-center rounded-xl border border-emerald-500/20 bg-emerald-500/10 text-emerald-400">
-          <TerminalSquare className="size-5" />
-          <Loader2 className="absolute -right-1 -top-1 size-4 animate-spin rounded-full bg-background" />
-        </div>
-        <div>
-          <p className="text-sm font-medium">
-            Starting {agentName ?? "execution"}…
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Scheduling the workload and preparing its terminal. You can leave
-            this page and come back.
-          </p>
-        </div>
-      </div>
-    </div>
-  );
 }

--- a/platform/frontend/src/app/chat/executions/page.client.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.tsx
@@ -16,15 +16,8 @@ import { AgentExecutionTerminal } from "@/components/agent-execution-terminal";
 import { AgentIcon } from "@/components/agent-icon";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { QueryLoadError } from "@/components/query-load-error";
+import { StandardDialog } from "@/components/standard-dialog";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -170,47 +163,41 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
           })
         }
       />
-      <Dialog
+      <StandardDialog
         open={connectionDialogOpen}
         onOpenChange={setConnectionDialogOpen}
+        title="Terminal connection details"
+        description="Attach to this execution from a shell with access to its cluster."
+        className="max-w-3xl"
+        bodyClassName="space-y-2"
       >
-        <DialogContent className="max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>Terminal connection details</DialogTitle>
-            <DialogDescription>
-              Attach to this execution from a shell with access to its cluster.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogBody className="space-y-2">
-            <p className="text-sm font-medium">Manual attach command</p>
-            <div className="flex flex-col gap-3 rounded-md border bg-slate-950 p-3 sm:flex-row sm:items-center">
-              <code className="min-w-0 flex-1 break-all font-mono text-xs text-emerald-400">
-                {connectionCommand}
-              </code>
-              <Button
-                className="shrink-0 self-end sm:self-auto"
-                variant="outline"
-                size="sm"
-                aria-label="Copy terminal command"
-                onClick={async () => {
-                  if (!connectionCommand) return;
-                  try {
-                    await copyToClipboard(connectionCommand);
-                    setCommandCopied(true);
-                    toast.success("Terminal command copied");
-                    setTimeout(() => setCommandCopied(false), 2000);
-                  } catch {
-                    toast.error("Failed to copy terminal command");
-                  }
-                }}
-              >
-                <Copy className="size-3.5" />
-                <span>{commandCopied ? "Copied!" : "Copy"}</span>
-              </Button>
-            </div>
-          </DialogBody>
-        </DialogContent>
-      </Dialog>
+        <p className="text-sm font-medium">Manual attach command</p>
+        <div className="flex flex-col gap-3 rounded-md border bg-slate-950 p-3 sm:flex-row sm:items-center">
+          <code className="min-w-0 flex-1 break-all font-mono text-xs text-emerald-400">
+            {connectionCommand}
+          </code>
+          <Button
+            className="shrink-0 self-end sm:self-auto"
+            variant="outline"
+            size="sm"
+            aria-label="Copy terminal command"
+            onClick={async () => {
+              if (!connectionCommand) return;
+              try {
+                await copyToClipboard(connectionCommand);
+                setCommandCopied(true);
+                toast.success("Terminal command copied");
+                setTimeout(() => setCommandCopied(false), 2000);
+              } catch {
+                toast.error("Failed to copy terminal command");
+              }
+            }}
+          >
+            <Copy className="size-3.5" />
+            <span>{commandCopied ? "Copied!" : "Copy"}</span>
+          </Button>
+        </div>
+      </StandardDialog>
     </main>
   );
 }

--- a/platform/frontend/src/components/agent-execution-terminal.test.tsx
+++ b/platform/frontend/src/components/agent-execution-terminal.test.tsx
@@ -48,6 +48,21 @@ describe("Agent execution terminal transport", () => {
     expect(websocketMock.connect).not.toHaveBeenCalled();
     expect(websocketMock.send).toHaveBeenCalledOnce();
   });
+
+  it("shows structured startup progress before the backend reports a phase", () => {
+    websocketMock.isConnected.mockReturnValue(false);
+    websocketMock.onConnectionChange.mockReturnValue(vi.fn());
+    const sessionHandlers = handlers();
+
+    createAgentExecutionTransport("task-1").open(sessionHandlers);
+
+    expect(sessionHandlers.onProgress).toHaveBeenCalledWith({
+      phase: "queued",
+      message: "Preparing the execution environment",
+      detail: null,
+      resourceName: null,
+    });
+  });
 });
 
 function handlers() {
@@ -56,5 +71,6 @@ function handlers() {
     onOutput: vi.fn(),
     onError: vi.fn(),
     onClosed: vi.fn(),
+    onProgress: vi.fn(),
   };
 }

--- a/platform/frontend/src/components/agent-execution-terminal.tsx
+++ b/platform/frontend/src/components/agent-execution-terminal.tsx
@@ -57,6 +57,15 @@ export function createAgentExecutionTransport(
 ): ExecSessionTransport {
   return {
     open: (handlers) => {
+      // An Agent attach always has a known first wait. Seed the shared progress
+      // panel immediately so neither execution surface flashes the generic
+      // "Connecting..." placeholder before the backend reports a finer phase.
+      handlers.onProgress?.({
+        phase: "queued",
+        message: "Preparing the execution environment",
+        detail: null,
+        resourceName: null,
+      });
       const subscriptions = [
         websocketService.subscribe(
           "agent_run_attach_started",

--- a/platform/frontend/src/components/exec/exec-terminal.test.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.test.tsx
@@ -7,6 +7,8 @@ const terminalHarness = vi.hoisted(() => {
     resizeHandler: null as
       | ((dimensions: { cols: number; rows: number }) => void)
       | null,
+    resizeObserverCallback: null as ResizeObserverCallback | null,
+    proposedDimensions: { cols: 80, rows: 24 },
     emitData(data: string) {
       this.dataHandler?.(data);
     },
@@ -35,7 +37,7 @@ vi.mock("@xterm/xterm", () => ({
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class FitAddon {
     fit = vi.fn();
-    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    proposeDimensions = vi.fn(() => terminalHarness.proposedDimensions);
   },
 }));
 
@@ -48,6 +50,9 @@ import {
 } from "./exec-terminal";
 
 global.ResizeObserver = class ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    terminalHarness.resizeObserverCallback = callback;
+  }
   observe() {}
   unobserve() {}
   disconnect() {}
@@ -58,6 +63,40 @@ describe("ExecTerminal", () => {
     vi.clearAllMocks();
     terminalHarness.dataHandler = null;
     terminalHarness.resizeHandler = null;
+    terminalHarness.resizeObserverCallback = null;
+    terminalHarness.proposedDimensions = { cols: 80, rows: 24 };
+  });
+
+  it("waits for a usable terminal grid before opening the remote session", async () => {
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+    terminalHarness.proposedDimensions = { cols: 1, rows: 1 };
+    const transport: ExecSessionTransport = {
+      open: vi.fn(() => vi.fn()),
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(
+      <ExecTerminal sessionKey="task-layout" transport={transport} isActive />,
+    );
+
+    await waitFor(() =>
+      expect(terminalHarness.resizeObserverCallback).not.toBeNull(),
+    );
+    expect(transport.open).not.toHaveBeenCalled();
+
+    terminalHarness.proposedDimensions = { cols: 120, rows: 40 };
+    act(() =>
+      terminalHarness.resizeObserverCallback?.(
+        [],
+        {} as unknown as ResizeObserver,
+      ),
+    );
+
+    await waitFor(() => expect(transport.open).toHaveBeenCalledOnce());
   });
 
   it("keeps the remote PTY synchronized with xterm dimension changes", async () => {

--- a/platform/frontend/src/components/exec/exec-terminal.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.tsx
@@ -181,58 +181,67 @@ export function ExecTerminal({
         }
       });
 
-      // Fit after a short delay to ensure container is measured
-      requestAnimationFrame(() => {
-        if (!disposed) {
-          try {
-            fitAddon.fit();
-          } catch {
-            // Container may not be visible yet
-          }
-        }
-      });
-
       terminalInstanceRef.current = terminal;
       fitAddonRef.current = fitAddon;
       initializedRef.current = true;
 
-      setStatus("connecting");
-      setProgress(null);
-      setConnectingSince(Date.now());
-      setErrorMessage(null);
+      let closeSession: (() => void) | undefined;
+      let layoutReady = false;
 
-      const closeSession = transportRef.current.open({
-        onProgress: (sessionProgress) => {
-          if (disposed) return;
-          setProgress(sessionProgress);
-        },
-        onStarted: (startedCommand) => {
-          if (disposed) return;
-          setStatus("connected");
-          setProgress(null);
-          setCommand(startedCommand);
-          onCommandChangeRef.current?.(startedCommand);
-          const dims = fitAddon.proposeDimensions();
-          if (isUsableTerminalDimensions(dims)) {
-            transportRef.current.sendResize(dims.cols, dims.rows);
-          }
-        },
-        onOutput: (data) => {
-          if (disposed) return;
-          terminal.write(data);
-        },
-        onError: (message) => {
-          if (disposed) return;
-          setStatus("error");
-          setErrorMessage(message);
-        },
-        onClosed: (reason) => {
-          if (disposed) return;
-          setClosedReason(reason);
-          setStatus("disconnected");
-          onClosedRef.current?.();
-        },
-      });
+      const fitAndOpenSession = () => {
+        if (disposed || closeSession) return;
+        const dims = fitAddon.proposeDimensions();
+        if (!layoutReady || !isUsableTerminalDimensions(dims)) return;
+        try {
+          fitAddon.fit();
+        } catch {
+          return;
+        }
+
+        setStatus("connecting");
+        setProgress(null);
+        setConnectingSince(Date.now());
+        setErrorMessage(null);
+
+        // Do not subscribe until the terminal has a real grid. Otherwise the
+        // first tmux frame can arrive at a transient 1-column tab width and
+        // remain scrambled in scrollback after the panel finishes laying out.
+        closeSession = transportRef.current.open({
+          onProgress: (sessionProgress) => {
+            if (disposed) return;
+            setProgress(sessionProgress);
+          },
+          onStarted: (startedCommand) => {
+            if (disposed) return;
+            setStatus("connected");
+            setProgress(null);
+            setCommand(startedCommand);
+            onCommandChangeRef.current?.(startedCommand);
+            const startedDims = fitAddon.proposeDimensions();
+            if (isUsableTerminalDimensions(startedDims)) {
+              transportRef.current.sendResize(
+                startedDims.cols,
+                startedDims.rows,
+              );
+            }
+          },
+          onOutput: (data) => {
+            if (disposed) return;
+            terminal.write(data);
+          },
+          onError: (message) => {
+            if (disposed) return;
+            setStatus("error");
+            setErrorMessage(message);
+          },
+          onClosed: (reason) => {
+            if (disposed) return;
+            setClosedReason(reason);
+            setStatus("disconnected");
+            onClosedRef.current?.();
+          },
+        });
+      };
 
       terminal.onData((data) => {
         const input = withoutMouseHoverReports(data);
@@ -242,20 +251,33 @@ export function ExecTerminal({
       // Resize observer
       const resizeObserver = new ResizeObserver(() => {
         if (disposed) return;
+        const dims = fitAddon.proposeDimensions();
+        if (!isUsableTerminalDimensions(dims)) return;
         try {
           fitAddon.fit();
         } catch {
           // Ignore fit errors during transitions
         }
+        fitAndOpenSession();
       });
 
       if (terminalRef.current) {
         resizeObserver.observe(terminalRef.current);
       }
 
+      // Two frames let Radix tabs and the responsive grid settle before the
+      // first PTY frame is allowed in. ResizeObserver remains the fallback for
+      // a panel that becomes visible later.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          layoutReady = true;
+          fitAndOpenSession();
+        });
+      });
+
       return () => {
         resizeObserver.disconnect();
-        closeSession();
+        closeSession?.();
       };
     };
 

--- a/platform/frontend/src/components/exec/exec-terminal.utils.test.ts
+++ b/platform/frontend/src/components/exec/exec-terminal.utils.test.ts
@@ -14,6 +14,12 @@ describe("isUsableTerminalDimensions", () => {
     ).toBe(false);
   });
 
+  it("rejects a transiently tiny grid while a terminal panel is laying out", () => {
+    expect(isUsableTerminalDimensions({ cols: 1, rows: 1 })).toBe(false);
+    expect(isUsableTerminalDimensions({ cols: 19, rows: 24 })).toBe(false);
+    expect(isUsableTerminalDimensions({ cols: 80, rows: 4 })).toBe(false);
+  });
+
   it("accepts positive integer terminal dimensions", () => {
     expect(isUsableTerminalDimensions({ cols: 120, rows: 40 })).toBe(true);
   });

--- a/platform/frontend/src/components/exec/exec-terminal.utils.ts
+++ b/platform/frontend/src/components/exec/exec-terminal.utils.ts
@@ -3,15 +3,20 @@ export type TerminalDimensions = {
   rows: number;
 };
 
-/** xterm may report NaN while a newly-mounted container has no layout yet. */
+/**
+ * xterm may report NaN or a technically positive but unusably tiny grid while
+ * a newly-mounted tab or responsive panel is still being laid out. Writing a
+ * TUI frame at that transient size permanently bakes the early wraps into its
+ * scrollback, even after the terminal is fitted to its real dimensions.
+ */
 export function isUsableTerminalDimensions(
   dimensions: TerminalDimensions | undefined,
 ): dimensions is TerminalDimensions {
   return (
     dimensions !== undefined &&
     Number.isInteger(dimensions.cols) &&
-    dimensions.cols > 0 &&
+    dimensions.cols >= 20 &&
     Number.isInteger(dimensions.rows) &&
-    dimensions.rows > 0
+    dimensions.rows >= 5
   );
 }

--- a/platform/frontend/src/components/terminal-playback.test.tsx
+++ b/platform/frontend/src/components/terminal-playback.test.tsx
@@ -2,16 +2,23 @@ import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalPlayback } from "./terminal-playback";
 
-const { terminal, fit } = vi.hoisted(() => ({
-  terminal: {
-    dispose: vi.fn(),
-    loadAddon: vi.fn(),
-    open: vi.fn(),
-    reset: vi.fn(),
-    write: vi.fn(),
-  },
-  fit: vi.fn(),
-}));
+const { terminal, fit, dimensions, proposeDimensions } = vi.hoisted(() => {
+  const dimensions = { current: { cols: 120, rows: 40 } };
+  return {
+    terminal: {
+      dispose: vi.fn(),
+      loadAddon: vi.fn(),
+      open: vi.fn(),
+      reset: vi.fn(),
+      write: vi.fn(),
+    },
+    fit: vi.fn(),
+    dimensions,
+    proposeDimensions: vi.fn(() => dimensions.current),
+  };
+});
+
+let resizeObserverCallback: ResizeObserverCallback | undefined;
 
 vi.mock("@xterm/xterm", () => ({
   Terminal: class Terminal {
@@ -26,6 +33,7 @@ vi.mock("@xterm/xterm", () => ({
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class FitAddon {
     fit = fit;
+    proposeDimensions = proposeDimensions;
   },
 }));
 
@@ -34,13 +42,35 @@ vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 describe("TerminalPlayback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    dimensions.current = { cols: 120, rows: 40 };
+    resizeObserverCallback = undefined;
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
     vi.stubGlobal(
       "ResizeObserver",
       class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeObserverCallback = callback;
+        }
         observe() {}
         disconnect() {}
       },
     );
+  });
+
+  it("waits to replay captured bytes until the panel has a usable grid", async () => {
+    dimensions.current = { cols: 1, rows: 1 };
+    render(<TerminalPlayback content="captured frame" />);
+
+    await waitFor(() => expect(resizeObserverCallback).toBeDefined());
+    expect(terminal.write).not.toHaveBeenCalled();
+
+    dimensions.current = { cols: 120, rows: 40 };
+    act(() => resizeObserverCallback?.([], {} as unknown as ResizeObserver));
+
+    expect(terminal.write).toHaveBeenCalledWith("captured frame");
   });
 
   it("replays raw terminal controls and appends streamed bytes", async () => {

--- a/platform/frontend/src/components/terminal-playback.tsx
+++ b/platform/frontend/src/components/terminal-playback.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { isUsableTerminalDimensions } from "./exec/exec-terminal.utils";
 
 /**
  * Replays a captured PTY byte stream through xterm so cursor movement, clears,
@@ -19,6 +20,7 @@ export function TerminalPlayback({ content }: { content: string }) {
 
     let disposed = false;
     let resizeObserver: ResizeObserver | undefined;
+    let initializedTerminal: import("@xterm/xterm").Terminal | null = null;
 
     const initialize = async () => {
       const [{ Terminal }, { FitAddon }] = await Promise.all([
@@ -43,30 +45,58 @@ export function TerminalPlayback({ content }: { content: string }) {
           cursor: "#34d399",
         },
       });
+      initializedTerminal = terminal;
 
       terminal.loadAddon(fitAddon);
       terminal.open(containerRef.current);
-      fitAddon.fit();
-      terminal.write(contentRef.current);
-      renderedContentRef.current = contentRef.current;
-      terminalRef.current = terminal;
+      let layoutReady = false;
+      let rendered = false;
+
+      const fitAndRender = () => {
+        if (disposed) return;
+        const dims = fitAddon.proposeDimensions();
+        if (!layoutReady || !isUsableTerminalDimensions(dims)) return;
+        try {
+          fitAddon.fit();
+        } catch {
+          return;
+        }
+        if (!rendered) {
+          terminal.write(contentRef.current);
+          renderedContentRef.current = contentRef.current;
+          terminalRef.current = terminal;
+          rendered = true;
+        }
+      };
 
       resizeObserver = new ResizeObserver(() => {
         if (disposed) return;
+        const dims = fitAddon.proposeDimensions();
+        if (!isUsableTerminalDimensions(dims)) return;
         try {
           fitAddon.fit();
         } catch {
           // The panel may be between layouts while an execution tab changes.
         }
+        fitAndRender();
       });
       resizeObserver.observe(containerRef.current);
+
+      // Avoid replaying a whole TUI recording into the transient dimensions
+      // produced while the surrounding tab/grid is still mounting.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          layoutReady = true;
+          fitAndRender();
+        });
+      });
     };
 
     void initialize();
     return () => {
       disposed = true;
       resizeObserver?.disconnect();
-      terminalRef.current?.dispose();
+      initializedTerminal?.dispose();
       terminalRef.current = null;
       renderedContentRef.current = "";
     };


### PR DESCRIPTION
## Problem

Execution startup used a standalone “Starting execution…” screen instead of the terminal's richer progress UI. The Agent Executions tab could still flash a generic “Connecting…” state, and live or retained terminal output could be replayed before its responsive container had usable dimensions, permanently scrambling TUI redraws. The manual attach dialog also assembled low-level dialog primitives without the standard body spacing.

## Change

- mount the shared execution terminal immediately while metadata is loading or the task is submitted
- use the scheduling, image-pull, agent-start, and terminal-attach progress states on both execution surfaces without a generic connecting flash
- keep the terminal mounted when execution metadata and its header arrive
- wait for a stable, usable xterm grid before opening a live attachment or replaying retained output
- reject transient tiny terminal dimensions during responsive layout
- use `StandardDialog` for terminal connection details, with a responsive command-and-copy layout
- remove the obsolete standalone booting view

## Validation

- frontend unit suite: 561 files, 5,081 tests passed
- focused execution terminal tests: 25 passed
- final connection-dialog behavior test: 6 passed
- frontend type-check passed
- frontend Knip passed
- targeted Biome checks passed

Docs audit: no documentation changes are needed; this only aligns and stabilizes existing execution UI behavior.
