### PR TITLE
fix(agents): recover completed runner output

### DIFF
--- a/platform/backend/src/k8s/runner-runtime/manager.ts
+++ b/platform/backend/src/k8s/runner-runtime/manager.ts
@@ -1,5 +1,6 @@
 import type { Readable, Writable } from "node:stream";
 import { Readable as NodeReadable } from "node:stream";
+import { finished } from "node:stream/promises";
 import type * as k8s from "@kubernetes/client-node";
 import { PatchStrategy, setHeaderOptions } from "@kubernetes/client-node";
 import type WebSocket from "ws";
@@ -383,6 +384,67 @@ class RunnerRuntimeManager {
       },
       { once: true },
     );
+  }
+
+  /**
+   * Copy the pod's retained stdout once, after the workload has settled.
+   *
+   * Kubernetes follow connections can close before the pod does. The live
+   * stream remains useful for progress, but this non-following read is the
+   * authoritative transcript captured immediately before teardown.
+   */
+  async snapshotLogs(params: {
+    session: AgentRun;
+    destination: Writable;
+    lines: number;
+    abortSignal?: AbortSignal;
+  }): Promise<void> {
+    if (params.abortSignal?.aborted) {
+      throw new Error("Runner output snapshot was aborted");
+    }
+
+    const clients = this.requireClients();
+    const pod = await this.findPodPhase(params.session);
+    if (!pod) {
+      throw new Error("This session has no pod to read logs from");
+    }
+
+    const snapshotFinished = finished(params.destination);
+    let request: AbortController;
+    try {
+      request = await clients.log.log(
+        params.session.runtimeScope,
+        pod.name,
+        RUNNER_CONTAINER_NAME,
+        params.destination,
+        {
+          follow: false,
+          tailLines: params.lines,
+          pretty: false,
+          timestamps: false,
+        },
+      );
+    } catch (error) {
+      params.destination.destroy();
+      await snapshotFinished.catch(() => undefined);
+      throw error;
+    }
+
+    const abortSnapshot = () => {
+      request.abort();
+      params.destination.destroy(
+        new Error("Runner output snapshot was aborted"),
+      );
+    };
+    params.abortSignal?.addEventListener("abort", abortSnapshot, {
+      once: true,
+    });
+    if (params.abortSignal?.aborted) abortSnapshot();
+    try {
+      await snapshotFinished;
+    } finally {
+      params.abortSignal?.removeEventListener("abort", abortSnapshot);
+    }
   }
 
   /** Pod carrying a session, or null when nothing is scheduled. */

--- a/platform/backend/src/services/runners/backends/kubernetes.ts
+++ b/platform/backend/src/services/runners/backends/kubernetes.ts
@@ -90,6 +90,20 @@ class KubernetesRunnerBackend implements RunnerBackend {
     });
   }
 
+  async snapshotOutput(params: {
+    session: AgentRun;
+    destination: Writable;
+    lines?: number;
+    abortSignal?: AbortSignal;
+  }): Promise<void> {
+    await runnerRuntimeManager.snapshotLogs({
+      session: params.session,
+      destination: params.destination,
+      lines: params.lines ?? RUNNER_LOG_TAIL_LINES,
+      abortSignal: params.abortSignal,
+    });
+  }
+
   async steer(params: {
     session: AgentRun;
     steerMode: AgentDeploymentSteerMode;

--- a/platform/backend/src/services/runners/backends/types.ts
+++ b/platform/backend/src/services/runners/backends/types.ts
@@ -102,6 +102,17 @@ export interface RunnerBackend {
     abortSignal?: AbortSignal;
   }): Promise<void>;
 
+  /**
+   * Read the output currently retained by the backend without following it.
+   * Resolves only after the complete snapshot has been written.
+   */
+  snapshotOutput(params: {
+    session: AgentRun;
+    destination: Writable;
+    lines?: number;
+    abortSignal?: AbortSignal;
+  }): Promise<void>;
+
   /** Interject into a live execution using the deployment's delivery mode. */
   steer(params: {
     session: AgentRun;

--- a/platform/backend/src/services/runners/output-capture.test.ts
+++ b/platform/backend/src/services/runners/output-capture.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, vi } from "@/test";
+import type { AgentRun } from "@/types";
+import type { RunnerBackend } from "./backends";
+import { RunnerOutputCapture } from "./output-capture";
+
+describe("RunnerOutputCapture", () => {
+  test("recovers the complete transcript after the live stream ends early", async () => {
+    const onTextDelta = vi.fn();
+    const backend = outputBackend({
+      live: "session protected\n",
+      snapshot: "session protected\nwork completed\n",
+    });
+    const capture = new RunnerOutputCapture({
+      backend,
+      session,
+      onTextDelta,
+    });
+
+    await capture.follow();
+    expect(capture.transcript).toBe("session protected\n");
+
+    await capture.recoverSnapshot();
+
+    expect(capture.transcript).toBe("session protected\nwork completed\n");
+    expect(capture.retainedLogs).toBe("session protected\nwork completed\n");
+    expect(onTextDelta).toHaveBeenCalledOnce();
+    expect(onTextDelta).toHaveBeenCalledWith("session protected\n");
+  });
+
+  test("retains streamed output when the final snapshot is unavailable", async () => {
+    const backend = outputBackend({
+      live: "partial but useful\n",
+      snapshotError: new Error("pod disappeared"),
+    });
+    const capture = new RunnerOutputCapture({ backend, session });
+
+    await capture.follow();
+    await capture.recoverSnapshot();
+
+    expect(capture.transcript).toBe("partial but useful\n");
+    expect(capture.retainedLogs).toBe("partial but useful\n");
+  });
+});
+
+const session = {
+  id: "run-1",
+} as AgentRun;
+
+function outputBackend(params: {
+  live: string;
+  snapshot?: string;
+  snapshotError?: Error;
+}): Pick<RunnerBackend, "streamOutput" | "snapshotOutput"> {
+  return {
+    async streamOutput({ destination }) {
+      destination.end(params.live);
+    },
+    async snapshotOutput({ destination }) {
+      if (params.snapshotError) throw params.snapshotError;
+      destination.end(params.snapshot ?? "");
+    },
+  };
+}

--- a/platform/backend/src/services/runners/output-capture.ts
+++ b/platform/backend/src/services/runners/output-capture.ts
@@ -1,0 +1,123 @@
+import { Writable } from "node:stream";
+import logger from "@/logging";
+import type { AgentRun } from "@/types";
+import type { RunnerBackend } from "./backends";
+
+/**
+ * Captures live runner output and replaces it with an authoritative snapshot
+ * before the runtime is torn down.
+ */
+export class RunnerOutputCapture {
+  private transcriptChunks: string[] = [];
+  private retainedLogsValue = "";
+
+  constructor(
+    private readonly params: {
+      backend: Pick<RunnerBackend, "streamOutput" | "snapshotOutput">;
+      session: AgentRun;
+      onTextDelta?: (delta: string) => void;
+    },
+  ) {}
+
+  get transcript(): string {
+    return this.transcriptChunks.join("");
+  }
+
+  get retainedLogs(): string {
+    return this.retainedLogsValue;
+  }
+
+  /** Follow output for live progress. A dropped stream does not end the run. */
+  follow(abortSignal?: AbortSignal): Promise<void> {
+    const destination = this.createDestination({
+      onChunk: (chunk) => {
+        this.appendLiveChunk(chunk);
+      },
+    });
+
+    return new Promise<void>((resolve) => {
+      destination.on("finish", resolve);
+      destination.on("close", resolve);
+      destination.on("error", resolve);
+      this.params.backend
+        .streamOutput({
+          session: this.params.session,
+          destination,
+          abortSignal,
+        })
+        .catch((error) => {
+          logger.warn(
+            { error, sessionId: this.params.session.id },
+            "Could not follow runner logs; the task continues without streamed output",
+          );
+          destination.destroy();
+          resolve();
+        });
+    });
+  }
+
+  /**
+   * Replace partial live output with the backend's complete retained snapshot.
+   * The live capture remains as a fallback when the final read is unavailable.
+   */
+  async recoverSnapshot(abortSignal?: AbortSignal): Promise<void> {
+    const snapshotChunks: string[] = [];
+    let snapshotLogs = "";
+    const destination = this.createDestination({
+      onChunk: (chunk) => {
+        snapshotChunks.push(chunk);
+        snapshotLogs = retainLogTail(snapshotLogs, chunk);
+      },
+    });
+
+    try {
+      await this.params.backend.snapshotOutput({
+        session: this.params.session,
+        destination,
+        abortSignal,
+      });
+    } catch (error) {
+      logger.warn(
+        { error, sessionId: this.params.session.id },
+        "Could not recover the final runner output snapshot; retaining streamed output",
+      );
+      return;
+    }
+
+    if (snapshotChunks.length === 0) return;
+    this.transcriptChunks = snapshotChunks;
+    this.retainedLogsValue = snapshotLogs;
+  }
+
+  private appendLiveChunk(chunk: string): void {
+    this.transcriptChunks.push(chunk);
+    this.retainedLogsValue = retainLogTail(this.retainedLogsValue, chunk);
+    this.params.onTextDelta?.(chunk);
+  }
+
+  private createDestination(params: {
+    onChunk: (chunk: string) => void;
+  }): Writable {
+    return new Writable({
+      write(chunk, _encoding, callback) {
+        params.onChunk(chunk.toString("utf8"));
+        callback();
+      },
+    });
+  }
+}
+
+// ===================== internals =====================
+
+const RETAINED_LOG_BYTES = 1024 * 1024;
+
+function retainLogTail(current: string, chunk: string): string {
+  const combined = current + chunk;
+  if (Buffer.byteLength(combined, "utf8") <= RETAINED_LOG_BYTES) {
+    return combined;
+  }
+  return Buffer.from(combined, "utf8")
+    .subarray(-RETAINED_LOG_BYTES)
+    .toString("utf8")
+    .replace(/^\uFFFD/, "");
+}

--- a/platform/backend/src/services/runners/pod-execution.ts
+++ b/platform/backend/src/services/runners/pod-execution.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { Writable } from "node:stream";
 import { DEFAULT_APP_NAME, toPlaceholderTitle } from "@archestra/shared";
 import type { A2AActor } from "@/agents/a2a/a2a-base";
 import type { A2AExecuteResult } from "@/agents/a2a-executor";
@@ -24,8 +23,9 @@ import type {
   AgentRunCompletionTarget,
 } from "@/types";
 import { ApiError } from "@/types";
-import { type RunnerBackend, resolveRunnerBackend } from "./backends";
+import { resolveRunnerBackend } from "./backends";
 import { buildRunnerLaunchSpec } from "./launch-spec";
+import { RunnerOutputCapture } from "./output-capture";
 import { generateAgentExecutionTitle } from "./title";
 
 /**
@@ -231,20 +231,14 @@ export async function resumeBackgroundTask(params: {
 /** Clean up a session whose task settled while no backend owned its run. */
 export async function cleanupBackgroundTask(session: AgentRun): Promise<void> {
   const backend = resolveRunnerBackend(session.backend);
-  let retainedLogs = "";
+  const output = new RunnerOutputCapture({ backend, session });
   const stopCapture = new AbortController();
-  const capture = followOutput({
-    backend,
-    session,
-    abortSignal: stopCapture.signal,
-    onChunk: (chunk) => {
-      retainedLogs = retainLogTail(retainedLogs, chunk);
-    },
-  });
+  const capture = output.follow(stopCapture.signal);
   await Promise.race([capture, delayMs(LOG_DRAIN_GRACE_MS)]);
   stopCapture.abort();
+  await output.recoverSnapshot(AbortSignal.timeout(OUTPUT_SNAPSHOT_TIMEOUT_MS));
   await backend.teardown(session);
-  await AgentRunModel.close({ id: session.id, logs: retainedLogs });
+  await AgentRunModel.close({ id: session.id, logs: output.retainedLogs });
 }
 
 async function followBackgroundTask(params: {
@@ -255,8 +249,11 @@ async function followBackgroundTask(params: {
 }): Promise<A2AExecuteResult> {
   const backend = resolveRunnerBackend(params.session.backend);
   const { session } = params;
-  const transcript: string[] = [];
-  let retainedLogs = "";
+  const output = new RunnerOutputCapture({
+    backend,
+    session,
+    onTextDelta: params.onTextDelta,
+  });
   let outcome: "succeeded" | "failed" | "aborted" = "failed";
 
   try {
@@ -275,16 +272,12 @@ async function followBackgroundTask(params: {
     // Logs are followed on their own promise: the backend outcome ends the
     // run, and a stream that dies early (runtime replaced, connection dropped)
     // must not be mistaken for the task finishing.
-    const streaming = followOutput({
-      backend,
-      session,
-      abortSignal: params.abortSignal,
-      onChunk: (chunk) => {
-        transcript.push(chunk);
-        retainedLogs = retainLogTail(retainedLogs, chunk);
-        params.onTextDelta?.(chunk);
-      },
-    });
+    const stopStreaming = new AbortController();
+    const streaming = output.follow(
+      params.abortSignal
+        ? AbortSignal.any([params.abortSignal, stopStreaming.signal])
+        : stopStreaming.signal,
+    );
 
     const completion = await backend.waitForCompletion({
       session,
@@ -296,8 +289,13 @@ async function followBackgroundTask(params: {
     // write and the backend's outcome race, and dropping it would truncate
     // the answer at exactly the point the reader cares about.
     await Promise.race([streaming, delayMs(LOG_DRAIN_GRACE_MS)]);
+    stopStreaming.abort();
 
-    const text = extractFinalAnswer(transcript.join(""));
+    await output.recoverSnapshot(
+      AbortSignal.timeout(OUTPUT_SNAPSHOT_TIMEOUT_MS),
+    );
+
+    const text = extractFinalAnswer(output.transcript);
 
     if (completion.outcome === "failed") {
       throw new ApiError(
@@ -335,52 +333,16 @@ async function followBackgroundTask(params: {
         "Runner session teardown did not complete",
       );
     });
-    await AgentRunModel.close({ id: session.id, logs: retainedLogs }).catch(
-      (error) => {
-        logger.warn(
-          { error, sessionId: session.id, taskId: session.taskId },
-          "Could not mark the Agent run as ended",
-        );
-      },
-    );
+    await AgentRunModel.close({
+      id: session.id,
+      logs: output.retainedLogs,
+    }).catch((error) => {
+      logger.warn(
+        { error, sessionId: session.id, taskId: session.taskId },
+        "Could not mark the Agent run as ended",
+      );
+    });
   }
-}
-
-/** Forward the session's output to `onChunk`, resolving when the stream ends. */
-function followOutput(params: {
-  backend: RunnerBackend;
-  session: AgentRun;
-  abortSignal?: AbortSignal;
-  onChunk: (chunk: string) => void;
-}): Promise<void> {
-  const destination = new Writable({
-    write(chunk, _encoding, callback) {
-      params.onChunk(chunk.toString("utf8"));
-      callback();
-    },
-  });
-
-  return new Promise<void>((resolve) => {
-    destination.on("finish", resolve);
-    destination.on("close", resolve);
-    destination.on("error", resolve);
-    params.backend
-      .streamOutput({
-        session: params.session,
-        destination,
-        abortSignal: params.abortSignal,
-      })
-      .catch((error) => {
-        // A run whose logs cannot be followed still runs; the transcript is
-        // poorer, but ending the task over it would be worse.
-        logger.warn(
-          { error, sessionId: params.session.id },
-          "Could not follow runner logs; the task continues without streamed output",
-        );
-        destination.destroy();
-        resolve();
-      });
-  });
 }
 
 function delayMs(ms: number, signal?: AbortSignal): Promise<void> {
@@ -424,15 +386,4 @@ export function extractFinalAnswer(transcript: string): string {
 }
 
 const LOG_DRAIN_GRACE_MS = 2_000;
-const RETAINED_LOG_BYTES = 1024 * 1024;
-
-function retainLogTail(current: string, chunk: string): string {
-  const combined = current + chunk;
-  if (Buffer.byteLength(combined, "utf8") <= RETAINED_LOG_BYTES) {
-    return combined;
-  }
-  return Buffer.from(combined, "utf8")
-    .subarray(-RETAINED_LOG_BYTES)
-    .toString("utf8")
-    .replace(/^\uFFFD/, "");
-}
+const OUTPUT_SNAPSHOT_TIMEOUT_MS = 10_000;

--- a/platform/frontend/src/components/terminal-playback.test.tsx
+++ b/platform/frontend/src/components/terminal-playback.test.tsx
@@ -70,7 +70,7 @@ describe("TerminalPlayback", () => {
     dimensions.current = { cols: 120, rows: 40 };
     act(() => resizeObserverCallback?.([], {} as unknown as ResizeObserver));
 
-    expect(terminal.write).toHaveBeenCalledWith("captured frame");
+    expect(terminal.write).toHaveBeenCalledWith("captured frame\u001b[?25l");
   });
 
   it("replays raw terminal controls and appends streamed bytes", async () => {
@@ -78,24 +78,24 @@ describe("TerminalPlayback", () => {
     const { rerender } = render(<TerminalPlayback content={firstFrame} />);
 
     await waitFor(() =>
-      expect(terminal.write).toHaveBeenCalledWith(firstFrame),
+      expect(terminal.write).toHaveBeenCalledWith(`${firstFrame}\u001b[?25l`),
     );
 
     await act(() =>
       rerender(<TerminalPlayback content={`${firstFrame}\r\nReady`} />),
     );
-    expect(terminal.write).toHaveBeenLastCalledWith("\r\nReady");
+    expect(terminal.write).toHaveBeenLastCalledWith("\r\nReady\u001b[?25l");
     expect(terminal.reset).not.toHaveBeenCalled();
   });
 
   it("resets the emulated screen when the transcript is replaced", async () => {
     const { rerender } = render(<TerminalPlayback content="first task" />);
     await waitFor(() =>
-      expect(terminal.write).toHaveBeenCalledWith("first task"),
+      expect(terminal.write).toHaveBeenCalledWith("first task\u001b[?25l"),
     );
 
     await act(() => rerender(<TerminalPlayback content="replacement" />));
     expect(terminal.reset).toHaveBeenCalledOnce();
-    expect(terminal.write).toHaveBeenLastCalledWith("replacement");
+    expect(terminal.write).toHaveBeenLastCalledWith("replacement\u001b[?25l");
   });
 });

--- a/platform/frontend/src/components/terminal-playback.tsx
+++ b/platform/frontend/src/components/terminal-playback.tsx
@@ -62,7 +62,7 @@ export function TerminalPlayback({ content }: { content: string }) {
           return;
         }
         if (!rendered) {
-          terminal.write(contentRef.current);
+          terminal.write(withHiddenCursor(contentRef.current));
           renderedContentRef.current = contentRef.current;
           terminalRef.current = terminal;
           rendered = true;
@@ -108,10 +108,10 @@ export function TerminalPlayback({ content }: { content: string }) {
 
     const rendered = renderedContentRef.current;
     if (content.startsWith(rendered)) {
-      terminal.write(content.slice(rendered.length));
+      terminal.write(withHiddenCursor(content.slice(rendered.length)));
     } else {
       terminal.reset();
-      terminal.write(content);
+      terminal.write(withHiddenCursor(content));
     }
     renderedContentRef.current = content;
   }, [content]);
@@ -125,4 +125,12 @@ export function TerminalPlayback({ content }: { content: string }) {
       />
     </div>
   );
+}
+
+// ===================== internals =====================
+
+const HIDE_CURSOR_SEQUENCE = "\u001b[?25l";
+
+function withHiddenCursor(content: string): string {
+  return `${content}${HIDE_CURSOR_SEQUENCE}`;
 }


### PR DESCRIPTION
## Problem

A Kubernetes log-follow connection can close while its background execution continues. The control plane then retained only the partial live buffer—sometimes just the first startup line—and used that same fragment as the completed task response. Retained terminal playback also displayed an inert cursor even though input was disabled.

## Approach

Keep the existing live stream for progress, then stop it and take a bounded-lifetime, non-following snapshot from the completed pod before teardown. The snapshot becomes the authoritative transcript and retained log; if that final read is unavailable, the partial live capture remains as a safe fallback. Completed xterm playback now appends the standard hide-cursor control after every replay or update.

## Validation

A behavior test simulates a follow stream ending after its first line and verifies that the completed snapshot replaces it, while a separate failure case verifies that useful streamed output survives when snapshot recovery is unavailable. Playback coverage verifies that initial, appended, and replacement frames all finish with the cursor hidden.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>