### PR TITLE
feat(chat): offer reasoning depth on OpenRouter, and mark reasoning models in the pickers

### DIFF
--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -3,7 +3,7 @@ title: Chat
 category: Agents
 order: 2
 description: Built-in Chat interface for working with agents and MCP tools
-lastUpdated: 2026-08-23
+lastUpdated: 2026-09-02
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -23,6 +23,8 @@ Reasoning models think before answering by default. A Low/Medium/High control si
 Low asks for as little reasoning as the model allows — on a Flash model that means skipping it. Medium reasons briefly. High reasons as deeply as the model can — useful for a tricky refactor, for example. Whenever the model reasons, it shows that reasoning in the conversation. Medium is the default, matching what these models do on their own, so a chat only changes behaviour when you ask it to.
 
 The control appears only on models that take a reasoning level: Gemini 3 and newer, the OpenAI GPT-5 and o-series models, and the Claude models that already reason.
+
+OpenRouter is covered too. Its models show the control whenever OpenRouter reports that the model reasons, which most of its catalog does. That includes models taking a thinking budget instead of a level — OpenRouter turns your choice into one for them.
 
 Self-hosted models count too. A model you serve with vLLM or Ollama shows the control when Archestra can tell it reasons — Ollama reports that itself, and for vLLM the model registry answers. Sync your models after upgrading if a model you expect is missing it.
 

--- a/platform/backend/src/routes/chat/model-fetchers/openrouter.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openrouter.test.ts
@@ -159,6 +159,7 @@ describe("fetchOpenrouterModels", () => {
     expect(model.capabilities).toEqual({
       contextLength: 128000,
       supportsToolCalling: true,
+      supportsReasoningEffort: false,
       inputModalities: null,
       outputModalities: null,
       promptPricePerToken: "0.00000015",
@@ -238,6 +239,62 @@ describe("fetchOpenrouterModels", () => {
     expect(model.capabilities?.promptPricePerToken).toBe("0");
   });
 
+  test("reads reasoning support from `reasoning`, not `reasoning_effort`", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                id: "deepseek/deepseek-r1",
+                // A model whose upstream takes a token budget: OpenRouter
+                // accepts a depth for it and converts one, but never lists
+                // `reasoning_effort`. Gating on that spelling would hide the
+                // control on a large share of the reasoning catalog.
+                supported_parameters: ["reasoning", "include_reasoning"],
+              },
+              {
+                id: "openai/gpt-4o",
+                supported_parameters: ["tools", "max_tokens"],
+              },
+            ],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+    const [reasoner, plain] = await fetchOpenrouterModels("test-api-key");
+
+    expect(reasoner.capabilities?.supportsReasoningEffort).toBe(true);
+    // Authoritatively false, not null: OpenRouter is the one that decides what
+    // it serves, so the registry must not open the control behind its back.
+    expect(plain.capabilities?.supportsReasoningEffort).toBe(false);
+  });
+
+  test("leaves reasoning support unknown when /models lists no parameters", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [{ id: "some/model", context_length: 64000 }],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+    const [model] = await fetchOpenrouterModels("test-api-key");
+
+    // Null, so a lower tier still gets to decide rather than being overruled
+    // by an absence.
+    expect(model.capabilities?.supportsReasoningEffort).toBeNull();
+  });
+
   test("returns capabilities for a model that only publishes architecture", async () => {
     mockFetch
       .mockResolvedValueOnce({
@@ -289,6 +346,7 @@ describe("fetchOpenrouterModels", () => {
     expect(model.capabilities).toEqual({
       contextLength: 64000,
       supportsToolCalling: false,
+      supportsReasoningEffort: false,
       inputModalities: null,
       outputModalities: null,
       promptPricePerToken: "0",
@@ -324,6 +382,7 @@ describe("fetchOpenrouterModels", () => {
     expect(model.capabilities).toEqual({
       contextLength: 2000000,
       supportsToolCalling: true,
+      supportsReasoningEffort: false,
       inputModalities: null,
       outputModalities: null,
       promptPricePerToken: null,

--- a/platform/backend/src/routes/chat/model-fetchers/openrouter.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openrouter.ts
@@ -159,6 +159,15 @@ function toFetchedCapabilities(
           (param) => param === "tools" || param === "tool_choice",
         )
       : null,
+    // `reasoning` and not `reasoning_effort`: the former is the parameter the
+    // chat route actually sends, and it is the wider of the two — every model
+    // listing `reasoning_effort` also lists `reasoning`, while a large share of
+    // reasoning models list only `reasoning` because their upstream takes a
+    // token budget that OpenRouter derives from the effort. Gating on the
+    // narrower field would hide the control on models that honor it.
+    supportsReasoningEffort: model.supported_parameters
+      ? model.supported_parameters.includes("reasoning")
+      : null,
     promptPricePerToken: normalizePrice(model.pricing?.prompt),
     completionPricePerToken: normalizePrice(model.pricing?.completion),
     cacheReadPricePerToken: normalizePrice(model.pricing?.input_cache_read),

--- a/platform/backend/src/routes/chat/openrouter-provider-options.ts
+++ b/platform/backend/src/routes/chat/openrouter-provider-options.ts
@@ -1,0 +1,52 @@
+/**
+ * Builds the complete `providerOptions.openrouter` object for a chat turn.
+ *
+ * Only reasoning depth lives here today, but the key is assigned wholesale by
+ * the caller — a second assignment would replace the first — so this stays the
+ * one writer, the way the Anthropic and Gemini builders do for their keys.
+ *
+ * The depth rides OpenRouter's unified `reasoning` object rather than OpenAI's
+ * top-level `reasoning_effort`, even though the transport is OpenAI-compatible
+ * and the SDK would happily send the latter. `reasoning` is the wider door: of
+ * the models OpenRouter reports as reasoning-capable, every one accepts
+ * `reasoning` while only about half also accept `reasoning_effort` — the rest
+ * are models whose upstream takes a token budget instead, and for those
+ * OpenRouter translates the effort into one itself. Sending `reasoning_effort`
+ * would silently reach nothing on that half.
+ *
+ * `low | medium | high` is OpenRouter's own vocabulary, so our levels pass
+ * through unmapped — no per-model catalog to consult, which is the point of
+ * routing through it.
+ *
+ * Deliberately not gated on the model row a second time. The composer already
+ * hides the control unless the row says the model reasons, and OpenRouter
+ * ignores the field on a model that does not (verified: a non-reasoning model
+ * answers normally with zero reasoning tokens, where Ollama would reject the
+ * request outright). A row-level gate here would instead cost the depth on any
+ * reasoning model whose row has not yet picked up `supported_parameters`.
+ *
+ * @see https://openrouter.ai/docs/guides/best-practices/reasoning
+ */
+import type { ThinkingEffort, ThinkingEffortSetting } from "@archestra/shared";
+
+type OpenRouterProviderOptions = {
+  reasoning: { effort: ThinkingEffort };
+};
+
+/**
+ * Returns undefined when the turn needs no OpenRouter-specific options, so the
+ * caller can leave `providerOptions` untouched.
+ */
+export function buildOpenRouterProviderOptions(params: {
+  provider: string;
+  thinkingEffort: ThinkingEffortSetting;
+}): OpenRouterProviderOptions | undefined {
+  const { provider, thinkingEffort } = params;
+
+  // No chosen depth sends no field at all, so the model reasons as it would.
+  if (provider !== "openrouter" || thinkingEffort === null) {
+    return undefined;
+  }
+
+  return { reasoning: { effort: thinkingEffort } };
+}

--- a/platform/backend/src/routes/chat/openrouter-reasoning.test.ts
+++ b/platform/backend/src/routes/chat/openrouter-reasoning.test.ts
@@ -119,6 +119,8 @@ describe("POST /api/chat OpenRouter `reasoning` delta", () => {
   let conversationId: string;
   let upstreamRequests: Array<{
     stream_options?: { include_usage?: boolean };
+    reasoning?: { effort?: string };
+    reasoning_effort?: string;
   }>;
 
   beforeEach(
@@ -226,5 +228,60 @@ describe("POST /api/chat OpenRouter `reasoning` delta", () => {
     // The compatible client only sends stream_options.include_usage when
     // asked; the openrouter config must keep it on or usage/cost is lost.
     expect(upstreamRequests[0]?.stream_options?.include_usage).toBe(true);
+  });
+
+  test.for([
+    "low",
+    "medium",
+    "high",
+  ] as const)("sends a chosen %s depth as OpenRouter's unified `reasoning` object", async (effort) => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        trigger: "submit-message",
+        thinkingEffort: effort,
+        messages: [
+          {
+            id: crypto.randomUUID(),
+            role: "user",
+            parts: [{ type: "text", text: "35 heads, 94 legs — how many?" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(upstreamRequests[0]?.reasoning).toEqual({ effort });
+    // Not the OpenAI spelling: only about half of OpenRouter's reasoning
+    // models accept `reasoning_effort`, so sending it instead would reach
+    // nothing on the rest.
+    expect(upstreamRequests[0]?.reasoning_effort).toBeUndefined();
+  });
+
+  test("sends no reasoning field when no depth was chosen", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        trigger: "submit-message",
+        thinkingEffort: null,
+        messages: [
+          {
+            id: crypto.randomUUID(),
+            role: "user",
+            parts: [{ type: "text", text: "35 heads, 94 legs — how many?" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // The model must reason exactly as it would untouched, which means no
+    // field at all rather than a level of ours standing in for its default.
+    expect(upstreamRequests[0]).not.toHaveProperty("reasoning");
+    expect(upstreamRequests[0]).not.toHaveProperty("reasoning_effort");
   });
 });

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -205,6 +205,7 @@ import {
 } from "./normalization/normalize-chat-messages";
 import { buildOllamaNativeProviderOptions } from "./ollama-native-params";
 import { buildOpenAiThinkingProviderOptions } from "./openai-provider-options";
+import { buildOpenRouterProviderOptions } from "./openrouter-provider-options";
 import { buildModelMessages } from "./prepare-model-messages";
 import { readOpenedAppRef } from "./read-opened-app-ref";
 import {
@@ -1482,6 +1483,20 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   streamTextConfig.providerOptions = {
                     ...streamTextConfig.providerOptions,
                     anthropic: anthropicProviderOptions,
+                  };
+                }
+
+                // Nothing else writes the `openrouter` key, so this may assign
+                // it outright.
+                const openRouterProviderOptions =
+                  buildOpenRouterProviderOptions({
+                    provider,
+                    thinkingEffort,
+                  });
+                if (openRouterProviderOptions) {
+                  streamTextConfig.providerOptions = {
+                    ...streamTextConfig.providerOptions,
+                    openrouter: openRouterProviderOptions,
                   };
                 }
 

--- a/platform/frontend/src/components/llm-model-select.test.tsx
+++ b/platform/frontend/src/components/llm-model-select.test.tsx
@@ -204,10 +204,52 @@ describe("LlmModelSearchableSelect", () => {
       screen.getByLabelText("Supports vision (images)"),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Supports tool calling")).toBeInTheDocument();
+    // Null is "nobody said", not "it reasons", so the glyph stays off.
+    expect(
+      screen.queryByLabelText("Supports reasoning"),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByLabelText("128,000 token context window"),
     ).toHaveTextContent("128K");
     expect(screen.getAllByText("vision-model-v1")).toHaveLength(1);
+  });
+
+  it("marks a reasoning model in the option row", async () => {
+    const user = userEvent.setup();
+    render(
+      <LlmModelSearchableSelect
+        value=""
+        onValueChange={vi.fn()}
+        options={[
+          {
+            value: "reasoning-model",
+            model: "Reasoning Model",
+            modelId: "openai/gpt-oss-20b",
+            description: "openai/gpt-oss-20b",
+            provider: "openrouter",
+            capabilities: {
+              contextLength: 131000,
+              inputModalities: ["text"],
+              outputModalities: ["text"],
+              supportsToolCalling: true,
+              supportsReasoningEffort: true,
+              recommendedForAgents: true,
+              pricePerMillionInput: null,
+              pricePerMillionOutput: null,
+              isCustomPrice: false,
+              priceSource: "default",
+              pricePerMillionCacheRead: null,
+              pricePerMillionCacheWrite: null,
+              cachePriceSource: "default",
+            },
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByLabelText("Supports reasoning")).toBeInTheDocument();
   });
 
   it("pins the routers to the top of the list", async () => {

--- a/platform/frontend/src/components/model-capability-indicators.tsx
+++ b/platform/frontend/src/components/model-capability-indicators.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  BrainIcon,
   FileText,
   ImageIcon,
   Layers,
@@ -38,13 +39,24 @@ export function ModelCapabilityBadges({
   const hasPdf = capabilities?.inputModalities?.includes("pdf");
   const hasToolCalling = capabilities?.supportsToolCalling;
   const lacksToolCalling = capabilities?.supportsToolCalling === false;
+  // Only `true` shows the glyph. The column is tri-state, and a null means no
+  // source claimed the model reasons rather than that it does not — the same
+  // reason the composer's depth control stays hidden on one.
+  const hasReasoning = capabilities?.supportsReasoningEffort === true;
   const notRecommended = capabilities?.recommendedForAgents === false;
   const hasAnyCapability =
-    hasText || hasVision || hasAudio || hasVideo || hasPdf || hasToolCalling;
+    hasText ||
+    hasVision ||
+    hasAudio ||
+    hasVideo ||
+    hasPdf ||
+    hasToolCalling ||
+    hasReasoning;
   const hasCapabilityData =
     capabilities != null &&
     (capabilities.inputModalities != null ||
-      capabilities.supportsToolCalling != null);
+      capabilities.supportsToolCalling != null ||
+      capabilities.supportsReasoningEffort != null);
 
   if (!hasCapabilityData) return <UnknownCapabilitiesBadge />;
   if (!hasAnyCapability && !lacksToolCalling && !notRecommended) return null;
@@ -67,6 +79,11 @@ export function ModelCapabilityBadges({
         {lacksToolCalling && <NoToolsBadge />}
         {hasToolCalling && (
           <CapabilityIcon icon={Settings2} label="Supports tool calling" />
+        )}
+        {/* Same glyph reasoning carries in the composer's depth control and in
+            the message stream, so the row and the control read as one thing. */}
+        {hasReasoning && (
+          <CapabilityIcon icon={BrainIcon} label="Supports reasoning" />
         )}
       </div>
     </TooltipProvider>

--- a/platform/shared/thinking-effort-support.test.ts
+++ b/platform/shared/thinking-effort-support.test.ts
@@ -86,6 +86,41 @@ describe("modelSupportsThinkingEffort", () => {
     ).toBe(false);
   });
 
+  test("an OpenRouter model is decided by its row, not its id", () => {
+    // Its ids carry a vendor prefix the id rules would otherwise recognize, but
+    // what OpenRouter serves under that name is its own catalog's business —
+    // the row carries what its `/models` response reported.
+    expect(
+      modelSupportsThinkingEffort({
+        provider: "openrouter",
+        modelId: "deepseek/deepseek-r1",
+        supportsReasoningEffort: true,
+      }),
+    ).toBe(true);
+    // A reasoning-capable vendor id is not enough on its own.
+    expect(
+      modelSupportsThinkingEffort({
+        provider: "openrouter",
+        modelId: "openai/gpt-5.2",
+        supportsReasoningEffort: false,
+      }),
+    ).toBe(false);
+  });
+
+  test.each([
+    false,
+    null,
+    undefined,
+  ])("an OpenRouter row of %s keeps the control hidden", (supportsReasoningEffort) => {
+    expect(
+      modelSupportsThinkingEffort({
+        provider: "openrouter",
+        modelId: "openai/gpt-4o",
+        supportsReasoningEffort,
+      }),
+    ).toBe(false);
+  });
+
   test("a vendor model ignores the column and keeps its id rule", () => {
     // A wrong row must not be able to switch the control on for a model whose
     // vendor would reject the field, nor off for one that takes it.

--- a/platform/shared/thinking-effort-support.ts
+++ b/platform/shared/thinking-effort-support.ts
@@ -15,11 +15,10 @@ import { supportsOpenAiThinkingEffort } from "./openai-models";
  * Cerebras catalogs — so the model id has to be checked even once the provider
  * matches.
  *
- * Self-hosted providers are the exception to "the id decides": an operator
- * names a model whatever they like (`--served-model-name`, an Ollama tag, a
- * fine-tune), so no rule written against the id can tell whether it reasons.
- * They are answered from `supportsReasoningEffort` on the row instead, which
- * carries what the serving backend or the registry said — see
+ * Self-hosted providers and OpenRouter are the exception to "the id decides":
+ * neither has a catalog a rule can be written against. They are answered from
+ * `supportsReasoningEffort` on the row instead, which carries what the serving
+ * backend, the provider's own catalog or the registry said — see
  * {@link modelSupportsThinkingEffort}.
  *
  * Lives apart from `thinking-effort.ts` so that file stays provider-neutral and
@@ -46,11 +45,11 @@ export function supportsThinkingEffort(
 
 /**
  * The composer's verdict for one model row: the id-based rules above, plus the
- * self-hosted providers that carry the answer on the row.
+ * providers that carry the answer on the row.
  *
  * `supportsReasoningEffort` is tri-state and only `true` opens the control. A
  * null means no source claimed the model reasons, and the false there is worth
- * more than the control: on this class of server an unwanted depth is not a
+ * more than the control: on a self-hosted server an unwanted depth is not a
  * cosmetic extra field — Ollama rejects `think` outright on a model that cannot
  * think, so a wrong `true` would turn every send into an error while a wrong
  * null only leaves the composer as it is today.
@@ -66,20 +65,24 @@ export function modelSupportsThinkingEffort(model: {
   supportsReasoningEffort?: boolean | null;
 }): boolean {
   const { provider, modelId, supportsReasoningEffort } = model;
-  if (isThinkingEffortSelfHostedProvider(provider)) {
+  if (isRowAnsweredThinkingEffortProvider(provider)) {
     return supportsReasoningEffort === true;
   }
   return supportsThinkingEffort(provider, modelId);
 }
 
 /**
- * Self-hosted providers whose depth the chat route can actually send: both
- * speak OpenAI's `reasoning_effort` on `/v1/chat/completions` — vLLM turns it
- * into the chat template's thinking switch, Ollama into its `think` field.
+ * Self-hosted providers whose depth the chat route sends as OpenAI's
+ * `reasoning_effort` on `/v1/chat/completions` — vLLM turns it into the chat
+ * template's thinking switch, Ollama into its `think` field.
  *
  * Listed explicitly rather than derived from the keyless-provider set they
  * currently match, so a future self-hosted provider does not silently inherit
  * a wire field its server has never seen.
+ *
+ * Distinct from {@link isRowAnsweredThinkingEffortProvider}: this one decides
+ * the wire field, that one decides who may be asked. OpenRouter is in the
+ * second set but not this one — it takes its own `reasoning` object instead.
  */
 const THINKING_EFFORT_SELF_HOSTED_PROVIDERS = new Set<SupportedProvider>([
   "ollama",
@@ -88,6 +91,30 @@ const THINKING_EFFORT_SELF_HOSTED_PROVIDERS = new Set<SupportedProvider>([
 
 export function isThinkingEffortSelfHostedProvider(provider: string): boolean {
   return THINKING_EFFORT_SELF_HOSTED_PROVIDERS.has(
+    provider as SupportedProvider,
+  );
+}
+
+/**
+ * Providers whose reasoning support no id-based rule can decide, so the model
+ * row answers instead.
+ *
+ * Self-hosted servers qualify because an operator names a model whatever they
+ * like (`--served-model-name`, an Ollama tag, a fine-tune). OpenRouter
+ * qualifies for the opposite reason: it resells hundreds of models from every
+ * vendor under `vendor/model` ids that turn over constantly, so the vendor
+ * catalogs the other branches consult say nothing about what it serves today.
+ * Its `/models` response reports `reasoning` in `supported_parameters` per
+ * model, which is what lands on the row — a first-party answer that stays
+ * current without shipping a new rule for every model it adds.
+ */
+const ROW_ANSWERED_THINKING_EFFORT_PROVIDERS = new Set<SupportedProvider>([
+  ...THINKING_EFFORT_SELF_HOSTED_PROVIDERS,
+  "openrouter",
+]);
+
+function isRowAnsweredThinkingEffortProvider(provider: string): boolean {
+  return ROW_ANSWERED_THINKING_EFFORT_PROVIDERS.has(
     provider as SupportedProvider,
   );
 }


### PR DESCRIPTION
## Problem

Chat's Low/Medium/High reasoning-depth control only appeared for the vendor providers (OpenAI, Anthropic, Gemini) and the two self-hosted ones (vLLM, Ollama). On an OpenRouter model the control was hidden, so there was no way to ask for more or less reasoning even when the underlying model supported it.

Separately, whether a model reasons was already stored on the model row and already decided whether that control appears — but nothing displayed it, so the only way to find out was to select a model and see whether the control showed up.

## Approach

**Wire format.** The depth rides OpenRouter's unified `reasoning` object, not OpenAI's top-level `reasoning_effort`. This is the load-bearing decision: of the 293 models OpenRouter reports as reasoning-capable, all 293 accept `reasoning` while only 153 also accept `reasoning_effort`. The remaining 140 reach upstreams that take a token budget rather than a level, and OpenRouter derives that budget from the effort itself. Sending the OpenAI spelling would have silently reached nothing on nearly half the reasoning catalog.

**Capability gating.** Which models offer the control is answered by the model row, the way the self-hosted providers already are, rather than by an id rule. OpenRouter resells hundreds of models under `vendor/model` ids that turn over constantly, so the vendor catalogs the other branches consult say nothing about what it serves today. Its `/models` response reports `reasoning` in `supported_parameters` per model, and the fetcher now lands that on the row — a first-party answer that stays current without shipping a new rule per model.

The two existing predicates are deliberately kept separate: one decides the wire field, the other decides who may be asked. OpenRouter is in the second set but not the first.

**Surfacing reasoning support.** The tri-state the gate reads is now shown in the shared capability row that both the chat model dialog and the canonical model dropdown render, using the same brain glyph the depth control and the message stream already use. Only a definite `true` lights it up; a null means no source claimed the model reasons, which is not the same as a claim that it does not.

## Tradeoff

The provider-options builder is not gated on the row a second time. The composer already hides the control unless the row says the model reasons, and OpenRouter ignores the field on a model that does not — verified below. A row-level gate would instead cost the depth on any reasoning model whose row has not yet picked up `supported_parameters`.

## Verified against a live OpenRouter account

Ran the production modules (`fetchOpenrouterModels`, `buildOpenRouterProviderOptions`, `modelSupportsThinkingEffort`) against the real API, then drove the running app in a browser.

The fetcher classified 454 models as 293 reasoning-capable, 128 not, 33 unknown, and a real model sync through the platform wrote the same split to the database. Depth reached the model and moved monotonically on `openai/gpt-oss-20b`, with `reasoning: {effort}` on the wire and no `reasoning_effort`:

| effort | reasoning tokens | answer |
|---|---|---|
| low | 46 | 23 chickens, 12 rabbits |
| medium | 78 | 23 chickens, 12 rabbits |
| high | 109 | 23 chickens, 12 rabbits |

`deepseek/deepseek-r1`, a token-budget upstream that never lists `reasoning_effort`, also honored the depth (609 reasoning tokens at Low) — the case the unified parameter exists for. A non-reasoning model (`openai/gpt-4o-mini`) answered normally with zero reasoning tokens and no error, which is what makes the second gate unnecessary.

In the app, against the same live account: the depth control appears on GPT OSS 20B and offers all four levels, two real chat turns returned the right answer with reasoning surfaced, and the control disappears entirely on GPT-4o mini through the same credential. In the model picker the GPT-4o-mini and GPT-4.1-mini rows carry no brain glyph while the GPT-5.4-mini rows do.
