### PR TITLE
fix(chat): add keyboard navigation to agent picker

### DIFF
--- a/platform/frontend/src/components/chat/initial-agent-selector.test.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
+import { InitialAgentSelector } from "./initial-agent-selector";
+
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/config/config.query");
+
+vi.mock("@/lib/agent.query", () => ({
+  useAgentCredentialReadiness: () => ({ data: undefined }),
+  useCreateProfile: () => ({ mutate: vi.fn() }),
+  useInternalAgents: () => ({
+    data: [
+      {
+        id: "agent-1",
+        name: "Alpha Agent",
+        agentType: "agent",
+        scope: "org",
+        authorId: null,
+        description: null,
+        icon: null,
+        systemPrompt: null,
+        backgroundExecution: null,
+        accessAllTools: true,
+      },
+      {
+        id: "agent-2",
+        name: "Beta Agent",
+        agentType: "agent",
+        scope: "org",
+        authorId: null,
+        description: null,
+        icon: null,
+        systemPrompt: null,
+        backgroundExecution: null,
+        accessAllTools: true,
+      },
+      {
+        id: "agent-3",
+        name: "Gamma Agent",
+        agentType: "agent",
+        scope: "org",
+        authorId: null,
+        description: null,
+        icon: null,
+        systemPrompt: null,
+        backgroundExecution: null,
+        accessAllTools: true,
+      },
+    ],
+  }),
+  useUpdateProfile: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/lib/agent-tools.query", () => ({
+  useAgentDelegations: () => ({ data: [] }),
+  useAllProfileTools: () => ({ data: { data: [] } }),
+  useAssignTool: () => ({ mutate: vi.fn() }),
+  useRemoveAgentDelegation: () => ({ mutate: vi.fn() }),
+  useSyncAgentDelegations: () => ({ mutate: vi.fn() }),
+  useUnassignTool: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/lib/knowledge/connector.query", () => ({
+  useConnectors: () => ({ data: [] }),
+}));
+
+vi.mock("@/lib/knowledge/knowledge-base.query", () => ({
+  useKnowledgeBases: () => ({ data: [] }),
+}));
+
+vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
+  fetchCatalogTools: vi.fn(),
+  useCatalogTools: () => ({ data: [] }),
+  useInternalMcpCatalog: () => ({ data: [] }),
+}));
+
+vi.mock("@/lib/mcp/mcp-install-orchestrator.hook", () => ({
+  useMcpInstallOrchestrator: () => ({
+    closeLocalInstall: vi.fn(),
+    closeNoAuthInstall: vi.fn(),
+    closeOAuth: vi.fn(),
+    handleLocalServerInstallConfirm: vi.fn(),
+    handleNoAuthConfirm: vi.fn(),
+    handleOAuthConfirm: vi.fn(),
+    handleRemoteServerInstallConfirm: vi.fn(),
+    isDialogOpened: () => false,
+    isInstalling: false,
+    isReauth: false,
+    localServerCatalogItem: null,
+    noAuthCatalogItem: null,
+    selectedCatalogItem: null,
+    triggerInstallByCatalogId: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/chat/mcp-install-dialogs", () => ({
+  McpInstallDialogs: () => null,
+}));
+vi.mock("@/app/mcp/registry/_parts/local-server-install-dialog", () => ({
+  LocalServerInstallDialog: () => null,
+}));
+vi.mock("@/app/mcp/registry/_parts/no-auth-install-dialog", () => ({
+  NoAuthInstallDialog: () => null,
+}));
+vi.mock("@/app/mcp/registry/_parts/remote-server-install-dialog", () => ({
+  RemoteServerInstallDialog: () => null,
+}));
+vi.mock("@/components/oauth-confirmation-dialog", () => ({
+  OAuthConfirmationDialog: () => null,
+}));
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(useHasPermissions).mockReturnValue({ data: true } as ReturnType<
+    typeof useHasPermissions
+  >);
+  vi.mocked(useSession).mockReturnValue({
+    data: { user: { id: "user-1" } },
+  } as ReturnType<typeof useSession>);
+  vi.mocked(useFeature).mockReturnValue(false);
+});
+
+describe("InitialAgentSelector keyboard navigation", () => {
+  it("moves through agents with arrow keys and selects with Enter", async () => {
+    const user = userEvent.setup();
+    const onAgentChange = vi.fn();
+    render(
+      <InitialAgentSelector
+        currentAgentId="agent-1"
+        onAgentChange={onAgentChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const search = await screen.findByRole("combobox", {
+      name: "Search agents",
+    });
+
+    expect(search).toHaveAttribute(
+      "aria-activedescendant",
+      screen.getByRole("option", { name: /Alpha Agent/ }).id,
+    );
+
+    await user.keyboard("{ArrowDown}");
+    expect(search).toHaveAttribute(
+      "aria-activedescendant",
+      screen.getByRole("option", { name: /Beta Agent/ }).id,
+    );
+
+    await user.keyboard("{ArrowUp}");
+    expect(search).toHaveAttribute(
+      "aria-activedescendant",
+      screen.getByRole("option", { name: /Alpha Agent/ }).id,
+    );
+
+    await user.keyboard("{ArrowUp}{Enter}");
+    expect(onAgentChange).toHaveBeenCalledWith("agent-3");
+  });
+});

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -20,7 +20,15 @@ import {
   XIcon,
 } from "lucide-react";
 import Link from "next/link";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ConnectorTypeIcon } from "@/app/knowledge/knowledge-bases/_parts/connector-icons";
 import { LocalServerInstallDialog } from "@/app/mcp/registry/_parts/local-server-install-dialog";
 import { NoAuthInstallDialog } from "@/app/mcp/registry/_parts/no-auth-install-dialog";
@@ -105,6 +113,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   filterAndSortInitialAgents,
+  getAdjacentAgentId,
   truncateAgentDescription,
 } from "./initial-agent-selector.utils";
 
@@ -144,6 +153,11 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
   const createProfile = useCreateProfile();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [highlightedAgentId, setHighlightedAgentId] = useState<string | null>(
+    null,
+  );
+  const agentListboxId = useId();
+  const agentOptionRefs = useRef(new Map<string, HTMLButtonElement>());
   const [editingAgentId, setEditingAgentId] = useState<string | null>(null);
   const [dialogView, setDialogView] = useState<
     | "settings"
@@ -166,6 +180,17 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
       userId,
     });
   }, [allAgents, search, currentAgentId, userId]);
+  const keyboardNavigableAgentIds = useMemo(
+    () =>
+      filteredAgents
+        .filter(
+          (agent) =>
+            resolveAgentConnectionGate(readinessByAgent.get(agent.id)).kind !==
+            "block",
+        )
+        .map((agent) => agent.id),
+    [filteredAgents, readinessByAgent],
+  );
 
   const currentAgent = useMemo(
     () =>
@@ -257,7 +282,62 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
     onAgentChange(agentId);
     setOpen(false);
     setSearch("");
+    setHighlightedAgentId(null);
   };
+
+  const handleSearchKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedAgentId((current) =>
+        getAdjacentAgentId({
+          agentIds: keyboardNavigableAgentIds,
+          currentAgentId: current,
+          direction: event.key === "ArrowDown" ? "next" : "previous",
+        }),
+      );
+      return;
+    }
+
+    if (
+      event.key === "Enter" &&
+      highlightedAgentId &&
+      keyboardNavigableAgentIds.includes(highlightedAgentId)
+    ) {
+      event.preventDefault();
+      handleAgentSelect(highlightedAgentId);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setHighlightedAgentId((current) => {
+      if (current && keyboardNavigableAgentIds.includes(current)) {
+        return current;
+      }
+      if (
+        currentAgentId &&
+        keyboardNavigableAgentIds.includes(currentAgentId)
+      ) {
+        return currentAgentId;
+      }
+      return keyboardNavigableAgentIds[0] ?? null;
+    });
+  }, [currentAgentId, keyboardNavigableAgentIds, open]);
+
+  useEffect(() => {
+    if (!open || !highlightedAgentId) {
+      return;
+    }
+
+    agentOptionRefs.current
+      .get(highlightedAgentId)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [highlightedAgentId, open]);
 
   const handleAddTool = useCallback(() => {
     if (currentAgentId) {
@@ -293,7 +373,10 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
         open={open}
         onOpenChange={(newOpen) => {
           setOpen(newOpen);
-          if (!newOpen) setSearch("");
+          if (!newOpen) {
+            setSearch("");
+            setHighlightedAgentId(null);
+          }
         }}
       >
         <PopoverTrigger asChild>
@@ -337,14 +420,29 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
               <Input
                 placeholder="Search..."
                 aria-label="Search agents"
+                role="combobox"
+                aria-autocomplete="list"
+                aria-controls={agentListboxId}
+                aria-expanded={open}
+                aria-activedescendant={
+                  highlightedAgentId
+                    ? `${agentListboxId}-option-${highlightedAgentId}`
+                    : undefined
+                }
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
+                onKeyDown={handleSearchKeyDown}
                 className="h-8 pl-8 text-sm rounded-lg border-0 bg-muted/50 focus-visible:ring-1"
                 autoFocus
               />
             </div>
           </div>
-          <div className="max-h-[300px] overflow-y-auto px-1.5 pb-1.5">
+          <div
+            id={agentListboxId}
+            role="listbox"
+            aria-label="Agents"
+            className="max-h-[300px] overflow-y-auto px-1.5 pb-1.5"
+          >
             {filteredAgents.length === 0 ? (
               <div className="py-6 text-center text-xs text-muted-foreground">
                 No agents found
@@ -352,6 +450,7 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
             ) : (
               filteredAgents.map((agent) => {
                 const isSelected = currentAgentId === agent.id;
+                const isHighlighted = highlightedAgentId === agent.id;
                 const canEdit = isAgentAdmin || agent.authorId === userId;
                 const gate = resolveAgentConnectionGate(
                   readinessByAgent.get(agent.id),
@@ -363,14 +462,27 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
                     className={cn(
                       "group w-full rounded-lg px-2.5 py-2 transition-colors",
                       isBlocked ? "opacity-60" : "hover:bg-accent",
-                      isSelected && "bg-accent",
+                      isHighlighted && "bg-accent",
                     )}
                   >
                     <div className="flex w-full items-center gap-2.5">
                       <button
+                        ref={(node) => {
+                          if (node) {
+                            agentOptionRefs.current.set(agent.id, node);
+                          } else {
+                            agentOptionRefs.current.delete(agent.id);
+                          }
+                        }}
+                        id={`${agentListboxId}-option-${agent.id}`}
                         type="button"
+                        role="option"
+                        aria-selected={isSelected}
                         disabled={isBlocked}
                         onClick={() => handleAgentSelect(agent.id)}
+                        onMouseMove={() => {
+                          if (!isBlocked) setHighlightedAgentId(agent.id);
+                        }}
                         className={cn(
                           "flex flex-1 items-center gap-2.5 text-left min-w-0",
                           isBlocked ? "cursor-not-allowed" : "cursor-pointer",

--- a/platform/frontend/src/components/chat/initial-agent-selector.utils.test.ts
+++ b/platform/frontend/src/components/chat/initial-agent-selector.utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { filterAndSortInitialAgents } from "./initial-agent-selector.utils";
+import {
+  filterAndSortInitialAgents,
+  getAdjacentAgentId,
+} from "./initial-agent-selector.utils";
 
 const userId = "user-1";
 
@@ -160,5 +163,67 @@ describe("filterAndSortInitialAgents", () => {
     });
 
     expect(result.map((agent) => agent.id)).toEqual(["a", "m", "z"]);
+  });
+});
+
+describe("getAdjacentAgentId", () => {
+  const agentIds = ["agent-1", "agent-2", "agent-3"];
+
+  it("moves in either direction and wraps at the ends", () => {
+    expect(
+      getAdjacentAgentId({
+        agentIds,
+        currentAgentId: "agent-2",
+        direction: "next",
+      }),
+    ).toBe("agent-3");
+    expect(
+      getAdjacentAgentId({
+        agentIds,
+        currentAgentId: "agent-2",
+        direction: "previous",
+      }),
+    ).toBe("agent-1");
+    expect(
+      getAdjacentAgentId({
+        agentIds,
+        currentAgentId: "agent-3",
+        direction: "next",
+      }),
+    ).toBe("agent-1");
+    expect(
+      getAdjacentAgentId({
+        agentIds,
+        currentAgentId: "agent-1",
+        direction: "previous",
+      }),
+    ).toBe("agent-3");
+  });
+
+  it("starts at the nearest end when nothing is highlighted", () => {
+    expect(
+      getAdjacentAgentId({
+        agentIds,
+        currentAgentId: null,
+        direction: "next",
+      }),
+    ).toBe("agent-1");
+    expect(
+      getAdjacentAgentId({
+        agentIds,
+        currentAgentId: null,
+        direction: "previous",
+      }),
+    ).toBe("agent-3");
+  });
+
+  it("returns null for an empty result list", () => {
+    expect(
+      getAdjacentAgentId({
+        agentIds: [],
+        currentAgentId: "agent-1",
+        direction: "next",
+      }),
+    ).toBeNull();
   });
 });

--- a/platform/frontend/src/components/chat/initial-agent-selector.utils.ts
+++ b/platform/frontend/src/components/chat/initial-agent-selector.utils.ts
@@ -78,6 +78,25 @@ export function truncateAgentDescription(description?: string | null) {
   return `${safeTruncation.trimEnd()}...`;
 }
 
+export function getAdjacentAgentId(params: {
+  agentIds: string[];
+  currentAgentId: string | null;
+  direction: "next" | "previous";
+}) {
+  const { agentIds, currentAgentId, direction } = params;
+  if (agentIds.length === 0) {
+    return null;
+  }
+
+  const currentIndex = currentAgentId ? agentIds.indexOf(currentAgentId) : -1;
+  if (currentIndex === -1) {
+    return direction === "next" ? agentIds[0] : (agentIds.at(-1) ?? null);
+  }
+
+  const offset = direction === "next" ? 1 : -1;
+  return agentIds[(currentIndex + offset + agentIds.length) % agentIds.length];
+}
+
 function getScopeOrder(scope: InitialAgentListItem["scope"]) {
   switch (scope) {
     case "personal":


### PR DESCRIPTION
## Summary

The chat agent picker could only change agents through pointer interaction. It now tracks an active option while the search field remains focused, supports wrapping Up/Down navigation, and selects the highlighted agent with Enter.

Blocked agents are excluded from keyboard navigation, the highlighted row scrolls into view, and the combobox/listbox relationship is exposed to assistive technology.

## Verification

Exercised the picker by opening it with an existing selection, moving down and back up, wrapping upward to the last option, and pressing Enter. The highlighted option changed on each arrow press and the final Enter selected the expected agent.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>