### PR TITLE
fix(chat): keep assistant actions within message column

### DIFF
--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -608,7 +608,7 @@ export function ChatMessages({
           feedback={contextCompactionFeedback}
         />
         <ConversationContent>
-          <div className="max-w-4xl mx-auto relative pb-8">
+          <div className="@container/chat max-w-4xl mx-auto relative pb-8">
             <SensitiveContextStickyIndicator
               visible={showStickyUnsafeIndicator}
             />

--- a/platform/frontend/src/components/chat/editable-assistant-message.tsx
+++ b/platform/frontend/src/components/chat/editable-assistant-message.tsx
@@ -106,12 +106,13 @@ export function EditableAssistantMessage({
     <Message from="assistant" className="group/message">
       {/* The actions are absolutely positioned outside the flow: mounting
           them when streaming ends must not steal width from the bubble,
-          which would make the finished text visibly rewrap. From md up they
-          hang off the bubble's right edge; that doesn't fit a phone viewport
-          (it would widen the horizontal scroll range), so below md they
-          overlay just under the bubble instead. Reveal is hover on desktop
-          and the tap-synthesized hover on touch; pointer-events gating keeps
-          the hidden panel from swallowing taps meant for the content. */}
+          which would make the finished text visibly rewrap. When the chat
+          column itself is wide enough they hang off the bubble's right edge;
+          otherwise they overlay just under the bubble. A container query is
+          important here because the right panel can narrow the chat without
+          changing the viewport breakpoint. Reveal is hover on desktop and
+          the tap-synthesized hover on touch; pointer-events gating keeps the
+          hidden panel from swallowing taps meant for the content. */}
       <div className="relative max-w-[80%]">
         <MessageContent className="max-w-none">
           <Response isStreaming={isStreaming}>{displayText}</Response>
@@ -130,7 +131,7 @@ export function EditableAssistantMessage({
             feedback={feedback}
             onFeedbackChange={onFeedbackChange}
             feedbackDisabled={feedbackDisabled}
-            className="pointer-events-none absolute top-full left-0 z-10 mt-1 opacity-0 transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 md:top-1/2 md:left-full md:mt-0 md:ml-2 md:-translate-y-1/2"
+            className="pointer-events-none absolute top-full left-0 z-10 mt-1 opacity-0 transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 @2xl/chat:top-1/2 @2xl/chat:left-full @2xl/chat:mt-0 @2xl/chat:ml-2 @2xl/chat:-translate-y-1/2"
           />
         )}
       </div>

--- a/platform/frontend/src/components/chat/editable-assistant-message.tsx
+++ b/platform/frontend/src/components/chat/editable-assistant-message.tsx
@@ -112,7 +112,9 @@ export function EditableAssistantMessage({
           important here because the right panel can narrow the chat without
           changing the viewport breakpoint. Reveal is hover on desktop and
           the tap-synthesized hover on touch; pointer-events gating keeps the
-          hidden panel from swallowing taps meant for the content. */}
+          hidden panel from swallowing taps meant for the content. The
+          positioning wrapper owns the visual gap as padding, creating a hover
+          bridge between the message and the buttons. */}
       <div className="relative max-w-[80%]">
         <MessageContent className="max-w-none">
           <Response isStreaming={isStreaming}>{displayText}</Response>
@@ -124,15 +126,16 @@ export function EditableAssistantMessage({
           )}
         </MessageContent>
         {showActions && (
-          <MessageActions
-            textToCopy={visibleText}
-            onEditClick={handleStartEdit}
-            editDisabled={editDisabled}
-            feedback={feedback}
-            onFeedbackChange={onFeedbackChange}
-            feedbackDisabled={feedbackDisabled}
-            className="pointer-events-none absolute top-full left-0 z-10 mt-1 opacity-0 transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 @2xl/chat:top-1/2 @2xl/chat:left-full @2xl/chat:mt-0 @2xl/chat:ml-2 @2xl/chat:-translate-y-1/2"
-          />
+          <div className="pointer-events-none absolute top-full left-0 z-10 pt-1 opacity-0 transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 @2xl/chat:top-1/2 @2xl/chat:left-full @2xl/chat:pt-0 @2xl/chat:pl-2 @2xl/chat:-translate-y-1/2">
+            <MessageActions
+              textToCopy={visibleText}
+              onEditClick={handleStartEdit}
+              editDisabled={editDisabled}
+              feedback={feedback}
+              onFeedbackChange={onFeedbackChange}
+              feedbackDisabled={feedbackDisabled}
+            />
+          </div>
         )}
       </div>
     </Message>


### PR DESCRIPTION
## Summary

Opening Chat's right-side panel can narrow the transcript while the viewport remains desktop-sized. The assistant action bar was still using the viewport breakpoint, so it could overlap the panel.

The transcript is now a named inline-size container. Assistant actions stay below the message in a narrow transcript and move beside it only once the transcript itself is at least 42rem wide, preserving the existing no-rewrap behavior when streaming finishes.

The visual spacing between a message and its actions now belongs to a positioned wrapper as padding. That padding forms a continuous hover target, so moving from the message to the buttons does not drop the controls in either the below-message or side placement.