### PR TITLE
fix(chat): restore selector focus rings

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -660,8 +660,10 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
             /* Same radius as the controls it clips: they are full-height and
                sit flush against the group's end caps, so a wider group radius
                rounds their outer corners while the inner ones keep the button
-               radius — a lopsided hover shape (T-1088). */
-            <div className="flex items-center h-8 rounded-md bg-muted/50 overflow-hidden">
+               radius — a lopsided hover shape (T-1088). Let keyboard focus
+               escape that clipping and stack above adjacent controls so its
+               ring stays intact. */
+            <div className="flex items-center h-8 rounded-md bg-muted/50 overflow-hidden has-[:focus-visible]:overflow-visible [&_button:focus-visible]:relative [&_button:focus-visible]:z-10">
               {(conversationId || onApiKeyChange) && (
                 <LlmProviderApiKeySelector
                   conversationId={conversationId}


### PR DESCRIPTION
The provider credential and model controls share an overflow-clipped capsule in the chat composer. That preserves rounded hover endcaps, but it cuts keyboard focus rings into partial brackets.

Keep the capsule clipped in its resting and hover states, then allow overflow only while a descendant is `:focus-visible`. The focused button is also raised above adjacent controls so the complete ring remains visible without regressing the capsule hover shape.