### PR TITLE
fix(knowledge): standardize model picker metadata

### DIFF
--- a/platform/frontend/src/app/settings/knowledge/page.test.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.test.tsx
@@ -206,6 +206,18 @@ function getRerankerModelTrigger() {
   return modelTrigger;
 }
 
+function getOcrModelTrigger() {
+  const modelTrigger = screen
+    .getAllByRole("combobox")
+    .find((el) => el.textContent?.includes("Select vision model"));
+
+  if (!modelTrigger) {
+    throw new Error("OCR model trigger not found");
+  }
+
+  return modelTrigger;
+}
+
 function makeCapabilities(
   overrides: Partial<ModelCapabilities> = {},
 ): ModelCapabilities {
@@ -573,6 +585,53 @@ describe("KnowledgeSettingsPage", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByLabelText("Supports tool calling"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows OCR model names, ids, modalities, and capabilities in the dropdown", async () => {
+      const user = userEvent.setup();
+      mockOrganization = {
+        embeddingChatApiKeyId: null,
+        embeddingModel: null,
+        rerankerChatApiKeyId: null,
+        rerankerModel: null,
+        ocrChatApiKeyId: "key-1",
+        ocrModel: null,
+      };
+      mockApiKeys = [
+        {
+          id: "key-1",
+          name: "Vision Key",
+          provider: "openai",
+          scope: "org",
+        },
+      ];
+      mockLlmModels = [
+        {
+          id: "vision-model-v1",
+          provider: "openai",
+          displayName: "Vision Model",
+          capabilities: makeCapabilities({
+            inputModalities: ["text", "image"],
+            supportsToolCalling: true,
+          }),
+        },
+      ];
+      renderPage();
+
+      await user.click(getOcrModelTrigger());
+
+      expect(screen.getByText("Vision Model")).toBeInTheDocument();
+      expect(screen.getByText("vision-model-v1")).toBeInTheDocument();
+      expect(screen.getByLabelText("Supports text input")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Supports vision (images)"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Supports tool calling"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("128,000 token context window"),
       ).toBeInTheDocument();
     });
   });

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -470,7 +470,7 @@ function OcrModelSelector({
   selectedKeyId: string | null;
 }) {
   const { data: apiKeys } = useAvailableLlmProviderApiKeys();
-  const { data: allModels, isPending: modelsLoading } = useModelsWithApiKeys();
+  const { data: allModels, isPending: modelsLoading } = useLlmModels();
 
   const selectedProvider = useMemo(() => {
     if (!selectedKeyId || !apiKeys) return null;
@@ -484,9 +484,10 @@ function OcrModelSelector({
       // Vision-capable models only. Modality metadata is advisory: a model
       // with none (a custom endpoint) stays selectable — the save probe sends
       // a real PDF page and is the actual gate.
-      if (!m.inputModalities) return true;
+      if (!m.capabilities?.inputModalities) return true;
       return (
-        m.inputModalities.includes("pdf") || m.inputModalities.includes("image")
+        m.capabilities.inputModalities.includes("pdf") ||
+        m.capabilities.inputModalities.includes("image")
       );
     });
   }, [allModels, selectedProvider]);
@@ -513,9 +514,14 @@ function OcrModelSelector({
       value={value ?? ""}
       onValueChange={(v) => onChange(v || null)}
       options={models.map((model) => ({
-        value: model.modelId,
-        model: model.modelId,
+        value: model.id,
+        model: model.displayName ?? model.id,
+        modelId: model.id,
         provider: model.provider,
+        description: model.displayName === model.id ? undefined : model.id,
+        capabilities: model.capabilities,
+        isFree: model.isFree,
+        isBest: model.isBest,
       }))}
       placeholder="Select vision model..."
       searchPlaceholder="Search vision models..."

--- a/platform/frontend/src/components/llm-model-select.tsx
+++ b/platform/frontend/src/components/llm-model-select.tsx
@@ -92,16 +92,20 @@ export function LlmModelOptionLabel({
   showPricing?: boolean;
   truncateModelName?: boolean;
 }) {
+  const secondaryText = showPricing
+    ? formatPricing(option)
+    : option.description;
+
   return (
-    <div className="flex min-w-0 items-center gap-2">
+    <div className="flex min-w-0 items-start gap-2">
       <Image
         src={providerLogoUrl(option.provider)}
         alt={builtInProviderLabel(option.provider)}
         width={16}
         height={16}
-        className="shrink-0 rounded dark:invert"
+        className="mt-0.5 shrink-0 rounded dark:invert"
       />
-      <div className="min-w-0 flex-1 flex flex-col">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
           <span
             className={cn(
@@ -114,26 +118,25 @@ export function LlmModelOptionLabel({
             {option.model}
           </span>
           <ModelBadges option={option} />
-          {option.capabilities && (
-            <div className="ml-auto flex max-w-full shrink-0 items-center gap-2">
-              <ModelCapabilityBadges
-                capabilities={option.capabilities}
-                showTextInput
-              />
-              <ModelContextLengthIndicator
-                contextLength={option.capabilities.contextLength}
-              />
-            </div>
-          )}
         </div>
-        {showPricing && (
-          <div className="truncate text-xs text-muted-foreground">
-            {formatPricing(option)}
-          </div>
-        )}
-        {!showPricing && option.description && (
-          <div className="truncate text-xs text-muted-foreground">
-            {option.description}
+        {(secondaryText || option.capabilities) && (
+          <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+            {secondaryText && (
+              <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                {secondaryText}
+              </span>
+            )}
+            {option.capabilities && (
+              <div className="ml-auto flex max-w-full shrink-0 items-center gap-2">
+                <ModelCapabilityBadges
+                  capabilities={option.capabilities}
+                  showTextInput
+                />
+                <ModelContextLengthIndicator
+                  contextLength={option.capabilities.contextLength}
+                />
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Knowledge model pickers presented uneven amounts of model metadata, and rich rows could wrap capability details alongside the model name in an awkward layout.

- source Document OCR options from the same available-model data used by reranking, including friendly names, native IDs, capability metadata, recommendation state, and badges
- reserve the first option line for the model name and badges, with descriptions, capabilities, and context on a consistent second line
- preserve OCR filtering to vision/PDF-capable models while keeping custom models without modality metadata selectable

## Verification

The Knowledge page integration coverage opens the OCR model picker and verifies the friendly name, native ID, text/vision support, tool support, and context window are all shown. The complete frontend test suite passes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>