### PR TITLE
feat(platform): add cursor pagination and move the three log lists onto it

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -82917,13 +82917,10 @@
           },
           {
             "schema": {
-              "default": 0,
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 9007199254740991
+              "type": "string"
             },
             "in": "query",
-            "name": "offset",
+            "name": "cursor",
             "required": false
           }
         ],
@@ -83281,40 +83278,23 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "currentPage": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 9007199254740991
-                        },
                         "limit": {
                           "type": "integer",
                           "minimum": 1,
                           "maximum": 9007199254740991
                         },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "maximum": 9007199254740991
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "maximum": 9007199254740991
+                        "nextCursor": {
+                          "nullable": true,
+                          "type": "string"
                         },
                         "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
                           "type": "boolean"
                         }
                       },
                       "required": [
-                        "currentPage",
                         "limit",
-                        "total",
-                        "totalPages",
-                        "hasNext",
-                        "hasPrev"
+                        "nextCursor",
+                        "hasNext"
                       ],
                       "additionalProperties": false
                     }
@@ -184076,13 +184056,10 @@
           },
           {
             "schema": {
-              "default": 0,
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 9007199254740991
+              "type": "string"
             },
             "in": "query",
-            "name": "offset",
+            "name": "cursor",
             "required": false
           }
         ],
@@ -184389,40 +184366,23 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "currentPage": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 9007199254740991
-                        },
                         "limit": {
                           "type": "integer",
                           "minimum": 1,
                           "maximum": 9007199254740991
                         },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "maximum": 9007199254740991
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "maximum": 9007199254740991
+                        "nextCursor": {
+                          "nullable": true,
+                          "type": "string"
                         },
                         "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
                           "type": "boolean"
                         }
                       },
                       "required": [
-                        "currentPage",
                         "limit",
-                        "total",
-                        "totalPages",
-                        "hasNext",
-                        "hasPrev"
+                        "nextCursor",
+                        "hasNext"
                       ],
                       "additionalProperties": false
                     }
@@ -284329,27 +284289,10 @@
           },
           {
             "schema": {
-              "default": 0,
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 9007199254740991
+              "type": "string"
             },
             "in": "query",
-            "name": "offset",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "createdAt",
-                "agentId",
-                "mcpServerName",
-                "method"
-              ]
-            },
-            "in": "query",
-            "name": "sortBy",
+            "name": "cursor",
             "required": false
           },
           {
@@ -284525,40 +284468,23 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "currentPage": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 9007199254740991
-                        },
                         "limit": {
                           "type": "integer",
                           "minimum": 1,
                           "maximum": 9007199254740991
                         },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "maximum": 9007199254740991
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "maximum": 9007199254740991
+                        "nextCursor": {
+                          "nullable": true,
+                          "type": "string"
                         },
                         "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
                           "type": "boolean"
                         }
                       },
                       "required": [
-                        "currentPage",
                         "limit",
-                        "total",
-                        "totalPages",
-                        "hasNext",
-                        "hasPrev"
+                        "nextCursor",
+                        "hasNext"
                       ],
                       "additionalProperties": false
                     }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -82884,28 +82884,6 @@
           },
           {
             "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "search",
-            "required": false,
-            "description": "Case-insensitive search across actor email, actor name, HTTP path, resource ID, and resource name"
-          },
-          {
-            "schema": {
-              "default": "desc",
-              "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
-            },
-            "in": "query",
-            "name": "sortDirection",
-            "required": false
-          },
-          {
-            "schema": {
               "default": 20,
               "type": "integer",
               "minimum": 1,
@@ -284232,7 +284210,7 @@
         "tags": [
           "MCP Tool Call"
         ],
-        "description": "Get all MCP tool calls with pagination and sorting\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`log:read`: View your own LLM proxy and MCP tool call logs",
+        "description": "Get all MCP tool calls with cursor pagination\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`log:read`: View your own LLM proxy and MCP tool call logs",
         "parameters": [
           {
             "schema": {
@@ -284272,9 +284250,9 @@
               "type": "string"
             },
             "in": "query",
-            "name": "search",
+            "name": "mcpServerName",
             "required": false,
-            "description": "Free-text search across MCP server name, tool name, and arguments (case-insensitive)"
+            "description": "Filter by exact MCP server name"
           },
           {
             "schema": {
@@ -284293,19 +284271,6 @@
             },
             "in": "query",
             "name": "cursor",
-            "required": false
-          },
-          {
-            "schema": {
-              "default": "desc",
-              "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
-            },
-            "in": "query",
-            "name": "sortDirection",
             "required": false
           }
         ],

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -286,7 +286,7 @@ pnpm rebuild <package-name>  # Enable scripts for specific package
 - **Error Handling**: Always use `throw new ApiError(statusCode, message)` for error responses - never use manual `reply.status().send({ error: ... })`. The centralized Fastify error handler formats all errors consistently as `{ error: { message, type } }` and logs appropriately.
 - **Protected Routes & Authentication**: Routes under `/api/` are protected by the auth middleware which guarantees `request.user` and `request.organizationId` exist. Never add redundant null checks like `if (!request.organizationId) throw new ApiError(401, "Unauthorized")` - just use `request.organizationId` directly. The middleware handles authentication; routes handle authorization and business logic.
 - **Type Organization**: Keep database schemas in `database/schemas/`, extract business types to dedicated `types/` files
-- **Pagination**: Use `PaginationQuerySchema` and `createPaginatedResponseSchema` for consistent pagination across APIs
+- **Pagination**: Use `PaginationQuerySchema` and `createPaginatedResponseSchema` for ordinary bounded tables that need page counts. Use `CursorQuerySchema` and `createCursorPaginatedResponseSchema` for write-hot or unbounded logs; keyset queries must fetch `limit + 1` rows and must not calculate totals.
 - **Sorting**: Use `SortingQuerySchema` or `createSortingQuerySchema` for standardized sorting parameters
 - **Database Types via drizzle-zod**: Never manually define TypeScript interfaces for database entities. Use `drizzle-zod` to generate Zod schemas from Drizzle table definitions, then infer types with `z.infer<>`. This keeps types in sync with the schema automatically:
 

--- a/platform/backend/src/database/utils/pagination.ts
+++ b/platform/backend/src/database/utils/pagination.ts
@@ -1,4 +1,6 @@
 import {
+  type CursorPaginationMeta,
+  type CursorQuery,
   calculatePaginationMeta,
   type PaginationMeta,
   type PaginationQuery,
@@ -42,5 +44,109 @@ export function createPaginatedResult<T>(
   return {
     data,
     pagination: calculatePaginationMeta(total, params),
+  };
+}
+
+// ===========================================================================
+// Cursor pagination
+// ===========================================================================
+
+/**
+ * Where a page ended, as the values a keyset predicate compares against.
+ *
+ * Two parts, because one is not enough: `value` is whatever the query sorts
+ * by and is rarely unique (many interactions share a millisecond), so `id`
+ * breaks the tie. Without it a row on a shared timestamp is either served
+ * twice or skipped at the page boundary.
+ */
+interface CursorPosition {
+  /** The sort column's value, as text. Dates are ISO 8601. */
+  value: string;
+  /** Primary key of the last row on the page. */
+  id: string;
+}
+
+export interface CursorPaginatedResult<T> {
+  data: T[];
+  pagination: CursorPaginationMeta;
+}
+
+/**
+ * Encode a position as an opaque cursor.
+ *
+ * base64url rather than plain JSON so it survives a query string untouched,
+ * and so it reads as a token a caller should pass back rather than a
+ * structure worth editing. It is *not* a security boundary: anyone can decode
+ * it. It does not need to be one, because every value inside it also appears
+ * in the response the caller just read.
+ */
+export function encodeCursor(position: CursorPosition): string {
+  return Buffer.from(JSON.stringify(position), "utf8").toString("base64url");
+}
+
+/**
+ * Decode a cursor, returning null for anything unusable.
+ *
+ * Null rather than a throw: a cursor arrives from a URL, so a truncated,
+ * stale or hand-edited one is an ordinary event, not an exception. Callers
+ * treat null as "start from the newest row", which is the same thing an
+ * absent cursor means. A bad cursor therefore costs the reader their place,
+ * never an error page.
+ */
+export function decodeCursor(
+  cursor: string | undefined,
+): CursorPosition | null {
+  if (!cursor) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(
+      Buffer.from(cursor, "base64url").toString("utf8"),
+    );
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "value" in parsed &&
+      "id" in parsed &&
+      typeof (parsed as CursorPosition).value === "string" &&
+      typeof (parsed as CursorPosition).id === "string"
+    ) {
+      return parsed as CursorPosition;
+    }
+  } catch {
+    // Fall through: unparseable is handled the same as absent.
+  }
+
+  return null;
+}
+
+/**
+ * Build a cursor-paginated result from a page fetched with `limit + 1` rows.
+ *
+ * The extra row is how "is there more" is answered without counting: if it
+ * came back, another page exists. It is dropped before the data is returned,
+ * so callers must fetch `limit + 1` and pass the whole thing here.
+ *
+ * @param rows - Up to `params.limit + 1` rows, in page order
+ * @param params - The cursor query the rows were fetched for
+ * @param toPosition - Reads the cursor position off a row
+ */
+export function createCursorPaginatedResult<T>(
+  rows: T[],
+  params: CursorQuery,
+  toPosition: (row: T) => CursorPosition,
+): CursorPaginatedResult<T> {
+  const hasNext = rows.length > params.limit;
+  const data = hasNext ? rows.slice(0, params.limit) : rows;
+  const last = data[data.length - 1];
+
+  return {
+    data,
+    pagination: {
+      limit: params.limit,
+      hasNext,
+      // A cursor past the end would invite a request that can only come back
+      // empty, so the end of the data is also the end of the cursors.
+      nextCursor: hasNext && last ? encodeCursor(toPosition(last)) : null,
+    },
   };
 }

--- a/platform/backend/src/models/audit-log.ts
+++ b/platform/backend/src/models/audit-log.ts
@@ -185,8 +185,8 @@ class AuditLogModel {
         const keyset = sql`(${schema.auditLogsTable.createdAt}, ${schema.auditLogsTable.eventSequence})`;
         conditions.push(
           sortDirection === "asc"
-            ? sql`${keyset} > (${at}, ${seq})`
-            : sql`${keyset} < (${at}, ${seq})`,
+            ? sql`${keyset} > (${position.value}::timestamptz, ${seq})`
+            : sql`${keyset} < (${position.value}::timestamptz, ${seq})`,
         );
       }
     }

--- a/platform/backend/src/models/audit-log.ts
+++ b/platform/backend/src/models/audit-log.ts
@@ -11,11 +11,15 @@ import {
   lte,
   or,
   type SQL,
+  sql,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import db, { schema } from "@/database";
 import {
+  type CursorPaginatedResult,
+  createCursorPaginatedResult,
   createPaginatedResult,
+  decodeCursor,
   type PaginatedResult,
 } from "@/database/utils/pagination";
 import type {
@@ -97,71 +101,10 @@ class AuditLogModel {
     resourceId?: string;
     search?: string;
   }): Promise<PaginatedResult<AuditLogWithImpersonator>> {
-    const {
-      organizationId,
-      limit,
-      offset,
-      sortDirection = "desc",
-      startDate,
-      endDate,
-      actorId,
-      action,
-      outcome,
-      actorType,
-      resourceType,
-      resourceId,
-      search,
-    } = opts;
+    const { limit, offset, sortDirection = "desc" } = opts;
 
-    const conditions: SQL[] = [
-      eq(schema.auditLogsTable.organizationId, organizationId),
-    ];
-
-    if (startDate) {
-      conditions.push(gte(schema.auditLogsTable.createdAt, startDate));
-    }
-    if (endDate) {
-      conditions.push(lte(schema.auditLogsTable.createdAt, endDate));
-    }
-    if (actorId) {
-      conditions.push(eq(schema.auditLogsTable.actorId, actorId));
-    }
-    if (action) {
-      conditions.push(eq(schema.auditLogsTable.action, action));
-    }
-    if (outcome) {
-      conditions.push(eq(schema.auditLogsTable.outcome, outcome));
-    }
-    if (actorType) {
-      conditions.push(eq(schema.auditLogsTable.actorType, actorType));
-    }
-    if (resourceType) {
-      conditions.push(eq(schema.auditLogsTable.resourceType, resourceType));
-    }
-    if (resourceId) {
-      conditions.push(eq(schema.auditLogsTable.resourceId, resourceId));
-    }
-    if (search) {
-      const searchCondition = buildSearchCondition(search);
-      if (searchCondition) {
-        conditions.push(searchCondition);
-      }
-    }
-
-    const whereClause = and(...conditions);
-
-    // Two-column sort: created_at tiebroken by event_sequence (postgres-assigned
-    // bigserial, always monotonic). The matching index covers both columns.
-    const orderBy =
-      sortDirection === "asc"
-        ? [
-            asc(schema.auditLogsTable.createdAt),
-            asc(schema.auditLogsTable.eventSequence),
-          ]
-        : [
-            desc(schema.auditLogsTable.createdAt),
-            desc(schema.auditLogsTable.eventSequence),
-          ];
+    const whereClause = and(...AuditLogModel.buildFilterConditions(opts));
+    const orderBy = AuditLogModel.buildOrderBy(sortDirection);
 
     const [data, [{ total }]] = await Promise.all([
       db
@@ -197,6 +140,83 @@ class AuditLogModel {
     );
   }
 
+  /**
+   * The same listing, walked by cursor instead of offset.
+   *
+   * Two costs disappear. There is no `count()`, so a page no longer scans
+   * every row in the organization to render a page number nobody navigates
+   * by. And there is no offset, so page one thousand costs what page one
+   * costs — the keyset predicate seeks straight to the position and reads
+   * `limit + 1` rows, where an offset would have read and thrown away
+   * everything above it.
+   *
+   * `(created_at, event_sequence)` is the key. `event_sequence` is a
+   * postgres-assigned bigserial, so the pair is strictly ordered and unique
+   * even when many rows share a timestamp, and the existing index covers it.
+   */
+  static async findCursorPaginated(opts: {
+    organizationId: string;
+    limit: number;
+    cursor?: string;
+    sortDirection?: SortDirection;
+    startDate?: Date;
+    endDate?: Date;
+    actorId?: string;
+    action?: AuditEventName;
+    outcome?: AuditOutcome;
+    actorType?: AuditActorType;
+    resourceType?: string;
+    resourceId?: string;
+    search?: string;
+  }): Promise<CursorPaginatedResult<AuditLogWithImpersonator>> {
+    const { limit, cursor, sortDirection = "desc" } = opts;
+
+    const conditions = AuditLogModel.buildFilterConditions(opts);
+
+    // An unreadable cursor is treated as no cursor, so a stale or truncated
+    // link lands on the newest page instead of erroring.
+    const position = decodeCursor(cursor);
+    if (position) {
+      const at = new Date(position.value);
+      const seq = Number(position.id);
+      if (!Number.isNaN(at.getTime()) && Number.isFinite(seq)) {
+        // Row comparison, not two ANDed predicates: `(a, b) < (x, y)` is one
+        // ordered comparison the planner can drive the composite index from.
+        const keyset = sql`(${schema.auditLogsTable.createdAt}, ${schema.auditLogsTable.eventSequence})`;
+        conditions.push(
+          sortDirection === "asc"
+            ? sql`${keyset} > (${at}, ${seq})`
+            : sql`${keyset} < (${at}, ${seq})`,
+        );
+      }
+    }
+
+    const rows = await db
+      .select({
+        ...getTableColumns(schema.auditLogsTable),
+        impersonatedByEmail: impersonatorUsers.email,
+      })
+      .from(schema.auditLogsTable)
+      .leftJoin(
+        impersonatorUsers,
+        eq(schema.auditLogsTable.impersonatedBy, impersonatorUsers.id),
+      )
+      .where(and(...conditions))
+      .orderBy(...AuditLogModel.buildOrderBy(sortDirection))
+      // One more than the page needs: its presence is what answers "is there
+      // another page", replacing the count this method no longer runs.
+      .limit(limit + 1);
+
+    return createCursorPaginatedResult(
+      rows as AuditLogWithImpersonator[],
+      { limit, cursor },
+      (row) => ({
+        value: row.createdAt.toISOString(),
+        id: String(row.eventSequence),
+      }),
+    );
+  }
+
   static async deleteOlderThan(opts: {
     organizationId: string;
     before: Date;
@@ -227,6 +247,79 @@ class AuditLogModel {
       .where(lt(schema.auditLogsTable.createdAt, before))
       .returning({ id: schema.auditLogsTable.id });
     return deleted.length;
+  }
+
+  /**
+   * The filter predicates both listing methods share, so the offset and
+   * cursor paths cannot drift into disagreeing about what a filter means.
+   */
+  private static buildFilterConditions(opts: {
+    organizationId: string;
+    startDate?: Date;
+    endDate?: Date;
+    actorId?: string;
+    action?: AuditEventName;
+    outcome?: AuditOutcome;
+    actorType?: AuditActorType;
+    resourceType?: string;
+    resourceId?: string;
+    search?: string;
+  }): SQL[] {
+    const conditions: SQL[] = [
+      eq(schema.auditLogsTable.organizationId, opts.organizationId),
+    ];
+
+    if (opts.startDate) {
+      conditions.push(gte(schema.auditLogsTable.createdAt, opts.startDate));
+    }
+    if (opts.endDate) {
+      conditions.push(lte(schema.auditLogsTable.createdAt, opts.endDate));
+    }
+    if (opts.actorId) {
+      conditions.push(eq(schema.auditLogsTable.actorId, opts.actorId));
+    }
+    if (opts.action) {
+      conditions.push(eq(schema.auditLogsTable.action, opts.action));
+    }
+    if (opts.outcome) {
+      conditions.push(eq(schema.auditLogsTable.outcome, opts.outcome));
+    }
+    if (opts.actorType) {
+      conditions.push(eq(schema.auditLogsTable.actorType, opts.actorType));
+    }
+    if (opts.resourceType) {
+      conditions.push(
+        eq(schema.auditLogsTable.resourceType, opts.resourceType),
+      );
+    }
+    if (opts.resourceId) {
+      conditions.push(eq(schema.auditLogsTable.resourceId, opts.resourceId));
+    }
+    if (opts.search) {
+      const searchCondition = buildSearchCondition(opts.search);
+      if (searchCondition) {
+        conditions.push(searchCondition);
+      }
+    }
+
+    return conditions;
+  }
+
+  /**
+   * Two-column sort: created_at tiebroken by event_sequence (a
+   * postgres-assigned bigserial, always monotonic). The matching index covers
+   * both columns, and the cursor's keyset predicate compares the same pair.
+   */
+  private static buildOrderBy(sortDirection: SortDirection) {
+    return sortDirection === "asc"
+      ? [
+          asc(schema.auditLogsTable.createdAt),
+          asc(schema.auditLogsTable.eventSequence),
+        ]
+      : [
+          desc(schema.auditLogsTable.createdAt),
+          desc(schema.auditLogsTable.eventSequence),
+        ];
   }
 }
 

--- a/platform/backend/src/models/audit-log.ts
+++ b/platform/backend/src/models/audit-log.ts
@@ -158,7 +158,6 @@ class AuditLogModel {
     organizationId: string;
     limit: number;
     cursor?: string;
-    sortDirection?: SortDirection;
     startDate?: Date;
     endDate?: Date;
     actorId?: string;
@@ -167,9 +166,8 @@ class AuditLogModel {
     actorType?: AuditActorType;
     resourceType?: string;
     resourceId?: string;
-    search?: string;
   }): Promise<CursorPaginatedResult<AuditLogWithImpersonator>> {
-    const { limit, cursor, sortDirection = "desc" } = opts;
+    const { limit, cursor } = opts;
 
     const conditions = AuditLogModel.buildFilterConditions(opts);
 
@@ -184,9 +182,7 @@ class AuditLogModel {
         // ordered comparison the planner can drive the composite index from.
         const keyset = sql`(${schema.auditLogsTable.createdAt}, ${schema.auditLogsTable.eventSequence})`;
         conditions.push(
-          sortDirection === "asc"
-            ? sql`${keyset} > (${position.value}::timestamptz, ${seq})`
-            : sql`${keyset} < (${position.value}::timestamptz, ${seq})`,
+          sql`${keyset} < (${position.value}::timestamptz, ${seq})`,
         );
       }
     }
@@ -202,7 +198,10 @@ class AuditLogModel {
         eq(schema.auditLogsTable.impersonatedBy, impersonatorUsers.id),
       )
       .where(and(...conditions))
-      .orderBy(...AuditLogModel.buildOrderBy(sortDirection))
+      .orderBy(
+        desc(schema.auditLogsTable.createdAt),
+        desc(schema.auditLogsTable.eventSequence),
+      )
       // One more than the page needs: its presence is what answers "is there
       // another page", replacing the count this method no longer runs.
       .limit(limit + 1);

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -1,5 +1,6 @@
 import type {
   ClientFilter,
+  CursorQuery,
   InteractionSource,
   PaginationQuery,
 } from "@archestra/shared";
@@ -37,7 +38,10 @@ import type { LockedChatAuditContext } from "@/content-encryption/locked-chat";
 import db, { schema } from "@/database";
 import { notDeleted } from "@/database/schemas/soft-deletable-table";
 import {
+  type CursorPaginatedResult,
   createPaginatedResult,
+  decodeCursor,
+  encodeCursor,
   type PaginatedResult,
 } from "@/database/utils/pagination";
 import logger from "@/logging";
@@ -94,6 +98,13 @@ const SESSION_SCAN_MAX_ROWS = 20_000;
  * round-trip to the distributed cache to share it between pods. Bounded well
  * above the number of distinct filter combinations in flight at once.
  */
+/**
+ * Returned by the session-list condition builder when the caller can reach
+ * no agents at all. A distinct value rather than `undefined`, which already
+ * means "no predicates" — returning that for a denial would list everything.
+ */
+const SESSION_ACCESS_DENIED = Symbol("session-access-denied");
+
 const sessionTotalCache = new LRUCacheManager<number>({
   maxSize: 500,
   defaultTtl: SESSION_TOTAL_CACHE_TTL_MS,
@@ -1177,6 +1188,224 @@ class InteractionModel {
       endDate?: Date;
     },
   ): Promise<PaginatedResult<SessionSummary>> {
+    const access = await InteractionModel.buildSessionConditions(
+      requestingUserId,
+      isAgentAdmin,
+      filters,
+    );
+    if (access === SESSION_ACCESS_DENIED) {
+      return createPaginatedResult([], 0, pagination);
+    }
+    const whereClause = access;
+
+    // The session total is the same for every page of one filter set, but the
+    // count it needs scans `interactions` — the largest, write-hot table — so
+    // paying it per page made a client walking the pages re-run a full scan on
+    // every request (the dominant cost of this endpoint, and enough on its own
+    // to push the query into statement timeout as the table grows). Compute it
+    // for the first page of a sweep and reuse it for the rest; a total that
+    // trails new rows by at most SESSION_TOTAL_CACHE_TTL_MS is the intended
+    // trade, since it only sizes the pager.
+    const sessionTotalCacheKey = JSON.stringify([
+      requestingUserId ?? null,
+      isAgentAdmin ?? false,
+      filters?.profileId ?? null,
+      filters?.userId ?? null,
+      filters?.source ?? null,
+      filters?.client ?? null,
+      filters?.externalAgentId ?? null,
+      filters?.sessionId ?? null,
+      filters?.startDate?.toISOString() ?? null,
+      filters?.endDate?.toISOString() ?? null,
+    ]);
+    const cachedTotal = sessionTotalCache.get(sessionTotalCacheKey);
+
+    // PHASE 1: Find only the session keys for this page. The summary query has
+    // several joins and aggregates; applying LIMIT after all of that made every
+    // page summarize every session in the table before discarding almost all of
+    // the work. Selecting the page first keeps the expensive phase bounded by
+    // the requested page instead of total history size.
+    const [sessionPage, [{ total }]] = await Promise.all([
+      InteractionModel.findSessionKeysForPage(whereClause, pagination),
+      // Total = distinct sessions + sessionless interactions (each its own
+      // "session"). Counted without COUNT(DISTINCT COALESCE(session_id,
+      // id::text)) — the per-row uuid cast defeats the session_id index — and
+      // without the conversations join the summary query needs for titles: the
+      // filters only touch interactions columns, and joining on the
+      // conversations PK can't change the count.
+      cachedTotal !== undefined
+        ? [{ total: cachedTotal }]
+        : db
+            .select({
+              total: sql<number>`COUNT(DISTINCT ${schema.interactionsTable.sessionId}) + COUNT(*) FILTER (WHERE ${schema.interactionsTable.sessionId} IS NULL)`,
+            })
+            .from(schema.interactionsTable)
+            .where(whereClause),
+    ]);
+
+    if (cachedTotal === undefined) {
+      sessionTotalCache.set(sessionTotalCacheKey, Number(total));
+    }
+
+    if (sessionPage.length === 0) {
+      return createPaginatedResult([], Number(total), pagination);
+    }
+
+    const sessions = await InteractionModel.summarizeSessionPage(
+      sessionPage,
+      whereClause,
+    );
+
+    return createPaginatedResult(sessions, Number(total), pagination);
+  }
+
+  /**
+   * The session keys for one page, most recently active first.
+   *
+   * Grouping the whole table to produce twenty keys meant every page paid a
+   * sequential scan of `interactions` plus a sort of one row per interaction —
+   * on a table whose row count grows with every proxied call, and large enough
+   * that the sort spilled to disk. Nothing about a page of recent sessions
+   * needs that: walking `interactions_created_at_idx` newest-first and taking
+   * distinct session keys in the order they first appear yields exactly the
+   * same ordering, because the first row seen for a session IS that session's
+   * most recent one. The scan stops as soon as the page is covered, so the
+   * cost tracks the page, not the history.
+   *
+   * Falls back to the whole-table grouping if a page cannot be filled within
+   * SESSION_SCAN_MAX_ROWS — a pathological case (a filter matching very few
+   * sessions spread over very many rows) where the walk would be the slower of
+   * the two. Correctness is identical either way.
+   */
+
+  /**
+   * The same session list, walked by cursor instead of offset.
+   *
+   * Two costs disappear. There is no total, so a page stops scanning every
+   * interaction in the table to count distinct sessions for a page number.
+   * And there is no offset, so a page deep in the log costs what the first
+   * page costs, instead of walking every session above it.
+   *
+   * Phase 1 changes shape entirely. The offset walk reads batches of
+   * interactions and dedupes session keys in memory, which needs
+   * `offset + limit` keys in hand before it can serve page N. A cursor
+   * cannot work that way, and does not need to: a session's place in the
+   * list is its newest interaction, so the list *is* the rows that have no
+   * newer sibling in their own session. Selecting those directly gives each
+   * session exactly once, in the right order, with no dedupe pass and no
+   * whole-table grouping to fall back to.
+   */
+  static async getSessionsCursor(
+    cursorQuery: CursorQuery,
+    requestingUserId?: string,
+    isAgentAdmin?: boolean,
+    filters?: {
+      profileId?: string;
+      userId?: string;
+      source?: InteractionSource;
+      client?: ClientFilter;
+      externalAgentId?: string;
+      sessionId?: string;
+      startDate?: Date;
+      endDate?: Date;
+    },
+  ): Promise<CursorPaginatedResult<SessionSummary>> {
+    const emptyPage = (): CursorPaginatedResult<SessionSummary> => ({
+      data: [],
+      pagination: {
+        limit: cursorQuery.limit,
+        hasNext: false,
+        nextCursor: null,
+      },
+    });
+
+    const access = await InteractionModel.buildSessionConditions(
+      requestingUserId,
+      isAgentAdmin,
+      filters,
+    );
+    if (access === SESSION_ACCESS_DENIED) {
+      return emptyPage();
+    }
+    const whereClause = access;
+
+    // One row past the page is fetched so its presence can answer "is there
+    // another page" — the job the total count used to do.
+    const heads = await InteractionModel.findSessionHeadsForCursor(
+      whereClause,
+      cursorQuery,
+    );
+    const hasNext = heads.length > cursorQuery.limit;
+    const pageRows = hasNext ? heads.slice(0, cursorQuery.limit) : heads;
+    if (pageRows.length === 0) {
+      return emptyPage();
+    }
+
+    const summaries = await InteractionModel.summarizeSessionPage(
+      pageRows.map(({ sessionId, interactionId }) => ({
+        sessionId,
+        interactionId,
+      })),
+      whereClause,
+    );
+
+    // The summary query groups, so its row order is not the head order. Emit
+    // in head order instead, because that is the order the cursor is cut from
+    // — returning them in any other order would make the next page skip or
+    // repeat rows.
+    const byKey = new Map(
+      summaries.map((summary) => [
+        summary.sessionId ?? summary.interactionId ?? "",
+        summary,
+      ]),
+    );
+    const data = pageRows.flatMap((row) => {
+      const summary = byKey.get(row.sessionId ?? row.interactionId ?? "");
+      return summary ? [summary] : [];
+    });
+
+    const last = pageRows[pageRows.length - 1];
+
+    return {
+      data,
+      pagination: {
+        limit: cursorQuery.limit,
+        hasNext,
+        // No cursor past the end: it could only produce an empty page.
+        nextCursor:
+          hasNext && last
+            ? encodeCursor({
+                value: last.headCreatedAt.toISOString(),
+                id: last.headId,
+              })
+            : null,
+      },
+    };
+  }
+
+  /**
+   * Access-control and filter predicates for the session list, shared by the
+   * offset and cursor paths so they cannot drift into showing different rows.
+   *
+   * Returns {@link SESSION_ACCESS_DENIED} when the caller can reach no agents.
+   * That is deliberately distinct from `undefined`, which means "no
+   * predicates, show everything" — conflating the two would turn a permission
+   * denial into a full listing.
+   */
+  private static async buildSessionConditions(
+    requestingUserId?: string,
+    isAgentAdmin?: boolean,
+    filters?: {
+      profileId?: string;
+      userId?: string;
+      source?: InteractionSource;
+      client?: ClientFilter;
+      externalAgentId?: string;
+      sessionId?: string;
+      startDate?: Date;
+      endDate?: Date;
+    },
+  ): Promise<SQL | undefined | typeof SESSION_ACCESS_DENIED> {
     // Build where clauses for access control
     const conditions: SQL[] = [];
 
@@ -1187,7 +1416,7 @@ class InteractionModel {
       );
 
       if (accessibleAgentIds.length === 0) {
-        return createPaginatedResult([], 0, pagination);
+        return SESSION_ACCESS_DENIED;
       }
 
       conditions.push(
@@ -1250,66 +1479,99 @@ class InteractionModel {
       conditions.push(lte(schema.interactionsTable.createdAt, filters.endDate));
     }
 
-    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+    return conditions.length > 0 ? and(...conditions) : undefined;
+  }
 
-    // For sessions, we use COALESCE to give null sessionIds a unique identifier
-    // based on the interaction ID so they appear as individual "sessions"
-    // Cast id to text since session_id is VARCHAR and id is UUID
-    const sessionGroupExpr = sql`COALESCE(${schema.interactionsTable.sessionId}, ${schema.interactionsTable.id}::text)`;
+  /**
+   * The newest interaction of each session, newest first, for one cursor page.
+   *
+   * A row qualifies when no newer row shares its session — that row is the
+   * session's head, and a session has exactly one, so the result needs no
+   * deduplication. Ordering by the head row's own `(created_at, id)` is
+   * therefore the same ordering as by the session's last activity, which is
+   * what makes a keyset cursor possible here at all.
+   *
+   * The `NOT EXISTS` probe runs against `interactions_session_created_at_idx`
+   * — `(session_id, created_at DESC)` — so it is an index lookup per candidate
+   * row rather than a scan. Sessionless rows skip the probe: each one is its
+   * own session, so it is always its own head.
+   *
+   * Fetches `limit + 1` rows; the caller uses the extra to decide whether
+   * another page exists.
+   */
+  private static async findSessionHeadsForCursor(
+    whereClause: SQL | undefined,
+    cursorQuery: CursorQuery,
+  ): Promise<
+    Array<{
+      sessionId: string | null;
+      interactionId: string | null;
+      headCreatedAt: Date;
+      headId: string;
+    }>
+  > {
+    const t = schema.interactionsTable;
 
-    // The session total is the same for every page of one filter set, but the
-    // count it needs scans `interactions` — the largest, write-hot table — so
-    // paying it per page made a client walking the pages re-run a full scan on
-    // every request (the dominant cost of this endpoint, and enough on its own
-    // to push the query into statement timeout as the table grows). Compute it
-    // for the first page of a sweep and reuse it for the rest; a total that
-    // trails new rows by at most SESSION_TOTAL_CACHE_TTL_MS is the intended
-    // trade, since it only sizes the pager.
-    const sessionTotalCacheKey = JSON.stringify([
-      requestingUserId ?? null,
-      isAgentAdmin ?? false,
-      filters?.profileId ?? null,
-      filters?.userId ?? null,
-      filters?.source ?? null,
-      filters?.client ?? null,
-      filters?.externalAgentId ?? null,
-      filters?.sessionId ?? null,
-      filters?.startDate?.toISOString() ?? null,
-      filters?.endDate?.toISOString() ?? null,
-    ]);
-    const cachedTotal = sessionTotalCache.get(sessionTotalCacheKey);
+    const conditions: SQL[] = [];
+    if (whereClause) conditions.push(whereClause);
 
-    // PHASE 1: Find only the session keys for this page. The summary query has
-    // several joins and aggregates; applying LIMIT after all of that made every
-    // page summarize every session in the table before discarding almost all of
-    // the work. Selecting the page first keeps the expensive phase bounded by
-    // the requested page instead of total history size.
-    const [sessionPage, [{ total }]] = await Promise.all([
-      InteractionModel.findSessionKeysForPage(whereClause, pagination),
-      // Total = distinct sessions + sessionless interactions (each its own
-      // "session"). Counted without COUNT(DISTINCT COALESCE(session_id,
-      // id::text)) — the per-row uuid cast defeats the session_id index — and
-      // without the conversations join the summary query needs for titles: the
-      // filters only touch interactions columns, and joining on the
-      // conversations PK can't change the count.
-      cachedTotal !== undefined
-        ? [{ total: cachedTotal }]
-        : db
-            .select({
-              total: sql<number>`COUNT(DISTINCT ${schema.interactionsTable.sessionId}) + COUNT(*) FILTER (WHERE ${schema.interactionsTable.sessionId} IS NULL)`,
-            })
-            .from(schema.interactionsTable)
-            .where(whereClause),
-    ]);
-
-    if (cachedTotal === undefined) {
-      sessionTotalCache.set(sessionTotalCacheKey, Number(total));
+    // An unreadable cursor is treated as absent, so a stale or hand-edited
+    // link lands on the newest page instead of erroring.
+    const position = decodeCursor(cursorQuery.cursor);
+    if (position) {
+      const at = new Date(position.value);
+      if (!Number.isNaN(at.getTime())) {
+        conditions.push(
+          sql`(${t.createdAt}, ${t.id}) < (${at}, ${position.id}::uuid)`,
+        );
+      }
     }
 
-    if (sessionPage.length === 0) {
-      return createPaginatedResult([], Number(total), pagination);
-    }
+    // Newer sibling in the same session => this row is not the head.
+    const newerSibling = sql`
+      NOT EXISTS (
+        SELECT 1
+        FROM ${t} AS newer
+        WHERE newer.session_id = ${t.sessionId}
+          AND (newer.created_at, newer.id) > (${t.createdAt}, ${t.id})
+      )
+    `;
+    conditions.push(sql`(${t.sessionId} IS NULL OR ${newerSibling})`);
 
+    const rows = await db
+      .select({
+        id: t.id,
+        sessionId: t.sessionId,
+        createdAt: t.createdAt,
+      })
+      .from(t)
+      .where(and(...conditions))
+      .orderBy(desc(t.createdAt), desc(t.id))
+      .limit(cursorQuery.limit + 1);
+
+    return rows.map((row) => ({
+      sessionId: row.sessionId,
+      interactionId: row.sessionId ? null : row.id,
+      headCreatedAt: row.createdAt,
+      headId: row.id,
+    }));
+  }
+
+  /**
+   * Phases 2 and 3 for one page of session keys: aggregate the sessions, then
+   * fetch the interaction window each row's tip is read from.
+   *
+   * Split out of {@link getSessions} so the offset and cursor paths share it.
+   * Everything expensive here is already bounded by the page, which is the
+   * property both phase-1 strategies exist to preserve.
+   */
+  private static async summarizeSessionPage(
+    sessionPage: Array<{
+      sessionId: string | null;
+      interactionId: string | null;
+    }>,
+    whereClause: SQL | undefined,
+  ): Promise<SessionSummary[]> {
     const pageSessionIds = sessionPage.flatMap((session) =>
       session.sessionId ? [session.sessionId] : [],
     );
@@ -1537,28 +1799,9 @@ class InteractionModel {
         claudeCodeTitle: lastInteraction?.claudeCodeTitle ?? null,
       };
     });
-
-    return createPaginatedResult(sessions, Number(total), pagination);
+    return sessions;
   }
 
-  /**
-   * The session keys for one page, most recently active first.
-   *
-   * Grouping the whole table to produce twenty keys meant every page paid a
-   * sequential scan of `interactions` plus a sort of one row per interaction —
-   * on a table whose row count grows with every proxied call, and large enough
-   * that the sort spilled to disk. Nothing about a page of recent sessions
-   * needs that: walking `interactions_created_at_idx` newest-first and taking
-   * distinct session keys in the order they first appear yields exactly the
-   * same ordering, because the first row seen for a session IS that session's
-   * most recent one. The scan stops as soon as the page is covered, so the
-   * cost tracks the page, not the history.
-   *
-   * Falls back to the whole-table grouping if a page cannot be filled within
-   * SESSION_SCAN_MAX_ROWS — a pathological case (a filter matching very few
-   * sessions spread over very many rows) where the walk would be the slower of
-   * the two. Correctness is identical either way.
-   */
   private static async findSessionKeysForPage(
     whereClause: SQL | undefined,
     pagination: PaginationQuery,

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -1522,7 +1522,7 @@ class InteractionModel {
       const at = new Date(position.value);
       if (!Number.isNaN(at.getTime())) {
         conditions.push(
-          sql`(${t.createdAt}, ${t.id}) < (${at}, ${position.id}::uuid)`,
+          sql`(${t.createdAt}, ${t.id}) < (${position.value}::timestamp, ${position.id}::uuid)`,
         );
       }
     }
@@ -1572,6 +1572,9 @@ class InteractionModel {
     }>,
     whereClause: SQL | undefined,
   ): Promise<SessionSummary[]> {
+    // Sessionless interactions each form their own group; real sessions group
+    // by their shared session id.
+    const sessionGroupExpr = sql`COALESCE(${schema.interactionsTable.sessionId}, ${schema.interactionsTable.id}::text)`;
     const pageSessionIds = sessionPage.flatMap((session) =>
       session.sessionId ? [session.sessionId] : [],
     );

--- a/platform/backend/src/models/mcp-tool-call.ts
+++ b/platform/backend/src/models/mcp-tool-call.ts
@@ -1,4 +1,5 @@
 import {
+  type CursorQuery,
   type PaginationQuery,
   redactCatalogToolArguments,
 } from "@archestra/shared";
@@ -32,10 +33,18 @@ import {
 import type { LockedChatAuditContext } from "@/content-encryption/locked-chat";
 import db, { schema } from "@/database";
 import {
+  type CursorPaginatedResult,
+  createCursorPaginatedResult,
   createPaginatedResult,
+  decodeCursor,
   type PaginatedResult,
 } from "@/database/utils/pagination";
-import type { InsertMcpToolCall, McpToolCall, SortingQuery } from "@/types";
+import type {
+  InsertMcpToolCall,
+  McpToolCall,
+  SortDirection,
+  SortingQuery,
+} from "@/types";
 import { escapeLikePattern } from "@/utils/sql-search";
 import AgentTeamModel from "./agent-team";
 
@@ -109,45 +118,13 @@ class McpToolCallModel {
     // Determine the ORDER BY clause based on sorting params
     const orderByClause = McpToolCallModel.getOrderByClause(sorting);
 
-    // Build where clauses
-    const conditions: SQL[] = [];
-    if (filters?.ownUserId) {
-      conditions.push(eq(schema.mcpToolCallsTable.userId, filters.ownUserId));
-    }
-
-    // Access control filter
-    if (userId && !isMcpServerAdmin) {
-      const accessibleAgentIds = await AgentTeamModel.getUserAccessibleAgentIds(
-        userId,
-        false,
-      );
-
-      if (accessibleAgentIds.length === 0) {
-        return createPaginatedResult([], 0, pagination);
-      }
-
-      conditions.push(
-        inArray(schema.mcpToolCallsTable.agentId, accessibleAgentIds),
-      );
-    }
-
-    // Date range filter
-    if (filters?.startDate) {
-      conditions.push(
-        gte(schema.mcpToolCallsTable.createdAt, filters.startDate),
-      );
-    }
-    if (filters?.endDate) {
-      conditions.push(lte(schema.mcpToolCallsTable.createdAt, filters.endDate));
-    }
-
-    // Free-text search filter (case-insensitive)
-    // Searches across: mcpServerName, toolCall.name, toolCall.arguments
-    if (filters?.search) {
-      const searchCondition = buildMcpToolCallSearchCondition(filters.search);
-      if (searchCondition) {
-        conditions.push(searchCondition);
-      }
+    const conditions = await McpToolCallModel.buildListConditions(
+      userId,
+      isMcpServerAdmin,
+      filters,
+    );
+    if (conditions === null) {
+      return createPaginatedResult([], 0, pagination);
     }
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
@@ -192,6 +169,102 @@ class McpToolCallModel {
   }
 
   /**
+   * The same listing, walked by cursor instead of offset.
+   *
+   * Drops the `count()` that scanned every visible row on each page load to
+   * render a page number, and drops the offset, so a page deep in the log
+   * costs what the first page costs.
+   *
+   * Ordered by `(created_at, id)` only. The offset method's other sort
+   * columns are deliberately not carried over: none of them is indexed, and
+   * several are nullable, which a keyset predicate handles badly — a NULL on
+   * either side makes the row comparison NULL and silently truncates the
+   * walk. Narrowing a log by server or tool name is what the search filter is
+   * for, and it stays available here.
+   */
+  static async findAllCursorPaginated(
+    cursorQuery: CursorQuery,
+    sortDirection: SortDirection | undefined,
+    userId?: string,
+    isMcpServerAdmin?: boolean,
+    filters?: {
+      agentId?: string;
+      startDate?: Date;
+      endDate?: Date;
+      search?: string;
+      /** Narrow to rows attributed to this user (the own-logs log:read view). */
+      ownUserId?: string;
+    },
+  ): Promise<CursorPaginatedResult<McpToolCall>> {
+    const { limit, cursor } = cursorQuery;
+    const ascending = sortDirection === "asc";
+
+    const conditions = await McpToolCallModel.buildListConditions(
+      userId,
+      isMcpServerAdmin,
+      filters,
+    );
+    if (conditions === null) {
+      return createCursorPaginatedResult([], cursorQuery, () => ({
+        value: "",
+        id: "",
+      }));
+    }
+
+    // An unreadable cursor is treated as no cursor, so a stale or truncated
+    // link lands on the newest page rather than erroring.
+    const position = decodeCursor(cursor);
+    if (position) {
+      const at = new Date(position.value);
+      if (!Number.isNaN(at.getTime())) {
+        const keyset = sql`(${schema.mcpToolCallsTable.createdAt}, ${schema.mcpToolCallsTable.id})`;
+        conditions.push(
+          ascending
+            ? sql`${keyset} > (${at}, ${position.id}::uuid)`
+            : sql`${keyset} < (${at}, ${position.id}::uuid)`,
+        );
+      }
+    }
+
+    const order = ascending ? asc : desc;
+    const rows = await db
+      .select({
+        ...getTableColumns(schema.mcpToolCallsTable),
+        userName: schema.usersTable.name,
+        agentDeletedAt: schema.agentsTable.deletedAt,
+        appName: schema.appsTable.name,
+        appDeletedAt: schema.appsTable.deletedAt,
+      })
+      .from(schema.mcpToolCallsTable)
+      .leftJoin(
+        schema.usersTable,
+        eq(schema.mcpToolCallsTable.userId, schema.usersTable.id),
+      )
+      .leftJoin(
+        schema.agentsTable,
+        eq(schema.mcpToolCallsTable.agentId, schema.agentsTable.id),
+      )
+      .leftJoin(
+        schema.appsTable,
+        eq(schema.mcpToolCallsTable.appId, schema.appsTable.id),
+      )
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(
+        order(schema.mcpToolCallsTable.createdAt),
+        order(schema.mcpToolCallsTable.id),
+      )
+      // One more than the page needs: its presence answers "is there another
+      // page", replacing the count this method no longer runs.
+      .limit(limit + 1);
+
+    return createCursorPaginatedResult(
+      rows.map((row) => toVisibleMcpToolCall(readMcpToolCallRow(row))),
+      cursorQuery,
+      (row) => ({ value: row.createdAt.toISOString(), id: row.id }),
+    );
+  }
+
+  /**
    * Helper to get the appropriate ORDER BY clause based on sorting params
    */
   private static getOrderByClause(sorting?: SortingQuery) {
@@ -210,6 +283,69 @@ class McpToolCallModel {
         // Default: newest first
         return desc(schema.mcpToolCallsTable.createdAt);
     }
+  }
+
+  /**
+   * Access-control and filter predicates shared by both listing methods, so
+   * the offset and cursor paths cannot drift into showing different rows.
+   *
+   * Returns null when the caller can reach no agents at all. That is distinct
+   * from an empty predicate list, which means "no filters, show everything" —
+   * conflating the two would turn a permission denial into a full listing.
+   */
+  private static async buildListConditions(
+    userId?: string,
+    isMcpServerAdmin?: boolean,
+    filters?: {
+      agentId?: string;
+      startDate?: Date;
+      endDate?: Date;
+      search?: string;
+      ownUserId?: string;
+    },
+  ): Promise<SQL[] | null> {
+    const conditions: SQL[] = [];
+
+    if (filters?.agentId) {
+      conditions.push(eq(schema.mcpToolCallsTable.agentId, filters.agentId));
+    }
+    if (filters?.ownUserId) {
+      conditions.push(eq(schema.mcpToolCallsTable.userId, filters.ownUserId));
+    }
+
+    if (userId && !isMcpServerAdmin) {
+      const accessibleAgentIds = await AgentTeamModel.getUserAccessibleAgentIds(
+        userId,
+        false,
+      );
+
+      if (accessibleAgentIds.length === 0) {
+        return null;
+      }
+
+      conditions.push(
+        inArray(schema.mcpToolCallsTable.agentId, accessibleAgentIds),
+      );
+    }
+
+    if (filters?.startDate) {
+      conditions.push(
+        gte(schema.mcpToolCallsTable.createdAt, filters.startDate),
+      );
+    }
+    if (filters?.endDate) {
+      conditions.push(lte(schema.mcpToolCallsTable.createdAt, filters.endDate));
+    }
+
+    // Free-text search across mcpServerName, toolCall.name, toolCall.arguments
+    if (filters?.search) {
+      const searchCondition = buildMcpToolCallSearchCondition(filters.search);
+      if (searchCondition) {
+        conditions.push(searchCondition);
+      }
+    }
+
+    return conditions;
   }
 
   static async findById(

--- a/platform/backend/src/models/mcp-tool-call.ts
+++ b/platform/backend/src/models/mcp-tool-call.ts
@@ -39,12 +39,7 @@ import {
   decodeCursor,
   type PaginatedResult,
 } from "@/database/utils/pagination";
-import type {
-  InsertMcpToolCall,
-  McpToolCall,
-  SortDirection,
-  SortingQuery,
-} from "@/types";
+import type { InsertMcpToolCall, McpToolCall, SortingQuery } from "@/types";
 import { escapeLikePattern } from "@/utils/sql-search";
 import AgentTeamModel from "./agent-team";
 
@@ -179,25 +174,22 @@ class McpToolCallModel {
    * columns are deliberately not carried over: none of them is indexed, and
    * several are nullable, which a keyset predicate handles badly — a NULL on
    * either side makes the row comparison NULL and silently truncates the
-   * walk. Narrowing a log by server or tool name is what the search filter is
-   * for, and it stays available here.
+   * walk. The cursor listing supports an exact server-name filter instead.
    */
   static async findAllCursorPaginated(
     cursorQuery: CursorQuery,
-    sortDirection: SortDirection | undefined,
     userId?: string,
     isMcpServerAdmin?: boolean,
     filters?: {
       agentId?: string;
       startDate?: Date;
       endDate?: Date;
-      search?: string;
+      mcpServerName?: string;
       /** Narrow to rows attributed to this user (the own-logs log:read view). */
       ownUserId?: string;
     },
   ): Promise<CursorPaginatedResult<McpToolCall>> {
     const { limit, cursor } = cursorQuery;
-    const ascending = sortDirection === "asc";
 
     const conditions = await McpToolCallModel.buildListConditions(
       userId,
@@ -219,14 +211,11 @@ class McpToolCallModel {
       if (!Number.isNaN(at.getTime())) {
         const keyset = sql`(${schema.mcpToolCallsTable.createdAt}, ${schema.mcpToolCallsTable.id})`;
         conditions.push(
-          ascending
-            ? sql`${keyset} > (${position.value}::timestamp, ${position.id}::uuid)`
-            : sql`${keyset} < (${position.value}::timestamp, ${position.id}::uuid)`,
+          sql`${keyset} < (${position.value}::timestamp, ${position.id}::uuid)`,
         );
       }
     }
 
-    const order = ascending ? asc : desc;
     const rows = await db
       .select({
         ...getTableColumns(schema.mcpToolCallsTable),
@@ -250,8 +239,8 @@ class McpToolCallModel {
       )
       .where(conditions.length > 0 ? and(...conditions) : undefined)
       .orderBy(
-        order(schema.mcpToolCallsTable.createdAt),
-        order(schema.mcpToolCallsTable.id),
+        desc(schema.mcpToolCallsTable.createdAt),
+        desc(schema.mcpToolCallsTable.id),
       )
       // One more than the page needs: its presence answers "is there another
       // page", replacing the count this method no longer runs.
@@ -301,6 +290,7 @@ class McpToolCallModel {
       startDate?: Date;
       endDate?: Date;
       search?: string;
+      mcpServerName?: string;
       ownUserId?: string;
     },
   ): Promise<SQL[] | null> {
@@ -311,6 +301,11 @@ class McpToolCallModel {
     }
     if (filters?.ownUserId) {
       conditions.push(eq(schema.mcpToolCallsTable.userId, filters.ownUserId));
+    }
+    if (filters?.mcpServerName) {
+      conditions.push(
+        eq(schema.mcpToolCallsTable.mcpServerName, filters.mcpServerName),
+      );
     }
 
     if (userId && !isMcpServerAdmin) {

--- a/platform/backend/src/models/mcp-tool-call.ts
+++ b/platform/backend/src/models/mcp-tool-call.ts
@@ -220,8 +220,8 @@ class McpToolCallModel {
         const keyset = sql`(${schema.mcpToolCallsTable.createdAt}, ${schema.mcpToolCallsTable.id})`;
         conditions.push(
           ascending
-            ? sql`${keyset} > (${at}, ${position.id}::uuid)`
-            : sql`${keyset} < (${at}, ${position.id}::uuid)`,
+            ? sql`${keyset} > (${position.value}::timestamp, ${position.id}::uuid)`
+            : sql`${keyset} < (${position.value}::timestamp, ${position.id}::uuid)`,
         );
       }
     }

--- a/platform/backend/src/routes/audit-log/audit-log.routes.ts
+++ b/platform/backend/src/routes/audit-log/audit-log.routes.ts
@@ -14,7 +14,6 @@ import {
   AuditLogWithImpersonatorSchema,
   AuditOutcomeSchema,
   constructResponseSchema,
-  SortDirectionSchema,
 } from "@/types";
 
 const auditLogRoutes: FastifyPluginAsyncZod = async (fastify) => {
@@ -56,15 +55,6 @@ const auditLogRoutes: FastifyPluginAsyncZod = async (fastify) => {
               .string()
               .optional()
               .describe("Filter by resource ID (e.g. a specific agent's ID)"),
-            search: z
-              .string()
-              .optional()
-              .describe(
-                "Case-insensitive search across actor email, actor name, HTTP path, resource ID, and resource name",
-              ),
-          })
-          .extend({
-            sortDirection: SortDirectionSchema.optional().default("desc"),
           })
           .merge(CursorQuerySchema),
         response: constructResponseSchema(
@@ -83,10 +73,8 @@ const auditLogRoutes: FastifyPluginAsyncZod = async (fastify) => {
           actorType,
           resourceType,
           resourceId,
-          search,
           limit,
           cursor,
-          sortDirection,
         },
         user,
         organizationId,
@@ -106,7 +94,6 @@ const auditLogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         organizationId,
         limit,
         cursor,
-        sortDirection,
         startDate: startDate ? new Date(startDate) : undefined,
         endDate: endDate ? new Date(endDate) : undefined,
         actorId: canSeeAllAuditLogs ? actorId : user.id,
@@ -115,7 +102,6 @@ const auditLogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         actorType,
         resourceType,
         resourceId,
-        search,
       });
 
       return reply.send(result);

--- a/platform/backend/src/routes/audit-log/audit-log.routes.ts
+++ b/platform/backend/src/routes/audit-log/audit-log.routes.ts
@@ -1,6 +1,6 @@
 import {
-  createPaginatedResponseSchema,
-  PaginationQuerySchema,
+  CursorQuerySchema,
+  createCursorPaginatedResponseSchema,
   RouteId,
 } from "@archestra/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
@@ -66,9 +66,9 @@ const auditLogRoutes: FastifyPluginAsyncZod = async (fastify) => {
           .extend({
             sortDirection: SortDirectionSchema.optional().default("desc"),
           })
-          .merge(PaginationQuerySchema),
+          .merge(CursorQuerySchema),
         response: constructResponseSchema(
-          createPaginatedResponseSchema(AuditLogWithImpersonatorSchema),
+          createCursorPaginatedResponseSchema(AuditLogWithImpersonatorSchema),
         ),
       },
     },
@@ -85,7 +85,7 @@ const auditLogRoutes: FastifyPluginAsyncZod = async (fastify) => {
           resourceId,
           search,
           limit,
-          offset,
+          cursor,
           sortDirection,
         },
         user,
@@ -102,10 +102,10 @@ const auditLogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         "admin",
       );
 
-      const result = await AuditLogModel.findPaginated({
+      const result = await AuditLogModel.findCursorPaginated({
         organizationId,
         limit,
-        offset,
+        cursor,
         sortDirection,
         startDate: startDate ? new Date(startDate) : undefined,
         endDate: endDate ? new Date(endDate) : undefined,

--- a/platform/backend/src/routes/audit-log/get.audit-log.route.test.ts
+++ b/platform/backend/src/routes/audit-log/get.audit-log.route.test.ts
@@ -1,8 +1,8 @@
 /**
  * Contract: GET /api/audit-logs
  * - Requires a successful permission check for RouteId.GetAuditLogs (admin-only).
- * - Returns paginated audit rows strictly scoped to request.organizationId.
- * - Query filters map to AuditLogModel.findPaginated; invalid pagination/sortDirection → 400.
+ * - Returns cursor-paginated audit rows strictly scoped to request.organizationId.
+ * - Query filters map to AuditLogModel.findCursorPaginated; invalid limits/sortDirection → 400.
  * - actorId, action (dotted), outcome, actorType, resourceType, resourceId filters
  *   narrow results; unknown filter values that fail the closed enum are rejected
  *   with 400.
@@ -28,13 +28,15 @@ const hasPermissionMock = vi.mocked(hasPermission);
 
 vi.mock("@/observability");
 
+type SeedAuditLogInput = Parameters<typeof AuditLogModel.create>[0] & {
+  createdAt?: Date;
+};
+
 function seedRow(
   organizationId: string,
-  overrides: Partial<
-    Omit<Parameters<typeof AuditLogModel.create>[0], "organizationId">
-  > = {},
+  overrides: Partial<Omit<SeedAuditLogInput, "organizationId">> = {},
 ) {
-  return AuditLogModel.create({
+  const input: SeedAuditLogInput = {
     actorId: null,
     actorType: "user",
     actorName: "Test Actor",
@@ -54,7 +56,8 @@ function seedRow(
     userAgent: null,
     ...overrides,
     organizationId,
-  });
+  };
+  return AuditLogModel.create(input);
 }
 
 describe("GET /api/audit-logs", () => {
@@ -112,7 +115,11 @@ describe("GET /api/audit-logs", () => {
     const body = response.json();
     expect(Array.isArray(body.data)).toBe(true);
     expect(body.data.length).toBeGreaterThan(0);
-    expect(body.pagination.total).toBeGreaterThan(0);
+    expect(body.pagination).toMatchObject({
+      limit: 20,
+      hasNext: false,
+      nextCursor: null,
+    });
     expect(body.data.some((r: AuditLog) => r.id === row.id)).toBe(true);
   });
 
@@ -242,7 +249,7 @@ describe("GET /api/audit-logs", () => {
     const body = response.json();
     // Both rows must be present — if actorUserId were re-wired as a filter
     // only one row would come back and this assertion would catch the regression.
-    expect(body.pagination.total).toBe(2);
+    expect(body.data).toHaveLength(2);
   });
 
   test("outcome filter narrows results to matching outcome", async () => {
@@ -479,35 +486,46 @@ describe("GET /api/audit-logs", () => {
     expect(body.data[0].resourceId).toBe("match");
   });
 
-  test("limit and offset produce stable, non-overlapping pages", async () => {
-    for (let i = 0; i < 5; i++) {
-      await seedRow(organizationId, {
-        actorEmail: `page-user-${i}@example.com`,
-      });
-    }
+  test("cursor pages with identical timestamps do not repeat or skip rows", async () => {
+    const createdAt = new Date("2026-01-02T03:04:05.000Z");
+    const seeded = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        seedRow(organizationId, {
+          actorEmail: `page-user-${i}@example.com`,
+          createdAt,
+        }),
+      ),
+    );
 
     const page1 = await app.inject({
       method: "GET",
-      url: "/api/audit-logs?limit=2&offset=0",
+      url: "/api/audit-logs?limit=2",
     });
+    const p1 = page1.json();
     const page2 = await app.inject({
       method: "GET",
-      url: "/api/audit-logs?limit=2&offset=2",
+      url: `/api/audit-logs?limit=2&cursor=${encodeURIComponent(p1.pagination.nextCursor)}`,
     });
+    const p2 = page2.json();
+    const page3 = await app.inject({
+      method: "GET",
+      url: `/api/audit-logs?limit=2&cursor=${encodeURIComponent(p2.pagination.nextCursor)}`,
+    });
+    const p3 = page3.json();
 
     expect(page1.statusCode).toBe(200);
     expect(page2.statusCode).toBe(200);
+    expect(page3.statusCode).toBe(200);
 
-    const p1 = page1.json();
-    const p2 = page2.json();
-    expect(p1.data.length).toBe(2);
-    expect(p2.data.length).toBe(2);
-
-    const p1Ids = new Set(p1.data.map((r: AuditLog) => r.id));
-    const overlap = p2.data.filter((r: AuditLog) => p1Ids.has(r.id));
-    expect(overlap.length).toBe(0);
-
-    expect(p1.pagination.total).toBe(p2.pagination.total);
+    const ids = [...p1.data, ...p2.data, ...p3.data].map(
+      (row: AuditLog) => row.id,
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(expect.arrayContaining(seeded.map((row) => row.id)));
+    expect(p3.pagination).toMatchObject({
+      hasNext: false,
+      nextCursor: null,
+    });
   });
 
   test("startDate / endDate boundary filtering works correctly", async () => {
@@ -543,7 +561,10 @@ describe("GET /api/audit-logs", () => {
     expect(response.statusCode).toBe(200);
     const body = response.json();
     expect(body.data).toEqual([]);
-    expect(body.pagination.total).toBe(0);
+    expect(body.pagination).toMatchObject({
+      hasNext: false,
+      nextCursor: null,
+    });
   });
 
   test("invalid sortDirection is rejected with 400", async () => {
@@ -579,13 +600,20 @@ describe("GET /api/audit-logs", () => {
     expect(response.statusCode).toBe(400);
   });
 
-  test("negative offset is rejected with 400", async () => {
-    const response = await app.inject({
-      method: "GET",
-      url: "/api/audit-logs?offset=-5",
+  test("legacy offsets and malformed cursors serve the newest page", async () => {
+    const newest = await seedRow(organizationId, {
+      createdAt: new Date("2099-01-01T00:00:00.000Z"),
     });
 
-    expect(response.statusCode).toBe(400);
+    for (const query of ["offset=999&page=999", "cursor=truncated"] as const) {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/audit-logs?limit=1&${query}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data[0].id).toBe(newest.id);
+    }
   });
 
   test("sortDirection=asc returns events in ascending createdAt order", async () => {
@@ -620,17 +648,17 @@ describe("GET /api/audit-logs", () => {
 
       const list = await app.inject({
         method: "GET",
-        url: "/api/audit-logs?limit=10&offset=0",
+        url: "/api/audit-logs?limit=10",
       });
       expect(list.statusCode).toBe(200);
-      expect(list.json().pagination.total).toBe(1);
+      expect(list.json().data).toHaveLength(1);
       expect(list.json().data[0].actorId).toBe(user.id);
 
       const forced = await app.inject({
         method: "GET",
-        url: `/api/audit-logs?limit=10&offset=0&actorId=${other.id}`,
+        url: `/api/audit-logs?limit=10&actorId=${other.id}`,
       });
-      expect(forced.json().pagination.total).toBe(1);
+      expect(forced.json().data).toHaveLength(1);
       expect(forced.json().data[0].actorId).toBe(user.id);
     });
 
@@ -643,9 +671,9 @@ describe("GET /api/audit-logs", () => {
 
       const list = await app.inject({
         method: "GET",
-        url: "/api/audit-logs?limit=10&offset=0",
+        url: "/api/audit-logs?limit=10",
       });
-      expect(list.json().pagination.total).toBe(2);
+      expect(list.json().data).toHaveLength(2);
     });
   });
 });

--- a/platform/backend/src/routes/audit-log/get.audit-log.route.test.ts
+++ b/platform/backend/src/routes/audit-log/get.audit-log.route.test.ts
@@ -2,12 +2,12 @@
  * Contract: GET /api/audit-logs
  * - Requires a successful permission check for RouteId.GetAuditLogs (admin-only).
  * - Returns cursor-paginated audit rows strictly scoped to request.organizationId.
- * - Query filters map to AuditLogModel.findCursorPaginated; invalid limits/sortDirection → 400.
+ * - Query filters map to AuditLogModel.findCursorPaginated; invalid limits → 400.
  * - actorId, action (dotted), outcome, actorType, resourceType, resourceId filters
  *   narrow results; unknown filter values that fail the closed enum are rejected
  *   with 400.
- * - search matches case-insensitively across actor email, actor name, HTTP path,
- *   resource ID, and resource name.
+ * - Results are always newest-first; retired free-text search and sorting
+ *   parameters are silently ignored.
  * - Legacy actorUserId param is not accepted by the route; it is silently ignored
  *   (Fastify strips unknown query params) — the regression guard verifies results are
  *   NOT narrowed when only actorUserId is passed.
@@ -191,7 +191,7 @@ describe("GET /api/audit-logs", () => {
     expect(ids).not.toContain(otherRow.id);
   });
 
-  test("cross-org isolation: searching another org row id from home org returns nothing", async ({
+  test("cross-org isolation: filtering by another org resource id returns nothing", async ({
     makeOrganization,
   }) => {
     const otherOrg = await makeOrganization();
@@ -201,7 +201,7 @@ describe("GET /api/audit-logs", () => {
 
     const response = await app.inject({
       method: "GET",
-      url: `/api/audit-logs?search=${encodeURIComponent(otherRow.resourceId ?? "")}`,
+      url: `/api/audit-logs?resourceId=${encodeURIComponent(otherRow.resourceId ?? "")}`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -373,63 +373,6 @@ describe("GET /api/audit-logs", () => {
     expect(body.data[0].id).toBe(targeted.id);
   });
 
-  test("search filter matches resource name case-insensitively", async () => {
-    const matchedRow = await seedRow(organizationId, {
-      resourceType: "agent",
-      resourceId: "renamed-agent-id",
-      resourceName: "Support Agent",
-    });
-    await seedRow(organizationId, {
-      resourceType: "agent",
-      resourceId: "other-agent-id",
-      resourceName: "Unrelated Agent",
-    });
-
-    const response = await app.inject({
-      method: "GET",
-      url: "/api/audit-logs?search=support",
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.data).toHaveLength(1);
-    expect(body.data[0].id).toBe(matchedRow.id);
-    expect(body.data[0].resourceName).toBe("Support Agent");
-  });
-
-  test("search filter matches actor email case-insensitively", async () => {
-    const matchedRow = await seedRow(organizationId, {
-      actorEmail: "UNIQUE-ADMIN@EXAMPLE.COM",
-    });
-    await seedRow(organizationId, { actorEmail: "other@example.com" });
-
-    const response = await app.inject({
-      method: "GET",
-      url: `/api/audit-logs?search=unique-admin%40example.com`,
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.data.length).toBeGreaterThan(0);
-    expect(body.data.some((r: AuditLog) => r.id === matchedRow.id)).toBe(true);
-  });
-
-  test("search filter matches http path", async () => {
-    const matchedRow = await seedRow(organizationId, {
-      httpPath: "/api/agents/unique-path-abc123",
-    });
-    await seedRow(organizationId, { httpPath: "/api/agents/other" });
-
-    const response = await app.inject({
-      method: "GET",
-      url: `/api/audit-logs?search=unique-path-abc123`,
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.data.some((r: AuditLog) => r.id === matchedRow.id)).toBe(true);
-  });
-
   test("combined action + resourceType filters AND together", async () => {
     await seedRow(organizationId, {
       action: "agent.created",
@@ -567,15 +510,6 @@ describe("GET /api/audit-logs", () => {
     });
   });
 
-  test("invalid sortDirection is rejected with 400", async () => {
-    const response = await app.inject({
-      method: "GET",
-      url: "/api/audit-logs?sortDirection=sideways",
-    });
-
-    expect(response.statusCode).toBe(400);
-  });
-
   test("sortBy is not an accepted query param (regression guard)", async () => {
     await seedRow(organizationId);
 
@@ -616,23 +550,23 @@ describe("GET /api/audit-logs", () => {
     }
   });
 
-  test("sortDirection=asc returns events in ascending createdAt order", async () => {
-    for (let i = 0; i < 3; i++) {
-      await seedRow(organizationId, { actorEmail: `sort-${i}@example.com` });
-    }
+  test("ignores retired search and sort inputs and stays newest-first", async () => {
+    await seedRow(organizationId, {
+      actorEmail: "search-target@example.com",
+      createdAt: new Date("2098-01-01T00:00:00.000Z"),
+    });
+    const newest = await seedRow(organizationId, {
+      actorEmail: "newest@example.com",
+      createdAt: new Date("2099-01-01T00:00:00.000Z"),
+    });
 
     const response = await app.inject({
       method: "GET",
-      url: "/api/audit-logs?sortDirection=asc",
+      url: "/api/audit-logs?limit=1&sortDirection=asc&search=search-target",
     });
 
     expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.data.length).toBeGreaterThan(0);
-    const sequences = body.data.map((r: AuditLog) => r.eventSequence);
-    for (let i = 1; i < sequences.length; i++) {
-      expect(sequences[i]).toBeGreaterThanOrEqual(sequences[i - 1]);
-    }
+    expect(response.json().data[0].id).toBe(newest.id);
   });
 
   describe("own-vs-all visibility (auditLog:read vs auditLog:admin)", () => {

--- a/platform/backend/src/routes/interaction.test.ts
+++ b/platform/backend/src/routes/interaction.test.ts
@@ -497,7 +497,7 @@ describe("interaction routes", () => {
     InteractionDeltaManager.reset();
     const sessions = await app.inject({
       method: "GET",
-      url: "/api/interactions/sessions?limit=10&offset=0&sessionId=route-delta-session",
+      url: "/api/interactions/sessions?limit=10&sessionId=route-delta-session",
     });
     expect(sessions.statusCode).toBe(200);
     const sessionRow = sessions.json().data[0];
@@ -568,7 +568,7 @@ describe("interaction routes", () => {
     // The Claude filter expands to every Claude client id → both Claude sessions.
     const filtered = await app.inject({
       method: "GET",
-      url: `/api/interactions/sessions?limit=50&offset=0&client=${CLAUDE_CLIENT_FILTER}`,
+      url: `/api/interactions/sessions?limit=50&client=${CLAUDE_CLIENT_FILTER}`,
     });
     expect(filtered.statusCode).toBe(200);
     expect(filtered.json().data).toHaveLength(2);
@@ -576,7 +576,7 @@ describe("interaction routes", () => {
     // The Codex filter → the single Codex session.
     const codex = await app.inject({
       method: "GET",
-      url: `/api/interactions/sessions?limit=50&offset=0&client=${CODEX_CLIENT_FILTER}`,
+      url: `/api/interactions/sessions?limit=50&client=${CODEX_CLIENT_FILTER}`,
     });
     expect(codex.statusCode).toBe(200);
     expect(codex.json().data).toHaveLength(1);
@@ -585,13 +585,13 @@ describe("interaction routes", () => {
     // No filter → all four sessions.
     const all = await app.inject({
       method: "GET",
-      url: "/api/interactions/sessions?limit=50&offset=0",
+      url: "/api/interactions/sessions?limit=50",
     });
     expect(all.statusCode).toBe(200);
     expect(all.json().data).toHaveLength(4);
   });
 
-  test("counts distinct sessions plus sessionless interactions in the sessions total", async ({
+  test("cursor-paginates distinct sessions plus sessionless interactions", async ({
     makeAgent,
   }) => {
     const agent = await makeAgent({
@@ -629,12 +629,124 @@ describe("interaction routes", () => {
 
     const response = await app.inject({
       method: "GET",
-      url: "/api/interactions/sessions?limit=2&offset=0",
+      url: "/api/interactions/sessions?limit=2",
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json().data).toHaveLength(2);
-    expect(response.json().pagination.total).toBe(4);
+    const first = response.json();
+    expect(first.data).toHaveLength(2);
+    expect(first.pagination.hasNext).toBe(true);
+
+    const next = await app.inject({
+      method: "GET",
+      url: `/api/interactions/sessions?limit=2&cursor=${encodeURIComponent(first.pagination.nextCursor)}`,
+    });
+    expect(next.statusCode).toBe(200);
+    expect(next.json().data).toHaveLength(2);
+    expect(next.json().pagination).toMatchObject({
+      hasNext: false,
+      nextCursor: null,
+    });
+  });
+
+  test("walks tied session heads once when interactions straddle page boundaries", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({
+      organizationId,
+      authorId: currentUser.id,
+      scope: "org",
+    });
+    const create = (sessionId: string, createdAt: Date) =>
+      InteractionModel.create({
+        profileId: agent.id,
+        sessionId,
+        source: "api",
+        request: {
+          model: "gpt-4",
+          messages: [],
+        } as unknown as InsertInteraction["request"],
+        response: {
+          id: "r",
+          object: "chat.completion" as const,
+          created: Date.now(),
+          model: "gpt-4",
+          choices: [],
+        } as unknown as InsertInteraction["response"],
+        type: "openai:chatCompletions",
+        createdAt,
+      });
+
+    const tiedAt = new Date("2026-01-04T00:00:00.000Z");
+    await create("straddling-session", new Date("2026-01-01T00:00:00.000Z"));
+    await create("straddling-session", tiedAt);
+    await create("tied-session-a", tiedAt);
+    await create("tied-session-b", tiedAt);
+    await create("older-session", new Date("2026-01-02T00:00:00.000Z"));
+
+    const firstResponse = await app.inject({
+      method: "GET",
+      url: "/api/interactions/sessions?limit=2",
+    });
+    expect(firstResponse.statusCode).toBe(200);
+    const first = firstResponse.json();
+    const secondResponse = await app.inject({
+      method: "GET",
+      url: `/api/interactions/sessions?limit=2&cursor=${encodeURIComponent(first.pagination.nextCursor)}`,
+    });
+    expect(secondResponse.statusCode).toBe(200);
+    const second = secondResponse.json();
+    expect(second.pagination).toMatchObject({
+      hasNext: false,
+      nextCursor: null,
+    });
+
+    const sessions = [...first.data, ...second.data].map(
+      (row: { sessionId: string }) => row.sessionId,
+    );
+
+    expect(sessions).toHaveLength(4);
+    expect(new Set(sessions).size).toBe(4);
+    expect(
+      sessions.filter((sessionId) => sessionId === "straddling-session"),
+    ).toHaveLength(1);
+  });
+
+  test("legacy offsets and malformed cursors serve the newest session", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({
+      organizationId,
+      authorId: currentUser.id,
+      scope: "org",
+    });
+    await InteractionModel.create({
+      profileId: agent.id,
+      sessionId: "newest-session",
+      source: "api",
+      request: {
+        model: "gpt-4",
+        messages: [],
+      } as unknown as InsertInteraction["request"],
+      response: {
+        id: "r",
+        object: "chat.completion" as const,
+        created: Date.now(),
+        model: "gpt-4",
+        choices: [],
+      } as unknown as InsertInteraction["response"],
+      type: "openai:chatCompletions",
+      createdAt: new Date("2099-01-01T00:00:00.000Z"),
+    });
+
+    for (const query of ["offset=999&page=999", "cursor=truncated"] as const) {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/interactions/sessions?limit=1&${query}`,
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data[0].sessionId).toBe("newest-session");
+    }
   });
 
   test("derives the newest preview for long sessions and for sessionless interactions", async ({
@@ -679,7 +791,7 @@ describe("interaction routes", () => {
 
     const response = await app.inject({
       method: "GET",
-      url: "/api/interactions/sessions?limit=10&offset=0",
+      url: "/api/interactions/sessions?limit=10",
     });
     expect(response.statusCode).toBe(200);
     const rows = response.json().data as Array<{
@@ -922,10 +1034,10 @@ describe("interaction routes", () => {
 
       const sessions = await app.inject({
         method: "GET",
-        url: "/api/interactions/sessions?limit=10&offset=0",
+        url: "/api/interactions/sessions?limit=10",
       });
       expect(sessions.statusCode).toBe(200);
-      expect(sessions.json().pagination.total).toBe(1);
+      expect(sessions.json().data).toHaveLength(1);
       expect(sessions.json().data[0].sessionId).toBe("own-session");
 
       const userIds = await app.inject({
@@ -1029,7 +1141,7 @@ describe("interaction routes", () => {
     const fetchSession = async (sessionId: string) => {
       const res = await app.inject({
         method: "GET",
-        url: `/api/interactions/sessions?limit=10&offset=0&sessionId=${sessionId}`,
+        url: `/api/interactions/sessions?limit=10&sessionId=${sessionId}`,
       });
       expect(res.statusCode).toBe(200);
       return res.json().data[0];
@@ -1135,7 +1247,7 @@ describe("interaction routes", () => {
     const fetchSession = async (sessionId: string) => {
       const res = await app.inject({
         method: "GET",
-        url: `/api/interactions/sessions?limit=10&offset=0&sessionId=${sessionId}`,
+        url: `/api/interactions/sessions?limit=10&sessionId=${sessionId}`,
       });
       expect(res.statusCode).toBe(200);
       return res.json().data[0];

--- a/platform/backend/src/routes/interaction.ts
+++ b/platform/backend/src/routes/interaction.ts
@@ -267,7 +267,7 @@ const interactionRoutes: FastifyPluginAsyncZod = async (fastify) => {
       fastify.log.info(
         {
           resultCount: result.data.length,
-          total: result.pagination.total,
+          hasNext: result.pagination.hasNext,
         },
         "GetInteractionSessions result",
       );

--- a/platform/backend/src/routes/interaction.ts
+++ b/platform/backend/src/routes/interaction.ts
@@ -1,5 +1,7 @@
 import {
   ClientFilterSchema,
+  CursorQuerySchema,
+  createCursorPaginatedResponseSchema,
   createPaginatedResponseSchema,
   InteractionSourceSchema,
   PaginationQuerySchema,
@@ -145,7 +147,7 @@ const interactionRoutes: FastifyPluginAsyncZod = async (fastify) => {
       fastify.log.info(
         {
           resultCount: result.data.length,
-          total: result.pagination.total,
+          hasNext: result.pagination.hasNext,
         },
         "GetInteractions result",
       );
@@ -192,9 +194,9 @@ const interactionRoutes: FastifyPluginAsyncZod = async (fastify) => {
               .optional()
               .describe("Filter by end date (ISO 8601 format)"),
           })
-          .merge(PaginationQuerySchema),
+          .merge(CursorQuerySchema),
         response: constructResponseSchema(
-          createPaginatedResponseSchema(SessionSummarySchema),
+          createCursorPaginatedResponseSchema(SessionSummarySchema),
         ),
       },
     },
@@ -209,14 +211,14 @@ const interactionRoutes: FastifyPluginAsyncZod = async (fastify) => {
           startDate,
           endDate,
           limit,
-          offset,
+          cursor,
         },
         user,
         organizationId,
       },
       reply,
     ) => {
-      const pagination = { limit, offset };
+      const cursorQuery = { limit, cursor };
 
       const isAgentAdmin = await hasAnyAgentTypeAdminPermission({
         userId: user.id,
@@ -242,13 +244,13 @@ const interactionRoutes: FastifyPluginAsyncZod = async (fastify) => {
           sessionId,
           startDate,
           endDate,
-          pagination,
+          cursorQuery,
         },
         "GetInteractionSessions request",
       );
 
-      const result = await InteractionModel.getSessions(
-        pagination,
+      const result = await InteractionModel.getSessionsCursor(
+        cursorQuery,
         user.id,
         isAgentAdmin,
         {

--- a/platform/backend/src/routes/mcp-tool-call.test.ts
+++ b/platform/backend/src/routes/mcp-tool-call.test.ts
@@ -33,14 +33,18 @@ describe("mcp-tool-call routes", () => {
   let ownRowId: string;
   let otherRowId: string;
 
-  const seedCall = (userId: string | null, method = "tools/call") =>
+  const seedCall = (
+    userId: string | null,
+    overrides: { method?: string; createdAt?: Date } = {},
+  ) =>
     McpToolCallModel.create({
       mcpServerName: "test-server",
-      method,
+      method: overrides.method ?? "tools/call",
       userId,
       agentId,
       toolCall: { id: "call-1", name: "test_tool", arguments: {} },
       toolResult: { content: [{ type: "text", text: "ok" }] },
+      createdAt: overrides.createdAt,
     });
 
   beforeEach(
@@ -99,22 +103,22 @@ describe("mcp-tool-call routes", () => {
 
     const response = await app.inject({
       method: "GET",
-      url: "/api/mcp-tool-calls?limit=10&offset=0",
+      url: "/api/mcp-tool-calls?limit=10",
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json().pagination.total).toBe(1);
+    expect(response.json().data).toHaveLength(1);
     expect(response.json().data[0].id).toBe(ownRowId);
   });
 
   test("the org admin (log:admin) lists every user's tool calls", async () => {
     const response = await app.inject({
       method: "GET",
-      url: "/api/mcp-tool-calls?limit=10&offset=0",
+      url: "/api/mcp-tool-calls?limit=10",
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json().pagination.total).toBe(3);
+    expect(response.json().data).toHaveLength(3);
   });
 
   test("the predefined platform_admin sees only their own tool calls", async ({
@@ -130,9 +134,9 @@ describe("mcp-tool-call routes", () => {
 
     const response = await app.inject({
       method: "GET",
-      url: "/api/mcp-tool-calls?limit=10&offset=0",
+      url: "/api/mcp-tool-calls?limit=10",
     });
-    expect(response.json().pagination.total).toBe(1);
+    expect(response.json().data).toHaveLength(1);
     expect(response.json().data[0].id).toBe(mine.id);
   });
 
@@ -175,19 +179,82 @@ describe("mcp-tool-call routes", () => {
 
     const invisible = await app.inject({
       method: "GET",
-      url: `/api/mcp-tool-calls?limit=10&offset=0&agentId=${privateAgent.id}`,
+      url: `/api/mcp-tool-calls?limit=10&agentId=${privateAgent.id}`,
     });
     expect(invisible.statusCode).toBe(200);
-    expect(invisible.json().pagination.total).toBe(0);
+    expect(invisible.json()).toMatchObject({
+      data: [],
+      pagination: { hasNext: false, nextCursor: null },
+    });
 
     // A visible org agent still only yields the caller's own rows.
     const mine = await seedCall(caller.id);
     const visible = await app.inject({
       method: "GET",
-      url: `/api/mcp-tool-calls?limit=10&offset=0&agentId=${agentId}`,
+      url: `/api/mcp-tool-calls?limit=10&agentId=${agentId}`,
     });
     expect(visible.statusCode).toBe(200);
-    expect(visible.json().pagination.total).toBe(1);
+    expect(visible.json().data).toHaveLength(1);
     expect(visible.json().data[0].id).toBe(mine.id);
+  });
+
+  test("returns an empty cursor page when the caller can access no agents", async ({
+    makeUser,
+  }) => {
+    currentUser = await makeUser();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/mcp-tool-calls?limit=10",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      data: [],
+      pagination: { limit: 10, hasNext: false, nextCursor: null },
+    });
+  });
+
+  test("walks identical timestamps without repeating or skipping rows", async () => {
+    const createdAt = new Date("2026-01-02T03:04:05.000Z");
+    const seeded = await Promise.all(
+      Array.from({ length: 5 }, () => seedCall(currentUser.id, { createdAt })),
+    );
+
+    const first = await app.inject({
+      method: "GET",
+      url: "/api/mcp-tool-calls?limit=4",
+    });
+    const firstBody = first.json();
+    const second = await app.inject({
+      method: "GET",
+      url: `/api/mcp-tool-calls?limit=4&cursor=${encodeURIComponent(firstBody.pagination.nextCursor)}`,
+    });
+    const secondBody = second.json();
+
+    const ids = [...firstBody.data, ...secondBody.data].map(
+      (row: { id: string }) => row.id,
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const row of seeded) expect(ids).toContain(row.id);
+    expect(secondBody.pagination).toMatchObject({
+      hasNext: false,
+      nextCursor: null,
+    });
+  });
+
+  test("ignores legacy offsets and malformed cursors", async () => {
+    const newest = await seedCall(currentUser.id, {
+      createdAt: new Date("2099-01-01T00:00:00.000Z"),
+    });
+
+    for (const query of ["offset=999&page=999", "cursor=truncated"] as const) {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/mcp-tool-calls?limit=1&${query}`,
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data[0].id).toBe(newest.id);
+    }
   });
 });

--- a/platform/backend/src/routes/mcp-tool-call.test.ts
+++ b/platform/backend/src/routes/mcp-tool-call.test.ts
@@ -35,10 +35,14 @@ describe("mcp-tool-call routes", () => {
 
   const seedCall = (
     userId: string | null,
-    overrides: { method?: string; createdAt?: Date } = {},
+    overrides: {
+      method?: string;
+      createdAt?: Date;
+      mcpServerName?: string;
+    } = {},
   ) =>
     McpToolCallModel.create({
-      mcpServerName: "test-server",
+      mcpServerName: overrides.mcpServerName ?? "test-server",
       method: overrides.method ?? "tools/call",
       userId,
       agentId,
@@ -256,5 +260,39 @@ describe("mcp-tool-call routes", () => {
       expect(response.statusCode).toBe(200);
       expect(response.json().data[0].id).toBe(newest.id);
     }
+  });
+
+  test("ignores retired sort inputs and stays newest-first", async () => {
+    await seedCall(currentUser.id, {
+      createdAt: new Date("2098-01-01T00:00:00.000Z"),
+    });
+    const newest = await seedCall(currentUser.id, {
+      createdAt: new Date("2099-01-01T00:00:00.000Z"),
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/mcp-tool-calls?limit=1&sortDirection=asc&sortBy=method",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().data[0].id).toBe(newest.id);
+  });
+
+  test("filters by exact MCP server name and ignores retired search", async () => {
+    const targeted = await seedCall(currentUser.id, {
+      mcpServerName: "target-server",
+    });
+    await seedCall(currentUser.id, { mcpServerName: "other-server" });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/mcp-tool-calls?mcpServerName=target-server&search=other-server",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().data.map((row: { id: string }) => row.id)).toEqual([
+      targeted.id,
+    ]);
   });
 });

--- a/platform/backend/src/routes/mcp-tool-call.ts
+++ b/platform/backend/src/routes/mcp-tool-call.ts
@@ -11,6 +11,7 @@ import {
   ApiError,
   constructResponseSchema,
   McpToolCallResponseSchema,
+  SortDirectionSchema,
   UuidIdSchema,
 } from "@/types";
 

--- a/platform/backend/src/routes/mcp-tool-call.ts
+++ b/platform/backend/src/routes/mcp-tool-call.ts
@@ -1,17 +1,15 @@
 import {
-  createPaginatedResponseSchema,
-  PaginationQuerySchema,
+  CursorQuerySchema,
+  createCursorPaginatedResponseSchema,
   RouteId,
 } from "@archestra/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { hasPermission, userHasPermission } from "@/auth";
-import { createPaginatedResult } from "@/database/utils/pagination";
 import { AgentTeamModel, McpToolCallModel } from "@/models";
 import {
   ApiError,
   constructResponseSchema,
-  createSortingQuerySchema,
   McpToolCallResponseSchema,
   UuidIdSchema,
 } from "@/types";
@@ -44,17 +42,12 @@ const mcpToolCallRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 "Free-text search across MCP server name, tool name, and arguments (case-insensitive)",
               ),
           })
-          .merge(PaginationQuerySchema)
-          .merge(
-            createSortingQuerySchema([
-              "createdAt",
-              "agentId",
-              "mcpServerName",
-              "method",
-            ] as const),
-          ),
+          .merge(CursorQuerySchema)
+          .extend({
+            sortDirection: SortDirectionSchema.optional().default("desc"),
+          }),
         response: constructResponseSchema(
-          createPaginatedResponseSchema(McpToolCallResponseSchema),
+          createCursorPaginatedResponseSchema(McpToolCallResponseSchema),
         ),
       },
     },
@@ -66,8 +59,7 @@ const mcpToolCallRoutes: FastifyPluginAsyncZod = async (fastify) => {
           endDate,
           search,
           limit,
-          offset,
-          sortBy,
+          cursor,
           sortDirection,
         },
         user,
@@ -76,8 +68,7 @@ const mcpToolCallRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
       reply,
     ) => {
-      const pagination = { limit, offset };
-      const sorting = { sortBy, sortDirection };
+      const cursorQuery = { limit, cursor };
       // log:read scopes the view to the caller's own attributed rows;
       // log:admin lifts it (agent-visibility filtering still applies).
       const canSeeAllLogs = await userHasPermission(
@@ -86,50 +77,38 @@ const mcpToolCallRoutes: FastifyPluginAsyncZod = async (fastify) => {
         "log",
         "admin",
       );
-      const filters = {
-        startDate: startDate ? new Date(startDate) : undefined,
-        endDate: endDate ? new Date(endDate) : undefined,
-        search: search || undefined,
-        ownUserId: canSeeAllLogs ? undefined : user.id,
-      };
-
-      if (agentId) {
-        // The per-agent listing previously skipped the access filter
-        // entirely; scope it like the main listing (own rows only without
-        // log:admin, and the agent must be visible to the caller).
-        const { success: isMcpServerAdmin } = await hasPermission(
-          { mcpServerInstallation: ["admin"] },
-          headers,
-        );
-        if (
-          !isMcpServerAdmin &&
-          !(await AgentTeamModel.userHasAgentAccess(user.id, agentId, false))
-        ) {
-          return reply.send(createPaginatedResult([], 0, pagination));
-        }
-        return reply.send(
-          await McpToolCallModel.getAllMcpToolCallsForAgentPaginated(
-            agentId,
-            pagination,
-            sorting,
-            undefined,
-            filters,
-          ),
-        );
-      }
-
       const { success: isMcpServerAdmin } = await hasPermission(
         { mcpServerInstallation: ["admin"] },
         headers,
       );
 
+      // The per-agent listing is the same query with one more predicate, so
+      // it runs through the same method rather than a parallel one that has
+      // to be kept in step with it.
+      if (
+        agentId &&
+        !isMcpServerAdmin &&
+        !(await AgentTeamModel.userHasAgentAccess(user.id, agentId, false))
+      ) {
+        return reply.send({
+          data: [],
+          pagination: { limit, hasNext: false, nextCursor: null },
+        });
+      }
+
       return reply.send(
-        await McpToolCallModel.findAllPaginated(
-          pagination,
-          sorting,
+        await McpToolCallModel.findAllCursorPaginated(
+          cursorQuery,
+          sortDirection,
           user.id,
           isMcpServerAdmin,
-          filters,
+          {
+            agentId,
+            startDate: startDate ? new Date(startDate) : undefined,
+            endDate: endDate ? new Date(endDate) : undefined,
+            search: search || undefined,
+            ownUserId: canSeeAllLogs ? undefined : user.id,
+          },
         ),
       );
     },

--- a/platform/backend/src/routes/mcp-tool-call.ts
+++ b/platform/backend/src/routes/mcp-tool-call.ts
@@ -11,7 +11,6 @@ import {
   ApiError,
   constructResponseSchema,
   McpToolCallResponseSchema,
-  SortDirectionSchema,
   UuidIdSchema,
 } from "@/types";
 
@@ -21,7 +20,7 @@ const mcpToolCallRoutes: FastifyPluginAsyncZod = async (fastify) => {
     {
       schema: {
         operationId: RouteId.GetMcpToolCalls,
-        description: "Get all MCP tool calls with pagination and sorting",
+        description: "Get all MCP tool calls with cursor pagination",
         tags: ["MCP Tool Call"],
         querystring: z
           .object({
@@ -36,17 +35,12 @@ const mcpToolCallRoutes: FastifyPluginAsyncZod = async (fastify) => {
               .datetime()
               .optional()
               .describe("Filter by end date (ISO 8601 format)"),
-            search: z
+            mcpServerName: z
               .string()
               .optional()
-              .describe(
-                "Free-text search across MCP server name, tool name, and arguments (case-insensitive)",
-              ),
+              .describe("Filter by exact MCP server name"),
           })
-          .merge(CursorQuerySchema)
-          .extend({
-            sortDirection: SortDirectionSchema.optional().default("desc"),
-          }),
+          .merge(CursorQuerySchema),
         response: constructResponseSchema(
           createCursorPaginatedResponseSchema(McpToolCallResponseSchema),
         ),
@@ -54,15 +48,7 @@ const mcpToolCallRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async (
       {
-        query: {
-          agentId,
-          startDate,
-          endDate,
-          search,
-          limit,
-          cursor,
-          sortDirection,
-        },
+        query: { agentId, startDate, endDate, mcpServerName, limit, cursor },
         user,
         organizationId,
         headers,
@@ -100,14 +86,13 @@ const mcpToolCallRoutes: FastifyPluginAsyncZod = async (fastify) => {
       return reply.send(
         await McpToolCallModel.findAllCursorPaginated(
           cursorQuery,
-          sortDirection,
           user.id,
           isMcpServerAdmin,
           {
             agentId,
             startDate: startDate ? new Date(startDate) : undefined,
             endDate: endDate ? new Date(endDate) : undefined,
-            search: search || undefined,
+            mcpServerName,
             ownUserId: canSeeAllLogs ? undefined : user.id,
           },
         ),

--- a/platform/e2e-tests/tests/audit-log.spec.ts
+++ b/platform/e2e-tests/tests/audit-log.spec.ts
@@ -38,7 +38,7 @@ test.describe("Audit log UI", {
 
     // Page heading and filter controls are part of the audit log table contract.
     await expect(
-      adminPage.getByPlaceholder(/Search audit events/i),
+      adminPage.getByRole("combobox", { name: "Filter by action" }),
     ).toBeVisible({ timeout: 15_000 });
 
     // Column headers are stable and part of the visual contract.

--- a/platform/e2e-tests/tests/llm-logs-slack-source.spec.ts
+++ b/platform/e2e-tests/tests/llm-logs-slack-source.spec.ts
@@ -95,10 +95,14 @@ async function runSlackChatOpsCompletion(
       async () => {
         const sessions = await request.get(
           `${API_BASE_URL}/api/interactions/sessions` +
-            `?limit=10&offset=0&sessionId=${encodeURIComponent(sessionId)}`,
+            `?limit=1&sessionId=${encodeURIComponent(sessionId)}`,
         );
         if (!sessions.ok()) return -1;
-        return (await sessions.json()).pagination.total;
+        const body = await sessions.json();
+        return body.data.some(
+          (session: { sessionId: string | null }) =>
+            session.sessionId === sessionId,
+        );
       },
       {
         timeout: 30_000,
@@ -106,7 +110,7 @@ async function runSlackChatOpsCompletion(
           "A Slack ChatOps stream that reported no usage was never recorded as an interaction",
       },
     )
-    .toBe(1);
+    .toBe(true);
 
   return { sessionId, prompt };
 }

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.test.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.test.tsx
@@ -13,8 +13,8 @@ import { AuditLogTable } from "./audit-log-table";
  * with network metadata reserved for the detail dialog,
  * resource NAME shown in grid (denormalized, snapshot fallback) for the
  * high-signal picker types only, while the raw resource id stays hidden,
- * detail dialog on row click, URL-driven filters (incl. the entity picker →
- * resourceId) + clear resets page.
+ * detail dialog on row click, structured URL-driven filters (incl. the entity
+ * picker → resourceId) + clear resets cursor pagination.
  */
 
 global.ResizeObserver = class ResizeObserver {
@@ -112,29 +112,23 @@ function makeEvent(overrides: Partial<AuditLog> = {}): AuditLog {
 
 function makeEmptyPagination() {
   return {
-    currentPage: 1,
     limit: 10,
-    total: 0,
-    totalPages: 0,
+    nextCursor: null,
     hasNext: false,
-    hasPrev: false,
   };
 }
 
-function makePagination(total = 1) {
+function makePagination() {
   return {
-    currentPage: 1,
     limit: 10,
-    total,
-    totalPages: 1,
+    nextCursor: null,
     hasNext: false,
-    hasPrev: false,
   };
 }
 
 function withRows(events: AuditLog[]) {
   return {
-    data: { data: events, pagination: makePagination(events.length) },
+    data: { data: events, pagination: makePagination() },
     isFetching: false,
     refetch: vi.fn(),
   };
@@ -208,6 +202,7 @@ describe("AuditLogTable", () => {
     expect(
       screen.getByRole("columnheader", { name: "Activity" }),
     ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Time/ })).toBeNull();
     expect(screen.queryByRole("columnheader", { name: "Where" })).toBeNull();
     expect(screen.queryByText("10.0.0.1")).toBeNull();
   });
@@ -416,7 +411,12 @@ describe("AuditLogTable", () => {
     ).toBeInTheDocument();
   });
 
-  it("reads action and resource filters from URL params and passes to useAuditLogs", () => {
+  it("keeps structured URL filters and removes retired free-text search", () => {
+    const replace = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+      replace,
+    } as unknown as ReturnType<typeof useRouter>);
     vi.mocked(useSearchParams).mockReturnValue(
       new URLSearchParams(
         "action=agent.updated&resourceType=role&search=alice",
@@ -431,10 +431,11 @@ describe("AuditLogTable", () => {
       expect.objectContaining({
         action: "agent.updated",
         resourceType: "role",
-        search: "alice",
-        offset: 0,
-        sortDirection: "desc",
       }),
+    );
+    expect(replace).toHaveBeenCalledWith(
+      "/audit/logs?action=agent.updated&resourceType=role",
+      { scroll: false },
     );
   });
 

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
@@ -1,20 +1,17 @@
 "use client";
 
-import type { ColumnDef, SortingState } from "@tanstack/react-table";
-import { ChevronDown, ChevronUp, User } from "lucide-react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { User } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import {
   CollectionFilters,
   FilterBar,
   FilterSelect,
   filterControlClass,
-  filterSearchClass,
 } from "@/components/filter-bar";
 import { QueryLoadError } from "@/components/query-load-error";
-import { SearchInput } from "@/components/search-input";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { DateTimeRangePicker } from "@/components/ui/date-time-range-picker";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
@@ -78,19 +75,6 @@ const LIST_NAME_RESOURCE_TYPES: ReadonlySet<string> = new Set([
 // ACTION_LABEL and the filter.
 type AuditLogRow = Omit<AuditLog, "action"> & { action: string };
 
-function SortIcon({ isSorted }: { isSorted: "asc" | "desc" | false }) {
-  const upArrow = <ChevronUp className="h-3 w-3" />;
-  const downArrow = <ChevronDown className="h-3 w-3" />;
-  if (isSorted === "asc") return upArrow;
-  if (isSorted === "desc") return downArrow;
-  return (
-    <div className="text-muted-foreground flex flex-col items-center">
-      {upArrow}
-      <span className="mt-[-4px]">{downArrow}</span>
-    </div>
-  );
-}
-
 export function AuditLogTable() {
   const router = useRouter();
   const pathname = usePathname();
@@ -98,7 +82,6 @@ export function AuditLogTable() {
 
   const startDateFromUrl = searchParams.get("startDate");
   const endDateFromUrl = searchParams.get("endDate");
-  const searchFromUrl = searchParams.get("search");
   const actionFromUrl = (searchParams.get("action") ?? ALL_VALUE) as
     | typeof ALL_VALUE
     | AuditEventName;
@@ -114,20 +97,19 @@ export function AuditLogTable() {
   const cursorFromUrl = searchParams.get("cursor");
   const pageFromUrl = searchParams.get("page");
   const pageSizeFromUrl = searchParams.get("pageSize");
+  const searchFromUrl = searchParams.get("search");
 
   const cursorPagination = useCursorPagination({
     defaultPageSize: DEFAULT_TABLE_LIMIT,
   });
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: "createdAt", desc: true },
-  ]);
-
   useEffect(() => {
-    if (!cursorFromUrl && !pageFromUrl && !pageSizeFromUrl) return;
+    if (!cursorFromUrl && !pageFromUrl && !pageSizeFromUrl && !searchFromUrl)
+      return;
     const params = new URLSearchParams(searchParams.toString());
     params.delete("cursor");
     params.delete("page");
     params.delete("pageSize");
+    params.delete("search");
     const query = params.toString();
     router.replace(query ? `${pathname}?${query}` : pathname, {
       scroll: false,
@@ -138,6 +120,7 @@ export function AuditLogTable() {
     pageSizeFromUrl,
     pathname,
     router,
+    searchFromUrl,
     searchParams,
   ]);
   const eventId = searchParams.get("event");
@@ -236,15 +219,6 @@ export function AuditLogTable() {
     [cursorPagination.goNewest, updateUrlParams],
   );
 
-  const sortDirection = sorting[0]?.desc === false ? "asc" : "desc";
-  const handleSortingChange = useCallback(
-    (nextSorting: SortingState) => {
-      setSorting(nextSorting);
-      cursorPagination.goNewest();
-    },
-    [cursorPagination.goNewest],
-  );
-
   const action = (ALL_ACTIONS as readonly string[]).includes(actionFromUrl)
     ? (actionFromUrl as AuditEventName)
     : undefined;
@@ -270,7 +244,6 @@ export function AuditLogTable() {
   } = useAuditLogs({
     limit: cursorPagination.pageSize,
     cursor: cursorPagination.cursor,
-    sortDirection,
     startDate: dateTimePicker.startDateParam,
     endDate: dateTimePicker.endDateParam,
     actorId,
@@ -279,7 +252,6 @@ export function AuditLogTable() {
     actorType,
     resourceType,
     resourceId,
-    search: searchFromUrl ?? undefined,
   });
 
   // Server-side search rather than a client filter over the first N members:
@@ -525,16 +497,7 @@ export function AuditLogTable() {
       },
       {
         id: "createdAt",
-        header: ({ column }) => (
-          <Button
-            variant="ghost"
-            className="h-auto !p-0 font-medium hover:bg-transparent"
-            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          >
-            Time
-            <SortIcon isSorted={column.getIsSorted()} />
-          </Button>
-        ),
+        header: "Time",
         size: 190,
         minSize: 175,
         cell: ({ row }) => (
@@ -556,7 +519,6 @@ export function AuditLogTable() {
   );
 
   const hasFilters =
-    !!searchFromUrl ||
     action !== undefined ||
     outcome !== undefined ||
     actorType !== undefined ||
@@ -674,15 +636,6 @@ export function AuditLogTable() {
               : []),
           ]}
         >
-          <SearchInput
-            isLoading={isFetching}
-            objectNamePlural="audit events"
-            searchFields={["actor", "path", "resource"]}
-            paramName="search"
-            className={filterSearchClass}
-            paginationMode="cursor"
-            onSearchChange={cursorPagination.goNewest}
-          />
           <FilterSelect
             value={action ?? ALL_VALUE}
             onValueChange={handleActionChange}
@@ -735,9 +688,6 @@ export function AuditLogTable() {
             : undefined
         }
         manualPagination
-        manualSorting
-        sorting={sorting}
-        onSortingChange={handleSortingChange}
         isLoading={isFetching}
         hasActiveFilters={hasFilters}
         emptyMessage="No audit events recorded yet. Administrative actions will appear here as they happen."

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
@@ -3,7 +3,7 @@
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { ChevronDown, ChevronUp, User } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CollectionFilters,
   FilterBar,
@@ -30,6 +30,7 @@ import {
 } from "@/lib/audit-log/audit-log.query";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useEnvironments } from "@/lib/environment.query";
+import { useCursorPagination } from "@/lib/hooks/use-cursor-pagination";
 import { useDateTimeRangePicker } from "@/lib/hooks/use-date-time-range-picker";
 import { useDialogUrlParam } from "@/lib/hooks/use-dialog-url-param";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
@@ -110,13 +111,34 @@ export function AuditLogTable() {
   const actorTypeFromUrl = (searchParams.get("actorType") ?? ALL_VALUE) as
     | typeof ALL_VALUE
     | AuditActorType;
+  const cursorFromUrl = searchParams.get("cursor");
+  const pageFromUrl = searchParams.get("page");
+  const pageSizeFromUrl = searchParams.get("pageSize");
 
-  const [pagination, setPagination] = useState({
-    pageIndex: 0,
-    pageSize: DEFAULT_TABLE_LIMIT,
+  const cursorPagination = useCursorPagination({
+    defaultPageSize: DEFAULT_TABLE_LIMIT,
   });
   const [sorting, setSorting] = useState<SortingState>([
     { id: "createdAt", desc: true },
+  ]);
+
+  useEffect(() => {
+    if (!cursorFromUrl && !pageFromUrl && !pageSizeFromUrl) return;
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("cursor");
+    params.delete("page");
+    params.delete("pageSize");
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  }, [
+    cursorFromUrl,
+    pageFromUrl,
+    pageSizeFromUrl,
+    pathname,
+    router,
+    searchParams,
   ]);
   const eventId = searchParams.get("event");
   const { data: eventFromUrl } = useAuditLog(eventId ?? undefined);
@@ -159,62 +181,69 @@ export function AuditLogTable() {
     endDateFromUrl,
     onDateRangeChange: useCallback(
       ({ startDate, endDate }) => {
-        setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+        cursorPagination.goNewest();
         updateUrlParams({ startDate, endDate });
       },
-      [updateUrlParams],
+      [cursorPagination.goNewest, updateUrlParams],
     ),
   });
 
   const handleActionChange = useCallback(
     (value: string) => {
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+      cursorPagination.goNewest();
       updateUrlParams({ action: value === ALL_VALUE ? null : value });
     },
-    [updateUrlParams],
+    [cursorPagination.goNewest, updateUrlParams],
   );
 
   const handleResourceChange = useCallback(
     (value: string) => {
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+      cursorPagination.goNewest();
       updateUrlParams({ resourceType: value === ALL_VALUE ? null : value });
     },
-    [updateUrlParams],
+    [cursorPagination.goNewest, updateUrlParams],
   );
 
   const handleActorChange = useCallback(
     (value: string) => {
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+      cursorPagination.goNewest();
       updateUrlParams({ actorId: value === ALL_VALUE ? null : value });
     },
-    [updateUrlParams],
+    [cursorPagination.goNewest, updateUrlParams],
   );
 
   const handleEntityChange = useCallback(
     (value: string) => {
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+      cursorPagination.goNewest();
       updateUrlParams({ resourceId: value === ALL_VALUE ? null : value });
     },
-    [updateUrlParams],
+    [cursorPagination.goNewest, updateUrlParams],
   );
 
   const handleOutcomeChange = useCallback(
     (value: string) => {
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+      cursorPagination.goNewest();
       updateUrlParams({ outcome: value === ALL_VALUE ? null : value });
     },
-    [updateUrlParams],
+    [cursorPagination.goNewest, updateUrlParams],
   );
 
   const handleActorTypeChange = useCallback(
     (value: string) => {
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+      cursorPagination.goNewest();
       updateUrlParams({ actorType: value === ALL_VALUE ? null : value });
     },
-    [updateUrlParams],
+    [cursorPagination.goNewest, updateUrlParams],
   );
 
   const sortDirection = sorting[0]?.desc === false ? "asc" : "desc";
+  const handleSortingChange = useCallback(
+    (nextSorting: SortingState) => {
+      setSorting(nextSorting);
+      cursorPagination.goNewest();
+    },
+    [cursorPagination.goNewest],
+  );
 
   const action = (ALL_ACTIONS as readonly string[]).includes(actionFromUrl)
     ? (actionFromUrl as AuditEventName)
@@ -239,8 +268,8 @@ export function AuditLogTable() {
     isLoadingError: isAuditLogsLoadError,
     refetch: refetchAuditLogs,
   } = useAuditLogs({
-    limit: pagination.pageSize,
-    offset: pagination.pageIndex * pagination.pageSize,
+    limit: cursorPagination.pageSize,
+    cursor: cursorPagination.cursor,
     sortDirection,
     startDate: dateTimePicker.startDateParam,
     endDate: dateTimePicker.endDateParam,
@@ -537,7 +566,7 @@ export function AuditLogTable() {
     dateTimePicker.startDate !== undefined;
 
   const clearFilters = useCallback(() => {
-    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    cursorPagination.goNewest();
     dateTimePicker.clearDateRange();
     updateUrlParams({
       search: null,
@@ -549,9 +578,11 @@ export function AuditLogTable() {
       actorId: null,
       startDate: null,
       endDate: null,
-      page: "1",
+      cursor: null,
+      page: null,
+      pageSize: null,
     });
-  }, [dateTimePicker, updateUrlParams]);
+  }, [cursorPagination.goNewest, dateTimePicker, updateUrlParams]);
 
   if (isAuditLogsLoadError) {
     return (
@@ -649,6 +680,8 @@ export function AuditLogTable() {
             searchFields={["actor", "path", "resource"]}
             paramName="search"
             className={filterSearchClass}
+            paginationMode="cursor"
+            onSearchChange={cursorPagination.goNewest}
           />
           <FilterSelect
             value={action ?? ALL_VALUE}
@@ -687,20 +720,24 @@ export function AuditLogTable() {
         columns={columns}
         data={rows}
         hideSelectedCount
-        pagination={
+        cursorPagination={
           paginationMeta
             ? {
-                pageIndex: pagination.pageIndex,
-                pageSize: pagination.pageSize,
-                total: paginationMeta.total,
+                pageIndex: cursorPagination.pageIndex,
+                pageSize: cursorPagination.pageSize,
+                hasNext: paginationMeta.hasNext,
+                canGoNewer: cursorPagination.canGoNewer,
+                onPageSizeChange: cursorPagination.setPageSize,
+                onNewer: cursorPagination.goNewer,
+                onOlder: () =>
+                  cursorPagination.goOlder(paginationMeta.nextCursor),
               }
             : undefined
         }
         manualPagination
-        onPaginationChange={setPagination}
         manualSorting
         sorting={sorting}
-        onSortingChange={setSorting}
+        onSortingChange={handleSortingChange}
         isLoading={isFetching}
         hasActiveFilters={hasFilters}
         emptyMessage="No audit events recorded yet. Administrative actions will appear here as they happen."

--- a/platform/frontend/src/app/llm/logs/page.client.test.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.test.tsx
@@ -55,6 +55,14 @@ const orgProxy = {
 
 const push = vi.fn();
 
+function makePagination() {
+  return {
+    limit: 10,
+    nextCursor: null,
+    hasNext: false,
+  };
+}
+
 type SessionSummary =
   archestraApiTypes.GetInteractionSessionsResponses["200"]["data"][number];
 
@@ -131,7 +139,7 @@ describe("LlmProxyLogsPage proxy filter", () => {
       data: [],
     } as unknown as ReturnType<typeof useUniqueUserIds>);
     vi.mocked(useInteractionSessions).mockReturnValue({
-      data: { data: [], pagination: { total: 0 } },
+      data: { data: [], pagination: makePagination() },
       isFetching: false,
     } as unknown as ReturnType<typeof useInteractionSessions>);
   });
@@ -159,21 +167,16 @@ describe("LlmProxyLogsPage proxy filter", () => {
   // This page keeps its filter in the URL rather than local state, so picking a
   // proxy is observable as the query params it writes (and the session query
   // re-derives from there on the next render).
-  it("filters sessions by the picked proxy, back on the first page", async () => {
+  it("filters sessions by the picked proxy without offset pagination params", async () => {
     const user = userEvent.setup();
     render(<LlmProxyLogsPage />);
 
     await openProxyFilter(user);
     await user.click(await screen.findByText("My Proxy"));
 
-    expect(push).toHaveBeenCalledWith(
-      expect.stringContaining("profileId=p1"),
-      expect.anything(),
-    );
-    expect(push).toHaveBeenCalledWith(
-      expect.stringContaining("page=1"),
-      expect.anything(),
-    );
+    expect(push).toHaveBeenCalledWith("/llm/logs?profileId=p1", {
+      scroll: false,
+    });
   });
 
   it("presents session context and usage without separate source and details columns", () => {
@@ -193,7 +196,7 @@ describe("LlmProxyLogsPage proxy filter", () => {
             userNames: ["Demo Admin"],
           }),
         ],
-        pagination: { total: 1 },
+        pagination: makePagination(),
       },
       isFetching: false,
     } as unknown as ReturnType<typeof useInteractionSessions>);
@@ -246,7 +249,7 @@ describe("LlmProxyLogsPage proxy filter", () => {
             ],
           }),
         ],
-        pagination: { total: 1 },
+        pagination: makePagination(),
       },
       isFetching: false,
     } as unknown as ReturnType<typeof useInteractionSessions>);
@@ -281,7 +284,7 @@ describe("LlmProxyLogsPage proxy filter", () => {
             ],
           }),
         ],
-        pagination: { total: 1 },
+        pagination: makePagination(),
       },
       isFetching: false,
     } as unknown as ReturnType<typeof useInteractionSessions>);
@@ -304,7 +307,7 @@ describe("LlmProxyLogsPage proxy filter", () => {
             virtualKeys: [],
           }),
         ],
-        pagination: { total: 1 },
+        pagination: makePagination(),
       },
       isFetching: false,
     } as unknown as ReturnType<typeof useInteractionSessions>);

--- a/platform/frontend/src/app/llm/logs/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.tsx
@@ -11,7 +11,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { Database, Layers, MessageSquare, MessagesSquare } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { AgentSelector } from "@/components/agent-selector";
 import { BilledCost } from "@/components/billed-cost";
 import { ClientSourceBadge } from "@/components/client-source-badge";
@@ -38,6 +38,7 @@ import {
 import { VirtualKeyBadge } from "@/components/virtual-key-badge";
 import { useProfiles } from "@/lib/agent.query";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useCursorPagination } from "@/lib/hooks/use-cursor-pagination";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useDateTimeRangePicker } from "@/lib/hooks/use-date-time-range-picker";
 import {
@@ -124,8 +125,9 @@ export default function LlmProxyLogsPage() {
 
 function SessionsTable() {
   const router = useRouter();
-  const { searchParams, pageIndex, pageSize, offset, updateQueryParams } =
+  const { searchParams, pathname, updateQueryParams } =
     useDataTableQueryParams();
+  const cursorPagination = useCursorPagination();
 
   // Get URL params
   const profileIdFromUrl = searchParams.get("profileId");
@@ -140,6 +142,23 @@ function SessionsTable() {
   const sourceFilter = sourceFromUrl || "all";
   const clientFilter = clientFromUrl || "all";
 
+  // Cursors are transient navigation state. Keep filters shareable, but scrub
+  // pagination from old links rather than exposing opaque cursors in the URL.
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    const hasLegacyPagination = ["cursor", "page", "pageSize"].some((key) =>
+      params.has(key),
+    );
+    if (!hasLegacyPagination) return;
+    params.delete("cursor");
+    params.delete("page");
+    params.delete("pageSize");
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  }, [pathname, router, searchParams]);
+
   // The logs search box only filters by session ID (free-text content search
   // was removed). Translate the typed term into a sessionId filter when it is a
   // valid session ID; otherwise it filters nothing and we surface a hint.
@@ -153,64 +172,64 @@ function SessionsTable() {
     endDateFromUrl,
     onDateRangeChange: useCallback(
       ({ startDate, endDate }) => {
+        cursorPagination.goNewest();
         updateQueryParams({
           startDate,
           endDate,
-          page: "1", // Reset to first page
+          page: null,
+          pageSize: null,
         });
       },
-      [updateQueryParams],
+      [cursorPagination.goNewest, updateQueryParams],
     ),
   });
 
-  const handlePaginationChange = useCallback(
-    (newPagination: { pageIndex: number; pageSize: number }) => {
-      updateQueryParams({
-        page: String(newPagination.pageIndex + 1),
-        pageSize: String(newPagination.pageSize),
-      });
-    },
-    [updateQueryParams],
-  );
-
   const handleProfileFilterChange = useCallback(
     (value: string) => {
+      cursorPagination.goNewest();
       updateQueryParams({
         profileId: value === "all" ? null : value,
-        page: "1", // Reset to first page
+        page: null,
+        pageSize: null,
       });
     },
-    [updateQueryParams],
+    [cursorPagination.goNewest, updateQueryParams],
   );
 
   const handleUserFilterChange = useCallback(
     (value: string) => {
+      cursorPagination.goNewest();
       updateQueryParams({
         userId: value === "all" ? null : value,
-        page: "1", // Reset to first page
+        page: null,
+        pageSize: null,
       });
     },
-    [updateQueryParams],
+    [cursorPagination.goNewest, updateQueryParams],
   );
 
   const handleSourceFilterChange = useCallback(
     (value: string) => {
+      cursorPagination.goNewest();
       updateQueryParams({
         source: value === "all" ? null : value,
-        page: "1", // Reset to first page
+        page: null,
+        pageSize: null,
       });
     },
-    [updateQueryParams],
+    [cursorPagination.goNewest, updateQueryParams],
   );
 
   const handleClientFilterChange = useCallback(
     (value: string) => {
+      cursorPagination.goNewest();
       updateQueryParams({
         client: value === "all" ? null : value,
-        page: "1", // Reset to first page
+        page: null,
+        pageSize: null,
       });
     },
-    [updateQueryParams],
+    [cursorPagination.goNewest, updateQueryParams],
   );
 
   const {
@@ -219,8 +238,8 @@ function SessionsTable() {
     isLoadingError,
     refetch: refetchSessions,
   } = useInteractionSessions({
-    limit: pageSize,
-    offset,
+    limit: cursorPagination.pageSize,
+    cursor: cursorPagination.cursor,
     profileId: profileFilter !== "all" ? profileFilter : undefined,
     userId: userFilter !== "all" ? userFilter : undefined,
     source:
@@ -250,6 +269,7 @@ function SessionsTable() {
     !!searchFromUrl;
 
   const clearFilters = useCallback(() => {
+    cursorPagination.goNewest();
     dateTimePicker.clearDateRange();
     updateQueryParams({
       profileId: null,
@@ -259,9 +279,10 @@ function SessionsTable() {
       startDate: null,
       endDate: null,
       search: null,
-      page: "1",
+      page: null,
+      pageSize: null,
     });
-  }, [dateTimePicker, updateQueryParams]);
+  }, [cursorPagination.goNewest, dateTimePicker, updateQueryParams]);
 
   const columns: ColumnDef<SessionData>[] = useMemo(
     () => [
@@ -507,6 +528,8 @@ function SessionsTable() {
               searchFields={["session ID"]}
               paramName="search"
               className="relative w-full"
+              paginationMode="cursor"
+              onSearchChange={cursorPagination.goNewest}
             />
             {searchIsNotSessionId && (
               <output className="absolute left-0 top-full z-20 mt-1 w-full rounded-md border bg-popover px-2 py-1 text-xs text-muted-foreground shadow-md">
@@ -598,12 +621,20 @@ function SessionsTable() {
         data={sessions}
         hideSelectedCount
         manualPagination
-        pagination={{
-          pageIndex,
-          pageSize,
-          total: paginationMeta?.total ?? 0,
-        }}
-        onPaginationChange={handlePaginationChange}
+        cursorPagination={
+          paginationMeta
+            ? {
+                pageIndex: cursorPagination.pageIndex,
+                pageSize: cursorPagination.pageSize,
+                hasNext: paginationMeta.hasNext,
+                canGoNewer: cursorPagination.canGoNewer,
+                onPageSizeChange: cursorPagination.setPageSize,
+                onNewer: cursorPagination.goNewer,
+                onOlder: () =>
+                  cursorPagination.goOlder(paginationMeta.nextCursor),
+              }
+            : undefined
+        }
         isLoading={isFetching}
         hasActiveFilters={hasFilters}
         emptyIcon={MessagesSquare}

--- a/platform/frontend/src/app/mcp/logs/page.client.test.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.test.tsx
@@ -60,11 +60,12 @@ async function openGatewayFilter(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByText("All Agents & MCP Gateways"));
 }
 
-describe("McpGatewayLogsPage gateway filter", () => {
+describe("McpGatewayLogsPage filters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useRouter).mockReturnValue({
       push,
+      replace: vi.fn(),
     } as unknown as ReturnType<typeof useRouter>);
     vi.mocked(useSearchParams).mockReturnValue(
       new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
@@ -83,7 +84,10 @@ describe("McpGatewayLogsPage gateway filter", () => {
       data: [],
     } as unknown as ReturnType<typeof useInternalMcpCatalog>);
     vi.mocked(useMcpToolCalls).mockReturnValue({
-      data: { data: [], pagination: { total: 0 } },
+      data: {
+        data: [],
+        pagination: { limit: 10, nextCursor: null, hasNext: false },
+      },
       isFetching: false,
     } as unknown as ReturnType<typeof useMcpToolCalls>);
   });
@@ -141,6 +145,41 @@ describe("McpGatewayLogsPage gateway filter", () => {
     );
   });
 
+  it("filters by MCP server with a searchable icon-and-name picker", async () => {
+    vi.mocked(useMcpServers).mockReturnValue({
+      data: [
+        {
+          name: "document-search-deployment",
+          catalogName: "Document Search",
+          catalogId: "document-search-catalog",
+        },
+      ],
+    } as unknown as ReturnType<typeof useMcpServers>);
+    vi.mocked(useInternalMcpCatalog).mockReturnValue({
+      data: [
+        {
+          id: "document-search-catalog",
+          name: "Document Search",
+          icon: "📚",
+        },
+      ],
+    } as unknown as ReturnType<typeof useInternalMcpCatalog>);
+    const user = userEvent.setup();
+    render(<McpGatewayLogsPage />);
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Filter by MCP server" }),
+    );
+    expect(screen.getByPlaceholderText("Search MCP servers…")).toBeVisible();
+    expect(screen.getByText("📚")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: /Document Search/ }));
+
+    expect(push).toHaveBeenCalledWith(
+      expect.stringContaining("mcpServerName=document-search-deployment"),
+      expect.anything(),
+    );
+  });
+
   it("presents the call context without separate method, server, and arguments columns", () => {
     vi.mocked(useMcpServers).mockReturnValue({
       data: [
@@ -183,7 +222,7 @@ describe("McpGatewayLogsPage gateway filter", () => {
             appName: null,
           },
         ],
-        pagination: { total: 1 },
+        pagination: { limit: 10, nextCursor: null, hasNext: false },
       },
       isFetching: false,
     } as unknown as ReturnType<typeof useMcpToolCalls>);
@@ -195,6 +234,7 @@ describe("McpGatewayLogsPage gateway filter", () => {
         screen.getByRole("columnheader", { name: header }),
       ).toBeInTheDocument();
     }
+    expect(screen.queryByRole("button", { name: /Time/ })).toBeNull();
     expect(screen.getByText("search_documents")).toBeVisible();
     expect(screen.getByText("Document Search")).toBeVisible();
     expect(screen.getByText("📚")).toBeInTheDocument();

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -6,14 +6,8 @@ import {
   isLockedChatUnavailableContent,
   parseFullToolName,
 } from "@archestra/shared";
-import type { ColumnDef, SortingState } from "@tanstack/react-table";
-import {
-  Boxes,
-  ChevronDown,
-  ChevronUp,
-  MessagesSquare,
-  User,
-} from "lucide-react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Boxes, MessagesSquare, User } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AgentSelector } from "@/components/agent-selector";
@@ -22,16 +16,14 @@ import {
   CollectionFilters,
   FilterBar,
   filterControlClass,
-  filterSearchClass,
 } from "@/components/filter-bar";
 import { LockedChatContentUnavailableLabel } from "@/components/locked-chat-content-unavailable";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { QueryLoadError } from "@/components/query-load-error";
-import { SearchInput } from "@/components/search-input";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { DateTimeRangePicker } from "@/components/ui/date-time-range-picker";
+import { SearchableSelect } from "@/components/ui/searchable-select";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useProfiles } from "@/lib/agent.query";
 import { useHasPermissions } from "@/lib/auth/auth.query";
@@ -50,31 +42,6 @@ import { ErrorBoundary } from "../../_parts/error-boundary";
 
 type McpToolCallData =
   archestraApiTypes.GetMcpToolCallsResponses["200"]["data"][number];
-
-function SortIcon({
-  isSorted,
-}: {
-  isSorted:
-    | NonNullable<
-        archestraApiTypes.GetMcpToolCallsData["query"]
-      >["sortDirection"]
-    | false;
-}) {
-  const upArrow = <ChevronUp className="h-3 w-3" />;
-  const downArrow = <ChevronDown className="h-3 w-3" />;
-  if (isSorted === "asc") {
-    return upArrow;
-  }
-  if (isSorted === "desc") {
-    return downArrow;
-  }
-  return (
-    <div className="text-muted-foreground flex flex-col items-center">
-      {upArrow}
-      <span className="mt-[-4px]">{downArrow}</span>
-    </div>
-  );
-}
 
 export default function McpGatewayLogsPage({
   initialData,
@@ -108,6 +75,7 @@ function McpToolCallsTable({
   const endDateFromUrl = searchParams.get("endDate");
   const profileIdFromUrl =
     searchParams.get("profileId") || searchParams.get("profileID");
+  const mcpServerNameFromUrl = searchParams.get("mcpServerName") ?? "all";
   const searchFromUrl = searchParams.get("search");
   const cursorFromUrl = searchParams.get("cursor");
   const pageFromUrl = searchParams.get("page");
@@ -117,21 +85,19 @@ function McpToolCallsTable({
   const cursorPagination = useCursorPagination({
     defaultPageSize: DEFAULT_TABLE_LIMIT,
   });
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: "createdAt", desc: true },
-  ]);
-
   useEffect(() => {
     setProfileFilter(profileIdFromUrl || "all");
     cursorPagination.goNewest();
   }, [cursorPagination.goNewest, profileIdFromUrl]);
 
   useEffect(() => {
-    if (!cursorFromUrl && !pageFromUrl && !pageSizeFromUrl) return;
+    if (!cursorFromUrl && !pageFromUrl && !pageSizeFromUrl && !searchFromUrl)
+      return;
     const params = new URLSearchParams(searchParams.toString());
     params.delete("cursor");
     params.delete("page");
     params.delete("pageSize");
+    params.delete("search");
     const query = params.toString();
     router.replace(query ? `${pathname}?${query}` : pathname, {
       scroll: false,
@@ -142,6 +108,7 @@ function McpToolCallsTable({
     pageSizeFromUrl,
     pathname,
     router,
+    searchFromUrl,
     searchParams,
   ]);
 
@@ -174,6 +141,14 @@ function McpToolCallsTable({
     [cursorPagination.goNewest, updateUrlParams],
   );
 
+  const handleMcpServerChange = useCallback(
+    (value: string) => {
+      cursorPagination.goNewest();
+      updateUrlParams({ mcpServerName: value === "all" ? null : value });
+    },
+    [cursorPagination.goNewest, updateUrlParams],
+  );
+
   // Date time range picker hook
   const dateTimePicker = useDateTimeRangePicker({
     startDateFromUrl,
@@ -190,15 +165,6 @@ function McpToolCallsTable({
     ),
   });
 
-  const sortDirection = sorting[0]?.desc ? "desc" : "asc";
-  const handleSortingChange = useCallback(
-    (nextSorting: SortingState) => {
-      setSorting(nextSorting);
-      cursorPagination.goNewest();
-    },
-    [cursorPagination.goNewest],
-  );
-
   const {
     data: mcpToolCallsResponse,
     isFetching,
@@ -206,12 +172,12 @@ function McpToolCallsTable({
     refetch: refetchMcpToolCalls,
   } = useMcpToolCalls({
     agentId: profileFilter !== "all" ? profileFilter : undefined,
+    mcpServerName:
+      mcpServerNameFromUrl !== "all" ? mcpServerNameFromUrl : undefined,
     limit: cursorPagination.pageSize,
     cursor: cursorPagination.cursor,
-    sortDirection,
     startDate: dateTimePicker.startDateParam,
     endDate: dateTimePicker.endDateParam,
-    search: searchFromUrl || undefined,
     initialData: initialData?.mcpToolCalls,
   });
 
@@ -253,6 +219,68 @@ function McpToolCallsTable({
 
   const mcpToolCalls = mcpToolCallsResponse?.data ?? [];
   const paginationMeta = mcpToolCallsResponse?.pagination;
+
+  const mcpServerOptions = useMemo(() => {
+    const installedByName = new Map(
+      (mcpServers ?? []).map((server) => [server.name, server]),
+    );
+    const serverNames = new Set(installedByName.keys());
+    for (const call of mcpToolCallsResponse?.data ?? []) {
+      serverNames.add(call.mcpServerName);
+    }
+
+    return [...serverNames]
+      .map((serverName) => {
+        const installed = installedByName.get(serverName);
+        const display = serverDisplayByName.get(serverName);
+        const displayName = display?.name ?? serverName;
+        const secondaryLabel =
+          displayName !== serverName
+            ? serverName
+            : installed
+              ? undefined
+              : "From logs";
+        const icon = (
+          <span
+            key={serverName}
+            className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+          >
+            <McpCatalogIcon
+              icon={display?.icon}
+              catalogId={display?.catalogId ?? installed?.catalogId}
+              size={14}
+            />
+          </span>
+        );
+        return {
+          value: serverName,
+          label: displayName,
+          searchText: `${displayName} ${serverName}`,
+          content: (
+            <span className="flex min-w-0 items-center gap-2">
+              {icon}
+              <span className="min-w-0">
+                <span className="block truncate font-medium">
+                  {displayName}
+                </span>
+                {secondaryLabel ? (
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {secondaryLabel}
+                  </span>
+                ) : null}
+              </span>
+            </span>
+          ),
+          selectedContent: (
+            <span className="flex min-w-0 items-center gap-2">
+              {icon}
+              <span className="truncate">{displayName}</span>
+            </span>
+          ),
+        };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [mcpServers, mcpToolCallsResponse?.data, serverDisplayByName]);
 
   const columns: ColumnDef<McpToolCallData>[] = [
     {
@@ -429,18 +457,7 @@ function McpToolCallsTable({
     },
     {
       id: "createdAt",
-      header: ({ column }) => {
-        return (
-          <Button
-            variant="ghost"
-            className="h-auto !p-0 font-medium hover:bg-transparent"
-            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          >
-            Time
-            <SortIcon isSorted={column.getIsSorted()} />
-          </Button>
-        );
-      },
+      header: "Time",
       size: 175,
       minSize: 160,
       cell: ({ row }) => (
@@ -461,8 +478,9 @@ function McpToolCallsTable({
 
   const hasFilters =
     profileFilter !== "all" ||
+    mcpServerNameFromUrl !== "all" ||
     dateTimePicker.startDate !== undefined ||
-    !!searchFromUrl;
+    dateTimePicker.endDate !== undefined;
 
   const clearFilters = useCallback(() => {
     setProfileFilter("all");
@@ -471,6 +489,7 @@ function McpToolCallsTable({
     updateUrlParams({
       profileId: null,
       profileID: null,
+      mcpServerName: null,
       startDate: null,
       endDate: null,
       search: null,
@@ -500,19 +519,6 @@ function McpToolCallsTable({
     />
   );
 
-  // Shared search input component
-  const searchInputComponent = (
-    <SearchInput
-      isLoading={isFetching}
-      objectNamePlural="tool calls"
-      searchFields={["tool name", "server name"]}
-      paramName="search"
-      className={filterSearchClass}
-      paginationMode="cursor"
-      onSearchChange={cursorPagination.goNewest}
-    />
-  );
-
   if (isMcpToolCallsLoadError) {
     return (
       <div className="space-y-4">
@@ -531,7 +537,6 @@ function McpToolCallsTable({
           leading
           onClearFilters={hasFilters ? clearFilters : undefined}
         >
-          {searchInputComponent}
           {/* Two people's personal gateways can both be called "My Gateway", so
             the picker carries each one's scope and owner email rather than a
             bare name. */}
@@ -553,6 +558,19 @@ function McpToolCallsTable({
             searchPlaceholder="Search agents and MCP gateways…"
             emptyMessage="No agents or MCP gateways found."
             className={filterControlClass({ active: profileFilter !== "all" })}
+          />
+          <SearchableSelect
+            value={mcpServerNameFromUrl}
+            onValueChange={handleMcpServerChange}
+            ariaLabel="Filter by MCP server"
+            searchPlaceholder="Search MCP servers…"
+            emptyMessage="No MCP servers found."
+            items={mcpServerOptions}
+            pinnedItems={[{ value: "all", label: "All MCP Servers" }]}
+            className={filterControlClass({
+              active: mcpServerNameFromUrl !== "all",
+            })}
+            contentClassName="min-w-[min(20rem,calc(100vw-2rem))]"
           />
           {datePickerComponent}
         </FilterBar>
@@ -577,9 +595,6 @@ function McpToolCallsTable({
             : undefined
         }
         manualPagination
-        manualSorting
-        sorting={sorting}
-        onSortingChange={handleSortingChange}
         isLoading={isFetching}
         hasActiveFilters={hasFilters}
         emptyIcon={MessagesSquare}

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -35,6 +35,7 @@ import { DateTimeRangePicker } from "@/components/ui/date-time-range-picker";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useProfiles } from "@/lib/agent.query";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useCursorPagination } from "@/lib/hooks/use-cursor-pagination";
 import { useDateTimeRangePicker } from "@/lib/hooks/use-date-time-range-picker";
 import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
@@ -108,11 +109,13 @@ function McpToolCallsTable({
   const profileIdFromUrl =
     searchParams.get("profileId") || searchParams.get("profileID");
   const searchFromUrl = searchParams.get("search");
+  const cursorFromUrl = searchParams.get("cursor");
+  const pageFromUrl = searchParams.get("page");
+  const pageSizeFromUrl = searchParams.get("pageSize");
 
   const [profileFilter, setProfileFilter] = useState(profileIdFromUrl || "all");
-  const [pagination, setPagination] = useState({
-    pageIndex: 0,
-    pageSize: DEFAULT_TABLE_LIMIT,
+  const cursorPagination = useCursorPagination({
+    defaultPageSize: DEFAULT_TABLE_LIMIT,
   });
   const [sorting, setSorting] = useState<SortingState>([
     { id: "createdAt", desc: true },
@@ -120,7 +123,27 @@ function McpToolCallsTable({
 
   useEffect(() => {
     setProfileFilter(profileIdFromUrl || "all");
-  }, [profileIdFromUrl]);
+    cursorPagination.goNewest();
+  }, [cursorPagination.goNewest, profileIdFromUrl]);
+
+  useEffect(() => {
+    if (!cursorFromUrl && !pageFromUrl && !pageSizeFromUrl) return;
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("cursor");
+    params.delete("page");
+    params.delete("pageSize");
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  }, [
+    cursorFromUrl,
+    pageFromUrl,
+    pageSizeFromUrl,
+    pathname,
+    router,
+    searchParams,
+  ]);
 
   // Helper to update URL params
   const updateUrlParams = useCallback(
@@ -142,13 +165,13 @@ function McpToolCallsTable({
   const handleProfileFilterChange = useCallback(
     (value: string) => {
       setProfileFilter(value);
-      setPagination((prev) => ({ ...prev, pageIndex: 0 })); // Reset to first page
+      cursorPagination.goNewest();
       updateUrlParams({
         profileId: value === "all" ? null : value,
         profileID: null,
       });
     },
-    [updateUrlParams],
+    [cursorPagination.goNewest, updateUrlParams],
   );
 
   // Date time range picker hook
@@ -157,28 +180,24 @@ function McpToolCallsTable({
     endDateFromUrl,
     onDateRangeChange: useCallback(
       ({ startDate, endDate }) => {
-        setPagination((prev) => ({ ...prev, pageIndex: 0 })); // Reset to first page
+        cursorPagination.goNewest();
         updateUrlParams({
           startDate,
           endDate,
         });
       },
-      [updateUrlParams],
+      [cursorPagination.goNewest, updateUrlParams],
     ),
   });
 
-  // Convert TanStack sorting to API format
-  const sortBy = sorting[0]?.id;
   const sortDirection = sorting[0]?.desc ? "desc" : "asc";
-  // Map UI column ids to API sort fields
-  const apiSortBy: NonNullable<
-    archestraApiTypes.GetMcpToolCallsData["query"]
-  >["sortBy"] =
-    sortBy === "method"
-      ? "method"
-      : sortBy === "createdAt"
-        ? "createdAt"
-        : undefined;
+  const handleSortingChange = useCallback(
+    (nextSorting: SortingState) => {
+      setSorting(nextSorting);
+      cursorPagination.goNewest();
+    },
+    [cursorPagination.goNewest],
+  );
 
   const {
     data: mcpToolCallsResponse,
@@ -187,9 +206,8 @@ function McpToolCallsTable({
     refetch: refetchMcpToolCalls,
   } = useMcpToolCalls({
     agentId: profileFilter !== "all" ? profileFilter : undefined,
-    limit: pagination.pageSize,
-    offset: pagination.pageIndex * pagination.pageSize,
-    sortBy: apiSortBy,
+    limit: cursorPagination.pageSize,
+    cursor: cursorPagination.cursor,
     sortDirection,
     startDate: dateTimePicker.startDateParam,
     endDate: dateTimePicker.endDateParam,
@@ -448,7 +466,7 @@ function McpToolCallsTable({
 
   const clearFilters = useCallback(() => {
     setProfileFilter("all");
-    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    cursorPagination.goNewest();
     dateTimePicker.clearDateRange();
     updateUrlParams({
       profileId: null,
@@ -456,9 +474,11 @@ function McpToolCallsTable({
       startDate: null,
       endDate: null,
       search: null,
-      page: "1",
+      cursor: null,
+      page: null,
+      pageSize: null,
     });
-  }, [dateTimePicker, updateUrlParams]);
+  }, [cursorPagination.goNewest, dateTimePicker, updateUrlParams]);
 
   // Shared date picker component
   const datePickerComponent = (
@@ -488,6 +508,8 @@ function McpToolCallsTable({
       searchFields={["tool name", "server name"]}
       paramName="search"
       className={filterSearchClass}
+      paginationMode="cursor"
+      onSearchChange={cursorPagination.goNewest}
     />
   );
 
@@ -540,22 +562,24 @@ function McpToolCallsTable({
         columns={columns}
         data={mcpToolCalls}
         hideSelectedCount
-        pagination={
+        cursorPagination={
           paginationMeta
             ? {
-                pageIndex: pagination.pageIndex,
-                pageSize: pagination.pageSize,
-                total: paginationMeta.total,
+                pageIndex: cursorPagination.pageIndex,
+                pageSize: cursorPagination.pageSize,
+                hasNext: paginationMeta.hasNext,
+                canGoNewer: cursorPagination.canGoNewer,
+                onPageSizeChange: cursorPagination.setPageSize,
+                onNewer: cursorPagination.goNewer,
+                onOlder: () =>
+                  cursorPagination.goOlder(paginationMeta.nextCursor),
               }
             : undefined
         }
         manualPagination
-        onPaginationChange={(newPagination) => {
-          setPagination(newPagination);
-        }}
         manualSorting
         sorting={sorting}
-        onSortingChange={setSorting}
+        onSortingChange={handleSortingChange}
         isLoading={isFetching}
         hasActiveFilters={hasFilters}
         emptyIcon={MessagesSquare}

--- a/platform/frontend/src/app/mcp/logs/page.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.tsx
@@ -19,12 +19,9 @@ export default async function McpGatewayLogsPageServer() {
     mcpToolCalls: {
       data: [],
       pagination: {
-        currentPage: 1,
         limit: DEFAULT_TABLE_LIMIT,
-        total: 0,
-        totalPages: 0,
+        nextCursor: null,
         hasNext: false,
-        hasPrev: false,
       },
     },
   };
@@ -35,8 +32,6 @@ export default async function McpGatewayLogsPageServer() {
       headers,
       query: {
         limit: DEFAULT_TABLE_LIMIT,
-        offset: 0,
-        sortBy: "createdAt",
         sortDirection: "desc",
       },
     });
@@ -47,12 +42,9 @@ export default async function McpGatewayLogsPageServer() {
       mcpToolCalls: mcpToolCallsResponse.data || {
         data: [],
         pagination: {
-          currentPage: 1,
           limit: DEFAULT_TABLE_LIMIT,
-          total: 0,
-          totalPages: 0,
+          nextCursor: null,
           hasNext: false,
-          hasPrev: false,
         },
       },
     };

--- a/platform/frontend/src/app/mcp/logs/page.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.tsx
@@ -32,7 +32,6 @@ export default async function McpGatewayLogsPageServer() {
       headers,
       query: {
         limit: DEFAULT_TABLE_LIMIT,
-        sortDirection: "desc",
       },
     });
     if (mcpToolCallsResponse.error) {

--- a/platform/frontend/src/components/search-input.test.tsx
+++ b/platform/frontend/src/components/search-input.test.tsx
@@ -1,14 +1,17 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SearchInput } from "./search-input";
 
 vi.mock("next/navigation");
 
+const mockPush = vi.fn();
+
 describe("SearchInput", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(useRouter).mockReturnValue({
-      push: vi.fn(),
+      push: mockPush,
     } as unknown as ReturnType<typeof useRouter>);
     vi.mocked(usePathname).mockReturnValue("/mcp/registry");
     vi.mocked(useSearchParams).mockReturnValue(
@@ -48,6 +51,31 @@ describe("SearchInput", () => {
     expect(screen.getByPlaceholderText("Search knowledge bases")).toHaveClass(
       "pl-9",
     );
+  });
+
+  it("removes cursor pagination from the URL when cursor-backed search changes", async () => {
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams(
+        "cursor=opaque&page=3&pageSize=10",
+      ) as unknown as ReturnType<typeof useSearchParams>,
+    );
+    render(
+      <SearchInput
+        placeholder="Search logs"
+        paginationMode="cursor"
+        debounceMs={0}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search logs"), {
+      target: { value: "tools" },
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/mcp/registry?search=tools", {
+        scroll: false,
+      });
+    });
   });
   /**
    * Typing used to produce no feedback at all: the debounce, the commit and the

--- a/platform/frontend/src/components/search-input.tsx
+++ b/platform/frontend/src/components/search-input.tsx
@@ -18,6 +18,7 @@ type SearchInputProps = {
   onSearchChange?: (value: string) => void;
   value?: string;
   syncQueryParams?: boolean;
+  paginationMode?: "offset" | "cursor";
   /**
    * Whether the list this box filters is currently fetching.
    *
@@ -42,6 +43,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
       onSearchChange,
       value,
       syncQueryParams = true,
+      paginationMode = "offset",
       isLoading = false,
     }: SearchInputProps,
     ref,
@@ -76,11 +78,21 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
         } else {
           params.delete(paramName);
         }
-        params.set("page", "1");
-        router.push(`${pathname}?${params.toString()}`, { scroll: false });
+        if (paginationMode === "cursor") {
+          params.delete("cursor");
+          params.delete("page");
+          params.delete("pageSize");
+        } else {
+          params.set("page", "1");
+        }
+        const query = params.toString();
+        router.push(query ? `${pathname}?${query}` : pathname, {
+          scroll: false,
+        });
       },
       [
         onSearchChange,
+        paginationMode,
         paramName,
         pathname,
         router,

--- a/platform/frontend/src/components/ui/data-table-pagination.tsx
+++ b/platform/frontend/src/components/ui/data-table-pagination.tsx
@@ -1,12 +1,27 @@
 import type { Table } from "@tanstack/react-table";
 
-import { TablePagination } from "@/components/ui/table-pagination";
+import {
+  CursorTablePagination,
+  TablePagination,
+} from "@/components/ui/table-pagination";
+
+export interface CursorPaginationState {
+  pageIndex: number;
+  pageSize: number;
+  hasNext: boolean;
+  canGoNewer: boolean;
+  onPageSizeChange: (pageSize: number) => void;
+  onNewer: () => void;
+  onOlder: () => void;
+}
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;
   totalRows?: number;
   hideSelectedCount?: boolean;
   compactPagination?: boolean;
+  cursorPagination?: CursorPaginationState;
+  rowCount?: number;
 }
 
 export function DataTablePagination<TData>({
@@ -14,11 +29,29 @@ export function DataTablePagination<TData>({
   totalRows,
   hideSelectedCount = false,
   compactPagination = false,
+  cursorPagination,
+  rowCount = 0,
 }: DataTablePaginationProps<TData>) {
   const paginationState = table.getState().pagination;
   const pageIndex = paginationState?.pageIndex ?? 0;
   const pageSize = paginationState?.pageSize ?? 10;
   const total = totalRows ?? table.getFilteredRowModel().rows.length;
+  const leftContent = hideSelectedCount ? null : (
+    <>
+      {table.getFilteredSelectedRowModel().rows.length} of{" "}
+      {table.getFilteredRowModel().rows.length} row(s) selected.
+    </>
+  );
+
+  if (cursorPagination) {
+    return (
+      <CursorTablePagination
+        {...cursorPagination}
+        rowCount={rowCount}
+        leftContent={leftContent}
+      />
+    );
+  }
 
   return (
     <TablePagination
@@ -33,14 +66,7 @@ export function DataTablePagination<TData>({
           table.setPageIndex(newPagination.pageIndex);
         }
       }}
-      leftContent={
-        hideSelectedCount ? null : (
-          <>
-            {table.getFilteredSelectedRowModel().rows.length} of{" "}
-            {table.getFilteredRowModel().rows.length} row(s) selected.
-          </>
-        )
-      }
+      leftContent={leftContent}
     />
   );
 }

--- a/platform/frontend/src/components/ui/data-table.tsx
+++ b/platform/frontend/src/components/ui/data-table.tsx
@@ -34,7 +34,10 @@ import {
 } from "@/lib/bulk-range-selection-context";
 import { cn } from "@/lib/utils";
 import { DATA_TABLE_SELECT_COLUMN_SIZE } from "./data-table.constants";
-import { DataTablePagination } from "./data-table-pagination";
+import {
+  type CursorPaginationState,
+  DataTablePagination,
+} from "./data-table-pagination";
 
 const COMPACT_ICON_COLUMN_IDS = new Set(["icon", "avatar", "select"]);
 const ACTIONS_COLUMN_ID = "actions";
@@ -52,6 +55,8 @@ interface DataTableProps<TData, TValue> {
     pageIndex: number;
     pageSize: number;
   }) => void;
+  /** Cursor pagination is intentionally separate from offset pagination. */
+  cursorPagination?: CursorPaginationState;
   manualPagination?: boolean;
   onSortingChange?: (sorting: SortingState) => void;
   manualSorting?: boolean;
@@ -124,6 +129,7 @@ export function DataTable<TData, TValue>({
   data,
   pagination,
   onPaginationChange,
+  cursorPagination,
   manualPagination = false,
   onSortingChange,
   manualSorting = false,
@@ -220,7 +226,12 @@ export function DataTable<TData, TValue>({
             pageIndex: pagination.pageIndex,
             pageSize: pagination.pageSize,
           }
-        : internalPagination,
+        : cursorPagination
+          ? {
+              pageIndex: cursorPagination.pageIndex,
+              pageSize: cursorPagination.pageSize,
+            }
+          : internalPagination,
     },
     onPaginationChange: (updater) => {
       const currentPagination = table.getState().pagination;
@@ -472,15 +483,20 @@ export function DataTable<TData, TValue>({
           </Table>
         </div>
       </div>
-      {(pagination || !manualPagination) &&
+      {(pagination || cursorPagination || !manualPagination) &&
         (!hidePaginationWhenSinglePage ||
-          (pagination?.total ?? data.length) >
-            (pagination?.pageSize ?? table.getState().pagination.pageSize)) && (
+          (cursorPagination
+            ? cursorPagination.pageIndex > 0 || cursorPagination.hasNext
+            : (pagination?.total ?? data.length) >
+              (pagination?.pageSize ??
+                table.getState().pagination.pageSize))) && (
           <DataTablePagination
             table={table}
             totalRows={pagination?.total}
             hideSelectedCount={hideSelectedCount ?? !rowSelection}
             compactPagination={compactPagination}
+            cursorPagination={cursorPagination}
+            rowCount={data.length}
           />
         )}
     </div>

--- a/platform/frontend/src/components/ui/table-pagination.tsx
+++ b/platform/frontend/src/components/ui/table-pagination.tsx
@@ -30,6 +30,19 @@ interface TablePaginationProps {
   compact?: boolean;
 }
 
+interface CursorTablePaginationProps {
+  pageIndex: number;
+  pageSize: number;
+  rowCount: number;
+  hasNext: boolean;
+  canGoNewer: boolean;
+  onPageSizeChange: (pageSize: number) => void;
+  onNewer: () => void;
+  onOlder: () => void;
+  /** Content to render on the left side (e.g., row selection count) */
+  leftContent?: React.ReactNode;
+}
+
 // --- Shared sub-components ---
 
 /** Rows-per-page selector, used by both desktop and mobile layouts */
@@ -242,5 +255,57 @@ export function TablePagination({
         </div>
       </div>
     </>
+  );
+}
+
+export function CursorTablePagination({
+  pageIndex,
+  pageSize,
+  rowCount,
+  hasNext,
+  canGoNewer,
+  onPageSizeChange,
+  onNewer,
+  onOlder,
+  leftContent,
+}: CursorTablePaginationProps) {
+  const firstRow = rowCount === 0 ? 0 : pageIndex * pageSize + 1;
+  const lastRow = rowCount === 0 ? 0 : firstRow + rowCount - 1;
+
+  return (
+    <div className="flex flex-col items-center gap-3 md:flex-row md:justify-between">
+      <div className="text-sm text-muted-foreground md:flex-1">
+        {leftContent}
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-3 md:gap-6">
+        <RowsPerPageSelect
+          pageSize={pageSize}
+          onPageSizeChange={onPageSizeChange}
+        />
+        <span className="min-w-[112px] text-center text-sm font-medium tabular-nums">
+          Showing {firstRow}&ndash;{lastRow}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onNewer}
+            disabled={!canGoNewer}
+          >
+            <ChevronLeft className="size-4" />
+            <span>Newer</span>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onOlder}
+            disabled={!hasNext}
+          >
+            <span>Older</span>
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/platform/frontend/src/lib/audit-log/audit-log.query.ts
+++ b/platform/frontend/src/lib/audit-log/audit-log.query.ts
@@ -32,7 +32,6 @@ const EMPTY_RESPONSE = (limit: number): AuditLogsResponse => ({
 export function useAuditLogs({
   limit = DEFAULT_TABLE_LIMIT,
   cursor,
-  sortDirection = "desc",
   startDate,
   endDate,
   actorId,
@@ -41,11 +40,9 @@ export function useAuditLogs({
   actorType,
   resourceType,
   resourceId,
-  search,
 }: {
   limit?: number;
   cursor?: string;
-  sortDirection?: AuditLogsQuery["sortDirection"];
   startDate?: string;
   endDate?: string;
   actorId?: string;
@@ -54,7 +51,6 @@ export function useAuditLogs({
   actorType?: AuditActorType;
   resourceType?: string;
   resourceId?: string;
-  search?: string;
 } = {}) {
   return useQuery({
     queryKey: [
@@ -62,7 +58,6 @@ export function useAuditLogs({
       {
         limit,
         cursor,
-        sortDirection,
         startDate,
         endDate,
         actorId,
@@ -71,7 +66,6 @@ export function useAuditLogs({
         actorType,
         resourceType,
         resourceId,
-        search,
       },
     ],
     queryFn: async () => {
@@ -79,7 +73,6 @@ export function useAuditLogs({
         query: {
           limit,
           ...(cursor ? { cursor } : {}),
-          ...(sortDirection ? { sortDirection } : {}),
           ...(startDate ? { startDate } : {}),
           ...(endDate ? { endDate } : {}),
           ...(actorId ? { actorId } : {}),
@@ -88,7 +81,6 @@ export function useAuditLogs({
           ...(actorType ? { actorType } : {}),
           ...(resourceType ? { resourceType } : {}),
           ...(resourceId ? { resourceId } : {}),
-          ...(search ? { search } : {}),
         },
       });
       // Screen renders its own QueryLoadError panel; don't also toast.

--- a/platform/frontend/src/lib/audit-log/audit-log.query.ts
+++ b/platform/frontend/src/lib/audit-log/audit-log.query.ts
@@ -23,18 +23,15 @@ export const AUDIT_LOG_QUERY_KEY = ["audit-logs"] as const;
 const EMPTY_RESPONSE = (limit: number): AuditLogsResponse => ({
   data: [],
   pagination: {
-    currentPage: 1,
     limit,
-    total: 0,
-    totalPages: 0,
+    nextCursor: null,
     hasNext: false,
-    hasPrev: false,
   },
 });
 
 export function useAuditLogs({
   limit = DEFAULT_TABLE_LIMIT,
-  offset = 0,
+  cursor,
   sortDirection = "desc",
   startDate,
   endDate,
@@ -47,7 +44,7 @@ export function useAuditLogs({
   search,
 }: {
   limit?: number;
-  offset?: number;
+  cursor?: string;
   sortDirection?: AuditLogsQuery["sortDirection"];
   startDate?: string;
   endDate?: string;
@@ -64,7 +61,7 @@ export function useAuditLogs({
       ...AUDIT_LOG_QUERY_KEY,
       {
         limit,
-        offset,
+        cursor,
         sortDirection,
         startDate,
         endDate,
@@ -81,7 +78,7 @@ export function useAuditLogs({
       const response = await getAuditLogs({
         query: {
           limit,
-          offset,
+          ...(cursor ? { cursor } : {}),
           ...(sortDirection ? { sortDirection } : {}),
           ...(startDate ? { startDate } : {}),
           ...(endDate ? { endDate } : {}),

--- a/platform/frontend/src/lib/hooks/use-cursor-pagination.test.ts
+++ b/platform/frontend/src/lib/hooks/use-cursor-pagination.test.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useCursorPagination } from "./use-cursor-pagination";
+
+describe("useCursorPagination", () => {
+  it("walks older with a cursor stack and returns newer without URL state", () => {
+    const { result } = renderHook(() =>
+      useCursorPagination({ defaultPageSize: 10 }),
+    );
+
+    act(() => result.current.goOlder("cursor-2"));
+    expect(result.current).toMatchObject({
+      cursor: "cursor-2",
+      pageIndex: 1,
+      canGoNewer: true,
+    });
+
+    act(() => result.current.goOlder("cursor-3"));
+    expect(result.current).toMatchObject({
+      cursor: "cursor-3",
+      pageIndex: 2,
+    });
+
+    act(() => result.current.goNewer());
+    expect(result.current).toMatchObject({
+      cursor: "cursor-2",
+      pageIndex: 1,
+    });
+
+    act(() => result.current.goNewer());
+    expect(result.current.cursor).toBeUndefined();
+    expect(result.current.pageIndex).toBe(0);
+    expect(result.current.canGoNewer).toBe(false);
+  });
+
+  it("resets the cursor stack when the page size changes", () => {
+    const { result } = renderHook(() => useCursorPagination());
+
+    act(() => result.current.goOlder("cursor-2"));
+    act(() => result.current.setPageSize(50));
+
+    expect(result.current).toMatchObject({
+      cursor: undefined,
+      pageIndex: 0,
+      pageSize: 50,
+      canGoNewer: false,
+    });
+  });
+});

--- a/platform/frontend/src/lib/hooks/use-cursor-pagination.ts
+++ b/platform/frontend/src/lib/hooks/use-cursor-pagination.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { DEFAULT_TABLE_LIMIT } from "@/consts";
+
+interface UseCursorPaginationOptions {
+  defaultPageSize?: number;
+}
+
+export function useCursorPagination({
+  defaultPageSize = DEFAULT_TABLE_LIMIT,
+}: UseCursorPaginationOptions = {}) {
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [cursorHistory, setCursorHistory] = useState<Array<string | null>>([]);
+  const [pageSize, setPageSizeState] = useState(defaultPageSize);
+
+  const goOlder = useCallback(
+    (nextCursor: string | null) => {
+      if (!nextCursor) return;
+      setCursorHistory((history) => [...history, cursor]);
+      setCursor(nextCursor);
+    },
+    [cursor],
+  );
+
+  const goNewer = useCallback(() => {
+    const previousCursor = cursorHistory.at(-1);
+    if (previousCursor === undefined) return;
+    setCursorHistory((history) => history.slice(0, -1));
+    setCursor(previousCursor);
+  }, [cursorHistory]);
+
+  const goNewest = useCallback(() => {
+    setCursorHistory([]);
+    setCursor(null);
+  }, []);
+
+  const setPageSize = useCallback((nextPageSize: number) => {
+    setPageSizeState(nextPageSize);
+    setCursorHistory([]);
+    setCursor(null);
+  }, []);
+
+  return {
+    cursor: cursor ?? undefined,
+    pageIndex: cursorHistory.length,
+    pageSize,
+    canGoNewer: cursorHistory.length > 0,
+    goOlder,
+    goNewer,
+    goNewest,
+    setPageSize,
+  };
+}

--- a/platform/frontend/src/lib/interactions/interaction.query.ts
+++ b/platform/frontend/src/lib/interactions/interaction.query.ts
@@ -178,7 +178,7 @@ export function useInteractionSessions({
   startDate,
   endDate,
   limit = DEFAULT_TABLE_LIMIT,
-  offset = 0,
+  cursor,
   initialData,
   toastOnError,
 }: {
@@ -190,7 +190,7 @@ export function useInteractionSessions({
   startDate?: string;
   endDate?: string;
   limit?: number;
-  offset?: number;
+  cursor?: string;
   initialData?: archestraApiTypes.GetInteractionSessionsResponses["200"];
   toastOnError?: boolean;
 } = {}) {
@@ -206,7 +206,7 @@ export function useInteractionSessions({
       startDate,
       endDate,
       limit,
-      offset,
+      cursor,
     ],
     queryFn: async () => {
       const response = await getInteractionSessions({
@@ -219,18 +219,15 @@ export function useInteractionSessions({
           ...(startDate ? { startDate } : {}),
           ...(endDate ? { endDate } : {}),
           limit,
-          offset,
+          ...(cursor ? { cursor } : {}),
         },
       });
       const emptyResponse = {
         data: [],
         pagination: {
-          currentPage: 1,
           limit,
-          total: 0,
-          totalPages: 0,
+          nextCursor: null,
           hasNext: false,
-          hasPrev: false,
         },
       };
 
@@ -238,7 +235,7 @@ export function useInteractionSessions({
       return response.data ?? emptyResponse;
     },
     initialData:
-      offset === 0 &&
+      !cursor &&
       limit === DEFAULT_TABLE_LIMIT &&
       !profileId &&
       !userId &&

--- a/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
@@ -59,8 +59,7 @@ export function useMcpToolCalls({
   endDate,
   search,
   limit = DEFAULT_TABLE_LIMIT,
-  offset = 0,
-  sortBy,
+  cursor,
   sortDirection = "desc",
   initialData,
 }: {
@@ -69,10 +68,7 @@ export function useMcpToolCalls({
   endDate?: string;
   search?: string;
   limit?: number;
-  offset?: number;
-  sortBy?: NonNullable<
-    archestraApiTypes.GetMcpToolCallsData["query"]
-  >["sortBy"];
+  cursor?: string;
   sortDirection?: NonNullable<
     archestraApiTypes.GetMcpToolCallsData["query"]
   >["sortDirection"];
@@ -86,8 +82,7 @@ export function useMcpToolCalls({
       endDate,
       search,
       limit,
-      offset,
-      sortBy,
+      cursor,
       sortDirection,
     ],
     queryFn: async () => {
@@ -98,8 +93,7 @@ export function useMcpToolCalls({
           ...(endDate ? { endDate } : {}),
           ...(search ? { search } : {}),
           limit,
-          offset,
-          ...(sortBy ? { sortBy } : {}),
+          ...(cursor ? { cursor } : {}),
           sortDirection,
         },
       });
@@ -109,22 +103,18 @@ export function useMcpToolCalls({
         response.data ?? {
           data: [],
           pagination: {
-            currentPage: 1,
             limit,
-            total: 0,
-            totalPages: 0,
+            nextCursor: null,
             hasNext: false,
-            hasPrev: false,
           },
         }
       );
     },
-    // Only use initialData for the first page (offset 0) with default sorting and default limit
+    // Only use initialData for the newest page with default sorting and limit.
     initialData:
-      offset === 0 &&
+      !cursor &&
       limit === DEFAULT_TABLE_LIMIT &&
       !agentId &&
-      sortBy === "createdAt" &&
       sortDirection === "desc" &&
       !startDate &&
       !endDate &&

--- a/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
@@ -55,46 +55,40 @@ const { getMcpToolCall, getMcpToolCalls } = archestraApiSdk;
 
 export function useMcpToolCalls({
   agentId,
+  mcpServerName,
   startDate,
   endDate,
-  search,
   limit = DEFAULT_TABLE_LIMIT,
   cursor,
-  sortDirection = "desc",
   initialData,
 }: {
   agentId?: string;
+  mcpServerName?: string;
   startDate?: string;
   endDate?: string;
-  search?: string;
   limit?: number;
   cursor?: string;
-  sortDirection?: NonNullable<
-    archestraApiTypes.GetMcpToolCallsData["query"]
-  >["sortDirection"];
   initialData?: archestraApiTypes.GetMcpToolCallsResponses["200"];
 } = {}) {
   return useQuery({
     queryKey: [
       "mcpToolCalls",
       agentId,
+      mcpServerName,
       startDate,
       endDate,
-      search,
       limit,
       cursor,
-      sortDirection,
     ],
     queryFn: async () => {
       const response = await getMcpToolCalls({
         query: {
           ...(agentId ? { agentId } : {}),
+          ...(mcpServerName ? { mcpServerName } : {}),
           ...(startDate ? { startDate } : {}),
           ...(endDate ? { endDate } : {}),
-          ...(search ? { search } : {}),
           limit,
           ...(cursor ? { cursor } : {}),
-          sortDirection,
         },
       });
       // Screen renders its own QueryLoadError panel; don't also toast.
@@ -115,10 +109,9 @@ export function useMcpToolCalls({
       !cursor &&
       limit === DEFAULT_TABLE_LIMIT &&
       !agentId &&
-      sortDirection === "desc" &&
+      !mcpServerName &&
       !startDate &&
-      !endDate &&
-      !search
+      !endDate
         ? initialData
         : undefined,
   });

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -6272,7 +6272,7 @@ export const hardResetMcpServer = <ThrowOnError extends boolean = false>(options
 export const reloadMcpServerTools = <ThrowOnError extends boolean = false>(options: Options<ReloadMcpServerToolsData, ThrowOnError>) => (options.client ?? client).post<ReloadMcpServerToolsResponses, ReloadMcpServerToolsErrors, ThrowOnError>({ url: '/api/mcp_server/{id}/reload-tools', ...options });
 
 /**
- * Get all MCP tool calls with pagination and sorting
+ * Get all MCP tool calls with cursor pagination
  *
  * Authentication:
  *

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -23614,7 +23614,7 @@ export type GetAuditLogsData = {
         search?: string;
         sortDirection?: 'asc' | 'desc';
         limit?: number;
-        offset?: number;
+        cursor?: string;
     };
     url: '/api/audit-logs';
 };
@@ -23721,12 +23721,9 @@ export type GetAuditLogsResponses = {
             impersonatedByEmail: string | null;
         }>;
         pagination: {
-            currentPage: number;
             limit: number;
-            total: number;
-            totalPages: number;
+            nextCursor: string | null;
             hasNext: boolean;
-            hasPrev: boolean;
         };
     };
 };
@@ -48321,7 +48318,7 @@ export type GetInteractionSessionsData = {
          */
         endDate?: string;
         limit?: number;
-        offset?: number;
+        cursor?: string;
     };
     url: '/api/interactions/sessions';
 };
@@ -48441,12 +48438,9 @@ export type GetInteractionSessionsResponses = {
             claudeCodeTitle: string | null;
         }>;
         pagination: {
-            currentPage: number;
             limit: number;
-            total: number;
-            totalPages: number;
+            nextCursor: string | null;
             hasNext: boolean;
-            hasPrev: boolean;
         };
     };
 };
@@ -72448,8 +72442,7 @@ export type GetMcpToolCallsData = {
          */
         search?: string;
         limit?: number;
-        offset?: number;
-        sortBy?: 'createdAt' | 'agentId' | 'mcpServerName' | 'method';
+        cursor?: string;
         sortDirection?: 'asc' | 'desc';
     };
     url: '/api/mcp-tool-calls';
@@ -72552,12 +72545,9 @@ export type GetMcpToolCallsResponses = {
             appName: string | null;
         }>;
         pagination: {
-            currentPage: number;
             limit: number;
-            total: number;
-            totalPages: number;
+            nextCursor: string | null;
             hasNext: boolean;
-            hasPrev: boolean;
         };
     };
 };

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -23608,11 +23608,6 @@ export type GetAuditLogsData = {
          * Filter by resource ID (e.g. a specific agent's ID)
          */
         resourceId?: string;
-        /**
-         * Case-insensitive search across actor email, actor name, HTTP path, resource ID, and resource name
-         */
-        search?: string;
-        sortDirection?: 'asc' | 'desc';
         limit?: number;
         cursor?: string;
     };
@@ -72438,12 +72433,11 @@ export type GetMcpToolCallsData = {
          */
         endDate?: string;
         /**
-         * Free-text search across MCP server name, tool name, and arguments (case-insensitive)
+         * Filter by exact MCP server name
          */
-        search?: string;
+        mcpServerName?: string;
         limit?: number;
         cursor?: string;
-        sortDirection?: 'asc' | 'desc';
     };
     url: '/api/mcp-tool-calls';
 };

--- a/platform/shared/pagination.ts
+++ b/platform/shared/pagination.ts
@@ -61,3 +61,74 @@ export function calculatePaginationMeta(
     hasPrev: currentPage > 1,
   };
 }
+
+// ===========================================================================
+// Cursor pagination
+// ===========================================================================
+//
+// A second, opt-in mode that sits alongside the offset mode above rather than
+// replacing it. Offset pagination stays the default: it is simpler, it lets
+// someone jump to a page, and on a table of a few thousand rows the count
+// that powers the pager is cheap.
+//
+// It stops being cheap on the log tables, which only ever grow. There the
+// total is a scan of every row on each page load purely to render "Page 1 of
+// N", and an offset lets a caller ask for a page so deep the query has to
+// group and sort the entire table before discarding almost all of it. A
+// cursor removes both at once: no total to compute, and no way to express a
+// deep page, because a cursor is opaque and only ever comes from the response
+// before it.
+//
+// An endpoint picks one mode. Most stay on offset.
+
+/**
+ * Query parameters for a cursor-paginated endpoint.
+ *
+ * Deliberately carries no `offset`. An endpoint on this schema cannot be
+ * asked for an arbitrary page: zod strips unknown keys, so a hand-written
+ * `?page=8500&offset=87000` is dropped and the request serves the newest
+ * rows. That guard belongs here rather than in the UI, because the API is
+ * reachable without it.
+ */
+export const CursorQuerySchema = z.object({
+  /** Number of items per page (default: 20, max: 100) */
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  /**
+   * Opaque position taken from a previous response's `nextCursor`. Omit it
+   * for the first (newest) page. Never build one by hand: the encoding is an
+   * implementation detail and may change.
+   */
+  cursor: z.string().optional(),
+});
+
+/**
+ * Pagination metadata for a cursor-paginated response.
+ *
+ * No `total` and no `totalPages`, which is the whole point — producing either
+ * costs a scan of the table. A null `nextCursor` is how a client learns it
+ * has reached the end, and it comes from reading one row more than the page
+ * needs rather than from counting anything.
+ */
+export const CursorPaginationMetaSchema = z.object({
+  /** Number of items per page */
+  limit: z.number().int().min(1),
+  /** Position to pass back for the next page, or null at the end */
+  nextCursor: z.string().nullable(),
+  /** Whether another page exists */
+  hasNext: z.boolean(),
+});
+
+export type CursorQuery = z.infer<typeof CursorQuerySchema>;
+export type CursorPaginationMeta = z.infer<typeof CursorPaginationMetaSchema>;
+
+/**
+ * Generic cursor-paginated response wrapper. Mirrors
+ * {@link createPaginatedResponseSchema} so a route swaps one for the other.
+ */
+export const createCursorPaginatedResponseSchema = <T extends z.ZodTypeAny>(
+  itemSchema: T,
+) =>
+  z.object({
+    data: z.array(itemSchema),
+    pagination: CursorPaginationMetaSchema,
+  });


### PR DESCRIPTION
## Why

Offset pagination stays unchanged for ordinary tables, but it scales poorly for the three append-only log views. Each page previously paid for a total count, and deep LLM session pages could fall back to grouping the full interactions table.

Cursor pagination removes both costs. The cursor is opaque, comes only from the previous response, and uses the existing time-and-ID indexes, so this requires no migration.

## What changed

- Added cursor query/response schemas and pagination helpers alongside the existing offset utilities.
- Moved LLM sessions, MCP tool calls, and audit logs to stable newest-first keyset pagination with an ID tie-breaker.
- Selected LLM sessions by their newest interaction so each session appears exactly once without a deep offset walk.
- Added a reusable cursor table footer and wired all three log pages to Newer / Older navigation, page-size changes, and filter resets.
- Kept cursor history in local UI state. Filters remain shareable, while legacy cursor, page, and pageSize parameters are removed from log URLs.
- Replaced MCP log free-text search with an exact, searchable MCP server picker that uses catalog identity when available and still represents servers found only in retained logs.
- Kept audit filtering structured and removed its broad free-text search.
- Regenerated the OpenAPI document and API client.

## Deliberate behavior changes

- These three endpoints no longer return a total, so their pages do not show page counts or offer a last-page jump.
- Reloading a log page returns to the newest results because cursor history is transient.
- Old page / offset inputs are ignored and serve the newest page.
- MCP and audit logs are fixed to newest-first time order; their API and table sorting controls are removed.
- MCP server filtering is exact rather than a broad scan across server names, tools, and arguments.

## Validation

Seeded 45 local records for each log type and traversed every page forward and back in the running app. The final-page button states, page-size reset, empty-access state, cursor-free URLs, and searchable MCP server picker were verified in the UI. Behavior tests cover identical timestamps, LLM sessions that straddle a page boundary, malformed cursors, terminal cursors, access filtering, fixed newest-first ordering, retired query inputs, and exact MCP server filtering.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>