### PR TITLE
fix(frontend): smooth Agent execution terminal history

### DIFF
--- a/platform/frontend/src/app/chat/executions/page.client.test.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.test.tsx
@@ -20,6 +20,7 @@ const cancelState = vi.hoisted(() => ({
 const terminalState = vi.hoisted(() => ({
   props: null as {
     taskId: string;
+    title?: string;
     showManualCommand?: boolean;
     showDisconnectedStatus?: boolean;
     onCommandChange?: (command: string | null) => void;
@@ -164,6 +165,29 @@ describe("BackgroundExecutionChatSession", () => {
     expect(
       screen.queryByRole("button", { name: "Stop" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps an attached terminal frame mounted when the execution completes", () => {
+    queryState.value.data = execution({
+      state: "TASK_STATE_WORKING",
+      endedAt: null,
+    });
+    const { rerender } = render(
+      <BackgroundExecutionChatSession taskId="task-1" />,
+    );
+    act(() => terminalState.props?.onCommandChange?.("kubectl exec example"));
+
+    queryState.value.data = execution({
+      state: "TASK_STATE_COMPLETED",
+      endedAt: "2026-08-28T18:00:00.000Z",
+    });
+    rerender(<BackgroundExecutionChatSession taskId="task-1" />);
+
+    expect(screen.getByText("Live terminal task-1")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Retained execution output"),
+    ).not.toBeInTheDocument();
+    expect(terminalState.props?.title).toBe("Output");
   });
 });
 

--- a/platform/frontend/src/app/chat/executions/page.client.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.tsx
@@ -38,6 +38,9 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
   const [connectionCommand, setConnectionCommand] = useState<string | null>(
     null,
   );
+  const [liveTerminalTaskId, setLiveTerminalTaskId] = useState<string | null>(
+    null,
+  );
   const [commandCopied, setCommandCopied] = useState(false);
   const execution = query.data;
 
@@ -55,6 +58,8 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
   }
 
   const live = !execution || execution.endedAt === null;
+  const preserveLiveTerminal = liveTerminalTaskId === taskId;
+  const showLiveTerminal = live || preserveLiveTerminal;
 
   return (
     <main className="flex h-full min-h-0 flex-col bg-background">
@@ -135,14 +140,17 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
       </header>
 
       <section className="flex min-h-0 flex-1 flex-col p-4 md:p-6">
-        {live ? (
+        {showLiveTerminal ? (
           <AgentExecutionTerminal
             taskId={taskId}
             active
-            title="Live terminal"
+            title={live ? "Live terminal" : "Output"}
             showManualCommand={false}
             showDisconnectedStatus={false}
-            onCommandChange={setConnectionCommand}
+            onCommandChange={(command) => {
+              setConnectionCommand(command);
+              if (command) setLiveTerminalTaskId(taskId);
+            }}
             onClosed={() => void query.refetch()}
           />
         ) : execution ? (

--- a/platform/frontend/src/components/exec/exec-terminal.test.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const terminalHarness = vi.hoisted(() => {
   return {
+    write: vi.fn(),
     dataHandler: null as ((data: string) => void) | null,
     resizeHandler: null as
       | ((dimensions: { cols: number; rows: number }) => void)
@@ -24,7 +25,7 @@ vi.mock("@xterm/xterm", () => ({
     loadAddon() {}
     open() {}
     dispose() {}
-    write() {}
+    write = terminalHarness.write;
     onData(handler: (data: string) => void) {
       terminalHarness.dataHandler = handler;
     }
@@ -65,6 +66,7 @@ describe("ExecTerminal", () => {
     terminalHarness.resizeHandler = null;
     terminalHarness.resizeObserverCallback = null;
     terminalHarness.proposedDimensions = { cols: 80, rows: 24 };
+    terminalHarness.write.mockReset();
   });
 
   it("waits for a usable terminal grid before opening the remote session", async () => {
@@ -271,6 +273,79 @@ describe("ExecTerminal", () => {
       "\x1b[<0;8;12M\x1b[<32;9;12M",
     );
     expect(transport.sendInput).toHaveBeenCalledTimes(2);
+  });
+
+  it("accelerates remote wheel scrolling without changing keyboard input", async () => {
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        handlers.onStarted(null);
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(
+      <ExecTerminal sessionKey="task-wheel" transport={transport} isActive />,
+    );
+    await screen.findByText("Connected");
+
+    terminalHarness.emitData("\x1b[<64;5;18M");
+    terminalHarness.emitData("j");
+
+    expect(transport.sendInput).toHaveBeenNthCalledWith(
+      1,
+      "\x1b[<64;5;18M".repeat(3),
+    );
+    expect(transport.sendInput).toHaveBeenNthCalledWith(2, "j");
+  });
+
+  it("does not render tmux's exit notice into the completed frame", async () => {
+    const session: { handlers: ExecSessionHandlers | null } = {
+      handlers: null,
+    };
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        session.handlers = handlers;
+        handlers.onStarted(null);
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(
+      <ExecTerminal sessionKey="task-exit" transport={transport} isActive />,
+    );
+    await screen.findByText("Connected");
+
+    act(() => session.handlers?.onOutput("done\r\n[exited]\r\n"));
+
+    expect(terminalHarness.write).toHaveBeenCalledWith("done");
+  });
+
+  it("keeps the last TUI frame when tmux exits its alternate screen", async () => {
+    const session: { handlers: ExecSessionHandlers | null } = {
+      handlers: null,
+    };
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        session.handlers = handlers;
+        handlers.onStarted(null);
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(
+      <ExecTerminal sessionKey="task-exit" transport={transport} isActive />,
+    );
+    await screen.findByText("Connected");
+
+    act(() => session.handlers?.onOutput("\u001b[?1049l\r\n[exited]\r\n"));
+
+    expect(terminalHarness.write).not.toHaveBeenCalled();
   });
 
   it("can retain the terminal frame without adding a disconnected banner", async () => {

--- a/platform/frontend/src/components/exec/exec-terminal.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.tsx
@@ -166,6 +166,7 @@ export function ExecTerminal({
           cursor: "#34d399",
         },
         scrollback: 5000,
+        scrollSensitivity: TERMINAL_SCROLL_SENSITIVITY,
       });
 
       terminal.loadAddon(fitAddon);
@@ -227,7 +228,8 @@ export function ExecTerminal({
           },
           onOutput: (data) => {
             if (disposed) return;
-            terminal.write(data);
+            const output = withoutTmuxExitNotice(data);
+            if (output) terminal.write(output);
           },
           onError: (message) => {
             if (disposed) return;
@@ -244,7 +246,7 @@ export function ExecTerminal({
       };
 
       terminal.onData((data) => {
-        const input = withoutMouseHoverReports(data);
+        const input = normalizeTerminalInput(data);
         if (input) transportRef.current.sendInput(input);
       });
 
@@ -393,14 +395,46 @@ export function ExecTerminal({
 // visible `^[[<35;...M` text. Hover has no useful terminal action, so drop only
 // motion reports whose low button bits mean "no button". Clicks, button drags,
 // wheel events, and ordinary keyboard input continue to the remote PTY.
-function withoutMouseHoverReports(data: string): string {
+function normalizeTerminalInput(data: string): string {
   return data.replace(SGR_MOUSE_REPORT_PATTERN, (report, encodedButton) => {
     const button = Number(encodedButton);
     const isMotion = (button & 32) !== 0;
     const hasNoButton = (button & 3) === 3;
-    return isMotion && hasNoButton ? "" : report;
+    if (isMotion && hasNoButton) return "";
+
+    // tmux owns scrolling while a TUI has mouse reporting enabled. One report
+    // per browser wheel tick makes its copy-mode history feel much slower than
+    // the rest of the app, so give wheel reports a modest boost. Clicks,
+    // drags, and keyboard input remain byte-for-byte unchanged.
+    const isWheel = (button & 64) !== 0;
+    return isWheel ? report.repeat(REMOTE_WHEEL_SCROLL_MULTIPLIER) : report;
   });
+}
+
+function withoutTmuxExitNotice(data: string): string {
+  const exitNoticeIndex = data.indexOf(TMUX_EXIT_NOTICE);
+  if (exitNoticeIndex === -1) return data;
+
+  // tmux can put the alternate-screen teardown and its own `[exited]` notice
+  // in the same final chunk. Replaying the teardown replaces the useful TUI
+  // frame with the empty shell screen just before the socket closes. Keep any
+  // output before that teardown and let the execution header convey the end.
+  const alternateScreenExitIndex = data.lastIndexOf(
+    ALTERNATE_SCREEN_EXIT_SEQUENCE,
+    exitNoticeIndex,
+  );
+  const visibleOutput = data.slice(
+    0,
+    alternateScreenExitIndex === -1
+      ? exitNoticeIndex
+      : alternateScreenExitIndex,
+  );
+  return visibleOutput.replace(/\r?\n$/, "");
 }
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: ESC begins every SGR mouse report.
 const SGR_MOUSE_REPORT_PATTERN = /\x1b\[<(\d+);\d+;\d+[Mm]/g;
+const TMUX_EXIT_NOTICE = "[exited]";
+const ALTERNATE_SCREEN_EXIT_SEQUENCE = "\u001b[?1049l";
+const REMOTE_WHEEL_SCROLL_MULTIPLIER = 3;
+const TERMINAL_SCROLL_SENSITIVITY = 3;

--- a/platform/frontend/src/components/terminal-playback.test.tsx
+++ b/platform/frontend/src/components/terminal-playback.test.tsx
@@ -11,6 +11,7 @@ const { terminal, fit, dimensions, proposeDimensions } = vi.hoisted(() => {
       open: vi.fn(),
       reset: vi.fn(),
       write: vi.fn(),
+      options: [] as unknown[],
     },
     fit: vi.fn(),
     dimensions,
@@ -22,6 +23,9 @@ let resizeObserverCallback: ResizeObserverCallback | undefined;
 
 vi.mock("@xterm/xterm", () => ({
   Terminal: class Terminal {
+    constructor(options: unknown) {
+      terminal.options.push(options);
+    }
     dispose = terminal.dispose;
     loadAddon = terminal.loadAddon;
     open = terminal.open;
@@ -44,6 +48,7 @@ describe("TerminalPlayback", () => {
     vi.clearAllMocks();
     dimensions.current = { cols: 120, rows: 40 };
     resizeObserverCallback = undefined;
+    terminal.options.length = 0;
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
       callback(0);
       return 0;
@@ -70,7 +75,9 @@ describe("TerminalPlayback", () => {
     dimensions.current = { cols: 120, rows: 40 };
     act(() => resizeObserverCallback?.([], {} as unknown as ResizeObserver));
 
-    expect(terminal.write).toHaveBeenCalledWith("captured frame\u001b[?25l");
+    expect(terminal.write).toHaveBeenCalledWith(
+      `captured frame${readOnlyTerminalState}`,
+    );
   });
 
   it("replays raw terminal controls and appends streamed bytes", async () => {
@@ -78,24 +85,61 @@ describe("TerminalPlayback", () => {
     const { rerender } = render(<TerminalPlayback content={firstFrame} />);
 
     await waitFor(() =>
-      expect(terminal.write).toHaveBeenCalledWith(`${firstFrame}\u001b[?25l`),
+      expect(terminal.write).toHaveBeenCalledWith(
+        `${firstFrame}${readOnlyTerminalState}`,
+      ),
     );
 
     await act(() =>
       rerender(<TerminalPlayback content={`${firstFrame}\r\nReady`} />),
     );
-    expect(terminal.write).toHaveBeenLastCalledWith("\r\nReady\u001b[?25l");
+    expect(terminal.write).toHaveBeenLastCalledWith(
+      `\r\nReady${readOnlyTerminalState}`,
+    );
     expect(terminal.reset).not.toHaveBeenCalled();
   });
 
   it("resets the emulated screen when the transcript is replaced", async () => {
     const { rerender } = render(<TerminalPlayback content="first task" />);
     await waitFor(() =>
-      expect(terminal.write).toHaveBeenCalledWith("first task\u001b[?25l"),
+      expect(terminal.write).toHaveBeenCalledWith(
+        `first task${readOnlyTerminalState}`,
+      ),
     );
 
     await act(() => rerender(<TerminalPlayback content="replacement" />));
     expect(terminal.reset).toHaveBeenCalledOnce();
-    expect(terminal.write).toHaveBeenLastCalledWith("replacement\u001b[?25l");
+    expect(terminal.write).toHaveBeenLastCalledWith(
+      `replacement${readOnlyTerminalState}`,
+    );
+  });
+
+  it("replays the retained frame when its grid dimensions change", async () => {
+    render(<TerminalPlayback content="captured frame" />);
+    await waitFor(() => expect(terminal.write).toHaveBeenCalledOnce());
+
+    dimensions.current = { cols: 90, rows: 30 };
+    act(() => resizeObserverCallback?.([], {} as unknown as ResizeObserver));
+
+    expect(terminal.reset).toHaveBeenCalledOnce();
+    expect(terminal.write).toHaveBeenLastCalledWith(
+      `captured frame${readOnlyTerminalState}`,
+    );
+  });
+
+  it("keeps retained playback locally scrollable", async () => {
+    render(<TerminalPlayback content="captured frame" />);
+    await waitFor(() => expect(terminal.write).toHaveBeenCalledOnce());
+
+    expect(terminal.options.at(-1)).toMatchObject({
+      disableStdin: true,
+      scrollSensitivity: 3,
+    });
+    expect(terminal.write).toHaveBeenCalledWith(
+      expect.stringContaining("\u001b[?1003l"),
+    );
   });
 });
+
+const readOnlyTerminalState =
+  "\u001b[?25l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l";

--- a/platform/frontend/src/components/terminal-playback.tsx
+++ b/platform/frontend/src/components/terminal-playback.tsx
@@ -39,6 +39,7 @@ export function TerminalPlayback({ content }: { content: string }) {
         fontFamily:
           "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
         scrollback: 5000,
+        scrollSensitivity: TERMINAL_SCROLL_SENSITIVITY,
         theme: {
           background: "#020617",
           foreground: "#34d399",
@@ -51,22 +52,35 @@ export function TerminalPlayback({ content }: { content: string }) {
       terminal.open(containerRef.current);
       let layoutReady = false;
       let rendered = false;
+      let renderedDimensions: { cols: number; rows: number } | null = null;
 
       const fitAndRender = () => {
         if (disposed) return;
         const dims = fitAddon.proposeDimensions();
         if (!layoutReady || !isUsableTerminalDimensions(dims)) return;
+        const dimensionsChanged =
+          renderedDimensions !== null &&
+          (renderedDimensions.cols !== dims.cols ||
+            renderedDimensions.rows !== dims.rows);
         try {
           fitAddon.fit();
         } catch {
           return;
         }
         if (!rendered) {
-          terminal.write(withHiddenCursor(contentRef.current));
+          terminal.write(withReadOnlyTerminalState(contentRef.current));
           renderedContentRef.current = contentRef.current;
           terminalRef.current = terminal;
           rendered = true;
+        } else if (dimensionsChanged) {
+          // A live TUI redraws after a PTY resize. A retained one cannot, so
+          // replay its byte stream into the new grid instead of reflowing a
+          // screen full of absolute cursor positions from the old dimensions.
+          terminal.reset();
+          terminal.write(withReadOnlyTerminalState(contentRef.current));
+          renderedContentRef.current = contentRef.current;
         }
+        renderedDimensions = dims;
       };
 
       resizeObserver = new ResizeObserver(() => {
@@ -108,10 +122,10 @@ export function TerminalPlayback({ content }: { content: string }) {
 
     const rendered = renderedContentRef.current;
     if (content.startsWith(rendered)) {
-      terminal.write(withHiddenCursor(content.slice(rendered.length)));
+      terminal.write(withReadOnlyTerminalState(content.slice(rendered.length)));
     } else {
       terminal.reset();
-      terminal.write(withHiddenCursor(content));
+      terminal.write(withReadOnlyTerminalState(content));
     }
     renderedContentRef.current = content;
   }, [content]);
@@ -129,8 +143,10 @@ export function TerminalPlayback({ content }: { content: string }) {
 
 // ===================== internals =====================
 
-const HIDE_CURSOR_SEQUENCE = "\u001b[?25l";
+const READ_ONLY_TERMINAL_STATE =
+  "\u001b[?25l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l";
+const TERMINAL_SCROLL_SENSITIVITY = 3;
 
-function withHiddenCursor(content: string): string {
-  return `${content}${HIDE_CURSOR_SEQUENCE}`;
+function withReadOnlyTerminalState(content: string): string {
+  return `${content}${READ_ONLY_TERMINAL_STATE}`;
 }


### PR DESCRIPTION
## Problem

Agent execution terminals scroll too slowly while a TUI owns mouse input. When a live execution finishes, tmux can also replace the useful final frame with its shutdown notice before the page swaps to a separate retained renderer. Retained playback can capture wheel input and become visually corrupted when its container changes dimensions.

## Approach

- Accelerate only remote mouse-wheel reports and normal xterm scrollback, preserving keyboard, click, and drag input.
- Keep an attached live terminal mounted as execution metadata settles, and suppress tmux shutdown cleanup that would erase the final TUI frame.
- Force completed playback into read-only local-scroll mode after every write and replay the recording into a new grid after layout changes instead of reflowing absolute cursor positions.