### PR TITLE
fix(runners): use 1M context for Claude Code

### DIFF
--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
@@ -1,5 +1,6 @@
 import {
   hasArchestraTokenPrefix,
+  resolveClaudeContextVariant,
   type SupportedProvider,
   stripClaudeContextVariantSuffix,
 } from "@archestra/shared";
@@ -124,9 +125,6 @@ function headerValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
-/** The window size the `[1m]` context-variant marker names. */
-const ONE_MILLION_TOKEN_CONTEXT = 1_000_000;
-
 export function extractBearerToken(
   authorization: string | string[] | undefined,
 ): string | undefined {
@@ -184,7 +182,6 @@ export async function appendClaudeContextVariants(
   const withVariants: ModelInfo[] = [];
   for (const model of models) {
     withVariants.push(model);
-    const variantId = `${model.id}[1m]`;
     // Resolved, not raw: an admin-set window is a statement about what this
     // model's endpoint actually serves, and it is what the rest of the
     // platform sizes against.
@@ -192,11 +189,11 @@ export async function appendClaudeContextVariants(
     const contextLength = catalogRow
       ? ModelModel.resolveArchitecturalContextLength(catalogRow)
       : null;
-    if (
-      contextLength != null &&
-      contextLength >= ONE_MILLION_TOKEN_CONTEXT &&
-      !listedIds.has(variantId)
-    ) {
+    const variantId = resolveClaudeContextVariant({
+      modelId: model.id,
+      contextLength,
+    });
+    if (variantId !== model.id && !listedIds.has(variantId)) {
       withVariants.push({
         ...model,
         id: variantId,

--- a/platform/backend/src/services/runners/launch-spec.test.ts
+++ b/platform/backend/src/services/runners/launch-spec.test.ts
@@ -401,6 +401,8 @@ describe("buildRunnerLaunchSpec", () => {
   }) => {
     const setup = await makeConfiguredAgent({
       provider: "anthropic",
+      modelId: "claude-opus-4-8",
+      contextLength: 1_000_000,
       makeOrganization,
       makeAdmin,
       makeMember,
@@ -457,6 +459,12 @@ describe("buildRunnerLaunchSpec", () => {
     );
     expect(spec.secretEnv.ANTHROPIC_CUSTOM_HEADERS).toMatch(
       /X-Archestra-Virtual-Key: arch_/,
+    );
+    expect(spec.env.ARCHESTRA_AGENT_BACKGROUND_EXECUTION_MODEL).toBe(
+      "claude-opus-4-8",
+    );
+    expect(spec.env.ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NATIVE_MODEL).toBe(
+      "claude-opus-4-8[1m]",
     );
 
     const virtualKey = await VirtualApiKeyModel.findById(virtualApiKeyId);
@@ -665,6 +673,7 @@ describe("buildRunnerLaunchSpec", () => {
 async function makeConfiguredAgent(params: {
   provider: SupportedProvider;
   modelId?: string;
+  contextLength?: number;
   makeOrganization: () => Promise<{ id: string }>;
   makeAdmin: () => Promise<User>;
   makeMember: (
@@ -706,6 +715,7 @@ async function makeConfiguredAgent(params: {
     modelId,
     inputModalities: ["text"],
     outputModalities: ["text"],
+    contextLength: params.contextLength,
     supportsToolCalling: true,
     lastSyncedAt: new Date(),
   });

--- a/platform/backend/src/services/runners/launch-spec.ts
+++ b/platform/backend/src/services/runners/launch-spec.ts
@@ -6,6 +6,7 @@ import {
   providerDisplayNames,
   requiresOpenAiResponsesApi,
   requiresResponsesApi,
+  resolveClaudeContextVariant,
   SESSION_ID_HEADER,
   SUBSCRIPTION_CREDENTIALS,
   type SubscriptionCredentialKind,
@@ -143,13 +144,14 @@ export async function buildRunnerLaunchSpec(params: {
     userId: actorUserId ?? "system",
     includeMemberChatDefault: false,
   });
+  const selectedModel = llm.modelId
+    ? await ModelModel.findById(llm.modelId)
+    : null;
   assertInferenceProtocolSupported({
     protocol: params.deployment.inferenceProtocol,
     provider: llm.selectedProvider,
     model: llm.selectedModel,
-    supportedEndpoints: llm.modelId
-      ? (await ModelModel.findById(llm.modelId))?.supportedEndpoints
-      : null,
+    supportedEndpoints: selectedModel?.supportedEndpoints,
   });
 
   const claudeCodeSubscriptionToken =
@@ -228,6 +230,14 @@ export async function buildRunnerLaunchSpec(params: {
     params.deployment.inferenceProtocol !== "anthropic"
       ? `${llm.selectedProvider}:${llm.selectedModel}`
       : llm.selectedModel;
+  const nativeModel = isClaudeCodeRuntime
+    ? resolveClaudeContextVariant({
+        modelId: llm.selectedModel,
+        contextLength: selectedModel
+          ? ModelModel.resolveArchitecturalContextLength(selectedModel)
+          : null,
+      })
+    : llm.selectedModel;
   const nonSecretEnv: Record<string, string> = {
     // The runner's own environment goes first: the addresses below must win.
     // An entry overriding ANTHROPIC_BASE_URL would be exactly the bypass the
@@ -245,7 +255,7 @@ export async function buildRunnerLaunchSpec(params: {
     // capability detection. Their single-provider virtual key keeps this
     // unambiguous at the Model Router while the generic runner retains the
     // qualified model id above.
-    ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NATIVE_MODEL: llm.selectedModel,
+    ARCHESTRA_AGENT_BACKGROUND_EXECUTION_NATIVE_MODEL: nativeModel,
     ARCHESTRA_AGENT_BACKGROUND_EXECUTION_MODEL_PROVIDER: llm.selectedProvider,
     ARCHESTRA_AGENT_BACKGROUND_EXECUTION_MODE: params.executionMode,
     ARCHESTRA_AGENT_BACKGROUND_EXECUTION_BANNER: executionBanner(

--- a/platform/shared/model-constants.test.ts
+++ b/platform/shared/model-constants.test.ts
@@ -10,6 +10,7 @@ import {
   providerDisplayNames,
   providerSearchTerms,
   requiresOpenAiResponsesApi,
+  resolveClaudeContextVariant,
   SMALL_MODEL_MAX_PARAMETERS,
   stripClaudeContextVariantSuffix,
 } from "./model-constants";
@@ -233,6 +234,44 @@ describe("stripClaudeContextVariantSuffix", () => {
     expect(stripClaudeContextVariantSuffix("claude-[1m]-opus")).toBe(
       "claude-[1m]-opus",
     );
+  });
+});
+
+describe("resolveClaudeContextVariant", () => {
+  test("selects the explicit 1M variant for a Claude model with a 1M window", () => {
+    expect(
+      resolveClaudeContextVariant({
+        modelId: "claude-opus-4-8",
+        contextLength: 1_000_000,
+      }),
+    ).toBe("claude-opus-4-8[1m]");
+  });
+
+  test("leaves smaller, unknown, non-Claude, and already-marked models unchanged", () => {
+    expect(
+      resolveClaudeContextVariant({
+        modelId: "claude-haiku-4-5",
+        contextLength: 200_000,
+      }),
+    ).toBe("claude-haiku-4-5");
+    expect(
+      resolveClaudeContextVariant({
+        modelId: "claude-uncatalogued",
+        contextLength: null,
+      }),
+    ).toBe("claude-uncatalogued");
+    expect(
+      resolveClaudeContextVariant({
+        modelId: "gpt-5.4",
+        contextLength: 1_000_000,
+      }),
+    ).toBe("gpt-5.4");
+    expect(
+      resolveClaudeContextVariant({
+        modelId: "claude-opus-4-8[1m]",
+        contextLength: 1_000_000,
+      }),
+    ).toBe("claude-opus-4-8[1m]");
   });
 });
 

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -871,6 +871,31 @@ export const CACHE_PRICE_MULTIPLIERS: Partial<
  * such as the `[1m]` in `claude-opus-4-8[1m]`.
  */
 const CLAUDE_CONTEXT_VARIANT_SUFFIX = /\[\d+[km]\]$/i;
+const ONE_MILLION_TOKEN_CONTEXT = 1_000_000;
+
+/**
+ * Select Claude's explicit 1M client variant when the model's catalogued
+ * architectural window supports it.
+ *
+ * Claude Code cannot infer subscription entitlements behind an LLM gateway,
+ * so callers that know the model serves 1M tokens must name the `[1m]`
+ * variant. Models with a smaller or unknown window retain their original id.
+ */
+export function resolveClaudeContextVariant(params: {
+  modelId: string;
+  contextLength: number | null;
+}): string {
+  if (
+    !/claude/i.test(params.modelId) ||
+    stripClaudeContextVariantSuffix(params.modelId) !== params.modelId ||
+    params.contextLength == null ||
+    params.contextLength < ONE_MILLION_TOKEN_CONTEXT
+  ) {
+    return params.modelId;
+  }
+
+  return `${params.modelId}[1m]`;
+}
 
 /**
  * Drop a client-side context-variant marker from a Claude model id.


### PR DESCRIPTION
## Summary

The maintained Claude Code background runtime passed the canonical base model id directly to the CLI. Behind an LLM gateway, Claude Code cannot infer subscription entitlement from that id and uses the smaller context window.

This change selects the explicit `[1m]` client variant when the catalog records a one-million-token architectural window. It keeps the canonical model id unchanged for proxy routing, attribution, and pricing, and shares the same resolver with Anthropic model discovery so launch and discovery cannot drift.

## Validation

A runner launch-spec integration test configures a 1M Anthropic model with a personal Claude Code subscription and observes the base model in the canonical execution environment plus the `[1m]` variant in the native CLI environment. Existing proxy-listing coverage continues to verify that only eligible Claude models advertise the long-context variant.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>