### PR TITLE
fix(frontend): make retained execution output scrollable

### DIFF
--- a/platform/frontend/src/components/terminal-playback.test.tsx
+++ b/platform/frontend/src/components/terminal-playback.test.tsx
@@ -12,6 +12,7 @@ const { terminal, fit, dimensions, proposeDimensions } = vi.hoisted(() => {
       reset: vi.fn(),
       write: vi.fn(),
       options: [] as unknown[],
+      registerCsiHandler: vi.fn(),
     },
     fit: vi.fn(),
     dimensions,
@@ -31,6 +32,7 @@ vi.mock("@xterm/xterm", () => ({
     open = terminal.open;
     reset = terminal.reset;
     write = terminal.write;
+    parser = { registerCsiHandler: terminal.registerCsiHandler };
   },
 }));
 
@@ -132,12 +134,25 @@ describe("TerminalPlayback", () => {
     await waitFor(() => expect(terminal.write).toHaveBeenCalledOnce());
 
     expect(terminal.options.at(-1)).toMatchObject({
+      convertEol: true,
       disableStdin: true,
+      scrollback: 50_000,
       scrollSensitivity: 3,
     });
     expect(terminal.write).toHaveBeenCalledWith(
       expect.stringContaining("\u001b[?1003l"),
     );
+
+    const setModeHandler = terminal.registerCsiHandler.mock.calls.find(
+      ([identifier]) => identifier.final === "h",
+    )?.[1];
+    const resetModeHandler = terminal.registerCsiHandler.mock.calls.find(
+      ([identifier]) => identifier.final === "l",
+    )?.[1];
+
+    expect(setModeHandler?.([1049])).toBe(true);
+    expect(resetModeHandler?.([47])).toBe(true);
+    expect(setModeHandler?.([25])).toBe(false);
   });
 });
 

--- a/platform/frontend/src/components/terminal-playback.tsx
+++ b/platform/frontend/src/components/terminal-playback.tsx
@@ -5,8 +5,8 @@ import { isUsableTerminalDimensions } from "./exec/exec-terminal.utils";
 
 /**
  * Replays a captured PTY byte stream through xterm so cursor movement, clears,
- * alternate-screen updates, and colour changes produce the same terminal
- * frame the user saw while the execution was live.
+ * and colour changes retain the terminal's live structure while completed
+ * output remains readable and scrollable.
  */
 export function TerminalPlayback({ content }: { content: string }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -32,13 +32,16 @@ export function TerminalPlayback({ content }: { content: string }) {
 
       const fitAddon = new FitAddon();
       const terminal = new Terminal({
-        convertEol: false,
+        // Retained logs can contain bare line feeds from the container log
+        // stream. Treat them as complete newlines so playback does not carry
+        // the previous line's cursor column into the next one.
+        convertEol: true,
         cursorBlink: false,
         disableStdin: true,
         fontSize: 12,
         fontFamily:
           "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
-        scrollback: 5000,
+        scrollback: RETAINED_SCROLLBACK_LINES,
         scrollSensitivity: TERMINAL_SCROLL_SENSITIVITY,
         theme: {
           background: "#020617",
@@ -47,6 +50,20 @@ export function TerminalPlayback({ content }: { content: string }) {
         },
       });
       initializedTerminal = terminal;
+
+      // Full-screen TUIs use the alternate screen because a live terminal
+      // should leave no history behind when they exit. That is exactly the
+      // wrong behavior for a retained recording: xterm cannot scroll an
+      // alternate buffer. Keep replay on the normal buffer so lines pushed
+      // above the viewport remain available to the reader.
+      terminal.parser.registerCsiHandler(
+        { prefix: "?", final: "h" },
+        containsAlternateScreenMode,
+      );
+      terminal.parser.registerCsiHandler(
+        { prefix: "?", final: "l" },
+        containsAlternateScreenMode,
+      );
 
       terminal.loadAddon(fitAddon);
       terminal.open(containerRef.current);
@@ -131,10 +148,10 @@ export function TerminalPlayback({ content }: { content: string }) {
   }, [content]);
 
   return (
-    <div className="min-h-0 flex-1 bg-slate-950 p-4 pb-2">
+    <div className="flex min-h-0 flex-1 overflow-hidden bg-slate-950 p-4 pb-2">
       <div
         ref={containerRef}
-        className="h-full"
+        className="min-h-0 flex-1 overflow-hidden"
         data-testid="terminal-playback"
       />
     </div>
@@ -145,8 +162,16 @@ export function TerminalPlayback({ content }: { content: string }) {
 
 const READ_ONLY_TERMINAL_STATE =
   "\u001b[?25l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l";
+const ALTERNATE_SCREEN_MODES = new Set([47, 1047, 1049]);
+const RETAINED_SCROLLBACK_LINES = 50_000;
 const TERMINAL_SCROLL_SENSITIVITY = 3;
 
 function withReadOnlyTerminalState(content: string): string {
   return `${content}${READ_ONLY_TERMINAL_STATE}`;
+}
+
+function containsAlternateScreenMode(params: (number | number[])[]): boolean {
+  return params.some(
+    (param) => typeof param === "number" && ALTERNATE_SCREEN_MODES.has(param),
+  );
 }


### PR DESCRIPTION
## Problem

Completed background executions can leave xterm in its alternate-screen buffer. That buffer intentionally has no history, so the post-run view cannot scroll upward. Bare line feeds in retained container output can also carry the previous cursor column forward, producing uneven line starts.

## Approach

Keep retained playback in xterm’s normal history buffer while preserving cursor movement and ANSI color rendering. Normalize bare line feeds as complete newlines, expand the retained history to cover the one-megabyte server-side log limit, and explicitly bound the xterm viewport inside the console.

The live interactive terminal is unchanged.

## Validation

A real Chromium playback with an alternate-screen recording and 100 output lines remained in the normal buffer, retained 91 scrollback lines in a 10-row viewport, and moved upward on a wheel gesture. The focused component test pins alternate-screen suppression and newline/history settings; the full frontend suite also passes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>