### PR TITLE
feat(chat): redesign suggested prompt actions

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -36,7 +36,7 @@ import { CreateProjectFromChatDialog } from "@/app/_parts/create-project-from-ch
 import { scheduledRunContext } from "@/app/_parts/scheduled-run-sidebar.utils";
 import { AgentExecutionCredentialPrompt } from "@/components/agent-execution-credential-prompt";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
-import { Suggestion } from "@/components/ai-elements/suggestion";
+import { Suggestion, Suggestions } from "@/components/ai-elements/suggestion";
 import { ApiKeyLoadError } from "@/components/api-key-load-error";
 import { AppLogo } from "@/components/app-logo";
 import {
@@ -3710,7 +3710,7 @@ export function ChatPageContent({
                         const prompts = currentAgent?.suggestedPrompts;
                         if (!prompts || prompts.length === 0) return null;
                         return (
-                          <div className="flex flex-wrap items-center justify-center gap-2 max-w-2xl">
+                          <Suggestions aria-label="Suggested prompts">
                             {prompts.map((sp) => (
                               <Suggestion
                                 key={`${sp.summaryTitle}-${sp.prompt}`}
@@ -3732,7 +3732,7 @@ export function ChatPageContent({
                                 }}
                               />
                             ))}
-                          </div>
+                          </Suggestions>
                         );
                       })()}
                       <div className="w-full max-w-4xl space-y-3">

--- a/platform/frontend/src/components/ai-elements/suggestion.tsx
+++ b/platform/frontend/src/components/ai-elements/suggestion.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowRight } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import type { ComponentProps } from "react";
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
@@ -15,7 +15,7 @@ export const Suggestions = ({
 }: SuggestionsProps) => (
   <fieldset
     className={cn(
-      "m-0 grid min-w-0 w-full max-w-xl grid-cols-2 gap-x-4 border-0 p-0 sm:gap-x-8",
+      "m-0 flex max-w-[34rem] flex-wrap justify-center gap-1 border-0 p-0",
       className,
     )}
     {...props}
@@ -45,7 +45,7 @@ export const Suggestion = ({
   return (
     <Button
       className={cn(
-        "group h-auto min-h-11 w-full cursor-pointer justify-between rounded-none border-b border-border/60 px-1 py-2.5 text-left font-normal text-muted-foreground hover:bg-transparent hover:text-foreground active:translate-y-px dark:hover:bg-transparent",
+        "group h-8 max-w-full cursor-pointer gap-1.5 rounded-md px-2.5 text-[13px] font-normal text-muted-foreground hover:bg-muted/60 hover:text-foreground active:translate-y-px",
         className,
       )}
       onClick={handleClick}
@@ -54,10 +54,10 @@ export const Suggestion = ({
       variant={variant}
       {...props}
     >
-      <span className="min-w-0 text-pretty">{children || suggestion}</span>
-      <ArrowRight
+      <span className="min-w-0 truncate">{children || suggestion}</span>
+      <ArrowUpRight
         aria-hidden="true"
-        className="size-3.5 shrink-0 opacity-40 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:opacity-80 group-focus-visible:translate-x-0.5 group-focus-visible:opacity-80 motion-reduce:transition-none"
+        className="size-3 shrink-0 opacity-35 transition-[opacity,transform] duration-150 group-hover:-translate-y-px group-hover:translate-x-px group-hover:opacity-70 group-focus-visible:-translate-y-px group-focus-visible:translate-x-px group-focus-visible:opacity-70 motion-reduce:transition-none"
       />
     </Button>
   );

--- a/platform/frontend/src/components/ai-elements/suggestion.tsx
+++ b/platform/frontend/src/components/ai-elements/suggestion.tsx
@@ -1,24 +1,27 @@
 "use client";
 
+import { ArrowRight } from "lucide-react";
 import type { ComponentProps } from "react";
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 
-export type SuggestionsProps = ComponentProps<typeof ScrollArea>;
+export type SuggestionsProps = ComponentProps<"fieldset">;
 
 export const Suggestions = ({
   className,
   children,
   ...props
 }: SuggestionsProps) => (
-  <ScrollArea className={cn("w-full overflow-x-auto", className)} {...props}>
-    <div className="flex flex-wrap items-center justify-center gap-2">
-      {children}
-    </div>
-    <ScrollBar className="hidden" orientation="horizontal" />
-  </ScrollArea>
+  <fieldset
+    className={cn(
+      "m-0 grid min-w-0 w-full max-w-xl grid-cols-2 gap-x-4 border-0 p-0 sm:gap-x-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </fieldset>
 );
 
 export type SuggestionProps = Omit<ComponentProps<typeof Button>, "onClick"> & {
@@ -30,7 +33,7 @@ export const Suggestion = ({
   suggestion,
   onClick,
   className,
-  variant = "outline",
+  variant = "ghost",
   size = "sm",
   children,
   ...props
@@ -41,14 +44,21 @@ export const Suggestion = ({
 
   return (
     <Button
-      className={cn("cursor-pointer rounded-full px-4", className)}
+      className={cn(
+        "group h-auto min-h-11 w-full cursor-pointer justify-between rounded-none border-b border-border/60 px-1 py-2.5 text-left font-normal text-muted-foreground hover:bg-transparent hover:text-foreground active:translate-y-px dark:hover:bg-transparent",
+        className,
+      )}
       onClick={handleClick}
       size={size}
       type="button"
       variant={variant}
       {...props}
     >
-      {children || suggestion}
+      <span className="min-w-0 text-pretty">{children || suggestion}</span>
+      <ArrowRight
+        aria-hidden="true"
+        className="size-3.5 shrink-0 opacity-40 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:opacity-80 group-focus-visible:translate-x-0.5 group-focus-visible:opacity-80 motion-reduce:transition-none"
+      />
     </Button>
   );
 };


### PR DESCRIPTION
## Summary

The empty chat screen currently renders an agent’s suggested prompts as a generic outline-pill cloud. This makes useful starting actions look like badges and gives the splash a boilerplate component-library feel.

This replaces that cloud with a responsive two-column action list. Prompts now use open spacing, quiet dividers, left-aligned labels, and a directional cue with restrained hover, focus, press, and reduced-motion states. Prompt submission and analytics behavior are unchanged.

## Verification

Loaded `/chat` through the local Tilt stack. Next rendered the route successfully and fetched the organization appearance settings. The repository pre-commit checks also pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>