### PR TITLE
fix(frontend): center execution terminal states

### DIFF
--- a/platform/frontend/src/app/chat/executions/page.client.test.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.test.tsx
@@ -106,10 +106,14 @@ describe("BackgroundExecutionChatSession", () => {
 
     render(<BackgroundExecutionChatSession taskId="task-1" />);
 
-    // Rendered as a status line (like the attach loader), not a red error card.
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Only the person who started this run can attach to it.",
-    );
+    // Rendered as an informational terminal state, not a generic error card.
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("Terminal unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Only the person who started this run can attach to it.",
+      ),
+    ).toBeInTheDocument();
     // The old full-page error card is gone.
     expect(
       screen.queryByText("Couldn't load this execution"),
@@ -241,6 +245,7 @@ describe("BackgroundExecutionChatSession", () => {
     expect(
       screen.getByText(/viewing its terminal output in read-only mode/i),
     ).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Read-only terminal");
     // None of the owner-only controls are rendered.
     expect(
       screen.queryByRole("button", { name: "Stop" }),

--- a/platform/frontend/src/app/chat/executions/page.client.tsx
+++ b/platform/frontend/src/app/chat/executions/page.client.tsx
@@ -9,7 +9,6 @@ import {
   TerminalSquare,
 } from "lucide-react";
 import Link from "next/link";
-import type { ReactNode } from "react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { AgentExecutionLogs } from "@/components/agent-execution-logs";
@@ -18,6 +17,7 @@ import { AgentExecutionTerminal } from "@/components/agent-execution-terminal";
 import { AgentIcon } from "@/components/agent-icon";
 import { ShareAgentExecutionDialog } from "@/components/chat/share-agent-execution-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
+import { ExecTerminalStatus } from "@/components/exec/exec-terminal-progress";
 import { StandardDialog } from "@/components/standard-dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -58,10 +58,11 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
     // of the loader's progress steps.
     return (
       <main className="flex h-full min-h-0 flex-col bg-background p-4 md:p-6">
-        <div className="flex flex-1 items-center justify-center rounded-md border bg-slate-950 p-6">
-          <output className="max-w-sm text-center text-sm font-medium text-slate-100">
-            Only the person who started this run can attach to it.
-          </output>
+        <div className="flex min-h-0 flex-1 overflow-hidden rounded-md border bg-slate-950">
+          <ExecTerminalStatus
+            title="Terminal unavailable"
+            detail="Only the person who started this run can attach to it."
+          />
         </div>
       </main>
     );
@@ -175,10 +176,13 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
         ) : execution ? (
           <>
             {live && (
-              <TerminalNotice>
-                Only the person who started this run can attach to it. You're
-                viewing its terminal output in read-only mode.
-              </TerminalNotice>
+              <div className="shrink-0 overflow-hidden rounded-md border bg-slate-950">
+                <ExecTerminalStatus
+                  title="Read-only terminal"
+                  detail="Only the person who started this run can attach to it. You're viewing its terminal output in read-only mode."
+                  compact
+                />
+              </div>
             )}
             <AgentExecutionLogs execution={execution} />
           </>
@@ -239,18 +243,5 @@ export function BackgroundExecutionChatSession({ taskId }: { taskId: string }) {
         </div>
       </StandardDialog>
     </main>
-  );
-}
-
-/**
- * An info line styled like the terminal box's own error/status messages
- * (`rounded-md border bg-slate-950`, red monospace) so access notices read as
- * part of the terminal surface instead of a mismatched page-level card.
- */
-function TerminalNotice({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex shrink-0 items-center justify-center rounded-md border bg-slate-950 p-4 text-center font-mono text-sm text-red-400">
-      {children}
-    </div>
   );
 }

--- a/platform/frontend/src/components/exec/exec-terminal-progress.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal-progress.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { AgentRunAttachPhase } from "@archestra/shared";
-import { Check, CircleAlert, Loader2 } from "lucide-react";
+import { Check, CircleAlert, Info, Loader2, TriangleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 
@@ -12,20 +12,6 @@ export type ExecSessionProgress = {
   detail: string | null;
   resourceName: string | null;
 };
-
-/**
- * The waits an attach goes through, as a person would describe them.
- *
- * Several protocol phases collapse into one step: "queued" and "scheduling"
- * are both "we do not have a machine yet", and splitting them would show a
- * step that ticks over without anything having visibly happened.
- */
-const STEPS: { label: string; phases: AgentRunAttachPhase[] }[] = [
-  { label: "Scheduling onto a node", phases: ["queued", "scheduling"] },
-  { label: "Pulling the agent image", phases: ["pulling"] },
-  { label: "Starting the agent session", phases: ["starting"] },
-  { label: "Opening the terminal", phases: ["attaching"] },
-];
 
 /**
  * Startup progress for a background execution's terminal.
@@ -137,7 +123,85 @@ export function ExecTerminalProgress({
   );
 }
 
+/** A terminal-sized status for waits, errors, and informational notices. */
+export function ExecTerminalStatus({
+  title,
+  detail,
+  tone = "info",
+  compact = false,
+}: {
+  title: string;
+  detail?: string | null;
+  tone?: "info" | "loading" | "warning" | "error";
+  compact?: boolean;
+}) {
+  const Icon =
+    tone === "loading"
+      ? Loader2
+      : tone === "error"
+        ? CircleAlert
+        : tone === "warning"
+          ? TriangleAlert
+          : Info;
+
+  return (
+    <div
+      role={tone === "error" ? "alert" : "status"}
+      className={cn(
+        "flex min-h-0 flex-1 items-center justify-center p-6",
+        compact && "flex-none p-4",
+      )}
+    >
+      <div
+        className={cn(
+          "flex w-full max-w-sm flex-col items-center gap-3 text-center",
+          compact && "max-w-xl flex-row text-left",
+        )}
+      >
+        <div
+          className={cn(
+            "flex size-9 shrink-0 items-center justify-center rounded-lg border bg-slate-900",
+            tone === "error" && "border-red-400/20 text-red-400",
+            tone === "warning" && "border-amber-400/20 text-amber-400",
+            (tone === "info" || tone === "loading") &&
+              "border-slate-800 text-slate-300",
+          )}
+        >
+          <Icon
+            className={cn(
+              "size-4",
+              tone === "loading" && "animate-spin motion-reduce:animate-none",
+            )}
+          />
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-slate-100">{title}</p>
+          {detail ? (
+            <p className="break-words text-xs leading-relaxed text-slate-400">
+              {detail}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ===================== internals =====================
+
+/**
+ * The waits an attach goes through, as a person would describe them.
+ *
+ * Several protocol phases collapse into one step: "queued" and "scheduling"
+ * are both "we do not have a machine yet", and splitting them would show a
+ * step that ticks over without anything having visibly happened.
+ */
+const STEPS: { label: string; phases: AgentRunAttachPhase[] }[] = [
+  { label: "Scheduling onto a node", phases: ["queued", "scheduling"] },
+  { label: "Pulling the agent image", phases: ["pulling"] },
+  { label: "Starting the agent session", phases: ["starting"] },
+  { label: "Opening the terminal", phases: ["attaching"] },
+];
 
 function StepIcon({ state }: { state: "done" | "active" | "pending" }) {
   if (state === "done") {

--- a/platform/frontend/src/components/exec/exec-terminal.test.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.test.tsx
@@ -216,7 +216,58 @@ describe("ExecTerminal", () => {
 
     render(<ExecTerminal sessionKey="task-3" transport={transport} isActive />);
 
-    expect(await screen.findByText("Connecting...")).toBeInTheDocument();
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Connecting to the terminal",
+    );
+  });
+
+  it("explains a failed attach as an accessible terminal error", async () => {
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        handlers.onError(
+          "Timed out waiting for the Agent pod to accept a terminal",
+        );
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(
+      <ExecTerminal sessionKey="task-error" transport={transport} isActive />,
+    );
+
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Unable to open the terminal")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Timed out waiting for the Agent pod to accept a terminal",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("separates a closed session's summary from its reason", async () => {
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        handlers.onClosed("The pod stopped responding");
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(
+      <ExecTerminal
+        sessionKey="task-closed"
+        transport={transport}
+        isActive
+        disconnectedLabel="Execution finished"
+      />,
+    );
+
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("Execution finished")).toBeInTheDocument();
+    expect(screen.getByText("The pod stopped responding")).toBeInTheDocument();
   });
 
   it("drops the startup progress once the session is live", async () => {

--- a/platform/frontend/src/components/exec/exec-terminal.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.tsx
@@ -10,6 +10,7 @@ import { isUsableTerminalDimensions } from "./exec-terminal.utils";
 import {
   type ExecSessionProgress,
   ExecTerminalProgress,
+  ExecTerminalStatus,
 } from "./exec-terminal-progress";
 
 type ConnectionStatus =
@@ -292,16 +293,6 @@ export function ExecTerminal({
     };
   }, [isActive, sessionKey, cleanup]);
 
-  const statusText = {
-    idle: "",
-    connecting: "Connecting...",
-    connected: "",
-    disconnected: closedReason
-      ? `${disconnectedLabel} — ${closedReason}`
-      : disconnectedLabel,
-    error: errorMessage || "Connection error",
-  }[status];
-
   const [commandCopied, setCommandCopied] = useState(false);
 
   const handleCopyCommand = useCallback(async () => {
@@ -330,21 +321,35 @@ export function ExecTerminal({
                 startedAt={connectingSince}
               />
             ) : (
-              <div className="flex items-center justify-center p-4 text-slate-400 text-sm font-mono">
-                {statusText}
-              </div>
+              <ExecTerminalStatus
+                title="Connecting to the terminal"
+                tone="loading"
+              />
             ))}
-          {(status === "error" ||
-            (status === "disconnected" && showDisconnectedStatus)) && (
-            <div
-              className={`flex items-center justify-center p-4 text-sm font-mono ${status === "error" ? "text-red-400" : "text-yellow-400"}`}
-            >
-              {statusText}
-            </div>
-          )}
+          {status === "error" ? (
+            <ExecTerminalStatus
+              title="Unable to open the terminal"
+              detail={errorMessage || "The terminal connection failed."}
+              tone="error"
+            />
+          ) : null}
+          {status === "disconnected" && showDisconnectedStatus ? (
+            <ExecTerminalStatus
+              title={disconnectedLabel}
+              detail={closedReason}
+              tone="warning"
+            />
+          ) : null}
           <div
             className="flex-1 min-h-0 p-4 pb-2"
-            style={{ display: status === "connecting" ? "none" : "block" }}
+            style={{
+              display:
+                status === "connecting" ||
+                status === "error" ||
+                (status === "disconnected" && showDisconnectedStatus)
+                  ? "none"
+                  : "block",
+            }}
           >
             <div ref={terminalRef} className="h-full" />
           </div>


### PR DESCRIPTION
## Summary

Background execution attach failures and informational notices were rendered as small monospace lines at the top of an otherwise empty terminal. This adds one shared terminal-state presentation that matches the existing startup progress placement, separates readable headings from technical detail, and applies the appropriate informational, warning, or error treatment.

The full terminal states now occupy and center within the available terminal surface. The live shared-view notice uses the same treatment in a compact form above read-only output.

## Validation

Exercised startup progress, connecting, attach timeout, disconnected, unavailable, and live read-only states in Chrome. Full-surface states stayed centered in both axes, and the read-only notice remained compact above retained output.