### PR TITLE
fix(deps): raise fast-uri to 3.1.6 for CVE-2026-75899/75931/75975/76172

### DIFF
--- a/platform/mcp_server_docker_image/package-lock.json
+++ b/platform/mcp_server_docker_image/package-lock.json
@@ -454,9 +454,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/platform/mcp_server_docker_image/package.json
+++ b/platform/mcp_server_docker_image/package.json
@@ -13,6 +13,6 @@
     "hono": ">=4.12.2",
     "ip-address": "10.3.1",
     "path-to-regexp": ">=8.4.0",
-    "fast-uri": "3.1.5"
+    "fast-uri": "3.1.6"
   }
 }

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -65,7 +65,7 @@ overrides:
   fast-xml-parser: 5.7.2
   fast-xml-builder: '>=1.1.7'
   samlify: '>=2.13.0'
-  fast-uri: '>=3.1.5'
+  fast-uri: '>=3.1.6 <4'
   ajv: 8.18.0
   axios: '>=1.18.0'
   minimatch: '>=10.2.3'
@@ -7817,8 +7817,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -12495,7 +12495,7 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
 
   '@fastify/cors@11.2.0':
     dependencies:
@@ -17208,7 +17208,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -18490,7 +18490,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -18506,7 +18506,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -19318,7 +19318,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -94,9 +94,11 @@ overrides:
   fast-xml-parser: 5.7.2
   fast-xml-builder: '>=1.1.7'
   samlify: '>=2.13.0'
-  # CVE-2026-16221 / CVE-2026-13676 (HIGH, interpretation conflict) fixed in
-  # 3.1.4, then CVE-2026-18446 (HIGH, same class) fixed in 3.1.5.
-  fast-uri: '>=3.1.5'
+  # CVE-2026-16221 / CVE-2026-13676 / CVE-2026-18446 / CVE-2026-75899 /
+  # CVE-2026-75931 / CVE-2026-75975 / CVE-2026-76172 (HIGH, URI parsing and
+  # validation flaws) fixed across 3.1.4-3.1.6. Keep every transitive consumer
+  # on the fully patched 3.x line.
+  fast-uri: '>=3.1.6 <4'
   ajv: 8.18.0
   # GHSA-gcfj-64vw-6mp9 (HIGH, prototype pollution) affects >=1.15.2, fixed in 1.18.0.
   axios: '>=1.18.0'


### PR DESCRIPTION
## What

Docker Scout is failing both image scans on `main` — [Platform](https://github.com/archestra-ai/archestra/actions/runs/33762498296/job/100672455035) and [MCP Server Base](https://github.com/archestra-ai/archestra/actions/runs/33762498296/job/100672455083) — with four HIGH advisories against `fast-uri`, all fixed in 3.1.6:

| CVE | Class | Affected |
| --- | --- | --- |
| CVE-2026-76172 | URI parsing | `>=3.0.0 <3.1.6` |
| CVE-2026-75975 | Improper input validation | `>=3.0.0 <3.1.6` |
| CVE-2026-75931 | Interpretation conflict | `>=3.1.3 <3.1.6` |
| CVE-2026-75899 | Double decoding of the same data | `>=3.1.2 <3.1.6` |

Each is CVSS 7.5. The existing override floor was `>=3.1.5`, which is one release short.

## Changes

- Raise the pnpm override to `>=3.1.6 <4` and refresh the comment above it to name all seven advisories this pin now covers.
- Bump the MCP server image's direct pin from `3.1.5` to `3.1.6`.
- Regenerate both lockfiles. `fast-uri` resolves to 3.1.6 in every transitive position.

The upper bound mirrors the `undici` pin: it keeps the floor from silently carrying consumers onto a 4.x major, which is not this pin's business.

## Notes

3.1.6 was published 2026-08-23, so it is past the 7-day `minimumReleaseAge` window and needs no exclusion entry. 3.1.7 exists but is a day old and stays out until it matures.

## Testing

- `pnpm install --frozen-lockfile` and `npm ci` both resolve cleanly against the regenerated lockfiles.
- `pnpm commit:check` passes across all six workspace tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>