### PR TITLE
ci: trigger website deploys via workflow_dispatch instead of Vercel deploy hook

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -364,10 +364,16 @@ jobs:
             echo "Release $TAG_NAME is already published; skipping."
           fi
 
+      # Dispatches the website repo's CLI deploy workflow. A Vercel deploy hook
+      # cannot be used: hooks create Git-integration deployments, which Vercel
+      # blocks when the website's head commit author is not a Vercel team member.
       - name: Trigger website deploy
         env:
-          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_VERCEL_DEPLOY_HOOK_URL }}
-        run: curl -fsS -X POST "$VERCEL_DEPLOY_HOOK_URL"
+          GH_TOKEN: ${{ secrets.WEBSITE_DEPLOY_GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy-to-vercel.yml \
+            --repo archestra-ai/website \
+            --ref main
 
   notify-release-failure:
     name: Notify release failure

--- a/.github/workflows/trigger-website-deploy-on-catalog-changes.yml
+++ b/.github/workflows/trigger-website-deploy-on-catalog-changes.yml
@@ -17,4 +17,4 @@ jobs:
     name: Trigger Website Deploy
     uses: ./.github/workflows/trigger-website-deploy.yml
     secrets:
-      WEBSITE_VERCEL_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_VERCEL_DEPLOY_HOOK_URL }}
+      WEBSITE_DEPLOY_GITHUB_TOKEN: ${{ secrets.WEBSITE_DEPLOY_GITHUB_TOKEN }}

--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -1,11 +1,17 @@
 name: Trigger Website Deploy
 
+# Dispatches the website repo's "Deploy to Vercel" GitHub Actions workflow,
+# which deploys production via the Vercel CLI. We can NOT use a Vercel deploy
+# hook here: deploy hooks create Git-integration deployments, and Vercel
+# blocks those whenever the website's head commit author is not a Vercel team
+# member (archestra-ai/website#659).
+
 on:
   workflow_call:
     secrets:
-      WEBSITE_VERCEL_DEPLOY_HOOK_URL:
+      WEBSITE_DEPLOY_GITHUB_TOKEN:
         required: true
-        description: Vercel deploy hook URL for the website
+        description: GitHub token with actions:write on archestra-ai/website
   workflow_dispatch:
 
 permissions: {}
@@ -19,8 +25,10 @@ jobs:
     name: Trigger Website Vercel Deploy
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Vercel Deploy Hook
+      - name: Dispatch website deploy workflow
         env:
-          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_VERCEL_DEPLOY_HOOK_URL }}
+          GH_TOKEN: ${{ secrets.WEBSITE_DEPLOY_GITHUB_TOKEN }}
         run: |
-          curl -fsS -X POST "$VERCEL_DEPLOY_HOOK_URL"
+          gh workflow run deploy-to-vercel.yml \
+            --repo archestra-ai/website \
+            --ref main


### PR DESCRIPTION
## Why

Website deploys triggered from this repo (catalog changes, releases, manual `trigger-website-deploy` runs) are stuck in **Blocked** in Vercel. The deploy hook creates Git-integration deployments, and Vercel blocks those whenever the website's head commit author is not a Vercel team member. archestra-ai/website#625 moved the website's own deploys to the Vercel CLI for exactly that reason — the hook path was left behind and is now a dead end.

## What

- `trigger-website-deploy.yml`: replace the deploy-hook `curl` with `gh workflow run deploy-to-vercel.yml --repo archestra-ai/website --ref main`
- `trigger-website-deploy-on-catalog-changes.yml`: pass the new secret through
- `release-please.yml`: same replacement for the inline post-release trigger

## Required setup before merging

Add a `WEBSITE_DEPLOY_GITHUB_TOKEN` repository secret: a fine-grained PAT or GitHub App token with **Actions: read and write** on `archestra-ai/website`. `WEBSITE_VERCEL_DEPLOY_HOOK_URL` is no longer used after this.

Companion PR (adds `workflow_dispatch` to the website deploy workflow, already open): archestra-ai/website#659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>