### PR TITLE
fix(frontend): identify MCP installs by owner

### DIFF
--- a/platform/frontend/src/app/mcp/logs/page.client.test.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.test.tsx
@@ -145,13 +145,22 @@ describe("McpGatewayLogsPage filters", () => {
     );
   });
 
-  it("filters by MCP server with a searchable icon-and-name picker", async () => {
+  it("distinguishes MCP server installations by owner instead of installation id", async () => {
     vi.mocked(useMcpServers).mockReturnValue({
       data: [
         {
-          name: "document-search-deployment",
+          name: "document-search-installation-a1b2c3",
           catalogName: "Document Search",
           catalogId: "document-search-catalog",
+          scope: "personal",
+          ownerEmail: "first.owner@example.com",
+        },
+        {
+          name: "document-search-installation-d4e5f6",
+          catalogName: "Document Search",
+          catalogId: "document-search-catalog",
+          scope: "personal",
+          ownerEmail: "second.owner@example.com",
         },
       ],
     } as unknown as ReturnType<typeof useMcpServers>);
@@ -171,13 +180,47 @@ describe("McpGatewayLogsPage filters", () => {
       screen.getByRole("combobox", { name: "Filter by MCP server" }),
     );
     expect(screen.getByPlaceholderText("Search MCP servers…")).toBeVisible();
-    expect(screen.getByText("📚")).toBeVisible();
-    await user.click(screen.getByRole("button", { name: /Document Search/ }));
+    expect(screen.getAllByText("📚")).toHaveLength(2);
+    expect(screen.getByText("first.owner@example.com")).toBeVisible();
+    expect(screen.getByText("second.owner@example.com")).toBeVisible();
+    expect(
+      screen.queryByText("document-search-installation-a1b2c3"),
+    ).toBeNull();
+    await user.click(
+      screen.getByRole("button", {
+        name: /Document Search.*first\.owner@example\.com/,
+      }),
+    );
 
     expect(push).toHaveBeenCalledWith(
-      expect.stringContaining("mcpServerName=document-search-deployment"),
+      expect.stringContaining(
+        "mcpServerName=document-search-installation-a1b2c3",
+      ),
       expect.anything(),
     );
+  });
+
+  it("uses the installation scope when an MCP server owner is unavailable", async () => {
+    vi.mocked(useMcpServers).mockReturnValue({
+      data: [
+        {
+          name: "shared-search-installation",
+          catalogName: "Document Search",
+          catalogId: "document-search-catalog",
+          scope: "org",
+          ownerEmail: null,
+        },
+      ],
+    } as unknown as ReturnType<typeof useMcpServers>);
+    const user = userEvent.setup();
+    render(<McpGatewayLogsPage />);
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Filter by MCP server" }),
+    );
+
+    expect(screen.getByText("Organization installation")).toBeVisible();
+    expect(screen.queryByText("shared-search-installation")).toBeNull();
   });
 
   it("presents the call context without separate method, server, and arguments columns", () => {

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -26,6 +26,7 @@ import { DateTimeRangePicker } from "@/components/ui/date-time-range-picker";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useProfiles } from "@/lib/agent.query";
+import { resourceOwnerLabel } from "@/lib/agent-owner-label";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useCursorPagination } from "@/lib/hooks/use-cursor-pagination";
 import { useDateTimeRangePicker } from "@/lib/hooks/use-date-time-range-picker";
@@ -235,7 +236,18 @@ function McpToolCallsTable({
         const display = serverDisplayByName.get(serverName);
         const displayName = display?.name ?? serverName;
         const secondaryLabel = installed
-          ? getMcpServerOwnerLabel(installed)
+          ? resourceOwnerLabel(
+              {
+                scope: installed.scope,
+                ownerEmail: installed.ownerEmail,
+                teamName: installed.teamDetails?.name,
+              },
+              {
+                personalFallback: "Owner unavailable",
+                teamFallback: "Team installation",
+                organization: "Organization installation",
+              },
+            )
           : "From logs";
         const icon = (
           <span
@@ -619,18 +631,6 @@ function getGatewayDisplayName(
   return (
     agent?.name ?? (row.agentId === null ? "Deleted MCP Gateway" : "Unknown")
   );
-}
-
-function getMcpServerOwnerLabel(
-  server: archestraApiTypes.GetMcpServersResponses["200"][number],
-) {
-  const ownerEmail = server.ownerEmail?.trim();
-  if (ownerEmail) return ownerEmail;
-  if (server.scope === "team") {
-    return server.teamDetails?.name?.trim() || "Team installation";
-  }
-  if (server.scope === "org") return "Organization installation";
-  return "Owner unavailable";
 }
 
 function formatMcpMethod(method: string) {

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -234,12 +234,9 @@ function McpToolCallsTable({
         const installed = installedByName.get(serverName);
         const display = serverDisplayByName.get(serverName);
         const displayName = display?.name ?? serverName;
-        const secondaryLabel =
-          displayName !== serverName
-            ? serverName
-            : installed
-              ? undefined
-              : "From logs";
+        const secondaryLabel = installed
+          ? getMcpServerOwnerLabel(installed)
+          : "From logs";
         const icon = (
           <span
             key={serverName}
@@ -255,7 +252,7 @@ function McpToolCallsTable({
         return {
           value: serverName,
           label: displayName,
-          searchText: `${displayName} ${serverName}`,
+          searchText: `${displayName} ${secondaryLabel} ${serverName}`,
           content: (
             <span className="flex min-w-0 items-center gap-2">
               {icon}
@@ -622,6 +619,18 @@ function getGatewayDisplayName(
   return (
     agent?.name ?? (row.agentId === null ? "Deleted MCP Gateway" : "Unknown")
   );
+}
+
+function getMcpServerOwnerLabel(
+  server: archestraApiTypes.GetMcpServersResponses["200"][number],
+) {
+  const ownerEmail = server.ownerEmail?.trim();
+  if (ownerEmail) return ownerEmail;
+  if (server.scope === "team") {
+    return server.teamDetails?.name?.trim() || "Team installation";
+  }
+  if (server.scope === "org") return "Organization installation";
+  return "Owner unavailable";
 }
 
 function formatMcpMethod(method: string) {

--- a/platform/frontend/src/lib/agent-owner-label.ts
+++ b/platform/frontend/src/lib/agent-owner-label.ts
@@ -74,6 +74,30 @@ export function agentOwnerLabel(agent: {
   scope: string;
   ownerEmail: string | null;
 }): string | null {
-  if (agent.scope !== "personal") return null;
-  return agent.ownerEmail;
+  return resourceOwnerLabel(agent);
+}
+
+/**
+ * Resolve a resource owner consistently while letting each surface decide how
+ * shared and unavailable ownership should be described.
+ */
+export function resourceOwnerLabel(
+  resource: {
+    scope: string;
+    ownerEmail: string | null | undefined;
+    teamName?: string | null;
+  },
+  labels: {
+    personalFallback?: string;
+    teamFallback?: string;
+    organization?: string;
+  } = {},
+): string | null {
+  if (resource.scope === "personal") {
+    return resource.ownerEmail?.trim() || labels.personalFallback || null;
+  }
+  if (resource.scope === "team") {
+    return resource.teamName?.trim() || labels.teamFallback || null;
+  }
+  return labels.organization || null;
 }


### PR DESCRIPTION
## Summary

The MCP server filter on /mcp/logs showed opaque installation names beneath repeated catalog display names, making installations difficult to distinguish.

Installed servers now show the owner email as the subtitle. When no owner email is available, the picker uses a readable team name, organization scope, or unavailable-owner fallback. The page resolves those labels through the shared resource owner-label utility. The underlying installation name remains the filter value and searchable text, so existing URLs and filtering behavior are unchanged.

## Validation

Exercised the picker with two same-named installations and confirmed each renders its distinct owner email while selecting the expected underlying installation. Also verified the ownerless organization fallback.