### PR TITLE
perf(chat): defer service icon catalog from initial load

### DIFF
--- a/platform/frontend/src/app/api/service-icons/route.test.ts
+++ b/platform/frontend/src/app/api/service-icons/route.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+describe("service icons route", () => {
+  it("serves a cacheable first page instead of the full catalog", async () => {
+    const response = GET(
+      new Request("http://localhost:3000/api/service-icons"),
+    );
+    const result = (await response.json()) as {
+      data: Array<{ title: string; slug: string }>;
+      total: number;
+    };
+
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=3600, stale-while-revalidate=86400",
+    );
+    expect(result.data).toHaveLength(120);
+    expect(result.total).toBeGreaterThan(result.data.length);
+    expect(result.data).toContainEqual(
+      expect.objectContaining({
+        title: "GitHub",
+        slug: "github",
+      }),
+    );
+  });
+
+  it("filters and paginates the catalog", async () => {
+    const response = GET(
+      new Request(
+        "http://localhost:3000/api/service-icons?q=github&offset=1&limit=2",
+      ),
+    );
+    const result = (await response.json()) as {
+      data: Array<{ title: string; slug: string }>;
+      total: number;
+    };
+
+    expect(result.total).toBeGreaterThan(1);
+    expect(result.data).toHaveLength(Math.min(2, result.total - 1));
+    expect(result.data.every((icon) => /github/i.test(icon.slug))).toBe(true);
+  });
+});

--- a/platform/frontend/src/app/api/service-icons/route.ts
+++ b/platform/frontend/src/app/api/service-icons/route.ts
@@ -1,0 +1,41 @@
+import * as simpleIcons from "simple-icons";
+import {
+  buildIconList,
+  filterIcons,
+} from "@/components/service-logo-picker.utils";
+
+const CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
+const PAGE_SIZE = 120;
+const ICONS = buildIconList(simpleIcons);
+
+export function GET(request: Request) {
+  const searchParams = new URL(request.url).searchParams;
+  const query = searchParams.get("q") ?? "";
+  const offset = parseNonNegativeInteger(searchParams.get("offset"), 0);
+  const limit = Math.max(
+    1,
+    Math.min(
+      parseNonNegativeInteger(searchParams.get("limit"), PAGE_SIZE),
+      PAGE_SIZE,
+    ),
+  );
+  const matchingIcons = filterIcons(ICONS, query);
+
+  return Response.json(
+    {
+      data: matchingIcons.slice(offset, offset + limit),
+      total: matchingIcons.length,
+    },
+    {
+      headers: {
+        "Cache-Control": CACHE_CONTROL,
+      },
+    },
+  );
+}
+
+function parseNonNegativeInteger(value: string | null, fallback: number) {
+  if (value === null) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/platform/frontend/src/components/service-logo-picker.hook.ts
+++ b/platform/frontend/src/components/service-logo-picker.hook.ts
@@ -1,0 +1,54 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import type { ServiceIcon } from "./service-logo-picker.utils";
+
+const PAGE_SIZE = 120;
+
+interface ServiceIconsResponse {
+  data: ServiceIcon[];
+  total: number;
+}
+
+export function useServiceIcons(query: string) {
+  const normalizedQuery = query.trim();
+
+  return useInfiniteQuery({
+    queryKey: ["service-icons", normalizedQuery],
+    queryFn: ({ pageParam, signal }) =>
+      fetchServiceIcons({
+        query: normalizedQuery,
+        offset: pageParam,
+        signal,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, pages) => {
+      const loadedCount = pages.reduce(
+        (count, page) => count + page.data.length,
+        0,
+      );
+      return loadedCount < lastPage.total ? loadedCount : undefined;
+    },
+    staleTime: 60 * 60 * 1000,
+  });
+}
+
+async function fetchServiceIcons({
+  query,
+  offset,
+  signal,
+}: {
+  query: string;
+  offset: number;
+  signal: AbortSignal;
+}): Promise<ServiceIconsResponse> {
+  const searchParams = new URLSearchParams({ limit: String(PAGE_SIZE) });
+  if (query) searchParams.set("q", query);
+  if (offset > 0) searchParams.set("offset", String(offset));
+
+  const response = await fetch(`/api/service-icons?${searchParams}`, {
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error("Failed to load service icons");
+  }
+  return response.json() as Promise<ServiceIconsResponse>;
+}

--- a/platform/frontend/src/components/service-logo-picker.test.tsx
+++ b/platform/frontend/src/components/service-logo-picker.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ServiceLogoPicker } from "./service-logo-picker";
@@ -35,7 +36,7 @@ describe("ServiceLogoPicker", () => {
       }),
     );
 
-    render(<ServiceLogoPicker onSelect={onSelect} />);
+    renderPicker(onSelect);
 
     expect(fetchMock).toHaveBeenCalledWith("/api/service-icons?limit=120", {
       signal: expect.any(AbortSignal),
@@ -49,8 +50,19 @@ describe("ServiceLogoPicker", () => {
   it("shows a useful fallback when the catalog cannot be loaded", async () => {
     fetchMock.mockRejectedValue(new Error("network unavailable"));
 
-    render(<ServiceLogoPicker onSelect={vi.fn()} />);
+    renderPicker(vi.fn());
 
     expect(await screen.findByText("Could not load logos")).toBeVisible();
   });
 });
+
+function renderPicker(onSelect: (dataUrl: string) => void) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ServiceLogoPicker onSelect={onSelect} />
+    </QueryClientProvider>,
+  );
+}

--- a/platform/frontend/src/components/service-logo-picker.test.tsx
+++ b/platform/frontend/src/components/service-logo-picker.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ServiceLogoPicker } from "./service-logo-picker";
+
+describe("ServiceLogoPicker", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(HTMLElement.prototype, "scrollTo");
+  });
+
+  it("loads the catalog only when the picker mounts", async () => {
+    const onSelect = vi.fn();
+    fetchMock.mockResolvedValue(
+      Response.json({
+        data: [
+          {
+            title: "GitHub",
+            slug: "github",
+            hex: "181717",
+            path: "M0 0h24v24H0z",
+          },
+        ],
+        total: 1,
+      }),
+    );
+
+    render(<ServiceLogoPicker onSelect={onSelect} />);
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/service-icons?limit=120", {
+      signal: expect.any(AbortSignal),
+    });
+    fireEvent.click(await screen.findByTitle("GitHub"));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.stringContaining("data:image/svg+xml"),
+    );
+  });
+
+  it("shows a useful fallback when the catalog cannot be loaded", async () => {
+    fetchMock.mockRejectedValue(new Error("network unavailable"));
+
+    render(<ServiceLogoPicker onSelect={vi.fn()} />);
+
+    expect(await screen.findByText("Could not load logos")).toBeVisible();
+  });
+});

--- a/platform/frontend/src/components/service-logo-picker.tsx
+++ b/platform/frontend/src/components/service-logo-picker.tsx
@@ -5,82 +5,29 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { useServiceIcons } from "./service-logo-picker.hook";
 import { iconToDataUrl, type ServiceIcon } from "./service-logo-picker.utils";
-
-const PAGE_SIZE = 120;
-
-interface ServiceIconsResponse {
-  data: ServiceIcon[];
-  total: number;
-}
 
 interface ServiceLogoPickerProps {
   onSelect: (dataUrl: string) => void;
 }
 
 export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
-  const [icons, setIcons] = useState<ServiceIcon[]>([]);
-  const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [loadFailed, setLoadFailed] = useState(false);
-  const [loadMoreFailed, setLoadMoreFailed] = useState(false);
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const requestVersionRef = useRef(0);
-
-  useEffect(() => {
-    const requestVersion = ++requestVersionRef.current;
-    const abortController = new AbortController();
-    const searchParams = new URLSearchParams({ limit: String(PAGE_SIZE) });
-    if (deferredQuery.trim()) {
-      searchParams.set("q", deferredQuery.trim());
-    }
-
-    setLoading(true);
-    setLoadingMore(false);
-    setLoadFailed(false);
-    setLoadMoreFailed(false);
-
-    fetch(`/api/service-icons?${searchParams}`, {
-      signal: abortController.signal,
-    })
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error("Failed to load service icons");
-        }
-        return response.json() as Promise<ServiceIconsResponse>;
-      })
-      .then((result) => {
-        if (requestVersion !== requestVersionRef.current) return;
-        setIcons(result.data);
-        setTotal(result.total);
-      })
-      .catch((error: unknown) => {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          return;
-        }
-        if (requestVersion === requestVersionRef.current) {
-          setLoadFailed(true);
-        }
-      })
-      .finally(() => {
-        if (
-          !abortController.signal.aborted &&
-          requestVersion === requestVersionRef.current
-        ) {
-          setLoading(false);
-        }
-      });
-
-    return () => abortController.abort();
-  }, [deferredQuery]);
+  const serviceIconsQuery = useServiceIcons(deferredQuery);
+  const icons = useMemo(
+    () => serviceIconsQuery.data?.pages.flatMap((page) => page.data) ?? [],
+    [serviceIconsQuery.data],
+  );
+  const total = serviceIconsQuery.data?.pages[0]?.total ?? 0;
 
   // Reset scroll when search changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally trigger on deferredQuery change
@@ -100,43 +47,16 @@ export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
       const el = e.currentTarget;
       const nearBottom =
         el.scrollTop + el.clientHeight >= el.scrollHeight - 100;
-      if (!nearBottom || loadingMore || icons.length >= total) return;
-
-      const searchParams = new URLSearchParams({
-        limit: String(PAGE_SIZE),
-        offset: String(icons.length),
-      });
-      if (deferredQuery.trim()) {
-        searchParams.set("q", deferredQuery.trim());
+      if (
+        !nearBottom ||
+        serviceIconsQuery.isFetchingNextPage ||
+        !serviceIconsQuery.hasNextPage
+      ) {
+        return;
       }
-
-      setLoadingMore(true);
-      setLoadMoreFailed(false);
-      const requestVersion = requestVersionRef.current;
-      fetch(`/api/service-icons?${searchParams}`)
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error("Failed to load more service icons");
-          }
-          return response.json() as Promise<ServiceIconsResponse>;
-        })
-        .then((result) => {
-          if (requestVersion !== requestVersionRef.current) return;
-          setIcons((current) => [...current, ...result.data]);
-          setTotal(result.total);
-        })
-        .catch(() => {
-          if (requestVersion === requestVersionRef.current) {
-            setLoadMoreFailed(true);
-          }
-        })
-        .finally(() => {
-          if (requestVersion === requestVersionRef.current) {
-            setLoadingMore(false);
-          }
-        });
+      void serviceIconsQuery.fetchNextPage();
     },
-    [deferredQuery, icons.length, loadingMore, total],
+    [serviceIconsQuery],
   );
 
   return (
@@ -159,11 +79,11 @@ export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
         style={{ height: 280 }}
         onScroll={handleScroll}
       >
-        {loading ? (
+        {serviceIconsQuery.isPending ? (
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
             <span>Loading logos...</span>
           </div>
-        ) : loadFailed ? (
+        ) : serviceIconsQuery.isError && icons.length === 0 ? (
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
             <span>Could not load logos</span>
           </div>
@@ -227,9 +147,9 @@ export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
             </div>
             {icons.length < total && (
               <p className="text-xs text-muted-foreground text-center py-2">
-                {loadingMore
+                {serviceIconsQuery.isFetchingNextPage
                   ? "Loading more..."
-                  : loadMoreFailed
+                  : serviceIconsQuery.isFetchNextPageError
                     ? "Could not load more logos"
                     : `Scroll for more (${total - icons.length} remaining)`}
               </p>

--- a/platform/frontend/src/components/service-logo-picker.tsx
+++ b/platform/frontend/src/components/service-logo-picker.tsx
@@ -5,18 +5,19 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import {
-  buildIconList,
-  filterIcons,
-  iconToDataUrl,
-  type ServiceIcon,
-} from "./service-logo-picker.utils";
+import { iconToDataUrl, type ServiceIcon } from "./service-logo-picker.utils";
+
+const PAGE_SIZE = 120;
+
+interface ServiceIconsResponse {
+  data: ServiceIcon[];
+  total: number;
+}
 
 interface ServiceLogoPickerProps {
   onSelect: (dataUrl: string) => void;
@@ -24,22 +25,62 @@ interface ServiceLogoPickerProps {
 
 export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
   const [icons, setIcons] = useState<ServiceIcon[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [loadMoreFailed, setLoadMoreFailed] = useState(false);
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const requestVersionRef = useRef(0);
 
   useEffect(() => {
-    import("simple-icons").then((module) => {
-      setIcons(buildIconList(module));
-      setLoading(false);
-    });
-  }, []);
+    const requestVersion = ++requestVersionRef.current;
+    const abortController = new AbortController();
+    const searchParams = new URLSearchParams({ limit: String(PAGE_SIZE) });
+    if (deferredQuery.trim()) {
+      searchParams.set("q", deferredQuery.trim());
+    }
 
-  const filtered = useMemo(
-    () => filterIcons(icons, deferredQuery),
-    [icons, deferredQuery],
-  );
+    setLoading(true);
+    setLoadingMore(false);
+    setLoadFailed(false);
+    setLoadMoreFailed(false);
+
+    fetch(`/api/service-icons?${searchParams}`, {
+      signal: abortController.signal,
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to load service icons");
+        }
+        return response.json() as Promise<ServiceIconsResponse>;
+      })
+      .then((result) => {
+        if (requestVersion !== requestVersionRef.current) return;
+        setIcons(result.data);
+        setTotal(result.total);
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        if (requestVersion === requestVersionRef.current) {
+          setLoadFailed(true);
+        }
+      })
+      .finally(() => {
+        if (
+          !abortController.signal.aborted &&
+          requestVersion === requestVersionRef.current
+        ) {
+          setLoading(false);
+        }
+      });
+
+    return () => abortController.abort();
+  }, [deferredQuery]);
 
   // Reset scroll when search changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally trigger on deferredQuery change
@@ -54,25 +95,49 @@ export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
     [onSelect],
   );
 
-  // Only render first N icons for performance, load more on scroll
-  const [visibleCount, setVisibleCount] = useState(120);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset on search change
-  useEffect(() => {
-    setVisibleCount(120);
-  }, [deferredQuery]);
-
   const handleScroll = useCallback(
     (e: React.UIEvent<HTMLDivElement>) => {
       const el = e.currentTarget;
-      if (el.scrollTop + el.clientHeight >= el.scrollHeight - 100) {
-        setVisibleCount((prev) => Math.min(prev + 120, filtered.length));
-      }
-    },
-    [filtered.length],
-  );
+      const nearBottom =
+        el.scrollTop + el.clientHeight >= el.scrollHeight - 100;
+      if (!nearBottom || loadingMore || icons.length >= total) return;
 
-  const visibleIcons = filtered.slice(0, visibleCount);
+      const searchParams = new URLSearchParams({
+        limit: String(PAGE_SIZE),
+        offset: String(icons.length),
+      });
+      if (deferredQuery.trim()) {
+        searchParams.set("q", deferredQuery.trim());
+      }
+
+      setLoadingMore(true);
+      setLoadMoreFailed(false);
+      const requestVersion = requestVersionRef.current;
+      fetch(`/api/service-icons?${searchParams}`)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error("Failed to load more service icons");
+          }
+          return response.json() as Promise<ServiceIconsResponse>;
+        })
+        .then((result) => {
+          if (requestVersion !== requestVersionRef.current) return;
+          setIcons((current) => [...current, ...result.data]);
+          setTotal(result.total);
+        })
+        .catch(() => {
+          if (requestVersion === requestVersionRef.current) {
+            setLoadMoreFailed(true);
+          }
+        })
+        .finally(() => {
+          if (requestVersion === requestVersionRef.current) {
+            setLoadingMore(false);
+          }
+        });
+    },
+    [deferredQuery, icons.length, loadingMore, total],
+  );
 
   return (
     <div className="flex flex-col">
@@ -98,7 +163,11 @@ export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
             <span>Loading logos...</span>
           </div>
-        ) : filtered.length === 0 ? (
+        ) : loadFailed ? (
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            <span>Could not load logos</span>
+          </div>
+        ) : icons.length === 0 ? (
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
             <span>No logos found</span>
           </div>
@@ -116,7 +185,7 @@ export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
               fits the large majority on one line and caps the rest at two.
             */}
             <div className="grid grid-cols-4 gap-1">
-              {visibleIcons.map((icon) => (
+              {icons.map((icon) => (
                 <button
                   key={icon.slug}
                   type="button"
@@ -156,9 +225,13 @@ export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
                 </button>
               ))}
             </div>
-            {visibleCount < filtered.length && (
+            {icons.length < total && (
               <p className="text-xs text-muted-foreground text-center py-2">
-                Scroll for more ({filtered.length - visibleCount} remaining)
+                {loadingMore
+                  ? "Loading more..."
+                  : loadMoreFailed
+                    ? "Could not load more logos"
+                    : `Scroll for more (${total - icons.length} remaining)`}
               </p>
             )}
           </>


### PR DESCRIPTION
## Why

The chat route's production HTML included the entire service-logo catalog in its initial client script graph, even though that data is only needed after opening an icon picker. That single optional dependency dominated the JavaScript payload for both new and existing conversations.

## What changed

- Keep the full service-icon package on the server instead of bundling it into the browser route.
- Add a cacheable, searchable, paginated endpoint capped at 120 icons per response.
- Load the first page only when the logo picker mounts, then fetch additional pages on scroll.
- Ignore stale responses when the search query changes and show useful initial/load-more failure states.

## Measured impact

Measured from production builds by fetching `/chat` and totaling the exact scripts referenced by its initial HTML:

| Initial `/chat` scripts | Before | After | Change |
| --- | ---: | ---: | ---: |
| Raw JavaScript | 10,366,820 B | 5,087,032 B | -50.9% |
| Gzip JavaScript | 3,638,804 B | 1,496,867 B | -58.9% |

The logo picker now fetches 129,173 B raw / 54,803 B gzip for its first 120-item page instead of loading the full ~4.9 MB catalog.