### PR TITLE
fix(frontend): raise light-mode theme chrome to WCAG contrast minimums

### DIFF
--- a/platform/frontend/src/app/themes.css
+++ b/platform/frontend/src/app/themes.css
@@ -6,6 +6,8 @@
  *
  * AUTO-GENERATED FILE - DO NOT EDIT DIRECTLY
  * Generated from shared/themes/tweakcn-themes.json
+ * Light-mode structural chrome and muted text are raised to WCAG contrast
+ * minimums by shared/themes/contrast-safe.ts; dark mode is emitted verbatim.
  * Run: pnpm codegen:theme-css
  */
 
@@ -27,8 +29,8 @@ html.theme-modern-minimal {
   --accent-foreground: oklch(0.38 0.14 265.52);
   --destructive: oklch(0.64 0.21 25.33);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.93 0.01 264.53);
-  --input: oklch(0.93 0.01 264.53);
+  --border: oklch(0.6669 0.01 264.53);
+  --input: oklch(0.6669 0.01 264.53);
   --ring: oklch(0.62 0.19 259.81);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -42,7 +44,7 @@ html.theme-modern-minimal {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.95 0.03 236.82);
   --sidebar-accent-foreground: oklch(0.38 0.14 265.52);
-  --sidebar-border: oklch(0.93 0.01 264.53);
+  --sidebar-border: oklch(0.652 0.01 264.53);
   --sidebar-ring: oklch(0.62 0.19 259.81);
   --font-sans: var(--font-inter);
   --font-serif: Source Serif 4, serif;
@@ -122,13 +124,13 @@ html.theme-clean-slate {
   --secondary: oklch(0.93 0.01 264.53);
   --secondary-foreground: oklch(0.37 0.03 259.73);
   --muted: oklch(0.97 0.00 264.54);
-  --muted-foreground: oklch(0.55 0.02 264.36);
+  --muted-foreground: oklch(0.5458 0.02 264.36);
   --accent: oklch(0.93 0.03 272.79);
   --accent-foreground: oklch(0.37 0.03 259.73);
   --destructive: oklch(0.64 0.21 25.33);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.87 0.01 258.34);
-  --input: oklch(0.87 0.01 258.34);
+  --border: oklch(0.6519 0.01 258.34);
+  --input: oklch(0.6519 0.01 258.34);
   --ring: oklch(0.59 0.20 277.12);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -142,7 +144,7 @@ html.theme-clean-slate {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.93 0.03 272.79);
   --sidebar-accent-foreground: oklch(0.37 0.03 259.73);
-  --sidebar-border: oklch(0.87 0.01 258.34);
+  --sidebar-border: oklch(0.6444 0.01 258.34);
   --sidebar-ring: oklch(0.59 0.20 277.12);
   --font-sans: var(--font-inter);
   --font-serif: var(--font-merriweather);
@@ -222,13 +224,13 @@ html.theme-mono {
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.20 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.55 0 0);
+  --muted-foreground: oklch(0.5457 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.20 0 0);
   --destructive: oklch(0.58 0.24 28.48);
   --destructive-foreground: oklch(0.97 0 0);
-  --border: oklch(0.92 0 0);
-  --input: oklch(0.92 0 0);
+  --border: oklch(0.6668 0 0);
+  --input: oklch(0.6668 0 0);
   --ring: oklch(0.71 0 0);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -242,7 +244,7 @@ html.theme-mono {
   --sidebar-primary-foreground: oklch(0.99 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.20 0 0);
-  --sidebar-border: oklch(0.92 0 0);
+  --sidebar-border: oklch(0.6594 0 0);
   --sidebar-ring: oklch(0.71 0 0);
   --font-sans: Geist Mono, monospace;
   --font-serif: Geist Mono, monospace;
@@ -327,8 +329,8 @@ html.theme-twitter {
   --accent-foreground: oklch(0.67 0.16 245.00);
   --destructive: oklch(0.62 0.24 25.77);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.93 0.01 231.66);
-  --input: oklch(0.98 0.00 228.78);
+  --border: oklch(0.6662 0.01 231.66);
+  --input: oklch(0.6668 0.00 228.78);
   --ring: oklch(0.68 0.16 243.35);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -342,7 +344,7 @@ html.theme-twitter {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.94 0.02 250.85);
   --sidebar-accent-foreground: oklch(0.67 0.16 245.00);
-  --sidebar-border: oklch(0.93 0.01 238.52);
+  --sidebar-border: oklch(0.6514 0.01 238.52);
   --sidebar-ring: oklch(0.68 0.16 243.35);
   --font-sans: var(--font-open-sans);
   --font-serif: Georgia, serif;
@@ -422,13 +424,13 @@ html.theme-tangerine {
   --secondary: oklch(0.97 0.00 264.54);
   --secondary-foreground: oklch(0.45 0.03 256.80);
   --muted: oklch(0.98 0.00 247.84);
-  --muted-foreground: oklch(0.55 0.02 264.36);
+  --muted-foreground: oklch(0.5247 0.02 264.36);
   --accent: oklch(0.91 0.02 243.82);
   --accent-foreground: oklch(0.38 0.14 265.52);
   --destructive: oklch(0.64 0.21 25.33);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.90 0.01 247.88);
-  --input: oklch(0.97 0.00 264.54);
+  --border: oklch(0.6216 0.01 247.88);
+  --input: oklch(0.622 0.00 264.54);
   --ring: oklch(0.64 0.17 36.44);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -442,7 +444,7 @@ html.theme-tangerine {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.91 0.02 243.82);
   --sidebar-accent-foreground: oklch(0.38 0.14 265.52);
-  --sidebar-border: oklch(0.93 0.01 264.53);
+  --sidebar-border: oklch(0.5917 0.01 264.53);
   --sidebar-ring: oklch(0.64 0.17 36.44);
   --font-sans: var(--font-inter);
   --font-serif: Source Serif 4, serif;
@@ -522,13 +524,13 @@ html.theme-bubblegum {
   --secondary: oklch(0.81 0.07 198.19);
   --secondary-foreground: oklch(0.32 0 0);
   --muted: oklch(0.88 0.05 212.10);
-  --muted-foreground: oklch(0.58 0 0);
+  --muted-foreground: oklch(0.4849 0 0);
   --accent: oklch(0.92 0.08 87.67);
   --accent-foreground: oklch(0.32 0 0);
   --destructive: oklch(0.71 0.17 21.96);
   --destructive-foreground: oklch(1.00 0 0);
   --border: oklch(0.62 0.18 348.14);
-  --input: oklch(0.92 0 0);
+  --input: oklch(0.6201 0 0);
   --ring: oklch(0.70 0.16 350.75);
   --chart-1: oklch(0.70 0.16 350.75);
   --chart-2: oklch(0.82 0.08 212.09);
@@ -542,7 +544,7 @@ html.theme-bubblegum {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.82 0.11 346.02);
   --sidebar-accent-foreground: oklch(0.32 0 0);
-  --sidebar-border: oklch(0.95 0.03 307.17);
+  --sidebar-border: oklch(0.5981 0.03 307.17);
   --sidebar-ring: oklch(0.66 0.21 354.31);
   --font-sans: var(--font-poppins);
   --font-serif: Lora, serif;
@@ -627,8 +629,8 @@ html.theme-caffeine {
   --accent-foreground: oklch(0.24 0 0);
   --destructive: oklch(0.58 0.19 33.34);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.88 0 0);
-  --input: oklch(0.88 0 0);
+  --border: oklch(0.652 0 0);
+  --input: oklch(0.652 0 0);
   --ring: oklch(0.43 0.04 41.99);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -642,7 +644,7 @@ html.theme-caffeine {
   --sidebar-primary-foreground: oklch(0.99 0 0);
   --sidebar-accent: oklch(0.98 0 0);
   --sidebar-accent-foreground: oklch(0.33 0 0);
-  --sidebar-border: oklch(0.94 0 0);
+  --sidebar-border: oklch(0.652 0 0);
   --sidebar-ring: oklch(0.77 0 0);
   --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
@@ -727,8 +729,8 @@ html.theme-amber-minimal {
   --accent-foreground: oklch(0.47 0.12 46.20);
   --destructive: oklch(0.64 0.21 25.33);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.93 0.01 264.53);
-  --input: oklch(0.93 0.01 264.53);
+  --border: oklch(0.6669 0.01 264.53);
+  --input: oklch(0.6669 0.01 264.53);
   --ring: oklch(0.77 0.16 70.08);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -742,7 +744,7 @@ html.theme-amber-minimal {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.99 0.02 95.28);
   --sidebar-accent-foreground: oklch(0.47 0.12 46.20);
-  --sidebar-border: oklch(0.93 0.01 264.53);
+  --sidebar-border: oklch(0.652 0.01 264.53);
   --sidebar-ring: oklch(0.77 0.16 70.08);
   --font-sans: var(--font-inter);
   --font-serif: Source Serif 4, serif;
@@ -827,8 +829,8 @@ html.theme-cosmic-night {
   --accent-foreground: oklch(0.30 0.06 282.42);
   --destructive: oklch(0.69 0.21 14.99);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.91 0.02 285.96);
-  --input: oklch(0.91 0.02 285.96);
+  --border: oklch(0.6451 0.02 285.96);
+  --input: oklch(0.6451 0.02 285.96);
   --ring: oklch(0.54 0.18 288.03);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -842,7 +844,7 @@ html.theme-cosmic-night {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.92 0.04 262.14);
   --sidebar-accent-foreground: oklch(0.30 0.06 282.42);
-  --sidebar-border: oklch(0.91 0.02 285.96);
+  --sidebar-border: oklch(0.6377 0.02 285.96);
   --sidebar-ring: oklch(0.54 0.18 288.03);
   --font-sans: var(--font-inter);
   --font-serif: Georgia, serif;
@@ -922,7 +924,7 @@ html.theme-doom-64 {
   --secondary: oklch(0.50 0.09 126.19);
   --secondary-foreground: oklch(1.00 0 0);
   --muted: oklch(0.78 0 0);
-  --muted-foreground: oklch(0.41 0 0);
+  --muted-foreground: oklch(0.4037 0 0);
   --accent: oklch(0.59 0.10 245.74);
   --accent-foreground: oklch(1.00 0 0);
   --destructive: oklch(0.71 0.20 46.46);
@@ -1022,13 +1024,13 @@ html.theme-mocha-mousse {
   --secondary: oklch(0.75 0.04 80.55);
   --secondary-foreground: oklch(1.00 0 0);
   --muted: oklch(0.85 0.04 49.09);
-  --muted-foreground: oklch(0.54 0.05 37.21);
+  --muted-foreground: oklch(0.4615 0.05 37.21);
   --accent: oklch(0.85 0.04 49.09);
   --accent-foreground: oklch(0.41 0.03 40.36);
   --destructive: oklch(0.22 0.01 52.96);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.75 0.04 80.55);
-  --input: oklch(0.75 0.04 80.55);
+  --border: oklch(0.6304 0.04 80.55);
+  --input: oklch(0.6304 0.04 80.55);
   --ring: oklch(0.61 0.06 44.36);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -1042,7 +1044,7 @@ html.theme-mocha-mousse {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.73 0.05 52.33);
   --sidebar-accent-foreground: oklch(1.00 0 0);
-  --sidebar-border: oklch(0.64 0.04 52.39);
+  --sidebar-border: oklch(0.5852 0.04 52.39);
   --sidebar-ring: oklch(0.61 0.06 44.36);
   --font-sans: var(--font-dm-sans);
   --font-serif: Georgia, serif;
@@ -1127,8 +1129,8 @@ html.theme-nature {
   --accent-foreground: oklch(0.43 0.12 144.31);
   --destructive: oklch(0.54 0.19 26.72);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.88 0.02 74.64);
-  --input: oklch(0.88 0.02 74.64);
+  --border: oklch(0.6449 0.02 74.64);
+  --input: oklch(0.6449 0.02 74.64);
   --ring: oklch(0.52 0.13 144.17);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -1142,7 +1144,7 @@ html.theme-nature {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.90 0.05 146.04);
   --sidebar-accent-foreground: oklch(0.43 0.12 144.31);
-  --sidebar-border: oklch(0.88 0.02 74.64);
+  --sidebar-border: oklch(0.6223 0.02 74.64);
   --sidebar-ring: oklch(0.52 0.13 144.17);
   --font-sans: var(--font-montserrat);
   --font-serif: var(--font-merriweather);
@@ -1222,13 +1224,13 @@ html.theme-sunset-horizon {
   --secondary: oklch(0.96 0.02 28.90);
   --secondary-foreground: oklch(0.56 0.13 32.74);
   --muted: oklch(0.97 0.02 39.40);
-  --muted-foreground: oklch(0.55 0.01 58.07);
+  --muted-foreground: oklch(0.5436 0.01 58.07);
   --accent: oklch(0.83 0.11 58.00);
   --accent-foreground: oklch(0.34 0.01 2.77);
   --destructive: oklch(0.61 0.21 22.24);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.93 0.04 38.69);
-  --input: oklch(0.93 0.04 38.69);
+  --border: oklch(0.6616 0.04 38.69);
+  --input: oklch(0.6616 0.04 38.69);
   --ring: oklch(0.74 0.16 34.71);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -1242,7 +1244,7 @@ html.theme-sunset-horizon {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.83 0.11 58.00);
   --sidebar-accent-foreground: oklch(0.34 0.01 2.77);
-  --sidebar-border: oklch(0.93 0.04 38.69);
+  --sidebar-border: oklch(0.6454 0.04 38.69);
   --sidebar-ring: oklch(0.74 0.16 34.71);
   --font-sans: var(--font-montserrat);
   --font-serif: var(--font-merriweather);
@@ -1427,8 +1429,8 @@ html.theme-vercel {
   --accent-foreground: oklch(0 0 0);
   --destructive: oklch(0.63 0.19 23.03);
   --destructive-foreground: oklch(1 0 0);
-  --border: oklch(0.92 0 0);
-  --input: oklch(0.94 0 0);
+  --border: oklch(0.6594 0 0);
+  --input: oklch(0.6594 0 0);
   --ring: oklch(0 0 0);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -1442,7 +1444,7 @@ html.theme-vercel {
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-accent: oklch(0.94 0 0);
   --sidebar-accent-foreground: oklch(0 0 0);
-  --sidebar-border: oklch(0.94 0 0);
+  --sidebar-border: oklch(0.6594 0 0);
   --sidebar-ring: oklch(0 0 0);
   --font-sans: Geist, sans-serif;
   --font-serif: Georgia, serif;
@@ -1522,13 +1524,13 @@ html.theme-claude {
   --secondary: oklch(0.92 0.01 92.99);
   --secondary-foreground: oklch(0.43 0.02 98.60);
   --muted: oklch(0.93 0.02 90.24);
-  --muted-foreground: oklch(0.61 0.01 97.42);
+  --muted-foreground: oklch(0.5174 0.01 97.42);
   --accent: oklch(0.92 0.01 92.99);
   --accent-foreground: oklch(0.27 0.02 98.94);
   --destructive: oklch(0.19 0.00 106.59);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.88 0.01 97.36);
-  --input: oklch(0.76 0.02 98.35);
+  --border: oklch(0.6519 0.01 97.36);
+  --input: oklch(0.6516 0.02 98.35);
   --ring: oklch(0.59 0.17 253.06);
   --chart-1: oklch(0.60 0.18 250);
   --chart-2: oklch(0.65 0.20 145);
@@ -1542,7 +1544,7 @@ html.theme-claude {
   --sidebar-primary-foreground: oklch(0.99 0 0);
   --sidebar-accent: oklch(0.92 0.01 92.99);
   --sidebar-accent-foreground: oklch(0.33 0 0);
-  --sidebar-border: oklch(0.94 0 0);
+  --sidebar-border: oklch(0.6447 0 0);
   --sidebar-ring: oklch(0.77 0 0);
   --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
@@ -1622,13 +1624,13 @@ html.theme-vintage-paper {
   --secondary: oklch(0.88 0.03 85.57);
   --secondary-foreground: oklch(0.43 0.03 64.93);
   --muted: oklch(0.92 0.02 83.06);
-  --muted-foreground: oklch(0.54 0.04 71.17);
+  --muted-foreground: oklch(0.5118 0.04 71.17);
   --accent: oklch(0.83 0.04 88.81);
   --accent-foreground: oklch(0.38 0.02 64.34);
   --destructive: oklch(0.55 0.14 32.91);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.86 0.03 84.59);
-  --input: oklch(0.86 0.03 84.59);
+  --border: oklch(0.6373 0.03 84.59);
+  --input: oklch(0.6373 0.03 84.59);
   --ring: oklch(0.62 0.08 65.54);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -1642,7 +1644,7 @@ html.theme-vintage-paper {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.83 0.04 88.81);
   --sidebar-accent-foreground: oklch(0.38 0.02 64.34);
-  --sidebar-border: oklch(0.86 0.03 84.59);
+  --sidebar-border: oklch(0.6069 0.03 84.59);
   --sidebar-ring: oklch(0.62 0.08 65.54);
   --font-sans: var(--font-libre-baskerville);
   --font-serif: Lora, serif;
@@ -1722,13 +1724,13 @@ html.theme-boxy-minimalistic {
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.97 0.001 106.424);
-  --muted-foreground: oklch(0.553 0.013 58.071);
+  --muted-foreground: oklch(0.5465 0.013 58.071);
   --accent: oklch(0.97 0.001 106.424);
   --accent-foreground: oklch(0.216 0.006 56.043);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(1 0 0);
-  --border: oklch(0.923 0.003 48.717);
-  --input: oklch(0.923 0.003 48.717);
+  --border: oklch(0.6671 0.003 48.717);
+  --input: oklch(0.6671 0.003 48.717);
   --ring: oklch(0.709 0.01 56.259);
   --chart-1: oklch(0.623 0.214 259.1);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -1742,7 +1744,7 @@ html.theme-boxy-minimalistic {
   --sidebar-primary-foreground: oklch(0.97 0.014 254.604);
   --sidebar-accent: oklch(0.97 0.001 106.424);
   --sidebar-accent-foreground: oklch(0.216 0.006 56.043);
-  --sidebar-border: oklch(0.923 0.003 48.717);
+  --sidebar-border: oklch(0.656 0.003 48.717);
   --sidebar-ring: oklch(0.709 0.01 56.259);
   --font-sans: var(--font-jetbrains-mono);
   --font-mono: var(--font-jetbrains-mono);
@@ -1828,8 +1830,8 @@ html.theme-catppuccin {
   --accent-foreground: oklch(0.305 0.03 263.965);
   --destructive: oklch(0.484 0.188 29.368);
   --destructive-foreground: oklch(0.969 0.014 21.071);
-  --border: oklch(0.92 0.006 264.529);
-  --input: oklch(0.895 0.008 264.52);
+  --border: oklch(0.6363 0.006 264.529);
+  --input: oklch(0.6363 0.008 264.52);
   --ring: oklch(0.554 0.25 296.956);
   --chart-1: oklch(0.554 0.25 296.956);
   --chart-2: oklch(0.771 0.057 304.762);
@@ -1843,7 +1845,7 @@ html.theme-catppuccin {
   --sidebar-primary-foreground: oklch(1 0 180);
   --sidebar-accent: oklch(0.832 0.023 264.439);
   --sidebar-accent-foreground: oklch(0.305 0.03 263.965);
-  --sidebar-border: oklch(0.92 0.006 264.529);
+  --sidebar-border: oklch(0.6235 0.006 264.529);
   --sidebar-ring: oklch(0.554 0.25 296.956);
   --font-sans: var(--font-montserrat);
   --font-serif: Georgia, serif;
@@ -1924,13 +1926,13 @@ html.theme-solarized-dark {
   --secondary: oklch(0.929 0.029 93.1);
   --secondary-foreground: oklch(0.524 0.027 202.0);
   --muted: oklch(0.929 0.029 93.1);
-  --muted-foreground: oklch(0.659 0.014 192.0);
+  --muted-foreground: oklch(0.5154 0.014 192.0);
   --accent: oklch(0.910 0.030 92.5);
   --accent-foreground: oklch(0.524 0.027 202.0);
   --destructive: oklch(0.545 0.242 27.0);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.863 0.035 93.0);
-  --input: oklch(0.863 0.035 93.0);
+  --border: oklch(0.6415 0.035 93.0);
+  --input: oklch(0.6415 0.035 93.0);
   --ring: oklch(0.572 0.152 241.0);
   --chart-1: oklch(0.572 0.152 241.0);
   --chart-2: oklch(0.620 0.107 192.5);
@@ -1944,7 +1946,7 @@ html.theme-solarized-dark {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.910 0.030 92.5);
   --sidebar-accent-foreground: oklch(0.524 0.027 202.0);
-  --sidebar-border: oklch(0.863 0.035 93.0);
+  --sidebar-border: oklch(0.6136 0.035 93.0);
   --sidebar-ring: oklch(0.572 0.152 241.0);
   --font-sans: var(--font-inter);
   --font-serif: Source Serif 4, serif;
@@ -2030,8 +2032,8 @@ html.theme-gruvbox-dark {
   --accent-foreground: oklch(0.215 0.014 52.0);
   --destructive: oklch(0.501 0.232 27.0);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.833 0.054 90.5);
-  --input: oklch(0.870 0.057 92.5);
+  --border: oklch(0.634 0.054 90.5);
+  --input: oklch(0.6338 0.057 92.5);
   --ring: oklch(0.500 0.160 82.8);
   --chart-1: oklch(0.500 0.160 82.8);
   --chart-2: oklch(0.599 0.183 44.5);
@@ -2045,7 +2047,7 @@ html.theme-gruvbox-dark {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.870 0.057 92.5);
   --sidebar-accent-foreground: oklch(0.215 0.014 52.0);
-  --sidebar-border: oklch(0.833 0.054 90.5);
+  --sidebar-border: oklch(0.5836 0.054 90.5);
   --sidebar-ring: oklch(0.500 0.160 82.8);
   --font-sans: var(--font-inter);
   --font-serif: Source Serif 4, serif;
@@ -2131,8 +2133,8 @@ html.theme-dracula-dark {
   --accent-foreground: oklch(0.267 0.025 280.0);
   --destructive: oklch(0.626 0.204 30.865);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.892 0.018 277.0);
-  --input: oklch(0.918 0.013 277.0);
+  --border: oklch(0.6479 0.018 277.0);
+  --input: oklch(0.6477 0.013 277.0);
   --ring: oklch(0.440 0.200 305.0);
   --chart-1: oklch(0.440 0.200 305.0);
   --chart-2: oklch(0.600 0.187 340.0);
@@ -2146,7 +2148,7 @@ html.theme-dracula-dark {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.944 0.018 340.0);
   --sidebar-accent-foreground: oklch(0.267 0.025 280.0);
-  --sidebar-border: oklch(0.892 0.018 277.0);
+  --sidebar-border: oklch(0.6222 0.018 277.0);
   --sidebar-ring: oklch(0.440 0.200 305.0);
   --font-sans: var(--font-inter);
   --font-serif: Source Serif 4, serif;
@@ -2232,8 +2234,8 @@ html.theme-monokai-dark {
   --accent-foreground: oklch(0.245 0.012 112.0);
   --destructive: oklch(0.613 0.243 30.277);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.876 0.024 108.5);
-  --input: oklch(0.906 0.019 108.5);
+  --border: oklch(0.6438 0.024 108.5);
+  --input: oklch(0.644 0.019 108.5);
   --ring: oklch(0.500 0.155 82.0);
   --chart-1: oklch(0.500 0.155 82.0);
   --chart-2: oklch(0.590 0.165 126.0);
@@ -2247,7 +2249,7 @@ html.theme-monokai-dark {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.942 0.016 108.0);
   --sidebar-accent-foreground: oklch(0.245 0.012 112.0);
-  --sidebar-border: oklch(0.876 0.024 108.5);
+  --sidebar-border: oklch(0.614 0.024 108.5);
   --sidebar-ring: oklch(0.500 0.155 82.0);
   --font-sans: var(--font-inter);
   --font-serif: Source Serif 4, serif;
@@ -2333,8 +2335,8 @@ html.theme-moonlight-dark {
   --accent-foreground: oklch(0.248 0.032 279.0);
   --destructive: oklch(0.600 0.236 30.033);
   --destructive-foreground: oklch(1.00 0 0);
-  --border: oklch(0.884 0.026 276.5);
-  --input: oklch(0.912 0.021 276.5);
+  --border: oklch(0.6458 0.026 276.5);
+  --input: oklch(0.6456 0.021 276.5);
   --ring: oklch(0.490 0.148 259.576);
   --chart-1: oklch(0.490 0.148 259.576);
   --chart-2: oklch(0.560 0.130 278.0);
@@ -2348,7 +2350,7 @@ html.theme-moonlight-dark {
   --sidebar-primary-foreground: oklch(1.00 0 0);
   --sidebar-accent: oklch(0.942 0.022 276.0);
   --sidebar-accent-foreground: oklch(0.248 0.032 279.0);
-  --sidebar-border: oklch(0.884 0.026 276.5);
+  --sidebar-border: oklch(0.6148 0.026 276.5);
   --sidebar-ring: oklch(0.490 0.148 259.576);
   --font-sans: var(--font-inter);
   --font-serif: Source Serif 4, serif;

--- a/platform/shared/themes/contrast-safe.test.ts
+++ b/platform/shared/themes/contrast-safe.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+import { contrastRatio, withAccessibleLightTokens } from "./contrast-safe";
+import { getSupportedThemeItems } from "./theme-utils";
+
+describe("withAccessibleLightTokens", () => {
+  test("raises a faint border to the 3:1 non-text minimum, preserving hue", () => {
+    const out = withAccessibleLightTokens({
+      background: "oklch(1 0 0)",
+      border: "oklch(0.93 0.01 264.53)", // ~1.2:1 against white
+    });
+    const ratio = contrastRatio(out.border, "oklch(1 0 0)");
+    expect(ratio).not.toBeNull();
+    expect(ratio as number).toBeGreaterThanOrEqual(3);
+    // Only lightness moves; chroma and hue are kept.
+    expect(out.border).toMatch(/0\.01 264\.53\)$/);
+  });
+
+  test("raises muted text to the 4.5:1 body-text minimum", () => {
+    const out = withAccessibleLightTokens({
+      background: "oklch(0.98 0 0)",
+      muted: "oklch(0.94 0 0)",
+      "muted-foreground": "oklch(0.72 0 0)", // ~2.8:1 against muted
+    });
+    expect(
+      contrastRatio(out["muted-foreground"], out.muted) as number,
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrastRatio(out["muted-foreground"], out.background) as number,
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test("leaves already-compliant tokens byte-for-byte unchanged", () => {
+    const input = {
+      background: "oklch(1 0 0)",
+      border: "oklch(0 0 0)", // 21:1 — far above target
+    };
+    expect(withAccessibleLightTokens(input).border).toBe(input.border);
+  });
+
+  test("leaves non-oklch and unrelated token values untouched", () => {
+    const input = {
+      background: "oklch(1 0 0)",
+      border: "#ccc", // not an oklch() value — cannot be reasoned about
+      radius: "0.5rem",
+    };
+    const out = withAccessibleLightTokens(input);
+    expect(out.border).toBe("#ccc");
+    expect(out.radius).toBe("0.5rem");
+  });
+
+  test("no-ops when the reference token is missing", () => {
+    const input = { border: "oklch(0.93 0.01 264.53)" };
+    expect(withAccessibleLightTokens(input).border).toBe(input.border);
+  });
+
+  test("every shipped light theme clears WCAG minimums for chrome and muted text", () => {
+    for (const theme of getSupportedThemeItems()) {
+      const light = withAccessibleLightTokens(theme.cssVars.light);
+      const bg = light.background;
+      const sidebar = light.sidebar ?? bg;
+      const muted = light.muted ?? bg;
+
+      expect(
+        contrastRatio(light.border, bg),
+        `${theme.name}: border vs background`,
+      ).toBeGreaterThanOrEqual(3);
+      expect(
+        contrastRatio(light.input, bg),
+        `${theme.name}: input vs background`,
+      ).toBeGreaterThanOrEqual(3);
+      expect(
+        contrastRatio(light["sidebar-border"], sidebar),
+        `${theme.name}: sidebar-border vs sidebar`,
+      ).toBeGreaterThanOrEqual(3);
+      expect(
+        contrastRatio(light["muted-foreground"], muted),
+        `${theme.name}: muted-foreground vs muted`,
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});

--- a/platform/shared/themes/contrast-safe.ts
+++ b/platform/shared/themes/contrast-safe.ts
@@ -1,0 +1,233 @@
+/**
+ * Contrast-safety pass for generated theme tokens.
+ *
+ * tweakcn's light palettes ship structural chrome (table/card/input borders,
+ * dividers, unchecked control outlines) and muted text at contrast ratios far
+ * below WCAG 2.2 minimums — most light themes render borders at ~1.2:1 against
+ * their background, so table grids and bulk-action checkboxes are nearly
+ * invisible. This module darkens only the offending tokens just enough to clear
+ * the target ratio, preserving each theme's hue and chroma so the palette's
+ * character is unchanged. It runs on the LIGHT variant only; dark mode is never
+ * touched.
+ *
+ * WCAG 2.2 targets:
+ *   - 1.4.11 Non-text Contrast: 3:1 for UI component boundaries/states
+ *   - 1.4.3 Contrast (Minimum): 4.5:1 for body/secondary text
+ */
+
+/**
+ * Raise the contrast of a light theme's structural and muted-text tokens to the
+ * WCAG minimums, returning a new token map. Tokens already meeting their target
+ * (or that are not plain `oklch()` values) are left byte-for-byte unchanged, so
+ * high-contrast themes (e.g. neo-brutalism) and non-color tokens are untouched.
+ */
+export function withAccessibleLightTokens(
+  light: Record<string, string>,
+): Record<string, string> {
+  const result = { ...light };
+  for (const rule of CONTRAST_RULES) {
+    const color = result[rule.token];
+    if (!color) continue;
+    const against = rule.against
+      .map((key) => result[key])
+      .filter((value): value is string => Boolean(value));
+    if (against.length === 0) continue;
+    result[rule.token] = ensureMinContrast(color, against, rule.ratio);
+  }
+  return result;
+}
+
+/**
+ * WCAG contrast ratio between two colors, each an `oklch()` string. Returns
+ * `null` if either value cannot be parsed as oklch.
+ *
+ * @public — reused by contrast-safe.test.ts to assert generated ratios.
+ */
+export function contrastRatio(a: string, b: string): number | null {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  if (la === null || lb === null) return null;
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// ============================================================================
+// Internal
+// ============================================================================
+
+interface ContrastRule {
+  /** Token to adjust. */
+  token: string;
+  /** Reference token(s); the token must clear the target against each of them. */
+  against: string[];
+  /** Minimum WCAG contrast ratio to reach. */
+  ratio: number;
+}
+
+/**
+ * Tokens whose light-mode contrast we guarantee, and what each is seen against:
+ *   - `border`   — table/card/popover borders and the default component border
+ *   - `input`    — input outlines and unchecked checkbox/radio outlines
+ *   - `sidebar-border` — sidebar dividers, seen against the sidebar surface
+ *   - `muted-foreground` — secondary text, seen on both muted and base surfaces
+ * Borders/outlines target 3:1 (1.4.11); muted text targets 4.5:1 (1.4.3).
+ */
+const CONTRAST_RULES: ContrastRule[] = [
+  { token: "border", against: ["background"], ratio: 3 },
+  { token: "input", against: ["background"], ratio: 3 },
+  { token: "sidebar-border", against: ["sidebar", "background"], ratio: 3 },
+  {
+    token: "muted-foreground",
+    against: ["muted", "background"],
+    ratio: 4.5,
+  },
+];
+
+/**
+ * Small cushion added to every target so the adjusted value stays at or above
+ * the WCAG minimum after the lightness is rounded for output.
+ */
+const CONTRAST_MARGIN = 0.03;
+
+interface Oklch {
+  L: number;
+  /** Original chroma/hue (and any alpha) tokens, preserved verbatim on output. */
+  rest: string[];
+}
+
+function ensureMinContrast(
+  color: string,
+  against: string[],
+  ratio: number,
+): string {
+  const parsed = parseOklch(color);
+  if (!parsed) return color; // not a plain oklch() value — leave it alone
+  const refLums = against
+    .map(relativeLuminance)
+    .filter((value): value is number => value !== null);
+  if (refLums.length === 0) return color;
+
+  const target = ratio + CONTRAST_MARGIN;
+  const worst = (L: number) => {
+    const lum = luminanceFromLightness(L, parsed);
+    return Math.min(...refLums.map((ref) => ratioFromLuminance(lum, ref)));
+  };
+  if (worst(parsed.L) >= target) return color; // already compliant
+
+  // Increase contrast by moving lightness away from the reference(s). Try both
+  // directions and keep whichever reaches the target with the smaller change;
+  // if neither extreme reaches it (out-of-gamut edge), take the better extreme.
+  const darker = solveLightness(parsed.L, 0, target, worst);
+  const lighter = solveLightness(parsed.L, 1, target, worst);
+  const best = pickBest(parsed.L, darker, lighter, worst, target);
+  return formatOklch({ ...parsed, L: best });
+}
+
+/**
+ * Binary-search the lightness between `from` and `bound` for the value closest
+ * to `from` whose worst-case contrast reaches `target`. Falls back to `bound`
+ * when the target is unreachable within the range.
+ */
+function solveLightness(
+  from: number,
+  bound: number,
+  target: number,
+  worst: (L: number) => number,
+): number {
+  if (worst(bound) < target) return bound;
+  let lo = from;
+  let hi = bound;
+  for (let i = 0; i < 40; i++) {
+    const mid = (lo + hi) / 2;
+    if (worst(mid) >= target) hi = mid;
+    else lo = mid;
+  }
+  return hi;
+}
+
+function pickBest(
+  from: number,
+  darker: number,
+  lighter: number,
+  worst: (L: number) => number,
+  target: number,
+): number {
+  const darkerOk = worst(darker) >= target;
+  const lighterOk = worst(lighter) >= target;
+  if (darkerOk && lighterOk) {
+    return Math.abs(darker - from) <= Math.abs(lighter - from)
+      ? darker
+      : lighter;
+  }
+  if (darkerOk) return darker;
+  if (lighterOk) return lighter;
+  // Neither direction reaches the target — return whichever extreme is best.
+  return worst(darker) >= worst(lighter) ? darker : lighter;
+}
+
+// ---- oklch <-> WCAG relative luminance ------------------------------------
+
+function relativeLuminance(color: string): number | null {
+  const parsed = parseOklch(color);
+  if (!parsed) return null;
+  return luminanceFromLightness(parsed.L, parsed);
+}
+
+function luminanceFromLightness(L: number, parsed: Oklch): number {
+  const [C, h] = readChromaHue(parsed);
+  const [r, g, b] = oklchToLinearSrgb(L, C, h);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function ratioFromLuminance(a: number, b: number): number {
+  const hi = Math.max(a, b);
+  const lo = Math.min(a, b);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function readChromaHue(parsed: Oklch): [number, number] {
+  const C = Number.parseFloat(parsed.rest[0] ?? "0") || 0;
+  const h = Number.parseFloat(parsed.rest[1] ?? "0") || 0;
+  return [C, h];
+}
+
+/** oklch → linear-light sRGB, clamped to gamut (Björn Ottosson's transform). */
+function oklchToLinearSrgb(L: number, C: number, h: number): number[] {
+  const hr = (h * Math.PI) / 180;
+  const a = C * Math.cos(hr);
+  const b = C * Math.sin(hr);
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const l = l_ ** 3;
+  const m = m_ ** 3;
+  const s = s_ ** 3;
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ].map((v) => Math.min(1, Math.max(0, v)));
+}
+
+function parseOklch(value: string): Oklch | null {
+  const match = value.match(/^oklch\(([^)]+)\)$/i);
+  if (!match) return null;
+  const tokens = match[1].trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+  const first = tokens[0];
+  const L = first.endsWith("%")
+    ? Number.parseFloat(first) / 100
+    : Number.parseFloat(first);
+  if (Number.isNaN(L)) return null;
+  return { L, rest: tokens.slice(1) };
+}
+
+function formatOklch(parsed: Oklch): string {
+  const L = formatNumber(parsed.L);
+  return `oklch(${[L, ...parsed.rest].join(" ")})`;
+}
+
+function formatNumber(n: number): string {
+  return Number.parseFloat(n.toFixed(4)).toString();
+}

--- a/platform/shared/themes/generate-theme-css.ts
+++ b/platform/shared/themes/generate-theme-css.ts
@@ -10,6 +10,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { withAccessibleLightTokens } from "./contrast-safe";
 import { mapThemeFontValue } from "./font-token-map";
 // Import theme configuration
 import { SUPPORTED_THEMES } from "./theme-config";
@@ -89,7 +90,9 @@ function generateThemeCSS(theme: ThemeItem): string {
   const className = `theme-${theme.name}`;
 
   // Light vars for base selector, dark vars for dark mode override.
-  const lightCSS = `html.${className} {\n${generateCSSVars(theme.cssVars.light)}\n}`;
+  // Structural chrome and muted text in the light palette are raised to WCAG
+  // minimums before emitting; dark vars are emitted verbatim.
+  const lightCSS = `html.${className} {\n${generateCSSVars(withAccessibleLightTokens(theme.cssVars.light))}\n}`;
   const darkCSS = `html.dark.${className} {\n${generateCSSVars(theme.cssVars.dark)}\n}`;
   return `/* ${theme.title} */\n${lightCSS}\n\n${darkCSS}`;
 }
@@ -107,6 +110,8 @@ function generateThemesCSS(): string {
  *
  * AUTO-GENERATED FILE - DO NOT EDIT DIRECTLY
  * Generated from shared/themes/tweakcn-themes.json
+ * Light-mode structural chrome and muted text are raised to WCAG contrast
+ * minimums by shared/themes/contrast-safe.ts; dark mode is emitted verbatim.
  * Run: pnpm codegen:theme-css
  */\n`;
 


### PR DESCRIPTION
## Summary

Light-mode borders, table separators, input outlines, unchecked controls, and muted text are nearly invisible in several shipped themes because their theme tokens fall below WCAG contrast minimums.

This adds a contrast-safety pass to theme CSS generation. It adjusts only non-compliant light-mode `border`, `input`, `sidebar-border`, and `muted-foreground` tokens, preserving hue and chroma; compliant values and all dark-mode tokens remain unchanged. The generated theme CSS is refreshed from the source theme data.

A data-driven unit test checks every shipped light theme for 3:1 structural contrast and 4.5:1 muted-text contrast, alongside preservation and parsing edge cases. The full shared package check passes with 927 tests.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>