### PR TITLE
fix(docker): update Dagger x/crypto for latest CVEs

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -105,9 +105,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     # anything lower here makes `go get` downgrade go-git back below 5.19.2 to satisfy it,
     # silently reintroducing cve-2026-71556. Do not lower without also lowering go-git.
     go get golang.org/x/net@v0.56.0 && \
-    # cve-2026-46597: x/crypto issue fixed in >= 0.52.0; keep this after x/net.
-    # Pinned to 0.53.0 for the same go-git 5.19.2 floor reason as x/net above.
-    go get golang.org/x/crypto@v0.53.0 && \
+    # cve-2026-46597: x/crypto issue fixed in >= 0.52.0.
+    # cve-2026-56855 and cve-2026-78662: x/crypto HIGH issues fixed in >= 0.56.0.
+    # Keep this after x/net so later dependency resolution cannot restore a vulnerable version.
+    go get golang.org/x/crypto@v0.56.0 && \
     # cve-2026-56865: x/mod/sumdb/tlog tile verification bypass (HIGH) fixed in >= 0.40.0.
     # cve-2026-56864: x/mod/sumdb accepts unauthenticated hashes; same fix version.
     # Arrives transitively (dagger and containerd both floor it at 0.36.0), so it needs


### PR DESCRIPTION
## Summary

The platform image scan reported two fixed HIGH vulnerabilities in the Dagger CLI binary: CVE-2026-56855 and CVE-2026-78662. Both affect golang.org/x/crypto versions below 0.56.0.

This updates the source-built Dagger CLI dependency floor from x/crypto 0.53.0 to 0.56.0, preserving the existing pinned Dagger release while removing the vulnerable module version from both full and slim platform images.

Failed scan: https://github.com/archestra-ai/archestra/actions/runs/33784052746/job/100744802413

## Validation

Built the Dagger Docker stage for linux/amd64 and inspected the compiled binary metadata and generated SBOM. The binary resolves golang.org/x/crypto to 0.56.0, and the vulnerable 0.55.0 package is absent.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>