### PR TITLE
feat(teams): label the team-member role by what it grants

### DIFF
--- a/platform/e2e-tests/tests/identity-providers.ee.spec.ts
+++ b/platform/e2e-tests/tests/identity-providers.ee.spec.ts
@@ -749,10 +749,13 @@ test.describe("Identity Provider Team Sync E2E", () => {
       actionName: "Edit",
     });
 
-    // Wait for the dialog and switch to the External Group Sync section
+    // Wait for the dialog and switch to the External Group Sync section.
+    // Scope to the section navigation: the Members info box renders an inline
+    // "External Group Sync" jump button with the same accessible name.
     const teamDialog = page.getByRole("dialog");
     await expect(teamDialog).toBeVisible();
     await teamDialog
+      .getByRole("navigation")
       .getByRole("button", { name: "External Group Sync" })
       .click();
 

--- a/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.test.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.test.tsx
@@ -126,6 +126,17 @@ beforeEach(() => {
 });
 
 describe("RoleMappingForm", () => {
+  it("distinguishes itself from External Group Sync", () => {
+    render(<TestWrapper identityProviderId="idp-1" />);
+
+    const note = screen
+      .getByText(/Sets the organization-wide role only/i)
+      .closest("p") as HTMLElement;
+    expect(note).toHaveTextContent(
+      /Team membership is synced per team via each team's External Group Sync\./,
+    );
+  });
+
   it("shows the template debugger without token claims", async () => {
     render(<TestWrapper identityProviderId="idp-1" />);
     expect(screen.getByText("Template Debugger")).toBeInTheDocument();

--- a/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.tsx
@@ -142,6 +142,12 @@ export function RoleMappingForm({
 
   const content = (
     <>
+      <p className="text-xs text-muted-foreground bg-muted/50 p-3 rounded-md">
+        Sets the organization-wide role only. Team membership is synced per team
+        via each team&apos;s{" "}
+        <span className="font-medium">External Group Sync</span>.
+      </p>
+
       {providerClaimHint && (
         <p className="text-sm text-muted-foreground bg-muted/50 p-3 rounded-md">
           {providerClaimHint.roleMappingNote}

--- a/platform/frontend/src/components/teams/team-management-dialog.members.test.tsx
+++ b/platform/frontend/src/components/teams/team-management-dialog.members.test.tsx
@@ -1,0 +1,172 @@
+import type { archestraApiTypes } from "@archestra/shared";
+import { archestraApiSdk } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
+import { useMemberSearch } from "@/lib/member.query";
+import { useActiveOrganization } from "@/lib/organization.query";
+import { TeamManagementDialog } from "./team-management-dialog";
+
+type Team = archestraApiTypes.GetTeamsResponses["200"]["data"][number];
+
+const { useTokensMock } = vi.hoisted(() => ({ useTokensMock: vi.fn() }));
+
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/config/config.query");
+vi.mock("@/lib/member.query");
+vi.mock("@/lib/organization.query");
+vi.mock("@/lib/config/config", () => ({
+  default: { enterpriseFeatures: { core: false } },
+}));
+vi.mock("@/lib/teams/team-token.query", () => ({ useTokens: useTokensMock }));
+vi.mock("@archestra/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@archestra/shared")>()),
+  archestraApiSdk: {
+    getTeamMembers: vi.fn(),
+    updateTeamMember: vi.fn(),
+    updateTeam: vi.fn(),
+  },
+}));
+
+const team = {
+  id: "team-1",
+  name: "Platform Engineering",
+  description: "",
+  labels: [],
+} as unknown as Team;
+
+// The role trigger's accessible name does not include its rendered value
+// (Radix SelectValue), so locate it by its visible content instead.
+async function findRoleTrigger(label: RegExp) {
+  return await waitFor(() => {
+    const trigger = screen
+      .getAllByRole("combobox")
+      .find((el) => label.test(el.textContent ?? ""));
+    if (!trigger) throw new Error(`No combobox showing ${label}`);
+    return trigger;
+  });
+}
+
+async function setupUserEvent() {
+  // Radix Select relies on pointer-capture + scrollIntoView, which jsdom
+  // does not implement.
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn();
+  window.HTMLElement.prototype.setPointerCapture = vi.fn();
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  const { default: userEvent } = await import("@testing-library/user-event");
+  return userEvent.setup();
+}
+
+function renderDialog() {
+  return render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <TeamManagementDialog open onOpenChange={vi.fn()} team={team} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useFeature).mockReturnValue(false as ReturnType<typeof useFeature>);
+  vi.mocked(useHasPermissions).mockReturnValue({ data: true } as ReturnType<
+    typeof useHasPermissions
+  >);
+  vi.mocked(useActiveOrganization).mockReturnValue({
+    data: { members: [{ userId: "u-1", user: { name: "Rosa Lindqvist" } }] },
+    // biome-ignore lint/suspicious/noExplicitAny: partial query result stub
+  } as any);
+  vi.mocked(useMemberSearch).mockReturnValue({
+    users: [],
+    isSearching: false,
+    onSearchQueryChange: vi.fn(),
+    emptyMessage: "",
+    // biome-ignore lint/suspicious/noExplicitAny: partial hook result stub
+  } as any);
+  useTokensMock.mockReturnValue({ data: { tokens: [] } });
+  vi.mocked(archestraApiSdk.getTeamMembers).mockResolvedValue({
+    data: [{ userId: "u-1", role: "member", name: "Rosa Lindqvist" }],
+    // biome-ignore lint/suspicious/noExplicitAny: partial sdk result stub
+  } as any);
+  vi.mocked(archestraApiSdk.updateTeam).mockResolvedValue({
+    data: team,
+    // biome-ignore lint/suspicious/noExplicitAny: partial sdk result stub
+  } as any);
+  vi.mocked(archestraApiSdk.updateTeamMember).mockResolvedValue({
+    data: {},
+    // biome-ignore lint/suspicious/noExplicitAny: partial sdk result stub
+  } as any);
+});
+
+describe("TeamManagementDialog member roles", () => {
+  it("labels the role control by what it grants, never as an RBAC role name", async () => {
+    const user = await setupUserEvent();
+    renderDialog();
+
+    const trigger = await findRoleTrigger(/not able to edit team/i);
+    await user.click(trigger);
+
+    const listbox = await screen.findByRole("listbox");
+    expect(
+      within(listbox).getByRole("option", { name: "Able to edit team" }),
+    ).toBeInTheDocument();
+    expect(
+      within(listbox).getByRole("option", { name: "Not able to edit team" }),
+    ).toBeInTheDocument();
+
+    // The two stored values share their names with organization-wide RBAC
+    // roles. Surfacing those names here is the confusion this wording exists
+    // to prevent, so no option may be labelled with one.
+    for (const option of within(listbox).getAllByRole("option")) {
+      expect(option).not.toHaveAccessibleName("Admin");
+      expect(option).not.toHaveAccessibleName("Member");
+    }
+  });
+
+  it("still sends the stored role value when the new label is chosen", async () => {
+    const user = await setupUserEvent();
+    renderDialog();
+
+    await user.click(await findRoleTrigger(/not able to edit team/i));
+    await user.click(
+      await screen.findByRole("option", { name: "Able to edit team" }),
+    );
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(archestraApiSdk.updateTeamMember).toHaveBeenCalledWith({
+        path: { id: "team-1", userId: "u-1" },
+        body: { role: "admin" },
+      });
+    });
+  });
+
+  it("explains what syncs and what does not, and jumps to External Group Sync", async () => {
+    const user = await setupUserEvent();
+    renderDialog();
+
+    const note = (
+      await screen.findByText(/only for adding members by hand/i)
+    ).closest("p");
+    // The docs link appends screen-reader-only text, so match around it.
+    expect(note).toHaveTextContent(/External Group Sync syncs membership and Role Mapping/);
+    expect(note).toHaveTextContent(/in your OIDC provider syncs roles — never this setting\./);
+
+    await user.click(
+      within(note as HTMLElement).getByRole("button", {
+        name: "External Group Sync",
+      }),
+    );
+    // The section behind the jump is enterprise-gated in this harness, so the
+    // license fallback standing in for it proves the navigation happened.
+    expect(
+      await screen.findByText(/Team Sync is an enterprise feature/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/teams/team-management-dialog.members.test.tsx
+++ b/platform/frontend/src/components/teams/team-management-dialog.members.test.tsx
@@ -155,8 +155,12 @@ describe("TeamManagementDialog member roles", () => {
       await screen.findByText(/only for adding members by hand/i)
     ).closest("p");
     // The docs link appends screen-reader-only text, so match around it.
-    expect(note).toHaveTextContent(/External Group Sync syncs membership and Role Mapping/);
-    expect(note).toHaveTextContent(/in your OIDC provider syncs roles — never this setting\./);
+    expect(note).toHaveTextContent(
+      /External Group Sync syncs membership and Role Mapping/,
+    );
+    expect(note).toHaveTextContent(
+      /in your OIDC provider syncs roles — never this setting\./,
+    );
 
     await user.click(
       within(note as HTMLElement).getByRole("button", {

--- a/platform/frontend/src/components/teams/team-management-dialog.tsx
+++ b/platform/frontend/src/components/teams/team-management-dialog.tsx
@@ -4,6 +4,8 @@ import {
   ADMIN_ROLE_NAME,
   archestraApiSdk,
   type archestraApiTypes,
+  DocsPage,
+  getDocsUrl,
   MEMBER_ROLE_NAME,
 } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -21,6 +23,7 @@ import {
   ProfileLabels,
   type ProfileLabelsRef,
 } from "@/components/agent-labels";
+import { ExternalDocsLink } from "@/components/external-docs-link";
 import { TabbedDialogShell } from "@/components/tabbed-dialog-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -389,6 +392,7 @@ export function TeamManagementDialog(props: TeamManagementDialogProps) {
           readOnlyDetails={!canEditDetails}
           memberChanges={memberChanges}
           onMemberChangesChange={setMemberChanges}
+          onGoToExternalGroups={() => setActiveSection("external-groups")}
         />
       )}
       {activeSection === "token" && mode === "edit" && (
@@ -422,6 +426,7 @@ function TeamSection(props: {
   readOnlyDetails: boolean;
   memberChanges: StagedMemberChanges;
   onMemberChangesChange: (changes: StagedMemberChanges) => void;
+  onGoToExternalGroups: () => void;
 }) {
   return (
     <div className="space-y-6">
@@ -478,6 +483,40 @@ function TeamSection(props: {
 
           <div className="space-y-4">
             <h3 className="text-sm font-medium">Members</h3>
+            <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-xs">
+              <p>
+                <span className="font-medium">Optional</span> — only for adding
+                members by hand.{" "}
+                <button
+                  type="button"
+                  onClick={props.onGoToExternalGroups}
+                  className="text-primary hover:underline"
+                >
+                  External Group Sync
+                </button>{" "}
+                syncs membership and{" "}
+                <ExternalDocsLink
+                  href={getDocsUrl(DocsPage.PlatformSsoRoleMapping)}
+                >
+                  Role Mapping
+                </ExternalDocsLink>{" "}
+                in your OIDC provider syncs roles — never this setting.
+              </p>
+              <div className="space-y-1 text-muted-foreground">
+                <p>
+                  <span className="font-medium text-foreground">
+                    Able to edit team
+                  </span>{" "}
+                  — rename it, manage members, rotate its token. This team only.
+                </p>
+                <p>
+                  <span className="font-medium text-foreground">
+                    Not able to edit team
+                  </span>{" "}
+                  — the default, and what sync assigns.
+                </p>
+              </div>
+            </div>
             <MembersSection
               open={props.open}
               team={props.team}
@@ -651,7 +690,7 @@ function MembersSection({
             {memberRows.map((row) => (
               <div
                 key={row.userId}
-                className="grid grid-cols-[minmax(0,1fr)_180px_40px] items-center gap-3 rounded-lg border p-3"
+                className="grid grid-cols-[minmax(0,1fr)_210px_40px] items-center gap-3 rounded-lg border p-3"
               >
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
@@ -678,8 +717,12 @@ function MembersSection({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value={ADMIN_ROLE_NAME}>Admin</SelectItem>
-                    <SelectItem value={MEMBER_ROLE_NAME}>Member</SelectItem>
+                    <SelectItem value={ADMIN_ROLE_NAME}>
+                      Able to edit team
+                    </SelectItem>
+                    <SelectItem value={MEMBER_ROLE_NAME}>
+                      Not able to edit team
+                    </SelectItem>
                   </SelectContent>
                 </Select>
                 <Button

--- a/platform/frontend/src/components/teams/team-management-external-sync.ee.test.tsx
+++ b/platform/frontend/src/components/teams/team-management-external-sync.ee.test.tsx
@@ -104,9 +104,7 @@ describe("TeamManagementExternalSyncSection", () => {
       .closest("p") as HTMLElement;
     expect(note).toHaveTextContent("Not able to edit team");
     expect(note).toHaveTextContent(/Org-wide roles are synced separately/);
-    expect(
-      screen.getByRole("link", { name: "Role Mapping" }),
-    ).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Role Mapping" })).toHaveAttribute(
       "href",
       "/settings/identity-providers?edit=idp-1&section=role-mapping",
     );

--- a/platform/frontend/src/components/teams/team-management-external-sync.ee.test.tsx
+++ b/platform/frontend/src/components/teams/team-management-external-sync.ee.test.tsx
@@ -86,6 +86,46 @@ describe("TeamManagementExternalSyncSection", () => {
     expect(screen.getByText("Add External Group Mapping")).toBeInTheDocument();
   });
 
+  it("says it syncs membership only and links Role Mapping for provider admins", () => {
+    vi.mocked(useHasPermissions).mockImplementation(
+      (permissions) =>
+        ({
+          data: permissions.identityProvider?.includes("update") ?? false,
+        }) as ReturnType<typeof useHasPermissions>,
+    );
+    useTeamSyncIdentityProviderOptionsMock.mockReturnValue({
+      data: [{ id: "idp-1", providerId: "keycloak", groupsExpression: null }],
+    });
+
+    renderSection();
+
+    const note = screen
+      .getByText(/matched users join as/i)
+      .closest("p") as HTMLElement;
+    expect(note).toHaveTextContent("Not able to edit team");
+    expect(note).toHaveTextContent(/Org-wide roles are synced separately/);
+    expect(
+      screen.getByRole("link", { name: "Role Mapping" }),
+    ).toHaveAttribute(
+      "href",
+      "/settings/identity-providers?edit=idp-1&section=role-mapping",
+    );
+  });
+
+  it("does not link Role Mapping for users who cannot edit identity providers", () => {
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
+    useTeamSyncIdentityProviderOptionsMock.mockReturnValue({
+      data: [{ id: "idp-1", providerId: "keycloak", groupsExpression: null }],
+    });
+
+    renderSection();
+
+    expect(screen.getByText(/matched users join as/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Role Mapping" })).toBeNull();
+  });
+
   it("hides the mapping controls in read-only mode", () => {
     vi.mocked(useHasPermissions).mockReturnValue({
       data: false,

--- a/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
+++ b/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
@@ -171,6 +171,25 @@ export function TeamManagementExternalSyncSection({
   return (
     <div className="space-y-6">
       <div className="grid max-w-3xl gap-4">
+        <div className="rounded-lg border bg-muted/30 p-3 text-xs">
+          <p>
+            Syncs <span className="font-medium">membership</span> only — matched
+            users join as{" "}
+            <span className="font-medium">Not able to edit team</span>. Org-wide
+            roles are synced separately by{" "}
+            {canUpdateIdentityProviders && selectedIdentityProvider ? (
+              <Link
+                href={`/settings/identity-providers?edit=${selectedIdentityProvider.id}&section=role-mapping`}
+                className="text-primary hover:underline"
+              >
+                Role Mapping
+              </Link>
+            ) : (
+              <span className="font-medium">Role Mapping</span>
+            )}{" "}
+            in the identity provider&apos;s settings.
+          </p>
+        </div>
         <div className="space-y-2">
           <Label>Identity Provider</Label>
           <FieldDescription>

--- a/platform/shared/docs.ts
+++ b/platform/shared/docs.ts
@@ -59,6 +59,7 @@ export const DocsPage = {
   PlatformResetUserPassword: "platform-reset-user-password",
   PlatformSecretsManagement: "platform-secrets-management",
   PlatformSlack: "platform-slack",
+  PlatformSsoRoleMapping: "platform-sso-role-mapping",
   PlatformSsoTeamSync: "platform-sso-team-sync",
   PlatformTelegram: "platform-telegram",
   PlatformSupportedLlmProviders: "platform-supported-llm-providers",


### PR DESCRIPTION
## Problem

The per-member dropdown in Edit Team → Members reuses the RBAC role names **Admin** and **Member**, so it reads as the organization-wide role. Which of the two related screens syncs what is also easy to conflate: External Group Sync syncs team membership, the identity provider's Role Mapping syncs the org-wide role, and this dropdown is synced by neither.

## Change

- Dropdown options are labeled by the one thing they control: **Able to edit team** / **Not able to edit team**. Stored values (`admin`/`member`) are unchanged, so nothing moves at the API or DB level.
- A note under Members states what each option grants and untangles the syncing. "External Group Sync" jumps to that section in the same dialog; "Role Mapping" links to its docs page (slug added to `shared/docs.ts`).
- The External Group Sync section gets the mirror note ("syncs membership only — matched users join as Not able to edit team"), deep-linking to the selected provider's Role Mapping section for users with `identityProvider:update`, plain text otherwise.
- The Role Mapping form gets the reverse note ("sets the organization-wide role only").

## Tests

New behavior pinned in unit tests: the options render under the new labels with no RBAC role name leaking through, picking "Able to edit team" still sends `role: "admin"`, the note's tab jump lands on the External Group Sync section, and the Role Mapping deep link is present exactly for users who can edit identity providers.

Docs page for the Edit Team screen follows in a separate PR.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>