### PR TITLE
fix(llm): apply configured upstream timeout to Bedrock

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1292,7 +1292,8 @@ These environment variables set the default base URL for each LLM provider. Per-
 
 - **`ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS`** - Headers/body timeout (milliseconds) for LLM-call fetches, applied as a custom undici dispatcher on both the chat→proxy and proxy→upstream hops.
   - Default: unset, i.e. undici's defaults (5 minutes for both headers and body timeout)
-  - Opt-in: set a larger value (e.g. `600000` for 10 minutes) when an upstream's time-to-first-token can exceed 5 minutes — typically a slow CPU-only Ollama or vLLM model — which otherwise fails with `Headers Timeout Error`
+  - Opt-in: raise it when an upstream can take more than 5 minutes to send headers or the next stream chunk
+  - Keep it below the load balancer's request or idle timeout. For a 600-second load balancer timeout, use `540000` so Archestra can report the upstream timeout before the load balancer closes the connection
   - Keep it finite so genuinely-dead upstreams still surface as errors
 
 - **`ARCHESTRA_LLM_COST_SUBSCRIPTION_AUTODETECT`** - Automatically classify subscription credentials as subscription usage.

--- a/platform/backend/src/clients/bedrock-client.ts
+++ b/platform/backend/src/clients/bedrock-client.ts
@@ -31,6 +31,8 @@ interface BedrockClientConfig {
     secretAccessKey: string;
     sessionToken?: string;
   }>;
+  /** Fetch implementation carrying proxy timeout and other transport policy. */
+  fetch?: typeof globalThis.fetch;
 }
 
 // Use SDK stream event type with raw bytes for passthrough
@@ -313,7 +315,7 @@ export class BedrockClient {
       logger.warn("[BedrockClient] no authentication configured");
     }
 
-    return fetch(url, {
+    return (this.config.fetch ?? globalThis.fetch)(url, {
       ...init,
       headers,
     });

--- a/platform/backend/src/clients/bedrock-credentials.ts
+++ b/platform/backend/src/clients/bedrock-credentials.ts
@@ -159,8 +159,9 @@ export function buildBedrockProvider(params: {
 export function buildBedrockClient(params: {
   apiKey?: string | null;
   baseUrl?: string | null;
+  fetch?: typeof globalThis.fetch;
 }): BedrockClient {
-  const { apiKey, baseUrl } = params;
+  const { apiKey, baseUrl, fetch } = params;
   const resolvedBaseUrl = getBedrockBaseUrl(baseUrl);
   const region = getBedrockRegion(resolvedBaseUrl);
 
@@ -169,6 +170,7 @@ export function buildBedrockClient(params: {
       baseUrl: resolvedBaseUrl,
       region,
       credentialProvider: getBedrockCredentialProvider(),
+      fetch,
     });
   }
 
@@ -180,6 +182,7 @@ export function buildBedrockClient(params: {
       accessKeyId: sigV4.accessKeyId,
       secretAccessKey: sigV4.secretAccessKey,
       sessionToken: sigV4.sessionToken,
+      fetch,
     });
   }
 
@@ -187,5 +190,6 @@ export function buildBedrockClient(params: {
     baseUrl: resolvedBaseUrl,
     region,
     apiKey: apiKey ?? undefined,
+    fetch,
   });
 }

--- a/platform/backend/src/clients/llm-upstream-dispatcher.ts
+++ b/platform/backend/src/clients/llm-upstream-dispatcher.ts
@@ -1,21 +1,35 @@
 import { Agent } from "undici";
 import config from "@/config";
 
+export function fetchWithLlmUpstreamDispatcher(
+  input: Parameters<typeof globalThis.fetch>[0],
+  init?: Parameters<typeof globalThis.fetch>[1],
+): ReturnType<typeof globalThis.fetch> {
+  const dispatcher = getLlmUpstreamDispatcher();
+  if (!dispatcher) {
+    return globalThis.fetch(input, init);
+  }
+
+  return globalThis.fetch(input, {
+    ...init,
+    dispatcher,
+  } as RequestInit);
+}
+
 /**
  * Shared undici dispatcher for outbound LLM-call fetches.
  *
  * Node's `globalThis.fetch` is backed by undici, whose default `headersTimeout`
  * and `bodyTimeout` are both 5 min — which aborts slow-but-healthy upstreams
- * with `UND_ERR_HEADERS_TIMEOUT`. This Agent raises both timeouts to a
- * configurable value and is injected per-request via the `dispatcher` option on
- * the LLM-call fetches (chat → proxy and proxy → upstream), keeping the change
- * scoped to LLM traffic rather than every fetch in the process.
+ * with `UND_ERR_HEADERS_TIMEOUT` or `UND_ERR_BODY_TIMEOUT`. This Agent raises
+ * both timeouts to a configurable value and is injected per-request via the
+ * `dispatcher` option on the LLM-call fetches (chat → proxy and proxy →
+ * upstream), keeping the change scoped to LLM traffic rather than every fetch
+ * in the process.
  *
  * Opt-in: when `ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS` is unset, this returns
  * `undefined` and callers leave undici's defaults untouched (no dispatcher).
  */
-let dispatcher: Agent | undefined;
-
 export function getLlmUpstreamDispatcher(): Agent | undefined {
   const upstreamTimeoutMs = config.llmProxy.upstreamTimeoutMs;
   if (!upstreamTimeoutMs) {
@@ -29,3 +43,5 @@ export function getLlmUpstreamDispatcher(): Agent | undefined {
 
   return dispatcher;
 }
+
+let dispatcher: Agent | undefined;

--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -1,5 +1,9 @@
 import { EventStreamCodec } from "@smithy/eventstream-codec";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
+import { Agent } from "undici";
+import { vi } from "vitest";
+import type { BedrockClient } from "@/clients/bedrock-client";
+import config from "@/config";
 import { describe, expect, test } from "@/test";
 import { Bedrock } from "@/types";
 import { bedrockAdapterFactory, getCommandInput } from "./bedrock";
@@ -872,6 +876,27 @@ describe("Bedrock client creation", () => {
     };
 
     expect(client.config.baseUrl).toBe(customBaseUrl);
+  });
+
+  test("applies the configured LLM upstream timeout to Bedrock requests", async () => {
+    config.llmProxy.upstreamTimeoutMs = 5_000;
+    const fetchMock = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ stopReason: "end_turn" })),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = bedrockAdapterFactory.createClient("test-key", {
+      baseUrl: "https://bedrock.example.com",
+      source: "chat",
+    }) as BedrockClient;
+
+    await client.converse("test-model", {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ dispatcher: expect.any(Agent) }),
+    );
   });
 });
 

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -9,6 +9,7 @@ import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 import { encode as toonEncode } from "@toon-format/toon";
 import type { BedrockClient } from "@/clients/bedrock-client";
 import { buildBedrockClient } from "@/clients/bedrock-credentials";
+import { fetchWithLlmUpstreamDispatcher } from "@/clients/llm-upstream-dispatcher";
 import config from "@/config";
 import logger from "@/logging";
 import { ModelModel } from "@/models";
@@ -2039,6 +2040,7 @@ export const bedrockAdapterFactory: LLMProvider<
     return buildBedrockClient({
       apiKey: apiKey ?? null,
       baseUrl: options?.baseUrl,
+      fetch: fetchWithLlmUpstreamDispatcher,
     });
   },
 


### PR DESCRIPTION
## Summary

Bedrock's custom fetch client bypassed `ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS` on the proxy-to-provider hop. Long gaps between Bedrock stream events therefore still hit undici's five-minute body timeout even when operators configured a larger value.

This threads the shared timeout-aware fetch through every Bedrock authentication path and adds a regression test around the actual outbound request. The deployment docs now recommend keeping Archestra's timeout below the load balancer timeout; for a 600-second load balancer timeout, use 540,000 ms.

## Verification

Reproduced with a valid Bedrock event stream that paused longer than a shorter global body timeout. Before the change it failed with `UND_ERR_BODY_TIMEOUT`; after the change it received both stream events using the configured upstream timeout.