### PR TITLE
fix(ui): align app permissions and table sizing

### DIFF
--- a/docs/pages/platform-apps.md
+++ b/docs/pages/platform-apps.md
@@ -3,7 +3,7 @@ title: MCP Apps
 category: Apps
 order: 1
 description: User-authored MCP Apps — sandboxed HTML interfaces with their own data store and tools
-lastUpdated: 2026-08-26
+lastUpdated: 2026-09-03
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -29,6 +29,8 @@ Run or author an app at `/a/:slug` (no chat chrome, no sidebar), or run it from 
 ## Who Can Use an App
 
 App settings offers four choices under "Who can use this app". **Personal** keeps it to you. **Users** shares it with people you name — a colleague, for example. **Teams** shares it with whole teams. **Organization** opens it to everyone.
+
+Visibility grants use access, not edit access. Team members can use a team app, but membership alone does not let them change it. App management follows the platform's [scoped resource permissions](./platform-access-control#scoped-resources).
 
 Sharing a chat does not share the apps it renders. Each viewer resolves an app against that app's own visibility. An app you have not shared with someone shows an access message in their view — a personal app in a chat you shared, for example. The chat's share dialog warns you when this will happen, and names the apps, so you can share them with the same people first.
 

--- a/platform/frontend/src/app/apps/_parts/app-card.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.test.tsx
@@ -274,7 +274,7 @@ describe("OwnedAppCard", () => {
     );
   });
 
-  it("offers view-only settings without delete when the app is outside the caller's scope", () => {
+  it("hides settings and delete when the app is outside the caller's scope", () => {
     vi.mocked(useAppAccess).mockReturnValue({
       canEdit: false,
       canDeleteApp: false,
@@ -282,9 +282,7 @@ describe("OwnedAppCard", () => {
 
     render(<AppCard app={ownedApp} />);
 
-    expect(
-      screen.getByRole("menuitem", { name: "View settings" }),
-    ).toBeVisible();
+    expect(screen.queryByRole("menuitem", { name: "Settings" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "Delete" })).toBeNull();
   });
 

--- a/platform/frontend/src/app/apps/_parts/app-card.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useAppAccess } from "@/lib/apps/use-app-access";
 import { takePendingProjectChatHandoff } from "@/lib/chat/pending-project-chat-handoff";
 import { AppCard } from "./app-card";
 
@@ -30,7 +30,7 @@ vi.mock("@/lib/app.query", () => ({
   useApp: () => ({ data: undefined }),
 }));
 
-vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/apps/use-app-access");
 
 // The card reads the locked-chat flag to decide whether to offer "Open as
 // locked chat". Off here: these tests are about the card's ordinary actions.
@@ -93,15 +93,10 @@ beforeEach(() => {
   vi.mocked(useRouter).mockReturnValue({
     push: pushMock,
   } as unknown as ReturnType<typeof useRouter>);
-  vi.mocked(useHasPermissions).mockReturnValue({
-    data: true,
-  } as ReturnType<typeof useHasPermissions>);
-  // The card now derives "is this someone else's app" from the server-computed
-  // viewerRole, not the session, but useSession is still mocked so the shared
-  // auth.query mock resolves cleanly.
-  vi.mocked(useSession).mockReturnValue({
-    data: { user: { id: "user-1" } },
-  } as ReturnType<typeof useSession>);
+  vi.mocked(useAppAccess).mockReturnValue({
+    canEdit: true,
+    canDeleteApp: true,
+  } as ReturnType<typeof useAppAccess>);
 });
 
 const ownedApp: Extract<AppListItem, { source: "owned" }> = {
@@ -277,6 +272,20 @@ describe("OwnedAppCard", () => {
     expect(screen.getByTestId("delete-dialog")).toHaveTextContent(
       "Delete My Owned App",
     );
+  });
+
+  it("offers view-only settings without delete when the app is outside the caller's scope", () => {
+    vi.mocked(useAppAccess).mockReturnValue({
+      canEdit: false,
+      canDeleteApp: false,
+    } as ReturnType<typeof useAppAccess>);
+
+    render(<AppCard app={ownedApp} />);
+
+    expect(
+      screen.getByRole("menuitem", { name: "View settings" }),
+    ).toBeVisible();
+    expect(screen.queryByRole("menuitem", { name: "Delete" })).toBeNull();
   });
 
   it("folds team names into the scope pill's label", () => {

--- a/platform/frontend/src/app/apps/_parts/app-card.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.test.tsx
@@ -30,7 +30,10 @@ vi.mock("@/lib/app.query", () => ({
   useApp: () => ({ data: undefined }),
 }));
 
-vi.mock("@/lib/apps/use-app-access");
+vi.mock("@/lib/apps/use-app-access", async (importActual) => ({
+  ...(await importActual<typeof import("@/lib/apps/use-app-access")>()),
+  useAppAccess: vi.fn(),
+}));
 
 // The card reads the locked-chat flag to decide whether to offer "Open as
 // locked chat". Off here: these tests are about the card's ordinary actions.
@@ -68,12 +71,14 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     children,
     onSelect,
     variant,
+    ...props
   }: {
     children: ReactNode;
     onSelect?: (e: { preventDefault: () => void }) => void;
     variant?: string;
-  }) => (
+  } & React.HTMLAttributes<HTMLDivElement>) => (
     <div
+      {...props}
       role="menuitem"
       data-variant={variant}
       tabIndex={0}
@@ -94,6 +99,14 @@ beforeEach(() => {
     push: pushMock,
   } as unknown as ReturnType<typeof useRouter>);
   vi.mocked(useAppAccess).mockReturnValue({
+    isAdmin: true,
+    isTeamAdmin: true,
+    canUpdate: true,
+    canDelete: true,
+    currentUserId: "user-1",
+    userTeamIds: new Set(),
+    isPending: false,
+    canModify: true,
     canEdit: true,
     canDeleteApp: true,
   } as ReturnType<typeof useAppAccess>);
@@ -274,16 +287,37 @@ describe("OwnedAppCard", () => {
     );
   });
 
-  it("hides settings and delete when the app is outside the caller's scope", () => {
+  it("disables settings and delete with the scope reason when the app is outside the caller's scope", () => {
+    const onOpenSettings = vi.fn();
     vi.mocked(useAppAccess).mockReturnValue({
+      isAdmin: false,
+      isTeamAdmin: false,
+      canUpdate: true,
+      canDelete: true,
+      currentUserId: "user-2",
+      userTeamIds: new Set(),
+      isPending: false,
+      canModify: false,
       canEdit: false,
       canDeleteApp: false,
     } as ReturnType<typeof useAppAccess>);
 
-    render(<AppCard app={ownedApp} />);
+    render(<AppCard app={ownedApp} onOpenSettings={onOpenSettings} />);
 
-    expect(screen.queryByRole("menuitem", { name: "Settings" })).toBeNull();
-    expect(screen.queryByRole("menuitem", { name: "Delete" })).toBeNull();
+    const settings = screen.getByRole("menuitem", { name: "Settings" });
+    const deleteAction = screen.getByRole("menuitem", { name: "Delete" });
+    expect(settings).toHaveAttribute("aria-disabled", "true");
+    expect(deleteAction).toHaveAttribute("aria-disabled", "true");
+    expect(
+      document.getElementById(
+        settings.getAttribute("aria-describedby") as string,
+      ),
+    ).toHaveTextContent("Only an admin can change this org-wide app");
+
+    fireEvent.click(settings);
+    fireEvent.click(deleteAction);
+    expect(onOpenSettings).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("delete-dialog")).not.toBeInTheDocument();
   });
 
   it("folds team names into the scope pill's label", () => {

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { LockedChatIcon } from "@/components/chat/locked-chat-icon";
 import { CreatedByCell } from "@/components/created-by-cell";
 import { LabelTags } from "@/components/label-tags";
@@ -44,7 +44,10 @@ import {
   usePinApp,
 } from "@/lib/app.query";
 import { appRunUrl } from "@/lib/apps/app-run-url";
-import { useAppAccess } from "@/lib/apps/use-app-access";
+import {
+  appActionDisabledReason,
+  useAppAccess,
+} from "@/lib/apps/use-app-access";
 import { setPendingProjectChatHandoff } from "@/lib/chat/pending-project-chat-handoff";
 import { useFeature } from "@/lib/config/config.query";
 import type { BulkCardSelectionProps } from "@/lib/hooks/use-bulk-card-selection";
@@ -248,6 +251,16 @@ function OwnedAppCard({
   // the card unmounts mid-navigation, so it never resets; only a failure does.
   const [isOpening, setIsOpening] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const settingsDisabledReason = appActionDisabledReason({
+    app,
+    access,
+    action: "update",
+  });
+  const deleteDisabledReason = appActionDisabledReason({
+    app,
+    access,
+    action: "delete",
+  });
 
   const handleOpen = async (lockedChat = false) => {
     setIsOpening(true);
@@ -282,7 +295,10 @@ function OwnedAppCard({
                 label={`Select ${app.name}`}
                 selection={selection}
                 disabled={selection.selectionDisabled || !access.canEdit}
-                disabledReason="You do not have permission to modify this app"
+                disabledReason={
+                  settingsDisabledReason ??
+                  "You do not have permission to modify this app"
+                }
               />
             ) : null}
             <AppTypeIcon owned icon={app.icon} />
@@ -329,12 +345,12 @@ function OwnedAppCard({
               pinned={!!app.pinnedAt}
               target={{ source: "owned", appId: app.id }}
             />
-            {access.canEdit ? (
-              <DropdownMenuItem onSelect={() => onOpenSettings?.(app)}>
-                <Settings className="h-4 w-4" />
-                <span>Settings</span>
-              </DropdownMenuItem>
-            ) : null}
+            <AppMenuItem
+              icon={<Settings className="h-4 w-4" />}
+              label="Settings"
+              disabledReason={settingsDisabledReason}
+              onSelect={() => onOpenSettings?.(app)}
+            />
             <DropdownMenuItem asChild>
               <Link href={appRunUrl(app)} target="_blank" rel="noreferrer">
                 <SquareArrowOutUpRight className="h-4 w-4" />
@@ -351,18 +367,14 @@ function OwnedAppCard({
                 Open as locked chat
               </DropdownMenuItem>
             ) : null}
-            {access.canDeleteApp ? (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  variant="destructive"
-                  onSelect={() => setDeleteOpen(true)}
-                >
-                  <Trash2 className="h-4 w-4" />
-                  Delete
-                </DropdownMenuItem>
-              </>
-            ) : null}
+            <DropdownMenuSeparator />
+            <AppMenuItem
+              icon={<Trash2 className="h-4 w-4" />}
+              label="Delete"
+              variant="destructive"
+              disabledReason={deleteDisabledReason}
+              onSelect={() => setDeleteOpen(true)}
+            />
           </CardOverflowMenu>
         </div>
 
@@ -523,5 +535,63 @@ function ExternalAppCard({
         </CardDescription>
       ) : null}
     </Card>
+  );
+}
+
+/**
+ * A refused menu item stays in the menu so the action remains discoverable.
+ * `aria-disabled` keeps it focusable, while the guarded select handler and the
+ * visible/screen-reader reason explain why it cannot run.
+ */
+function AppMenuItem({
+  icon,
+  label,
+  onSelect,
+  disabledReason,
+  variant,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onSelect: () => void;
+  disabledReason?: string;
+  variant?: "default" | "destructive";
+}) {
+  const reasonId = useId();
+  const isDisabled = !!disabledReason;
+  const content = (
+    <DropdownMenuItem
+      aria-disabled={isDisabled || undefined}
+      aria-describedby={isDisabled ? reasonId : undefined}
+      className={isDisabled ? "cursor-not-allowed opacity-50" : undefined}
+      variant={variant}
+      onSelect={(event) => {
+        if (isDisabled) {
+          event.preventDefault();
+          return;
+        }
+        onSelect();
+      }}
+    >
+      {icon}
+      <span>{label}</span>
+      {disabledReason ? (
+        <span id={reasonId} aria-hidden="true" className="sr-only">
+          {disabledReason}
+        </span>
+      ) : null}
+    </DropdownMenuItem>
+  );
+
+  if (!disabledReason) return content;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="cursor-not-allowed">{content}</div>
+      </TooltipTrigger>
+      <TooltipContent side="left" className="max-w-64">
+        {disabledReason}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -329,10 +329,12 @@ function OwnedAppCard({
               pinned={!!app.pinnedAt}
               target={{ source: "owned", appId: app.id }}
             />
-            <DropdownMenuItem onSelect={() => onOpenSettings?.(app)}>
-              <Settings className="h-4 w-4" />
-              <span>{access.canEdit ? "Settings" : "View settings"}</span>
-            </DropdownMenuItem>
+            {access.canEdit ? (
+              <DropdownMenuItem onSelect={() => onOpenSettings?.(app)}>
+                <Settings className="h-4 w-4" />
+                <span>Settings</span>
+              </DropdownMenuItem>
+            ) : null}
             <DropdownMenuItem asChild>
               <Link href={appRunUrl(app)} target="_blank" rel="noreferrer">
                 <SquareArrowOutUpRight className="h-4 w-4" />

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -44,7 +44,7 @@ import {
   usePinApp,
 } from "@/lib/app.query";
 import { appRunUrl } from "@/lib/apps/app-run-url";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useAppAccess } from "@/lib/apps/use-app-access";
 import { setPendingProjectChatHandoff } from "@/lib/chat/pending-project-chat-handoff";
 import { useFeature } from "@/lib/config/config.query";
 import type { BulkCardSelectionProps } from "@/lib/hooks/use-bulk-card-selection";
@@ -82,10 +82,12 @@ function CardSelectionCheckbox({
   label,
   selection,
   disabled = false,
+  disabledReason = "Installed apps are managed through their MCP server",
 }: {
   label: string;
   selection?: BulkCardSelectionProps;
   disabled?: boolean;
+  disabledReason?: string;
 }) {
   const checkbox = (
     <Checkbox
@@ -103,15 +105,14 @@ function CardSelectionCheckbox({
 
   if (!disabled) return checkbox;
 
-  const reason = "Installed apps are managed through their MCP server";
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="inline-flex cursor-not-allowed" title={reason}>
+        <span className="inline-flex cursor-not-allowed" title={disabledReason}>
           {checkbox}
         </span>
       </TooltipTrigger>
-      <TooltipContent>{reason}</TooltipContent>
+      <TooltipContent>{disabledReason}</TooltipContent>
     </Tooltip>
   );
 }
@@ -233,7 +234,7 @@ function OwnedAppCard({
   const router = useRouter();
   const openApp = useOpenAppInChat();
   const lockedChatEnabled = useFeature("lockedChatEnabled") ?? false;
-  const { data: canDelete } = useHasPermissions({ app: ["delete"] });
+  const access = useAppAccess(app);
   // A personal app the caller only reaches through app:admin oversight
   // (viewerRole "admin") — i.e. someone else's personal app — gets a visible
   // "Owned by <name>" badge (mirroring the Projects page) so an admin can tell
@@ -280,6 +281,8 @@ function OwnedAppCard({
               <CardSelectionCheckbox
                 label={`Select ${app.name}`}
                 selection={selection}
+                disabled={selection.selectionDisabled || !access.canEdit}
+                disabledReason="You do not have permission to modify this app"
               />
             ) : null}
             <AppTypeIcon owned icon={app.icon} />
@@ -328,7 +331,7 @@ function OwnedAppCard({
             />
             <DropdownMenuItem onSelect={() => onOpenSettings?.(app)}>
               <Settings className="h-4 w-4" />
-              Settings
+              <span>{access.canEdit ? "Settings" : "View settings"}</span>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <Link href={appRunUrl(app)} target="_blank" rel="noreferrer">
@@ -346,7 +349,7 @@ function OwnedAppCard({
                 Open as locked chat
               </DropdownMenuItem>
             ) : null}
-            {canDelete ? (
+            {access.canDeleteApp ? (
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem

--- a/platform/frontend/src/app/apps/_parts/app-tools-editor.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-editor.test.tsx
@@ -317,4 +317,19 @@ describe("AppToolsEditor", () => {
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     expect(fetchCatalogToolsMock).not.toHaveBeenCalled();
   });
+
+  it("honors a per-app read-only state despite the global update permission", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppToolsEditor appId={APP_ID} readOnly />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("create_issue")).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(fetchCatalogToolsMock).not.toHaveBeenCalled();
+  });
 });

--- a/platform/frontend/src/app/apps/_parts/app-tools-editor.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-editor.tsx
@@ -56,6 +56,7 @@ export function AppToolsEditor({
   environmentId,
   selectedToolIds,
   onSelectionChange,
+  readOnly = false,
 }: {
   appId: string;
   /**
@@ -73,11 +74,14 @@ export function AppToolsEditor({
    */
   selectedToolIds?: Set<string>;
   onSelectionChange?: (next: Set<string>) => void;
+  /** Force the assigned-tools summary even when the caller has app:update. */
+  readOnly?: boolean;
 }) {
   const { data: app } = useApp(environmentId === undefined ? appId : null);
   const { data: assigned, isPending } = useAppTools(appId);
   const { data: catalogs = [] } = useInternalMcpCatalog();
-  const { data: canEdit } = useHasPermissions({ app: ["update"] });
+  const { data: hasUpdatePermission } = useHasPermissions({ app: ["update"] });
+  const canEdit = hasUpdatePermission === true && !readOnly;
   const assignTool = useAssignToolToApp();
   const unassignTool = useUnassignToolFromApp();
 
@@ -175,7 +179,7 @@ export function AppToolsEditor({
     queries: candidates.map((c) => ({
       queryKey: ["mcp-catalog", c.id, "tools"] as const,
       queryFn: () => fetchCatalogTools(c.id),
-      enabled: canEdit === true,
+      enabled: canEdit,
     })),
   });
 
@@ -327,7 +331,7 @@ export function AppToolsEditor({
     [candidates, toolsByCatalog, selectedByCatalog],
   );
 
-  if (canEdit !== true) {
+  if (!canEdit) {
     return (
       <AssignedToolsReadOnly
         isPending={isPending && !assigned}

--- a/platform/frontend/src/app/apps/_parts/apps-table.tsx
+++ b/platform/frontend/src/app/apps/_parts/apps-table.tsx
@@ -32,6 +32,10 @@ import {
   useOpenExternalAppInChat,
   usePinApp,
 } from "@/lib/app.query";
+import {
+  computeAppAccess,
+  useAppAccessContext,
+} from "@/lib/apps/use-app-access";
 import type { BulkRangeSelectionController } from "@/lib/bulk-range-selection";
 import { setPendingProjectChatHandoff } from "@/lib/chat/pending-project-chat-handoff";
 import { AppTypeIcon } from "./app-card";
@@ -61,6 +65,7 @@ export function AppsTable({
   const openOwnedApp = useOpenAppInChat();
   const openExternalApp = useOpenExternalAppInChat();
   const pinApp = usePinApp();
+  const accessContext = useAppAccessContext();
   // Row-scoped "Opening…" indicator; mirrors the card overlay. Stays set
   // through the redirect (the table unmounts on success); only a failure
   // resets it.
@@ -113,9 +118,12 @@ export function AppsTable({
     createSelectColumn<AppListItem>({
       rowLabel: (app) => `Select ${app.name}`,
       allLabel: "Select all apps on this page",
-      canSelect: (app) => app.source === "owned",
-      disabledReason: () =>
-        "Installed apps are managed through their MCP server",
+      canSelect: (app) =>
+        app.source === "owned" && computeAppAccess(app, accessContext).canEdit,
+      disabledReason: (app) =>
+        app.source === "owned"
+          ? "You do not have permission to modify this app"
+          : "Installed apps are managed through their MCP server",
     }),
     {
       id: "name",
@@ -208,25 +216,31 @@ export function AppsTable({
     },
   ];
 
-  const ownedAppActions = (app: OwnedApp): TableRowAction[] => [
-    {
-      icon: <Settings className="h-4 w-4" />,
-      label: "Settings",
-      onClick: () => onOpenSettings({ id: app.id }),
-    },
-    {
-      icon: <SquareArrowOutUpRight className="h-4 w-4" />,
-      label: "Open in new tab",
-      onClick: () => window.open(`/a/${app.id}`, "_blank", "noreferrer"),
-    },
-    {
-      icon: <Trash2 className="h-4 w-4" />,
-      label: "Delete",
-      variant: "destructive",
-      permissions: { app: ["delete"] },
-      onClick: () => setDeletingApp(app),
-    },
-  ];
+  const ownedAppActions = (app: OwnedApp): TableRowAction[] => {
+    const access = computeAppAccess(app, accessContext);
+    return [
+      {
+        icon: <Settings className="h-4 w-4" />,
+        label: access.canEdit ? "Settings" : "View settings",
+        onClick: () => onOpenSettings({ id: app.id }),
+      },
+      {
+        icon: <SquareArrowOutUpRight className="h-4 w-4" />,
+        label: "Open in new tab",
+        onClick: () => window.open(`/a/${app.id}`, "_blank", "noreferrer"),
+      },
+      ...(access.canDeleteApp
+        ? [
+            {
+              icon: <Trash2 className="h-4 w-4" />,
+              label: "Delete",
+              variant: "destructive" as const,
+              onClick: () => setDeletingApp(app),
+            },
+          ]
+        : []),
+    ];
+  };
 
   const externalAppActions = (
     app: Extract<AppListItem, { source: "external" }>,

--- a/platform/frontend/src/app/apps/_parts/apps-table.tsx
+++ b/platform/frontend/src/app/apps/_parts/apps-table.tsx
@@ -219,11 +219,15 @@ export function AppsTable({
   const ownedAppActions = (app: OwnedApp): TableRowAction[] => {
     const access = computeAppAccess(app, accessContext);
     return [
-      {
-        icon: <Settings className="h-4 w-4" />,
-        label: access.canEdit ? "Settings" : "View settings",
-        onClick: () => onOpenSettings({ id: app.id }),
-      },
+      ...(access.canEdit
+        ? [
+            {
+              icon: <Settings className="h-4 w-4" />,
+              label: "Settings",
+              onClick: () => onOpenSettings({ id: app.id }),
+            },
+          ]
+        : []),
       {
         icon: <SquareArrowOutUpRight className="h-4 w-4" />,
         label: "Open in new tab",

--- a/platform/frontend/src/app/apps/_parts/apps-table.tsx
+++ b/platform/frontend/src/app/apps/_parts/apps-table.tsx
@@ -159,7 +159,7 @@ export function AppsTable({
     },
     {
       id: "sharing",
-      size: 180,
+      size: 160,
       header: "Sharing",
       cell: ({ row }) => {
         const app = row.original;
@@ -300,6 +300,8 @@ export function AppsTable({
         emptyIcon={AppWindow}
         emptyMessage="No apps here yet"
         hidePaginationWhenSinglePage
+        fixedWidthColumnIds={["sharing"]}
+        flexibleColumnIds={["name"]}
       />
 
       {deletingApp && (

--- a/platform/frontend/src/app/apps/_parts/apps-table.tsx
+++ b/platform/frontend/src/app/apps/_parts/apps-table.tsx
@@ -33,6 +33,7 @@ import {
   usePinApp,
 } from "@/lib/app.query";
 import {
+  appActionDisabledReason,
   computeAppAccess,
   useAppAccessContext,
 } from "@/lib/apps/use-app-access";
@@ -122,7 +123,11 @@ export function AppsTable({
         app.source === "owned" && computeAppAccess(app, accessContext).canEdit,
       disabledReason: (app) =>
         app.source === "owned"
-          ? "You do not have permission to modify this app"
+          ? (appActionDisabledReason({
+              app,
+              access: computeAppAccess(app, accessContext),
+              action: "update",
+            }) ?? "You do not have permission to modify this app")
           : "Installed apps are managed through their MCP server",
     }),
     {
@@ -218,31 +223,39 @@ export function AppsTable({
 
   const ownedAppActions = (app: OwnedApp): TableRowAction[] => {
     const access = computeAppAccess(app, accessContext);
+    const settingsDisabledReason = appActionDisabledReason({
+      app,
+      access,
+      action: "update",
+    });
+    const deleteDisabledReason = appActionDisabledReason({
+      app,
+      access,
+      action: "delete",
+    });
     return [
-      ...(access.canEdit
-        ? [
-            {
-              icon: <Settings className="h-4 w-4" />,
-              label: "Settings",
-              onClick: () => onOpenSettings({ id: app.id }),
-            },
-          ]
-        : []),
+      {
+        icon: <Settings className="h-4 w-4" />,
+        label: "Settings",
+        permissions: { app: ["update"] },
+        disabled: !!settingsDisabledReason,
+        disabledTooltip: settingsDisabledReason,
+        onClick: () => onOpenSettings({ id: app.id }),
+      },
       {
         icon: <SquareArrowOutUpRight className="h-4 w-4" />,
         label: "Open in new tab",
         onClick: () => window.open(`/a/${app.id}`, "_blank", "noreferrer"),
       },
-      ...(access.canDeleteApp
-        ? [
-            {
-              icon: <Trash2 className="h-4 w-4" />,
-              label: "Delete",
-              variant: "destructive" as const,
-              onClick: () => setDeletingApp(app),
-            },
-          ]
-        : []),
+      {
+        icon: <Trash2 className="h-4 w-4" />,
+        label: "Delete",
+        permissions: { app: ["delete"] },
+        disabled: !!deleteDisabledReason,
+        disabledTooltip: deleteDisabledReason,
+        variant: "destructive" as const,
+        onClick: () => setDeletingApp(app),
+      },
     ];
   };
 

--- a/platform/frontend/src/app/apps/page.client.test.tsx
+++ b/platform/frontend/src/app/apps/page.client.test.tsx
@@ -233,11 +233,29 @@ describe("AppSection cards", () => {
       screen.getByText("2 apps selected", { selector: '[aria-hidden="true"]' }),
     ).toBeVisible();
   });
+
+  it("keeps Sharing compact while the app name absorbs table width", () => {
+    const { container } = renderAppSection([ownedApp], "table");
+
+    expect(container.querySelector('th[data-column-id="sharing"]')).toHaveStyle(
+      { width: "160px" },
+    );
+    expect(
+      (container.querySelector('th[data-column-id="name"]') as HTMLElement)
+        .style.width,
+    ).toBe("");
+  });
 });
 
-function renderAppSection(apps: AppListItem[] = [ownedApp, externalApp]) {
+function renderAppSection(
+  apps: AppListItem[] = [ownedApp, externalApp],
+  defaultMode: "cards" | "table" = "cards",
+) {
   return render(
-    <TableCardView storageKey="apps-test-view" defaultMode="cards">
+    <TableCardView
+      storageKey={`apps-test-view-${defaultMode}`}
+      defaultMode={defaultMode}
+    >
       <FilterBar>
         <span>Filters</span>
       </FilterBar>

--- a/platform/frontend/src/app/apps/page.client.test.tsx
+++ b/platform/frontend/src/app/apps/page.client.test.tsx
@@ -30,6 +30,11 @@ vi.mock("@/lib/app.query", () => ({
 
 vi.mock("@/lib/auth/auth.query", () => ({
   useHasPermissions: () => ({ data: true }),
+  useSession: () => ({ data: { user: { id: "user-1" } } }),
+}));
+
+vi.mock("@/lib/organization.query", () => ({
+  useOrganizationMembers: () => ({ data: [] }),
 }));
 
 const { appAccessState } = vi.hoisted(() => ({
@@ -60,6 +65,12 @@ vi.mock("@/lib/apps/use-app-access", () => {
 
 vi.mock("@/lib/config/config.query", () => ({
   useFeature: () => false,
+}));
+
+vi.mock("@/lib/teams/team.query", () => ({
+  useAssignableTeams: () => ({
+    data: [{ id: "leadership", name: "Leadership" }],
+  }),
 }));
 
 vi.mock("@/components/ui/permission-button", () => ({
@@ -244,6 +255,28 @@ describe("AppSection cards", () => {
       (container.querySelector('th[data-column-id="name"]') as HTMLElement)
         .style.width,
     ).toBe("");
+  });
+
+  it("warns about losing chat authoring access in bulk visibility too", () => {
+    renderAppSection([
+      {
+        ...ownedApp,
+        scope: "team",
+        teams: [{ id: "leadership", name: "Leadership" }],
+      },
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select My Owned App" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Edit visibility" }));
+
+    expect(
+      screen.getByText("You are not a member of the selected teams"),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/will not be able to modify this app through chat/i),
+    ).toBeVisible();
   });
 });
 

--- a/platform/frontend/src/app/apps/page.client.test.tsx
+++ b/platform/frontend/src/app/apps/page.client.test.tsx
@@ -51,6 +51,10 @@ vi.mock("@/lib/apps/use-app-access", () => {
     useAppAccessContext: () => access,
     useAppAccess: () => ({ ...access, ...appAccessState }),
     computeAppAccess: () => ({ ...access, ...appAccessState }),
+    appActionDisabledReason: () =>
+      appAccessState.canEdit
+        ? undefined
+        : "Only an admin can change this org-wide app",
   };
 });
 
@@ -203,7 +207,7 @@ describe("AppSection cards", () => {
     });
     expect(checkbox).toBeDisabled();
     expect(
-      screen.getByTitle("You do not have permission to modify this app"),
+      screen.getByTitle("Only an admin can change this org-wide app"),
     ).toContainElement(checkbox);
 
     fireEvent.click(checkbox);

--- a/platform/frontend/src/app/apps/page.client.test.tsx
+++ b/platform/frontend/src/app/apps/page.client.test.tsx
@@ -272,7 +272,7 @@ describe("AppSection cards", () => {
     fireEvent.click(screen.getByRole("button", { name: "Edit visibility" }));
 
     expect(
-      screen.getByText("You are not a member of the selected teams"),
+      screen.getByText("You are not a member of the selected teams."),
     ).toBeVisible();
     expect(
       screen.getByText(/will not be able to modify this app through chat/i),

--- a/platform/frontend/src/app/apps/page.client.test.tsx
+++ b/platform/frontend/src/app/apps/page.client.test.tsx
@@ -1,7 +1,7 @@
 import type { archestraApiTypes } from "@archestra/shared";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FilterBar } from "@/components/filter-bar";
 import { TableCardView } from "@/components/table-card-view";
 import { AppSection, matchesKind } from "./page.client";
@@ -31,6 +31,28 @@ vi.mock("@/lib/app.query", () => ({
 vi.mock("@/lib/auth/auth.query", () => ({
   useHasPermissions: () => ({ data: true }),
 }));
+
+const { appAccessState } = vi.hoisted(() => ({
+  appAccessState: { canEdit: true, canDeleteApp: true },
+}));
+
+vi.mock("@/lib/apps/use-app-access", () => {
+  const access = {
+    isAdmin: true,
+    isTeamAdmin: true,
+    canUpdate: true,
+    canDelete: true,
+    currentUserId: "user-1",
+    userTeamIds: new Set<string>(),
+    isPending: false,
+    canModify: true,
+  };
+  return {
+    useAppAccessContext: () => access,
+    useAppAccess: () => ({ ...access, ...appAccessState }),
+    computeAppAccess: () => ({ ...access, ...appAccessState }),
+  };
+});
 
 vi.mock("@/lib/config/config.query", () => ({
   useFeature: () => false,
@@ -111,6 +133,11 @@ const externalApp: Extract<AppListItem, { source: "external" }> = {
   requiresInput: false,
 };
 
+beforeEach(() => {
+  appAccessState.canEdit = true;
+  appAccessState.canDeleteApp = true;
+});
+
 describe("matchesKind", () => {
   it("matches every app when kind is all", () => {
     expect(matchesKind(ownedApp, "all")).toBe(true);
@@ -163,6 +190,23 @@ describe("AppSection cards", () => {
 
     fireEvent.click(checkbox);
 
+    expect(screen.queryByText("1 app selected")).not.toBeInTheDocument();
+  });
+
+  it("keeps an owned app out of bulk selection when scope rules deny changes", () => {
+    appAccessState.canEdit = false;
+    appAccessState.canDeleteApp = false;
+    renderAppSection([ownedApp]);
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Select My Owned App",
+    });
+    expect(checkbox).toBeDisabled();
+    expect(
+      screen.getByTitle("You do not have permission to modify this app"),
+    ).toContainElement(checkbox);
+
+    fireEvent.click(checkbox);
     expect(screen.queryByText("1 app selected")).not.toBeInTheDocument();
   });
 

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -53,6 +53,10 @@ import {
   useBulkUpdateAppVisibility,
 } from "@/lib/app.query";
 import { sortAppsPinnedFirst } from "@/lib/apps/app-sort";
+import {
+  computeAppAccess,
+  useAppAccessContext,
+} from "@/lib/apps/use-app-access";
 import { reportBulkOutcome } from "@/lib/bulk-action";
 import { useBulkCardSelection } from "@/lib/hooks/use-bulk-card-selection";
 import { useBulkSelection } from "@/lib/hooks/use-bulk-selection";
@@ -333,6 +337,12 @@ export function AppSection({
   const [bulkVisibilityOpen, setBulkVisibilityOpen] = useState(false);
   const bulkDelete = useBulkDeleteApps();
   const bulkVisibility = useBulkUpdateAppVisibility();
+  const accessContext = useAppAccessContext();
+  const canSelect = useCallback(
+    (app: AppListItem) =>
+      app.source === "owned" && computeAppAccess(app, accessContext).canEdit,
+    [accessContext],
+  );
   const {
     rowSelection,
     setRowSelection,
@@ -344,7 +354,7 @@ export function AppSection({
   } = useBulkSelection({
     rows: apps,
     getId: getAppRowKey,
-    canSelect: (app) => app.source === "owned",
+    canSelect,
     filterSignature: `${title}:${apps.map(getAppRowKey).join(",")}`,
     matchDescription: "were built here",
   });
@@ -353,7 +363,7 @@ export function AppSection({
     getRowId: getAppRowKey,
     rowSelection,
     setRowSelection,
-    canSelect: (app) => app.source === "owned",
+    canSelect,
     rangeSelection,
   });
   const selectedOwnedApps = selected.filter(
@@ -409,9 +419,7 @@ export function AppSection({
         }
         cards={
           <TableCardSelectionScope
-            rowIds={apps
-              .filter((app) => app.source === "owned")
-              .map(getAppRowKey)}
+            rowIds={apps.filter(canSelect).map(getAppRowKey)}
             onVisibleRowIdsChange={onPageRowIdsChange}
           >
             <TableCardGrid>

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/label-select";
 import { LoadingState, LoadingWrapper } from "@/components/loading";
 import { AppSettingsDialog } from "@/components/mcp-app/app-settings-dialog";
+import { AppTeamAccessWarning } from "@/components/mcp-app/app-team-access-warning";
 import { PageLayout } from "@/components/page-layout";
 import { QueryLoadError } from "@/components/query-load-error";
 import {
@@ -473,9 +474,20 @@ export function AppSection({
           items={selectedOwnedApps.map((app) => ({
             id: app.id,
             scope: app.scope,
-            teams: [],
-            users: [],
+            teams: app.teams,
+            users: app.users,
           }))}
+          renderTeamSelectionNotice={(teamIds) => (
+            <AppTeamAccessWarning
+              scope="team"
+              selectedTeamIds={teamIds}
+              isAppAdmin={accessContext.isAdmin}
+              userTeamIds={accessContext.userTeamIds}
+              subject={
+                selectedOwnedApps.length === 1 ? "this app" : "these apps"
+              }
+            />
+          )}
           onApply={async (change) => {
             const outcome = await bulkVisibility.mutateAsync({
               apps: selectedApps,

--- a/platform/frontend/src/app/plugins/page.client.test.tsx
+++ b/platform/frontend/src/app/plugins/page.client.test.tsx
@@ -107,7 +107,7 @@ describe("PluginsPage", () => {
   });
 
   it("groups related facts into a compact table", () => {
-    render(<PluginsPage />);
+    const { container } = render(<PluginsPage />);
 
     for (const name of [
       "Plugin",
@@ -125,6 +125,16 @@ describe("PluginsPage", () => {
       ).not.toBeInTheDocument();
     }
     expect(screen.getByText("13 files")).toBeVisible();
+    expect(container.querySelector('th[data-column-id="source"]')).toHaveStyle({
+      width: "180px",
+    });
+    expect(
+      (
+        container.querySelector(
+          'th[data-column-id="displayName"]',
+        ) as HTMLElement
+      ).style.width,
+    ).toBe("");
   });
 
   it("attributes the vendor's own plugin to its author, not the deployment", () => {

--- a/platform/frontend/src/app/plugins/page.client.tsx
+++ b/platform/frontend/src/app/plugins/page.client.tsx
@@ -497,7 +497,7 @@ function PluginsList() {
     },
     {
       id: "source",
-      size: 250,
+      size: 180,
       header: "Source",
       cell: ({ row }) => {
         const plugin = row.original;
@@ -922,6 +922,7 @@ function PluginsList() {
                     fixedWidthColumnIds={[
                       "compatibility",
                       "visibility",
+                      "source",
                       "updatedAt",
                     ]}
                     flexibleColumnIds={["displayName"]}

--- a/platform/frontend/src/components/agent-icon-picker.tsx
+++ b/platform/frontend/src/components/agent-icon-picker.tsx
@@ -42,6 +42,8 @@ interface AgentIconPickerProps {
   value: string | null;
   onChange: (icon: string | null) => void;
   className?: string;
+  /** Show the current icon without allowing it to be changed or removed. */
+  disabled?: boolean;
   /** Show a "Logos" tab with pre-built service brand logos */
   showLogos?: boolean;
   fallbackType?: AgentIconPickerFallback;
@@ -51,6 +53,7 @@ export function AgentIconPicker({
   value,
   onChange,
   className,
+  disabled = false,
   showLogos = false,
   fallbackType = "agent",
 }: AgentIconPickerProps) {
@@ -127,13 +130,22 @@ export function AgentIconPicker({
               : Bot;
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={disabled ? false : open}
+      onOpenChange={(next) => {
+        if (!disabled) setOpen(next);
+      }}
+    >
       <PopoverTrigger asChild>
         <button
           type="button"
-          aria-label={value ? "Change icon" : "Choose icon"}
+          aria-label={disabled ? "Icon" : value ? "Change icon" : "Choose icon"}
+          disabled={disabled}
           className={cn(
-            "relative group flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border-2 border-dashed hover:border-primary/50 hover:bg-accent transition-colors cursor-pointer",
+            "relative group flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border-2 border-dashed transition-colors",
+            disabled
+              ? "cursor-default opacity-80"
+              : "cursor-pointer hover:border-primary/50 hover:bg-accent",
             value && "border-solid border-border",
             className,
           )}
@@ -153,7 +165,7 @@ export function AgentIconPicker({
           ) : (
             <FallbackIcon className="h-5 w-5 text-muted-foreground" />
           )}
-          {value && (
+          {value && !disabled && (
             // biome-ignore lint/a11y/useSemanticElements: can't use <button> here as it's nested inside PopoverTrigger's <button>
             <div
               role="button"

--- a/platform/frontend/src/components/agent-run-credential-prompt.tsx
+++ b/platform/frontend/src/components/agent-run-credential-prompt.tsx
@@ -5,6 +5,10 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import { RuntimeCredentialConnectionDialog } from "@/components/runtime-credential-connection-dialog";
 import { Button } from "@/components/ui/button";
+import {
+  CompactWarning,
+  CompactWarningText,
+} from "@/components/ui/compact-warning";
 import { useFeature } from "@/lib/config/config.query";
 import {
   type RuntimeCredentialDefinition,
@@ -64,17 +68,14 @@ export function AgentRuntimeCredentialPrompt({
     <>
       {/* Deliberately slimmer than an <Alert>: this sits directly under the
           composer, where a full padded alert block dwarfs the input row. */}
-      <div
-        role="alert"
-        className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-amber-500/50 bg-amber-50 px-2.5 py-1.5 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-950/50 dark:text-amber-200"
-      >
-        <KeyRound className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+      <CompactWarning className="mt-2">
+        <KeyRound />
         <span className="font-medium">
           {missing.length === 1
             ? `${missing[0].label} is required`
             : `${missing.length} connections are required`}
         </span>
-        <span className="text-amber-800 dark:text-amber-300">{helperText}</span>
+        <CompactWarningText>{helperText}</CompactWarningText>
         {definition ? (
           <Button
             type="button"
@@ -97,7 +98,7 @@ export function AgentRuntimeCredentialPrompt({
             </Link>
           </Button>
         )}
-      </div>
+      </CompactWarning>
       {connecting && (
         <RuntimeCredentialConnectionDialog
           definition={connecting}

--- a/platform/frontend/src/components/bulk-visibility-dialog.tsx
+++ b/platform/frontend/src/components/bulk-visibility-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ResourceVisibilityScope } from "@archestra/shared";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { SkillScopeSelector } from "@/app/skills/_parts/skill-scope-selector";
 import { FormDialog } from "@/components/form-dialog";
 import { Button } from "@/components/ui/button";
@@ -43,6 +43,7 @@ export function BulkVisibilityDialog({
   onOpenChange,
   onApply,
   isPending,
+  renderTeamSelectionNotice,
 }: {
   items: readonly BulkVisibilityItem[];
   noun: string;
@@ -56,6 +57,8 @@ export function BulkVisibilityDialog({
    */
   onApply: (change: BulkVisibilityChange) => Promise<boolean>;
   isPending: boolean;
+  /** Optional resource-specific consequence of the staged team selection. */
+  renderTeamSelectionNotice?: (teamIds: readonly string[]) => ReactNode;
 }) {
   const common = commonVisibility(items);
   const [scope, setScope] = useState<ResourceVisibilityScope>(
@@ -106,6 +109,9 @@ export function BulkVisibilityDialog({
           userIds={userIds}
           onUserIdsChange={setUserIds}
         />
+        {scope === "team" && renderTeamSelectionNotice ? (
+          <div className="mt-3">{renderTeamSelectionNotice(teamIds)}</div>
+        ) : null}
       </div>
 
       <DialogStickyFooter>

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -3,6 +3,10 @@ import userEvent from "@testing-library/user-event";
 import { type ReactNode, useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const { authPermissionState } = vi.hoisted(() => ({
+  authPermissionState: { granted: false },
+}));
+
 // ── Mock heavy dependencies before module import ─────────────────────────────
 
 vi.mock("@modelcontextprotocol/ext-apps/app-bridge", async (importActual) => ({
@@ -68,7 +72,7 @@ vi.mock("@/lib/hooks/use-app-name");
 // Avoid pulling the real auth client / app query (and their network deps) into
 // the test; the edit pencil is covered by app-frame.test.tsx.
 vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: false }),
+  useHasPermissions: () => ({ data: authPermissionState.granted }),
   useSession: () => ({ data: undefined }),
 }));
 
@@ -79,6 +83,8 @@ vi.mock("@/lib/app.query", () => ({
 
 vi.mock("@/lib/apps/use-app-access", () => ({
   useAppAccess: vi.fn(() => ({ canEdit: true, isPending: false })),
+  appActionDisabledReason: ({ access }: { access: { canEdit: boolean } }) =>
+    access.canEdit ? undefined : "Only an admin can change this org-wide app",
 }));
 
 // Session-recording hooks pull TanStack Query mutations; this suite renders
@@ -127,6 +133,7 @@ const mockUseAppAccess = vi.mocked(useAppAccess);
 // earlier test set, so re-seed the default here: one test's owned-app fixture
 // (a name, a fullscreen-by-default flag) must not leak into the next.
 beforeEach(() => {
+  authPermissionState.granted = false;
   mockUseApp.mockReturnValue({ data: undefined } as ReturnType<typeof useApp>);
   mockUseAppAccess.mockReturnValue({
     canEdit: true,
@@ -1529,6 +1536,7 @@ describe("McpAppSection owned-app panel chrome", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearAllAppDiagnostics();
+    authPermissionState.granted = true;
   });
 
   // Renders an owned app on the panel surface so the panel chrome (settings gear
@@ -1611,7 +1619,7 @@ describe("McpAppSection owned-app panel chrome", () => {
     ).toBeInTheDocument();
   });
 
-  it("hides app settings when the viewer cannot edit the app", async () => {
+  it("disables app settings with the scope reason when the viewer cannot edit the app", async () => {
     mockUseAppAccess.mockReturnValue({
       canEdit: false,
       isPending: false,
@@ -1619,9 +1627,13 @@ describe("McpAppSection owned-app panel chrome", () => {
 
     await renderOwnedPanel();
 
+    const settings = screen.getByRole("button", { name: /^settings$/i });
+    expect(settings).toHaveAttribute("aria-disabled", "true");
     expect(
-      screen.queryByRole("button", { name: /^settings$/i }),
-    ).not.toBeInTheDocument();
+      document.getElementById(
+        settings.getAttribute("aria-describedby") as string,
+      ),
+    ).toHaveTextContent("Only an admin can change this org-wide app");
     expect(screen.queryByTestId("settings-form")).not.toBeInTheDocument();
   });
 

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -78,7 +78,7 @@ vi.mock("@/lib/app.query", () => ({
 }));
 
 vi.mock("@/lib/apps/use-app-access", () => ({
-  useAppAccess: () => ({ canEdit: true, isPending: false }),
+  useAppAccess: vi.fn(() => ({ canEdit: true, isPending: false })),
 }));
 
 // Session-recording hooks pull TanStack Query mutations; this suite renders
@@ -111,6 +111,7 @@ vi.mock("@/components/mcp-app/app-settings-form", () => ({
 import { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
 import { McpAppRuntime } from "@/components/mcp-app/mcp-app-view";
 import { useApp } from "@/lib/app.query";
+import { useAppAccess } from "@/lib/apps/use-app-access";
 import {
   clearAllAppDiagnostics,
   reportAppDiagnostic,
@@ -120,12 +121,17 @@ import { AppsProvider, type PanelApp, useApps } from "./apps-context";
 import { McpAppSection } from "./mcp-app-container";
 
 const mockUseApp = vi.mocked(useApp);
+const mockUseAppAccess = vi.mocked(useAppAccess);
 
 // `vi.clearAllMocks()` clears recorded calls but keeps a `mockReturnValue` an
 // earlier test set, so re-seed the default here: one test's owned-app fixture
 // (a name, a fullscreen-by-default flag) must not leak into the next.
 beforeEach(() => {
   mockUseApp.mockReturnValue({ data: undefined } as ReturnType<typeof useApp>);
+  mockUseAppAccess.mockReturnValue({
+    canEdit: true,
+    isPending: false,
+  } as ReturnType<typeof useAppAccess>);
 });
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -1603,6 +1609,20 @@ describe("McpAppSection owned-app panel chrome", () => {
     expect(
       screen.getByRole("button", { name: /^settings$/i }),
     ).toBeInTheDocument();
+  });
+
+  it("hides app settings when the viewer cannot edit the app", async () => {
+    mockUseAppAccess.mockReturnValue({
+      canEdit: false,
+      isPending: false,
+    } as ReturnType<typeof useAppAccess>);
+
+    await renderOwnedPanel();
+
+    expect(
+      screen.queryByRole("button", { name: /^settings$/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("settings-form")).not.toBeInTheDocument();
   });
 
   it("closes settings when a newly rendered app takes the panel", async () => {

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -77,6 +77,10 @@ vi.mock("@/lib/app.query", () => ({
   useDeleteApp: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
 
+vi.mock("@/lib/apps/use-app-access", () => ({
+  useAppAccess: () => ({ canEdit: true, isPending: false }),
+}));
+
 // Session-recording hooks pull TanStack Query mutations; this suite renders
 // without a QueryClient, so stub the module (recording flows have their own
 // coverage).

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -36,7 +36,10 @@ import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useApp } from "@/lib/app.query";
-import { useAppAccess } from "@/lib/apps/use-app-access";
+import {
+  appActionDisabledReason,
+  useAppAccess,
+} from "@/lib/apps/use-app-access";
 import {
   getAppDiagnosticCounts,
   subscribeAppDiagnostics,
@@ -336,6 +339,13 @@ export function McpAppEntryContent({
   const inlineHeightCap = useInlineHeightCap();
   const { data: ownedApp, isSuccess: ownedAppResolved } = useApp(appId ?? null);
   const ownedAppAccess = useAppAccess(ownedApp);
+  const settingsDisabledReason = ownedApp
+    ? appActionDisabledReason({
+        app: ownedApp,
+        access: ownedAppAccess,
+        action: "update",
+      })
+    : undefined;
   // An owned app this viewer cannot mount, which happens for two very different
   // reasons the API deliberately does not tell apart: the app was deleted, or it
   // is perfectly healthy and simply not theirs to open (the ordinary case for a
@@ -548,8 +558,11 @@ export function McpAppEntryContent({
               disabled={recorder.status !== "idle"}
             />
           ) : null}
-          {isOwnedInPanel && ownedAppAccess.canEdit ? (
-            <McpAppSettingsButton onClick={() => setSettingsOpen(true)} />
+          {isOwnedInPanel ? (
+            <McpAppSettingsButton
+              disabledReason={settingsDisabledReason}
+              onClick={() => setSettingsOpen(true)}
+            />
           ) : null}
           {/* The bar is the only chrome the panel has, so it carries the way
               into fullscreen and the way back out. Escape alone doesn't cut it

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -36,6 +36,7 @@ import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useApp } from "@/lib/app.query";
+import { useAppAccess } from "@/lib/apps/use-app-access";
 import {
   getAppDiagnosticCounts,
   subscribeAppDiagnostics,
@@ -334,6 +335,7 @@ export function McpAppEntryContent({
   // render time) and to seed the settings dialog.
   const inlineHeightCap = useInlineHeightCap();
   const { data: ownedApp, isSuccess: ownedAppResolved } = useApp(appId ?? null);
+  const ownedAppAccess = useAppAccess(ownedApp);
   // An owned app this viewer cannot mount, which happens for two very different
   // reasons the API deliberately does not tell apart: the app was deleted, or it
   // is perfectly healthy and simply not theirs to open (the ordinary case for a
@@ -519,18 +521,22 @@ export function McpAppEntryContent({
             {headerName}
           </span>
           {isOwnedInPanel && !ownedApp.enabled ? (
-            <button
-              type="button"
-              onClick={() => setSettingsOpen(true)}
-              title="Disabled — only you can see this app. Click to enable."
-            >
-              <Badge
-                variant="outline"
-                className="cursor-pointer transition-colors hover:bg-accent hover:text-accent-foreground"
+            ownedAppAccess.canEdit ? (
+              <button
+                type="button"
+                onClick={() => setSettingsOpen(true)}
+                title="Disabled — only you can see this app. Click to enable."
               >
-                Disabled
-              </Badge>
-            </button>
+                <Badge
+                  variant="outline"
+                  className="cursor-pointer transition-colors hover:bg-accent hover:text-accent-foreground"
+                >
+                  Disabled
+                </Badge>
+              </button>
+            ) : (
+              <Badge variant="outline">Disabled</Badge>
+            )
           ) : null}
         </>
       }
@@ -542,7 +548,7 @@ export function McpAppEntryContent({
               disabled={recorder.status !== "idle"}
             />
           ) : null}
-          {isOwnedInPanel ? (
+          {isOwnedInPanel && ownedAppAccess.canEdit ? (
             <McpAppSettingsButton onClick={() => setSettingsOpen(true)} />
           ) : null}
           {/* The bar is the only chrome the panel has, so it carries the way
@@ -591,7 +597,7 @@ export function McpAppEntryContent({
     return (
       <>
         {liveSurface}
-        {isOwnedInPanel ? (
+        {isOwnedInPanel && ownedAppAccess.canEdit ? (
           <AppSettingsDialog
             appId={appId}
             open={settingsOpen}

--- a/platform/frontend/src/components/identity-fields.tsx
+++ b/platform/frontend/src/components/identity-fields.tsx
@@ -22,6 +22,7 @@ export function IdentityFields({
   onIconChange,
   fallbackType,
   showLogos,
+  disabled,
   children,
 }: {
   icon: string | null;
@@ -34,6 +35,8 @@ export function IdentityFields({
    * pick, so the layout stays the same and only the opening tab differs.
    */
   showLogos?: boolean;
+  /** Render the icon as orientation rather than an edit control. */
+  disabled?: boolean;
   /** The labelled fields that sit under the picker. */
   children: React.ReactNode;
 }) {
@@ -44,6 +47,7 @@ export function IdentityFields({
         onChange={onIconChange}
         fallbackType={fallbackType}
         showLogos={showLogos}
+        disabled={disabled}
       />
       {children}
     </div>

--- a/platform/frontend/src/components/mcp-app/app-settings-dialog.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-dialog.test.tsx
@@ -65,6 +65,11 @@ const userPermissions = {
   ...adminPermissionsSeed,
   app: ["read", "update", "admin", "team-admin"],
 } satisfies Permissions;
+const teamViewerPermissions = {
+  ...adminPermissionsSeed,
+  app: ["read", "update", "delete"],
+  team: ["read"],
+} satisfies Permissions;
 
 const server = setupServer(
   http.get(`${API_ORIGIN}/api/teams`, () => HttpResponse.json(teamsSeed)),
@@ -73,6 +78,9 @@ const server = setupServer(
   ),
   http.get(`${API_ORIGIN}/api/organization`, () =>
     HttpResponse.json(organizationSeed),
+  ),
+  http.get(`${API_ORIGIN}/api/organization/members`, () =>
+    HttpResponse.json([]),
   ),
   http.get(`${API_ORIGIN}/api/internal_mcp_catalog`, () =>
     HttpResponse.json([]),
@@ -218,6 +226,29 @@ describe("AppSettingsDialog", () => {
       app.name,
     );
   });
+
+  it("shows team members settings without edit controls when they cannot manage the app", async () => {
+    server.use(
+      http.get(APP_URL, () =>
+        HttpResponse.json({
+          ...app,
+          scope: "team",
+          teams: [{ id: "team-1", name: "Design" }],
+          viewerRole: "shared",
+        } satisfies archestraApiTypes.GetAppResponses["200"]),
+      ),
+    );
+
+    renderDialog(createQueryClient(teamViewerPermissions));
+
+    expect(await screen.findByText("View-only settings")).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Name *" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(screen.getAllByRole("button", { name: "Close" })[0]).toBeEnabled();
+    expect(
+      screen.getByText(/only a team admin who belongs to one of the teams/i),
+    ).toBeVisible();
+  });
 });
 
 function renderDialog(queryClient = createQueryClient()): void {
@@ -251,12 +282,14 @@ function renderControlledDialog(): void {
   );
 }
 
-function createQueryClient(): QueryClient {
+function createQueryClient(
+  permissions: Permissions = userPermissions,
+): QueryClient {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
   });
   queryClient.setQueryData(authQueryKeys.session(), sessionSeed);
-  queryClient.setQueryData(authQueryKeys.userPermissions(), userPermissions);
+  queryClient.setQueryData(authQueryKeys.userPermissions(), permissions);
   return queryClient;
 }
 

--- a/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useApp } from "@/lib/app.query";
+import { useAppAccess } from "@/lib/apps/use-app-access";
 
 // Ties the footer's Save button to the settings form via the HTML `form` attr.
 // Only one settings dialog is open at a time, so a single id is safe.
@@ -42,6 +43,7 @@ export function AppSettingsDialog({
     isLoadingError,
     refetch,
   } = useApp(open ? appId : null, { toastOnError: false });
+  const access = useAppAccess(app);
   const [status, setStatus] = useState({ saving: false, disabled: false });
 
   return (
@@ -91,9 +93,9 @@ export function AppSettingsDialog({
             variant="outline"
             onClick={() => onOpenChange(false)}
           >
-            Cancel
+            {app && !access.isPending && !access.canEdit ? "Close" : "Cancel"}
           </Button>
-          {app ? (
+          {app && !access.isPending && access.canEdit ? (
             <Button
               type="submit"
               form={APP_SETTINGS_FORM_ID}

--- a/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
@@ -49,7 +49,7 @@ vi.mock("@/lib/app.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/apps/use-app-access");
 vi.mock("@/lib/teams/team.query");
 vi.mock("@/lib/organization.query");
 
@@ -122,7 +122,7 @@ vi.mock("@/components/agent-icon-picker", () => ({
   ),
 }));
 
-import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useAppAccess } from "@/lib/apps/use-app-access";
 import { useOrganizationMembers } from "@/lib/organization.query";
 import { useAssignableTeams } from "@/lib/teams/team.query";
 import { AppSettingsForm } from "./app-settings-form";
@@ -132,6 +132,7 @@ const APP = {
   name: "Budget",
   description: "Team budget tracker",
   scope: "personal",
+  authorId: "author-id",
   enabled: true,
   locked: false,
   teams: [],
@@ -172,12 +173,18 @@ function submitForm(container: HTMLElement) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(useHasPermissions).mockReturnValue({
-    data: true,
-  } as ReturnType<typeof useHasPermissions>);
-  vi.mocked(useSession).mockReturnValue({
-    data: { user: { id: "author-id" } },
-  } as unknown as ReturnType<typeof useSession>);
+  vi.mocked(useAppAccess).mockReturnValue({
+    canEdit: true,
+    canDeleteApp: true,
+    canModify: true,
+    isAdmin: true,
+    isTeamAdmin: true,
+    canUpdate: true,
+    canDelete: true,
+    currentUserId: "author-id",
+    userTeamIds: new Set(),
+    isPending: false,
+  });
   vi.mocked(useOrganizationMembers).mockReturnValue({
     data: [],
   } as unknown as ReturnType<typeof useOrganizationMembers>);
@@ -191,6 +198,27 @@ beforeEach(() => {
 });
 
 describe("AppSettingsForm save", () => {
+  test("warns an app admin who is outside every selected team", () => {
+    vi.mocked(useAssignableTeams).mockReturnValue({
+      data: [{ id: "leadership", name: "Leadership" }],
+    } as ReturnType<typeof useAssignableTeams>);
+
+    renderForm({
+      app: {
+        ...APP,
+        scope: "team",
+        teams: [{ id: "leadership", name: "Leadership" }],
+      },
+    });
+
+    expect(
+      screen.getByText("You are not a member of the selected teams"),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/you will not be able to modify this app through chat/i),
+    ).toBeVisible();
+  });
+
   test("keeps labels under Advanced and saves an in-progress label", async () => {
     const user = userEvent.setup();
     const { container, onBack } = renderForm();

--- a/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
@@ -212,7 +212,7 @@ describe("AppSettingsForm save", () => {
     });
 
     expect(
-      screen.getByText("You are not a member of the selected teams"),
+      screen.getByText("You are not a member of the selected teams."),
     ).toBeVisible();
     expect(
       screen.getByText(/you will not be able to modify this app through chat/i),

--- a/platform/frontend/src/components/mcp-app/app-settings-form.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.tsx
@@ -12,6 +12,7 @@ import { AdvancedLabelsSection } from "@/components/advanced-labels-section";
 import type { ProfileLabel, ProfileLabelsRef } from "@/components/agent-labels";
 import { EnvironmentSelector } from "@/components/environment-selector";
 import { IdentityFields } from "@/components/identity-fields";
+import { AppTeamAccessWarning } from "@/components/mcp-app/app-team-access-warning";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { FieldDescription } from "@/components/ui/field-description";
 import { Input } from "@/components/ui/input";
@@ -272,11 +273,6 @@ export function AppSettingsForm({
   // plain personal app, quietly un-sharing it.
   const userSelectionMissing = scope === "user" && userIds.length === 0;
   const selectionMissing = teamSelectionMissing || userSelectionMissing;
-  const outsideSelectedTeams =
-    scope === "team" &&
-    teamIds.length > 0 &&
-    isAppAdmin &&
-    !teamIds.some((teamId) => userTeamIds.has(teamId));
   const readOnly = isAccessPending || !canEdit;
   // Save waits only while the assignments query is in flight. If it errors,
   // Save re-enables: identity/visibility still save, and the tool diff is
@@ -623,18 +619,12 @@ export function AppSettingsForm({
                 }
                 emptyMessage="No teams found."
               />
-              {outsideSelectedTeams ? (
-                <Alert variant="warning">
-                  <AlertTriangle />
-                  <AlertTitle>
-                    You are not a member of the selected teams
-                  </AlertTitle>
-                  <AlertDescription>
-                    You can still manage settings as an app administrator, but
-                    you will not be able to modify this app through chat.
-                  </AlertDescription>
-                </Alert>
-              ) : null}
+              <AppTeamAccessWarning
+                scope={scope}
+                selectedTeamIds={teamIds}
+                isAppAdmin={!!isAppAdmin}
+                userTeamIds={userTeamIds}
+              />
             </div>
           )}
 

--- a/platform/frontend/src/components/mcp-app/app-settings-form.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.tsx
@@ -4,7 +4,7 @@ import type {
   archestraApiTypes,
   ResourceVisibilityScope,
 } from "@archestra/shared";
-import { Globe, User, UserRound, Users } from "lucide-react";
+import { AlertTriangle, Globe, User, UserRound, Users } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { AppToolsEditor } from "@/app/apps/_parts/app-tools-editor";
@@ -12,6 +12,7 @@ import { AdvancedLabelsSection } from "@/components/advanced-labels-section";
 import type { ProfileLabel, ProfileLabelsRef } from "@/components/agent-labels";
 import { EnvironmentSelector } from "@/components/environment-selector";
 import { IdentityFields } from "@/components/identity-fields";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { FieldDescription } from "@/components/ui/field-description";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -37,7 +38,8 @@ import {
   useUnassignToolFromApp,
   useUpdateApp,
 } from "@/lib/app.query";
-import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useAppAccess } from "@/lib/apps/use-app-access";
+import { notYoursToChange } from "@/lib/design/resource-lexicon";
 import { useOrganizationMembers } from "@/lib/organization.query";
 import { useAssignableTeams } from "@/lib/teams/team.query";
 
@@ -83,11 +85,15 @@ export function AppSettingsForm({
   /** Reports save button state (must be a stable callback, e.g. a setState). */
   onStatusChange?: (status: { saving: boolean; disabled: boolean }) => void;
 }) {
-  const { data: canUpdate } = useHasPermissions({ app: ["update"] });
-  const { data: isAppAdmin } = useHasPermissions({ app: ["admin"] });
-  const { data: isAppTeamAdmin } = useHasPermissions({ app: ["team-admin"] });
+  const {
+    canEdit,
+    isAdmin: isAppAdmin,
+    isTeamAdmin: isAppTeamAdmin,
+    currentUserId,
+    userTeamIds,
+    isPending: isAccessPending,
+  } = useAppAccess(app);
   const { data: teams } = useAssignableTeams({ isResourceAdmin: !!isAppAdmin });
-  const { data: session } = useSession();
   const { data: members = [] } = useOrganizationMembers();
 
   const updateApp = useUpdateApp();
@@ -158,13 +164,13 @@ export function AppSettingsForm({
   const memberOptions = useMemo(
     () =>
       members
-        .filter((member) => member.id !== session?.user?.id)
+        .filter((member) => member.id !== currentUserId)
         .map((member) => ({
           userId: member.id,
           name: member.name,
           email: member.email,
         })),
-    [members, session?.user?.id],
+    [members, currentUserId],
   );
 
   const enabledOptions = [
@@ -189,7 +195,7 @@ export function AppSettingsForm({
     {
       value: "unlocked" as const,
       label: "Unlocked",
-      description: "Agents (and you) can modify the app normally",
+      description: "Authorized editors and their agents can modify the app",
     },
     {
       value: "locked" as const,
@@ -266,6 +272,12 @@ export function AppSettingsForm({
   // plain personal app, quietly un-sharing it.
   const userSelectionMissing = scope === "user" && userIds.length === 0;
   const selectionMissing = teamSelectionMissing || userSelectionMissing;
+  const outsideSelectedTeams =
+    scope === "team" &&
+    teamIds.length > 0 &&
+    isAppAdmin &&
+    !teamIds.some((teamId) => userTeamIds.has(teamId));
+  const readOnly = isAccessPending || !canEdit;
   // Save waits only while the assignments query is in flight. If it errors,
   // Save re-enables: identity/visibility still save, and the tool diff is
   // skipped below while the selection is unseeded (clearing it by accident is
@@ -283,9 +295,9 @@ export function AppSettingsForm({
   useEffect(() => {
     onStatusChange?.({
       saving,
-      disabled: saving || toolsLoading || selectionMissing,
+      disabled: readOnly || saving || toolsLoading || selectionMissing,
     });
-  }, [saving, toolsLoading, selectionMissing, onStatusChange]);
+  }, [readOnly, saving, toolsLoading, selectionMissing, onStatusChange]);
 
   // Serializes the handler itself: the state-based `saving` guard lags a
   // render, so a rapid resubmit could reread a stale tool-diff snapshot and
@@ -294,7 +306,7 @@ export function AppSettingsForm({
 
   const onSubmit = form.handleSubmit(async (values) => {
     if (submitInFlight.current) return;
-    if (saving || toolsLoading || selectionMissing) return;
+    if (readOnly || saving || toolsLoading || selectionMissing) return;
     submitInFlight.current = true;
     try {
       await submitSettings(values);
@@ -325,9 +337,6 @@ export function AppSettingsForm({
       });
       if (!result) return;
     }
-    // Visibility is editable on its own permissions; identity + environment only
-    // when the caller can update the app, so omit those fields otherwise (mirrors
-    // the field-limited bodies the old publish popover / rename dialog sent).
     // "Shared with named people" is stored as a personal app plus grants, so the
     // fourth option collapses back to `personal` here. Both lists are always
     // sent: switching away from Teams or Users must revoke what it left behind,
@@ -337,7 +346,7 @@ export function AppSettingsForm({
       teamIds: scope === "team" ? teamIds : [],
       userIds: scope === "user" ? userIds : [],
     };
-    if (canUpdate) {
+    if (canEdit) {
       body.name = values.name.trim();
       body.description = values.description.trim() || null;
       body.icon = values.icon;
@@ -358,7 +367,7 @@ export function AppSettingsForm({
     const result = await updateApp.mutateAsync({ appId: app.id, body });
     if (!result) return;
 
-    if (canUpdate && seededToolIds) {
+    if (canEdit && seededToolIds) {
       const results = await Promise.all([
         ...[...selectedToolIds]
           .filter((id) => !seededToolIds.has(id))
@@ -409,166 +418,176 @@ export function AppSettingsForm({
       className="flex min-h-0 flex-1 flex-col"
     >
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
-        {canUpdate && (
-          <>
-            <IdentityFields
-              icon={form.watch("icon")}
-              onIconChange={(icon) =>
-                form.setValue("icon", icon, { shouldDirty: true })
-              }
-              fallbackType="app"
-            >
-              <div className="space-y-2">
-                <Label htmlFor="app-settings-name">Name *</Label>
-                <Input
-                  id="app-settings-name"
-                  aria-invalid={!!form.formState.errors.name}
-                  {...form.register("name", {
-                    required: "Name is required.",
-                    maxLength: {
-                      value: 100,
-                      message: "Name must be 100 characters or fewer.",
-                    },
-                    validate: (value) =>
-                      value.trim().length > 0 || "Name is required.",
-                  })}
-                />
-                {form.formState.errors.name?.message ? (
-                  <p className="text-xs text-destructive">
-                    {form.formState.errors.name.message}
-                  </p>
-                ) : null}
-              </div>
-            </IdentityFields>
+        {!isAccessPending && !canEdit ? (
+          <Alert variant="info">
+            <AlertTriangle />
+            <AlertTitle>View-only settings</AlertTitle>
+            <AlertDescription>
+              {notYoursToChange({ resource: "app", scope: app.scope })}
+            </AlertDescription>
+          </Alert>
+        ) : null}
 
-            <div className="space-y-2">
-              <Label htmlFor="app-settings-slug">URL</Label>
-              <FieldDescription id="app-settings-slug-help">
-                Where this app opens. Changing it breaks links that used the old
-                URL.
-              </FieldDescription>
-              <div className="flex items-center gap-1">
-                <span className="shrink-0 text-sm text-muted-foreground">
-                  /a/
-                </span>
-                <Input
-                  id="app-settings-slug"
-                  placeholder="sales-dashboard"
-                  aria-invalid={!!form.formState.errors.slug}
-                  // Only one of the two is rendered at a time, so point at
-                  // whichever is actually in the DOM or the message goes
-                  // unannounced (same wiring as components/ui/form.tsx).
-                  aria-describedby={
-                    form.formState.errors.slug
-                      ? "app-settings-slug-help app-settings-slug-error"
-                      : "app-settings-slug-help"
-                  }
-                  {...form.register("slug", {
-                    maxLength: {
-                      value: 100,
-                      message: "URL must be 100 characters or fewer.",
-                    },
-                    validate: (value) =>
-                      value.trim() === "" ||
-                      SLUG_PATTERN.test(value.trim()) ||
-                      "Use lowercase letters, numbers and single hyphens.",
-                  })}
-                />
-              </div>
-              {form.formState.errors.slug?.message ? (
-                <p
-                  id="app-settings-slug-error"
-                  className="text-xs text-destructive"
-                >
-                  {form.formState.errors.slug.message}
-                </p>
-              ) : null}
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="app-settings-description">Description</Label>
-              <Textarea
-                id="app-settings-description"
-                aria-invalid={!!form.formState.errors.description}
-                {...form.register("description", {
-                  maxLength: {
-                    value: 500,
-                    message: "Description must be 500 characters or fewer.",
-                  },
-                })}
-              />
-              {form.formState.errors.description?.message ? (
-                <p className="text-xs text-destructive">
-                  {form.formState.errors.description.message}
-                </p>
-              ) : null}
-            </div>
-
-            <EnvironmentSelector
-              value={environmentId}
-              onChange={setEnvironmentId}
-              resource="app"
-              helpText="The app can be assigned and call MCP tools from this environment plus the Default environment."
+        <IdentityFields
+          icon={form.watch("icon")}
+          onIconChange={(icon) =>
+            form.setValue("icon", icon, { shouldDirty: true })
+          }
+          fallbackType="app"
+          disabled={readOnly}
+        >
+          <div className="space-y-2">
+            <Label htmlFor="app-settings-name">Name *</Label>
+            <Input
+              id="app-settings-name"
+              disabled={readOnly}
+              aria-invalid={!!form.formState.errors.name}
+              {...form.register("name", {
+                required: "Name is required.",
+                maxLength: {
+                  value: 100,
+                  message: "Name must be 100 characters or fewer.",
+                },
+                validate: (value) =>
+                  value.trim().length > 0 || "Name is required.",
+              })}
             />
+            {form.formState.errors.name?.message ? (
+              <p className="text-xs text-destructive">
+                {form.formState.errors.name.message}
+              </p>
+            ) : null}
+          </div>
+        </IdentityFields>
 
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold">Tools</h3>
-              {toolsSeeded ? (
-                <AppToolsEditor
-                  appId={app.id}
-                  environmentId={environmentId}
-                  selectedToolIds={selectedToolIds}
-                  onSelectionChange={setSelectedToolIds}
-                />
-              ) : (
-                // Unseeded selection: the checklist would misrepresent every
-                // assigned tool as unchecked, and staged edits would be
-                // dropped by the save's unseeded-diff skip.
-                <p className="text-sm text-muted-foreground">
-                  {appToolsQuery.isPending
-                    ? "Loading tools…"
-                    : "Tool assignments couldn't be loaded. Saving keeps the app's current tools."}
-                </p>
-              )}
-            </div>
+        <div className="space-y-2">
+          <Label htmlFor="app-settings-slug">URL</Label>
+          <FieldDescription id="app-settings-slug-help">
+            Where this app opens. Changing it breaks links that used the old
+            URL.
+          </FieldDescription>
+          <div className="flex items-center gap-1">
+            <span className="shrink-0 text-sm text-muted-foreground">/a/</span>
+            <Input
+              id="app-settings-slug"
+              disabled={readOnly}
+              placeholder="sales-dashboard"
+              aria-invalid={!!form.formState.errors.slug}
+              // Only one of the two is rendered at a time, so point at
+              // whichever is actually in the DOM or the message goes
+              // unannounced (same wiring as components/ui/form.tsx).
+              aria-describedby={
+                form.formState.errors.slug
+                  ? "app-settings-slug-help app-settings-slug-error"
+                  : "app-settings-slug-help"
+              }
+              {...form.register("slug", {
+                maxLength: {
+                  value: 100,
+                  message: "URL must be 100 characters or fewer.",
+                },
+                validate: (value) =>
+                  value.trim() === "" ||
+                  SLUG_PATTERN.test(value.trim()) ||
+                  "Use lowercase letters, numbers and single hyphens.",
+              })}
+            />
+          </div>
+          {form.formState.errors.slug?.message ? (
+            <p
+              id="app-settings-slug-error"
+              className="text-xs text-destructive"
+            >
+              {form.formState.errors.slug.message}
+            </p>
+          ) : null}
+        </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="app-settings-open-mode">Opens in</Label>
-              {selectedOpenModeDescription ? (
-                <FieldDescription>
-                  {selectedOpenModeDescription}
-                </FieldDescription>
-              ) : null}
-              <Select
-                value={openMode}
-                onValueChange={(next) =>
-                  setOpenMode(next as "inline" | "fullscreen")
-                }
-              >
-                <SelectTrigger id="app-settings-open-mode" className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent position="popper">
-                  {openModeOptions.map((option) => (
-                    <SelectItem
-                      key={option.value}
-                      value={option.value}
-                      description={option.description}
-                    >
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </>
-        )}
+        <div className="space-y-2">
+          <Label htmlFor="app-settings-description">Description</Label>
+          <Textarea
+            id="app-settings-description"
+            disabled={readOnly}
+            aria-invalid={!!form.formState.errors.description}
+            {...form.register("description", {
+              maxLength: {
+                value: 500,
+                message: "Description must be 500 characters or fewer.",
+              },
+            })}
+          />
+          {form.formState.errors.description?.message ? (
+            <p className="text-xs text-destructive">
+              {form.formState.errors.description.message}
+            </p>
+          ) : null}
+        </div>
+
+        <EnvironmentSelector
+          value={environmentId}
+          onChange={setEnvironmentId}
+          resource="app"
+          disabled={readOnly}
+          helpText="The app can be assigned and call MCP tools from this environment plus the Default environment."
+        />
+
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">Tools</h3>
+          {toolsSeeded ? (
+            <AppToolsEditor
+              appId={app.id}
+              environmentId={environmentId}
+              selectedToolIds={selectedToolIds}
+              onSelectionChange={setSelectedToolIds}
+              readOnly={readOnly}
+            />
+          ) : (
+            // Unseeded selection: the checklist would misrepresent every
+            // assigned tool as unchecked, and staged edits would be
+            // dropped by the save's unseeded-diff skip.
+            <p className="text-sm text-muted-foreground">
+              {appToolsQuery.isPending
+                ? "Loading tools…"
+                : "Tool assignments couldn't be loaded. Saving keeps the app's current tools."}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="app-settings-open-mode">Opens in</Label>
+          {selectedOpenModeDescription ? (
+            <FieldDescription>{selectedOpenModeDescription}</FieldDescription>
+          ) : null}
+          <Select
+            value={openMode}
+            disabled={readOnly}
+            onValueChange={(next) =>
+              setOpenMode(next as "inline" | "fullscreen")
+            }
+          >
+            <SelectTrigger id="app-settings-open-mode" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent position="popper">
+              {openModeOptions.map((option) => (
+                <SelectItem
+                  key={option.value}
+                  value={option.value}
+                  description={option.description}
+                >
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
         <VisibilitySelector
           heading="Who can use this app"
           value={scope}
           options={options}
           onValueChange={setScope}
+          readOnly={readOnly}
         >
           {scope === "user" && (
             <div className="space-y-2">
@@ -581,6 +600,7 @@ export function AppSettingsForm({
                 searchPlaceholder="Search users..."
                 emptyMessage="No users found."
                 className="w-full"
+                disabled={readOnly}
               />
             </div>
           )}
@@ -589,7 +609,7 @@ export function AppSettingsForm({
             <div className="space-y-2">
               <Label>Teams</Label>
               <MultiSelectCombobox
-                disabled={!canShareTeams || hasNoTeams}
+                disabled={readOnly || !canShareTeams || hasNoTeams}
                 options={
                   teams?.map((team) => ({
                     value: team.id,
@@ -603,6 +623,18 @@ export function AppSettingsForm({
                 }
                 emptyMessage="No teams found."
               />
+              {outsideSelectedTeams ? (
+                <Alert variant="warning">
+                  <AlertTriangle />
+                  <AlertTitle>
+                    You are not a member of the selected teams
+                  </AlertTitle>
+                  <AlertDescription>
+                    You can still manage settings as an app administrator, but
+                    you will not be able to modify this app through chat.
+                  </AlertDescription>
+                </Alert>
+              ) : null}
             </div>
           )}
 
@@ -613,6 +645,7 @@ export function AppSettingsForm({
             ) : null}
             <Select
               value={enabledStatus}
+              disabled={readOnly}
               onValueChange={(next) =>
                 setEnabledStatus(next as "disabled" | "enabled")
               }
@@ -641,6 +674,7 @@ export function AppSettingsForm({
             ) : null}
             <Select
               value={lockedStatus}
+              disabled={readOnly}
               onValueChange={(next) =>
                 setLockedStatus(next as "unlocked" | "locked")
               }
@@ -663,7 +697,7 @@ export function AppSettingsForm({
           </div>
         </VisibilitySelector>
 
-        {canUpdate && (
+        {canEdit && (
           <AdvancedLabelsSection
             ref={labelsRef}
             labels={labels}

--- a/platform/frontend/src/components/mcp-app/app-team-access-warning.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-team-access-warning.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AppTeamAccessWarning } from "./app-team-access-warning";
+
+describe("AppTeamAccessWarning", () => {
+  it("warns an app administrator outside every selected team", () => {
+    render(
+      <AppTeamAccessWarning
+        scope="team"
+        selectedTeamIds={["leadership"]}
+        isAppAdmin
+        userTeamIds={new Set(["engineering"])}
+      />,
+    );
+
+    expect(
+      screen.getByText("You are not a member of the selected teams"),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/will not be able to modify this app through chat/i),
+    ).toBeVisible();
+  });
+
+  it("does not warn when the administrator belongs to a selected team", () => {
+    render(
+      <AppTeamAccessWarning
+        scope="team"
+        selectedTeamIds={["engineering", "leadership"]}
+        isAppAdmin
+        userTeamIds={new Set(["engineering"])}
+      />,
+    );
+
+    expect(
+      screen.queryByText("You are not a member of the selected teams"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not warn non-admins or non-team visibility", () => {
+    const { rerender } = render(
+      <AppTeamAccessWarning
+        scope="team"
+        selectedTeamIds={["leadership"]}
+        isAppAdmin={false}
+        userTeamIds={new Set()}
+      />,
+    );
+
+    expect(
+      screen.queryByText("You are not a member of the selected teams"),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <AppTeamAccessWarning
+        scope="org"
+        selectedTeamIds={["leadership"]}
+        isAppAdmin
+        userTeamIds={new Set()}
+      />,
+    );
+    expect(
+      screen.queryByText("You are not a member of the selected teams"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/mcp-app/app-team-access-warning.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-team-access-warning.test.tsx
@@ -14,11 +14,12 @@ describe("AppTeamAccessWarning", () => {
     );
 
     expect(
-      screen.getByText("You are not a member of the selected teams"),
+      screen.getByText("You are not a member of the selected teams."),
     ).toBeVisible();
     expect(
       screen.getByText(/will not be able to modify this app through chat/i),
     ).toBeVisible();
+    expect(screen.getByRole("alert")).toHaveClass("py-1.5", "text-xs");
   });
 
   it("does not warn when the administrator belongs to a selected team", () => {
@@ -32,7 +33,7 @@ describe("AppTeamAccessWarning", () => {
     );
 
     expect(
-      screen.queryByText("You are not a member of the selected teams"),
+      screen.queryByText("You are not a member of the selected teams."),
     ).not.toBeInTheDocument();
   });
 
@@ -47,7 +48,7 @@ describe("AppTeamAccessWarning", () => {
     );
 
     expect(
-      screen.queryByText("You are not a member of the selected teams"),
+      screen.queryByText("You are not a member of the selected teams."),
     ).not.toBeInTheDocument();
 
     rerender(
@@ -59,7 +60,7 @@ describe("AppTeamAccessWarning", () => {
       />,
     );
     expect(
-      screen.queryByText("You are not a member of the selected teams"),
+      screen.queryByText("You are not a member of the selected teams."),
     ).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/mcp-app/app-team-access-warning.tsx
+++ b/platform/frontend/src/components/mcp-app/app-team-access-warning.tsx
@@ -1,6 +1,9 @@
 import type { ResourceVisibilityScope } from "@archestra/shared";
 import { AlertTriangle } from "lucide-react";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  CompactWarning,
+  CompactWarningText,
+} from "@/components/ui/compact-warning";
 
 /**
  * One warning for every Apps visibility editor. App administrators may assign
@@ -30,13 +33,15 @@ export function AppTeamAccessWarning({
   if (!outsideSelectedTeams) return null;
 
   return (
-    <Alert variant="warning">
+    <CompactWarning>
       <AlertTriangle />
-      <AlertTitle>You are not a member of the selected teams</AlertTitle>
-      <AlertDescription>
+      <span className="font-medium">
+        You are not a member of the selected teams.
+      </span>
+      <CompactWarningText>
         You can still manage settings as an app administrator, but you will not
         be able to modify {subject} through chat.
-      </AlertDescription>
-    </Alert>
+      </CompactWarningText>
+    </CompactWarning>
   );
 }

--- a/platform/frontend/src/components/mcp-app/app-team-access-warning.tsx
+++ b/platform/frontend/src/components/mcp-app/app-team-access-warning.tsx
@@ -1,0 +1,42 @@
+import type { ResourceVisibilityScope } from "@archestra/shared";
+import { AlertTriangle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+/**
+ * One warning for every Apps visibility editor. App administrators may assign
+ * any team, but chat authoring follows team membership; selecting only teams
+ * they do not belong to therefore preserves settings access while removing
+ * their ability to continue modifying the app through chat.
+ */
+export function AppTeamAccessWarning({
+  scope,
+  selectedTeamIds,
+  isAppAdmin,
+  userTeamIds,
+  subject = "this app",
+}: {
+  scope: ResourceVisibilityScope | "user";
+  selectedTeamIds: readonly string[];
+  isAppAdmin: boolean;
+  userTeamIds: ReadonlySet<string>;
+  subject?: string;
+}) {
+  const outsideSelectedTeams =
+    scope === "team" &&
+    selectedTeamIds.length > 0 &&
+    isAppAdmin &&
+    !selectedTeamIds.some((teamId) => userTeamIds.has(teamId));
+
+  if (!outsideSelectedTeams) return null;
+
+  return (
+    <Alert variant="warning">
+      <AlertTriangle />
+      <AlertTitle>You are not a member of the selected teams</AlertTitle>
+      <AlertDescription>
+        You can still manage settings as an app administrator, but you will not
+        be able to modify {subject} through chat.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
@@ -10,6 +10,7 @@ import {
 import Link from "next/link";
 import type React from "react";
 import { Button } from "@/components/ui/button";
+import { PermissionButton } from "@/components/ui/permission-button";
 import {
   Tooltip,
   TooltipContent,
@@ -101,18 +102,27 @@ export function McpAppRefreshButton({
   );
 }
 
-export function McpAppSettingsButton({ onClick }: { onClick: () => void }) {
+export function McpAppSettingsButton({
+  onClick,
+  disabledReason,
+}: {
+  onClick: () => void;
+  disabledReason?: string;
+}) {
   return (
-    <Button
+    <PermissionButton
+      permissions={{ app: ["update"] }}
       type="button"
       onClick={onClick}
+      disabled={!!disabledReason}
+      tooltip={disabledReason}
       variant="ghost"
       size="sm"
       className={LABELED_BUTTON_CLASS}
     >
       <Settings className="h-3.5 w-3.5" />
       Settings
-    </Button>
+    </PermissionButton>
   );
 }
 

--- a/platform/frontend/src/components/ui/compact-warning.tsx
+++ b/platform/frontend/src/components/ui/compact-warning.tsx
@@ -1,0 +1,35 @@
+import type React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Slim inline warning for space-constrained form and composer surfaces. Unlike
+ * the full Alert, its title and explanation share a row and wrap only when the
+ * available width requires it.
+ */
+export function CompactWarning({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-amber-500/50 bg-amber-50 px-2.5 py-1.5 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-950/50 dark:text-amber-200 [&>svg]:size-3.5 [&>svg]:shrink-0 [&>svg]:text-amber-600 dark:[&>svg]:text-amber-400",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CompactWarningText({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn("text-amber-800 dark:text-amber-300", className)}
+      {...props}
+    />
+  );
+}

--- a/platform/frontend/src/lib/apps/use-app-access.test.ts
+++ b/platform/frontend/src/lib/apps/use-app-access.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { type AppAccessContext, computeAppAccess } from "./use-app-access";
+import {
+  type AppAccessContext,
+  appActionDisabledReason,
+  computeAppAccess,
+} from "./use-app-access";
 
 const baseContext: AppAccessContext = {
   isAdmin: false,
@@ -52,5 +56,40 @@ describe("computeAppAccess", () => {
 
     expect(access.canEdit).toBe(true);
     expect(access.canDeleteApp).toBe(true);
+  });
+});
+
+describe("appActionDisabledReason", () => {
+  const orgApp = {
+    scope: "org" as const,
+    authorId: "someone-else",
+    teams: [],
+  };
+
+  it("names the base permission before evaluating the app scope", () => {
+    const access = computeAppAccess(orgApp, {
+      ...baseContext,
+      canUpdate: false,
+    });
+
+    expect(
+      appActionDisabledReason({ app: orgApp, access, action: "update" }),
+    ).toBe("Available to roles with the Apps (update) permission");
+  });
+
+  it("names the scope rule when the role permits updates", () => {
+    const access = computeAppAccess(orgApp, baseContext);
+
+    expect(
+      appActionDisabledReason({ app: orgApp, access, action: "update" }),
+    ).toBe("Only an admin can change this org-wide app");
+  });
+
+  it("returns no reason when the action is available", () => {
+    const access = computeAppAccess(orgApp, { ...baseContext, isAdmin: true });
+
+    expect(
+      appActionDisabledReason({ app: orgApp, access, action: "update" }),
+    ).toBeUndefined();
   });
 });

--- a/platform/frontend/src/lib/apps/use-app-access.test.ts
+++ b/platform/frontend/src/lib/apps/use-app-access.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useMyTeams } from "@/lib/teams/team.query";
 import {
   type AppAccessContext,
   appActionDisabledReason,
   computeAppAccess,
+  useAppAccessContext,
 } from "./use-app-access";
+
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/teams/team.query");
 
 const baseContext: AppAccessContext = {
   isAdmin: false,
@@ -91,5 +98,33 @@ describe("appActionDisabledReason", () => {
     expect(
       appActionDisabledReason({ app: orgApp, access, action: "update" }),
     ).toBeUndefined();
+  });
+});
+
+describe("useAppAccessContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+      isPending: false,
+    } as unknown as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "me" } },
+    } as unknown as ReturnType<typeof useSession>);
+    vi.mocked(useMyTeams).mockReturnValue({
+      data: [{ id: "my-team", name: "My team" }],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useMyTeams>);
+  });
+
+  it("keeps collection access facts stable when their query data has not changed", () => {
+    const { result, rerender } = renderHook(() => useAppAccessContext());
+    const initialContext = result.current;
+    const initialTeamIds = result.current.userTeamIds;
+
+    rerender();
+
+    expect(result.current).toBe(initialContext);
+    expect(result.current.userTeamIds).toBe(initialTeamIds);
   });
 });

--- a/platform/frontend/src/lib/apps/use-app-access.test.ts
+++ b/platform/frontend/src/lib/apps/use-app-access.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { type AppAccessContext, computeAppAccess } from "./use-app-access";
+
+const baseContext: AppAccessContext = {
+  isAdmin: false,
+  isTeamAdmin: false,
+  canUpdate: true,
+  canDelete: true,
+  currentUserId: "me",
+  userTeamIds: new Set(["my-team"]),
+  isPending: false,
+};
+
+describe("computeAppAccess", () => {
+  it("does not treat an app:update permission or authorship as authority over a team app", () => {
+    const access = computeAppAccess(
+      {
+        scope: "team",
+        authorId: "me",
+        teams: [{ id: "my-team", name: "My team" }],
+      },
+      baseContext,
+    );
+
+    expect(access.canEdit).toBe(false);
+    expect(access.canDeleteApp).toBe(false);
+  });
+
+  it("allows a team admin to modify apps assigned to one of their teams", () => {
+    const access = computeAppAccess(
+      {
+        scope: "team",
+        authorId: "someone-else",
+        teams: [{ id: "my-team", name: "My team" }],
+      },
+      { ...baseContext, isTeamAdmin: true },
+    );
+
+    expect(access.canEdit).toBe(true);
+    expect(access.canDeleteApp).toBe(true);
+  });
+
+  it("allows an app admin to manage a team app without team membership", () => {
+    const access = computeAppAccess(
+      {
+        scope: "team",
+        authorId: "someone-else",
+        teams: [{ id: "other-team", name: "Other team" }],
+      },
+      { ...baseContext, isAdmin: true },
+    );
+
+    expect(access.canEdit).toBe(true);
+    expect(access.canDeleteApp).toBe(true);
+  });
+});

--- a/platform/frontend/src/lib/apps/use-app-access.ts
+++ b/platform/frontend/src/lib/apps/use-app-access.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { archestraApiTypes } from "@archestra/shared";
+import { useMemo } from "react";
 import { computeCanModifyAgent } from "@/components/agent-pages/use-agent-access";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { formatPermissionConstraint } from "@/lib/auth/auth.utils";
@@ -88,21 +89,37 @@ export function useAppAccessContext(): AppAccessContext {
   });
   const { data: session } = useSession();
 
-  return {
-    isAdmin: !!isAdmin,
-    isTeamAdmin: !!isTeamAdmin,
-    canUpdate: !!canUpdate,
-    canDelete: !!canDelete,
-    currentUserId: session?.user?.id,
-    userTeamIds: new Set((userTeams ?? []).map((team) => team.id)),
-    isPending:
-      isAdminPending ||
-      isTeamAdminPending ||
-      isUpdatePending ||
-      isDeletePending ||
-      isTeamsPermissionPending ||
+  return useMemo(
+    () => ({
+      isAdmin: !!isAdmin,
+      isTeamAdmin: !!isTeamAdmin,
+      canUpdate: !!canUpdate,
+      canDelete: !!canDelete,
+      currentUserId: session?.user?.id,
+      userTeamIds: new Set((userTeams ?? []).map((team) => team.id)),
+      isPending:
+        isAdminPending ||
+        isTeamAdminPending ||
+        isUpdatePending ||
+        isDeletePending ||
+        isTeamsPermissionPending ||
+        isTeamsLoading,
+    }),
+    [
+      canDelete,
+      canUpdate,
+      isAdmin,
+      isAdminPending,
+      isDeletePending,
+      isTeamAdmin,
+      isTeamAdminPending,
       isTeamsLoading,
-  };
+      isTeamsPermissionPending,
+      isUpdatePending,
+      session?.user?.id,
+      userTeams,
+    ],
+  );
 }
 
 export function useAppAccess(

--- a/platform/frontend/src/lib/apps/use-app-access.ts
+++ b/platform/frontend/src/lib/apps/use-app-access.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import type { archestraApiTypes } from "@archestra/shared";
+import { computeCanModifyAgent } from "@/components/agent-pages/use-agent-access";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useMyTeams } from "@/lib/teams/team.query";
+
+type AppListItem = archestraApiTypes.GetAppsResponses["200"]["data"][number];
+type OwnedApp = Extract<AppListItem, { source: "owned" }>;
+
+export interface AppAccessContext {
+  isAdmin: boolean;
+  isTeamAdmin: boolean;
+  canUpdate: boolean;
+  canDelete: boolean;
+  currentUserId: string | undefined;
+  userTeamIds: ReadonlySet<string>;
+  isPending: boolean;
+}
+
+/**
+ * Resolve what the caller may do to one owned app. The backend applies the
+ * same scope rule as agents and skills, so the frontend delegates to their
+ * shared predicate instead of treating the coarse `app:update` permission as
+ * sufficient on its own.
+ */
+export function computeAppAccess(
+  app: Pick<OwnedApp, "scope" | "authorId" | "teams"> | null | undefined,
+  context: AppAccessContext,
+) {
+  const canModify = computeCanModifyAgent({
+    agent: app,
+    isAdmin: context.isAdmin,
+    isTeamAdmin: context.isTeamAdmin,
+    currentUserId: context.currentUserId,
+    userTeamIds: context.userTeamIds,
+  });
+
+  return {
+    ...context,
+    canModify,
+    canEdit: context.canUpdate && canModify,
+    canDeleteApp: context.canDelete && canModify,
+  };
+}
+
+/** Fetch the caller-level facts once for collections such as the Apps table. */
+export function useAppAccessContext(): AppAccessContext {
+  const { data: isAdmin, isPending: isAdminPending } = useHasPermissions({
+    app: ["admin"],
+  });
+  const { data: isTeamAdmin, isPending: isTeamAdminPending } =
+    useHasPermissions({ app: ["team-admin"] });
+  const { data: canUpdate, isPending: isUpdatePending } = useHasPermissions({
+    app: ["update"],
+  });
+  const { data: canDelete, isPending: isDeletePending } = useHasPermissions({
+    app: ["delete"],
+  });
+  const { data: canReadTeams, isPending: isTeamsPermissionPending } =
+    useHasPermissions({ team: ["read"] });
+  const { data: userTeams, isLoading: isTeamsLoading } = useMyTeams({
+    enabled: !!canReadTeams,
+  });
+  const { data: session } = useSession();
+
+  return {
+    isAdmin: !!isAdmin,
+    isTeamAdmin: !!isTeamAdmin,
+    canUpdate: !!canUpdate,
+    canDelete: !!canDelete,
+    currentUserId: session?.user?.id,
+    userTeamIds: new Set((userTeams ?? []).map((team) => team.id)),
+    isPending:
+      isAdminPending ||
+      isTeamAdminPending ||
+      isUpdatePending ||
+      isDeletePending ||
+      isTeamsPermissionPending ||
+      isTeamsLoading,
+  };
+}
+
+export function useAppAccess(
+  app: Pick<OwnedApp, "scope" | "authorId" | "teams"> | null | undefined,
+) {
+  return computeAppAccess(app, useAppAccessContext());
+}

--- a/platform/frontend/src/lib/apps/use-app-access.ts
+++ b/platform/frontend/src/lib/apps/use-app-access.ts
@@ -3,6 +3,8 @@
 import type { archestraApiTypes } from "@archestra/shared";
 import { computeCanModifyAgent } from "@/components/agent-pages/use-agent-access";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { formatPermissionConstraint } from "@/lib/auth/auth.utils";
+import { notYoursToChange } from "@/lib/design/resource-lexicon";
 import { useMyTeams } from "@/lib/teams/team.query";
 
 type AppListItem = archestraApiTypes.GetAppsResponses["200"]["data"][number];
@@ -42,6 +44,28 @@ export function computeAppAccess(
     canEdit: context.canUpdate && canModify,
     canDeleteApp: context.canDelete && canModify,
   };
+}
+
+export function appActionDisabledReason({
+  app,
+  access,
+  action,
+}: {
+  app: Pick<OwnedApp, "scope" | "authorId" | "teams">;
+  access: ReturnType<typeof computeAppAccess>;
+  action: "update" | "delete";
+}): string | undefined {
+  if (access.isPending) return "Checking permissions…";
+
+  const hasPermission =
+    action === "update" ? access.canUpdate : access.canDelete;
+  if (!hasPermission) {
+    return formatPermissionConstraint({ app: [action] });
+  }
+  if (!access.canModify) {
+    return notYoursToChange({ resource: "app", scope: app.scope });
+  }
+  return undefined;
 }
 
 /** Fetch the caller-level facts once for collections such as the Apps table. */

--- a/platform/frontend/src/lib/design/resource-lexicon.test.ts
+++ b/platform/frontend/src/lib/design/resource-lexicon.test.ts
@@ -19,8 +19,14 @@ const RESOURCES = Object.keys(RESOURCE_LEXICON) as ResourceKey[];
  * of the same date.
  */
 describe("resource lexicon", () => {
-  it("covers the four entity surfaces", () => {
-    expect(RESOURCES).toEqual(["agent", "mcp_gateway", "skill", "mcp_server"]);
+  it("covers the five entity surfaces", () => {
+    expect(RESOURCES).toEqual([
+      "agent",
+      "mcp_gateway",
+      "skill",
+      "mcp_server",
+      "app",
+    ]);
   });
 
   it("takes the agent-shaped names from the route configs rather than repeating them", () => {
@@ -59,7 +65,7 @@ describe("resource lexicon", () => {
       "Only this skill's author or an admin can change it",
     );
     expect(notYoursToChange({ resource: "skill", scope: "team" })).toBe(
-      "Only this skill's author, a team admin of the teams it is shared with, or an admin can change it",
+      "Only a team admin who belongs to one of the teams this skill is shared with, or an admin, can change it",
     );
     expect(notYoursToChange({ resource: "skill", scope: "org" })).toBe(
       "Only an admin can change this org-wide skill",

--- a/platform/frontend/src/lib/design/resource-lexicon.ts
+++ b/platform/frontend/src/lib/design/resource-lexicon.ts
@@ -32,7 +32,7 @@ import {
  * resource that cannot actually happen. Naming is a separate axis, so it gets
  * a separate key.
  */
-export type ResourceKey = AgentPageKind | "skill" | "mcp_server";
+export type ResourceKey = AgentPageKind | "skill" | "mcp_server" | "app";
 
 export interface ResourceNames {
   /** Title case: a page title, or a button's object ("Create Agent"). */
@@ -55,6 +55,11 @@ export const RESOURCE_LEXICON: Record<ResourceKey, ResourceNames> = {
     singular: "MCP Server",
     singularInSentence: "MCP server",
     plural: "MCP Servers",
+  },
+  app: {
+    singular: "App",
+    singularInSentence: "app",
+    plural: "Apps",
   },
 };
 
@@ -135,7 +140,7 @@ export function notYoursToChange({
     case "personal":
       return `Only this ${name}'s author or an admin can change it`;
     case "team":
-      return `Only this ${name}'s author, a team admin of the teams it is shared with, or an admin can change it`;
+      return `Only a team admin who belongs to one of the teams this ${name} is shared with, or an admin, can change it`;
     case "org":
       return `Only an admin can change this org-wide ${name}`;
   }


### PR DESCRIPTION
## Problem

The Apps UI treated coarse update and delete permissions as sufficient for every visible app. Team members could therefore reach mutation controls that the scoped backend authorization would reject. App administrators could also assign an app only to teams they do not belong to without seeing that chat authoring would no longer be available to them. Separately, compact metadata columns in the Apps and Plugins tables could absorb disproportionate horizontal space.

## Approach

- Centralize the frontend app access decision so cards, tables, bulk selection, and settings follow the same personal, team, and organization scope rules as the backend.
- Keep settings and delete actions discoverable but disabled when refused, with the exact RBAC or per-app scope reason available on hover and to assistive technology.
- Apply the same disabled settings behavior to owned apps shown in the chat side panel.
- Prevent refused bulk selection and mutation requests from reaching the backend.
- Warn app administrators when a single or bulk team selection excludes all of their team memberships, using one shared app warning component across every Apps visibility editor.
- Preserve actual team and user assignments when opening bulk visibility editing.
- Clarify Unlocked and scoped-access copy, and document that use access does not imply edit access.
- Keep the Apps Sharing and Plugins Source columns compact while their primary name columns absorb available table width.

## Validation

- Full frontend suite: 570 files, 5,166 tests passed.
- Focused app access/settings and warning suite passed.
- Affected Apps and Plugins page suites passed.
- Frontend TypeScript check passed.
- Frontend dependency/export analysis passed.
- Docs link check passed.
- Verified the permission and table-layout flows in Chrome against the local stack.