### PR TITLE
fix(chat): focus prompt after selecting an agent

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -322,7 +322,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
     [focusTextarea, onAgentChange],
   );
 
-  const handleModelSelectorOpenChange = useCallback(
+  const handleSelectorOpenChange = useCallback(
     (open: boolean) => {
       if (!open) {
         focusTextarea();
@@ -693,13 +693,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
                   agentLlmApiKeyId={agentLlmApiKeyId}
                   suppressAutoSelect={agentRequiresPerUserConnect}
                   connectRequestToken={subscriptionConnectRequest}
-                  onOpenChange={(open) => {
-                    if (!open) {
-                      setTimeout(() => {
-                        textareaRef.current?.focus();
-                      }, 100);
-                    }
-                  }}
+                  onOpenChange={handleSelectorOpenChange}
                 />
               )}
               {subscriptionConnectRequired && onSubscriptionConnect && (
@@ -717,7 +711,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
                 <ModelSelector
                   selectedModel={selectedModel}
                   onModelChange={onModelChange}
-                  onOpenChange={handleModelSelectorOpenChange}
+                  onOpenChange={handleSelectorOpenChange}
                   apiKeyId={
                     conversationId
                       ? currentConversationChatApiKeyId

--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -306,15 +306,29 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   const canShowProviderSettings =
     !runtimeMode && canSeeProviderSettings === true;
 
+  const focusTextarea = useCallback(() => {
+    // Popover restores focus to its trigger as it closes. Wait until that
+    // finishes before returning focus to the prompt for the user's next input.
+    setTimeout(() => {
+      textareaRef.current?.focus();
+    }, 100);
+  }, [textareaRef]);
+
+  const handleAgentChange = useCallback(
+    (agentId: string) => {
+      onAgentChange?.(agentId);
+      focusTextarea();
+    },
+    [focusTextarea, onAgentChange],
+  );
+
   const handleModelSelectorOpenChange = useCallback(
     (open: boolean) => {
       if (!open) {
-        setTimeout(() => {
-          textareaRef.current?.focus();
-        }, 100);
+        focusTextarea();
       }
     },
-    [textareaRef],
+    [focusTextarea],
   );
 
   return (
@@ -380,7 +394,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
                       </p>
                       <InitialAgentSelector
                         currentAgentId={selectorAgentId}
-                        onAgentChange={onAgentChange}
+                        onAgentChange={handleAgentChange}
                       />
                     </div>
                   )}
@@ -626,7 +640,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
             onAgentChange && (
               <InitialAgentSelector
                 currentAgentId={selectorAgentId}
-                onAgentChange={onAgentChange}
+                onAgentChange={handleAgentChange}
               />
             )}
           {!runtimeMode &&

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -1,5 +1,6 @@
 import { type ChatSkillMetadata, E2eTestId } from "@archestra/shared";
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import { forwardRef } from "react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LOCKED_CHAT_DRAFT_SHORTCUT_EVENT } from "@/consts";
@@ -216,24 +217,28 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
       Submit {status ?? "unset"}
     </button>
   ),
-  PromptInputTextarea: ({
-    placeholder,
-    onKeyDown,
-    disabled,
-    "data-testid": testId,
-  }: {
-    placeholder?: string;
-    onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
-    disabled?: boolean;
-    "data-testid"?: string;
-  }) => (
-    <textarea
-      data-testid={testId}
-      disabled={disabled}
-      onKeyDown={onKeyDown}
-      placeholder={placeholder}
-    />
-  ),
+  PromptInputTextarea: forwardRef<
+    HTMLTextAreaElement,
+    {
+      placeholder?: string;
+      onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+      disabled?: boolean;
+      "data-testid"?: string;
+    }
+  >(function MockPromptInputTextarea(
+    { placeholder, onKeyDown, disabled, "data-testid": testId },
+    ref,
+  ) {
+    return (
+      <textarea
+        ref={ref}
+        data-testid={testId}
+        disabled={disabled}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+      />
+    );
+  }),
   PromptInputTools: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="prompt-tools">{children}</div>
   ),
@@ -265,6 +270,23 @@ vi.mock("@/components/chat/chat-tools-display", () => ({
 
 vi.mock("@/components/chat/model-selector", () => ({
   ModelSelector: () => <div data-testid="model-selector" />,
+}));
+
+vi.mock("@/components/chat/initial-agent-selector", () => ({
+  InitialAgentSelector: ({
+    onAgentChange,
+  }: {
+    onAgentChange: (agentId: string) => void;
+  }) => (
+    <button
+      type="button"
+      onKeyDown={(event) => {
+        if (event.key === "Enter") onAgentChange("agent-2");
+      }}
+    >
+      Select agent
+    </button>
+  ),
 }));
 
 // The Apps Hackathon recorder cluster is a self-contained feature with its own
@@ -405,6 +427,43 @@ describe("ArchestraPromptInput", () => {
     mockToolbarState.isNarrow = false;
     mockConversationState.conversation = null;
     localStorage.clear();
+  });
+
+  it("returns keyboard focus to the prompt after selecting an agent", () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(useHasPermissions).mockImplementation(
+        (permissions) =>
+          ({
+            data: "chatAgentPicker" in permissions,
+            isPending: false,
+            isLoading: false,
+          }) as ReturnType<typeof useHasPermissions>,
+      );
+      const onAgentChange = vi.fn();
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          selectorAgentId="agent-1"
+          onAgentChange={onAgentChange}
+        />,
+      );
+
+      const agentSelector = screen.getByRole("button", {
+        name: "Select agent",
+      });
+      agentSelector.focus();
+      fireEvent.keyDown(agentSelector, { key: "Enter" });
+
+      expect(onAgentChange).toHaveBeenCalledWith("agent-2");
+      expect(agentSelector).toHaveFocus();
+
+      act(() => vi.advanceTimersByTime(100));
+
+      expect(screen.getByTestId(E2eTestId.ChatPromptTextarea)).toHaveFocus();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("turns the composer into a focused run launcher", () => {


### PR DESCRIPTION
## Summary

After an agent is selected from the chat composer, return keyboard focus to the prompt once the selector popover finishes closing so the user can immediately start typing. Agent, model, and provider-key selectors now share the same focus-return helper in both expanded and collapsed toolbar layouts.

A composer behavior test selects an agent with Enter and verifies that focus moves from the selector to the prompt textarea.