### PR TITLE
feat(agent-runtime): preserve native TUIs in delegated runs

### DIFF
--- a/docs/pages/platform-agent-runtime.md
+++ b/docs/pages/platform-agent-runtime.md
@@ -38,7 +38,8 @@ Invocation is explicit and surface-specific:
 
 Agent Runtime runs have two launch modes. Chat starts the image in
 **interactive** mode and exposes its live terminal. Maintained Claude Code,
-Codex, and OpenCode images run their native TUIs. Delegation from another Agent, A2A,
+Codex, OpenCode, Hermes, and OpenClaw images run their native TUIs in both
+interactive and delegated one-shot runs. Delegation from another Agent, A2A,
 incoming email, schedules, and task tools uses **one-shot** mode. The same
 image receives the task, exits when it is finished, and lets Archestra settle
 the durable task and deliver its result. This is selected by the invocation
@@ -377,7 +378,9 @@ the run.
 
 ## View Runs from an Agent
 
-An Agent with Agent Runtime configured has a **Runs** tab. Use it to:
+An Agent with Agent Runtime configured has a **Runs** tab. A running run opens
+its live terminal, while a completed run opens its retained terminal output;
+there is no separate output-mode selector. Use this tab to:
 
 - review run outcomes and timestamps
 - read live or retained container logs
@@ -391,7 +394,10 @@ stopping the run. For a raw diagnostic shell, set
 
 After the pod is removed, Archestra retains the complete container transcript
 as independently compressed chunks and replays those chunks into the terminal
-view. The transcript follows the run's task retention period, which is
+view. Native TUI recordings preserve their original terminal geometry and
+scale as one canvas to fit narrower viewers, with scrolling as a fallback at
+very small widths. They do not reflow and jumble the interface. The transcript
+follows the run's task retention period, which is
 90 days by default. Set
 `ARCHESTRA_AGENT_RUNTIME_TRANSCRIPT_MAX_BYTES` to cap the
 uncompressed transcript size accepted from one run. A run beyond that ceiling

--- a/platform/agent_images/bin/archestra-claude-code
+++ b/platform/agent_images/bin/archestra-claude-code
@@ -117,34 +117,11 @@ HOOK
       > "${settings_file}"
     args+=(--settings "${settings_file}")
 
-    claude "${args[@]}" "${ARCHESTRA_AGENT_RUNTIME_TASK:?}" &
-    claude_pid=$!
-
-    # Bounded by the run's own lifetime: the pod's TTL and the platform's
-    # cancellation both outrank this loop, so it never becomes the reason a
-    # session hangs. A vanished process without a marker means Claude Code
-    # exited on its own — normal for an error path.
-    while kill -0 "${claude_pid}" 2>/dev/null; do
-      if [[ -f "${done_marker}" ]]; then
-        # Let the pane settle on the finished frame before tearing it down,
-        # then end the session the way a person would.
-        sleep 2
-        kill -TERM "${claude_pid}" 2>/dev/null || true
-        break
-      fi
-      sleep 2
-    done
-    wait "${claude_pid}" 2>/dev/null || true
-
-    # The fence tells the platform where the prose starts; without it the
-    # "answer" would be a recording of the TUI redrawing itself.
-    printf '\n===ARCHESTRA-FINAL-ANSWER===\n'
-    if [[ -s "${answer_file}" ]]; then
-      cat "${answer_file}"
-    else
-      echo "The session ended without producing a final message."
-    fi
-    printf '\n'
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    exec "${script_dir}/archestra-tui-run" \
+      "${done_marker}" \
+      "${answer_file}" \
+      claude "${args[@]}" "${ARCHESTRA_AGENT_RUNTIME_TASK:?}"
     ;;
   *)
     echo "archestra: unknown Agent Runtime mode" >&2

--- a/platform/agent_images/bin/archestra-codex
+++ b/platform/agent_images/bin/archestra-codex
@@ -7,8 +7,39 @@ if [[ "${ARCHESTRA_LLM_PROXY_PROTOCOL:-}" != "openai_responses" ]]; then
 fi
 
 runtime_dir="${ARCHESTRA_AGENT_RUNTIME_DIR:-/var/run/archestra}"
+runtime_mode="${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}"
 export CODEX_HOME="${runtime_dir}/codex"
 mkdir -p "${CODEX_HOME}"
+notify_config=""
+if [[ "${runtime_mode}" == "one_shot" ]] \
+  && [[ "${ARCHESTRA_AGENT_RUNTIME_PLAIN:-0}" != "1" ]]; then
+  notify_script="${runtime_dir}/codex-notify.sh"
+  cat > "${notify_script}" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+runtime_dir="${ARCHESTRA_AGENT_RUNTIME_DIR:-/var/run/archestra}"
+payload="${1:-}"
+if [[ -z "${payload}" ]]; then
+  exit 0
+fi
+task="$(cat "${runtime_dir}/task.md" 2>/dev/null || true)"
+answer="$(jq -r --arg task "${task}" '
+  if .type == "agent-turn-complete"
+    and ((.["input-messages"] // []) | index($task)) != null
+  then
+    .["last-assistant-message"] // empty
+  else
+    empty
+  end
+' <<<"${payload}")"
+if [[ -n "${answer}" ]]; then
+  printf '%s\n' "${answer}" > "${runtime_dir}/final-answer.txt"
+  touch "${runtime_dir}/turn-complete"
+fi
+HOOK
+  chmod 0700 "${notify_script}"
+  notify_config="notify = [$(jq -Rn --arg value "${notify_script}" '$value')]"
+fi
 developer_instructions="$({
   printf '%s\n\n' "${ARCHESTRA_AGENT_RUNTIME_SYSTEM_PROMPT:-}"
   printf '%s' "Complete the delegated task fully in this isolated runner. Use the local shell and file tools directly. Do not stop after announcing a plan. Verify the work and report the concrete result."
@@ -19,6 +50,7 @@ model_provider = "archestra"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 developer_instructions = ${developer_instructions}
+${notify_config}
 
 [model_providers.archestra]
 name = "Archestra"
@@ -52,7 +84,7 @@ common_args=(
   --config model_provider='"archestra"'
 )
 
-case "${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}" in
+case "${runtime_mode}" in
   interactive)
     # No subcommand means Codex's native full-screen TUI. The positional prompt
     # starts the first turn; subsequent terminal input stays in the same Codex
@@ -60,11 +92,19 @@ case "${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}" in
     exec codex "${common_args[@]}" -- "$(cat "${task_file}")"
     ;;
   one_shot)
-    exec codex exec \
-      "${common_args[@]}" \
-      --skip-git-repo-check \
-      --color always \
-      -- "$(cat "${task_file}")"
+    if [[ "${ARCHESTRA_AGENT_RUNTIME_PLAIN:-0}" == "1" ]]; then
+      exec codex exec \
+        "${common_args[@]}" \
+        --skip-git-repo-check \
+        --color always \
+        -- "$(cat "${task_file}")"
+    fi
+
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    exec "${script_dir}/archestra-tui-run" \
+      "${runtime_dir}/turn-complete" \
+      "${runtime_dir}/final-answer.txt" \
+      codex "${common_args[@]}" -- "$(cat "${task_file}")"
     ;;
   *)
     echo "archestra: unknown Agent Runtime mode" >&2

--- a/platform/agent_images/bin/archestra-hermes
+++ b/platform/agent_images/bin/archestra-hermes
@@ -7,8 +7,40 @@ if [[ "${ARCHESTRA_LLM_PROXY_PROTOCOL:-}" != "openai_chat" ]]; then
 fi
 
 runtime_dir="${ARCHESTRA_AGENT_RUNTIME_DIR:-/var/run/archestra}"
+runtime_mode="${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}"
 export HERMES_HOME="${runtime_dir}/hermes"
 mkdir -p "${HERMES_HOME}"
+completion_hook=""
+if [[ "${runtime_mode}" == "one_shot" ]] \
+  && [[ "${ARCHESTRA_AGENT_RUNTIME_PLAIN:-0}" != "1" ]]; then
+  completion_hook="${runtime_dir}/hermes-completion-hook.sh"
+  cat > "${completion_hook}" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+runtime_dir="${ARCHESTRA_AGENT_RUNTIME_DIR:-/var/run/archestra}"
+payload="$(cat)"
+event="$(jq -r '.hook_event_name // empty' <<<"${payload}")"
+session_id="$(jq -r '.session_id // empty' <<<"${payload}")"
+session_file="${runtime_dir}/hermes-main-session"
+if [[ "${event}" == "on_session_start" ]]; then
+  if [[ -n "${session_id}" && ! -e "${session_file}" ]]; then
+    printf '%s\n' "${session_id}" > "${session_file}"
+  fi
+  exit 0
+fi
+if [[ "${event}" != "post_llm_call" ]] \
+  || [[ ! -s "${session_file}" ]] \
+  || [[ "${session_id}" != "$(cat "${session_file}")" ]]; then
+  exit 0
+fi
+answer="$(jq -r '.extra.assistant_response // empty' <<<"${payload}")"
+if [[ -n "${answer}" ]]; then
+  printf '%s\n' "${answer}" > "${runtime_dir}/final-answer.txt"
+  touch "${runtime_dir}/turn-complete"
+fi
+HOOK
+  chmod 0700 "${completion_hook}"
+fi
 jq -n \
   --arg base_url "${OPENAI_BASE_URL:?}" \
   --arg model "${ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL:?}" \
@@ -16,7 +48,8 @@ jq -n \
   --arg mcp_url "${ARCHESTRA_MCP_GATEWAY_URL:?}" \
   --arg gateway_token "${ARCHESTRA_MCP_GATEWAY_TOKEN:?}" \
   --arg system_prompt "${ARCHESTRA_AGENT_RUNTIME_SYSTEM_PROMPT:-}" \
-  '{
+  --arg completion_hook "${completion_hook}" \
+  '({
     providers:{archestra:{
       name:"Archestra",
       base_url:$base_url,
@@ -41,7 +74,13 @@ jq -n \
         "X-Archestra-Session-Id":$task_id
       }
     }}
-  }' > "${HERMES_HOME}/config.yaml"
+  } + if $completion_hook == "" then {} else {
+    hooks_auto_accept:true,
+    hooks:{
+      on_session_start:[{command:$completion_hook}],
+      post_llm_call:[{command:$completion_hook}]
+    }
+  } end)' > "${HERMES_HOME}/config.yaml"
 chmod 0600 "${HERMES_HOME}/config.yaml"
 
 # Hermes reads its ordinary config from ~/.hermes.
@@ -50,6 +89,60 @@ ln -sf "${HERMES_HOME}/config.yaml" "${HOME}/.hermes/config.yaml"
 task_file="${runtime_dir}/task.md"
 printf '%s\n' "${ARCHESTRA_AGENT_RUNTIME_TASK:?}" > "${task_file}"
 
+completion_watcher="${runtime_dir}/hermes-completion-watch.py"
+cat > "${completion_watcher}" <<'PYTHON'
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+database_path = Path(sys.argv[1])
+task = sys.argv[2]
+answer_path = Path(sys.argv[3])
+done_path = Path(sys.argv[4])
+
+while not done_path.exists():
+    try:
+        if database_path.exists():
+            with sqlite3.connect(database_path, timeout=0.2) as database:
+                session = database.execute(
+                    """
+                    SELECT sessions.id
+                    FROM sessions
+                    JOIN messages ON messages.session_id = sessions.id
+                    WHERE sessions.source = 'tui'
+                      AND sessions.parent_session_id IS NULL
+                      AND messages.role = 'user'
+                      AND messages.content = ?
+                    ORDER BY sessions.started_at DESC
+                    LIMIT 1
+                    """,
+                    (task,),
+                ).fetchone()
+                if session:
+                    assistant = database.execute(
+                        """
+                        SELECT content
+                        FROM messages
+                        WHERE session_id = ?
+                          AND role = 'assistant'
+                          AND active = 1
+                          AND finish_reason IS NOT NULL
+                        ORDER BY id DESC
+                        LIMIT 1
+                        """,
+                        (session[0],),
+                    ).fetchone()
+                    if assistant and assistant[0].strip():
+                        answer_path.write_text(f"{assistant[0].strip()}\n", encoding="utf-8")
+                        done_path.touch()
+                        break
+    except (OSError, sqlite3.Error):
+        pass
+    time.sleep(0.2)
+PYTHON
+chmod 0600 "${completion_watcher}"
+
 common_args=(
   --provider archestra
   --model "${ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL:?}"
@@ -57,7 +150,7 @@ common_args=(
   --accept-hooks
 )
 
-case "${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}" in
+case "${runtime_mode}" in
   interactive)
     exec hermes chat \
       "${common_args[@]}" \
@@ -65,16 +158,34 @@ case "${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}" in
       --query "$(cat "${task_file}")"
     ;;
   one_shot)
-    set +e
-    hermes chat \
-      "${common_args[@]}" \
-      --query "$(cat "${task_file}")" \
-      2>&1 | tee "${runtime_dir}/hermes-output.log"
-    status=${PIPESTATUS[0]}
-    set -e
-    if [[ ${status} -ne 0 ]] || grep -Eq 'HTTP [45][0-9]{2}:|Traceback \(most recent call last\)|LLM request failed|api_validation_error|Context length exceeded|\[exit [1-9][0-9]*\]|Failed to ' "${runtime_dir}/hermes-output.log"; then
-      exit 1
+    if [[ "${ARCHESTRA_AGENT_RUNTIME_PLAIN:-0}" == "1" ]]; then
+      set +e
+      hermes chat \
+        "${common_args[@]}" \
+        --query "$(cat "${task_file}")" \
+        2>&1 | tee "${runtime_dir}/hermes-output.log"
+      status=${PIPESTATUS[0]}
+      set -e
+      if [[ ${status} -ne 0 ]] || grep -Eq 'HTTP [45][0-9]{2}:|Traceback \(most recent call last\)|LLM request failed|api_validation_error|Context length exceeded|\[exit [1-9][0-9]*\]|Failed to ' "${runtime_dir}/hermes-output.log"; then
+        exit 1
+      fi
+      exit 0
     fi
+
+    python3 "${completion_watcher}" \
+      "${HERMES_HOME}/state.db" \
+      "$(cat "${task_file}")" \
+      "${runtime_dir}/final-answer.txt" \
+      "${runtime_dir}/turn-complete" &
+
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    exec "${script_dir}/archestra-tui-run" \
+      "${runtime_dir}/turn-complete" \
+      "${runtime_dir}/final-answer.txt" \
+      hermes chat \
+        "${common_args[@]}" \
+        --tui \
+        --query "$(cat "${task_file}")"
     ;;
   *)
     echo "archestra: unknown Agent Runtime mode" >&2

--- a/platform/agent_images/bin/archestra-openclaw
+++ b/platform/agent_images/bin/archestra-openclaw
@@ -29,6 +29,7 @@ resolve_docker_desktop_url() {
 }
 
 runtime_dir="${ARCHESTRA_AGENT_RUNTIME_DIR:-/var/run/archestra}"
+runtime_mode="${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}"
 config_file="${runtime_dir}/openclaw.json"
 task_file="${runtime_dir}/task.md"
 model="${ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL:?}"
@@ -36,6 +37,86 @@ runtime_instructions="${ARCHESTRA_AGENT_RUNTIME_SYSTEM_PROMPT:-}"
 export OPENCLAW_STATE_DIR="${runtime_dir}/openclaw-state"
 export OPENCLAW_CONFIG_PATH="${config_file}"
 mkdir -p "${OPENCLAW_STATE_DIR}"
+
+completion_plugin_dir=""
+if [[ "${runtime_mode}" == "one_shot" ]] \
+  && [[ "${ARCHESTRA_AGENT_RUNTIME_PLAIN:-0}" != "1" ]]; then
+  completion_plugin_dir="${runtime_dir}/openclaw-completion"
+  mkdir -p "${completion_plugin_dir}"
+  cat > "${completion_plugin_dir}/package.json" <<'JSON'
+{
+  "name": "archestra-openclaw-completion",
+  "version": "1.0.0",
+  "type": "module",
+  "openclaw": {
+    "extensions": ["./index.mjs"]
+  }
+}
+JSON
+  cat > "${completion_plugin_dir}/openclaw.plugin.json" <<'JSON'
+{
+  "id": "archestra-completion",
+  "name": "Archestra completion",
+  "description": "Settles a delegated Agent Runtime task after the native TUI finishes its turn.",
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}
+JSON
+  cat > "${completion_plugin_dir}/index.mjs" <<'PLUGIN'
+import { writeFile } from "node:fs/promises";
+
+function messageText(message) {
+  if (!message || message.role !== "assistant") return "";
+  if (typeof message.content === "string") return message.content;
+  if (!Array.isArray(message.content)) return "";
+  return message.content
+    .filter((part) => part?.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+export default {
+  id: "archestra-completion",
+  name: "Archestra completion",
+  description: "Settles delegated native-TUI runs.",
+  configSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  },
+  register(api) {
+    api.on("agent_end", async (event, context) => {
+      const runtimeDir = process.env.ARCHESTRA_AGENT_RUNTIME_DIR ?? "/var/run/archestra";
+      const taskId = process.env.ARCHESTRA_AGENT_RUNTIME_TASK_ID;
+      const expectedSessionKey = taskId ? `agent:main:${taskId}` : undefined;
+      if (expectedSessionKey && context?.sessionKey !== expectedSessionKey) return;
+
+      const answer = [...event.messages]
+        .reverse()
+        .map(messageText)
+        .find((text) => text.trim().length > 0)
+        ?.trim();
+
+      if (answer) {
+        await writeFile(`${runtimeDir}/final-answer.txt`, `${answer}\n`, "utf8");
+      } else if (event.error) {
+        await writeFile(`${runtimeDir}/final-answer.txt`, `${event.error}\n`, "utf8");
+      }
+      if (!event.success) {
+        await writeFile(`${runtimeDir}/turn-complete.failed`, "", "utf8");
+      }
+      await writeFile(`${runtimeDir}/turn-complete`, "", "utf8");
+    });
+  },
+};
+PLUGIN
+fi
 
 # OpenClaw deliberately owns its generated system prompt. Its supported
 # extension point is the workspace bootstrap files, so expose the Agent's
@@ -93,7 +174,8 @@ jq -n \
   --arg mcp_url "${openclaw_mcp_url}" \
   --arg api "${openclaw_api}" \
   --arg workspace "${PWD}" \
-  '{
+  --arg completion_plugin_dir "${completion_plugin_dir}" \
+  '({
     logging:{level:"error",consoleLevel:"silent"},
     models:{
       mode:"replace",
@@ -128,7 +210,18 @@ jq -n \
         }
       }
     }
-  }' > "${config_file}"
+  } + if $completion_plugin_dir == "" then {} else {
+    plugins:{
+      allow:["archestra-completion"],
+      load:{paths:[$completion_plugin_dir]},
+      entries:{
+        "archestra-completion":{
+          enabled:true,
+          hooks:{allowConversationAccess:true}
+        }
+      }
+    }
+  } end)' > "${config_file}"
 chmod 0600 "${config_file}"
 if [[ -n "${runtime_instructions}" && "${soul_created}" != true ]]; then
   printf '%s\n\n# Delegated task\n\n%s\n' \
@@ -140,7 +233,7 @@ fi
 
 session_key="agent:main:${ARCHESTRA_AGENT_RUNTIME_TASK_ID:?}"
 
-case "${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}" in
+case "${runtime_mode}" in
   interactive)
     set +e
     openclaw tui \
@@ -152,17 +245,29 @@ case "${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}" in
     exit "${status}"
     ;;
   one_shot)
-    set +e
-    openclaw agent \
-      --local \
-      --session-key "${session_key}" \
-      --model "archestra/${model}" \
-      --message-file "${task_file}" 2>&1 | tee "${runtime_dir}/openclaw-output.log"
-    status=${PIPESTATUS[0]}
-    set -e
-    if [[ ${status} -ne 0 ]] || grep -Eq "FailoverError:|LLM request failed|network connection error|empty response retries exhausted|Agent couldn't generate a response" "${runtime_dir}/openclaw-output.log"; then
-      exit 1
+    if [[ "${ARCHESTRA_AGENT_RUNTIME_PLAIN:-0}" == "1" ]]; then
+      set +e
+      openclaw agent \
+        --local \
+        --session-key "${session_key}" \
+        --model "archestra/${model}" \
+        --message-file "${task_file}" 2>&1 | tee "${runtime_dir}/openclaw-output.log"
+      status=${PIPESTATUS[0]}
+      set -e
+      if [[ ${status} -ne 0 ]] || grep -Eq "FailoverError:|LLM request failed|network connection error|empty response retries exhausted|Agent couldn't generate a response" "${runtime_dir}/openclaw-output.log"; then
+        exit 1
+      fi
+      exit 0
     fi
+
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    "${script_dir}/archestra-tui-run" \
+      "${runtime_dir}/turn-complete" \
+      "${runtime_dir}/final-answer.txt" \
+      openclaw tui \
+        --local \
+        --session "${session_key}" \
+        --message "$(cat "${task_file}")"
     ;;
   *)
     echo "archestra: unknown Agent Runtime mode" >&2

--- a/platform/agent_images/bin/archestra-opencode
+++ b/platform/agent_images/bin/archestra-opencode
@@ -7,6 +7,7 @@ if [[ "${ARCHESTRA_LLM_PROXY_PROTOCOL:-}" != "openai_responses" ]]; then
 fi
 
 runtime_dir="${ARCHESTRA_AGENT_RUNTIME_DIR:-/var/run/archestra}"
+runtime_mode="${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}"
 config_file="${runtime_dir}/opencode.json"
 instructions_file="${runtime_dir}/opencode-instructions.md"
 task_file="${runtime_dir}/task.md"
@@ -23,10 +24,52 @@ export OPENCODE_CONFIG="${config_file}"
 export OPENCODE_CONFIG_DIR="${runtime_dir}/config"
 export OPENCODE_DISABLE_AUTOUPDATE=1
 export OPENCODE_DISABLE_PROJECT_CONFIG=1
-export OPENCODE_PURE=1
 
 printf '%s\n' "${ARCHESTRA_AGENT_RUNTIME_SYSTEM_PROMPT:-}" > "${instructions_file}"
 printf '%s\n' "${ARCHESTRA_AGENT_RUNTIME_TASK:?}" > "${task_file}"
+
+completion_plugin=""
+if [[ "${runtime_mode}" == "one_shot" ]] \
+  && [[ "${ARCHESTRA_AGENT_RUNTIME_PLAIN:-0}" != "1" ]]; then
+  completion_plugin="${runtime_dir}/opencode-completion.js"
+  cat > "${completion_plugin}" <<'PLUGIN'
+import { writeFile } from "node:fs/promises";
+
+export const ArchestraCompletion = async ({ client, directory }) => ({
+  event: async ({ event }) => {
+    if (event.type !== "session.idle") return;
+
+    const sessionID = event.properties?.sessionID;
+    if (!sessionID) return;
+
+    const sessionResponse = await client.session.get({
+      path: { id: sessionID },
+      query: { directory },
+    });
+    if (sessionResponse.data?.parentID) return;
+
+    const response = await client.session.messages({
+      path: { id: sessionID },
+      query: { directory },
+    });
+    const messages = response.data ?? [];
+    const assistant = [...messages]
+      .reverse()
+      .find((message) => message.info?.role === "assistant");
+    const answer = (assistant?.parts ?? [])
+      .filter((part) => part.type === "text" && !part.ignored)
+      .map((part) => part.text)
+      .join("")
+      .trim();
+    if (!answer) return;
+
+    const runtimeDir = process.env.ARCHESTRA_AGENT_RUNTIME_DIR ?? "/var/run/archestra";
+    await writeFile(`${runtimeDir}/final-answer.txt`, `${answer}\n`, "utf8");
+    await writeFile(`${runtimeDir}/turn-complete`, "", "utf8");
+  },
+});
+PLUGIN
+fi
 
 jq -n \
   --arg model "${model}" \
@@ -36,9 +79,10 @@ jq -n \
   --arg mcp_url "${ARCHESTRA_MCP_GATEWAY_URL:?}" \
   --arg mcp_token "${ARCHESTRA_MCP_GATEWAY_TOKEN:?}" \
   --arg instructions_file "${instructions_file}" \
+  --arg completion_plugin "${completion_plugin}" \
   --argjson context_length "${context_length}" \
   --argjson output_length "${output_length}" \
-  '{
+  '({
     "$schema":"https://opencode.ai/config.json",
     autoupdate:false,
     model:("archestra/" + $model),
@@ -72,11 +116,14 @@ jq -n \
         "X-Archestra-Session-Id":$task_id
       }
     }}
-  }' > "${config_file}"
+  } + if $completion_plugin == "" then {} else {
+    plugin:[("file://" + $completion_plugin)]
+  } end)' > "${config_file}"
 chmod 0600 "${config_file}" "${instructions_file}" "${task_file}"
 
-case "${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}" in
+case "${runtime_mode}" in
   interactive)
+    export OPENCODE_PURE=1
     exec opencode \
       --pure \
       --auto \
@@ -84,11 +131,23 @@ case "${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}" in
       --prompt "$(cat "${task_file}")"
     ;;
   one_shot)
-    exec opencode run \
-      --pure \
-      --auto \
-      --model "archestra/${model}" \
-      -- "$(cat "${task_file}")"
+    if [[ "${ARCHESTRA_AGENT_RUNTIME_PLAIN:-0}" == "1" ]]; then
+      export OPENCODE_PURE=1
+      exec opencode run \
+        --pure \
+        --auto \
+        --model "archestra/${model}" \
+        -- "$(cat "${task_file}")"
+    fi
+
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    exec "${script_dir}/archestra-tui-run" \
+      "${runtime_dir}/turn-complete" \
+      "${runtime_dir}/final-answer.txt" \
+      opencode \
+        --auto \
+        --model "archestra/${model}" \
+        --prompt "$(cat "${task_file}")"
     ;;
   *)
     echo "archestra: unknown Agent Runtime mode" >&2

--- a/platform/agent_images/bin/archestra-tui-exec
+++ b/platform/agent_images/bin/archestra-tui-exec
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) < 4:
+        print(
+            "usage: archestra-tui-exec <completion-marker> <frame-file> <command> [args...]",
+            file=sys.stderr,
+        )
+        return 64
+
+    completion_marker = Path(sys.argv[1])
+    frame_file = Path(sys.argv[2])
+    command = sys.argv[3:]
+    parent_process_group = os.getpgrp()
+
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.setpgid(0, 0)
+        os.kill(os.getpid(), signal.SIGSTOP)
+        os.execvp(command[0], command)
+
+    os.setpgid(child_pid, child_pid)
+    os.waitpid(child_pid, os.WUNTRACED)
+    os.tcsetpgrp(0, child_pid)
+    os.killpg(child_pid, signal.SIGCONT)
+
+    child_status: int | None = None
+    try:
+        while child_status is None:
+            exited_pid, status = os.waitpid(child_pid, os.WNOHANG)
+            if exited_pid == child_pid:
+                child_status = status
+                break
+            if completion_marker.exists():
+                time.sleep(2)
+                capture_frame(frame_file)
+                child_status = stop_process_group(child_pid)
+                break
+            time.sleep(0.2)
+    finally:
+        signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        os.tcsetpgrp(0, parent_process_group)
+
+    if completion_marker.exists():
+        return 0
+    return os.waitstatus_to_exitcode(child_status)
+
+
+def capture_frame(frame_file: Path) -> None:
+    pane = os.environ.get("TMUX_PANE")
+    if not pane:
+        return
+    result = subprocess.run(
+        ["tmux", "capture-pane", "-p", "-e", "-t", pane],
+        check=False,
+        stdout=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        return
+    size_result = subprocess.run(
+        [
+            "tmux",
+            "display-message",
+            "-p",
+            "-t",
+            pane,
+            "#{pane_width}x#{pane_height}",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+    )
+    size = size_result.stdout.strip()
+    metadata = (
+        b"\x1b]777;archestra-terminal-size=" + size + b"\x07"
+        if size_result.returncode == 0 and re.fullmatch(rb"[0-9]+x[0-9]+", size)
+        else b""
+    )
+    clean_lines = [
+        line for line in result.stdout.splitlines(keepends=True) if b"?1;2c" not in line
+    ]
+    frame_file.write_bytes(metadata + b"".join(clean_lines))
+
+
+def stop_process_group(child_pid: int) -> int:
+    try:
+        os.killpg(child_pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        exited_pid, status = os.waitpid(child_pid, os.WNOHANG)
+        if exited_pid == child_pid:
+            return status
+        time.sleep(0.05)
+
+    try:
+        os.killpg(child_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    return os.waitpid(child_pid, 0)[1]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/platform/agent_images/bin/archestra-tui-run
+++ b/platform/agent_images/bin/archestra-tui-run
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: archestra-tui-run <completion-marker> <answer-file> <command> [args...]" >&2
+  exit 64
+fi
+
+done_marker="$1"
+answer_file="$2"
+failed_marker="${done_marker}.failed"
+completed_frame="${done_marker}.frame"
+shift 2
+
+rm -f "${done_marker}" "${failed_marker}" "${completed_frame}" "${answer_file}"
+
+child_pid=""
+child_target=""
+
+stop_child() {
+  if [[ -n "${child_pid}" ]]; then
+    kill -TERM -- "${child_target}" 2>/dev/null || true
+    for _ in {1..8}; do
+      if ! kill -0 "${child_pid}" 2>/dev/null; then
+        return
+      fi
+      sleep 0.25
+    done
+    kill -KILL -- "${child_target}" 2>/dev/null || true
+  fi
+}
+
+forward_signal() {
+  stop_child
+  wait "${child_pid}" 2>/dev/null || true
+  exit 143
+}
+trap forward_signal INT TERM
+
+reset_terminal() {
+  # Full-screen clients can leave origin mode, a restricted scroll region, or
+  # DECLRMM horizontal margins active. Spell out the reset for terminal
+  # players that do not implement RIS (ESC c) completely.
+  printf '\033[?1000l\033[?1002l\033[?1003l\033[?1006l\033[?69l\033[?6l\033[r\033[0m\033[2J\033[H'
+}
+
+watch_for_completion() {
+  # Agent Runtime bounds this process with the run deadline and pod lifecycle.
+  # This loop only bridges a client's end-of-turn callback to its otherwise
+  # persistent TUI process.
+  while kill -0 "${child_pid}" 2>/dev/null; do
+    if [[ -f "${done_marker}" ]]; then
+      # Keep the completed frame visible long enough for tmux's pipe-pane to
+      # capture it before closing the client. Save the visible pane as well:
+      # full-screen clients restore the shell screen during shutdown, but the
+      # retained transcript should finish on the native interface the user saw.
+      sleep 2
+      if [[ -n "${TMUX_PANE:-}" ]] && command -v tmux >/dev/null 2>&1; then
+        # Some clients probe terminal capabilities during teardown. tmux can
+        # briefly paint the terminal's device-attribute reply as text; it is not
+        # part of the interface and should not survive in the completed frame.
+        geometry="$(tmux display-message -p -t "${TMUX_PANE}" '#{pane_width}x#{pane_height}' 2>/dev/null || true)"
+        if [[ "${geometry}" =~ ^[0-9]+x[0-9]+$ ]]; then
+          printf '\033]777;archestra-terminal-size=%s\007' "${geometry}" \
+            > "${completed_frame}"
+        else
+          : > "${completed_frame}"
+        fi
+        tmux capture-pane -p -e -t "${TMUX_PANE}" \
+          | sed '/?1;2c/d' \
+          >> "${completed_frame}" || true
+      fi
+      stop_child
+      return
+    fi
+    sleep 1
+  done
+}
+
+if [[ -t 0 ]]; then
+  # Give the client the actual tmux pty so it receives browser resizes and
+  # input. The supervisor keeps it in the foreground while independently
+  # watching for completion.
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  set +e
+  "${script_dir}/archestra-tui-exec" \
+    "${done_marker}" \
+    "${completed_frame}" \
+    "$@"
+  status=$?
+  set -e
+else
+  "$@" &
+  child_pid=$!
+  child_target="${child_pid}"
+  watch_for_completion &
+  completion_watcher_pid=$!
+  set +e
+  wait "${child_pid}" 2>/dev/null
+  status=$?
+  wait "${completion_watcher_pid}" 2>/dev/null || true
+  set -e
+fi
+
+if [[ ! -f "${done_marker}" ]]; then
+  if [[ ${status} -eq 0 ]]; then
+    echo "archestra: the TUI exited without completing its turn" >&2
+    exit 1
+  fi
+  exit "${status}"
+fi
+
+# Native clients may leave scroll regions, margins, or application modes set
+# while shutting down. Reset before writing the machine-readable answer so it
+# cannot wrap into a one-column strip in the retained terminal.
+reset_terminal
+printf '\n===ARCHESTRA-FINAL-ANSWER===\n'
+if [[ -s "${answer_file}" ]]; then
+  cat "${answer_file}"
+else
+  echo "The session ended without producing a final message."
+fi
+printf '\n===ARCHESTRA-FINAL-ANSWER-END===\n'
+if [[ -s "${completed_frame}" ]]; then
+  reset_terminal
+  cat "${completed_frame}"
+fi
+if [[ -f "${failed_marker}" ]]; then
+  exit 1
+fi

--- a/platform/backend/src/k8s/agent-runtime/manifests.test.ts
+++ b/platform/backend/src/k8s/agent-runtime/manifests.test.ts
@@ -283,7 +283,11 @@ describe("the container bootstrap", () => {
     // A one-shot agent writes its whole answer in its final instant; without
     // the drain the pane exit tears down pipe-pane first and the transcript
     // ends up empty.
-    expect(script()).toContain('agent session exited"; sleep 2; exit');
+    expect(script()).toContain("exit-code; sleep 2; exit");
+  });
+
+  it("gives detached TUIs a browser-sized canvas before anyone attaches", () => {
+    expect(script()).toContain("tmux new-session -d -x 120 -y 40 -s agent");
   });
 
   it("lets terminal wheel events scroll tmux history", () => {

--- a/platform/backend/src/k8s/agent-runtime/manifests.ts
+++ b/platform/backend/src/k8s/agent-runtime/manifests.ts
@@ -105,11 +105,11 @@ function buildAgentRuntimeBootstrapScript(): string {
     // mirror down before it is copied out — the durable transcript (and the
     // completion message built from it) arrives empty while the pane showed a
     // full answer.
-    `printf '%s\n' '/bin/sh ${AGENT_RUNTIME_DIR}/entry.sh; status=$?; printf "%s\\n" "$status" > ${exitCodeFile}; echo; echo "[agent-runtime] agent session exited"; sleep 2; exit "$status"' > ${AGENT_RUNTIME_DIR}/session.sh`,
+    `printf '%s\n' '/bin/sh ${AGENT_RUNTIME_DIR}/entry.sh; status=$?; printf "%s\\n" "$status" > ${exitCodeFile}; sleep 2; exit "$status"' > ${AGENT_RUNTIME_DIR}/session.sh`,
     // Create the pane before starting the Agent so its output cannot race the
     // pipe setup. A fast one-shot client used to finish before pipe-pane was
     // attached, leaving its durable transcript empty.
-    `tmux new-session -d -s ${AGENT_RUNTIME_TMUX_SESSION} 'while :; do sleep 1; done'`,
+    `tmux new-session -d -x 120 -y 40 -s ${AGENT_RUNTIME_TMUX_SESSION} 'while :; do sleep 1; done'`,
     // Let browser terminals send wheel events to tmux. Its WheelUpPane binding
     // enters copy mode and scrolls tmux's own history; without mouse mode,
     // xterm falls back to cursor-key sequences that get typed into the pane.

--- a/platform/backend/src/services/agent-runtime/claude-code-entrypoint.test.ts
+++ b/platform/backend/src/services/agent-runtime/claude-code-entrypoint.test.ts
@@ -1,0 +1,120 @@
+import { execFile } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const ENTRYPOINT = path.resolve(
+  import.meta.dirname,
+  "../../../../agent_images/bin/archestra-claude-code",
+);
+
+describe("Claude Code image entrypoint", () => {
+  test.each([
+    "one_shot",
+    "interactive",
+  ] as const)("configures and starts %s run in the native TUI", async (mode) => {
+    const root = await mkdtemp(path.join(tmpdir(), "archestra-claude-code-"));
+    try {
+      const bin = path.join(root, "bin");
+      const runtime = path.join(root, "runtime");
+      const workspace = path.join(root, "workspace");
+      const home = path.join(root, "home");
+      await Promise.all([
+        mkdir(bin, { recursive: true }),
+        mkdir(runtime, { recursive: true }),
+        mkdir(workspace, { recursive: true }),
+        mkdir(home, { recursive: true }),
+      ]);
+      await writeExecutable(
+        path.join(bin, "claude"),
+        `#!/bin/sh
+printf '%s\n' "$@" > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-args"
+if [ "$ARCHESTRA_AGENT_RUNTIME_MODE" = "one_shot" ]; then
+  settings=""
+  previous=""
+  for argument in "$@"; do
+    if [ "$previous" = "--settings" ]; then settings="$argument"; fi
+    previous="$argument"
+  done
+  transcript="$ARCHESTRA_AGENT_RUNTIME_DIR/transcript.jsonl"
+  printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"Claude finished the task."}]}}' > "$transcript"
+  hook_script="$(jq -r '.hooks.Stop[0].hooks[0].command' "$settings")"
+  printf '{"transcript_path":"%s"}' "$transcript" | "$hook_script"
+  trap 'exit 0' TERM
+  while :; do sleep 1; done
+fi
+`,
+      );
+
+      const result = await execFileAsync("bash", [ENTRYPOINT], {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          HOME: home,
+          PATH: `${bin}:${process.env.PATH}`,
+          ARCHESTRA_LLM_PROXY_PROTOCOL: "anthropic",
+          ARCHESTRA_AGENT_RUNTIME_DIR: runtime,
+          ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL: "test-model",
+          ARCHESTRA_AGENT_RUNTIME_TASK_ID:
+            "12345678-abcd-4000-8000-123456789abc",
+          ARCHESTRA_AGENT_RUNTIME_TASK: "Run the task.",
+          ARCHESTRA_AGENT_RUNTIME_SYSTEM_PROMPT:
+            "Follow the configured Agent instructions.",
+          ARCHESTRA_AGENT_RUNTIME_MODE: mode,
+          ARCHESTRA_MCP_GATEWAY_URL: "http://localhost:9000/v1/mcp/test",
+          ARCHESTRA_MCP_GATEWAY_TOKEN: "test-token",
+          ANTHROPIC_AUTH_TOKEN: "test-key",
+          ANTHROPIC_BASE_URL: "http://localhost:9000/v1/model-router/test",
+        },
+      });
+
+      const mcpConfig = JSON.parse(
+        await readFile(path.join(runtime, "claude-mcp.json"), "utf8"),
+      );
+      expect(mcpConfig.mcpServers.archestra.headers.Authorization).toBe(
+        "Bearer test-token",
+      );
+
+      const args = (await readFile(path.join(runtime, "captured-args"), "utf8"))
+        .trim()
+        .split("\n");
+      expect(args).toContain("--strict-mcp-config");
+      expect(args.at(-1)).toBe("Run the task.");
+      expect(args.includes("--print")).toBe(false);
+
+      if (mode === "one_shot") {
+        expect(args).toContain("--settings");
+        expect(result.stdout).toContain("===ARCHESTRA-FINAL-ANSWER===");
+        expect(result.stdout).toContain("Claude finished the task.");
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a non-Anthropic protocol before starting Claude Code", async () => {
+    await expect(
+      execFileAsync("bash", [ENTRYPOINT], {
+        env: {
+          ...process.env,
+          ARCHESTRA_LLM_PROXY_PROTOCOL: "openai_responses",
+        },
+      }),
+    ).rejects.toMatchObject({ code: 78 });
+  });
+});
+
+async function writeExecutable(file: string, contents: string): Promise<void> {
+  await writeFile(file, contents, "utf8");
+  await chmod(file, 0o755);
+}

--- a/platform/backend/src/services/agent-runtime/codex-entrypoint.test.ts
+++ b/platform/backend/src/services/agent-runtime/codex-entrypoint.test.ts
@@ -1,0 +1,112 @@
+import { execFile } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const ENTRYPOINT = path.resolve(
+  import.meta.dirname,
+  "../../../../agent_images/bin/archestra-codex",
+);
+
+describe("Codex image entrypoint", () => {
+  test.each([
+    "one_shot",
+    "interactive",
+  ] as const)("configures and starts %s run in the native TUI", async (mode) => {
+    const root = await mkdtemp(path.join(tmpdir(), "archestra-codex-"));
+    try {
+      const bin = path.join(root, "bin");
+      const runtime = path.join(root, "runtime");
+      const workspace = path.join(root, "workspace");
+      await Promise.all([
+        mkdir(bin, { recursive: true }),
+        mkdir(workspace, { recursive: true }),
+      ]);
+      await writeExecutable(
+        path.join(bin, "codex"),
+        `#!/bin/sh
+printf '%s\n' "$@" > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-args"
+if [ "$ARCHESTRA_AGENT_RUNTIME_MODE" = "one_shot" ]; then
+  notify_script="$(awk -F'"' '/^notify =/ { print $2 }' "$CODEX_HOME/config.toml")"
+  "$notify_script" '{"type":"agent-turn-complete","input-messages":["A subagent task."],"last-assistant-message":"Ignore this subagent answer."}'
+  test ! -e "$ARCHESTRA_AGENT_RUNTIME_DIR/turn-complete"
+  "$notify_script" '{"type":"agent-turn-complete","input-messages":["Run the task."],"last-assistant-message":"Codex finished the task."}'
+  trap 'exit 0' TERM
+  while :; do sleep 1; done
+fi
+`,
+      );
+
+      const result = await execFileAsync("bash", [ENTRYPOINT], {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          ARCHESTRA_LLM_PROXY_PROTOCOL: "openai_responses",
+          ARCHESTRA_AGENT_RUNTIME_DIR: runtime,
+          ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL: "test-model",
+          ARCHESTRA_AGENT_RUNTIME_TASK_ID:
+            "12345678-abcd-4000-8000-123456789abc",
+          ARCHESTRA_AGENT_RUNTIME_TASK: "Run the task.",
+          ARCHESTRA_AGENT_RUNTIME_SYSTEM_PROMPT:
+            "Follow the configured Agent instructions.",
+          ARCHESTRA_AGENT_RUNTIME_MODE: mode,
+          ARCHESTRA_MCP_GATEWAY_URL: "http://localhost:9000/v1/mcp/test",
+          ARCHESTRA_MCP_GATEWAY_TOKEN: "test-token",
+          OPENAI_API_KEY: "test-key",
+          OPENAI_BASE_URL: "http://localhost:9000/v1/model-router/test",
+        },
+      });
+
+      const config = await readFile(
+        path.join(runtime, "codex", "config.toml"),
+        "utf8",
+      );
+      expect(config).toContain('wire_api = "responses"');
+      expect(config).toContain(
+        '"X-Archestra-Run-Id" = "12345678-abcd-4000-8000-123456789abc"',
+      );
+      expect(config.includes("notify = [")).toBe(mode === "one_shot");
+
+      const args = (await readFile(path.join(runtime, "captured-args"), "utf8"))
+        .trim()
+        .split("\n");
+      expect(args[0]).toBe("--dangerously-bypass-approvals-and-sandbox");
+      expect(args).not.toContain("exec");
+      expect(args.at(-1)).toBe("Run the task.");
+
+      if (mode === "one_shot") {
+        expect(result.stdout).toContain("===ARCHESTRA-FINAL-ANSWER===");
+        expect(result.stdout).toContain("Codex finished the task.");
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a non-Responses protocol before starting Codex", async () => {
+    await expect(
+      execFileAsync("bash", [ENTRYPOINT], {
+        env: {
+          ...process.env,
+          ARCHESTRA_LLM_PROXY_PROTOCOL: "openai_chat",
+        },
+      }),
+    ).rejects.toMatchObject({ code: 78 });
+  });
+});
+
+async function writeExecutable(file: string, contents: string): Promise<void> {
+  await writeFile(file, contents, "utf8");
+  await chmod(file, 0o755);
+}

--- a/platform/backend/src/services/agent-runtime/hermes-entrypoint.test.ts
+++ b/platform/backend/src/services/agent-runtime/hermes-entrypoint.test.ts
@@ -1,0 +1,132 @@
+import { execFile } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const ENTRYPOINT = path.resolve(
+  import.meta.dirname,
+  "../../../../agent_images/bin/archestra-hermes",
+);
+
+describe("Hermes image entrypoint", () => {
+  test.each([
+    "one_shot",
+    "interactive",
+  ] as const)("configures and starts %s run in the native TUI", async (mode) => {
+    const root = await mkdtemp(path.join(tmpdir(), "archestra-hermes-"));
+    try {
+      const bin = path.join(root, "bin");
+      const runtime = path.join(root, "runtime");
+      const workspace = path.join(root, "workspace");
+      const home = path.join(root, "home");
+      await Promise.all([
+        mkdir(bin, { recursive: true }),
+        mkdir(workspace, { recursive: true }),
+        mkdir(home, { recursive: true }),
+      ]);
+      await writeExecutable(
+        path.join(bin, "hermes"),
+        `#!/bin/sh
+printf '%s\n' "$@" > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-args"
+if [ "$ARCHESTRA_AGENT_RUNTIME_MODE" = "one_shot" ]; then
+  hook_script="$(jq -r '.hooks.post_llm_call[0].command' "$HERMES_HOME/config.yaml")"
+  printf '%s' '{"hook_event_name":"on_session_start","session_id":"main-session","extra":{}}' | "$hook_script"
+  printf '%s' '{"hook_event_name":"post_llm_call","session_id":"subagent-session","extra":{"assistant_response":"Ignore this subagent answer."}}' | "$hook_script"
+  test ! -e "$ARCHESTRA_AGENT_RUNTIME_DIR/turn-complete"
+  python3 - "$HERMES_HOME/state.db" <<'PYTHON'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as database:
+    database.execute("CREATE TABLE sessions (id TEXT, source TEXT, parent_session_id TEXT, started_at REAL)")
+    database.execute("CREATE TABLE messages (id INTEGER, session_id TEXT, role TEXT, content TEXT, active INTEGER, finish_reason TEXT)")
+    database.execute("INSERT INTO sessions VALUES ('main-session', 'tui', NULL, 1)")
+    database.execute("INSERT INTO messages VALUES (1, 'main-session', 'user', 'Run the task.', 1, NULL)")
+    database.execute("INSERT INTO messages VALUES (2, 'main-session', 'assistant', 'Hermes finished the task.', 1, 'stop')")
+PYTHON
+  trap 'exit 0' TERM
+  while :; do sleep 1; done
+fi
+`,
+      );
+
+      const result = await execFileAsync("bash", [ENTRYPOINT], {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          HOME: home,
+          PATH: `${bin}:${process.env.PATH}`,
+          ARCHESTRA_LLM_PROXY_PROTOCOL: "openai_chat",
+          ARCHESTRA_AGENT_RUNTIME_DIR: runtime,
+          ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL: "test-model",
+          ARCHESTRA_AGENT_RUNTIME_TASK_ID:
+            "12345678-abcd-4000-8000-123456789abc",
+          ARCHESTRA_AGENT_RUNTIME_TASK: "Run the task.",
+          ARCHESTRA_AGENT_RUNTIME_SYSTEM_PROMPT:
+            "Follow the configured Agent instructions.",
+          ARCHESTRA_AGENT_RUNTIME_MODE: mode,
+          ARCHESTRA_MCP_GATEWAY_URL: "http://localhost:9000/v1/mcp/test",
+          ARCHESTRA_MCP_GATEWAY_TOKEN: "test-token",
+          OPENAI_API_KEY: "test-key",
+          OPENAI_BASE_URL: "http://localhost:9000/v1/model-router/test",
+        },
+      });
+
+      const config = JSON.parse(
+        await readFile(path.join(runtime, "hermes", "config.yaml"), "utf8"),
+      );
+      expect(config.providers.archestra.transport).toBe("openai_chat");
+      expect(config.mcp_servers.archestra.headers.Authorization).toBe(
+        "Bearer test-token",
+      );
+      if (mode === "one_shot") {
+        expect(config.hooks).toEqual({
+          on_session_start: [
+            { command: `${runtime}/hermes-completion-hook.sh` },
+          ],
+          post_llm_call: [{ command: `${runtime}/hermes-completion-hook.sh` }],
+        });
+        expect(config.hooks_auto_accept).toBe(true);
+        expect(result.stdout).toContain("===ARCHESTRA-FINAL-ANSWER===");
+        expect(result.stdout).toContain("Hermes finished the task.");
+      } else {
+        expect(config.hooks).toBeUndefined();
+      }
+
+      const args = (await readFile(path.join(runtime, "captured-args"), "utf8"))
+        .trim()
+        .split("\n");
+      expect(args[0]).toBe("chat");
+      expect(args).toContain("--tui");
+      expect(args.at(-1)).toBe("Run the task.");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a non-Chat protocol before starting Hermes", async () => {
+    await expect(
+      execFileAsync("bash", [ENTRYPOINT], {
+        env: {
+          ...process.env,
+          ARCHESTRA_LLM_PROXY_PROTOCOL: "openai_responses",
+        },
+      }),
+    ).rejects.toMatchObject({ code: 78 });
+  });
+});
+
+async function writeExecutable(file: string, contents: string): Promise<void> {
+  await writeFile(file, contents, "utf8");
+  await chmod(file, 0o755);
+}

--- a/platform/backend/src/services/agent-runtime/openclaw-entrypoint.test.ts
+++ b/platform/backend/src/services/agent-runtime/openclaw-entrypoint.test.ts
@@ -36,11 +36,44 @@ describe("OpenClaw image entrypoint", () => {
         path.join(bin, "openclaw"),
         `#!/bin/sh
 cp "$PWD/SOUL.md" "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-soul.md"
-printf 'OpenClaw test response\\n'
+printf '%s\n' "$@" > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-args"
+plugin_dir="$(jq -r '.plugins.load.paths[0]' "$OPENCLAW_CONFIG_PATH")"
+PLUGIN_PATH="$plugin_dir/index.mjs" node --input-type=module <<'JS'
+const plugin = await import("file://" + process.env.PLUGIN_PATH);
+const { access } = await import("node:fs/promises");
+let agentEnd;
+plugin.default.register({
+  on(name, handler) {
+    if (name === "agent_end") agentEnd = handler;
+  },
+});
+await agentEnd(
+  {
+    success: true,
+    messages: [{ role: "assistant", content: [{ type: "text", text: "Ignore this subagent answer." }] }],
+  },
+  { sessionKey: "agent:main:subagent-session" },
+);
+try {
+  await access(process.env.ARCHESTRA_AGENT_RUNTIME_DIR + "/turn-complete");
+  throw new Error("subagent completion settled the run");
+} catch (error) {
+  if (error.code !== "ENOENT") throw error;
+}
+await agentEnd(
+  {
+    success: true,
+    messages: [{ role: "assistant", content: [{ type: "text", text: "OpenClaw finished the task." }] }],
+  },
+  { sessionKey: "agent:main:12345678-abcd-4000-8000-123456789abc" },
+);
+JS
+trap 'exit 0' TERM
+while :; do sleep 1; done
 `,
       );
 
-      await execFileAsync("bash", [ENTRYPOINT], {
+      const result = await execFileAsync("bash", [ENTRYPOINT], {
         cwd: workspace,
         env: {
           ...process.env,
@@ -70,6 +103,23 @@ printf 'OpenClaw test response\\n'
         consoleLevel: "silent",
       });
       expect(config.agents.defaults.skipBootstrap).toBe(true);
+      expect(config.plugins).toEqual({
+        allow: ["archestra-completion"],
+        load: { paths: [`${runtime}/openclaw-completion`] },
+        entries: {
+          "archestra-completion": {
+            enabled: true,
+            hooks: { allowConversationAccess: true },
+          },
+        },
+      });
+      const args = (await readFile(path.join(runtime, "captured-args"), "utf8"))
+        .trim()
+        .split("\n");
+      expect(args[0]).toBe("tui");
+      expect(args).not.toContain("agent");
+      expect(result.stdout).toContain("===ARCHESTRA-FINAL-ANSWER===");
+      expect(result.stdout).toContain("OpenClaw finished the task.");
       expect(
         await readFile(path.join(runtime, "captured-soul.md"), "utf8"),
       ).toContain("Follow the configured Agent instructions.");

--- a/platform/backend/src/services/agent-runtime/opencode-entrypoint.test.ts
+++ b/platform/backend/src/services/agent-runtime/opencode-entrypoint.test.ts
@@ -20,7 +20,7 @@ const ENTRYPOINT = path.resolve(
 
 describe("OpenCode image entrypoint", () => {
   test.each([
-    ["one_shot", ["run", "--pure", "--auto"]],
+    ["one_shot", ["--auto", "--model"]],
     ["interactive", ["--pure", "--auto"]],
   ] as const)("configures and starts %s run", async (mode, prefix) => {
     const root = await mkdtemp(path.join(tmpdir(), "archestra-opencode-"));
@@ -37,10 +37,40 @@ describe("OpenCode image entrypoint", () => {
         `#!/bin/sh
 printf '%s\n' "$@" > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-args"
 env > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-env"
+if [ "$ARCHESTRA_AGENT_RUNTIME_MODE" = "one_shot" ]; then
+  plugin_path="$(jq -r '.plugin[0] | sub("^file://"; "")' "$OPENCODE_CONFIG")"
+  PLUGIN_PATH="$plugin_path" node --input-type=module <<'JS'
+const plugin = await import("file://" + process.env.PLUGIN_PATH);
+const { access } = await import("node:fs/promises");
+const hooks = await plugin.ArchestraCompletion({
+  client: {
+    session: {
+      get: async ({ path }) => ({
+        data: path.id === "subagent-session" ? { id: path.id, parentID: "session-1" } : { id: path.id },
+      }),
+      messages: async () => ({
+        data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "OpenCode finished the task." }] }],
+      }),
+    },
+  },
+  directory: process.cwd(),
+});
+await hooks.event({ event: { type: "session.idle", properties: { sessionID: "subagent-session" } } });
+try {
+  await access(process.env.ARCHESTRA_AGENT_RUNTIME_DIR + "/turn-complete");
+  throw new Error("subagent completion settled the run");
+} catch (error) {
+  if (error.code !== "ENOENT") throw error;
+}
+await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-1" } } });
+JS
+  trap 'exit 0' TERM
+  while :; do sleep 1; done
+fi
 `,
       );
 
-      await execFileAsync("bash", [ENTRYPOINT], {
+      const result = await execFileAsync("bash", [ENTRYPOINT], {
         cwd: workspace,
         env: {
           ...process.env,
@@ -102,6 +132,15 @@ env > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-env"
           },
         },
       });
+      if (mode === "one_shot") {
+        expect(config.plugin).toEqual([
+          `file://${runtime}/opencode-completion.js`,
+        ]);
+        expect(result.stdout).toContain("===ARCHESTRA-FINAL-ANSWER===");
+        expect(result.stdout).toContain("OpenCode finished the task.");
+      } else {
+        expect(config.plugin).toBeUndefined();
+      }
       expect(
         await readFile(path.join(runtime, "opencode-instructions.md"), "utf8"),
       ).toBe("Follow the configured Agent instructions.\n");
@@ -119,6 +158,9 @@ env > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-env"
       );
       expect(capturedEnv).toContain("OPENCODE_DISABLE_PROJECT_CONFIG=1");
       expect(capturedEnv).toContain(`OPENCODE_CONFIG=${runtime}/opencode.json`);
+      expect(capturedEnv.includes("OPENCODE_PURE=1")).toBe(
+        mode === "interactive",
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/platform/backend/src/services/agent-runtime/pod-run.test.ts
+++ b/platform/backend/src/services/agent-runtime/pod-run.test.ts
@@ -76,6 +76,17 @@ describe("extractFinalAnswer", () => {
     expect(extractFinalAnswer(transcript)).toBe("the real answer");
   });
 
+  test("stops at the end fence before the preserved final TUI frame", () => {
+    const transcript = [
+      "===ARCHESTRA-FINAL-ANSWER===",
+      "the durable answer",
+      "===ARCHESTRA-FINAL-ANSWER-END===",
+      "\u001b[2J\u001b[H╭─ Codex ─╮",
+      "│ completed │",
+    ].join("\n");
+    expect(extractFinalAnswer(transcript)).toBe("the durable answer\n");
+  });
+
   test("falls back to the transcript when the fence has nothing after it", () => {
     // The runtime died mid-write; a partial recording beats an empty answer.
     const transcript = "some output\n===ARCHESTRA-FINAL-ANSWER===\n";

--- a/platform/backend/src/services/agent-runtime/pod-run.ts
+++ b/platform/backend/src/services/agent-runtime/pod-run.ts
@@ -393,6 +393,7 @@ function delayMs(ms: number, signal?: AbortSignal): Promise<void> {
  * whole transcript is the answer, exactly as before.
  */
 const FINAL_ANSWER_FENCE = "===ARCHESTRA-FINAL-ANSWER===";
+const FINAL_ANSWER_END_FENCE = "===ARCHESTRA-FINAL-ANSWER-END===";
 
 /**
  * Take what a runtime fenced as its final answer, else the whole transcript.
@@ -403,7 +404,9 @@ const FINAL_ANSWER_FENCE = "===ARCHESTRA-FINAL-ANSWER===";
 export function extractFinalAnswer(transcript: string): string {
   const start = transcript.lastIndexOf(FINAL_ANSWER_FENCE);
   if (start === -1) return transcript;
-  const answer = transcript.slice(start + FINAL_ANSWER_FENCE.length);
+  const answerStart = start + FINAL_ANSWER_FENCE.length;
+  const end = transcript.indexOf(FINAL_ANSWER_END_FENCE, answerStart);
+  const answer = transcript.slice(answerStart, end === -1 ? undefined : end);
   // A fence with nothing after it means the runtime died mid-write; the
   // transcript is worth more than an empty string.
   return answer.trim() === "" ? transcript : answer.replace(/^\r?\n/, "");

--- a/platform/frontend/src/app/chat/runs/page.client.test.tsx
+++ b/platform/frontend/src/app/chat/runs/page.client.test.tsx
@@ -24,6 +24,7 @@ const terminalState = vi.hoisted(() => ({
     showManualCommand?: boolean;
     showDisconnectedStatus?: boolean;
     onCommandChange?: (command: string | null) => void;
+    onError?: () => void;
   } | null,
 }));
 
@@ -135,6 +136,18 @@ describe("AgentRunChatSession", () => {
       showManualCommand: false,
       showDisconnectedStatus: false,
     });
+  });
+
+  it("refreshes run state when completion wins the terminal attach race", () => {
+    queryState.value.data = run({
+      state: "TASK_STATE_WORKING",
+      endedAt: null,
+    });
+
+    render(<AgentRunChatSession taskId="task-1" />);
+    act(() => terminalState.props?.onError?.());
+
+    expect(queryState.value.refetch).toHaveBeenCalledOnce();
   });
 
   it("moves agent and terminal details into the run actions menu", async () => {

--- a/platform/frontend/src/app/chat/runs/page.client.tsx
+++ b/platform/frontend/src/app/chat/runs/page.client.tsx
@@ -162,6 +162,7 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
               setConnectionCommand(command);
               if (command) setLiveTerminalTaskId(taskId);
             }}
+            onError={() => void query.refetch()}
             onClosed={() => void query.refetch()}
           />
         ) : run ? (

--- a/platform/frontend/src/components/agent-pages/agent-runs.test.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-runs.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentRun } from "@/lib/agent-runtime.query";
+
+const { state, refetch } = vi.hoisted(() => ({
+  state: { runs: [] as AgentRun[] },
+  refetch: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-runtime.query", () => ({
+  useAgentRuns: () => ({
+    data: state.runs,
+    isPending: false,
+    isError: false,
+    refetch,
+  }),
+}));
+
+vi.mock("@/lib/auth/auth.query", () => ({
+  useSession: () => ({ data: { user: { id: "user-1" } } }),
+}));
+
+vi.mock("@/components/agent-run-state", () => ({
+  AgentRunState: () => <span>Run state</span>,
+}));
+
+vi.mock("@/components/agent-run-terminal", () => ({
+  AgentRunTerminal: () => <div>Live terminal</div>,
+}));
+
+vi.mock("@/components/agent-run-logs", () => ({
+  AgentRunLogs: () => <div>Retained output</div>,
+}));
+
+import { AgentRuns } from "./agent-runs";
+
+describe("AgentRuns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.runs = [createRun(null)];
+  });
+
+  it("shows the live terminal while a run is active and retained output when it ends", () => {
+    const view = render(<AgentRuns agentId="agent-1" />);
+
+    expect(screen.getByText("Live terminal")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Output" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Terminal" })).toBeNull();
+
+    state.runs = [createRun("2026-09-03T20:00:05.000Z")];
+    view.rerender(<AgentRuns agentId="agent-1" />);
+
+    expect(screen.getByText("Retained output")).toBeInTheDocument();
+    expect(screen.queryByText("Live terminal")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Output" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Terminal" })).toBeNull();
+  });
+});
+
+function createRun(endedAt: string | null): AgentRun {
+  return {
+    id: "run-1",
+    organizationId: "org-1",
+    taskId: "12345678-abcd-4000-8000-123456789abc",
+    agentId: "agent-1",
+    actorKind: "user",
+    actorId: "user-1",
+    actorUserId: "user-1",
+    title: "Native TUI verification",
+    pinnedAt: null,
+    projectId: null,
+    workloadName: "agent-agent-1-task-1",
+    backend: "kubernetes",
+    runtimeScope: "archestra-dev",
+    virtualApiKeyId: null,
+    startedAt: "2026-09-03T20:00:00.000Z",
+    endedAt,
+    state: endedAt ? "TASK_STATE_COMPLETED" : "TASK_STATE_WORKING",
+    statusReason: null,
+    stateChangedAt: "2026-09-03T20:00:05.000Z",
+  };
+}

--- a/platform/frontend/src/components/agent-pages/agent-runs.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-runs.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { formatDistanceToNow } from "date-fns";
-import { ScrollText, TerminalSquare } from "lucide-react";
+import { TerminalSquare } from "lucide-react";
 import { useState } from "react";
 import { AgentRunLogs } from "@/components/agent-run-logs";
 import { AgentRunState } from "@/components/agent-run-state";
 import { AgentRunTerminal } from "@/components/agent-run-terminal";
-import { DeploymentConsoleTabList } from "@/components/deployment-console";
 import { QueryLoadError } from "@/components/query-load-error";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,7 +16,6 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { type AgentRun, useAgentRuns } from "@/lib/agent-runtime.query";
 import { useSession } from "@/lib/auth/auth.query";
 import { cn } from "@/lib/utils";
@@ -122,75 +120,59 @@ export function AgentRuns({ agentId }: { agentId: string }) {
           key={selected.taskId}
           run={selected}
           canAttach={selected.actorUserId === session?.user.id}
+          onClosed={() => void refetch()}
         />
       )}
     </div>
   );
 }
 
-function RunDetails({ run, canAttach }: { run: AgentRun; canAttach: boolean }) {
+function RunDetails({
+  run,
+  canAttach,
+  onClosed,
+}: {
+  run: AgentRun;
+  canAttach: boolean;
+  onClosed: () => void;
+}) {
   const active = !run.endedAt;
-  const defaultTab = active && canAttach ? "shell" : "logs";
-  const [tab, setTab] = useState(defaultTab);
 
   return (
-    <Tabs
-      value={tab}
-      onValueChange={setTab}
-      className="flex min-h-0 flex-col gap-0"
-    >
-      <section className="flex min-h-0 flex-1 flex-col">
-        <div className="flex flex-shrink-0 items-center justify-between gap-4 border-b px-5 py-3.5">
-          <div className="min-w-0">
-            <div className="flex min-w-0 items-center gap-2">
-              <h2 className="truncate text-sm font-medium">{run.title}</h2>
-              <AgentRunState
-                state={run.state}
-                statusReason={run.statusReason}
-                compact
-              />
-            </div>
-            <p className="mt-1 flex flex-wrap items-center gap-x-1.5 text-[11px] text-muted-foreground">
-              <span className="font-mono">{shortTaskId(run.taskId)}</span>
-              <span aria-hidden>·</span>
-              <span>{new Date(run.startedAt).toLocaleString()}</span>
-            </p>
-          </div>
-          <DeploymentConsoleTabList
-            variant="compact"
-            tabs={[
-              {
-                value: "logs",
-                label: "Output",
-                icon: <ScrollText className="size-3" />,
-              },
-              {
-                value: "shell",
-                label: "Terminal",
-                icon: <TerminalSquare className="size-3" />,
-                disabled: !active || !canAttach,
-                disabledReason: !active
-                  ? "The terminal is available only while the run is running"
-                  : "Only the person who started this run can open its terminal",
-              },
-            ]}
-          />
-        </div>
-
-        <div className="flex min-h-0 flex-1 flex-col p-4">
-          <TabsContent value="logs" className="flex min-h-0 flex-1 flex-col">
-            <AgentRunLogs run={run} title="" />
-          </TabsContent>
-          <TabsContent value="shell" className="flex min-h-0 flex-1 flex-col">
-            <AgentRunTerminal
-              taskId={run.taskId}
-              active={tab === "shell" && active && canAttach}
-              title=""
+    <section className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-shrink-0 items-center gap-4 border-b px-5 py-3.5">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <h2 className="truncate text-sm font-medium">{run.title}</h2>
+            <AgentRunState
+              state={run.state}
+              statusReason={run.statusReason}
+              compact
             />
-          </TabsContent>
+          </div>
+          <p className="mt-1 flex flex-wrap items-center gap-x-1.5 text-[11px] text-muted-foreground">
+            <span className="font-mono">{shortTaskId(run.taskId)}</span>
+            <span aria-hidden>·</span>
+            <span>{new Date(run.startedAt).toLocaleString()}</span>
+          </p>
         </div>
-      </section>
-    </Tabs>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col p-4">
+        {active && canAttach ? (
+          <AgentRunTerminal
+            taskId={run.taskId}
+            active
+            title=""
+            showDisconnectedStatus={false}
+            onError={onClosed}
+            onClosed={onClosed}
+          />
+        ) : (
+          <AgentRunLogs run={run} title="" />
+        )}
+      </div>
+    </section>
   );
 }
 

--- a/platform/frontend/src/components/agent-run-logs.test.tsx
+++ b/platform/frontend/src/components/agent-run-logs.test.tsx
@@ -1,5 +1,5 @@
 import type { ServerWebSocketMessage } from "@archestra/shared";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentRun } from "@/lib/agent-runtime.query";
 
@@ -85,6 +85,45 @@ describe("AgentRunLogs", () => {
       "title",
       "The complete transcript exceeded this deployment's storage limit.",
     );
+  });
+
+  it("retries when completed metadata arrives before retained output", async () => {
+    render(<AgentRunLogs run={completedRun} />);
+    expect(socket.send).toHaveBeenCalledTimes(1);
+
+    emit({
+      type: "agent_run_logs_ended",
+      payload: {
+        runId: "task-1",
+        source: "tail",
+        truncated: false,
+      },
+    });
+
+    await waitFor(() => expect(socket.send).toHaveBeenCalledTimes(2));
+    expect(socket.send).toHaveBeenLastCalledWith({
+      type: "subscribe_agent_run_logs",
+      payload: { runId: "task-1" },
+    });
+
+    emit({
+      type: "agent_run_logs",
+      payload: { runId: "task-1", logs: "retained output" },
+    });
+    emit({
+      type: "agent_run_logs_ended",
+      payload: {
+        runId: "task-1",
+        source: "full",
+        truncated: false,
+        totalBytes: 15,
+      },
+    });
+
+    expect(screen.getByTestId("terminal-playback")).toHaveTextContent(
+      "retained output",
+    );
+    expect(screen.getByText("Full transcript")).toBeInTheDocument();
   });
 });
 

--- a/platform/frontend/src/components/agent-run-logs.tsx
+++ b/platform/frontend/src/components/agent-run-logs.tsx
@@ -38,6 +38,15 @@ export function AgentRunLogs({
   } = useDeploymentLogAutoScroll();
 
   useEffect(() => {
+    let receivedOutput = false;
+    let emptyRetryCount = 0;
+    let emptyRetryTimer: ReturnType<typeof setTimeout> | undefined;
+    const subscribeToLogs = () => {
+      websocketService.send({
+        type: "subscribe_agent_run_logs",
+        payload: { runId: run.taskId },
+      });
+    };
     setContent("");
     setError(undefined);
     setIsStreaming(!run.endedAt);
@@ -49,6 +58,7 @@ export function AgentRunLogs({
         "agent_run_logs",
         (message: AgentRunLogsMessage) => {
           if (message.payload.runId === run.taskId) {
+            receivedOutput = true;
             setContent((value) => value + message.payload.logs);
             followNewOutput();
           }
@@ -67,6 +77,15 @@ export function AgentRunLogs({
         "agent_run_logs_ended",
         (message: AgentRunLogsEndedMessage) => {
           if (message.payload.runId === run.taskId) {
+            if (!receivedOutput && emptyRetryCount < EMPTY_LOG_RETRY_LIMIT) {
+              emptyRetryCount += 1;
+              setIsStreaming(true);
+              emptyRetryTimer = setTimeout(
+                subscribeToLogs,
+                EMPTY_LOG_RETRY_DELAY_MS * emptyRetryCount,
+              );
+              return;
+            }
             setIsStreaming(false);
             if (message.payload.source) {
               setRetainedStatus({
@@ -78,11 +97,9 @@ export function AgentRunLogs({
         },
       ),
     ];
-    websocketService.send({
-      type: "subscribe_agent_run_logs",
-      payload: { runId: run.taskId },
-    });
+    subscribeToLogs();
     return () => {
+      if (emptyRetryTimer) clearTimeout(emptyRetryTimer);
       for (const unsubscribe of subscriptions) unsubscribe();
       websocketService.send({
         type: "unsubscribe_agent_run_logs",
@@ -128,6 +145,9 @@ export function AgentRunLogs({
     />
   );
 }
+
+const EMPTY_LOG_RETRY_LIMIT = 3;
+const EMPTY_LOG_RETRY_DELAY_MS = 250;
 
 function RetainedTranscriptStatus({
   status,

--- a/platform/frontend/src/components/agent-run-terminal.tsx
+++ b/platform/frontend/src/components/agent-run-terminal.tsx
@@ -22,6 +22,7 @@ export function AgentRunTerminal({
   showManualCommand,
   showDisconnectedStatus,
   onCommandChange,
+  onError,
   onClosed,
 }: {
   taskId: string;
@@ -30,6 +31,7 @@ export function AgentRunTerminal({
   showManualCommand?: boolean;
   showDisconnectedStatus?: boolean;
   onCommandChange?: (command: string | null) => void;
+  onError?: () => void;
   onClosed?: () => void;
 }) {
   const transport = useMemo<ExecSessionTransport>(
@@ -47,6 +49,7 @@ export function AgentRunTerminal({
       showManualCommand={showManualCommand}
       showDisconnectedStatus={showDisconnectedStatus}
       onCommandChange={onCommandChange}
+      onError={onError}
       onClosed={onClosed}
     />
   );

--- a/platform/frontend/src/components/exec/exec-terminal.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.tsx
@@ -82,6 +82,7 @@ interface ExecTerminalProps {
   /** Whether a closed PTY should add a status banner above its retained frame. */
   showDisconnectedStatus?: boolean;
   onCommandChange?: (command: string | null) => void;
+  onError?: () => void;
   onClosed?: () => void;
 }
 
@@ -95,6 +96,7 @@ export function ExecTerminal({
   disconnectedLabel = "Session terminated",
   showDisconnectedStatus = true,
   onCommandChange,
+  onError,
   onClosed,
 }: ExecTerminalProps) {
   // Read through a ref so a new transport object on every render cannot
@@ -103,6 +105,8 @@ export function ExecTerminal({
   transportRef.current = transport;
   const onClosedRef = useRef(onClosed);
   onClosedRef.current = onClosed;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
   const onCommandChangeRef = useRef(onCommandChange);
   onCommandChangeRef.current = onCommandChange;
   const terminalRef = useRef<HTMLDivElement>(null);
@@ -236,6 +240,7 @@ export function ExecTerminal({
             if (disposed) return;
             setStatus("error");
             setErrorMessage(message);
+            onErrorRef.current?.();
           },
           onClosed: (reason) => {
             if (disposed) return;

--- a/platform/frontend/src/components/terminal-playback.test.tsx
+++ b/platform/frontend/src/components/terminal-playback.test.tsx
@@ -10,6 +10,7 @@ const { terminal, fit, dimensions, proposeDimensions } = vi.hoisted(() => {
       loadAddon: vi.fn(),
       open: vi.fn(),
       reset: vi.fn(),
+      resize: vi.fn(),
       write: vi.fn(),
       options: [] as unknown[],
       registerCsiHandler: vi.fn(),
@@ -31,6 +32,7 @@ vi.mock("@xterm/xterm", () => ({
     loadAddon = terminal.loadAddon;
     open = terminal.open;
     reset = terminal.reset;
+    resize = terminal.resize;
     write = terminal.write;
     parser = { registerCsiHandler: terminal.registerCsiHandler };
   },
@@ -48,6 +50,7 @@ vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 describe("TerminalPlayback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fit.mockImplementation(() => {});
     dimensions.current = { cols: 120, rows: 40 };
     resizeObserverCallback = undefined;
     terminal.options.length = 0;
@@ -129,6 +132,65 @@ describe("TerminalPlayback", () => {
     );
   });
 
+  it("preserves a completed TUI's recorded grid instead of reflowing it", async () => {
+    fit.mockImplementation(() => {
+      terminal.resize(dimensions.current.cols, dimensions.current.rows);
+    });
+    render(
+      <TerminalPlayback
+        content={
+          "\u001b]777;archestra-terminal-size=160x40\u0007\u001b[2JHermes"
+        }
+      />,
+    );
+
+    await waitFor(() =>
+      expect(terminal.write).toHaveBeenCalledWith(
+        `\u001b[2JHermes${readOnlyTerminalState}`,
+      ),
+    );
+    expect(terminal.resize).toHaveBeenCalledWith(160, 40);
+    expect(terminal.write).not.toHaveBeenCalledWith(
+      expect.stringContaining("archestra-terminal-size"),
+    );
+
+    dimensions.current = { cols: 90, rows: 30 };
+    act(() => resizeObserverCallback?.([], {} as unknown as ResizeObserver));
+
+    expect(terminal.reset).not.toHaveBeenCalled();
+    expect(terminal.resize).toHaveBeenCalledTimes(1);
+  });
+
+  it("scales a recorded grid as one canvas on a narrower viewport", async () => {
+    const { getByTestId } = render(
+      <TerminalPlayback
+        content={
+          "\u001b]777;archestra-terminal-size=160x40\u0007\u001b[2JClaude Code"
+        }
+      />,
+    );
+    await waitFor(() => expect(terminal.write).toHaveBeenCalledOnce());
+
+    const viewport = getByTestId("terminal-playback-viewport");
+    const playback = getByTestId("terminal-playback");
+    Object.defineProperties(viewport, {
+      clientWidth: { configurable: true, value: 720 },
+    });
+    Object.defineProperties(playback, {
+      offsetHeight: { configurable: true, value: 600 },
+      offsetWidth: { configurable: true, value: 1280 },
+    });
+
+    act(() => resizeObserverCallback?.([], {} as unknown as ResizeObserver));
+
+    expect(playback.style.transform).toBe("scale(0.5375)");
+    expect(playback.parentElement).toHaveStyle({
+      height: "322.5px",
+      width: "688px",
+    });
+    expect(terminal.resize).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps retained playback locally scrollable", async () => {
     render(<TerminalPlayback content="captured frame" />);
     await waitFor(() => expect(terminal.write).toHaveBeenCalledOnce());
@@ -136,6 +198,7 @@ describe("TerminalPlayback", () => {
     expect(terminal.options.at(-1)).toMatchObject({
       convertEol: true,
       disableStdin: true,
+      lineHeight: 1.2,
       scrollback: 1_000_000,
       scrollSensitivity: 3,
     });

--- a/platform/frontend/src/components/terminal-playback.tsx
+++ b/platform/frontend/src/components/terminal-playback.tsx
@@ -9,11 +9,16 @@ import { isUsableTerminalDimensions } from "./exec/exec-terminal.utils";
  * output remains readable and scrollable.
  */
 export function TerminalPlayback({ content }: { content: string }) {
+  const recording = parseTerminalRecording(content);
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const recordingFrameRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<import("@xterm/xterm").Terminal | null>(null);
-  const contentRef = useRef(content);
+  const updateRecordedScaleRef = useRef<() => void>(() => {});
+  const recordingRef = useRef(recording);
   const renderedContentRef = useRef("");
-  contentRef.current = content;
+  const recordedDimensionsRef = useRef<TerminalDimensions | null>(null);
+  recordingRef.current = recording;
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -41,6 +46,7 @@ export function TerminalPlayback({ content }: { content: string }) {
         fontSize: 12,
         fontFamily:
           "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+        lineHeight: TERMINAL_LINE_HEIGHT,
         scrollback: RETAINED_SCROLLBACK_LINES,
         scrollSensitivity: TERMINAL_SCROLL_SENSITIVITY,
         theme: {
@@ -71,8 +77,63 @@ export function TerminalPlayback({ content }: { content: string }) {
       let rendered = false;
       let renderedDimensions: { cols: number; rows: number } | null = null;
 
+      const updateRecordedScale = () => {
+        const viewport = viewportRef.current;
+        const frame = recordingFrameRef.current;
+        const container = containerRef.current;
+        if (
+          !recordingRef.current.dimensions ||
+          !viewport ||
+          !frame ||
+          !container
+        ) {
+          return;
+        }
+
+        const naturalWidth = container.offsetWidth;
+        const naturalHeight = container.offsetHeight;
+        if (naturalWidth <= 0 || naturalHeight <= 0) return;
+
+        const availableWidth = Math.max(
+          0,
+          viewport.clientWidth - RETAINED_TERMINAL_HORIZONTAL_PADDING_PX,
+        );
+        const scale = Math.min(
+          1,
+          Math.max(MIN_RETAINED_TERMINAL_SCALE, availableWidth / naturalWidth),
+        );
+
+        container.style.transform = `scale(${scale})`;
+        container.style.transformOrigin = "top left";
+        frame.style.width = `${naturalWidth * scale}px`;
+        frame.style.height = `${naturalHeight * scale}px`;
+      };
+      updateRecordedScaleRef.current = updateRecordedScale;
+
       const fitAndRender = () => {
         if (disposed) return;
+        const currentRecording = recordingRef.current;
+        if (currentRecording.dimensions) {
+          if (!layoutReady) return;
+          if (
+            !sameDimensions(renderedDimensions, currentRecording.dimensions)
+          ) {
+            terminal.resize(
+              currentRecording.dimensions.cols,
+              currentRecording.dimensions.rows,
+            );
+          }
+          if (!rendered) {
+            terminal.write(withReadOnlyTerminalState(currentRecording.content));
+            renderedContentRef.current = currentRecording.content;
+            recordedDimensionsRef.current = currentRecording.dimensions;
+            terminalRef.current = terminal;
+            rendered = true;
+          }
+          renderedDimensions = currentRecording.dimensions;
+          updateRecordedScale();
+          return;
+        }
         const dims = fitAddon.proposeDimensions();
         if (!layoutReady || !isUsableTerminalDimensions(dims)) return;
         const dimensionsChanged =
@@ -85,8 +146,9 @@ export function TerminalPlayback({ content }: { content: string }) {
           return;
         }
         if (!rendered) {
-          terminal.write(withReadOnlyTerminalState(contentRef.current));
-          renderedContentRef.current = contentRef.current;
+          terminal.write(withReadOnlyTerminalState(currentRecording.content));
+          renderedContentRef.current = currentRecording.content;
+          recordedDimensionsRef.current = null;
           terminalRef.current = terminal;
           rendered = true;
         } else if (dimensionsChanged) {
@@ -94,14 +156,21 @@ export function TerminalPlayback({ content }: { content: string }) {
           // replay its byte stream into the new grid instead of reflowing a
           // screen full of absolute cursor positions from the old dimensions.
           terminal.reset();
-          terminal.write(withReadOnlyTerminalState(contentRef.current));
-          renderedContentRef.current = contentRef.current;
+          terminal.write(withReadOnlyTerminalState(currentRecording.content));
+          renderedContentRef.current = currentRecording.content;
         }
         renderedDimensions = dims;
       };
 
       resizeObserver = new ResizeObserver(() => {
         if (disposed) return;
+        if (recordingRef.current.dimensions) {
+          // Fitting changes xterm's column count and corrupts full-screen TUI
+          // recordings that use absolute cursor positions. Keep the captured
+          // grid intact and scale its canvas as a single unit instead.
+          updateRecordedScale();
+          return;
+        }
         const dims = fitAddon.proposeDimensions();
         if (!isUsableTerminalDimensions(dims)) return;
         try {
@@ -111,7 +180,7 @@ export function TerminalPlayback({ content }: { content: string }) {
         }
         fitAndRender();
       });
-      resizeObserver.observe(containerRef.current);
+      resizeObserver.observe(viewportRef.current ?? containerRef.current);
 
       // Avoid replaying a whole TUI recording into the transient dimensions
       // produced while the surrounding tab/grid is still mounting.
@@ -129,7 +198,9 @@ export function TerminalPlayback({ content }: { content: string }) {
       resizeObserver?.disconnect();
       initializedTerminal?.dispose();
       terminalRef.current = null;
+      updateRecordedScaleRef.current = () => {};
       renderedContentRef.current = "";
+      recordedDimensionsRef.current = null;
     };
   }, []);
 
@@ -137,23 +208,64 @@ export function TerminalPlayback({ content }: { content: string }) {
     const terminal = terminalRef.current;
     if (!terminal) return;
 
+    const nextRecording = parseTerminalRecording(content);
     const rendered = renderedContentRef.current;
-    if (content.startsWith(rendered)) {
-      terminal.write(withReadOnlyTerminalState(content.slice(rendered.length)));
+    const dimensionsChanged = !sameDimensions(
+      recordedDimensionsRef.current,
+      nextRecording.dimensions,
+    );
+    if (nextRecording.dimensions && dimensionsChanged) {
+      terminal.resize(
+        nextRecording.dimensions.cols,
+        nextRecording.dimensions.rows,
+      );
+      terminal.reset();
+      terminal.write(withReadOnlyTerminalState(nextRecording.content));
+      requestAnimationFrame(() => updateRecordedScaleRef.current());
+    } else if (nextRecording.content.startsWith(rendered)) {
+      terminal.write(
+        withReadOnlyTerminalState(nextRecording.content.slice(rendered.length)),
+      );
     } else {
       terminal.reset();
-      terminal.write(withReadOnlyTerminalState(content));
+      terminal.write(withReadOnlyTerminalState(nextRecording.content));
     }
-    renderedContentRef.current = content;
+    renderedContentRef.current = nextRecording.content;
+    recordedDimensionsRef.current = nextRecording.dimensions;
   }, [content]);
 
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden bg-slate-950 p-4 pb-2">
+    <div
+      ref={viewportRef}
+      className="flex min-h-0 flex-1 overflow-auto bg-slate-950 p-4 pb-2"
+      data-testid="terminal-playback-viewport"
+    >
       <div
-        ref={containerRef}
-        className="min-h-0 flex-1 overflow-hidden"
-        data-testid="terminal-playback"
-      />
+        ref={recordingFrameRef}
+        className={recording.dimensions ? "shrink-0" : "flex min-h-0 flex-1"}
+        style={
+          recording.dimensions
+            ? {
+                height: `calc(${recording.dimensions.rows * 1.2}em + 0.5rem)`,
+                width: `calc(${recording.dimensions.cols}ch + 0.5rem)`,
+              }
+            : undefined
+        }
+      >
+        <div
+          ref={containerRef}
+          className={recording.dimensions ? "shrink-0" : "min-h-0 flex-1"}
+          data-testid="terminal-playback"
+          style={
+            recording.dimensions
+              ? {
+                  height: `calc(${recording.dimensions.rows * 1.2}em + 0.5rem)`,
+                  width: `calc(${recording.dimensions.cols}ch + 0.5rem)`,
+                }
+              : undefined
+          }
+        />
+      </div>
     </div>
   );
 }
@@ -165,6 +277,23 @@ const READ_ONLY_TERMINAL_STATE =
 const ALTERNATE_SCREEN_MODES = new Set([47, 1047, 1049]);
 const RETAINED_SCROLLBACK_LINES = 1_000_000;
 const TERMINAL_SCROLL_SENSITIVITY = 3;
+const TERMINAL_LINE_HEIGHT = 1.2;
+const MIN_RETAINED_TERMINAL_SCALE = 0.5;
+const RETAINED_TERMINAL_HORIZONTAL_PADDING_PX = 32;
+const TERMINAL_SIZE_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\]777;archestra-terminal-size=(\\d+)x(\\d+)${String.fromCharCode(7)}`,
+  "g",
+);
+
+interface TerminalDimensions {
+  cols: number;
+  rows: number;
+}
+
+interface TerminalRecording {
+  content: string;
+  dimensions: TerminalDimensions | null;
+}
 
 function withReadOnlyTerminalState(content: string): string {
   return `${content}${READ_ONLY_TERMINAL_STATE}`;
@@ -174,4 +303,23 @@ function containsAlternateScreenMode(params: (number | number[])[]): boolean {
   return params.some(
     (param) => typeof param === "number" && ALTERNATE_SCREEN_MODES.has(param),
   );
+}
+
+function parseTerminalRecording(content: string): TerminalRecording {
+  let dimensions: TerminalDimensions | null = null;
+  const sanitizedContent = content.replace(
+    TERMINAL_SIZE_PATTERN,
+    (_marker, cols: string, rows: string) => {
+      dimensions = { cols: Number(cols), rows: Number(rows) };
+      return "";
+    },
+  );
+  return { content: sanitizedContent, dimensions };
+}
+
+function sameDimensions(
+  left: TerminalDimensions | null,
+  right: TerminalDimensions | null,
+): boolean {
+  return left?.cols === right?.cols && left?.rows === right?.rows;
 }


### PR DESCRIPTION
## Summary

- Run Claude Code, Codex, OpenCode, Hermes, and OpenClaw one-shot tasks through their native TUIs while client-specific completion signals settle the durable task.
- Capture the final tmux frame with its terminal geometry, replay it on a stable grid, and scale the intact canvas for narrower screens so full-screen layouts do not reflow or jumble.
- Move Chat and Agent Runs automatically from the live terminal to retained output, remove the redundant Agent Runs output/terminal toggle, and retry the short completion-time transcript race.

## Validation

Exercised the complete workflow in the local Tilt environment by opening live and retained run views for all five maintained clients in Chrome, including wide and narrow completed-session playback. Runtime entrypoint, completion extraction, terminal transition, log retry, and fixed-geometry playback behavior are covered by focused backend and frontend tests.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>