### PR TITLE
ci: use GitHub App for website deploys

### DIFF
--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -7,6 +7,15 @@ inputs:
   private-key:
     description: GitHub App private key.
     required: true
+  owner:
+    description: Owner of the GitHub App installation.
+    required: false
+  repositories:
+    description: Comma or newline-separated repositories to grant token access to.
+    required: false
+  permission-actions:
+    description: Actions permission level for the generated token.
+    required: false
 outputs:
   token:
     description: Generated GitHub App token.
@@ -20,3 +29,6 @@ runs:
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+        repositories: ${{ inputs.repositories }}
+        permission-actions: ${{ inputs.permission-actions }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -369,7 +369,7 @@ jobs:
       # blocks when the website's head commit author is not a Vercel team member.
       - name: Generate website deployment token
         id: generate-website-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: ./.github/actions/github-app-token
         with:
           app-id: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_ID }}
           private-key: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -367,9 +367,19 @@ jobs:
       # Dispatches the website repo's CLI deploy workflow. A Vercel deploy hook
       # cannot be used: hooks create Git-integration deployments, which Vercel
       # blocks when the website's head commit author is not a Vercel team member.
+      - name: Generate website deployment token
+        id: generate-website-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_PRIVATE_KEY }}
+          owner: archestra-ai
+          repositories: website
+          permission-actions: write
+
       - name: Trigger website deploy
         env:
-          GH_TOKEN: ${{ secrets.WEBSITE_DEPLOY_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-website-token.outputs.token }}
         run: |
           gh workflow run deploy-to-vercel.yml \
             --repo archestra-ai/website \

--- a/.github/workflows/trigger-website-deploy-on-catalog-changes.yml
+++ b/.github/workflows/trigger-website-deploy-on-catalog-changes.yml
@@ -17,4 +17,5 @@ jobs:
     name: Trigger Website Deploy
     uses: ./.github/workflows/trigger-website-deploy.yml
     secrets:
-      WEBSITE_DEPLOY_GITHUB_TOKEN: ${{ secrets.WEBSITE_DEPLOY_GITHUB_TOKEN }}
+      ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_ID: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_ID }}
+      ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_PRIVATE_KEY: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -28,9 +28,15 @@ jobs:
     name: Trigger Website Vercel Deploy
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout GitHub App token action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/github-app-token
+
       - name: Generate website deployment token
         id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: ./.github/actions/github-app-token
         with:
           app-id: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_ID }}
           private-key: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -9,9 +9,12 @@ name: Trigger Website Deploy
 on:
   workflow_call:
     secrets:
-      WEBSITE_DEPLOY_GITHUB_TOKEN:
+      ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_ID:
         required: true
-        description: GitHub token with actions:write on archestra-ai/website
+        description: App ID for the Archestra Website Deploy GitHub App
+      ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_PRIVATE_KEY:
+        required: true
+        description: Private key for the Archestra Website Deploy GitHub App
   workflow_dispatch:
 
 permissions: {}
@@ -25,9 +28,19 @@ jobs:
     name: Trigger Website Vercel Deploy
     runs-on: ubuntu-latest
     steps:
+      - name: Generate website deployment token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ARCHESTRA_WEBSITE_DEPLOY_GITHUB_APP_PRIVATE_KEY }}
+          owner: archestra-ai
+          repositories: website
+          permission-actions: write
+
       - name: Dispatch website deploy workflow
         env:
-          GH_TOKEN: ${{ secrets.WEBSITE_DEPLOY_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh workflow run deploy-to-vercel.yml \
             --repo archestra-ai/website \


### PR DESCRIPTION
## Why

Website deploy dispatches currently depend on a long-lived personal access token, which requires rotation and ties production automation to an individual account.

## What

- mint short-lived installation tokens from the organization-owned Archestra Website Deploy GitHub App
- extend the repository-local GitHub App token wrapper for cross-repository scope and Actions permissions
- sparse-checkout only that local action in the standalone deploy workflow; the release workflow reuses its existing checkout
- scope generated tokens to archestra-ai/website with Actions write permission
- use the App credentials for manual/catalog deploys and post-release deploys

The App installation itself is restricted to the website repository.

## Validation

- YAML parsing and zizmor checks passed
- manual branch dispatch successfully exercised sparse checkout, minted the App installation token through the local wrapper, and triggered the cross-repository workflow: https://github.com/archestra-ai/archestra/actions/runs/33810615413
- resulting website production deployment completed successfully: https://github.com/archestra-ai/website/actions/runs/33810636463

No automated test was added because this is declarative workflow configuration; the end-to-end manual dispatch validates the changed behavior.