### PR TITLE
fix(deps): update TOON to address CVE-2026-82404

### DIFF
--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -117,7 +117,7 @@
     "@smithy/eventstream-codec": "^4.2.11",
     "@smithy/signature-v4": "^5.3.11",
     "@smithy/util-utf8": "^4.2.2",
-    "@toon-format/toon": "^2.1.0",
+    "@toon-format/toon": "^2.3.1",
     "@types/pdf-parse": "^1.1.5",
     "ai": "catalog:",
     "asana": "3.1.11",

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -370,8 +370,8 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2
       '@toon-format/toon':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.3.1
+        version: 2.3.1
       '@types/pdf-parse':
         specifier: ^1.1.5
         version: 1.1.5
@@ -5865,8 +5865,8 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@toon-format/toon@2.1.0':
-    resolution: {integrity: sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==}
+  '@toon-format/toon@2.3.1':
+    resolution: {integrity: sha512-sWqEMeAJGMda9qRrfPKrX3C4c33CO9SJuvJzzrcBEn5sbDB+k6pSLkDsfN0rVnLQwR97MV3sDgVbcxQNsq8xVw==}
 
   '@turbo/darwin-64@2.9.14':
     resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
@@ -16547,7 +16547,7 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@toon-format/toon@2.1.0': {}
+  '@toon-format/toon@2.3.1': {}
 
   '@turbo/darwin-64@2.9.14':
     optional: true


### PR DESCRIPTION
The platform image scan detects CVE-2026-82404 in @toon-format/toon 2.1.0. The affected range is below 2.3.1.

Raise the backend dependency floor to 2.3.1 and refresh the pnpm lockfile. This keeps the update within the existing 2.x line and uses a release that has cleared the repository's seven-day minimum release-age window.

Verified the real TOON encode/decode path preserves own __proto__ data without changing Object.prototype. The backend provider matrix also passes all 129 applicable scenarios with the updated package.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>