### PR TITLE
perf(chat): streamline new chat initialization

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -45391,6 +45391,18 @@
             "name": "includeTools",
             "required": false,
             "description": "Attach each agent's assigned tools. Defaults to true. Pass false from callers that only need the roster itself — the tool refs carry every tool's name and description, which on an organization of any size is the great majority of this response's bytes. Agents come back with an empty `tools` array when it is off, meaning 'not requested' rather than 'none assigned'."
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "chat"
+              ]
+            },
+            "in": "query",
+            "name": "view",
+            "required": false,
+            "description": "Return the lightweight agent fields needed to initialize chat. Large embedded icons, system prompts, sharing metadata, and unrelated list hydration are omitted; fetch an individual agent before editing it."
           }
         ],
         "responses": {

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -20,6 +20,7 @@ import {
   count,
   desc,
   eq,
+  getTableColumns,
   ilike,
   inArray,
   isNotNull,
@@ -875,13 +876,17 @@ class AgentModel {
        * "not requested" rather than "none assigned".
        */
       includeTools?: boolean;
+      /**
+       * Return the compact roster used to initialize chat. The response keeps
+       * the full Agent wire shape for compatibility, but fields the chat does
+       * not consume are empty and oversized embedded icons are omitted.
+       */
+      view?: "chat";
     },
   ): Promise<Agent[]> {
     // Tools are attached afterwards as slim refs via one batched query:
     // joining them here multiplied every agent row (system prompt included)
     // by that agent's tool count.
-    let query = db.select().from(schema.agentsTable).$dynamic();
-
     // Build where conditions
     const whereConditions: SQL[] = [
       getAgentStatusCondition(options?.status ?? "active"),
@@ -949,12 +954,14 @@ class AgentModel {
       whereConditions.push(inArray(schema.agentsTable.id, accessibleAgentIds));
     }
 
-    // Apply all where conditions if any exist
-    if (whereConditions.length > 0) {
-      query = query.where(and(...whereConditions));
-    }
-
-    const rows = await query;
+    const where = and(...whereConditions);
+    const rows =
+      options?.view === "chat"
+        ? await db
+            .select(CHAT_AGENT_ROW_COLUMNS)
+            .from(schema.agentsTable)
+            .where(where)
+        : await db.select().from(schema.agentsTable).where(where);
 
     const agents: Agent[] = rows.map((agent) => ({
       ...agent,
@@ -968,10 +975,13 @@ class AgentModel {
     }));
     const agentIds = agents.map((agent) => agent.id);
 
+    const isChatView = options?.view === "chat";
+
     // Populate tools, teams, and labels for all agents with bulk queries to
-    // avoid N+1
+    // avoid N+1. Chat starts from scalar configuration plus a few small
+    // relation lists; editing fetches the individual full agent on demand.
     const [toolRows, teamsMap, usersMap, labelsMap] = await Promise.all([
-      agentIds.length > 0 && options?.includeTools !== false
+      agentIds.length > 0 && options?.includeTools !== false && !isChatView
         ? db
             .select({
               agentId: schema.agentToolsTable.agentId,
@@ -984,9 +994,15 @@ class AgentModel {
             )
             .where(inArray(schema.agentToolsTable.agentId, agentIds))
         : Promise.resolve([]),
-      AgentTeamModel.getTeamDetailsForAgents(agentIds),
-      AgentUserModel.getUserDetailsForAgents(agentIds),
-      AgentLabelModel.getLabelsForAgents(agentIds),
+      isChatView
+        ? Promise.resolve(new Map())
+        : AgentTeamModel.getTeamDetailsForAgents(agentIds),
+      isChatView
+        ? Promise.resolve(new Map())
+        : AgentUserModel.getUserDetailsForAgents(agentIds),
+      isChatView
+        ? Promise.resolve(new Map())
+        : AgentLabelModel.getLabelsForAgents(agentIds),
     ]);
 
     const agentsById = new Map(agents.map((agent) => [agent.id, agent]));
@@ -1002,7 +1018,7 @@ class AgentModel {
     }
 
     await Promise.all([
-      AgentModel.populateAuthorNames(agents),
+      isChatView ? Promise.resolve() : AgentModel.populateAuthorNames(agents),
       AgentModel.populateKnowledgeBaseIds(agents),
       AgentModel.populateConnectorIds(agents),
       AgentModel.populateSuggestedPrompts(agents),
@@ -4039,3 +4055,17 @@ function mostRecent(a: Date | null, b: Date | null): Date | null {
 }
 
 export default AgentModel;
+
+// The chat roster appears before the picker opens. Emoji and short URL icons
+// are cheap enough to keep inline; base64 image data is fetched only for the
+// selected agent through the existing detail endpoint.
+const MAX_INLINE_CHAT_AGENT_ICON_CHARS = 1_024;
+const CHAT_AGENT_ROW_COLUMNS = {
+  ...getTableColumns(schema.agentsTable),
+  systemPrompt: sql<string | null>`null`,
+  icon: sql<string | null>`case
+    when length(${schema.agentsTable.icon}) <= ${MAX_INLINE_CHAT_AGENT_ICON_CHARS}
+      then ${schema.agentsTable.icon}
+    else null
+  end`,
+};

--- a/platform/backend/src/routes/agent.test.ts
+++ b/platform/backend/src/routes/agent.test.ts
@@ -1508,6 +1508,60 @@ describe("agent routes", () => {
       expect((await findAgent("&includeTools=true")).tools).toHaveLength(1);
     });
 
+    test("returns a compact roster for chat without changing the default response", async ({
+      makeAgent,
+      makeTool,
+      makeAgentTool,
+    }) => {
+      const embeddedIcon = `data:image/png;base64,${"A".repeat(2_048)}`;
+      const systemPrompt = "Follow the configured operating instructions.";
+      const agent = await makeAgent({
+        name: `Compact Chat Agent ${crypto.randomUUID().slice(0, 8)}`,
+        organizationId,
+        scope: "org",
+        authorId: user.id,
+        icon: embeddedIcon,
+        systemPrompt,
+      });
+      const tool = await makeTool({});
+      await makeAgentTool(agent.id, tool.id);
+
+      const chatResponse = await app.inject({
+        method: "GET",
+        url: "/api/agents/all?excludeBuiltIn=true&view=chat",
+      });
+
+      expect(chatResponse.statusCode).toBe(200);
+      const chatAgent = chatResponse
+        .json()
+        .find((candidate: { id: string }) => candidate.id === agent.id);
+      expect(chatAgent).toMatchObject({
+        id: agent.id,
+        name: agent.name,
+        icon: null,
+        systemPrompt: null,
+        tools: [],
+        teams: [],
+        users: [],
+        labels: [],
+      });
+
+      const defaultResponse = await app.inject({
+        method: "GET",
+        url: "/api/agents/all?excludeBuiltIn=true",
+      });
+
+      expect(defaultResponse.statusCode).toBe(200);
+      const fullAgent = defaultResponse
+        .json()
+        .find((candidate: { id: string }) => candidate.id === agent.id);
+      expect(fullAgent).toMatchObject({
+        icon: embeddedIcon,
+        systemPrompt,
+      });
+      expect(fullAgent.tools).toHaveLength(1);
+    });
+
     test("should exclude built-in agents when excludeBuiltIn=true", async ({
       makeAgent,
       seedAndAssignArchestraTools,

--- a/platform/backend/src/routes/agent.ts
+++ b/platform/backend/src/routes/agent.ts
@@ -321,6 +321,12 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
             .describe(
               "Attach each agent's assigned tools. Defaults to true. Pass false from callers that only need the roster itself — the tool refs carry every tool's name and description, which on an organization of any size is the great majority of this response's bytes. Agents come back with an empty `tools` array when it is off, meaning 'not requested' rather than 'none assigned'.",
             ),
+          view: z
+            .enum(["chat"])
+            .optional()
+            .describe(
+              "Return the lightweight agent fields needed to initialize chat. Large embedded icons, system prompts, sharing metadata, and unrelated list hydration are omitted; fetch an individual agent before editing it.",
+            ),
         }),
         response: constructResponseSchema(z.array(SelectAgentSchema)),
       },
@@ -336,6 +342,7 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
           excludeOtherPersonalAgents,
           status,
           includeTools,
+          view,
         },
         user,
         organizationId,
@@ -379,6 +386,7 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
             : undefined,
           status,
           includeTools,
+          view,
         }),
       );
     },

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -102,7 +102,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { Version } from "@/components/version";
-import { useDefaultAgentId, useInternalAgents } from "@/lib/agent.query";
+import { useChatAgents, useDefaultAgentId } from "@/lib/agent.query";
 import {
   useAgentRuntimePreflight,
   useStartAgentRun,
@@ -434,9 +434,9 @@ export function ChatPageContent({
   const canUseProviderSettings =
     canReadLlmProvider === true && canReadLlmModels === true;
 
-  // Fetch internal agents for dialog editing
+  // Fetch the compact roster needed to resolve the new-chat agent.
   const { data: internalAgents = [], isPending: isLoadingAgents } =
-    useInternalAgents({ enabled: hasChatAccess });
+    useChatAgents({ enabled: hasChatAccess });
   const { data: defaultAgentId } = useDefaultAgentId();
   const runtimeEnabled = useFeature("agentRuntime") === true;
   const startAgentRunMutation = useStartAgentRun();
@@ -1851,6 +1851,14 @@ export function ChatPageContent({
       ? (conversationAgentId ?? promptAgentId ?? undefined)
       : (initialAgentId ?? undefined);
 
+  // Browser setup fans out through the agent's tools, delegations, enabled
+  // subagents, and installation state. On a new chat none of that can affect
+  // the first useful composer render, so let the roster and model settle first
+  // instead of making those requests compete with initialization.
+  const shouldCheckBrowserTools =
+    !!browserToolsAgentId &&
+    (Boolean(conversationId) || (!isLoadingAgents && !isModelsLoading));
+
   const playwrightSetupAgentId = isReadOnlyConversation
     ? undefined
     : conversationId
@@ -1858,7 +1866,9 @@ export function ChatPageContent({
       : (initialAgentId ?? undefined);
 
   const { hasPlaywrightMcpTools, isLoading: isLoadingBrowserTools } =
-    useHasPlaywrightMcpTools(browserToolsAgentId, conversationToolsStateId);
+    useHasPlaywrightMcpTools(browserToolsAgentId, conversationToolsStateId, {
+      enabled: shouldCheckBrowserTools,
+    });
   // Show while loading so it doesn't flash hidden for members whose agent already has playwright
   // tools. Once loading is done, hides only if the user lacks permission AND agent has no tools.
   const showBrowserButton =
@@ -1876,7 +1886,10 @@ export function ChatPageContent({
     conversationToolsStateId,
     {
       enabled:
-        !isReadOnlyConversation && hasChatAccess && canUpdateAgent !== false,
+        shouldCheckBrowserTools &&
+        !isReadOnlyConversation &&
+        hasChatAccess &&
+        canUpdateAgent !== false,
     },
   );
   // Two different answers, and they must not be spelled the same way.

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -343,7 +343,7 @@ vi.mock("@/lib/chat/chat-placeholder.hook", () => ({
 }));
 
 vi.mock("@/lib/skills/skill.query", () => ({
-  useSkillsPaginated: () => mockUseSkillsPaginated(),
+  useSkillsPaginated: (...args: unknown[]) => mockUseSkillsPaginated(...args),
 }));
 
 vi.mock("@/lib/auth/auth.query");
@@ -1342,6 +1342,28 @@ describe("ArchestraPromptInput", () => {
       });
     });
 
+    it("does not load the skills catalog for a blank composer", () => {
+      mockControllerState.value = "";
+
+      render(<ArchestraPromptInput {...defaultProps} />);
+
+      expect(mockUseSkillsPaginated).toHaveBeenCalledWith(
+        { limit: 100, forAgentId: defaultProps.agentId },
+        { enabled: false },
+      );
+    });
+
+    it("loads the skills catalog when the draft starts with a slash", () => {
+      mockControllerState.value = "/";
+
+      render(<ArchestraPromptInput {...defaultProps} />);
+
+      expect(mockUseSkillsPaginated).toHaveBeenCalledWith(
+        { limit: 100, forAgentId: defaultProps.agentId },
+        { enabled: true },
+      );
+    });
+
     it("submits a bare skill command with skill metadata and an empty prompt", () => {
       const onSubmit = vi.fn();
       mockControllerState.value = "/my-skill";
@@ -1604,6 +1626,18 @@ describe("ArchestraPromptInput", () => {
     // The new-chat draft key is agent-independent (so a typed prompt survives
     // an agent switch); the agentId prop below no longer affects the key.
     const draftKey = NEW_CHAT_DRAFT_STORAGE_KEY;
+
+    it.each([
+      "null",
+      "undefined",
+    ])("discards a serialized %s sentinel instead of painting it into the composer", (sentinel) => {
+      localStorage.setItem(draftKey, sentinel);
+
+      render(<ArchestraPromptInput {...defaultProps} agentId={agentId} />);
+
+      expect(mockTextInputSetInput).toHaveBeenCalledWith("");
+      expect(localStorage.getItem(draftKey)).toBeNull();
+    });
 
     it("keeps the saved draft when the consumer rejects the submit", () => {
       const text = "draft text the user typed";

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -357,9 +357,16 @@ const PromptInputContent = ({
   const skillSlashCommandsEnabled = orgData?.skillToolsEnabled ?? false;
   // Scoped to the conversation agent's environment: a slash command must not
   // offer a skill the backend's activation gate would refuse.
+  // The catalog can be hundreds of kilobytes and a blank composer has no use
+  // for it. Start the query only when the draft can actually be a command.
+  const isSkillCommandDraft = controller.textInput.value
+    .trimStart()
+    .startsWith("/");
   const { data: skillsData } = useSkillsPaginated(
     { limit: 100, forAgentId: agentId ?? undefined },
-    { enabled: skillSlashCommandsEnabled && !!agentId },
+    {
+      enabled: skillSlashCommandsEnabled && !!agentId && isSkillCommandDraft,
+    },
   );
   const skillCommands = useMemo<SkillCommand[]>(() => {
     if (!skillSlashCommandsEnabled || !skillsData?.data) {
@@ -422,7 +429,7 @@ const PromptInputContent = ({
   // Restore draft on mount or conversation change
   useEffect(() => {
     isRestored.current = false;
-    const savedDraft = localStorage.getItem(storageKey);
+    const savedDraft = getRestorableDraft(localStorage, storageKey);
     if (savedDraft) {
       controller.textInput.setInput(savedDraft);
     } else {
@@ -1352,3 +1359,19 @@ const ArchestraPromptInput = ({
 };
 
 export default ArchestraPromptInput;
+
+// Older clients could leave serialized nullish sentinels in prompt storage.
+// They are state markers, not user drafts, and briefly painting one into the
+// controlled textarea exposes the literal word during chat initialization.
+function getRestorableDraft(storage: Storage, key: string): string | null {
+  const draft = storage.getItem(key);
+  if (!draft) return null;
+
+  const normalized = draft.trim().toLowerCase();
+  if (normalized === "null" || normalized === "undefined") {
+    storage.removeItem(key);
+    return null;
+  }
+
+  return draft;
+}

--- a/platform/frontend/src/components/chat/initial-agent-selector.test.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.test.tsx
@@ -5,80 +5,68 @@ import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { InitialAgentSelector } from "./initial-agent-selector";
 
-vi.mock("@/lib/auth/auth.query");
-vi.mock("@/lib/config/config.query");
-
-vi.mock("@/lib/agent.query", () => ({
-  useAgentCredentialReadiness: () => ({ data: undefined }),
-  useCreateProfile: () => ({ mutate: vi.fn() }),
-  useInternalAgents: () => ({
-    data: [
-      {
-        id: "agent-1",
-        name: "Alpha Agent",
-        agentType: "agent",
-        scope: "org",
-        authorId: null,
-        description: null,
-        icon: null,
-        systemPrompt: null,
-        runtime: null,
-        accessAllTools: true,
-      },
-      {
-        id: "agent-2",
-        name: "Beta Agent",
-        agentType: "agent",
-        scope: "org",
-        authorId: null,
-        description: null,
-        icon: null,
-        systemPrompt: null,
-        runtime: null,
-        accessAllTools: true,
-      },
-      {
-        id: "agent-3",
-        name: "Gamma Agent",
-        agentType: "agent",
-        scope: "org",
-        authorId: null,
-        description: null,
-        icon: null,
-        systemPrompt: null,
-        runtime: null,
-        accessAllTools: true,
-      },
-    ],
-  }),
-  useUpdateProfile: () => ({ mutate: vi.fn() }),
-}));
-
-vi.mock("@/lib/agent-tools.query", () => ({
-  useAgentDelegations: () => ({ data: [] }),
-  useAllProfileTools: () => ({ data: { data: [] } }),
-  useAssignTool: () => ({ mutate: vi.fn() }),
-  useRemoveAgentDelegation: () => ({ mutate: vi.fn() }),
-  useSyncAgentDelegations: () => ({ mutate: vi.fn() }),
-  useUnassignTool: () => ({ mutate: vi.fn() }),
-}));
-
-vi.mock("@/lib/knowledge/connector.query", () => ({
-  useConnectors: () => ({ data: [] }),
-}));
-
-vi.mock("@/lib/knowledge/knowledge-base.query", () => ({
-  useKnowledgeBases: () => ({ data: [] }),
-}));
-
-vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
-  fetchCatalogTools: vi.fn(),
-  useCatalogTools: () => ({ data: [] }),
-  useInternalMcpCatalog: () => ({ data: [] }),
-}));
-
-vi.mock("@/lib/mcp/mcp-install-orchestrator.hook", () => ({
-  useMcpInstallOrchestrator: () => ({
+const {
+  agents,
+  mockUseAgentCredentialReadiness,
+  mockUseAgentDelegations,
+  mockUseAllProfileTools,
+  mockUseConnectors,
+  mockUseInternalMcpCatalog,
+  mockUseKnowledgeBases,
+  mockUseMcpInstallOrchestrator,
+  mockUseProfile,
+} = vi.hoisted(() => ({
+  agents: [
+    {
+      id: "agent-1",
+      name: "Alpha Agent",
+      agentType: "agent",
+      scope: "org",
+      authorId: null,
+      description: null,
+      icon: null,
+      systemPrompt: null,
+      runtime: null,
+      accessAllTools: true,
+    },
+    {
+      id: "agent-2",
+      name: "Beta Agent",
+      agentType: "agent",
+      scope: "org",
+      authorId: null,
+      description: null,
+      icon: null,
+      systemPrompt: null,
+      runtime: null,
+      accessAllTools: true,
+    },
+    {
+      id: "agent-3",
+      name: "Gamma Agent",
+      agentType: "agent",
+      scope: "org",
+      authorId: null,
+      description: null,
+      icon: null,
+      systemPrompt: null,
+      runtime: null,
+      accessAllTools: true,
+    },
+  ],
+  mockUseAgentCredentialReadiness: vi.fn((_options?: unknown) => ({
+    data: undefined,
+  })),
+  mockUseAgentDelegations: vi.fn((_agentId?: string, _options?: unknown) => ({
+    data: [],
+  })),
+  mockUseAllProfileTools: vi.fn((_options?: unknown) => ({
+    data: { data: [] },
+  })),
+  mockUseConnectors: vi.fn((_options?: unknown) => ({ data: [] })),
+  mockUseInternalMcpCatalog: vi.fn((_options?: unknown) => ({ data: [] })),
+  mockUseKnowledgeBases: vi.fn((_options?: unknown) => ({ data: [] })),
+  mockUseMcpInstallOrchestrator: vi.fn((_options?: unknown) => ({
     closeLocalInstall: vi.fn(),
     closeNoAuthInstall: vi.fn(),
     closeOAuth: vi.fn(),
@@ -93,7 +81,54 @@ vi.mock("@/lib/mcp/mcp-install-orchestrator.hook", () => ({
     noAuthCatalogItem: null,
     selectedCatalogItem: null,
     triggerInstallByCatalogId: vi.fn(),
-  }),
+  })),
+  mockUseProfile: vi.fn((id: string | undefined, _options?: unknown) => ({
+    data: agents.find((agent) => agent.id === id),
+  })),
+}));
+
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/config/config.query");
+
+vi.mock("@/lib/agent.query", () => ({
+  useAgentCredentialReadiness: (options?: unknown) =>
+    mockUseAgentCredentialReadiness(options),
+  useChatAgents: () => ({ data: agents }),
+  useCreateProfile: () => ({ mutate: vi.fn() }),
+  useInternalAgents: () => ({ data: agents }),
+  useProfile: (id: string | undefined, options?: unknown) =>
+    mockUseProfile(id, options),
+  useUpdateProfile: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/lib/agent-tools.query", () => ({
+  useAgentDelegations: (agentId?: string, options?: unknown) =>
+    mockUseAgentDelegations(agentId, options),
+  useAllProfileTools: (options?: unknown) => mockUseAllProfileTools(options),
+  useAssignTool: () => ({ mutate: vi.fn() }),
+  useRemoveAgentDelegation: () => ({ mutate: vi.fn() }),
+  useSyncAgentDelegations: () => ({ mutate: vi.fn() }),
+  useUnassignTool: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/lib/knowledge/connector.query", () => ({
+  useConnectors: (options?: unknown) => mockUseConnectors(options),
+}));
+
+vi.mock("@/lib/knowledge/knowledge-base.query", () => ({
+  useKnowledgeBases: (options?: unknown) => mockUseKnowledgeBases(options),
+}));
+
+vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
+  fetchCatalogTools: vi.fn(),
+  useCatalogTools: () => ({ data: [] }),
+  useInternalMcpCatalog: (options?: unknown) =>
+    mockUseInternalMcpCatalog(options),
+}));
+
+vi.mock("@/lib/mcp/mcp-install-orchestrator.hook", () => ({
+  useMcpInstallOrchestrator: (options?: unknown) =>
+    mockUseMcpInstallOrchestrator(options),
 }));
 
 vi.mock("@/components/chat/mcp-install-dialogs", () => ({
@@ -168,5 +203,40 @@ describe("InitialAgentSelector keyboard navigation", () => {
 
     await user.keyboard("{ArrowUp}{Enter}");
     expect(onAgentChange).toHaveBeenCalledWith("agent-3");
+  });
+
+  it("defers management queries until the picker opens", async () => {
+    const user = userEvent.setup();
+    render(
+      <InitialAgentSelector currentAgentId="agent-1" onAgentChange={vi.fn()} />,
+    );
+
+    expect(mockUseAgentCredentialReadiness).toHaveBeenLastCalledWith({
+      enabled: false,
+    });
+    expect(mockUseInternalMcpCatalog).toHaveBeenLastCalledWith({
+      enabled: false,
+    });
+    expect(mockUseAllProfileTools).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(mockUseKnowledgeBases).toHaveBeenLastCalledWith({ enabled: false });
+    expect(mockUseConnectors).toHaveBeenLastCalledWith({ enabled: false });
+    expect(mockUseProfile).toHaveBeenCalledWith("agent-1", { enabled: false });
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(mockUseAgentCredentialReadiness).toHaveBeenLastCalledWith({
+      enabled: true,
+    });
+    expect(mockUseInternalMcpCatalog).toHaveBeenLastCalledWith({
+      enabled: true,
+    });
+    expect(mockUseAllProfileTools).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+    expect(mockUseKnowledgeBases).toHaveBeenLastCalledWith({ enabled: true });
+    expect(mockUseConnectors).toHaveBeenLastCalledWith({ enabled: true });
+    expect(mockUseProfile).toHaveBeenCalledWith("agent-1", { enabled: true });
   });
 });

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -73,8 +73,10 @@ import {
 } from "@/components/ui/tooltip";
 import {
   useAgentCredentialReadiness,
+  useChatAgents,
   useCreateProfile,
   useInternalAgents,
+  useProfile,
   useUpdateProfile,
 } from "@/lib/agent.query";
 import { useInvalidateToolAssignmentQueries } from "@/lib/agent-tools.hook";
@@ -129,13 +131,22 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
   currentAgentId,
   onAgentChange,
 }: InitialAgentSelectorProps) {
-  const { data: allAgents = [] } = useInternalAgents();
-  const { data: credentialReadiness } = useAgentCredentialReadiness();
+  const { data: allAgents = [] } = useChatAgents();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [highlightedAgentId, setHighlightedAgentId] = useState<string | null>(
+    null,
+  );
+  const [editingAgentId, setEditingAgentId] = useState<string | null>(null);
+  const [cloningAgentId, setCloningAgentId] = useState<string | null>(null);
+  const { data: credentialReadiness } = useAgentCredentialReadiness({
+    enabled: open,
+  });
   const readinessByAgent = useMemo(
     () => indexReadinessByAgent(credentialReadiness),
     [credentialReadiness],
   );
-  const installOrchestrator = useMcpInstallOrchestrator();
+  const installOrchestrator = useMcpInstallOrchestrator({ enabled: open });
   // Connecting is per server, so several missing ones are walked one at a time:
   // each install refreshes readiness, and the row re-offers whatever is left.
   const connectMissing = useCallback(
@@ -150,14 +161,9 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
   const userId = session?.user?.id;
   const { data: isAgentAdmin } = useHasPermissions({ agent: ["admin"] });
   const createProfile = useCreateProfile();
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-  const [highlightedAgentId, setHighlightedAgentId] = useState<string | null>(
-    null,
-  );
   const agentListboxId = useId();
   const agentOptionRefs = useRef(new Map<string, HTMLButtonElement>());
-  const [editingAgentId, setEditingAgentId] = useState<string | null>(null);
+  const cloningStartedForRef = useRef<string | null>(null);
   const [dialogView, setDialogView] = useState<
     | "settings"
     | "add-tool"
@@ -191,11 +197,19 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
     [filteredAgents, readinessByAgent],
   );
 
-  const currentAgent = useMemo(
+  const currentAgentSummary = useMemo(
     () =>
       allAgents.find((a) => a.id === currentAgentId) ?? allAgents[0] ?? null,
     [allAgents, currentAgentId],
   );
+  // The roster omits large embedded icons and editing-only fields. Hydrate one
+  // record only after the picker opens; that detail response can itself be
+  // large, so it must not compete with the first useful composer render.
+  const { data: currentAgentDetail } = useProfile(
+    currentAgentSummary?.id ?? undefined,
+    { enabled: open },
+  );
+  const currentAgent = currentAgentDetail ?? currentAgentSummary;
   const displayAgentName = currentAgent?.name ?? "Select agent";
   const effectiveAgentId = currentAgent?.id ?? currentAgentId;
   const shouldLoadAgentManagementDetails = open || !!editingAgentId;
@@ -220,12 +234,15 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
     knowledgeSource: ["read"],
   });
   const { data: catalogItems = [] } = useInternalMcpCatalog({
-    enabled: !!canReadMcpRegistry,
+    enabled: shouldLoadAgentManagementDetails && !!canReadMcpRegistry,
   });
   const { data: assignedToolsData } = useAllProfileTools({
     filters: { agentId: effectiveAgentId ?? undefined },
     skipPagination: true,
-    enabled: !!effectiveAgentId && !!canReadToolPolicy,
+    enabled:
+      shouldLoadAgentManagementDetails &&
+      !!effectiveAgentId &&
+      !!canReadToolPolicy,
   });
 
   const assignedCatalogs = useMemo(() => {
@@ -238,6 +255,7 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
 
   const { data: triggerDelegations = [] } = useAgentDelegations(
     effectiveAgentId ?? undefined,
+    { enabled: shouldLoadAgentManagementDetails },
   );
   const triggerSubagents = useMemo(() => {
     const targetIds = new Set(triggerDelegations.map((d) => d.id));
@@ -246,10 +264,10 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
 
   // Knowledge base data for connector icons in avatar group
   const { data: knowledgeBasesData } = useKnowledgeBases({
-    enabled: !!canReadKnowledgeBase,
+    enabled: shouldLoadAgentManagementDetails && !!canReadKnowledgeBase,
   });
   const { data: connectorsData } = useConnectors({
-    enabled: !!canReadKnowledgeBase,
+    enabled: shouldLoadAgentManagementDetails && !!canReadKnowledgeBase,
   });
 
   const allKnowledgeBases = knowledgeBasesData ?? [];
@@ -345,10 +363,35 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
     }
   }, [currentAgentId]);
 
-  const editingAgent = useMemo(
-    () => allAgents.find((a) => a.id === editingAgentId) ?? null,
-    [allAgents, editingAgentId],
-  );
+  const { data: editingAgent } = useProfile(editingAgentId ?? undefined);
+  const { data: cloningAgent } = useProfile(cloningAgentId ?? undefined);
+
+  useEffect(() => {
+    if (!cloningAgent || cloningStartedForRef.current === cloningAgent.id) {
+      return;
+    }
+
+    cloningStartedForRef.current = cloningAgent.id;
+    setCloningAgentId(null);
+    createProfile.mutate(
+      {
+        name: `Copy ${cloningAgent.name}`,
+        scope: "personal",
+        agentType: "agent",
+        description: cloningAgent.description,
+        systemPrompt: cloningAgent.systemPrompt,
+        icon: cloningAgent.icon,
+      },
+      {
+        onSuccess: (newAgent) => {
+          if (newAgent?.id) {
+            onAgentChange(newAgent.id);
+            setEditingAgentId(newAgent.id);
+          }
+        },
+      },
+    );
+  }, [cloningAgent, createProfile, onAgentChange]);
 
   const editingKbs = useMemo(() => {
     const ids = editingAgent?.knowledgeBaseIds ?? [];
@@ -559,25 +602,9 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
                               setOpen(false);
                               setEditingAgentId(agent.id);
                             } else {
-                              createProfile.mutate(
-                                {
-                                  name: `Copy ${agent.name}`,
-                                  scope: "personal",
-                                  agentType: "agent",
-                                  description: agent.description,
-                                  systemPrompt: agent.systemPrompt,
-                                  icon: agent.icon,
-                                },
-                                {
-                                  onSuccess: (newAgent) => {
-                                    if (newAgent?.id) {
-                                      onAgentChange(newAgent.id);
-                                      setOpen(false);
-                                      setEditingAgentId(newAgent.id);
-                                    }
-                                  },
-                                },
-                              );
+                              setOpen(false);
+                              cloningStartedForRef.current = null;
+                              setCloningAgentId(agent.id);
                             }
                           }}
                         >
@@ -633,7 +660,12 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
         >
           <DialogTitle className="sr-only">Agent Settings</DialogTitle>
 
-          {dialogView === "settings" && (
+          {!editingAgent ? (
+            <div className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              <span>Loading agent…</span>
+            </div>
+          ) : dialogView === "settings" ? (
             <AgentSettingsView
               agent={editingAgent}
               onAddTool={() => setDialogView("add-tool")}
@@ -648,7 +680,7 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
               matchedKnowledgeBases={editingKbs}
               matchedConnectors={editingConnectors}
             />
-          )}
+          ) : null}
 
           {dialogView === "add-tool" && editingAgent && (
             <AddToolView

--- a/platform/frontend/src/components/chat/model-selector.test.tsx
+++ b/platform/frontend/src/components/chat/model-selector.test.tsx
@@ -190,7 +190,10 @@ describe("ModelSelector coverage matrix", () => {
   it("shows the loading spinner while a real fetch is in flight", () => {
     setQuery({ isPending: true, isFetching: true, isLoading: true });
     renderSelector({ variant: "default" });
-    expect(screen.getByText("Loading models...")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Loading models" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Loading models...")).not.toBeInTheDocument();
   });
 
   // A disabled query is `isPending` yet never fetches, so it must not render the

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -600,9 +600,8 @@ export const ModelSelector = memo(function ModelSelector({
   // If loading, show loading state
   if (isLoading) {
     return (
-      <PromptInputButton className="w-[150px]" disabled>
+      <PromptInputButton aria-label="Loading models" className="w-8" disabled>
         <Loader2 className="size-4 animate-spin" />
-        <ModelSelectorName>Loading models...</ModelSelectorName>
       </PromptInputButton>
     );
   }

--- a/platform/frontend/src/components/chat/new-chat-composer.test.tsx
+++ b/platform/frontend/src/components/chat/new-chat-composer.test.tsx
@@ -46,7 +46,7 @@ vi.mock("@/lib/agent-runtime.query", () => ({
 
 vi.mock("@/lib/agent.query", () => ({
   useDefaultAgentId: () => ({ data: null }),
-  useInternalAgents: () => ({
+  useChatAgents: () => ({
     data: [
       {
         id: "runtime-agent",

--- a/platform/frontend/src/components/chat/new-chat-composer.tsx
+++ b/platform/frontend/src/components/chat/new-chat-composer.tsx
@@ -4,7 +4,7 @@ import type { FileUIPart } from "ai";
 import { useMemo } from "react";
 import ArchestraPromptInput from "@/app/chat/prompt-input";
 import { AgentRuntimeCredentialPrompt } from "@/components/agent-run-credential-prompt";
-import { useDefaultAgentId, useInternalAgents } from "@/lib/agent.query";
+import { useChatAgents, useDefaultAgentId } from "@/lib/agent.query";
 import { useAgentRuntimePreflight } from "@/lib/agent-runtime.query";
 import { useMemberDefaultModel } from "@/lib/chat/chat.query";
 import { useInitialChatModelState } from "@/lib/chat/use-initial-chat-model-state.hook";
@@ -56,7 +56,7 @@ export function NewChatComposer({
   isProjectLoading?: boolean;
   isSubmitting?: boolean;
 }) {
-  const { data: internalAgents = [] } = useInternalAgents();
+  const { data: internalAgents = [] } = useChatAgents();
   const { data: defaultAgentId } = useDefaultAgentId();
   const { modelsByProvider, isPending: isModelsLoading } =
     useLlmModelsByProvider();

--- a/platform/frontend/src/components/chat/playwright-install-dialog.test.tsx
+++ b/platform/frontend/src/components/chat/playwright-install-dialog.test.tsx
@@ -82,6 +82,7 @@ function setup(options: {
     hasCustomSelection: boolean;
     enabledToolIds: string[];
   } | null;
+  enabled?: boolean;
 }) {
   const {
     installState,
@@ -119,7 +120,10 @@ function setup(options: {
   mockUseAgentDelegations.mockReturnValue({ data: [], isLoading: false });
 
   return renderHook(
-    () => usePlaywrightSetupRequired(AGENT_ID, CONVERSATION_ID),
+    () =>
+      usePlaywrightSetupRequired(AGENT_ID, CONVERSATION_ID, {
+        enabled: options.enabled,
+      }),
     { wrapper },
   );
 }
@@ -212,5 +216,24 @@ describe("usePlaywrightSetupRequired", () => {
     });
 
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it("keeps browser setup queries disabled until chat initialization finishes", () => {
+    setup({ installState: "not-installed", enabled: false });
+
+    expect(mockUseProfileToolsWithIds).toHaveBeenCalledWith(AGENT_ID, {
+      enabled: false,
+    });
+    expect(mockUseConversationEnabledTools).toHaveBeenCalledWith(
+      CONVERSATION_ID,
+      { enabled: false },
+    );
+    expect(mockUseAgentDelegations).toHaveBeenCalledWith(AGENT_ID, {
+      enabled: false,
+    });
+    expect(mockUseMcpServers).toHaveBeenCalledWith({
+      catalogId: PLAYWRIGHT_MCP_CATALOG_ID,
+      enabled: false,
+    });
   });
 });

--- a/platform/frontend/src/components/chat/playwright-install-dialog.tsx
+++ b/platform/frontend/src/components/chat/playwright-install-dialog.tsx
@@ -50,11 +50,13 @@ export function usePlaywrightSetupRequired(
   }, []);
 
   const { data: profileTools = [], isLoading: isLoadingTools } =
-    useProfileToolsWithIds(agentId);
-  const { data: enabledToolsData } =
-    useConversationEnabledTools(conversationId);
+    useProfileToolsWithIds(agentId, { enabled: options?.enabled });
+  const { data: enabledToolsData } = useConversationEnabledTools(
+    conversationId,
+    { enabled: options?.enabled },
+  );
   const { data: delegatedAgents = [], isLoading: isLoadingDelegations } =
-    useAgentDelegations(agentId);
+    useAgentDelegations(agentId, { enabled: options?.enabled });
 
   // Check if current user has Playwright installed using lightweight queries only
   // (no mutations) to avoid interfering with install state in the dialog/right panel
@@ -142,6 +144,7 @@ export function usePlaywrightSetupRequired(
     queries: enabledSubAgentIds.map((id) => ({
       queryKey: ["agents", id, "tools", "mcp-only"] as const,
       queryFn: () => fetchAgentMcpTools(id),
+      enabled: options?.enabled ?? true,
     })),
   });
 

--- a/platform/frontend/src/lib/agent.query.test.ts
+++ b/platform/frontend/src/lib/agent.query.test.ts
@@ -1,10 +1,14 @@
 import { archestraApiSdk } from "@archestra/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useCreateProfile, useUpdateProfile } from "@/lib/agent.query";
+import {
+  useChatAgents,
+  useCreateProfile,
+  useUpdateProfile,
+} from "@/lib/agent.query";
 import { isReportedApiError } from "@/lib/utils";
 
 // Partial: `@/consts` (pulled in by agent.query.ts) reads real exports of this
@@ -16,6 +20,7 @@ vi.mock("@archestra/shared", async (importOriginal) => {
     archestraApiSdk: {
       ...actual.archestraApiSdk,
       createAgent: vi.fn(),
+      getAllAgents: vi.fn(),
       updateAgent: vi.fn(),
     },
   };
@@ -119,5 +124,30 @@ describe("agent write mutations", () => {
     });
 
     expect(toast.success).toHaveBeenCalledWith("System prompt saved");
+  });
+});
+
+describe("chat agent roster", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requests the compact chat view without tool payloads", async () => {
+    sdk.getAllAgents.mockResolvedValue({
+      data: [{ id: "agent-1", name: "Agent" }],
+      error: undefined,
+    } as never);
+
+    const { result } = setup(() => useChatAgents());
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(sdk.getAllAgents).toHaveBeenCalledWith({
+      query: {
+        agentType: "agent",
+        excludeBuiltIn: true,
+        includeTools: false,
+        view: "chat",
+      },
+    });
   });
 });

--- a/platform/frontend/src/lib/agent.query.ts
+++ b/platform/frontend/src/lib/agent.query.ts
@@ -55,14 +55,27 @@ const internalAgentsQuery = {
   includeTools: false,
 } as const;
 
+const chatAgentsQuery = {
+  ...internalAgentsQuery,
+  view: "chat",
+} as const;
+
 export const internalAgentsQueryKey = [
   "agents",
   "all",
   internalAgentsQuery,
 ] as const;
 
+const chatAgentsQueryKey = ["agents", "chat-roster", chatAgentsQuery] as const;
+
 export async function fetchInternalAgents() {
   const { data, error } = await getAllAgents({ query: internalAgentsQuery });
+  throwOnApiError(error, { toastOnError: false });
+  return data ?? [];
+}
+
+async function fetchChatAgents() {
+  const { data, error } = await getAllAgents({ query: chatAgentsQuery });
   throwOnApiError(error, { toastOnError: false });
   return data ?? [];
 }
@@ -302,7 +315,10 @@ export function useDefaultMcpGateway(params?: {
   });
 }
 
-export function useProfile(id: string | undefined) {
+export function useProfile(
+  id: string | undefined,
+  params?: { enabled?: boolean },
+) {
   const queryClient = useQueryClient();
 
   return useQuery({
@@ -313,7 +329,7 @@ export function useProfile(id: string | undefined) {
       throwOnApiError(error, { allowNotFound: true, toastOnError: false });
       return data ?? null;
     },
-    enabled: !!id,
+    enabled: !!id && (params?.enabled ?? true),
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     /**
@@ -327,11 +343,11 @@ export function useProfile(id: string | undefined) {
      * resolve on the first render and the rest fetch immediately, rather than
      * one round trip later.
      *
-     * Safe because the list endpoints serialise agents with the same
-     * `SelectAgentSchema` this route returns, so a row is a whole agent rather
-     * than a summary of one. `initialDataUpdatedAt` carries the list's age
-     * across, so a stale row still revalidates on its normal schedule instead
-     * of being trusted indefinitely.
+     * Safe because findCachedAgent excludes the compact chat roster; the
+     * remaining list endpoints serialise whole agents with the same
+     * `SelectAgentSchema` this route returns. `initialDataUpdatedAt` carries
+     * the list's age across, so a stale row still revalidates on its normal
+     * schedule instead of being trusted indefinitely.
      */
     initialData: () =>
       id ? findCachedAgent(queryClient, id)?.agent : undefined,
@@ -671,6 +687,20 @@ export function useInternalAgents(params?: { enabled?: boolean }) {
   });
 }
 
+/**
+ * Lightweight roster for chat initialization. Large embedded images and
+ * editing-only fields stay out of this query; the selected/edited agent is
+ * hydrated through useProfile when its full record is needed.
+ */
+export function useChatAgents(params?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: chatAgentsQueryKey,
+    queryFn: fetchChatAgents,
+    enabled: params?.enabled,
+    meta: PERSISTED_QUERY_META,
+  });
+}
+
 export function useOrgScopedAgents() {
   return useQuery({
     queryKey: [
@@ -748,6 +778,10 @@ function findCachedAgent(
   for (const query of queryClient
     .getQueryCache()
     .findAll({ queryKey: ["agents"] })) {
+    // The chat roster deliberately carries a partial Agent wire shape. It is
+    // enough to paint and initialize chat, but must never seed an editing form
+    // as though it came from the full detail endpoint.
+    if (query.queryKey[1] === "chat-roster") continue;
     const cached: unknown = query.state.data;
     const rows = Array.isArray(cached)
       ? cached

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -915,6 +915,7 @@ export async function fetchConversationEnabledTools(conversationId: string) {
  */
 export function useConversationEnabledTools(
   conversationId: string | undefined,
+  options?: { enabled?: boolean },
 ) {
   return useQuery({
     queryKey: ["conversation", conversationId, "enabled-tools"],
@@ -931,7 +932,7 @@ export function useConversationEnabledTools(
       }
       return result.data;
     },
-    enabled: !!conversationId,
+    enabled: !!conversationId && (options?.enabled ?? true),
     staleTime: 30 * 1000, // 30 seconds
     gcTime: 5 * 60 * 1000,
   });
@@ -1002,11 +1003,14 @@ export async function fetchAgentMcpTools(agentId: string | undefined) {
  * Get profile tools with IDs (for the manage tools dialog)
  * Returns full tool objects including IDs needed for enabled tools junction table
  */
-export function useProfileToolsWithIds(agentId: string | undefined) {
+export function useProfileToolsWithIds(
+  agentId: string | undefined,
+  options?: { enabled?: boolean },
+) {
   return useQuery({
     queryKey: ["agents", agentId, "tools", "mcp-only"],
     queryFn: () => fetchAgentMcpTools(agentId),
-    enabled: !!agentId,
+    enabled: !!agentId && (options?.enabled ?? true),
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000,
     placeholderData: keepPreviousData,
@@ -1142,9 +1146,11 @@ function useBrowserInstallation(onInstallComplete?: (agentId: string) => void) {
 export function useHasPlaywrightMcpTools(
   agentId: string | undefined,
   conversationId?: string,
-  options?: { autoAssignAfterInstall?: boolean },
+  options?: { autoAssignAfterInstall?: boolean; enabled?: boolean },
 ) {
-  const toolsQuery = useProfileToolsWithIds(agentId);
+  const toolsQuery = useProfileToolsWithIds(agentId, {
+    enabled: options?.enabled,
+  });
   const queryClient = useQueryClient();
   const conversationIdRef = useRef(conversationId);
   conversationIdRef.current = conversationId;
@@ -1215,6 +1221,7 @@ export function useHasPlaywrightMcpTools(
   // Fetch user's Playwright server to check reinstallRequired
   const playwrightServersQuery = useMcpServers({
     catalogId: PLAYWRIGHT_MCP_CATALOG_ID,
+    enabled: options?.enabled,
   });
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;

--- a/platform/frontend/src/lib/llm-models.query.test.tsx
+++ b/platform/frontend/src/lib/llm-models.query.test.tsx
@@ -7,6 +7,7 @@ import {
   LAZY_MODEL_SYNC_REFETCH_DELAY_MS,
   useLlmModels,
 } from "./llm-models.query";
+import { PERSISTED_QUERY_META } from "./query-persistence";
 
 vi.mock("@archestra/shared", () => ({
   archestraApiSdk: {
@@ -75,6 +76,25 @@ describe("useLlmModels", () => {
     });
     expect(archestraApiSdk.getLlmModels).toHaveBeenCalledTimes(1);
   });
+
+  it("marks the model catalog for session restoration", async () => {
+    vi.mocked(archestraApiSdk.getLlmModels).mockResolvedValue(
+      makeGetLlmModelsResult([makeModel()]),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    renderHook(() => useLlmModels(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await flushQuery();
+
+    expect(
+      queryClient.getQueryCache().find({ queryKey: ["llm-models", null] })
+        ?.meta,
+    ).toEqual(PERSISTED_QUERY_META);
+  });
 });
 
 async function flushQuery() {
@@ -83,10 +103,11 @@ async function flushQuery() {
   });
 }
 
-function createWrapper() {
-  const queryClient = new QueryClient({
+function createWrapper(
+  queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
-  });
+  }),
+) {
   return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );

--- a/platform/frontend/src/lib/llm-models.query.ts
+++ b/platform/frontend/src/lib/llm-models.query.ts
@@ -15,6 +15,7 @@ import {
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { toBulkOutcome } from "@/lib/bulk-action";
+import { PERSISTED_QUERY_META } from "@/lib/query-persistence";
 import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
@@ -67,6 +68,10 @@ export function useLlmModels(params?: LlmModelsParams) {
     // preventing display name flicker (e.g. "Claude Opus 4.1" → raw ID → back).
     placeholderData: keepPreviousData,
     enabled: params?.enabled,
+    // The model list is small, contains no credentials, and is required to
+    // replace the new-chat composer's loading placeholder with the saved model.
+    // Restoring it makes a refresh immediately usable while revalidation runs.
+    meta: PERSISTED_QUERY_META,
   });
 }
 

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -13409,6 +13409,10 @@ export type GetAllAgentsData = {
          * Attach each agent's assigned tools. Defaults to true. Pass false from callers that only need the roster itself — the tool refs carry every tool's name and description, which on an organization of any size is the great majority of this response's bytes. Agents come back with an empty `tools` array when it is off, meaning 'not requested' rather than 'none assigned'.
          */
         includeTools?: boolean;
+        /**
+         * Return the lightweight agent fields needed to initialize chat. Large embedded icons, system prompts, sharing metadata, and unrelated list hydration are omitted; fetch an individual agent before editing it.
+         */
+        view?: 'chat';
     };
     url: '/api/agents/all';
 };


### PR DESCRIPTION
## Summary

- add a compact chat roster view that omits editing-only relations, system prompts, and oversized embedded icons
- persist the compact roster and model catalog across refreshes
- defer skills, agent-management, browser-tool, and setup queries until the user action that needs them
- replace the clipped model-loading label with an accessible spinner and reject serialized nullish draft sentinels

## Why

A cache-disabled reload showed that the document shell was fast, but initialization was competing with several large API responses. The agent roster alone was about 833 KB of JSON for 134 agents, mostly embedded icons and system prompts. The compact projection is about 187 KB (77.5% smaller) and fits the existing session-persistence budget. A selected-agent detail response was another roughly 239 KB, so it is now gated behind opening the picker.