### PR TITLE
fix(openrouter): apply attribution to all request paths

### DIFF
--- a/platform/backend/src/clients/openrouter-attribution.test.ts
+++ b/platform/backend/src/clients/openrouter-attribution.test.ts
@@ -1,21 +1,38 @@
+import config from "@/config";
 import { describe, expect, test } from "@/test";
 import { openRouterAttributionHeaders } from "./openrouter-attribution";
 
 describe("openRouterAttributionHeaders", () => {
-  test("sends the referer and both title header names", () => {
+  test("returns the configured attribution", () => {
+    config.llm.openrouter.referer = "https://deployment.example";
+    config.llm.openrouter.title = "Deployment";
+    config.llm.openrouter.categories = "productivity";
+
     const headers = openRouterAttributionHeaders();
 
-    expect(headers["HTTP-Referer"]).toBeTruthy();
-    // X-OpenRouter-Title is the current name; X-Title is the legacy alias.
-    expect(headers["X-OpenRouter-Title"]).toBeTruthy();
-    expect(headers["X-Title"]).toBe(headers["X-OpenRouter-Title"]);
+    expect(headers).toEqual({
+      "HTTP-Referer": "https://deployment.example",
+      "X-OpenRouter-Title": "Deployment",
+      "X-Title": "Deployment",
+      "X-OpenRouter-Categories": "productivity",
+    });
   });
 
-  test("sends the marketplace categories", () => {
-    const headers = openRouterAttributionHeaders();
+  test("lets caller attribution override configured defaults case-insensitively", () => {
+    const headers = openRouterAttributionHeaders({
+      "X-Custom-Auth": "keep-me",
+      "http-referer": "https://caller.example",
+      "x-OPENrouter-title": "Caller",
+      "x-openrouter-categories": "roleplay,game",
+      "X-OpenRouter-App-Visibility": "hidden",
+    });
 
-    expect(headers["X-OpenRouter-Categories"]).toBe(
-      "general-chat,personal-agent",
-    );
+    expect(headers).toEqual({
+      "X-Custom-Auth": "keep-me",
+      "http-referer": "https://caller.example",
+      "x-OPENrouter-title": "Caller",
+      "x-openrouter-categories": "roleplay,game",
+      "X-OpenRouter-App-Visibility": "hidden",
+    });
   });
 });

--- a/platform/backend/src/clients/openrouter-attribution.ts
+++ b/platform/backend/src/clients/openrouter-attribution.ts
@@ -1,20 +1,39 @@
 import config from "@/config";
 
+const TITLE_HEADERS = new Set(["x-openrouter-title", "x-title"]);
+
 /**
- * OpenRouter attribution headers for ranking and analytics. Shared by the
- * direct path (`createDirectLLMModel`) and the LLM proxy adapter so both
- * attribute requests identically. Each header is omitted when its config
- * value is unset.
- *
- * `X-OpenRouter-Title` is the current header name; `X-Title` is the legacy
- * alias OpenRouter still accepts — both are sent so attribution survives
- * either name being phased out.
+ * Adds the configured OpenRouter attribution defaults without replacing
+ * caller-provided attribution. Header names are matched case-insensitively,
+ * and either supported title alias overrides both configured title aliases.
  */
-export function openRouterAttributionHeaders(): Record<string, string> {
+export function openRouterAttributionHeaders<
+  HeaderValue extends string | string[] | undefined = string,
+>(
+  headers?: Record<string, HeaderValue> | null,
+): Record<string, HeaderValue | string> {
   const { referer, title, categories } = config.llm.openrouter;
-  return {
+  const defaults: Record<string, string> = {
     ...(referer ? { "HTTP-Referer": referer } : {}),
     ...(title ? { "X-OpenRouter-Title": title, "X-Title": title } : {}),
     ...(categories ? { "X-OpenRouter-Categories": categories } : {}),
   };
+  const incomingNames = new Set(
+    Object.keys(headers ?? {}).map((name) => name.toLowerCase()),
+  );
+  const hasIncomingTitle = [...TITLE_HEADERS].some((name) =>
+    incomingNames.has(name),
+  );
+
+  for (const name of Object.keys(defaults)) {
+    const normalizedName = name.toLowerCase();
+    if (
+      incomingNames.has(normalizedName) ||
+      (hasIncomingTitle && TITLE_HEADERS.has(normalizedName))
+    ) {
+      delete defaults[name];
+    }
+  }
+
+  return { ...defaults, ...(headers ?? {}) };
 }

--- a/platform/backend/src/knowledge-base/embedding-clients/index.test.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/index.test.ts
@@ -221,6 +221,45 @@ describe("callEmbedding dimensions handling", () => {
   });
 });
 
+describe("OpenRouter embedding attribution", () => {
+  const BASE_URL = "https://openrouter-embedding.example.com/v1";
+  let capturedHeaders: Headers;
+  useMswServer(
+    http.post(`${BASE_URL}/embeddings`, ({ request }) => {
+      capturedHeaders = request.headers;
+      return HttpResponse.json({
+        object: "list",
+        data: [
+          {
+            object: "embedding",
+            embedding: encodeEmbedding([0.1, 0.2]),
+            index: 0,
+          },
+        ],
+        model: "openai/text-embedding-3-small",
+        usage: { prompt_tokens: 1, total_tokens: 1 },
+      });
+    }),
+  );
+
+  test("attributes direct embedding requests to Archestra", async () => {
+    await callEmbedding({
+      inputs: ["hello"],
+      model: "openai/text-embedding-3-small",
+      apiKey: "k",
+      baseUrl: BASE_URL,
+      provider: "openrouter",
+    });
+
+    expect(capturedHeaders.get("HTTP-Referer")).toBe("https://archestra.ai");
+    expect(capturedHeaders.get("X-OpenRouter-Title")).toBe("Archestra");
+    expect(capturedHeaders.get("X-OpenRouter-Categories")).toBe(
+      "general-chat,personal-agent",
+    );
+    expect(capturedHeaders.get("X-Title")).toBe("Archestra");
+  });
+});
+
 describe("callEmbedding response validation", () => {
   const BASE_URL = "https://embed-validate.example.com/v1";
   let responseBody: Record<string, unknown>;

--- a/platform/backend/src/knowledge-base/embedding-clients/openai.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/openai.ts
@@ -25,8 +25,9 @@ export async function callOpenAIEmbedding(params: {
   apiKey: string;
   baseUrl?: string | null;
   dimensions?: number;
+  headers?: Record<string, string>;
 }): Promise<EmbeddingApiResponse> {
-  const { inputs, model, apiKey, baseUrl, dimensions } = params;
+  const { inputs, model, apiKey, baseUrl, dimensions, headers } = params;
   // OpenAI-compatible APIs are text-only: reject non-text inputs.
   // Images should never reach here because connectors only ingest images when
   // the embedding model's inputModalities includes "image", which OpenAI models don't.
@@ -42,6 +43,7 @@ export async function callOpenAIEmbedding(params: {
   const client = new OpenAI({
     apiKey,
     baseURL: baseUrl ?? undefined,
+    defaultHeaders: headers,
   });
 
   try {

--- a/platform/backend/src/knowledge-base/embedding-clients/registry.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/registry.ts
@@ -2,6 +2,7 @@ import type {
   SupportedProvider,
   SupportedProviderDiscriminator,
 } from "@archestra/shared";
+import { openRouterAttributionHeaders } from "@/clients/openrouter-attribution";
 import { callAzureEmbedding } from "./azure";
 import { callBedrockEmbedding } from "./bedrock";
 import { callCohereEmbedding } from "./cohere";
@@ -52,6 +53,16 @@ const OPENAI_WIRE_FIXED_DIMENSION: EmbeddingAdapter = {
   discriminator: "openai:embeddings",
 };
 
+const OPENROUTER_WIRE: EmbeddingAdapter = {
+  call: (params) =>
+    callOpenAIEmbedding({
+      ...params,
+      apiKey: params.apiKey ?? KEYLESS_PLACEHOLDER,
+      headers: openRouterAttributionHeaders(),
+    }),
+  discriminator: "openai:embeddings",
+};
+
 /**
  * Which embedding client (if any) each provider uses.
  *
@@ -99,7 +110,7 @@ export const EMBEDDING_ADAPTERS: Record<
 
   // OpenAI-compatible, honor the `dimensions` parameter.
   openai: OPENAI_WIRE,
-  openrouter: OPENAI_WIRE,
+  openrouter: OPENROUTER_WIRE,
   zhipuai: OPENAI_WIRE,
 
   // OpenAI-compatible, fixed native dimension — drop `dimensions`.

--- a/platform/backend/src/routes/chat/model-fetchers/openrouter.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openrouter.test.ts
@@ -42,7 +42,11 @@ describe("fetchOpenrouterModels", () => {
     const models = await fetchOpenrouterModels(
       "test-api-key",
       "https://openrouter.example/api/v1",
-      { "HTTP-Referer": "https://app.example" },
+      {
+        "X-Custom-Auth": "keep-me",
+        "HTTP-Referer": "https://caller.example",
+        "X-OpenRouter-Title": "Caller",
+      },
     );
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -51,7 +55,10 @@ describe("fetchOpenrouterModels", () => {
       "https://openrouter.example/api/v1/models",
       {
         headers: {
-          "HTTP-Referer": "https://app.example",
+          "X-Custom-Auth": "keep-me",
+          "HTTP-Referer": "https://caller.example",
+          "X-OpenRouter-Title": "Caller",
+          "X-OpenRouter-Categories": "general-chat,personal-agent",
           Authorization: "Bearer test-api-key",
         },
       },
@@ -61,7 +68,10 @@ describe("fetchOpenrouterModels", () => {
       "https://openrouter.example/api/v1/embeddings/models",
       {
         headers: {
-          "HTTP-Referer": "https://app.example",
+          "X-Custom-Auth": "keep-me",
+          "HTTP-Referer": "https://caller.example",
+          "X-OpenRouter-Title": "Caller",
+          "X-OpenRouter-Categories": "general-chat,personal-agent",
           Authorization: "Bearer test-api-key",
         },
       },

--- a/platform/backend/src/routes/chat/model-fetchers/openrouter.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openrouter.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { openRouterAttributionHeaders } from "@/clients/openrouter-attribution";
 import config from "@/config";
 import logger from "@/logging";
 import { ModelInputModalitySchema, ModelOutputModalitySchema } from "@/types";
@@ -62,14 +63,14 @@ export async function fetchOpenrouterModels(
       url: joinBaseUrl(baseUrl, "/models"),
       apiKey,
       errorLabel: "OpenRouter models",
-      extraHeaders,
+      extraHeaders: openRouterAttributionHeaders(extraHeaders),
       schema: OpenRouterGenerationModelsResponseSchema,
     }),
     fetchModelsWithBearerAuth({
       url: joinBaseUrl(baseUrl, "/embeddings/models"),
       apiKey,
       errorLabel: "OpenRouter embedding models",
-      extraHeaders,
+      extraHeaders: openRouterAttributionHeaders(extraHeaders),
       schema: OpenRouterEmbeddingModelsResponseSchema,
     }),
   ]);

--- a/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
@@ -3,6 +3,33 @@ import { describe, expect, test } from "@/test";
 import { Openrouter } from "@/types";
 import { openrouterAdapterFactory } from "./openrouter";
 
+describe("openrouterAdapterFactory.createClient", () => {
+  test("per-key attribution overrides configured defaults", () => {
+    const client = openrouterAdapterFactory.createClient("test-key", {
+      baseUrl: "https://openrouter.example/api/v1",
+      source: "api",
+      defaultHeaders: {
+        "X-Custom-Auth": "keep-me",
+        "http-referer": "https://caller.example",
+        "X-OpenRouter-Title": "Caller",
+        "X-Title": "Legacy caller",
+        "X-OpenRouter-App-Visibility": "hidden",
+      },
+    }) as unknown as {
+      _options: { defaultHeaders: Record<string, string> };
+    };
+
+    expect(client._options.defaultHeaders).toEqual({
+      "X-Custom-Auth": "keep-me",
+      "http-referer": "https://caller.example",
+      "X-OpenRouter-Title": "Caller",
+      "X-Title": "Legacy caller",
+      "X-OpenRouter-App-Visibility": "hidden",
+      "X-OpenRouter-Categories": "general-chat,personal-agent",
+    });
+  });
+});
+
 function createResponse(
   message: Openrouter.Types.ChatCompletionsResponse["choices"][0]["message"],
 ): Openrouter.Types.ChatCompletionsResponse {

--- a/platform/backend/src/routes/proxy/adapters/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.ts
@@ -263,10 +263,7 @@ export const openrouterAdapterFactory: LLMProvider<
       apiKey: rawApiKey,
       baseURL: options.baseUrl ?? config.llm.openrouter.baseUrl,
       fetch: customFetch,
-      defaultHeaders: {
-        ...openRouterAttributionHeaders(),
-        ...(options.defaultHeaders ?? {}),
-      },
+      defaultHeaders: openRouterAttributionHeaders(options.defaultHeaders),
     });
   },
 

--- a/platform/backend/src/routes/proxy/routes/openrouter.test.ts
+++ b/platform/backend/src/routes/proxy/routes/openrouter.test.ts
@@ -1,0 +1,55 @@
+import Fastify from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import config from "@/config";
+import { describe, expect, test } from "@/test";
+import openrouterProxyRoutes from "./openrouter";
+
+describe("OpenRouter proxy routes", () => {
+  test("adds configured defaults without replacing caller attribution", async () => {
+    let receivedHeaders: Record<string, string | string[] | undefined> = {};
+    const upstream = Fastify();
+    upstream.get("/credits", (request) => {
+      receivedHeaders = request.headers;
+      return { data: { total_credits: 1 } };
+    });
+    config.llm.openrouter.baseUrl = await upstream.listen({
+      port: 0,
+      host: "127.0.0.1",
+    });
+    config.llm.openrouter.referer = "https://deployment.example";
+    config.llm.openrouter.title = "Deployment";
+    config.llm.openrouter.categories = "productivity";
+
+    const app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    await app.register(openrouterProxyRoutes);
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/openrouter/credits",
+        headers: {
+          authorization: "Bearer test-openrouter-key",
+          "x-openrouter-title": "Caller",
+          "x-custom-auth": "keep-me",
+        },
+      });
+
+      expect(response.statusCode, response.body).toBe(200);
+      expect(receivedHeaders["http-referer"]).toBe(
+        "https://deployment.example",
+      );
+      expect(receivedHeaders["x-openrouter-title"]).toBe("Caller");
+      expect(receivedHeaders["x-title"]).toBeUndefined();
+      expect(receivedHeaders["x-openrouter-categories"]).toBe("productivity");
+      expect(receivedHeaders["x-custom-auth"]).toBe("keep-me");
+    } finally {
+      await app.close();
+      await upstream.close();
+    }
+  });
+});

--- a/platform/backend/src/routes/proxy/routes/openrouter.ts
+++ b/platform/backend/src/routes/proxy/routes/openrouter.ts
@@ -8,6 +8,7 @@ import { RouteId } from "@archestra/shared";
 import fastifyHttpProxy from "@fastify/http-proxy";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { openRouterAttributionHeaders } from "@/clients/openrouter-attribution";
 import config from "@/config";
 import logger from "@/logging";
 import { constructResponseSchema, Openrouter, UuidIdSchema } from "@/types";
@@ -26,6 +27,10 @@ const openrouterProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
     upstream: config.llm.openrouter.baseUrl,
     prefix: API_PREFIX,
     rewritePrefix: "",
+    replyOptions: {
+      rewriteRequestHeaders: (_request, headers) =>
+        openRouterAttributionHeaders(headers),
+    },
     preHandler: createProxyPreHandler({
       apiPrefix: API_PREFIX,
       endpointSuffix: CHAT_COMPLETIONS_SUFFIX,


### PR DESCRIPTION
## Summary

OpenRouter attribution defaults were applied to chat requests, but model discovery, direct embeddings, and generic passthrough requests did not use them consistently.

This change applies the existing configured attribution defaults at each outbound OpenRouter boundary. Generic passthrough remains supported, and caller-provided attribution continues to override deployment defaults.

## Behavior changes

- Existing `ARCHESTRA_OPENROUTER_REFERER`, `ARCHESTRA_OPENROUTER_TITLE`, and `ARCHESTRA_OPENROUTER_CATEGORIES` overrides remain supported.
- Caller-provided attribution and unrelated headers are preserved. Header names are matched case-insensitively.
- Missing attribution defaults are added to chat, model discovery, direct knowledge-base embeddings, and arbitrary passthrough endpoints.
- Existing OpenRouter endpoint behavior and API schemas remain unchanged.

## Verification

Exercised a real passthrough request against a local upstream and observed deployment defaults combined with a caller-provided title. Focused tests also cover chat, model discovery, and direct embedding requests.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
