### PR TITLE
fix(agent-runtime): preserve startup progress across reloads

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -64586,6 +64586,40 @@
                         "owner",
                         "shared"
                       ]
+                    },
+                    "startupProgress": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "phase": {
+                          "type": "string",
+                          "enum": [
+                            "queued",
+                            "scheduling",
+                            "pulling",
+                            "starting",
+                            "attaching"
+                          ]
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "detail": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "resourceName": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "phase",
+                        "message",
+                        "detail",
+                        "resourceName"
+                      ],
+                      "additionalProperties": false
                     }
                   },
                   "required": [
@@ -345858,6 +345892,40 @@
                           "owner",
                           "shared"
                         ]
+                      },
+                      "startupProgress": {
+                        "nullable": true,
+                        "type": "object",
+                        "properties": {
+                          "phase": {
+                            "type": "string",
+                            "enum": [
+                              "queued",
+                              "scheduling",
+                              "pulling",
+                              "starting",
+                              "attaching"
+                            ]
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "resourceName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "phase",
+                          "message",
+                          "detail",
+                          "resourceName"
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [

--- a/platform/backend/src/k8s/agent-runtime/manager.ts
+++ b/platform/backend/src/k8s/agent-runtime/manager.ts
@@ -479,6 +479,17 @@ class AgentRuntimeManager {
     return { name: pod.metadata.name, phase: pod.status?.phase ?? "Unknown" };
   }
 
+  /** Point-in-time startup state used to seed a newly loaded run page. */
+  async getStartupProgress(
+    session: Pick<AgentRunRecord, "taskId" | "runtimeScope">,
+  ): Promise<AgentRuntimeStartupProgress & { resourceName: string | null }> {
+    const pod = await this.findPod(session);
+    return {
+      ...describeAgentRuntimeStartupProgress(pod),
+      resourceName: pod?.metadata?.name ?? null,
+    };
+  }
+
   /**
    * The whole pod object behind `findPodPhase`.
    *
@@ -486,7 +497,9 @@ class AgentRuntimeManager {
    * has room, the image will not pull — is the only thing worth telling
    * someone watching a run start.
    */
-  async findPod(session: AgentRunRecord): Promise<k8s.V1Pod | null> {
+  async findPod(
+    session: Pick<AgentRunRecord, "taskId" | "runtimeScope">,
+  ): Promise<k8s.V1Pod | null> {
     const clients = this.requireClients();
     const pods = await clients.coreApi.listNamespacedPod({
       namespace: session.runtimeScope,

--- a/platform/backend/src/routes/agent-runtime/agent-runtime.routes.test.ts
+++ b/platform/backend/src/routes/agent-runtime/agent-runtime.routes.test.ts
@@ -105,6 +105,12 @@ describe("Agent Runtime routes", () => {
     );
     config.agentRuntime.enabled = true;
     Reflect.set(agentRuntimeManager, "clusterReachable", true);
+    vi.spyOn(agentRuntimeManager, "getStartupProgress").mockResolvedValue({
+      phase: "scheduling",
+      message: "Waiting for a node with room for this run",
+      detail: "No eligible node is currently available",
+      resourceName: "agent-run-example",
+    });
   });
 
   afterEach(async () => {
@@ -811,7 +817,19 @@ describe("Agent Runtime routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual(
-      expect.objectContaining({ taskId: task.id, viewerRole: "owner" }),
+      expect.objectContaining({
+        taskId: task.id,
+        viewerRole: "owner",
+        startupProgress: {
+          phase: "scheduling",
+          message: "Waiting for a node with room for this run",
+          detail: "No eligible node is currently available",
+          resourceName: "agent-run-example",
+        },
+      }),
+    );
+    expect(agentRuntimeManager.getStartupProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: task.id }),
     );
   });
 
@@ -858,8 +876,10 @@ describe("Agent Runtime routes", () => {
         taskId: task.id,
         projectId: project.id,
         viewerRole: "shared",
+        startupProgress: null,
       }),
     );
+    expect(agentRuntimeManager.getStartupProgress).not.toHaveBeenCalled();
   });
 
   test("opens an organization-shared run read-only for a colleague and 404s without a share", async ({

--- a/platform/backend/src/routes/agent-runtime/agent-runtime.routes.ts
+++ b/platform/backend/src/routes/agent-runtime/agent-runtime.routes.ts
@@ -11,6 +11,7 @@ import {
   userHasPermission,
 } from "@/auth";
 import config from "@/config";
+import logger from "@/logging";
 import {
   A2ATaskModel,
   AgentModel,
@@ -37,7 +38,9 @@ import {
 } from "@/services/agent-runtime/start-task";
 import {
   type Agent,
+  type AgentRunSession,
   AgentRunShareVisibilitySchema,
+  type AgentRunStartupProgress,
   ApiError,
   constructResponseSchema,
   GetAgentRunResponseSchema,
@@ -389,7 +392,11 @@ const agentRuntimeRoutes: FastifyPluginAsyncZod = async (fastify) => {
         organizationId: request.organizationId,
       });
       if (owned) {
-        return reply.send({ ...owned, viewerRole: "owner" as const });
+        return reply.send({
+          ...owned,
+          viewerRole: "owner" as const,
+          startupProgress: await inspectStartupProgress(owned),
+        });
       }
 
       // Non-owners may still open the run read-only when a share grants
@@ -415,7 +422,11 @@ const agentRuntimeRoutes: FastifyPluginAsyncZod = async (fastify) => {
             })
           : false;
         if (explicitlyShared || sharedThroughProject) {
-          return reply.send({ ...shared, viewerRole: "shared" as const });
+          return reply.send({
+            ...shared,
+            viewerRole: "shared" as const,
+            startupProgress: null,
+          });
         }
       }
 
@@ -717,6 +728,26 @@ type OwnedRunRequest = {
   user: { id: string };
   organizationId: string;
 };
+
+async function inspectStartupProgress(
+  run: AgentRunSession,
+): Promise<AgentRunStartupProgress | null> {
+  if (run.endedAt || run.lastModelActivityAt) return null;
+
+  try {
+    return await resolveAgentRuntimeBackendDriver(
+      run.backend,
+    ).getStartupProgress(run);
+  } catch (error) {
+    // Run metadata remains useful even when the runtime control plane cannot
+    // be inspected. The live attach path may still recover independently.
+    logger.warn(
+      { error, taskId: run.taskId },
+      "Could not inspect Agent Runtime startup progress",
+    );
+    return null;
+  }
+}
 
 async function requireOwnedRun(request: OwnedRunRequest) {
   const run = await AgentRunModel.findForActorByTaskId({

--- a/platform/backend/src/services/agent-runtime/backends/kubernetes.ts
+++ b/platform/backend/src/services/agent-runtime/backends/kubernetes.ts
@@ -5,6 +5,7 @@ import { agentRuntimeManager } from "@/k8s/agent-runtime";
 import type {
   AgentRunInput,
   AgentRunRecord,
+  AgentRunStartupProgress,
   AgentRuntimeSteerMode,
 } from "@/types";
 import { ApiError } from "@/types";
@@ -73,6 +74,12 @@ class KubernetesAgentRuntimeBackendDriver implements AgentRuntimeBackendDriver {
       }
       await delay(POD_START_POLL_MS, params.abortSignal);
     }
+  }
+
+  async getStartupProgress(
+    session: Pick<AgentRunRecord, "taskId" | "runtimeScope">,
+  ): Promise<AgentRunStartupProgress> {
+    return agentRuntimeManager.getStartupProgress(session);
   }
 
   async streamOutput(params: {

--- a/platform/backend/src/services/agent-runtime/backends/types.ts
+++ b/platform/backend/src/services/agent-runtime/backends/types.ts
@@ -4,6 +4,7 @@ import type WebSocket from "ws";
 import type {
   AgentRunInput,
   AgentRunRecord,
+  AgentRunStartupProgress,
   AgentRuntimeBackend,
   AgentRuntimeResources,
   AgentRuntimeSteerMode,
@@ -93,6 +94,11 @@ export interface AgentRuntimeBackendDriver {
     session: AgentRunRecord;
     abortSignal?: AbortSignal;
   }): Promise<void>;
+
+  /** Inspect the runtime's current startup wait without opening a terminal. */
+  getStartupProgress(
+    session: Pick<AgentRunRecord, "taskId" | "runtimeScope">,
+  ): Promise<AgentRunStartupProgress>;
 
   /** Follow the session's output. Resolves when the stream ends. */
   streamOutput(params: {

--- a/platform/backend/src/types/agent-runtime.ts
+++ b/platform/backend/src/types/agent-runtime.ts
@@ -1,3 +1,4 @@
+import { AGENT_RUN_ATTACH_PHASES } from "@archestra/shared";
 import {
   createInsertSchema,
   createSelectSchema,
@@ -248,9 +249,22 @@ export const SelectAgentRunSessionSchema = SelectAgentRunSchema.extend({
  */
 export const AgentRunViewerRoleSchema = z.enum(["owner", "shared"]);
 
+/** A point-in-time view of what an active runtime is waiting on. */
+export const AgentRunStartupProgressSchema = z.object({
+  phase: z.enum(AGENT_RUN_ATTACH_PHASES),
+  message: z.string(),
+  detail: z.string().nullable(),
+  resourceName: z.string().nullable(),
+});
+export type AgentRunStartupProgress = z.infer<
+  typeof AgentRunStartupProgressSchema
+>;
+
 /** A single run session plus the viewer's relationship to it. */
 export const GetAgentRunResponseSchema = SelectAgentRunSessionSchema.extend({
   viewerRole: AgentRunViewerRoleSchema,
+  /** Present on the detail endpoint while an owned run is starting. */
+  startupProgress: AgentRunStartupProgressSchema.nullable().optional(),
 });
 
 export const UpdateAgentRunSchema = createUpdateSchema(schema.agentRunsTable)

--- a/platform/frontend/src/components/agent-run-terminal.test.tsx
+++ b/platform/frontend/src/components/agent-run-terminal.test.tsx
@@ -48,21 +48,6 @@ describe("Agent run terminal transport", () => {
     expect(websocketMock.connect).not.toHaveBeenCalled();
     expect(websocketMock.send).toHaveBeenCalledOnce();
   });
-
-  it("shows structured startup progress before the backend reports a phase", () => {
-    websocketMock.isConnected.mockReturnValue(false);
-    websocketMock.onConnectionChange.mockReturnValue(vi.fn());
-    const sessionHandlers = handlers();
-
-    createAgentRunTransport("task-1").open(sessionHandlers);
-
-    expect(sessionHandlers.onProgress).toHaveBeenCalledWith({
-      phase: "queued",
-      message: "Preparing the run environment",
-      detail: null,
-      resourceName: null,
-    });
-  });
 });
 
 function handlers() {

--- a/platform/frontend/src/components/agent-run-terminal.tsx
+++ b/platform/frontend/src/components/agent-run-terminal.tsx
@@ -12,6 +12,8 @@ import {
   type ExecSessionTransport,
   ExecTerminal,
 } from "@/components/exec/exec-terminal";
+import type { ExecSessionProgress } from "@/components/exec/exec-terminal-progress";
+import { useMyAgentRun } from "@/lib/agent-runtime.query";
 import websocketService from "@/lib/websocket/websocket";
 
 /** Shared tmux terminal for Agent detail and Chat run sessions. */
@@ -34,6 +36,8 @@ export function AgentRunTerminal({
   onError?: () => void;
   onClosed?: () => void;
 }) {
+  const runQuery = useMyAgentRun(taskId, active);
+  const run = runQuery.data?.taskId === taskId ? runQuery.data : null;
   const transport = useMemo<ExecSessionTransport>(
     () => createAgentRunTransport(taskId),
     [taskId],
@@ -43,11 +47,16 @@ export function AgentRunTerminal({
     <ExecTerminal
       sessionKey={taskId}
       transport={transport}
-      isActive={active}
+      // The metadata snapshot supplies both the original start time and the
+      // current runtime phase. Opening the WebSocket first would briefly show
+      // a fresh 0:00 counter on every reload before correcting itself.
+      isActive={active && !!run}
       title={title}
       disconnectedLabel="Run finishing…"
       showManualCommand={showManualCommand}
       showDisconnectedStatus={showDisconnectedStatus}
+      initialProgress={run?.startupProgress ?? DEFAULT_STARTUP_PROGRESS}
+      progressStartedAt={parseStartedAt(run?.startedAt)}
       onCommandChange={onCommandChange}
       onError={onError}
       onClosed={onClosed}
@@ -58,15 +67,6 @@ export function AgentRunTerminal({
 export function createAgentRunTransport(taskId: string): ExecSessionTransport {
   return {
     open: (handlers) => {
-      // An Agent attach always has a known first wait. Seed the shared progress
-      // panel immediately so neither run surface flashes the generic
-      // "Connecting..." placeholder before the backend reports a finer phase.
-      handlers.onProgress?.({
-        phase: "queued",
-        message: "Preparing the run environment",
-        detail: null,
-        resourceName: null,
-      });
       const subscriptions = [
         websocketService.subscribe(
           "agent_run_attach_started",
@@ -149,4 +149,19 @@ export function createAgentRunTransport(taskId: string): ExecSessionTransport {
         payload: { runId: taskId, cols, rows },
       }),
   };
+}
+
+// ===================== internals =====================
+
+const DEFAULT_STARTUP_PROGRESS: ExecSessionProgress = {
+  phase: "queued",
+  message: "Preparing the run environment",
+  detail: null,
+  resourceName: null,
+};
+
+function parseStartedAt(startedAt: string | undefined): number | undefined {
+  if (!startedAt) return undefined;
+  const parsed = new Date(startedAt).getTime();
+  return Number.isFinite(parsed) ? parsed : undefined;
 }

--- a/platform/frontend/src/components/exec/exec-terminal.test.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.test.tsx
@@ -152,6 +152,95 @@ describe("ExecTerminal", () => {
     expect(screen.queryByText("Connecting...")).not.toBeInTheDocument();
   });
 
+  it("keeps persisted startup progress and elapsed time across page loads", async () => {
+    const startedAt = Date.now() - 122_000;
+    const transport: ExecSessionTransport = {
+      open: () => vi.fn(),
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+
+    render(
+      <ExecTerminal
+        sessionKey="task-persisted-progress"
+        transport={transport}
+        isActive
+        initialProgress={{
+          phase: "scheduling",
+          message: "Waiting for a node with room for this run",
+          detail: "No eligible node is currently available",
+          resourceName: "agent-run-example",
+        }}
+        progressStartedAt={startedAt}
+      />,
+    );
+
+    expect(
+      await screen.findByText("Waiting for a node with room for this run"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("timer")).toHaveTextContent("2:02");
+    expect(
+      screen.getByText("No eligible node is currently available"),
+    ).toBeInTheDocument();
+  });
+
+  it("prefers live startup progress over a stale persisted snapshot", async () => {
+    const session: { handlers: ExecSessionHandlers | null } = {
+      handlers: null,
+    };
+    const transport: ExecSessionTransport = {
+      open: (handlers) => {
+        session.handlers = handlers;
+        return vi.fn();
+      },
+      sendInput: vi.fn(),
+      sendResize: vi.fn(),
+    };
+    const initialProgress = {
+      phase: "scheduling" as const,
+      message: "Waiting for a node",
+      detail: null,
+      resourceName: null,
+    };
+    const { rerender } = render(
+      <ExecTerminal
+        sessionKey="task-live-progress"
+        transport={transport}
+        isActive
+        initialProgress={initialProgress}
+      />,
+    );
+    await screen.findByText("Waiting for a node");
+
+    act(() =>
+      session.handlers?.onProgress?.({
+        phase: "pulling",
+        message: "Pulling the agent image",
+        detail: null,
+        resourceName: "agent-run-example",
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Pulling the agent image",
+      ),
+    );
+
+    rerender(
+      <ExecTerminal
+        sessionKey="task-live-progress"
+        transport={transport}
+        isActive
+        initialProgress={{ ...initialProgress }}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Pulling the agent image",
+    );
+    expect(screen.queryByText("Waiting for a node")).not.toBeInTheDocument();
+  });
+
   /**
    * The startup phase is conveyed by a spinner moving down a list, which a
    * screen reader user cannot see. The phase text has to be announced instead.

--- a/platform/frontend/src/components/exec/exec-terminal.tsx
+++ b/platform/frontend/src/components/exec/exec-terminal.tsx
@@ -81,6 +81,10 @@ interface ExecTerminalProps {
   disconnectedLabel?: string;
   /** Whether a closed PTY should add a status banner above its retained frame. */
   showDisconnectedStatus?: boolean;
+  /** Snapshot shown immediately while the live transport catches up. */
+  initialProgress?: ExecSessionProgress | null;
+  /** Stable start time for the elapsed counter, such as the run's start. */
+  progressStartedAt?: number;
   onCommandChange?: (command: string | null) => void;
   onError?: () => void;
   onClosed?: () => void;
@@ -95,6 +99,8 @@ export function ExecTerminal({
   showManualCommand = true,
   disconnectedLabel = "Session terminated",
   showDisconnectedStatus = true,
+  initialProgress = null,
+  progressStartedAt,
   onCommandChange,
   onError,
   onClosed,
@@ -103,6 +109,9 @@ export function ExecTerminal({
   // retrigger the effect; `sessionKey` is the reconnect signal.
   const transportRef = useRef(transport);
   transportRef.current = transport;
+  const initialProgressRef = useRef(initialProgress);
+  initialProgressRef.current = initialProgress;
+  const hasTransportProgressRef = useRef(false);
   const onClosedRef = useRef(onClosed);
   onClosedRef.current = onClosed;
   const onErrorRef = useRef(onError);
@@ -205,7 +214,8 @@ export function ExecTerminal({
         }
 
         setStatus("connecting");
-        setProgress(null);
+        hasTransportProgressRef.current = false;
+        setProgress(initialProgressRef.current);
         setConnectingSince(Date.now());
         setErrorMessage(null);
 
@@ -215,6 +225,7 @@ export function ExecTerminal({
         closeSession = transportRef.current.open({
           onProgress: (sessionProgress) => {
             if (disposed) return;
+            hasTransportProgressRef.current = true;
             setProgress(sessionProgress);
           },
           onStarted: (startedCommand) => {
@@ -298,6 +309,12 @@ export function ExecTerminal({
     };
   }, [isActive, sessionKey, cleanup]);
 
+  useEffect(() => {
+    if (status === "connecting" && !hasTransportProgressRef.current) {
+      setProgress(initialProgress);
+    }
+  }, [initialProgress, status]);
+
   const [commandCopied, setCommandCopied] = useState(false);
 
   const handleCopyCommand = useCallback(async () => {
@@ -323,7 +340,7 @@ export function ExecTerminal({
             (progress ? (
               <ExecTerminalProgress
                 progress={progress}
-                startedAt={connectingSince}
+                startedAt={progressStartedAt ?? connectingSince}
               />
             ) : (
               <ExecTerminalStatus

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -18385,6 +18385,12 @@ export type GetMyAgentRunResponses = {
         projectName: string | null;
         projectIcon: string | null;
         viewerRole: 'owner' | 'shared';
+        startupProgress?: {
+            phase: 'queued' | 'scheduling' | 'pulling' | 'starting' | 'attaching';
+            message: string;
+            detail: string | null;
+            resourceName: string | null;
+        } | null;
     };
 };
 
@@ -88884,6 +88890,12 @@ export type GetProjectRunsResponses = {
         projectName: string | null;
         projectIcon: string | null;
         viewerRole: 'owner' | 'shared';
+        startupProgress?: {
+            phase: 'queued' | 'scheduling' | 'pulling' | 'starting' | 'attaching';
+            message: string;
+            detail: string | null;
+            resourceName: string | null;
+        } | null;
     }>;
 };
 


### PR DESCRIPTION
## Summary

- add a point-in-time startup snapshot to an owned active run so a freshly loaded page immediately shows the runtime's real phase, scheduler or image detail, and resource name
- anchor startup elapsed time to the run's original start time instead of each browser attach attempt
- wait for the initial run snapshot before opening the live terminal, then keep WebSocket progress authoritative so polling cannot overwrite a newer phase
- stop inspecting the runtime after the first model request and omit backend-native startup details from shared read-only views
- keep run metadata available if runtime inspection itself temporarily fails

## Verification

A controlled local Agent Runtime run was made deliberately unschedulable. Before refresh it showed `0:14`; after a full Chrome reload it painted in under a second at `0:17` with the same scheduler explanation and resource name. The disposable run was canceled afterward.

Behavior-focused route and terminal tests cover the startup snapshot, elapsed-time anchor, and live-progress precedence.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>