### PR TITLE
fix(chat): include tool schemas in compaction and guard Bedrock images

### DIFF
--- a/platform/backend/src/routes/chat/context-compaction-threshold.test.ts
+++ b/platform/backend/src/routes/chat/context-compaction-threshold.test.ts
@@ -1,0 +1,87 @@
+import { ModelModel } from "@/models";
+import { expect, test } from "@/test";
+import type { ChatMessage } from "@/types";
+import { compactMessagesForChat } from "./context-compaction";
+
+test("auto-compaction includes chat-override tool schemas in its context threshold", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const modelId = "global.anthropic.claude-sonnet-5-threshold-test";
+  const model = await ModelModel.create({
+    externalId: `bedrock/${modelId}`,
+    provider: "bedrock",
+    modelId,
+    description: "Bedrock context threshold test model",
+    contextLength: 1_000,
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    supportsToolCalling: true,
+    ignored: false,
+    lastSyncedAt: new Date(),
+  });
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+    modelId: model.id,
+  });
+  const messages: ChatMessage[] = [
+    {
+      id: "earlier-user-message",
+      role: "user",
+      parts: [{ type: "text", text: "Earlier question." }],
+    },
+    {
+      id: "earlier-assistant-message",
+      role: "assistant",
+      parts: [{ type: "text", text: "Earlier answer." }],
+    },
+    {
+      id: "current-user-message",
+      role: "user",
+      parts: [{ type: "text", text: "Continue." }],
+    },
+  ];
+  const baseParams = {
+    conversationId: conversation.id,
+    organizationId: conversation.organizationId,
+    userId: conversation.userId,
+    agentId: agent.id,
+    provider: "bedrock" as const,
+    selectedModel: modelId,
+    modelId: model.id,
+    messages,
+    trigger: "auto" as const,
+  };
+
+  const belowThreshold = await compactMessagesForChat(baseParams);
+  expect(belowThreshold.reason).toBe("below_threshold");
+
+  const abortController = new AbortController();
+  abortController.abort();
+  const overThreshold = await compactMessagesForChat({
+    ...baseParams,
+    tools: {
+      large_schema_tool: {
+        description: "A tool with a large schema.",
+        inputSchema: {
+          jsonSchema: {
+            type: "object",
+            properties: {
+              payload: {
+                type: "string",
+                description: "schema context ".repeat(1_000),
+              },
+            },
+          },
+        },
+      },
+    },
+    abortSignal: abortController.signal,
+  });
+
+  // The aborted result proves the threshold was crossed without invoking a
+  // summarization model. Before tool schemas were counted this stayed below
+  // the threshold and returned `below_threshold`.
+  expect(overThreshold.reason).toBe("aborted");
+});

--- a/platform/backend/src/routes/chat/context-compaction.ts
+++ b/platform/backend/src/routes/chat/context-compaction.ts
@@ -43,6 +43,7 @@ import type {
 import { extractTaggedText } from "@/utils/generate-tagged-text";
 import { resolveProviderApiKey } from "@/utils/llm-api-key-resolution";
 import { resolveAgentLlmOrDefault } from "@/utils/llm-resolution";
+import { estimateToolsTokens } from "./context-window-breakdown";
 import {
   estimateFileTokens,
   isTextLikeMediaType,
@@ -108,6 +109,8 @@ export type ContextCompactionParams = {
   agentLlmApiKeyId?: string | null;
   messages: ChatMessage[];
   systemPrompt?: string;
+  /** AI SDK tool definitions included in the main model request. */
+  tools?: Record<string, unknown>;
   trigger: ConversationCompactionTrigger;
   onCompactionStart?: () => void;
   abortSignal?: AbortSignal;
@@ -210,6 +213,7 @@ async function runCompactMessagesForChat(
       provider: params.provider,
       selectedModel: params.selectedModel,
       systemPrompt: params.systemPrompt,
+      tools: params.tools,
       messages: existingMessages,
     });
     messagesTokenEstimate = decision.estimatedTokens;
@@ -359,6 +363,7 @@ export function __testEstimateChatMessagesTokens(params: {
   provider: SupportedProvider;
   model?: string;
   systemPrompt?: string;
+  tools?: Record<string, unknown>;
   messages: ChatMessage[];
 }): number {
   return estimateChatMessagesTokens(params);
@@ -535,6 +540,7 @@ async function shouldAutoCompact(params: {
   provider: SupportedProvider;
   selectedModel: string;
   systemPrompt?: string;
+  tools?: Record<string, unknown>;
   messages: ChatMessage[];
 }): Promise<{ shouldCompact: boolean; estimatedTokens: number }> {
   const estimatedTokens = estimateChatMessagesTokens({
@@ -1269,6 +1275,7 @@ function estimateChatMessagesTokens(params: {
    */
   model?: string;
   systemPrompt?: string;
+  tools?: Record<string, unknown>;
   messages: ChatMessage[];
 }): number {
   const tokenizer = getTokenizer(params.provider, params.model);
@@ -1288,8 +1295,15 @@ function estimateChatMessagesTokens(params: {
   const systemTokens = params.systemPrompt
     ? Math.ceil(params.systemPrompt.length / 4)
     : 0;
+  const toolTokens = params.tools
+    ? estimateToolsTokens({
+        provider: params.provider,
+        model: params.model ?? "",
+        tools: params.tools,
+      })
+    : 0;
 
-  return messageTokens + systemTokens + extraTokens;
+  return messageTokens + systemTokens + toolTokens + extraTokens;
 }
 
 function getMessageTextForTokenEstimate(message: ChatMessage): {

--- a/platform/backend/src/routes/chat/context-window-breakdown.ts
+++ b/platform/backend/src/routes/chat/context-window-breakdown.ts
@@ -28,6 +28,21 @@ export const PDF_BYTES_PER_TOKEN = TOKEN_ESTIMATE.pdfBytesPerToken;
 export const BINARY_BYTES_PER_TOKEN = TOKEN_ESTIMATE.binaryBytesPerToken;
 export const IMAGE_TOKEN_MAX_ESTIMATE = TOKEN_ESTIMATE.imageTokenMaxEstimate;
 
+/** Estimate the fixed context cost of the tool definitions sent on a turn. */
+export function estimateToolsTokens(params: {
+  provider: SupportedProvider;
+  model: string;
+  tools: Record<string, unknown>;
+}): number {
+  const tokenizer = getTokenizer(params.provider, params.model);
+  return Object.entries(params.tools).reduce((total, [name, tool]) => {
+    const serialized = serializeToolForEstimate(name, tool);
+    return serialized
+      ? total + estimateTextTokens(tokenizer, serialized)
+      : total;
+  }, 0);
+}
+
 // Keep the streamed payload bounded: ship the biggest contributors per category
 // and fold the rest into a single "Other" row so totals still reconcile.
 const MAX_ITEMS_PER_CATEGORY = 12;

--- a/platform/backend/src/routes/chat/normalization/enforce-request-size-limit.ts
+++ b/platform/backend/src/routes/chat/normalization/enforce-request-size-limit.ts
@@ -1,10 +1,18 @@
 import type { SupportedProvider } from "@archestra/shared";
 import type { ChatMessage } from "@/types";
 
+const BASE64_MARKER = ";base64,";
+const MiB = 1024 * 1024;
+
 // Anthropic's documented request-size limits, including Amazon Bedrock's 20 MB
 // cap (the direct Claude API allows 32 MB).
 const REQUEST_SIZE_LIMITS_DOC_URL =
   "https://platform.claude.com/docs/en/api/overview#request-size-limits";
+
+// Bedrock validates the base64-encoded image carried by the Converse JSON
+// request against a 5 MiB ceiling. Base64 expands three input bytes into four
+// wire bytes, so the largest raw image that can pass is 3.75 MiB.
+const BEDROCK_IMAGE_LIMIT_BYTES = (5 * MiB * 3) / 4;
 
 /**
  * Per-provider maximum attachment size. These are the providers' documented
@@ -32,9 +40,12 @@ export function providerAttachmentLimitBytes(
   return PROVIDER_ATTACHMENT_LIMIT_BYTES[provider];
 }
 
-const BASE64_MARKER = ";base64,";
-
-const MiB = 1024 * 1024;
+/** Maximum decoded size of one inline image for providers with such a limit. */
+export function providerImageAttachmentLimitBytes(
+  provider: SupportedProvider,
+): number | undefined {
+  return provider === "bedrock" ? BEDROCK_IMAGE_LIMIT_BYTES : undefined;
+}
 
 export class RequestTooLargeError extends Error {
   readonly provider: SupportedProvider;
@@ -72,7 +83,26 @@ export function assertRequestWithinProviderPayloadLimit(params: {
     return;
   }
 
-  const { fileBytes, fileCount } = measureInlineAttachments(params.messages);
+  const { fileBytes, fileCount, attachments } = measureInlineAttachments(
+    params.messages,
+  );
+  const imageLimitBytes = providerImageAttachmentLimitBytes(params.provider);
+  if (imageLimitBytes !== undefined) {
+    const oversizedImage = attachments.find(
+      (attachment) =>
+        attachment.mediaType.startsWith("image/") &&
+        attachment.fileBytes > imageLimitBytes,
+    );
+    if (oversizedImage) {
+      throw new RequestTooLargeError({
+        provider: params.provider,
+        fileBytes: oversizedImage.fileBytes,
+        limitBytes: imageLimitBytes,
+        fileCount: 1,
+      });
+    }
+  }
+
   // Compare in whole MB — the unit shown to the user — so a file that rounds to
   // the cap is not rejected with a self-contradictory "20 MB, max 20 MB".
   if (Math.round(fileBytes / MiB) > Math.floor(limitBytes / MiB)) {
@@ -88,9 +118,11 @@ export function assertRequestWithinProviderPayloadLimit(params: {
 function measureInlineAttachments(messages: ChatMessage[]): {
   fileBytes: number;
   fileCount: number;
+  attachments: Array<{ fileBytes: number; mediaType: string }>;
 } {
   let fileBytes = 0;
   let fileCount = 0;
+  const attachments: Array<{ fileBytes: number; mediaType: string }> = [];
   for (const message of messages) {
     if (!message.parts?.length) {
       continue;
@@ -109,13 +141,24 @@ function measureInlineAttachments(messages: ChatMessage[]): {
       }
       // Attachments are carried inline as base64; the decoded file is 3/4 of
       // that length — the size the user recognizes and what the message reports.
-      const base64Length =
-        part.url.length - (markerIndex + BASE64_MARKER.length);
-      fileBytes += Math.floor((base64Length * 3) / 4);
+      const payload = part.url.slice(markerIndex + BASE64_MARKER.length);
+      const paddingBytes = payload.endsWith("==")
+        ? 2
+        : payload.endsWith("=")
+          ? 1
+          : 0;
+      const attachmentBytes =
+        Math.floor((payload.length * 3) / 4) - paddingBytes;
+      const mediaType =
+        typeof part.mediaType === "string" && part.mediaType.length > 0
+          ? part.mediaType
+          : part.url.slice(5, part.url.indexOf(";"));
+      fileBytes += attachmentBytes;
       fileCount += 1;
+      attachments.push({ fileBytes: attachmentBytes, mediaType });
     }
   }
-  return { fileBytes, fileCount };
+  return { fileBytes, fileCount, attachments };
 }
 
 function formatRequestTooLargeMessage(params: {
@@ -124,8 +167,8 @@ function formatRequestTooLargeMessage(params: {
   limitBytes: number;
   fileCount: number;
 }): string {
-  const fileMB = Math.round(params.fileBytes / MiB);
-  const limitMB = Math.floor(params.limitBytes / MiB);
+  const fileMB = formatMegabytes(params.fileBytes, true);
+  const limitMB = formatMegabytes(params.limitBytes, false);
   const label = providerLabel(params.provider);
   const subject =
     params.fileCount > 1
@@ -140,6 +183,14 @@ function formatRequestTooLargeMessage(params: {
     `The most you can send is ${limitMB} MB. ${fix}\n` +
     REQUEST_SIZE_LIMITS_DOC_URL
   );
+}
+
+function formatMegabytes(bytes: number, roundUp: boolean): string {
+  const megabytes = bytes / MiB;
+  const hundredths = roundUp
+    ? Math.ceil(megabytes * 100)
+    : Math.floor(megabytes * 100);
+  return String(hundredths / 100);
 }
 
 function providerLabel(provider: SupportedProvider): string {

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -59,6 +59,10 @@ export async function materializeAttachments({
   // in the Files panel (and the sandbox, when it fits) instead of inflating the
   // request past what the provider accepts. Unbounded when omitted.
   inlineByteLimit = Number.POSITIVE_INFINITY,
+  // Some providers impose a tighter per-image ceiling than their overall
+  // request limit. Keep an oversized image in the Files panel instead of
+  // sending a request the provider will reject.
+  inlineImageByteLimit = inlineByteLimit,
   // The locked chat's browser-held key. Its attachment rows hold sealed bytes
   // and filenames, so rehydrating one for the provider needs the key; null for
   // an ordinary chat, whose rows are plaintext.
@@ -71,6 +75,7 @@ export async function materializeAttachments({
   rerouteBinaryDocsToSandbox?: boolean;
   sandboxAvailable?: boolean;
   inlineByteLimit?: number;
+  inlineImageByteLimit?: number;
   conversationKey?: ConversationContentKey | null;
 }): Promise<ChatMessage[]> {
   const refIds = collectRefIds(messages);
@@ -103,6 +108,7 @@ export async function materializeAttachments({
     rerouteBinaryDocsToSandbox,
     sandboxAvailable,
     inlineByteLimit,
+    inlineImageByteLimit,
   };
 
   const inlinedIds = Array.from(byId.values())
@@ -133,6 +139,7 @@ type MaterializePolicy = {
   rerouteBinaryDocsToSandbox: boolean;
   sandboxAvailable: boolean;
   inlineByteLimit: number;
+  inlineImageByteLimit: number;
 };
 
 /**
@@ -149,8 +156,12 @@ function bypassReason(
   attachment: Attachment,
   policy: MaterializePolicy,
 ): "unreadable" | "too_large_to_send" | null {
-  const { ingestibleMimeTypes, rerouteBinaryDocsToSandbox, inlineByteLimit } =
-    policy;
+  const {
+    ingestibleMimeTypes,
+    rerouteBinaryDocsToSandbox,
+    inlineByteLimit,
+    inlineImageByteLimit,
+  } = policy;
   const modelCannotRead =
     ingestibleMimeTypes !== undefined &&
     !ingestibleMimeTypes.has(attachment.mimeType);
@@ -161,10 +172,13 @@ function bypassReason(
 
   // Text has a tighter budget than binary: an over-budget text document would
   // blow the context window even though the provider would accept the bytes.
-  const textBudget = isInlineableTextMimeType(attachment.mimeType)
-    ? Math.min(INLINE_TEXT_MAX_BYTES, inlineByteLimit)
+  const attachmentBudget = attachment.mimeType.startsWith("image/")
+    ? Math.min(inlineByteLimit, inlineImageByteLimit)
     : inlineByteLimit;
-  return attachment.fileSize > textBudget ? "too_large_to_send" : null;
+  const effectiveBudget = isInlineableTextMimeType(attachment.mimeType)
+    ? Math.min(INLINE_TEXT_MAX_BYTES, attachmentBudget)
+    : attachmentBudget;
+  return attachment.fileSize > effectiveBudget ? "too_large_to_send" : null;
 }
 
 function collectRefIds(messages: ChatMessage[]): string[] {

--- a/platform/backend/src/routes/chat/prepare-model-messages.test.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.test.ts
@@ -272,6 +272,101 @@ function inlinePdfMessage(base64Length: number): ChatMessage[] {
   ];
 }
 
+function inlineImageMessage(decodedBytes: number): ChatMessage[] {
+  const base64 = Buffer.alloc(decodedBytes).toString("base64");
+  return [
+    {
+      role: "user",
+      parts: [
+        { type: "text", text: "Describe this image." },
+        {
+          type: "file",
+          url: `data:image/png;base64,${base64}`,
+          mediaType: "image/png",
+          filename: "image.png",
+        },
+      ],
+    },
+  ];
+}
+
+test("bedrock: an oversized stored image stays out of the provider request", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  const bytes = Buffer.from("small fixture bytes", "utf8");
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "oversized.png",
+    mimeType: "image/png",
+    // Bedrock's 5 MiB encoded-image ceiling allows at most 3.75 MiB of raw
+    // image bytes. The metadata size drives the decision without allocating a
+    // multi-megabyte test fixture.
+    fileSize: 4 * 1024 * 1024,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const { modelMessages } = await __test.buildModelMessagesForProvider({
+    messages: [
+      {
+        role: "user",
+        parts: [
+          { type: "text", text: "Describe this image." },
+          {
+            type: "file",
+            url: `/api/chat/attachments/${row.id}/content`,
+            mediaType: "image/png",
+            filename: "oversized.png",
+          },
+        ],
+      },
+    ],
+    provider: "bedrock",
+    conversationId: conversation.id,
+    ingestibleMimeTypes: new Set(["image/png"]),
+    sandboxAvailable: false,
+  });
+
+  expect(hasFilePart(modelMessages)).toBe(false);
+  expect(textContent(modelMessages)).toContain(
+    "too large to send to this model",
+  );
+  expect(textContent(modelMessages)).toContain("Files panel");
+});
+
+test("bedrock: an oversized legacy inline image is rejected before the provider call", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+
+  const error = await __test
+    .buildModelMessagesForProvider({
+      messages: inlineImageMessage(4 * 1024 * 1024),
+      provider: "bedrock",
+      conversationId: conversation.id,
+      sandboxAvailable: false,
+    })
+    .then(
+      () => null,
+      (caught) => caught,
+    );
+
+  expect(error).toBeInstanceOf(Error);
+  expect(error.message).toContain("AWS Bedrock");
+  expect(error.message).toContain("3.75 MB");
+});
+
 test("bedrock: an inline PDF whose payload exceeds the provider limit is rejected, reporting the decoded file size", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/routes/chat/prepare-model-messages.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.ts
@@ -25,6 +25,7 @@ import { applyPromptCacheBreakpoints } from "./normalization/apply-prompt-cache"
 import {
   assertRequestWithinProviderPayloadLimit,
   providerAttachmentLimitBytes,
+  providerImageAttachmentLimitBytes,
 } from "./normalization/enforce-request-size-limit";
 import { materializeAttachments } from "./normalization/materialize-attachments";
 import { prepareMessagesForProvider } from "./normalization/prepare-for-provider";
@@ -92,6 +93,8 @@ export async function buildModelMessages(params: {
   inputModalities?: ModelInputModality[] | null;
   agentLlmApiKeyId?: string | null;
   systemPrompt?: string;
+  /** AI SDK tool definitions included in the main model request. */
+  tools?: Record<string, unknown>;
   abortSignal?: AbortSignal;
   emit: (event: CompactionStreamEvent) => void;
   /**
@@ -254,6 +257,11 @@ async function buildModelMessagesForProvider(params: {
     config.chat.attachmentInlineBytesLimit,
     providerLimit ?? Number.POSITIVE_INFINITY,
   );
+  const providerImageLimit = providerImageAttachmentLimitBytes(params.provider);
+  const inlineImageByteLimit = Math.min(
+    inlineByteLimit,
+    providerImageLimit ?? Number.POSITIVE_INFINITY,
+  );
   const materialized = await materializeAttachments({
     messages: params.messages,
     conversationId: params.conversationId,
@@ -264,6 +272,7 @@ async function buildModelMessagesForProvider(params: {
       PROVIDERS_WITHOUT_DOCUMENT_CONTENT_PARTS.has(params.provider),
     sandboxAvailable: params.sandboxAvailable,
     inlineByteLimit,
+    inlineImageByteLimit,
     conversationKey: params.conversationKey ?? null,
   });
   // Reject oversized inline attachments here, before the provider call, so the

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -1241,6 +1241,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     inputModalities: modelRow?.inputModalities ?? null,
                     agentLlmApiKeyId: agent.llmApiKeyId,
                     systemPrompt,
+                    tools: supportsToolCalling ? mcpTools : undefined,
                     abortSignal: chatAbortController.signal,
                     emit: (event) => writer.write(event),
                     // LockedChat: never generate/persist a compaction summary.

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -1203,6 +1203,10 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(Object.keys(call.tools ?? {})).toEqual(
       expect.arrayContaining([searchToolsName, runToolName]),
     );
+    expect(mockCompactMessagesForChat).toHaveBeenCalledTimes(1);
+    expect(
+      Object.keys(mockCompactMessagesForChat.mock.calls[0]?.[0].tools),
+    ).toEqual(expect.arrayContaining([searchToolsName, runToolName]));
   });
 
   test("omits tools from streamText when the conversation model doesn't support tool calling", async ({


### PR DESCRIPTION
## Summary

Auto-compaction estimated the system prompt and message history without the active tool definitions. Tool-heavy chat overrides could therefore remain below the 80% threshold locally even when the assembled provider request exceeded the selected model context window. Bedrock image handling also applied the overall request cap without enforcing the tighter Converse per-image limit.

This change:

- uses the same tool-schema estimator as the Context Window visualizer when deciding whether to auto-compact
- passes the exact active tool set from the chat route while preserving tool-less model behavior
- keeps Bedrock images above 3.75 MiB raw out of provider requests because their base64 representation exceeds the 5 MiB Converse ceiling
- rejects oversized legacy inline images locally with an actionable limit instead of waiting for a provider validation error

## Verification

A Bedrock Sonnet 5 chat override reproduced the per-image validation failure before the change. A direct AWS SDK control confirmed that an under-5-MiB raw image still exceeds the encoded Converse ceiling. Retrying the same local chat after the patch completed normally and reported that the image remained available in the Files panel.

Regression coverage exercises database-backed attachment materialization, legacy inline-image preflight, auto-compaction thresholding against a selected Bedrock model with a large tool schema, and route propagation of the active tool set.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>