### PR TITLE
fix(tests): stabilize attachment ordering and local backend resource use

### DIFF
--- a/platform/backend/src/models/conversation-attachment.test.ts
+++ b/platform/backend/src/models/conversation-attachment.test.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import { expect, test } from "@/test";
 
@@ -41,6 +42,48 @@ test("create + findByIdWithData round-trips bytes and metadata", async ({
   expect(fetchedRow.fileData.equals(bytes)).toBe(true);
   expect(fetchedRow.originalName).toBe("hello.txt");
   expect(fetchedRow.mimeType).toBe("text/plain");
+});
+
+test("same-millisecond attachments resolve the later insert by filename", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+  const first = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "duplicate.txt",
+    mimeType: "text/plain",
+    fileSize: 2,
+    contentHash: "duplicate-v1",
+    fileData: Buffer.from("v1"),
+  });
+  const second = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "duplicate.txt",
+    mimeType: "text/plain",
+    fileSize: 2,
+    contentHash: "duplicate-v2",
+    fileData: Buffer.from("v2"),
+  });
+
+  expect(first.createdAt).toEqual(second.createdAt);
+  expect(second.id > first.id).toBe(true);
+  const latest = await ConversationAttachmentModel.findLatestByNameWithData({
+    conversationId: conversation.id,
+    originalName: "duplicate.txt",
+  });
+  expect(latest?.id).toBe(second.id);
+  expect(latest?.fileData.toString("utf8")).toBe("v2");
 });
 
 test("findById omits fileData (metadata-only)", async ({

--- a/platform/backend/src/models/conversation-attachment.ts
+++ b/platform/backend/src/models/conversation-attachment.ts
@@ -10,6 +10,7 @@ import {
 import db, { schema } from "@/database";
 import type { ConversationContentKey } from "@/types/conversation";
 import { normalizeByteaField } from "@/utils/normalize-bytea";
+import { uuidv7 } from "@/utils/uuid";
 
 type ConversationAttachment =
   typeof schema.conversationAttachmentsTable.$inferSelect;
@@ -58,11 +59,16 @@ class ConversationAttachmentModel {
     >,
     conversationKey?: AttachmentKey,
   ): Promise<ConversationAttachment> {
+    // Filename lookup promises latest-wins and breaks createdAt ties by id.
+    // A monotonic v7 id preserves insertion order when rapid writes share the
+    // same millisecond; a random v4 id makes that selection nondeterministic.
+    const id = uuidv7();
     const [result] = await db
       .insert(schema.conversationAttachmentsTable)
       .values(
         conversationKey
           ? {
+              id,
               ...params,
               lockedChat: true,
               originalName: encryptLockedChatText(params.originalName, {
@@ -80,7 +86,7 @@ class ConversationAttachmentModel {
                   })
                 : params.textPreview,
             }
-          : params,
+          : { id, ...params },
       )
       .returning();
     // Hand the caller back what it stored, not the ciphertext it now holds.

--- a/platform/backend/src/test/vitest-resource-limits.test.ts
+++ b/platform/backend/src/test/vitest-resource-limits.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { calculateVitestResourceLimits } from "./vitest-resource-limits";
+
+const GIB = 1024 ** 3;
+
+describe("calculateVitestResourceLimits", () => {
+  test("keeps a large developer machine below the local CPU and heap caps", () => {
+    expect(
+      calculateVitestResourceLimits({
+        isCI: false,
+        availableParallelism: 18,
+        totalMemoryBytes: 64 * GIB,
+      }),
+    ).toEqual({ maxWorkers: 4, maxOldSpaceMb: 3072 });
+  });
+
+  test("scales down further on ordinary developer hardware", () => {
+    expect(
+      calculateVitestResourceLimits({
+        isCI: false,
+        availableParallelism: 8,
+        totalMemoryBytes: 16 * GIB,
+      }),
+    ).toEqual({ maxWorkers: 1, maxOldSpaceMb: 3072 });
+    expect(
+      calculateVitestResourceLimits({
+        isCI: false,
+        availableParallelism: 4,
+        totalMemoryBytes: 8 * GIB,
+      }),
+    ).toEqual({ maxWorkers: 1, maxOldSpaceMb: 2048 });
+  });
+
+  test("preserves the existing throughput-oriented CI sizing", () => {
+    expect(
+      calculateVitestResourceLimits({
+        isCI: true,
+        availableParallelism: 16,
+        totalMemoryBytes: 64 * GIB,
+      }),
+    ).toEqual({ maxWorkers: 12, maxOldSpaceMb: 4096 });
+  });
+});

--- a/platform/backend/src/test/vitest-resource-limits.ts
+++ b/platform/backend/src/test/vitest-resource-limits.ts
@@ -1,0 +1,68 @@
+export function calculateVitestResourceLimits(params: {
+  isCI: boolean;
+  availableParallelism: number;
+  totalMemoryBytes: number;
+}): { maxWorkers: number; maxOldSpaceMb: number } {
+  const { isCI, availableParallelism, totalMemoryBytes } = params;
+  if (isCI) {
+    const maxWorkers = Math.min(
+      availableParallelism,
+      Math.max(1, Math.floor(totalMemoryBytes / CI_MEMORY_PER_WORKER_BYTES)),
+    );
+    return {
+      maxWorkers,
+      maxOldSpaceMb: Math.max(
+        MIN_CI_OLD_SPACE_MB,
+        Math.floor(
+          (totalMemoryBytes * CI_OLD_SPACE_MEMORY_FRACTION) /
+            maxWorkers /
+            BYTES_PER_MIB,
+        ),
+      ),
+    };
+  }
+
+  // Forks duplicate the module graph and PGlite database. Keep interactive
+  // machines responsive while retaining enough parallelism to beat one or two
+  // workers on representative backend suites.
+  const cpuWorkers = Math.max(
+    1,
+    Math.min(
+      MAX_LOCAL_WORKERS,
+      Math.floor(availableParallelism * LOCAL_CPU_FRACTION),
+    ),
+  );
+  const memoryWorkers = Math.max(
+    1,
+    Math.floor(
+      (totalMemoryBytes * LOCAL_MEMORY_FRACTION) /
+        ESTIMATED_LOCAL_WORKER_RSS_BYTES,
+    ),
+  );
+  const maxWorkers = Math.min(cpuWorkers, memoryWorkers);
+  const memoryBudgetPerWorkerMb = Math.floor(
+    (totalMemoryBytes * LOCAL_MEMORY_FRACTION) / maxWorkers / BYTES_PER_MIB,
+  );
+
+  return {
+    maxWorkers,
+    maxOldSpaceMb: Math.max(
+      MIN_LOCAL_OLD_SPACE_MB,
+      Math.min(MAX_LOCAL_OLD_SPACE_MB, memoryBudgetPerWorkerMb),
+    ),
+  };
+}
+
+const BYTES_PER_MIB = 1024 ** 2;
+const BYTES_PER_GIB = 1024 ** 3;
+
+const CI_MEMORY_PER_WORKER_BYTES = 5 * BYTES_PER_GIB;
+const CI_OLD_SPACE_MEMORY_FRACTION = 0.75;
+const MIN_CI_OLD_SPACE_MB = 2048;
+
+const LOCAL_CPU_FRACTION = 0.25;
+const LOCAL_MEMORY_FRACTION = 0.25;
+const MAX_LOCAL_WORKERS = 4;
+const ESTIMATED_LOCAL_WORKER_RSS_BYTES = 3 * BYTES_PER_GIB;
+const MIN_LOCAL_OLD_SPACE_MB = 1536;
+const MAX_LOCAL_OLD_SPACE_MB = 3072;

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -4,40 +4,34 @@ import os from "node:os";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 import { vitestLogPolicy } from "../vitest.shared";
+import { calculateVitestResourceLimits } from "./src/test/vitest-resource-limits";
 
 const isCI = process.env.CI === "true";
 
 /**
- * Bound the fork count by BOTH cores and memory. CPU half: 50% of cores
- * locally (leaves the other half for the human); CI runs all cores because the
- * memory cap is the real limit there. Memory half: with the forks pool each
- * worker loads the full module graph + its own PGlite (WASM) independently —
- * up to ~3 GB RSS per fork, not shared like the threads pool's single address
- * space — so cap at ~5 GB/fork or a shard OOM-kills the runner (cgroup OOM
- * aborts a worker abruptly, not with a clean Vitest error). Yields 12 forks on
- * the 16-vCPU / 64-GB CI runner, and half-cores (memory permitting) locally.
- * Trusts os.totalmem() to report real available RAM — valid on the bare-VM CI
- * runner, but it would over-report (and stop protecting) inside a
- * cgroup-limited container.
+ * Fork workers each load the backend graph and a PGlite database. CI keeps the
+ * throughput-oriented sizing used by its isolated shards. Local runs reserve
+ * most CPU and memory for the developer's other work instead of treating an
+ * interactive machine like a dedicated runner.
  */
-const MAX_WORKERS = Math.min(
-  isCI
-    ? os.availableParallelism()
-    : Math.max(1, Math.floor(os.availableParallelism() * 0.5)),
-  Math.max(1, Math.floor(os.totalmem() / (5 * 1024 ** 3))),
-);
+const { maxWorkers: MAX_WORKERS, maxOldSpaceMb: MAX_OLD_SPACE_MB } =
+  calculateVitestResourceLimits({
+    isCI,
+    availableParallelism: os.availableParallelism(),
+    totalMemoryBytes: os.totalmem(),
+  });
 
 /**
- * Per-fork V8 old-space ceiling, in MB — three quarters of RAM divided over
- * the forks that share it, floored at V8's own 2 GB default so this can only
- * ever raise the ceiling, never lower it. Kept below total memory so the
- * kernel OOM killer (which kills abruptly, with no heap diagnostics) stays out
- * of play even when every fork peaks together.
+ * Node compile data is safe to reuse across local runs: Node validates entries
+ * by content, and every Vitest fork inherits this path when it starts. CI owns
+ * its separately cached path in the workflow.
  */
-const MAX_OLD_SPACE_MB = Math.max(
-  2048,
-  Math.floor((os.totalmem() * 0.75) / MAX_WORKERS / 1024 ** 2),
-);
+if (!isCI && !process.env.NODE_COMPILE_CACHE) {
+  process.env.NODE_COMPILE_CACHE = path.resolve(
+    __dirname,
+    "node_modules/.cache/node-compile-cache",
+  );
+}
 
 /**
  * Partition test files by whether they use Vitest module mocking.
@@ -143,19 +137,9 @@ export default defineConfig({
 
     maxWorkers: MAX_WORKERS,
 
-    // Pin each fork's V8 old-space ceiling instead of inheriting it from the
-    // host's size. V8 derives its default from total system memory (~2 GB on a
-    // 7 GB machine, ~4 GB on 16 GB), and GitHub-hosted runner hardware depends
-    // on repository VISIBILITY: public repos get 4-vCPU/16-GB, private repos
-    // 2-vCPU/7-GB. So the same suite that fits comfortably here aborts with
-    // "FATAL ERROR: Ineffective mark-compacts near heap limit" on a private
-    // mirror of this repo, where the cap silently halves to 2 GB while
-    // MAX_WORKERS simultaneously collapses to 1 — concentrating every file in
-    // the shard into one long-lived heap (the mock-free project runs
-    // isolate: false, so module state accumulates across files by design).
-    // Deriving the ceiling from memory-per-fork keeps the value the big
-    // runners already get (~4 GB) and gives the small ones the headroom their
-    // single fork actually has.
+    // Pin each fork's V8 old-space ceiling. CI divides most runner memory over
+    // its workers; local runs cap each heap at 3 GB and their aggregate budget
+    // near one quarter of system memory.
     //
     // This is test.execArgv, NOT poolOptions.forks.execArgv: Vitest 4 composes
     // a worker's arguments from the pool defaults, the resolve conditions and
@@ -163,8 +147,13 @@ export default defineConfig({
     // nothing here (verified: the flag never reaches the fork's process.execArgv).
     execArgv: [`--max-old-space-size=${MAX_OLD_SPACE_MB}`],
 
-    // Increase concurrency on CI for faster test execution
-    maxConcurrency: isCI ? 12 : 6,
+    // No current backend tests opt into test.concurrent. Keep future local
+    // concurrency conservative while CI retains its dedicated-runner setting.
+    maxConcurrency: isCI ? 12 : 2,
+
+    // Persist transformed modules between local reruns. CI instead uses its
+    // workflow caches, and avoids the experimental cache path entirely.
+    experimental: { fsModuleCache: !isCI },
 
     // Sequence settings
     sequence: {


### PR DESCRIPTION
## Summary

- generate monotonic UUIDv7 attachment IDs so same-millisecond filename lookups consistently return the later insert
- pin that behavior with a same-timestamp attachment regression test
- separate local and CI Vitest resource sizing: local runs use at most 25% of CPUs, roughly 25% of memory, four forks, and 3 GB per heap; CI retains its throughput-oriented sizing
- enable persistent Vitest module and Node compile caches for faster local reruns

## Evidence

The flaky copy-file assertion returned the first of two rapid same-name attachments because equal created timestamps fell through to random UUIDv4 ordering. A 100-pair reproduction selected the older row 33 times; the deterministic same-timestamp regression now passes.

On an 18-core, 64-GB development machine, the previous config launched nine PGlite-backed forks with 5.3-GB heap ceilings. The new config resolves to four forks with 3-GB ceilings. A representative ten-file benchmark took 25.1s with one worker, 26.2s with two, and 20.4s with four. The focused warm-cache rerun completed in 9.1s and left no worker processes behind.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>