### PR TITLE
fix(frontend): show saved restricted environments in selectors

### DIFF
--- a/platform/frontend/src/components/environment-selector.test.tsx
+++ b/platform/frontend/src/components/environment-selector.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useEnvironments } from "@/lib/environment.query";
 import { useDefaultEnvironment } from "@/lib/organization.query";
@@ -8,6 +9,12 @@ import { EnvironmentSelector } from "./environment-selector";
 vi.mock("@/lib/auth/auth.query");
 vi.mock("@/lib/organization.query");
 vi.mock("@/lib/environment.query", () => ({ useEnvironments: vi.fn() }));
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
 
 function setCanManageEnvironments(canManage: boolean) {
   vi.mocked(useHasPermissions).mockReturnValue({
@@ -49,5 +56,50 @@ describe("EnvironmentSelector — Manage environments link", () => {
     expect(
       screen.getByRole("link", { name: /manage environments/i }),
     ).toHaveAttribute("href", "/settings/environments");
+  });
+});
+
+describe("EnvironmentSelector — saved value", () => {
+  beforeEach(() => {
+    vi.mocked(useDefaultEnvironment).mockReturnValue({
+      name: "Default",
+      description: "",
+    } as unknown as ReturnType<typeof useDefaultEnvironment>);
+  });
+
+  test("keeps a saved restricted environment visible while allowing a move to default", async () => {
+    setCanManageEnvironments(false);
+    const onChange = vi.fn();
+    vi.mocked(useEnvironments).mockReturnValue({
+      data: {
+        environments: [
+          {
+            id: "env-restricted",
+            name: "Restricted Environment",
+            description: "",
+            restricted: true,
+          },
+        ],
+      },
+    } as unknown as ReturnType<typeof useEnvironments>);
+    render(
+      <EnvironmentSelector
+        value="env-restricted"
+        onChange={onChange}
+        resource="agent"
+      />,
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Environment" });
+    expect(trigger).toHaveTextContent("Restricted Environment");
+    expect(trigger).toBeEnabled();
+
+    const user = userEvent.setup();
+    await user.click(trigger);
+    expect(
+      screen.queryByRole("option", { name: "Restricted Environment" }),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: "Default" }));
+    expect(onChange).toHaveBeenCalledWith(null);
   });
 });

--- a/platform/frontend/src/components/environment-selector.tsx
+++ b/platform/frontend/src/components/environment-selector.tsx
@@ -84,8 +84,16 @@ export function EnvironmentSelector({
     (environment) => !environment.restricted || canDeployRestricted,
   );
   const hasCustomEnvironmentOptions = accessibleEnvironments.length > 0;
+  const selectedValue = value ?? DEFAULT_ENVIRONMENT_VALUE;
+  const isDefaultSelected = selectedValue === DEFAULT_ENVIRONMENT_VALUE;
 
-  if (hideWhenOnlyDefault && !hasCustomEnvironmentOptions) return null;
+  if (
+    hideWhenOnlyDefault &&
+    !hasCustomEnvironmentOptions &&
+    isDefaultSelected
+  ) {
+    return null;
+  }
 
   const options = [
     {
@@ -99,10 +107,23 @@ export function EnvironmentSelector({
       description: environment.description ?? "",
     })),
   ];
-  const selectedValue = value ?? DEFAULT_ENVIRONMENT_VALUE;
-  const selectedDescription = options.find(
-    (option) => option.value === selectedValue,
-  )?.description;
+  // A saved restricted environment remains the record's current value even
+  // when this user cannot assign it to another record. Keep it out of the
+  // selectable options, but still name it in the trigger so edit forms never
+  // render a valid persisted environment as a blank field.
+  const selectedEnvironment = environments.find(
+    (environment) => environment.id === selectedValue,
+  );
+  const selectedOption =
+    options.find((option) => option.value === selectedValue) ??
+    (selectedEnvironment
+      ? {
+          value: selectedEnvironment.id,
+          label: selectedEnvironment.name,
+          description: selectedEnvironment.description ?? "",
+        }
+      : undefined);
+  const selectedDescription = selectedOption?.description;
 
   return (
     <div className={cn("grid gap-2", className)}>
@@ -133,7 +154,9 @@ export function EnvironmentSelector({
       )}
       <Select
         value={selectedValue}
-        disabled={disabled || !hasCustomEnvironmentOptions}
+        disabled={
+          disabled || (!hasCustomEnvironmentOptions && isDefaultSelected)
+        }
         onValueChange={(next) =>
           onChange(next === DEFAULT_ENVIRONMENT_VALUE ? null : next)
         }
@@ -143,7 +166,9 @@ export function EnvironmentSelector({
           className="w-full"
           data-testid={E2eTestId.SelectEnvironment}
         >
-          <SelectValue />
+          <SelectValue>
+            {selectedOption ? <span>{selectedOption.label}</span> : null}
+          </SelectValue>
         </SelectTrigger>
         <SelectContent position="popper">
           {options.map((option) => (


### PR DESCRIPTION
## Summary

- Keep a persisted restricted environment visible when an editor cannot deploy new resources to it.
- Keep the restricted environment out of assignable options while allowing the resource to move back to Default.

## Verification

A component regression test opens an editor with a saved restricted environment, verifies its label is populated, confirms it is not offered as an assignable option, and moves the resource to Default.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>