### PR TITLE
fix(ci): skip Claude reviews in private mirrors

### DIFF
--- a/.github/workflows/claude-coreteam-review.yml
+++ b/.github/workflows/claude-coreteam-review.yml
@@ -21,6 +21,7 @@ jobs:
   determine-token:
     name: Determine Token
     if: |
+      github.repository == 'archestra-ai/archestra' &&
       !contains(github.event.pull_request.title, '[WIP]') &&
       !github.event.pull_request.draft
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The core-team Claude review workflow relies on a GitHub App installed on the public repository. Private mirrors do not carry that installation, so otherwise healthy mirrored pull requests receive an unactionable failing review check.

Gate the workflow at its first job to the canonical public repository. Public pull requests retain the existing reviewer behavior; mirrored pull requests skip it cleanly.