### PR TITLE
feat(agent-runtime): expose run id to workloads

### DIFF
--- a/platform/backend/src/models/agent-run.ts
+++ b/platform/backend/src/models/agent-run.ts
@@ -29,7 +29,9 @@ import A2AMessageModel from "./a2a/message";
  * task's state machine is the record of how the work is going.
  */
 class AgentRunModel {
-  static async create(run: InsertAgentRunRecord): Promise<AgentRunRecord> {
+  static async create(
+    run: InsertAgentRunRecord & { id?: AgentRunRecord["id"] },
+  ): Promise<AgentRunRecord> {
     const [created] = await db
       .insert(schema.agentRunsTable)
       .values(run)

--- a/platform/backend/src/services/agent-runtime/launch-spec.test.ts
+++ b/platform/backend/src/services/agent-runtime/launch-spec.test.ts
@@ -41,6 +41,7 @@ describe("buildAgentRunLaunchSpec", () => {
       makeLlmProviderApiKey,
       makeAgent,
     });
+    const runId = crypto.randomUUID();
 
     const { spec, virtualApiKeyId } = await buildAgentRunLaunchSpec({
       runtime: {
@@ -49,9 +50,11 @@ describe("buildAgentRunLaunchSpec", () => {
           { key: "CUSTOM_SETTING", value: "preserved" },
           { key: "OPENAI_BASE_URL", value: "https://bypass.invalid" },
           { key: "ARCHESTRA_MCP_GATEWAY_TOKEN", value: "bypass-token" },
+          { key: "ARCHESTRA_AGENT_RUNTIME_RUN_ID", value: "bypass-run" },
         ],
       },
       taskId: crypto.randomUUID(),
+      runId,
       agentId: setup.agent.id,
       actor: {
         id: setup.user.id,
@@ -72,6 +75,7 @@ describe("buildAgentRunLaunchSpec", () => {
       ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL: "selected-model",
       ARCHESTRA_AGENT_RUNTIME_MODEL_PROVIDER: "gemini",
       ARCHESTRA_AGENT_RUNTIME_MODEL_OUTPUT_LENGTH: "16384",
+      ARCHESTRA_AGENT_RUNTIME_RUN_ID: runId,
       ARCHESTRA_LLM_PROXY_PROTOCOL: "openai_responses",
       ARCHESTRA_LLM_PROXY_URL: `https://platform.example.test/v1/model-router/${setup.agent.id}`,
       OPENAI_BASE_URL: `https://platform.example.test/v1/model-router/${setup.agent.id}`,
@@ -136,6 +140,7 @@ describe("buildAgentRunLaunchSpec", () => {
     const { spec, virtualApiKeyId } = await buildAgentRunLaunchSpec({
       runtime: runtime(agent, "openai_responses"),
       taskId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
       agentId: agent.id,
       actor: {
         id: user.id,
@@ -182,6 +187,7 @@ describe("buildAgentRunLaunchSpec", () => {
     const { spec, virtualApiKeyId } = await buildAgentRunLaunchSpec({
       runtime: runtime(setup.agent, "openai_responses"),
       taskId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
       agentId: setup.agent.id,
       actor: {
         id: "system",
@@ -232,6 +238,7 @@ describe("buildAgentRunLaunchSpec", () => {
     const { spec } = await buildAgentRunLaunchSpec({
       runtime: runtime(setup.agent, "anthropic"),
       taskId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
       agentId: setup.agent.id,
       actor: {
         id: setup.user.id,
@@ -277,6 +284,7 @@ describe("buildAgentRunLaunchSpec", () => {
       buildAgentRunLaunchSpec({
         runtime: runtime(setup.agent, "anthropic"),
         taskId: crypto.randomUUID(),
+        runId: crypto.randomUUID(),
         agentId: setup.agent.id,
         actor: {
           id: setup.user.id,
@@ -315,6 +323,7 @@ describe("buildAgentRunLaunchSpec", () => {
       buildAgentRunLaunchSpec({
         runtime: runtime(setup.agent, "openai_chat"),
         taskId: crypto.randomUUID(),
+        runId: crypto.randomUUID(),
         agentId: setup.agent.id,
         actor: {
           id: setup.user.id,
@@ -370,6 +379,7 @@ describe("buildAgentRunLaunchSpec", () => {
     const { spec } = await buildAgentRunLaunchSpec({
       runtime: configuredRuntime,
       taskId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
       agentId: setup.agent.id,
       actor: {
         id: setup.user.id,
@@ -424,10 +434,12 @@ describe("buildAgentRunLaunchSpec", () => {
       value: "claude-subscription-token",
     });
     const taskId = crypto.randomUUID();
+    const runId = crypto.randomUUID();
 
     const { spec, virtualApiKeyId } = await buildAgentRunLaunchSpec({
       runtime: configuredRuntime,
       taskId,
+      runId,
       agentId: setup.agent.id,
       actor: {
         id: setup.user.id,
@@ -464,6 +476,7 @@ describe("buildAgentRunLaunchSpec", () => {
       "1000000",
     );
     expect(spec.env.ARCHESTRA_AGENT_RUNTIME_MODEL_OUTPUT_LENGTH).toBe("16384");
+    expect(spec.env.ARCHESTRA_AGENT_RUNTIME_RUN_ID).toBe(runId);
 
     const virtualKey = await VirtualApiKeyModel.findById(virtualApiKeyId);
     expect(virtualKey?.keyType).toBe("passthrough");
@@ -495,6 +508,7 @@ describe("buildAgentRunLaunchSpec", () => {
       buildAgentRunLaunchSpec({
         runtime: configuredRuntime,
         taskId: crypto.randomUUID(),
+        runId: crypto.randomUUID(),
         agentId: setup.agent.id,
         actor: {
           id: setup.user.id,
@@ -548,6 +562,7 @@ describe("buildAgentRunLaunchSpec", () => {
     const { virtualApiKeyId } = await buildAgentRunLaunchSpec({
       runtime: configuredRuntime,
       taskId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
       agentId: setup.agent.id,
       actor: {
         id: setup.user.id,
@@ -592,6 +607,7 @@ describe("buildAgentRunLaunchSpec", () => {
       buildAgentRunLaunchSpec({
         runtime: configuredRuntime,
         taskId: crypto.randomUUID(),
+        runId: crypto.randomUUID(),
         agentId: setup.agent.id,
         actor: {
           id: setup.user.id,
@@ -649,6 +665,7 @@ describe("buildAgentRunLaunchSpec", () => {
       buildAgentRunLaunchSpec({
         runtime: configuredRuntime,
         taskId: crypto.randomUUID(),
+        runId: crypto.randomUUID(),
         agentId: setup.agent.id,
         actor: {
           id: setup.user.id,

--- a/platform/backend/src/services/agent-runtime/launch-spec.ts
+++ b/platform/backend/src/services/agent-runtime/launch-spec.ts
@@ -78,6 +78,8 @@ export async function buildAgentRunLaunchSpec(params: {
   runtime: ResolvedAgentRuntime;
   /** The A2A task this run carries; its id names the workload. */
   taskId: string;
+  /** The user-facing Agent run id used by /chat/runs/:id and telemetry. */
+  runId: string;
   /** Agent the task belongs to, for the proxy and gateway routes. */
   agentId: string;
   actor: A2AActor;
@@ -257,6 +259,7 @@ export async function buildAgentRunLaunchSpec(params: {
     ),
     ARCHESTRA_AGENT_RUNTIME_AGENT_ID: params.runtime.agentId,
     ARCHESTRA_AGENT_RUNTIME_AGENT_NAME: agent.name,
+    ARCHESTRA_AGENT_RUNTIME_RUN_ID: params.runId,
     ARCHESTRA_AGENT_RUNTIME_TASK_ID: params.taskId,
     ARCHESTRA_AGENT_RUNTIME_MODEL: runtimeModel,
     // Native CLIs use provider-published model slugs for local metadata and
@@ -392,6 +395,7 @@ const RESERVED_RUNTIME_ENV_KEYS = new Set([
   "ARCHESTRA_AGENT_RUNTIME_MODEL_OUTPUT_LENGTH",
   "ARCHESTRA_AGENT_RUNTIME_MODEL_PROVIDER",
   "ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL",
+  "ARCHESTRA_AGENT_RUNTIME_RUN_ID",
   "ARCHESTRA_AGENT_RUNTIME_STEER_FIFO",
   "ARCHESTRA_AGENT_RUNTIME_TASK_ID",
   "ARCHESTRA_LLM_PROXY_PROTOCOL",

--- a/platform/backend/src/services/agent-runtime/pod-run.ts
+++ b/platform/backend/src/services/agent-runtime/pod-run.ts
@@ -75,10 +75,12 @@ async function startAgentRunSession(params: {
     defaultNetworkPolicy: organization?.defaultNetworkPolicy,
   });
   const inputFiles = await AgentRunInputModel.findByTaskId(params.taskId);
+  const runId = randomUUID();
 
   const { spec, virtualApiKeyId } = await buildAgentRunLaunchSpec({
     runtime: params.runtime,
     taskId: params.taskId,
+    runId,
     agentId: params.agentId,
     actor: params.actor,
     organizationId: params.organizationId,
@@ -94,6 +96,7 @@ async function startAgentRunSession(params: {
   // objects, so a crash between the two must leave a record, not an orphan.
   const placeholderTitle = toPlaceholderTitle(params.task ?? "Run");
   const session = await AgentRunModel.create({
+    id: runId,
     organizationId: params.organizationId,
     taskId: params.taskId,
     agentId: params.runtime.agentId,


### PR DESCRIPTION
## Summary

- generate the user-facing Agent run UUID before constructing the workload launch spec
- inject it as the reserved `ARCHESTRA_AGENT_RUNTIME_RUN_ID` environment variable while preserving the task ID lifecycle contract
- allow the Agent run model to persist that preallocated UUID

This lets runtime tools attach traces and logs to the exact `/chat/runs/:id` session without conflating it with the durable A2A task UUID.

## Validation

- `ARCHESTRA_DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm exec vitest run src/services/agent-runtime/launch-spec.test.ts` (12 passed)
- `pnpm type-check`
- `ARCHESTRA_DATABASE_URL=postgresql://test:test@localhost:5432/test pnpm knip`
- `pnpm exec biome check backend/src/models/agent-run.ts backend/src/services/agent-runtime/launch-spec.ts backend/src/services/agent-runtime/launch-spec.test.ts backend/src/services/agent-runtime/pod-run.ts`

## Documentation

No user-facing documentation change: this is an internal runtime-injected correlation variable, not an operator-configurable setting.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>