### PR TITLE
fix(docker): upgrade packages for fixed container CVEs

### DIFF
--- a/platform/mcp_server_docker_image/Dockerfile
+++ b/platform/mcp_server_docker_image/Dockerfile
@@ -136,7 +136,7 @@ RUN apk add --no-cache \
    # Fixed-version-available curl/libcurl vulnerabilities are resolved in 8.22.0-r0.
    # The explicit `apk add curl` above installs them, so explicit floors below ensure
    # a cached layer cannot retain the older packages.
-   # Fixed-version-available util-linux vulnerabilities are resolved in 2.41.6-r0.
+   # Fixed-version-available util-linux vulnerabilities are resolved in 2.41.6-r1.
    # CVE-2026-11824, CVE-2026-11822: sqlite vulnerabilities (HIGH) fixed in 3.53.4-r0.
    # The pinned python:3.12-alpine base ships sqlite-libs 3.51.2-r0 (a python3
    # runtime dependency), so it must be upgraded explicitly here.
@@ -149,7 +149,7 @@ RUN apk add --no-cache \
    # go-builder stage already uses.
    apk upgrade --no-cache nodejs bind openssl zlib expat sqlite-libs && \
    apk add --no-cache --upgrade "curl>=8.22.0-r0" "libcurl>=8.22.0-r0" \
-       "util-linux>=2.41.6-r0" && \
+       "util-linux>=2.41.6-r1" && \
    # CVE-2026-63076, CVE-2026-63075, CVE-2026-63072, CVE-2026-54874, CVE-2026-18798,
    # CVE-2026-14457, CVE-2026-14456: OpenSSL vulnerabilities (HIGH) fixed in 3.5.8-r0.
    # `openssl` is already in the bare `apk upgrade` list above, but that cannot express a

--- a/platform/p4_shim_docker_image/Dockerfile
+++ b/platform/p4_shim_docker_image/Dockerfile
@@ -14,7 +14,11 @@ ARG NODE_IMAGE=node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489
 FROM ${NODE_IMAGE}
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends tini \
+  && apt-get install -y --no-install-recommends tini libpcre2-8-0 \
+  # CVE-2026-86145: reject a repository snapshot that predates the pcre2 fix.
+  && dpkg --compare-versions \
+    "$(dpkg-query --show --showformat='${Version}' libpcre2-8-0)" \
+    ge 10.42-1+deb12u1 \
   && rm -rf /var/lib/apt/lists/*
 
 # The entrypoint is `node /app/server.mjs`, server.mjs imports nothing outside


### PR DESCRIPTION
## Summary

- require Alpine util-linux 2.41.6-r1 or newer in the MCP server base image to resolve CVE-2026-78408
- explicitly upgrade Debian libpcre2 in the p4 shim and fail the build if it is older than 10.42-1+deb12u1, resolving CVE-2026-86145
- preserve version floors so cached or stale repository state cannot silently reintroduce either vulnerable package

This addresses the fixed-version-available HIGH findings currently blocking the MCP server base and p4 shim image scans in the merge queue.