### PR TITLE
fix(chat): recover default selections after transient fetch failures

### DIFF
--- a/platform/frontend/src/lib/agent.query.test.ts
+++ b/platform/frontend/src/lib/agent.query.test.ts
@@ -158,7 +158,9 @@ describe("chat agent roster", () => {
     sdk.getAllAgents
       .mockResolvedValueOnce({
         data: undefined,
-        error: { error: { message: "boom", type: "api_internal_error" } },
+        error: {
+          error: { message: "boom", type: "api_internal_server_error" },
+        },
       } as never)
       .mockResolvedValueOnce({
         data: [{ id: "agent-1", name: "Agent" }],

--- a/platform/frontend/src/lib/agent.query.test.ts
+++ b/platform/frontend/src/lib/agent.query.test.ts
@@ -150,4 +150,32 @@ describe("chat agent roster", () => {
       },
     });
   });
+
+  // A transient roster failure must self-heal: the app-wide default is
+  // `retry: false`, so without the query's own retry a single blip left the
+  // new-chat composer stranded on "Select agent" with no default (T-1317).
+  it("recovers the roster after a transient fetch failure", async () => {
+    sdk.getAllAgents
+      .mockResolvedValueOnce({
+        data: undefined,
+        error: { error: { message: "boom", type: "api_internal_error" } },
+      } as never)
+      .mockResolvedValueOnce({
+        data: [{ id: "agent-1", name: "Agent" }],
+        error: undefined,
+      } as never);
+
+    // retryDelay: 0 keeps the retry instant; the query's own retry still
+    // overrides the client-wide `retry: false`.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useChatAgents(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: "agent-1", name: "Agent" }]);
+    expect(sdk.getAllAgents).toHaveBeenCalledTimes(2);
+  });
 });

--- a/platform/frontend/src/lib/agent.query.ts
+++ b/platform/frontend/src/lib/agent.query.ts
@@ -14,7 +14,10 @@ import {
 import { toBulkOutcome } from "@/lib/bulk-action";
 import { incomingEmailKeys } from "@/lib/chatops/incoming-email.query";
 import { useAllMatching } from "@/lib/hooks/use-all-matching";
-import { PERSISTED_QUERY_META } from "@/lib/query-persistence";
+import {
+  BOOTSTRAP_QUERY_RETRY,
+  PERSISTED_QUERY_META,
+} from "@/lib/query-persistence";
 import { reportApiError, throwOnApiError } from "@/lib/utils";
 
 const {
@@ -697,6 +700,10 @@ export function useChatAgents(params?: { enabled?: boolean }) {
     queryKey: chatAgentsQueryKey,
     queryFn: fetchChatAgents,
     enabled: params?.enabled,
+    // The new-chat composer resolves its default agent (and, in turn, its
+    // default model) from this roster. Recover from a transient fetch failure
+    // rather than latching an empty roster into "Select agent" (T-1317).
+    retry: BOOTSTRAP_QUERY_RETRY,
     meta: PERSISTED_QUERY_META,
   });
 }

--- a/platform/frontend/src/lib/llm-models.query.test.tsx
+++ b/platform/frontend/src/lib/llm-models.query.test.tsx
@@ -1,6 +1,6 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -94,6 +94,34 @@ describe("useLlmModels", () => {
       queryClient.getQueryCache().find({ queryKey: ["llm-models", null] })
         ?.meta,
     ).toEqual(PERSISTED_QUERY_META);
+  });
+
+  // A transient catalog failure must self-heal: the app-wide default is
+  // `retry: false`, so without the query's own retry a single blip left the
+  // new-chat composer stranded on "Select model" with no default (T-1317).
+  it("recovers the model catalog after a transient fetch failure", async () => {
+    // Real timers + retryDelay: 0 so the retry is instant without the fake
+    // timers the other cases install for the lazy-sync refetch.
+    vi.useRealTimers();
+    vi.mocked(archestraApiSdk.getLlmModels)
+      .mockResolvedValueOnce({
+        data: undefined,
+        error: { error: { message: "boom", type: "api_internal_error" } },
+        request: new Request("http://localhost/api/llm-models/available"),
+        response: new Response(null),
+      } as Awaited<ReturnType<typeof archestraApiSdk.getLlmModels>>)
+      .mockResolvedValueOnce(makeGetLlmModelsResult([makeModel()]));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+    });
+    const { result } = renderHook(() => useLlmModels(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(archestraApiSdk.getLlmModels).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/platform/frontend/src/lib/llm-models.query.test.tsx
+++ b/platform/frontend/src/lib/llm-models.query.test.tsx
@@ -106,10 +106,12 @@ describe("useLlmModels", () => {
     vi.mocked(archestraApiSdk.getLlmModels)
       .mockResolvedValueOnce({
         data: undefined,
-        error: { error: { message: "boom", type: "api_internal_error" } },
+        error: {
+          error: { message: "boom", type: "api_internal_server_error" },
+        },
         request: new Request("http://localhost/api/llm-models/available"),
         response: new Response(null),
-      } as Awaited<ReturnType<typeof archestraApiSdk.getLlmModels>>)
+      } as never)
       .mockResolvedValueOnce(makeGetLlmModelsResult([makeModel()]));
 
     const queryClient = new QueryClient({

--- a/platform/frontend/src/lib/llm-models.query.ts
+++ b/platform/frontend/src/lib/llm-models.query.ts
@@ -15,7 +15,10 @@ import {
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { toBulkOutcome } from "@/lib/bulk-action";
-import { PERSISTED_QUERY_META } from "@/lib/query-persistence";
+import {
+  BOOTSTRAP_QUERY_RETRY,
+  PERSISTED_QUERY_META,
+} from "@/lib/query-persistence";
 import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
@@ -68,6 +71,10 @@ export function useLlmModels(params?: LlmModelsParams) {
     // preventing display name flicker (e.g. "Claude Opus 4.1" → raw ID → back).
     placeholderData: keepPreviousData,
     enabled: params?.enabled,
+    // The new-chat composer resolves its default model from this catalog.
+    // Recover from a transient fetch failure rather than latching an empty
+    // catalog into "Select model" (T-1317).
+    retry: BOOTSTRAP_QUERY_RETRY,
     // The model list is small, contains no credentials, and is required to
     // replace the new-chat composer's loading placeholder with the saved model.
     // Restoring it makes a refresh immediately usable while revalidation runs.

--- a/platform/frontend/src/lib/query-persistence.ts
+++ b/platform/frontend/src/lib/query-persistence.ts
@@ -22,6 +22,18 @@ import {
 export const PERSISTED_QUERY_META = { persist: true } as const;
 
 /**
+ * Bounded retry for the shell/bootstrap queries the new-chat composer cannot
+ * draw without — the agent roster and the model catalog. The app-wide default
+ * is `retry: false`, so without this a single transient fetch failure of either
+ * strands the composer on its "Select agent" / "Select model" placeholders with
+ * no default selected: the new-chat screen stays mounted, so nothing refetches
+ * until the user navigates away and back (T-1317). These are idempotent GETs,
+ * so retrying a transient failure a few times is safe.
+ */
+export const BOOTSTRAP_QUERY_RETRY = (failureCount: number): boolean =>
+  failureCount < 3;
+
+/**
  * Restore the previous snapshot into `client`.
  *
  * Call this once on the client after mount. Queries already in flight keep


### PR DESCRIPTION
## Summary

A transient failure while loading the compact agent roster or model catalog could leave a new chat without usable default selections for the rest of the mounted session. These two idempotent bootstrap queries now use a bounded three-retry policy while the application-wide no-retry default remains unchanged.

## Validation

In Chrome, against separate public-`main` and patched dev servers backed by the same local stack, the first agent-roster and model-catalog XHRs were forced to return 503. Public `main` made no recovery request and the new-chat state remained unresolved. With this change, both requests retried and the live composer resolved its agent and model; neither selector placeholder remained. A same-tab agent-specific chat → existing conversation → New Chat navigation also retained resolved defaults.

The deterministic hook tests reproduce the same one-failure-then-success sequence. The complete frontend test suite, type-check, dead-code analysis, and changed-file lint pass.