### PR TITLE
feat(llm): support Anthropic models through Vertex AI

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -133788,6 +133788,9 @@
                         "anthropicWifEnabled": {
                           "type": "boolean"
                         },
+                        "anthropicKeylessAuthEnabled": {
+                          "type": "boolean"
+                        },
                         "bedrockIamAuthEnabled": {
                           "type": "boolean"
                         },
@@ -133942,6 +133945,7 @@
                         "byosVaultKvVersion",
                         "azureOpenAiEntraIdEnabled",
                         "anthropicWifEnabled",
+                        "anthropicKeylessAuthEnabled",
                         "bedrockIamAuthEnabled",
                         "geminiVertexAiEnabled",
                         "incomingEmail",

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -2,7 +2,7 @@
 title: Deployment
 category: Archestra Platform
 order: 3
-lastUpdated: 2026-09-03
+lastUpdated: 2026-09-06
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -1157,6 +1157,20 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Set `ARCHESTRA_ANTHROPIC_BASE_URL=https://<resource-name>.services.ai.azure.com/anthropic`
   - Uses Azure Identity `DefaultAzureCredential` with token scope `https://ai.azure.com/.default`
   - Claude deployments must already exist in the Azure resource. Microsoft lists additional Claude prerequisites: paid eligible subscription, supported region, Azure Marketplace access for partner models, permission to subscribe to model offerings, and Contributor or Owner role on the resource group. Azure also requires Anthropic deployment metadata: `industry`, `organizationName`, and `countryCode`.
+
+- **`ARCHESTRA_ANTHROPIC_VERTEX_AI_ENABLED`** - Enable Claude through Vertex AI.
+  - Default: `false`
+  - Uses Application Default Credentials when no credentials file is set
+  - Do not enable another keyless Anthropic authentication mode at the same time
+
+- **`ARCHESTRA_ANTHROPIC_VERTEX_AI_PROJECT`** - Google Cloud project ID for Claude on Vertex AI.
+  - Required when: `ARCHESTRA_ANTHROPIC_VERTEX_AI_ENABLED=true`
+
+- **`ARCHESTRA_ANTHROPIC_VERTEX_AI_LOCATION`** - Vertex AI location for Claude requests.
+  - Default: `global`
+
+- **`ARCHESTRA_ANTHROPIC_VERTEX_AI_CREDENTIALS_FILE`** - Path to a Google Cloud service account JSON key file.
+  - Optional when Application Default Credentials are available
 
 - **`ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID`**, **`ARCHESTRA_ANTHROPIC_ORGANIZATION_ID`**, **`ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID`** - Enable keyless Anthropic authentication via [Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation).
   - All three are required, plus one identity token source (below). A partial configuration logs a warning at startup and disables WIF.

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -3,7 +3,7 @@ title: Supported LLM Providers
 category: LLM Proxy
 order: 2
 description: LLM providers supported by Archestra Platform
-lastUpdated: 2026-08-29
+lastUpdated: 2026-09-06
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -133,6 +133,16 @@ Claude Foundry deployments must exist in Azure before requests will work. Use th
 Azure requires Anthropic deployment metadata when creating Claude deployments: `industry`, `organizationName`, and `countryCode`. In Azure CLI this may require an ARM REST deployment call with `properties.modelProviderData`.
 
 See Microsoft's [Claude on Foundry guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-claude) for the Azure endpoint and authentication details.
+
+### Anthropic on Vertex AI
+
+Archestra can use Claude models published through Google Vertex AI. This mode uses Application Default Credentials and requires no Anthropic API key.
+
+Set `ARCHESTRA_ANTHROPIC_VERTEX_AI_ENABLED=true`, then configure the project and location. The default location is `global`. Archestra discovers Claude models from Model Garden and adds them to the Anthropic model picker.
+
+Enable each Claude model in Model Garden before using it. Google may require accepting provider terms during activation.
+
+See the [deployment environment variables](/docs/platform-deployment#environment-variables) for the full configuration.
 
 ### Workload Identity Federation (keyless)
 

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -14,6 +14,11 @@ ARCHESTRA_ANTHROPIC_BASE_URL=https://api.anthropic.com
 # ARCHESTRA_ANTHROPIC_WORKSPACE_ID=wrkspc_...
 # ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic.com/token
 # ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN=
+# Claude through Vertex AI (uses ADC, workload identity, or a credentials file)
+# ARCHESTRA_ANTHROPIC_VERTEX_AI_ENABLED=true
+# ARCHESTRA_ANTHROPIC_VERTEX_AI_PROJECT=my-gcp-project
+# ARCHESTRA_ANTHROPIC_VERTEX_AI_LOCATION=global
+# ARCHESTRA_ANTHROPIC_VERTEX_AI_CREDENTIALS_FILE=/path/to/service-account-key.json
 ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 # Gemini via Vertex AI instead of Google AI Studio (uses ADC, not an API key)
 # ARCHESTRA_GEMINI_VERTEX_AI_ENABLED=true

--- a/platform/backend/src/clients/anthropic-keyless-auth.ts
+++ b/platform/backend/src/clients/anthropic-keyless-auth.ts
@@ -1,0 +1,14 @@
+import { isAzureAiFoundryBaseUrl } from "@/clients/azure-url";
+import config from "@/config";
+import { anthropicVertexClient } from "./anthropic-vertex";
+import { anthropicWorkloadIdentity } from "./anthropic-workload-identity";
+import { isAnthropicAzureFoundryEntraIdEnabled } from "./azure-openai-credentials";
+
+export function isAnthropicKeylessAuthEnabled(): boolean {
+  return (
+    anthropicVertexClient.isEnabled() ||
+    anthropicWorkloadIdentity.isEnabled() ||
+    (isAnthropicAzureFoundryEntraIdEnabled() &&
+      isAzureAiFoundryBaseUrl(config.llm.anthropic.baseUrl))
+  );
+}

--- a/platform/backend/src/clients/anthropic-vertex-request.test.ts
+++ b/platform/backend/src/clients/anthropic-vertex-request.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import { buildAnthropicVertexRequest } from "./anthropic-vertex-request";
+
+describe("buildAnthropicVertexRequest", () => {
+  test("rewrites a Messages request to Vertex rawPredict with Google auth", async () => {
+    const request = await buildAnthropicVertexRequest({
+      input: "https://api.anthropic.com/v1/messages",
+      init: {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer caller-token",
+          "x-api-key": "caller-key",
+          "anthropic-version": "2023-06-01",
+          "anthropic-beta": "prompt-caching-2024-07-31",
+          "x-custom-header": "preserved",
+        },
+        body: JSON.stringify({
+          model: "claude-sonnet-5",
+          max_tokens: 32,
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      },
+      project: "test-project",
+      location: "global",
+      authHeaders: {
+        Authorization: "Bearer google-token",
+        "x-goog-user-project": "test-project",
+      },
+    });
+
+    expect(request.url).toBe(
+      "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/anthropic/models/claude-sonnet-5:rawPredict",
+    );
+    expect(await request.json()).toEqual({
+      anthropic_version: "vertex-2023-10-16",
+      max_tokens: 32,
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    expect(request.headers.get("Authorization")).toBe("Bearer google-token");
+    expect(request.headers.get("x-api-key")).toBeNull();
+    expect(request.headers.get("anthropic-version")).toBeNull();
+    expect(request.headers.get("anthropic-beta")).toBeNull();
+    expect(request.headers.get("x-custom-header")).toBe("preserved");
+    expect(request.headers.get("x-goog-user-project")).toBe("test-project");
+  });
+
+  test("uses streamRawPredict and preserves the stream flag", async () => {
+    const request = await buildAnthropicVertexRequest({
+      input: "https://us-east5-aiplatform.googleapis.com/v1/v1/messages",
+      init: {
+        method: "POST",
+        body: JSON.stringify({
+          model: "claude-sonnet-4-5@20250929",
+          stream: true,
+          anthropic_version: "custom-version",
+          messages: [],
+        }),
+      },
+      project: "test-project",
+      location: "us-east5",
+      authHeaders: { Authorization: "Bearer google-token" },
+    });
+
+    expect(request.url).toBe(
+      "https://us-east5-aiplatform.googleapis.com/v1/projects/test-project/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict",
+    );
+    expect(await request.json()).toEqual({
+      stream: true,
+      anthropic_version: "custom-version",
+      messages: [],
+    });
+  });
+
+  test("rejects model IDs that could escape the publisher-model path", async () => {
+    await expect(
+      buildAnthropicVertexRequest({
+        input: "https://api.anthropic.com/v1/messages",
+        init: {
+          method: "POST",
+          body: JSON.stringify({ model: "../endpoints/other" }),
+        },
+        project: "test-project",
+        location: "global",
+        authHeaders: {},
+      }),
+    ).rejects.toThrow("Invalid Anthropic Vertex AI model ID");
+  });
+});

--- a/platform/backend/src/clients/anthropic-vertex-request.ts
+++ b/platform/backend/src/clients/anthropic-vertex-request.ts
@@ -1,0 +1,90 @@
+const ANTHROPIC_MESSAGES_PATH = "/v1/messages";
+const ANTHROPIC_VERTEX_API_VERSION = "vertex-2023-10-16";
+const ANTHROPIC_VERTEX_MODEL_ID_PATTERN = /^[a-zA-Z0-9._@-]+$/;
+
+export function getAnthropicVertexApiRoot(location: string): string {
+  if (location === "global") {
+    return "https://aiplatform.googleapis.com/v1";
+  }
+  if (location === "us" || location === "eu") {
+    return `https://aiplatform.${location}.rep.googleapis.com/v1`;
+  }
+  return `https://${location}-aiplatform.googleapis.com/v1`;
+}
+
+/**
+ * Convert the Anthropic SDK's canonical Messages request into Vertex AI's
+ * publisher-model request. The server-controlled Google credential always
+ * replaces caller-supplied provider credentials.
+ */
+export async function buildAnthropicVertexRequest(params: {
+  input: RequestInfo | URL;
+  init?: RequestInit;
+  project: string;
+  location: string;
+  authHeaders: HeadersInit;
+}): Promise<Request> {
+  const { input, init, project, location, authHeaders } = params;
+  const request = new Request(input, init);
+  const sourceUrl = new URL(request.url);
+
+  if (
+    request.method.toUpperCase() !== "POST" ||
+    !sourceUrl.pathname.endsWith(ANTHROPIC_MESSAGES_PATH)
+  ) {
+    return request;
+  }
+
+  const body = await parseRequestBody(request);
+  const model = body.model;
+  if (
+    typeof model !== "string" ||
+    !ANTHROPIC_VERTEX_MODEL_ID_PATTERN.test(model)
+  ) {
+    throw new Error("Invalid Anthropic Vertex AI model ID");
+  }
+
+  delete body.model;
+  body.anthropic_version ??= ANTHROPIC_VERTEX_API_VERSION;
+
+  const operation = body.stream === true ? "streamRawPredict" : "rawPredict";
+  const url = new URL(
+    `${getAnthropicVertexApiRoot(location)}/projects/${encodeURIComponent(project)}/locations/${encodeURIComponent(location)}/publishers/anthropic/models/${model}:${operation}`,
+  );
+  const headers = buildVertexHeaders(request.headers, authHeaders);
+
+  return new Request(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: request.signal,
+  });
+}
+
+async function parseRequestBody(
+  request: Request,
+): Promise<Record<string, unknown>> {
+  const body = (await request.json()) as unknown;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("Expected an object body for Anthropic Vertex AI request");
+  }
+  return body as Record<string, unknown>;
+}
+
+function buildVertexHeaders(
+  sourceHeaders: Headers,
+  authHeaders: HeadersInit,
+): Headers {
+  const headers = new Headers(sourceHeaders);
+  headers.delete("authorization");
+  headers.delete("x-api-key");
+  headers.delete("anthropic-version");
+  headers.delete("anthropic-beta");
+  headers.delete("content-length");
+
+  new Headers(authHeaders).forEach((value, name) => {
+    headers.set(name, value);
+  });
+  headers.set("content-type", "application/json");
+  return headers;
+}

--- a/platform/backend/src/clients/anthropic-vertex.ts
+++ b/platform/backend/src/clients/anthropic-vertex.ts
@@ -1,0 +1,101 @@
+import { createVertexAnthropic } from "@ai-sdk/google-vertex/anthropic";
+import { GoogleAuth } from "google-auth-library";
+import config from "@/config";
+import {
+  buildAnthropicVertexRequest,
+  getAnthropicVertexApiRoot,
+} from "./anthropic-vertex-request";
+
+class AnthropicVertexClient {
+  private googleAuth: GoogleAuth | null = null;
+  private googleAuthConfigKey = "";
+
+  isEnabled(): boolean {
+    return config.llm.anthropic.vertexAi.enabled;
+  }
+
+  createModel(params: { modelId: string; fetch?: typeof globalThis.fetch }) {
+    const { project, location, credentialsFile } = this.getConfig();
+    const provider = createVertexAnthropic({
+      project,
+      location,
+      fetch: params.fetch,
+      googleAuthOptions: {
+        projectId: project,
+        ...(credentialsFile && { keyFilename: credentialsFile }),
+      },
+    });
+    return provider(params.modelId);
+  }
+
+  createFetch(
+    delegateFetch: typeof globalThis.fetch = globalThis.fetch,
+  ): typeof globalThis.fetch {
+    return async (input, init) => {
+      const { project, location } = this.getConfig();
+      const request = await buildAnthropicVertexRequest({
+        input,
+        init,
+        project,
+        location,
+        authHeaders: await this.getRequestHeaders(),
+      });
+      return delegateFetch(request);
+    };
+  }
+
+  getApiRoot(): string {
+    return getAnthropicVertexApiRoot(this.getConfig().location);
+  }
+
+  async getRequestHeaders(): Promise<Headers> {
+    const { project } = this.getConfig();
+    const authClient = await this.getGoogleAuth().getClient();
+    const googleHeaders = await authClient.getRequestHeaders();
+    const headers = new Headers();
+    googleHeaders.forEach((value, name) => {
+      headers.set(name, value);
+    });
+    // Local user ADC needs an explicit quota project. Service-account and
+    // workload-identity credentials also accept this header.
+    headers.set("x-goog-user-project", project);
+    return headers;
+  }
+
+  getProject(): string {
+    return this.getConfig().project;
+  }
+
+  private getGoogleAuth(): GoogleAuth {
+    const { project, credentialsFile } = this.getConfig();
+    const configKey = `${project}\u0000${credentialsFile}`;
+    if (this.googleAuth && this.googleAuthConfigKey === configKey) {
+      return this.googleAuth;
+    }
+
+    this.googleAuth = new GoogleAuth({
+      scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+      projectId: project,
+      ...(credentialsFile && { keyFilename: credentialsFile }),
+    });
+    this.googleAuthConfigKey = configKey;
+    return this.googleAuth;
+  }
+
+  private getConfig(): {
+    project: string;
+    location: string;
+    credentialsFile: string;
+  } {
+    const { project, location, credentialsFile } =
+      config.llm.anthropic.vertexAi;
+    if (!project) {
+      throw new Error(
+        "Anthropic Vertex AI is enabled but ARCHESTRA_ANTHROPIC_VERTEX_AI_PROJECT is not set",
+      );
+    }
+    return { project, location, credentialsFile };
+  }
+}
+
+export const anthropicVertexClient = new AnthropicVertexClient();

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -47,7 +47,8 @@ import {
 } from "ai";
 import { createOllama } from "ollama-ai-provider-v2";
 import { isAnthropicNativeEndpoint } from "@/clients/anthropic-endpoint";
-import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
+import { anthropicVertexClient } from "@/clients/anthropic-vertex";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import {
   buildAzureDeploymentBaseUrl,
@@ -401,7 +402,7 @@ export async function createLLMModelForAgent(params: {
   const isApiKeyOptional = isProviderApiKeyOptional({
     provider,
     azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-    anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
+    anthropicKeylessAuthEnabled: isAnthropicKeylessAuthEnabled(),
   });
 
   logger.info(
@@ -607,18 +608,24 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
   // --- Native SDK providers (use their own SDK, call client(modelName)) ---
 
   anthropic: {
-    createModel: ({ apiKey, modelName, baseURL, headers, fetch }) =>
-      createAnthropic({
-        apiKey,
-        baseURL,
-        headers,
-        // Models that think by default return their thinking text only on
-        // request — see createAnthropicThinkingDisplayFetch.
-        fetch: createAnthropicThinkingDisplayFetch(fetch),
-      })(modelName),
+    createModel: ({ apiKey, modelName, baseURL, headers, fetch, direct }) =>
+      direct && anthropicVertexClient.isEnabled()
+        ? anthropicVertexClient.createModel({
+            modelId: modelName,
+            fetch: createAnthropicThinkingDisplayFetch(fetch),
+          })
+        : createAnthropic({
+            apiKey,
+            baseURL,
+            headers,
+            // Models that think by default return their thinking text only on
+            // request — see createAnthropicThinkingDisplayFetch.
+            fetch: createAnthropicThinkingDisplayFetch(fetch),
+          })(modelName),
     defaultBaseUrl: config.llm.anthropic.baseUrl,
-    apiKeyRequiredMessage:
-      "Anthropic API key is required. Please configure ANTHROPIC_API_KEY.",
+    apiKeyRequiredMessage: isAnthropicKeylessAuthEnabled()
+      ? undefined
+      : "Anthropic API key is required. Please configure ANTHROPIC_API_KEY.",
     proxiedPathSuffix: "/v1",
   },
 

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2573,6 +2573,14 @@ const config = {
         identityTokenFile: process.env.ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE,
         identityToken: process.env.ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN,
       }),
+      vertexAi: {
+        enabled: process.env.ARCHESTRA_ANTHROPIC_VERTEX_AI_ENABLED === "true",
+        project: process.env.ARCHESTRA_ANTHROPIC_VERTEX_AI_PROJECT || "",
+        location:
+          process.env.ARCHESTRA_ANTHROPIC_VERTEX_AI_LOCATION || "global",
+        credentialsFile:
+          process.env.ARCHESTRA_ANTHROPIC_VERTEX_AI_CREDENTIALS_FILE || "",
+      },
     },
     gemini: {
       baseUrl:

--- a/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
@@ -76,6 +76,7 @@ const mockGetAzureOpenAiBearerTokenProvider = vi.hoisted(() => vi.fn());
 
 vi.mock("@/clients/azure-openai-credentials", () => ({
   getAzureOpenAiBearerTokenProvider: mockGetAzureOpenAiBearerTokenProvider,
+  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
   isAzureOpenAiEntraIdEnabled: mockIsAzureOpenAiEntraIdEnabled,
 }));
 

--- a/platform/backend/src/models/llm-provider-api-key.ts
+++ b/platform/backend/src/models/llm-provider-api-key.ts
@@ -10,7 +10,7 @@ import {
   subscriptionKindFromCredential,
 } from "@archestra/shared";
 import { and, asc, desc, eq, ilike, inArray, ne, or, sql } from "drizzle-orm";
-import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import config from "@/config";
 import db, { schema, type Transaction } from "@/database";
@@ -1255,7 +1255,7 @@ function canUseProviderApiKey(
 function getConfiguredProvidersWithOptionalApiKey(): SupportedProvider[] {
   const providers = getProvidersWithOptionalApiKey({
     azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-    anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
+    anthropicKeylessAuthEnabled: isAnthropicKeylessAuthEnabled(),
   });
   if (config.llm.gemini.vertexAi.enabled) {
     providers.push("gemini");

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { anthropicVertexClient } from "@/clients/anthropic-vertex";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import config, { type AnthropicWifConfig } from "@/config";
 import { ApiError } from "@/types";
-import { fetchAnthropicModels } from "./anthropic";
+import {
+  fetchAnthropicModels,
+  fetchAnthropicModelsViaVertexAi,
+} from "./anthropic";
 
 // No module mocks: drive the real WIF client + fetcher through the fetch
 // boundary and real config, keeping this file in the fast vitest project.
@@ -68,6 +72,7 @@ describe("fetchAnthropicModels", () => {
   beforeEach(() => {
     anthropicWorkloadIdentity.resetForTests();
     config.llm.anthropic.wif = null;
+    config.llm.anthropic.vertexAi.enabled = false;
     vi.stubEnv("ANTHROPIC_API_KEY", "");
     vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "");
   });
@@ -156,5 +161,83 @@ describe("fetchAnthropicModels", () => {
 
     expect(error).toBeInstanceOf(ApiError);
     expect(error.statusCode).toBe(502);
+  });
+
+  test("discovers versioned and alias Claude models from Vertex AI", async () => {
+    config.llm.anthropic.vertexAi.enabled = true;
+    config.llm.anthropic.vertexAi.project = "test-project";
+    vi.spyOn(anthropicVertexClient, "getRequestHeaders").mockResolvedValue(
+      new Headers({ Authorization: "Bearer google-token" }),
+    );
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (!url.searchParams.has("pageToken")) {
+        return new Response(
+          JSON.stringify({
+            publisherModels: [
+              {
+                name: "publishers/anthropic/models/claude-opus-4-1",
+                versionId: "20250805",
+              },
+              {
+                name: "publishers/other/models/not-claude",
+                versionId: "default",
+              },
+            ],
+            nextPageToken: "next-page",
+          }),
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          publisherModels: [
+            {
+              name: "publishers/anthropic/models/claude-sonnet-5",
+              versionId: "default",
+            },
+          ],
+        }),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchAnthropicModelsViaVertexAi()).resolves.toEqual([
+      {
+        id: "claude-opus-4-1@20250805",
+        displayName: "Claude Opus 4.1",
+        provider: "anthropic",
+      },
+      {
+        id: "claude-sonnet-5",
+        displayName: "Claude Sonnet 5",
+        provider: "anthropic",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("routes keyless Anthropic model discovery through Vertex AI", async () => {
+    config.llm.anthropic.vertexAi.enabled = true;
+    config.llm.anthropic.vertexAi.project = "test-project";
+    vi.spyOn(anthropicVertexClient, "getRequestHeaders").mockResolvedValue(
+      new Headers({ Authorization: "Bearer google-token" }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          publisherModels: [
+            {
+              name: "publishers/anthropic/models/claude-sonnet-5",
+              versionId: "default",
+            },
+          ],
+        }),
+      ),
+    );
+
+    await expect(fetchAnthropicModels("", null)).resolves.toMatchObject([
+      { id: "claude-sonnet-5", provider: "anthropic" },
+    ]);
   });
 });

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -1,3 +1,4 @@
+import { anthropicVertexClient } from "@/clients/anthropic-vertex";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import {
   getAzureAiFoundryBearerTokenProvider,
@@ -14,6 +15,10 @@ export async function fetchAnthropicModels(
   baseUrlOverride?: string | null,
   extraHeaders?: Record<string, string> | null,
 ): Promise<ModelInfo[]> {
+  if (!apiKey && anthropicVertexClient.isEnabled()) {
+    return fetchAnthropicModelsViaVertexAi();
+  }
+
   const baseUrl = baseUrlOverride || config.llm.anthropic.baseUrl;
   const url = joinBaseUrl(baseUrl, "/v1/models?limit=100");
 
@@ -50,6 +55,43 @@ export async function fetchAnthropicModels(
   }));
 }
 
+export async function fetchAnthropicModelsViaVertexAi(): Promise<ModelInfo[]> {
+  const models: ModelInfo[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const url = new URL(
+      "https://aiplatform.googleapis.com/v1beta1/publishers/anthropic/models",
+    );
+    url.searchParams.set("pageSize", "100");
+    if (pageToken) {
+      url.searchParams.set("pageToken", pageToken);
+    }
+
+    const response = await fetch(url, {
+      headers: await anthropicVertexClient.getRequestHeaders(),
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.error(
+        { status: response.status, error: errorText },
+        "Failed to fetch Anthropic Vertex AI models",
+      );
+      throw modelFetchError("Anthropic Vertex AI models", response.status);
+    }
+
+    const data = (await response.json()) as VertexPublisherModelsResponse;
+    models.push(
+      ...(data.publisherModels ?? [])
+        .map(toAnthropicVertexModelInfo)
+        .filter((model): model is ModelInfo => model !== null),
+    );
+    pageToken = data.nextPageToken || undefined;
+  } while (pageToken);
+
+  return models;
+}
+
 /**
  * Build the auth headers for a direct Anthropic HTTP call: `x-api-key` for a
  * real key, else the Azure-Foundry-Entra or Workload-Identity bearer when those
@@ -74,4 +116,41 @@ export async function getAnthropicAuthHeaders(
   }
 
   return { "x-api-key": "" };
+}
+
+interface VertexPublisherModelsResponse {
+  publisherModels?: Array<{
+    name?: string;
+    versionId?: string;
+  }>;
+  nextPageToken?: string;
+}
+
+function toAnthropicVertexModelInfo(
+  model: NonNullable<VertexPublisherModelsResponse["publisherModels"]>[number],
+): ModelInfo | null {
+  const modelId = model.name?.replace("publishers/anthropic/models/", "");
+  if (!modelId?.startsWith("claude-")) {
+    return null;
+  }
+
+  const versionId = model.versionId?.trim();
+  const versionedModelId =
+    versionId && versionId !== "default" && !modelId.includes("@")
+      ? `${modelId}@${versionId}`
+      : modelId;
+
+  return {
+    id: versionedModelId,
+    displayName: formatAnthropicVertexModelName(modelId),
+    provider: "anthropic",
+  };
+}
+
+function formatAnthropicVertexModelName(modelId: string): string {
+  return modelId
+    .replace(/-(\d+)-(\d+)(?=-|$)/g, "-$1.$2")
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -6,6 +6,7 @@ import {
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { getEmailProviderInfo } from "@/agents/incoming-email";
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
@@ -130,6 +131,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
               byosVaultKvVersion: z.enum(["1", "2"]).nullable(),
               azureOpenAiEntraIdEnabled: z.boolean(),
               anthropicWifEnabled: z.boolean(),
+              anthropicKeylessAuthEnabled: z.boolean(),
               bedrockIamAuthEnabled: z.boolean(),
               geminiVertexAiEnabled: z.boolean(),
               incomingEmail: z.object({
@@ -269,6 +271,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           byosVaultKvVersion: getByosVaultKvVersion(),
           azureOpenAiEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
           anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
+          anthropicKeylessAuthEnabled: isAnthropicKeylessAuthEnabled(),
           bedrockIamAuthEnabled: isBedrockIamAuthEnabled(),
           geminiVertexAiEnabled: isVertexAiEnabled(),
           incomingEmail: getEmailProviderInfo(),

--- a/platform/backend/src/routes/llm-provider-api-keys.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.ts
@@ -19,7 +19,7 @@ import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { hasPermission, userHasPermission } from "@/auth";
-import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import {
   type BedrockSigV4Credentials,
@@ -465,7 +465,7 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 isProviderApiKeyOptional({
                   provider: data.provider,
                   azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-                  anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
+                  anthropicKeylessAuthEnabled: isAnthropicKeylessAuthEnabled(),
                 }) || data.apiKey
               );
             },
@@ -636,10 +636,10 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
       } else if (
         body.provider === "anthropic" &&
         !actualApiKeyValue &&
-        anthropicWorkloadIdentity.isEnabled()
+        isAnthropicKeylessAuthEnabled()
       ) {
-        // Keyless Anthropic key backed by Workload Identity Federation —
-        // exercises the token exchange and model listing end to end.
+        // Exercise the configured keyless credential and model listing end to
+        // end, whether it comes from Vertex AI, WIF, or Azure Foundry.
         await testApiKeyOrThrow({
           organizationId,
           provider: body.provider,
@@ -671,7 +671,7 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         !isProviderApiKeyOptional({
           provider: body.provider,
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
+          anthropicKeylessAuthEnabled: isAnthropicKeylessAuthEnabled(),
         })
       ) {
         throw new ApiError(
@@ -725,7 +725,7 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         isProviderApiKeyOptional({
           provider: body.provider,
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
+          anthropicKeylessAuthEnabled: isAnthropicKeylessAuthEnabled(),
         });
       if (canSync) {
         try {
@@ -1128,9 +1128,9 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
           );
         } else if (
           apiKeyFromDB.provider === "anthropic" &&
-          anthropicWorkloadIdentity.isEnabled()
+          isAnthropicKeylessAuthEnabled()
         ) {
-          // Keyless Anthropic WIF key — re-test with the updated runtime settings.
+          // Re-test the configured keyless Anthropic runtime settings.
           await testApiKeyOrThrow({
             organizationId,
             provider: apiKeyFromDB.provider,

--- a/platform/backend/src/routes/llm-provider-models.ts
+++ b/platform/backend/src/routes/llm-provider-models.ts
@@ -15,7 +15,7 @@ import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { userHasPermission } from "@/auth";
 import { LRUCacheManager } from "@/cache-manager";
-import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
@@ -751,7 +751,7 @@ async function syncVisibleApiKeyModels(params: {
     !isProviderApiKeyOptional({
       provider: apiKey.provider,
       azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-      anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
+      anthropicKeylessAuthEnabled: isAnthropicKeylessAuthEnabled(),
     })
   ) {
     if (apiKey.secretId) {

--- a/platform/backend/src/routes/proxy/adapters/anthropic-vertex.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-vertex.test.ts
@@ -1,0 +1,74 @@
+import type AnthropicProvider from "@anthropic-ai/sdk";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { anthropicVertexClient } from "@/clients/anthropic-vertex";
+import config from "@/config";
+import { anthropicAdapterFactory } from "./anthropic";
+
+describe("anthropicAdapterFactory Vertex AI", () => {
+  const originalVertexAiConfig = { ...config.llm.anthropic.vertexAi };
+
+  beforeEach(() => {
+    config.llm.anthropic.vertexAi.enabled = true;
+    config.llm.anthropic.vertexAi.project = "test-project";
+    config.llm.anthropic.vertexAi.location = "global";
+  });
+
+  afterEach(() => {
+    Object.assign(config.llm.anthropic.vertexAi, originalVertexAiConfig);
+    vi.restoreAllMocks();
+  });
+
+  test("uses server Google auth and sends the Vertex publisher-model shape", async () => {
+    vi.spyOn(anthropicVertexClient, "getRequestHeaders").mockResolvedValue(
+      new Headers({
+        Authorization: "Bearer google-token",
+        "x-goog-user-project": "test-project",
+      }),
+    );
+    const upstreamFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}"));
+
+    const client = anthropicAdapterFactory.createClient("caller-key", {
+      defaultHeaders: {},
+      source: "api",
+    }) as AnthropicProvider & {
+      _options?: {
+        defaultHeaders?: Record<string, string>;
+        fetch?: typeof globalThis.fetch;
+      };
+    };
+
+    expect(client._options?.defaultHeaders?.Authorization).toBe(
+      "Bearer <vertex-ai-managed>",
+    );
+
+    await client._options?.fetch?.(
+      "https://aiplatform.googleapis.com/v1/v1/messages",
+      {
+        method: "POST",
+        headers: {
+          "x-api-key": "caller-key",
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: "claude-sonnet-5",
+          max_tokens: 16,
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      },
+    );
+
+    const request = upstreamFetch.mock.calls[0]?.[0] as Request;
+    expect(request.url).toBe(
+      "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/anthropic/models/claude-sonnet-5:rawPredict",
+    );
+    expect(request.headers.get("Authorization")).toBe("Bearer google-token");
+    expect(request.headers.get("x-api-key")).toBeNull();
+    expect(await request.json()).toEqual({
+      anthropic_version: "vertex-2023-10-16",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "Hello" }],
+    });
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -6,6 +6,7 @@ import {
 } from "@archestra/shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
+import { anthropicVertexClient } from "@/clients/anthropic-vertex";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import {
   getAzureAiFoundryBearerTokenProvider,
@@ -1493,6 +1494,23 @@ export const anthropicAdapterFactory: LLMProvider<
     const isAuthToken = apiKey?.startsWith("Bearer:") ?? false;
     const token = isAuthToken && apiKey ? apiKey.slice(7) : undefined;
     const regularApiKey = isAuthToken ? undefined : apiKey;
+
+    if (anthropicVertexClient.isEnabled()) {
+      return new AnthropicProvider({
+        maxRetries: PROXY_SDK_MAX_RETRIES,
+        apiKey: null,
+        authToken: null,
+        baseURL: anthropicVertexClient.getApiRoot(),
+        fetch: anthropicVertexClient.createFetch(customFetch),
+        timeout: ANTHROPIC_CLIENT_TIMEOUT_MS,
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          // The fetch wrapper replaces this sentinel with a fresh Google OAuth
+          // token and removes Anthropic-only authentication headers.
+          Authorization: "Bearer <vertex-ai-managed>",
+        },
+      });
+    }
 
     if (!apiKey && isAnthropicAzureFoundryEntraIdEnabled()) {
       return new AnthropicProvider({

--- a/platform/backend/src/routes/proxy/adapters/azure.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/observability");
 
 vi.mock("@/clients/azure-openai-credentials", () => ({
   getAzureOpenAiBearerTokenProvider: vi.fn(() => async () => "entra-token"),
+  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
   isAzureOpenAiEntraIdEnabled: vi.fn(() => false),
 }));
 

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -31,7 +31,8 @@ import {
 } from "@opentelemetry/api";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
-import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
+import { anthropicVertexClient } from "@/clients/anthropic-vertex";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
 import { modelsDevClient } from "@/clients/models-dev-client";
@@ -2499,12 +2500,16 @@ function createDownstreamAbortSignal(params: {
  * caller-supplied Authorization value is not a credential and cannot stand in
  * for authentication.
  *
- * Azure (Entra ID) and Anthropic (workload identity) are deliberately absent:
- * both fall back to server credentials only when no caller key is present, so a
- * key supplied there is a genuine provider secret that the upstream validates.
+ * Azure (Entra ID) and Anthropic workload identity are deliberately absent:
+ * both fall back to server credentials only when no caller key is present. In
+ * Anthropic Vertex AI mode, the configured Google credential always replaces
+ * caller credentials, matching Gemini's Vertex behavior.
  */
 function providerSuppliesServerCredential(providerName: string): boolean {
-  return providerName === "gemini" && isVertexAiEnabled();
+  return (
+    (providerName === "gemini" && isVertexAiEnabled()) ||
+    (providerName === "anthropic" && anthropicVertexClient.isEnabled())
+  );
 }
 
 function shouldUseKeylessProviderApiKey(params: {
@@ -2535,7 +2540,7 @@ function shouldUseKeylessProviderApiKey(params: {
   return isProviderApiKeyOptional({
     provider: row.provider,
     azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-    anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
+    anthropicKeylessAuthEnabled: isAnthropicKeylessAuthEnabled(),
   });
 }
 

--- a/platform/backend/src/routes/proxy/routes/anthropic.ts
+++ b/platform/backend/src/routes/proxy/routes/anthropic.ts
@@ -3,6 +3,7 @@ import fastifyHttpProxy from "@fastify/http-proxy";
 import type { FastifyRequest } from "fastify";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
 import config from "@/config";
 import logger from "@/logging";
 import { fetchAnthropicModels } from "@/routes/chat/model-fetchers/anthropic";
@@ -148,6 +149,7 @@ const anthropicProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
       request,
       provider: "anthropic",
       token: extractAnthropicToken(request.headers),
+      allowKeyless: isAnthropicKeylessAuthEnabled(),
     });
     logger.debug({ agentId }, "[UnifiedProxy] Listing Anthropic models");
     return toAnthropicModelsList(

--- a/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-model-listing.ts
@@ -64,8 +64,9 @@ export async function resolveProxyModelsApiKey(params: {
   request: Pick<FastifyRequest, "ip">;
   provider: SupportedProvider;
   token: string | undefined;
+  allowKeyless?: boolean;
 }): Promise<ResolvedProxyModelsKey> {
-  const { request, provider, token } = params;
+  const { request, provider, token, allowKeyless = false } = params;
 
   if (!token) {
     throw new ApiError(
@@ -88,11 +89,11 @@ export async function resolveProxyModelsApiKey(params: {
       expectedProvider: provider,
       expectedOrganizationId: null,
     });
-    if (!resolved.apiKey) {
+    if (!resolved.apiKey && !allowKeyless) {
       throw new ApiError(401, `Could not resolve an API key for ${provider}.`);
     }
     assertSubscriptionCredentialForProvider({
-      apiKey: resolved.apiKey,
+      apiKey: resolved.apiKey ?? "",
       provider,
     });
     await virtualKeyRateLimiter.recordSuccess({ credential: token });
@@ -106,7 +107,7 @@ export async function resolveProxyModelsApiKey(params: {
     // baseUrl), and a custom inference gateway may not serve `/models`. Fall
     // back to the provider default (undefined) when no base is configured.
     return {
-      apiKey: resolved.apiKey,
+      apiKey: resolved.apiKey ?? "",
       baseUrl: providerKey?.baseUrl ?? undefined,
       extraHeaders: providerKey?.extraHeaders ?? null,
     };

--- a/platform/backend/src/services/system-key-manager.test.ts
+++ b/platform/backend/src/services/system-key-manager.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, vi } from "vitest";
+
+vi.mock("@/clients/anthropic-keyless-auth", () => ({
+  isAnthropicKeylessAuthEnabled: vi.fn(),
+}));
+vi.mock("@/clients/anthropic-vertex", () => ({
+  anthropicVertexClient: { isEnabled: vi.fn() },
+}));
+vi.mock("@/clients/anthropic-workload-identity", () => ({
+  anthropicWorkloadIdentity: { isEnabled: vi.fn() },
+}));
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  isAzureOpenAiEntraIdEnabled: vi.fn(),
+}));
+vi.mock("@/clients/bedrock-credentials", () => ({
+  isBedrockIamAuthEnabled: vi.fn(),
+}));
+vi.mock("@/clients/gemini-client", () => ({
+  isVertexAiEnabled: vi.fn(),
+}));
+vi.mock("@/routes/chat/model-fetchers/anthropic", () => ({
+  fetchAnthropicModels: vi.fn(),
+  fetchAnthropicModelsViaVertexAi: vi.fn(),
+}));
+vi.mock("@/routes/chat/model-fetchers/azure", () => ({
+  fetchAzureModels: vi.fn(),
+}));
+vi.mock("@/routes/chat/model-fetchers/bedrock", () => ({
+  fetchBedrockModels: vi.fn(),
+  fetchBedrockModelsViaIam: vi.fn(),
+}));
+vi.mock("@/routes/chat/model-fetchers/gemini", () => ({
+  fetchGeminiModels: vi.fn(),
+  fetchGeminiModelsViaVertexAi: vi.fn(),
+}));
+
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
+import { anthropicVertexClient } from "@/clients/anthropic-vertex";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
+import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
+import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
+import { isVertexAiEnabled } from "@/clients/gemini-client";
+import { LlmProviderApiKeyModel } from "@/models";
+import {
+  fetchAnthropicModels,
+  fetchAnthropicModelsViaVertexAi,
+} from "@/routes/chat/model-fetchers/anthropic";
+import { fetchAzureModels } from "@/routes/chat/model-fetchers/azure";
+import { fetchBedrockModelsViaIam } from "@/routes/chat/model-fetchers/bedrock";
+import { fetchGeminiModelsViaVertexAi } from "@/routes/chat/model-fetchers/gemini";
+import { systemKeyManager } from "@/services/system-key-manager";
+import { describe, expect, test } from "@/test";
+
+describe("systemKeyManager", () => {
+  beforeEach(() => {
+    vi.mocked(isVertexAiEnabled).mockReturnValue(true);
+    vi.mocked(isAnthropicKeylessAuthEnabled).mockReturnValue(true);
+    vi.mocked(anthropicVertexClient.isEnabled).mockReturnValue(true);
+    vi.mocked(anthropicWorkloadIdentity.isEnabled).mockReturnValue(false);
+    vi.mocked(isAzureOpenAiEntraIdEnabled).mockReturnValue(false);
+    vi.mocked(isBedrockIamAuthEnabled).mockReturnValue(false);
+    vi.mocked(fetchGeminiModelsViaVertexAi).mockResolvedValue([]);
+    vi.mocked(fetchAnthropicModelsViaVertexAi).mockResolvedValue([]);
+    vi.mocked(fetchAnthropicModels).mockResolvedValue([]);
+    vi.mocked(fetchAzureModels).mockResolvedValue([]);
+    vi.mocked(fetchBedrockModelsViaIam).mockResolvedValue([]);
+  });
+
+  test("renames existing Vertex system keys to identify their model provider", async ({
+    makeOrganization,
+  }) => {
+    const organization = await makeOrganization();
+    const geminiKey = await LlmProviderApiKeyModel.createSystemKey({
+      organizationId: organization.id,
+      name: "Vertex AI",
+      provider: "gemini",
+    });
+    const anthropicKey = await LlmProviderApiKeyModel.createSystemKey({
+      organizationId: organization.id,
+      name: "Anthropic Vertex AI",
+      provider: "anthropic",
+    });
+
+    await systemKeyManager.syncSystemKeys(organization.id);
+
+    await expect(
+      LlmProviderApiKeyModel.findSystemKey("gemini"),
+    ).resolves.toMatchObject({
+      id: geminiKey.id,
+      name: "Vertex AI (Gemini)",
+    });
+    await expect(
+      LlmProviderApiKeyModel.findSystemKey("anthropic"),
+    ).resolves.toMatchObject({
+      id: anthropicKey.id,
+      name: "Vertex AI (Anthropic)",
+    });
+  });
+});

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -1,10 +1,8 @@
 import type { SupportedProvider } from "@archestra/shared";
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
+import { anthropicVertexClient } from "@/clients/anthropic-vertex";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
-import {
-  isAnthropicAzureFoundryEntraIdEnabled,
-  isAzureOpenAiEntraIdEnabled,
-} from "@/clients/azure-openai-credentials";
-import { isAzureAiFoundryBaseUrl } from "@/clients/azure-url";
+import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
 import { modelsDevClient } from "@/clients/models-dev-client";
@@ -15,7 +13,10 @@ import {
   LlmProviderApiKeyModelLinkModel,
   ModelModel,
 } from "@/models";
-import { fetchAnthropicModels } from "@/routes/chat/model-fetchers/anthropic";
+import {
+  fetchAnthropicModels,
+  fetchAnthropicModelsViaVertexAi,
+} from "@/routes/chat/model-fetchers/anthropic";
 import { fetchAzureModels } from "@/routes/chat/model-fetchers/azure";
 import { fetchBedrockModelsViaIam } from "@/routes/chat/model-fetchers/bedrock";
 import { fetchGeminiModelsViaVertexAi } from "@/routes/chat/model-fetchers/gemini";
@@ -82,26 +83,24 @@ class SystemKeyManager {
       },
     },
     {
-      // One entry covers both keyless Anthropic auth methods (Azure Foundry
-      // Entra ID and Workload Identity Federation): system keys are looked up
-      // per provider, so two "anthropic" entries would delete each other's key.
+      // One entry covers every keyless Anthropic auth method: system keys are
+      // looked up per provider, so separate entries would delete each other.
       provider: "anthropic",
       // Lazy so the created key's name reflects whichever method is actually
       // active at sync time, not the value captured at class construction.
       get name() {
+        if (anthropicVertexClient.isEnabled()) {
+          return "Anthropic Vertex AI";
+        }
         return anthropicWorkloadIdentity.isEnabled()
           ? "Anthropic Workload Identity Federation"
           : "Anthropic Azure Foundry Entra ID";
       },
-      isEnabled: () =>
-        (isAnthropicAzureFoundryEntraIdEnabled() &&
-          isAzureAiFoundryBaseUrl(config.llm.anthropic.baseUrl)) ||
-        anthropicWorkloadIdentity.isEnabled(),
+      isEnabled: () => isAnthropicKeylessAuthEnabled(),
       customFetch: async () => {
-        const models = await fetchAnthropicModels(
-          "",
-          config.llm.anthropic.baseUrl,
-        );
+        const models = anthropicVertexClient.isEnabled()
+          ? await fetchAnthropicModelsViaVertexAi()
+          : await fetchAnthropicModels("", config.llm.anthropic.baseUrl);
         return models.map((m) => ({ id: m.id, displayName: m.displayName }));
       },
     },

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -65,7 +65,7 @@ class SystemKeyManager {
   private readonly keylessProviders: KeylessProviderConfig[] = [
     {
       provider: "gemini",
-      name: "Vertex AI",
+      name: "Vertex AI (Gemini)",
       isEnabled: () => isVertexAiEnabled(),
       customFetch: async () => {
         const models = await fetchGeminiModelsViaVertexAi();
@@ -90,7 +90,7 @@ class SystemKeyManager {
       // active at sync time, not the value captured at class construction.
       get name() {
         if (anthropicVertexClient.isEnabled()) {
-          return "Anthropic Vertex AI";
+          return "Vertex AI (Anthropic)";
         }
         return anthropicWorkloadIdentity.isEnabled()
           ? "Anthropic Workload Identity Federation"
@@ -163,7 +163,13 @@ class SystemKeyManager {
 
     if (enabled) {
       if (existingKey) {
-        // Key exists, sync models
+        // Keep auto-managed labels current when naming becomes more specific or
+        // when an Anthropic deployment changes its keyless auth method.
+        if (existingKey.name !== name) {
+          await LlmProviderApiKeyModel.update(existingKey.id, { name });
+        }
+
+        // Sync models after reconciling the system-managed metadata.
         logger.debug(
           { provider, apiKeyId: existingKey.id },
           "System key exists, syncing models",

--- a/platform/backend/src/utils/llm-api-key-resolution.ts
+++ b/platform/backend/src/utils/llm-api-key-resolution.ts
@@ -9,7 +9,7 @@ import {
   type SupportedProvider,
   subscriptionKindFromCredential,
 } from "@archestra/shared";
-import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
+import { isAnthropicKeylessAuthEnabled } from "@/clients/anthropic-keyless-auth";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import config, { getProviderEnvApiKey } from "@/config";
 import logger from "@/logging";
@@ -182,7 +182,7 @@ export async function resolveProviderApiKey(params: {
       isProviderApiKeyOptional({
         provider,
         azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
-        anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
+        anthropicKeylessAuthEnabled: isAnthropicKeylessAuthEnabled(),
       }) ||
       (provider === "gemini" && config.llm.gemini.vertexAi.enabled) ||
       (provider === "bedrock" && config.llm.bedrock.iamAuthEnabled)

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -166,7 +166,7 @@ export default function ApiKeysPage() {
   const bulkDeleteMutation = useBulkDeleteLlmProviderApiKeys();
   const byosEnabled = useFeature("byosEnabled");
   const azureOpenAiEntraIdEnabled = useFeature("azureOpenAiEntraIdEnabled");
-  const anthropicWifEnabled = useFeature("anthropicWifEnabled");
+  const anthropicKeylessAuthEnabled = useFeature("anthropicKeylessAuthEnabled");
 
   // Dialog states
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -621,7 +621,7 @@ export default function ApiKeysPage() {
             isProviderApiKeyOptional({
               provider: row.original.provider,
               azureEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
-              anthropicWifEnabled: anthropicWifEnabled === true,
+              anthropicKeylessAuthEnabled: anthropicKeylessAuthEnabled === true,
             }) ? (
               <>
                 <CheckCircle2 className="h-4 w-4 text-green-500" />
@@ -688,7 +688,7 @@ export default function ApiKeysPage() {
       openDeleteDialog,
       getKeyUsage,
       azureOpenAiEntraIdEnabled,
-      anthropicWifEnabled,
+      anthropicKeylessAuthEnabled,
       currentUserId,
       providerCatalog,
     ],

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -168,7 +168,7 @@ function AddApiKeyDialog({
   const createMutation = useCreateLlmProviderApiKey();
   const byosEnabled = useFeature("byosEnabled");
   const azureOpenAiEntraIdEnabled = useFeature("azureOpenAiEntraIdEnabled");
-  const anthropicWifEnabled = useFeature("anthropicWifEnabled");
+  const anthropicKeylessAuthEnabled = useFeature("anthropicKeylessAuthEnabled");
   const bedrockIamAuthEnabled = useFeature("bedrockIamAuthEnabled");
   const geminiVertexAiEnabled = useFeature("geminiVertexAiEnabled");
 
@@ -196,7 +196,7 @@ function AddApiKeyDialog({
       : isProviderApiKeyOptional({
           provider: formValues.provider,
           azureEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
-          anthropicWifEnabled: anthropicWifEnabled === true,
+          anthropicKeylessAuthEnabled: anthropicKeylessAuthEnabled === true,
         }) || formValues.apiKey);
 
   const handleCreate = form.handleSubmit(async (values) => {

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
@@ -73,7 +73,7 @@ export function CreateLlmProviderApiKeyDialog({
   const { data: existingKeys = [] } = useLlmProviderApiKeys({ enabled: open });
   const byosEnabled = useFeature("byosEnabled");
   const azureOpenAiEntraIdEnabled = useFeature("azureOpenAiEntraIdEnabled");
-  const anthropicWifEnabled = useFeature("anthropicWifEnabled");
+  const anthropicKeylessAuthEnabled = useFeature("anthropicKeylessAuthEnabled");
   const bedrockIamAuthEnabled = useFeature("bedrockIamAuthEnabled");
   const geminiVertexAiEnabled = useFeature("geminiVertexAiEnabled");
   const { data: canCreateOrgScopedKey } = useHasPermissions({
@@ -106,7 +106,7 @@ export function CreateLlmProviderApiKeyDialog({
   const formValues = form.watch();
   const isValid = getIsCreateFormValid({
     azureOpenAiEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
-    anthropicWifEnabled: anthropicWifEnabled === true,
+    anthropicKeylessAuthEnabled: anthropicKeylessAuthEnabled === true,
     byosEnabled: Boolean(byosEnabled),
     values: formValues,
   });
@@ -281,13 +281,13 @@ function getDefaultFormValues(params: {
 
 function getIsCreateFormValid(params: {
   azureOpenAiEntraIdEnabled: boolean;
-  anthropicWifEnabled: boolean;
+  anthropicKeylessAuthEnabled: boolean;
   byosEnabled: boolean;
   values: LlmProviderApiKeyFormValues;
 }) {
   const {
     azureOpenAiEntraIdEnabled,
-    anthropicWifEnabled,
+    anthropicKeylessAuthEnabled,
     byosEnabled,
     values,
   } = params;
@@ -308,7 +308,7 @@ function getIsCreateFormValid(params: {
         : isProviderApiKeyOptional({
             provider: values.provider,
             azureEntraIdEnabled: azureOpenAiEntraIdEnabled,
-            anthropicWifEnabled,
+            anthropicKeylessAuthEnabled,
           }) || values.apiKey),
   );
 }

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -499,7 +499,7 @@ export function LlmProviderApiKeyForm({
   const appName = useAppName();
   const byosEnabled = useFeature("byosEnabled");
   const azureOpenAiEntraIdEnabled = useFeature("azureOpenAiEntraIdEnabled");
-  const anthropicWifEnabled = useFeature("anthropicWifEnabled");
+  const anthropicKeylessAuthEnabled = useFeature("anthropicKeylessAuthEnabled");
   const { data: providerBaseUrls } = useProviderBaseUrls();
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
   const { data: isLlmProviderApiKeyAdmin } = useHasPermissions({
@@ -1406,7 +1406,8 @@ export function LlmProviderApiKeyForm({
                     {isProviderApiKeyOptional({
                       provider,
                       azureEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
-                      anthropicWifEnabled: anthropicWifEnabled === true,
+                      anthropicKeylessAuthEnabled:
+                        anthropicKeylessAuthEnabled === true,
                     }) ? (
                       <span className="font-normal text-muted-foreground">
                         (optional)

--- a/platform/frontend/src/mocks/data/config.ts
+++ b/platform/frontend/src/mocks/data/config.ts
@@ -47,6 +47,7 @@ export function makeConfig(
       byosVaultKvVersion: "1",
       azureOpenAiEntraIdEnabled: false,
       anthropicWifEnabled: false,
+      anthropicKeylessAuthEnabled: false,
       bedrockIamAuthEnabled: false,
       geminiVertexAiEnabled: false,
       incomingEmail: { enabled: false },

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -36734,6 +36734,7 @@ export type GetConfigResponses = {
             byosVaultKvVersion: '1' | '2';
             azureOpenAiEntraIdEnabled: boolean;
             anthropicWifEnabled: boolean;
+            anthropicKeylessAuthEnabled: boolean;
             bedrockIamAuthEnabled: boolean;
             geminiVertexAiEnabled: boolean;
             incomingEmail: {

--- a/platform/shared/model-constants.test.ts
+++ b/platform/shared/model-constants.test.ts
@@ -145,12 +145,12 @@ describe("provider API key optional helpers", () => {
     ).toBe(true);
   });
 
-  test("treats Anthropic as optional only when Workload Identity Federation is enabled", () => {
+  test("treats Anthropic as optional when keyless authentication is enabled", () => {
     expect(isProviderApiKeyOptional({ provider: "anthropic" })).toBe(false);
     expect(
       isProviderApiKeyOptional({
         provider: "anthropic",
-        anthropicWifEnabled: true,
+        anthropicKeylessAuthEnabled: true,
       }),
     ).toBe(true);
   });
@@ -165,7 +165,7 @@ describe("provider API key optional helpers", () => {
       getProvidersWithOptionalApiKey({ azureEntraIdEnabled: true }),
     ).toEqual(["ollama", "ollama-native", "vllm", "azure"]);
     expect(
-      getProvidersWithOptionalApiKey({ anthropicWifEnabled: true }),
+      getProvidersWithOptionalApiKey({ anthropicKeylessAuthEnabled: true }),
     ).toEqual(["ollama", "ollama-native", "vllm", "anthropic"]);
   });
 });

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -378,12 +378,16 @@ export function providerRequiresPerUserCredential(
 export function isProviderApiKeyOptional(params: {
   provider: SupportedProvider;
   azureEntraIdEnabled?: boolean;
+  anthropicKeylessAuthEnabled?: boolean;
+  /** @deprecated Pass anthropicKeylessAuthEnabled instead. */
   anthropicWifEnabled?: boolean;
 }): boolean {
   return (
     PROVIDERS_WITH_OPTIONAL_API_KEY.has(params.provider) ||
     (params.provider === "azure" && params.azureEntraIdEnabled === true) ||
-    (params.provider === "anthropic" && params.anthropicWifEnabled === true)
+    (params.provider === "anthropic" &&
+      (params.anthropicKeylessAuthEnabled === true ||
+        params.anthropicWifEnabled === true))
   );
 }
 
@@ -479,13 +483,18 @@ export function isModelRouterSupportedProvider(
 
 export function getProvidersWithOptionalApiKey(params?: {
   azureEntraIdEnabled?: boolean;
+  anthropicKeylessAuthEnabled?: boolean;
+  /** @deprecated Pass anthropicKeylessAuthEnabled instead. */
   anthropicWifEnabled?: boolean;
 }): SupportedProvider[] {
   const providers = [...PROVIDERS_WITH_OPTIONAL_API_KEY];
   if (params?.azureEntraIdEnabled === true) {
     providers.push("azure");
   }
-  if (params?.anthropicWifEnabled === true) {
+  if (
+    params?.anthropicKeylessAuthEnabled === true ||
+    params?.anthropicWifEnabled === true
+  ) {
     providers.push("anthropic");
   }
   return providers;


### PR DESCRIPTION
## Summary

Anthropic could only be configured against native-compatible endpoints, so deployments using Claude through Vertex AI could not discover or invoke those models.

This adds a deployment-wide Vertex AI mode for Anthropic that:

- authenticates with Application Default Credentials or an optional credentials file
- discovers Claude publisher models and syncs a keyless system provider
- translates Anthropic Messages requests to rawPredict and streamRawPredict while replacing caller provider credentials with Google OAuth
- uses the native Vertex Anthropic AI SDK path for direct calls and exposes the generalized keyless capability to the UI
- documents the configuration and Model Garden prerequisite

Vertex mode intentionally owns Anthropic routing for the deployment; other keyless Anthropic modes should not be enabled simultaneously.

## Validation

With Claude enabled in Model Garden, the local Tilt stack discovered Claude Sonnet 5 through the authenticated Archestra API, created the Vertex-backed system provider, and returned the expected unary and streaming responses through the Anthropic proxy. The direct-client path also completed successfully through the Vertex Anthropic provider.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>