### PR TITLE
fix(agents): preserve useful task lifecycle updates

### DIFF
--- a/platform/backend/src/agents/chatops/chatops-response.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-response.test.ts
@@ -15,4 +15,26 @@ describe("compactChatOpsResponse", () => {
   test("leaves ordinary foreground replies unchanged", () => {
     expect(compactChatOpsResponse("The answer is 4.")).toBe("The answer is 4.");
   });
+
+  test("removes narration before a structured background run launch", () => {
+    const launch = [
+      "🧰 *Codex is working on it*",
+      "• Task: Re-run the automated review and report its verdict",
+      "• Live run: https://example.com/chat/runs/22e2e62d-e552-4f41-afce-415e6fb4f214",
+      "• Reply in this thread to steer the running task.",
+    ].join("\n");
+
+    expect(
+      compactChatOpsResponse(
+        `I'll delegate this to the coding agent.\n${launch}`,
+      ),
+    ).toBe(launch);
+  });
+
+  test("leaves an unrelated live-run link unchanged", () => {
+    const response =
+      "See the existing run:\n• Live run: https://example.com/chat/runs/22e2e62d-e552-4f41-afce-415e6fb4f214";
+
+    expect(compactChatOpsResponse(response)).toBe(response);
+  });
 });

--- a/platform/backend/src/agents/chatops/chatops-response.ts
+++ b/platform/backend/src/agents/chatops/chatops-response.ts
@@ -3,7 +3,33 @@ const TASK_ID_PATTERN =
 
 export function compactChatOpsResponse(text: string): string {
   const taskStart = text.match(TASK_ID_PATTERN);
-  if (!taskStart) return text;
+  if (taskStart) {
+    return `Task ${taskStart[1]} started — I’ll post the result here when it’s ready.`;
+  }
 
-  return `Task ${taskStart[1]} started — I’ll post the result here when it’s ready.`;
+  const structuredLaunch = extractStructuredRunLaunch(text);
+  return structuredLaunch ?? text;
+}
+
+function extractStructuredRunLaunch(text: string): string | null {
+  const lines = text.split("\n");
+  const liveRunIndex = lines.findIndex((line) =>
+    /^\s*[•*-]\s*Live run:\s*<?https?:\/\/\S+\/chat\/runs\/[0-9a-f-]+/i.test(
+      line,
+    ),
+  );
+  if (liveRunIndex < 0) return null;
+
+  const taskIndex = lines.findLastIndex(
+    (line, index) =>
+      index < liveRunIndex && /^\s*[•*-]\s*Task:\s*\S/i.test(line),
+  );
+  if (taskIndex < 0) return null;
+
+  const headingIndex = taskIndex - 1;
+  const launchStart =
+    headingIndex >= 0 && /\bworking on it\b/i.test(lines[headingIndex])
+      ? headingIndex
+      : taskIndex;
+  return lines.slice(launchStart).join("\n").trim();
 }

--- a/platform/backend/src/agents/task-completion-notification.test.ts
+++ b/platform/backend/src/agents/task-completion-notification.test.ts
@@ -13,15 +13,31 @@ describe("buildTaskCompletionNotification", () => {
     ).toBeNull();
   });
 
-  test("posts a concise PR update after the background run completes", () => {
+  test("extracts a PR URL when the completed output is a native transcript", () => {
     expect(
       buildTaskCompletionNotification({
         state: "TASK_STATE_COMPLETED",
         statusReason: null,
         output:
-          "[tool] archestra__run_tool\nDone: https://github.com/example/project/pull/42\n[waiting for direction]",
+          "Initializing agent...\nhttps://github.com/example/project/pull/42\n[archestra] agent session exited",
       }),
     ).toBe("PR ready: https://github.com/example/project/pull/42");
+  });
+
+  test("keeps a useful completion report that also links to a PR", () => {
+    const output = [
+      "Private PR: https://github.com/example/project/pull/42",
+      "Exact review verdict: No findings.",
+      "The native review session was archived.",
+    ].join("\n");
+
+    expect(
+      buildTaskCompletionNotification({
+        state: "TASK_STATE_COMPLETED",
+        statusReason: null,
+        output,
+      }),
+    ).toBe(output);
   });
 
   test("does not narrate a working task before it has a useful result", () => {

--- a/platform/backend/src/agents/task-completion-notification.ts
+++ b/platform/backend/src/agents/task-completion-notification.ts
@@ -15,13 +15,17 @@ export function buildTaskCompletionNotification(params: {
   }
 
   if (params.state === "TASK_STATE_COMPLETED") {
+    const output = conciseOutput(params.output);
+    if (output) {
+      return output;
+    }
+
     const pullRequestUrl = findPullRequestUrl(params.output);
     if (pullRequestUrl) {
       return `PR ready: ${pullRequestUrl}`;
     }
 
-    const output = conciseOutput(params.output);
-    return output || "Task finished.";
+    return "Task finished.";
   }
 
   const outcome =


### PR DESCRIPTION
## Summary

- preserve a concise background-task completion report even when it contains a pull-request URL
- retain the existing `PR ready` fallback for raw native-terminal transcripts
- remove routing narration before a structured background-run launch while preserving the full launch card
- cover detailed completion, native transcript fallback, structured launch, and non-launch link behavior

## Why

Background coding runs already produce useful launch and completion reports. The notification path could replace a detailed completion with only `PR ready`, while ChatOps could expose model narration before an otherwise well-formatted launch card. Both made the task lifecycle less clear in the originating thread.

## Validation

- `ARCHESTRA_DATABASE_URL=postgresql://unused:unused@localhost:5432/unused pnpm --dir backend exec vitest run src/agents/chatops/chatops-response.test.ts src/agents/task-completion-notification.test.ts` (15 passed)
- `pnpm --dir backend exec tsc --noEmit --pretty false`
- `pnpm exec biome check backend/src/agents/chatops/chatops-response.ts backend/src/agents/chatops/chatops-response.test.ts backend/src/agents/task-completion-notification.ts backend/src/agents/task-completion-notification.test.ts`
- `git diff --check`

## Documentation

Audited `docs/pages`; these internal task-notification selection rules are not documented, so no docs change is needed.