### PR TITLE
fix(agents): keep task completion notifications concise

### DIFF
--- a/platform/backend/src/agents/task-completion-notification.test.ts
+++ b/platform/backend/src/agents/task-completion-notification.test.ts
@@ -40,6 +40,27 @@ describe("buildTaskCompletionNotification", () => {
     ).toBe(output);
   });
 
+  test("reduces a verbose PR completion report to its review link", () => {
+    const output = [
+      "The implementation is complete, but here is a long internal chronology.",
+      "The policy gate required an audience-narrowing remedy before one operation.",
+      "A raw push was blocked, so delivery used a repository-specific workaround.",
+      "A local configuration file was unavailable and another login path was used.",
+      "The pull request description could not be edited through the first command.",
+      "Validation eventually passed after several unrelated diagnostics and retries.",
+      "Review: https://github.com/example/project/pull/42#issuecomment-123456",
+      "The task is ready for human review and promotion.",
+    ].join("\n");
+
+    expect(
+      buildTaskCompletionNotification({
+        state: "TASK_STATE_COMPLETED",
+        statusReason: null,
+        output,
+      }),
+    ).toBe("PR ready: https://github.com/example/project/pull/42");
+  });
+
   test("does not narrate a working task before it has a useful result", () => {
     expect(
       buildTaskCompletionNotification({

--- a/platform/backend/src/agents/task-completion-notification.ts
+++ b/platform/backend/src/agents/task-completion-notification.ts
@@ -16,7 +16,7 @@ export function buildTaskCompletionNotification(params: {
 
   if (params.state === "TASK_STATE_COMPLETED") {
     const output = conciseOutput(params.output);
-    if (output) {
+    if (output && isCompactCompletionReport(output)) {
       return output;
     }
 
@@ -25,7 +25,7 @@ export function buildTaskCompletionNotification(params: {
       return `PR ready: ${pullRequestUrl}`;
     }
 
-    return "Task finished.";
+    return output || "Task finished.";
   }
 
   const outcome =
@@ -41,6 +41,13 @@ function findPullRequestUrl(output: string): string | null {
     /https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+/g,
   );
   return matches?.at(-1) ?? null;
+}
+
+function isCompactCompletionReport(output: string): boolean {
+  return (
+    output.length <= MAX_COMPLETION_REPORT_CHARS &&
+    output.split("\n").length <= MAX_COMPLETION_REPORT_LINES
+  );
 }
 
 function conciseOutput(output: string): string {
@@ -92,3 +99,6 @@ function looksLikeTerminalControlStream(output: string): boolean {
   );
   return (bareControlSequences?.length ?? 0) >= 3;
 }
+
+const MAX_COMPLETION_REPORT_CHARS = 600;
+const MAX_COMPLETION_REPORT_LINES = 6;


### PR DESCRIPTION
Long Agent Runtime completions could post a front-truncated block of execution chronology into the originating messaging thread when the result also contained a pull-request URL. This keeps genuinely compact completion reports, but reduces verbose PR-bearing output to a single PR-ready link while leaving no-PR completion behavior unchanged. A regression test reproduces the verbose policy and delivery-detail case and verifies the concise notification. Documentation was audited; this internal notification-selection behavior does not require a docs change.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>