### PR TITLE
fix(frontend): make the missing-connections control self-explanatory

### DIFF
--- a/platform/frontend/src/components/agent-form.utils.ts
+++ b/platform/frontend/src/components/agent-form.utils.ts
@@ -100,16 +100,10 @@ export const TOOL_CONNECTION_PROMPTING: Record<
 };
 
 /**
- * What the setting is for, ahead of what the chosen option does — the fixed
- * lead-in that {@link TOOL_CONNECTION_PROMPTING} is read against.
- *
- * The per-choice line names a consequence ("nothing up front", "the chat opens
- * by naming…") without ever saying which decision it is a consequence of, so a
- * reader who has not opened the menu has no anchor for it. This one sentence is
- * that anchor: it states the question the options answer, so the changing line
- * beneath it reads as "…and here is when". Kept record-neutral for the same
- * reason as the lines it precedes — one string has to serve an agent, a gateway
- * and a proxy alike.
+ * The fixed lead-in {@link TOOL_CONNECTION_PROMPTING} is read against. The
+ * per-choice line names a consequence without saying which decision it answers,
+ * so this states the question. Record-neutral, for the same reason as those
+ * lines — one string serves an agent, a gateway and a proxy alike.
  */
 export const MISSING_CREDENTIAL_SUMMARY =
   "Some tools need a credential the user must connect first. This decides when they are prompted for it.";

--- a/platform/frontend/src/components/agent-form.utils.ts
+++ b/platform/frontend/src/components/agent-form.utils.ts
@@ -100,6 +100,21 @@ export const TOOL_CONNECTION_PROMPTING: Record<
 };
 
 /**
+ * What the setting is for, ahead of what the chosen option does — the fixed
+ * lead-in that {@link TOOL_CONNECTION_PROMPTING} is read against.
+ *
+ * The per-choice line names a consequence ("nothing up front", "the chat opens
+ * by naming…") without ever saying which decision it is a consequence of, so a
+ * reader who has not opened the menu has no anchor for it. This one sentence is
+ * that anchor: it states the question the options answer, so the changing line
+ * beneath it reads as "…and here is when". Kept record-neutral for the same
+ * reason as the lines it precedes — one string has to serve an agent, a gateway
+ * and a proxy alike.
+ */
+export const MISSING_CREDENTIAL_SUMMARY =
+  "Some tools need a credential the user must connect first. This decides when they are prompted for it.";
+
+/**
  * How each connectivity choice reads as a tone: an enforcement scale (lenient
  * → informational → fully enforced), never the error palette — the strictest
  * choice is a setting, not a failure.

--- a/platform/frontend/src/components/agent-tool-behavior-settings.test.tsx
+++ b/platform/frontend/src/components/agent-tool-behavior-settings.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  MISSING_CREDENTIAL_SUMMARY,
+  TOOL_CONNECTION_PROMPTING,
+} from "./agent-form.utils";
+import { AgentToolBehaviorSettings } from "./agent-tool-behavior-settings";
+
+type Props = React.ComponentProps<typeof AgentToolBehaviorSettings>;
+
+function renderSettings(overrides: Partial<Props> = {}) {
+  const props: Props = {
+    progressiveToolLoading: false,
+    onProgressiveToolLoadingChange: () => {},
+    missingCredentialBehavior: "allow",
+    onMissingCredentialBehaviorChange: () => {},
+    locked: false,
+    toolExposureDocsUrl: "https://example.test/exposure",
+    toolConnectionsDocsUrl: "https://example.test/connections",
+    ...overrides,
+  };
+  return render(<AgentToolBehaviorSettings {...props} />);
+}
+
+describe("AgentToolBehaviorSettings — missing-connections status", () => {
+  // What was reported as unclear: the closed control shows only a terse label
+  // ("When a tool needs it") and Radix keeps the menu — where each choice is
+  // spelled out — unmounted while the setting is merely being read. So the
+  // status has to be stated inline, and it has to say both what the setting is
+  // for and what the current choice does.
+
+  it("always states what the setting is for, whatever the choice", () => {
+    for (const behavior of ["allow", "warn", "block"] as const) {
+      const { unmount } = renderSettings({
+        missingCredentialBehavior: behavior,
+      });
+
+      expect(screen.getByText(MISSING_CREDENTIAL_SUMMARY)).toBeInTheDocument();
+
+      unmount();
+    }
+  });
+
+  it("states the selected option's effect without opening the menu", () => {
+    for (const behavior of ["allow", "warn", "block"] as const) {
+      const { unmount } = renderSettings({
+        missingCredentialBehavior: behavior,
+      });
+
+      expect(
+        screen.getByText(TOOL_CONNECTION_PROMPTING[behavior]),
+      ).toBeInTheDocument();
+
+      unmount();
+    }
+  });
+
+  it("shows the effect of the current choice, not of the other choices", () => {
+    renderSettings({ missingCredentialBehavior: "block" });
+
+    expect(
+      screen.getByText(TOOL_CONNECTION_PROMPTING.block),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(TOOL_CONNECTION_PROMPTING.allow),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(TOOL_CONNECTION_PROMPTING.warn),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the purpose summary but reports the pinned effect when locked", () => {
+    // All mode pins the behavior and disables the control, so the second line
+    // reports what All mode does instead of a per-choice line the reader
+    // cannot change — while the purpose summary still stands.
+    renderSettings({ locked: true, missingCredentialBehavior: "allow" });
+
+    expect(screen.getByText(MISSING_CREDENTIAL_SUMMARY)).toBeInTheDocument();
+    expect(
+      screen.getByText(/All mode always asks when a tool needs it\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(TOOL_CONNECTION_PROMPTING.allow),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/agent-tool-behavior-settings.test.tsx
+++ b/platform/frontend/src/components/agent-tool-behavior-settings.test.tsx
@@ -23,11 +23,9 @@ function renderSettings(overrides: Partial<Props> = {}) {
 }
 
 describe("AgentToolBehaviorSettings — missing-connections status", () => {
-  // What was reported as unclear: the closed control shows only a terse label
-  // ("When a tool needs it") and Radix keeps the menu — where each choice is
-  // spelled out — unmounted while the setting is merely being read. So the
-  // status has to be stated inline, and it has to say both what the setting is
-  // for and what the current choice does.
+  // Reported as unclear: the closed select shows only a terse label and the
+  // menu stays unmounted while the setting is read, so the status — what the
+  // setting is for and what the current choice does — must be stated inline.
 
   it("always states what the setting is for, whatever the choice", () => {
     for (const behavior of ["allow", "warn", "block"] as const) {
@@ -71,8 +69,7 @@ describe("AgentToolBehaviorSettings — missing-connections status", () => {
 
   it("keeps the purpose summary but reports the pinned effect when locked", () => {
     // All mode pins the behavior and disables the control, so the second line
-    // reports what All mode does instead of a per-choice line the reader
-    // cannot change — while the purpose summary still stands.
+    // reports the pinned effect while the purpose summary still stands.
     renderSettings({ locked: true, missingCredentialBehavior: "allow" });
 
     expect(screen.getByText(MISSING_CREDENTIAL_SUMMARY)).toBeInTheDocument();

--- a/platform/frontend/src/components/agent-tool-behavior-settings.tsx
+++ b/platform/frontend/src/components/agent-tool-behavior-settings.tsx
@@ -19,6 +19,7 @@ import { Switch } from "@/components/ui/switch";
 
 import {
   MISSING_CREDENTIAL_BEHAVIOR_OPTIONS,
+  MISSING_CREDENTIAL_SUMMARY,
   MISSING_CREDENTIAL_TONE,
   TOOL_CONNECTION_PROMPTING,
 } from "./agent-form.utils";
@@ -129,13 +130,28 @@ export function AgentToolBehaviorSettings({
           <Label htmlFor="missing-credential-behavior">
             Missing connections
           </Label>
-          {/* The question, not the answer: the select beside this already
-              names the choice, and the menu spells out what each one does.
-              Repeating the chosen option's whole sentence here said the same
-              thing three times in one row. */}
+          {/* Purpose first, then current status. The trigger beside this shows
+              only the terse option label ("When a tool needs it"), and Radix
+              keeps the menu — where each choice is spelled out — unmounted
+              while the setting is merely being read, so the closed control was
+              four words with no statement of what they do. The fixed summary
+              says what the setting is for; the line under it states what the
+              chosen option does, so the control's status is legible without
+              reopening the menu, and changes as the selection changes. When All
+              mode has pinned the behavior the control is disabled, so the
+              second line reports the pinned effect instead of a choice the
+              reader cannot make. Each branch is a <span> so machine-translate
+              only ever swaps text within an element, never re-parents a bare
+              node next to the link. */}
           <FieldDescription>
-            When to ask a user to connect credentials.{" "}
-            {locked && <>All mode always asks when a tool needs it. </>}
+            <span>{MISSING_CREDENTIAL_SUMMARY} </span>
+            {locked ? (
+              <span>All mode always asks when a tool needs it. </span>
+            ) : (
+              <span>
+                {TOOL_CONNECTION_PROMPTING[missingCredentialBehavior]}{" "}
+              </span>
+            )}
             <ExternalDocsLink
               href={toolConnectionsDocsUrl}
               className="underline"

--- a/platform/frontend/src/components/agent-tool-behavior-settings.tsx
+++ b/platform/frontend/src/components/agent-tool-behavior-settings.tsx
@@ -130,19 +130,12 @@ export function AgentToolBehaviorSettings({
           <Label htmlFor="missing-credential-behavior">
             Missing connections
           </Label>
-          {/* Purpose first, then current status. The trigger beside this shows
-              only the terse option label ("When a tool needs it"), and Radix
-              keeps the menu — where each choice is spelled out — unmounted
-              while the setting is merely being read, so the closed control was
-              four words with no statement of what they do. The fixed summary
-              says what the setting is for; the line under it states what the
-              chosen option does, so the control's status is legible without
-              reopening the menu, and changes as the selection changes. When All
-              mode has pinned the behavior the control is disabled, so the
-              second line reports the pinned effect instead of a choice the
-              reader cannot make. Each branch is a <span> so machine-translate
-              only ever swaps text within an element, never re-parents a bare
-              node next to the link. */}
+          {/* Purpose first, then the current status stated inline: the closed
+              select shows only a terse label and Radix leaves the menu
+              unmounted while the setting is read. The status line changes with
+              the selection; when All mode pins the behavior it reports the
+              pinned effect instead. Spans keep machine-translate from
+              re-parenting a bare node next to the link. */}
           <FieldDescription>
             <span>{MISSING_CREDENTIAL_SUMMARY} </span>
             {locked ? (


### PR DESCRIPTION
## What

Makes the agent tool-connection control ("Missing connections") self-explanatory in the agent tool-behavior settings.

The closed `Select` showed only a terse option label (e.g. "When a tool needs it"), and Radix keeps the menu — where each choice is spelled out — unmounted while the setting is merely being read. So a reader saw four words with no statement of what they do, and nothing said what the setting was even for.

## Change

The field description now reads **purpose first, then current status**:

1. A fixed one-line summary of what the setting decides (`MISSING_CREDENTIAL_SUMMARY`), record-neutral so the same string serves an agent, a gateway, and a proxy.
2. The selected option's effect (`TOOL_CONNECTION_PROMPTING[...]`), which changes as the selection changes — so the control's status is legible without reopening the menu.

When All mode has pinned the behavior the control is disabled, so the second line reports the pinned effect instead of a choice the reader cannot make. Each line is wrapped in a `<span>` so machine-translate only swaps text within an element and never re-parents a bare node next to the docs link.

This addresses the reported unclarity and the follow-up request to prefix the choice-dependent status text with a concise summary of what the setting is for.

## Files

- `frontend/src/components/agent-form.utils.ts` — add `MISSING_CREDENTIAL_SUMMARY`.
- `frontend/src/components/agent-tool-behavior-settings.tsx` — render summary + current-choice status inline.
- `frontend/src/components/agent-tool-behavior-settings.test.tsx` — new behavior tests.

## Validation

- New focused tests (4) pass: purpose summary always shown; selected option's effect shown without opening the menu; only the current choice's effect shown; locked/All mode keeps the summary and reports the pinned effect.
- Full frontend test suite green (578 files, 5229 tests).
- `type-check`, `knip`, `biome` clean across all workspace packages (pre-commit `turbo check:commit`).
- Chrome manual acceptance against the running stack: all three dropdown states and All mode verified.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>