### PR TITLE
fix(agents): enforce concise task completions

### DIFF
--- a/platform/backend/src/agents/task-completion-notification.test.ts
+++ b/platform/backend/src/agents/task-completion-notification.test.ts
@@ -61,6 +61,24 @@ describe("buildTaskCompletionNotification", () => {
     ).toBe("PR ready: https://github.com/example/project/pull/42");
   });
 
+  test("enforces the four-line worker completion contract", () => {
+    const output = [
+      "CI is fully green and the implementation is complete.",
+      "Done — the setting now explains the selected behavior inline.",
+      "PR: https://github.com/example/project/pull/42",
+      "Validation: focused and full checks passed.",
+      "Demo: posted to the task thread.",
+    ].join("\n");
+
+    expect(
+      buildTaskCompletionNotification({
+        state: "TASK_STATE_COMPLETED",
+        statusReason: null,
+        output,
+      }),
+    ).toBe("PR ready: https://github.com/example/project/pull/42");
+  });
+
   test("does not narrate a working task before it has a useful result", () => {
     expect(
       buildTaskCompletionNotification({

--- a/platform/backend/src/agents/task-completion-notification.ts
+++ b/platform/backend/src/agents/task-completion-notification.ts
@@ -100,5 +100,5 @@ function looksLikeTerminalControlStream(output: string): boolean {
   return (bareControlSequences?.length ?? 0) >= 3;
 }
 
-const MAX_COMPLETION_REPORT_CHARS = 600;
-const MAX_COMPLETION_REPORT_LINES = 6;
+const MAX_COMPLETION_REPORT_CHARS = 500;
+const MAX_COMPLETION_REPORT_LINES = 4;


### PR DESCRIPTION
## Problem

Agent runners promise completion reports of at most four lines and 500 characters, but the platform accepted six lines and 600 characters. A five-line report therefore leaked an internal CI preamble into Slack instead of collapsing to the useful PR link.

## Change

Align the platform completion boundary with the runner contract: reports beyond four lines or 500 characters fall back to a concise PR-ready notification when a pull request URL is present.

## Validation

Replayed the five-line shape observed in a real Lobster run and confirmed it reduces to a single PR-ready line. The focused backend suite passes with 13 tests, and backend type-check plus both knip modes are clean. No documentation describes this internal notification threshold, so no docs change is needed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>