### PR TITLE
fix(frontend): simplify missing-connections description

### DIFF
--- a/platform/frontend/src/components/agent-form.utils.ts
+++ b/platform/frontend/src/components/agent-form.utils.ts
@@ -99,12 +99,7 @@ export const TOOL_CONNECTION_PROMPTING: Record<
     "Nothing can be sent until every credential the tools need is connected.",
 };
 
-/**
- * The fixed lead-in {@link TOOL_CONNECTION_PROMPTING} is read against. The
- * per-choice line names a consequence without saying which decision it answers,
- * so this states the question. Record-neutral, for the same reason as those
- * lines — one string serves an agent, a gateway and a proxy alike.
- */
+/** Record-neutral purpose copy shared by agents, gateways, and proxies. */
 export const MISSING_CREDENTIAL_SUMMARY =
   "Some tools need a credential the user must connect first. This decides when they are prompted for it.";
 

--- a/platform/frontend/src/components/agent-tool-behavior-settings.test.tsx
+++ b/platform/frontend/src/components/agent-tool-behavior-settings.test.tsx
@@ -1,9 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import {
-  MISSING_CREDENTIAL_SUMMARY,
-  TOOL_CONNECTION_PROMPTING,
-} from "./agent-form.utils";
+import { MISSING_CREDENTIAL_SUMMARY } from "./agent-form.utils";
 import { AgentToolBehaviorSettings } from "./agent-tool-behavior-settings";
 
 type Props = React.ComponentProps<typeof AgentToolBehaviorSettings>;
@@ -22,11 +19,7 @@ function renderSettings(overrides: Partial<Props> = {}) {
   return render(<AgentToolBehaviorSettings {...props} />);
 }
 
-describe("AgentToolBehaviorSettings — missing-connections status", () => {
-  // Reported as unclear: the closed select shows only a terse label and the
-  // menu stays unmounted while the setting is read, so the status — what the
-  // setting is for and what the current choice does — must be stated inline.
-
+describe("AgentToolBehaviorSettings — missing-connections purpose", () => {
   it("always states what the setting is for, whatever the choice", () => {
     for (const behavior of ["allow", "warn", "block"] as const) {
       const { unmount } = renderSettings({
@@ -37,47 +30,5 @@ describe("AgentToolBehaviorSettings — missing-connections status", () => {
 
       unmount();
     }
-  });
-
-  it("states the selected option's effect without opening the menu", () => {
-    for (const behavior of ["allow", "warn", "block"] as const) {
-      const { unmount } = renderSettings({
-        missingCredentialBehavior: behavior,
-      });
-
-      expect(
-        screen.getByText(TOOL_CONNECTION_PROMPTING[behavior]),
-      ).toBeInTheDocument();
-
-      unmount();
-    }
-  });
-
-  it("shows the effect of the current choice, not of the other choices", () => {
-    renderSettings({ missingCredentialBehavior: "block" });
-
-    expect(
-      screen.getByText(TOOL_CONNECTION_PROMPTING.block),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(TOOL_CONNECTION_PROMPTING.allow),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(TOOL_CONNECTION_PROMPTING.warn),
-    ).not.toBeInTheDocument();
-  });
-
-  it("keeps the purpose summary but reports the pinned effect when locked", () => {
-    // All mode pins the behavior and disables the control, so the second line
-    // reports the pinned effect while the purpose summary still stands.
-    renderSettings({ locked: true, missingCredentialBehavior: "allow" });
-
-    expect(screen.getByText(MISSING_CREDENTIAL_SUMMARY)).toBeInTheDocument();
-    expect(
-      screen.getByText(/All mode always asks when a tool needs it\./),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(TOOL_CONNECTION_PROMPTING.allow),
-    ).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/agent-tool-behavior-settings.tsx
+++ b/platform/frontend/src/components/agent-tool-behavior-settings.tsx
@@ -130,21 +130,11 @@ export function AgentToolBehaviorSettings({
           <Label htmlFor="missing-credential-behavior">
             Missing connections
           </Label>
-          {/* Purpose first, then the current status stated inline: the closed
-              select shows only a terse label and Radix leaves the menu
-              unmounted while the setting is read. The status line changes with
-              the selection; when All mode pins the behavior it reports the
-              pinned effect instead. Spans keep machine-translate from
-              re-parenting a bare node next to the link. */}
+          {/* Keep the closed setting focused on its purpose. The richer
+              per-option explanations belong in the open menu. The span keeps
+              machine-translate from re-parenting a bare node next to the link. */}
           <FieldDescription>
             <span>{MISSING_CREDENTIAL_SUMMARY} </span>
-            {locked ? (
-              <span>All mode always asks when a tool needs it. </span>
-            ) : (
-              <span>
-                {TOOL_CONNECTION_PROMPTING[missingCredentialBehavior]}{" "}
-              </span>
-            )}
             <ExternalDocsLink
               href={toolConnectionsDocsUrl}
               className="underline"


### PR DESCRIPTION
## What

Keep the closed “Missing connections” setting focused on its purpose instead of appending the currently selected option’s longer explanation. The per-option explanations remain available inside the dropdown.