### PR TITLE
docs(skills): fix migration recipes and stale development guidance

### DIFF
--- a/.codex/skills/archestra-dev-backend-tests/SKILL.md
+++ b/.codex/skills/archestra-dev-backend-tests/SKILL.md
@@ -11,7 +11,7 @@ Run commands from `platform/` unless specifically instructed otherwise. Run a si
 
 `backend/vitest.config.ts` splits test files into two projects at config-load time by grepping file content:
 
-- **`clean`** — files with NO `vi.mock`/`vi.doMock`/`vi.hoisted` run with `isolate: false`: worker threads share the module cache, so the backend module graph is imported once per worker instead of once per file. This is the fast path.
+- **`clean`** — files with NO `vi.mock`/`vi.doMock`/`vi.hoisted` run with `isolate: false`: files in the same worker process share the module cache, so the backend module graph is imported once per worker instead of once per file. This is the fast path.
 - **`mocked`** — files using module mocking keep full isolation, because Vitest never resets the module-mock registry between files in a shared worker (vitest-dev/vitest#4894).
 
 Consequences:
@@ -39,7 +39,7 @@ test("...", async () => {
 
 Unhandled requests fail the test loudly. The helper's lifecycle is per test (it must be — the shared setup restores `globalThis.fetch` after every test); don't hand-roll `setupServer` with `beforeAll` listen.
 
-Wire-level gotchas learned in past conversions: clients retry — gitbeaker retries 429/502 up to 10× with backoff and openai retries 429/5xx (serve a non-retried status like 500, or account for the retries); MSW 2.x route paths use path-to-regexp 8, which rejects RegExp paths and bare `*` — use `:param` segments (URL-encoded slashes like `%2F` stay one segment and decode in the param).
+Wire-level gotchas learned in past conversions: clients retry — gitbeaker retries 429/502 up to 10× with backoff and openai retries 429/5xx (choose a status that the specific client does not retry, or configure/account for its retries; OpenAI retries 500); MSW 2.x route paths use path-to-regexp 8, which rejects RegExp paths and bare `*` — use `:param` segments (URL-encoded slashes like `%2F` stay one segment and decode in the param).
 
 ## Module mocking rules
 

--- a/.codex/skills/archestra-dev-backend/SKILL.md
+++ b/.codex/skills/archestra-dev-backend/SKILL.md
@@ -34,8 +34,8 @@ Use this skill before changing files under `platform/backend/` (except unit test
 - Plugins are typed as `FastifyPluginAsyncZod` (fastify-type-provider-zod); schemas are Zod.
 - Wrap response schemas with `constructResponseSchema` from `@/types` for consistent 400/401/403/404/500 responses.
 - Errors: `throw new ApiError(status, message)` (from `@/types`) only — never `reply.status().send(...)`; the central error handler formats `{ error: { message, type } }`.
-- Routes under `/api/` are behind the auth middleware: `request.user` and `request.organizationId` are guaranteed — no redundant null checks.
-- Pagination: `PaginationQuerySchema` + `createPaginatedResponseSchema` from `@archestra/shared`.
+- Routes that pass ordinary API authentication have `request.user` and `request.organizationId` — no redundant null checks. Public, webhook, and callback routes exempted in `backend/src/auth/fastify-plugin/middleware.ts` follow their own authentication contracts; the `/api/` prefix alone is not a guarantee.
+- Pagination: use `PaginationQuerySchema` + `createPaginatedResponseSchema` from `@archestra/shared` for bounded tables needing page counts. For write-hot or unbounded logs, use `CursorQuerySchema` + `createCursorPaginatedResponseSchema`; fetch `limit + 1` rows and do not calculate totals.
 - Sorting: `SortingQuerySchema` or `createSortingQuerySchema` from `@/types`.
 
 ## Data access

--- a/.codex/skills/archestra-dev-e2e/SKILL.md
+++ b/.codex/skills/archestra-dev-e2e/SKILL.md
@@ -11,14 +11,26 @@ Run commands from `platform/` unless specifically instructed otherwise.
 
 ## Commands
 
+For the Docker-lite environment used by most CI specs:
+
 ```bash
-pnpm test:e2e
+pnpm test:e2e:lite:up
+pnpm test:e2e:lite -- --project=chromium tests/agents.spec.ts
+pnpm test:e2e:lite:down
+```
+
+The harness refuses to start if another stack holds its ports. Stop that stack before starting lite.
+
+For an existing Tilt development stack:
+
+```bash
 tilt trigger e2e-test-dependencies
+pnpm test:e2e
 ```
 
 `tilt trigger e2e-test-dependencies` starts the e2e dependency stack via the `helm/e2e-tests` chart: WireMock, Keycloak (with pre-configured test users), Vault, and mock MCP servers. It does not seed the database.
 
-In development, e2e tests use the development database. Local data can make e2e tests fail locally.
+Against the Tilt stack, e2e tests use the development database. Local data can make e2e tests fail locally.
 
 Check WireMock health at `http://localhost:9092/__admin/health`.
 
@@ -37,18 +49,29 @@ ARCHESTRA_GEMINI_BASE_URL=http://localhost:9092/gemini
 ## Local and CI setup
 
 - Local e2e dependencies deploy through `dev/Tiltfile.test`, which installs the `helm/e2e-tests` chart (`helm upgrade --install e2e-tests`) and port-forwards WireMock to `9092`.
-- CI uses a kind cluster and Helm deployment.
+- CI splits into lite (a quickstart-mode container with sidecars), host-Kubernetes (Kind + Helm for host kubectl, NetworkPolicy, and Helm fixtures), and pristine quickstart (keyless onboarding). See `.github/workflows/platform-e2e-tests.yml` from the repo root.
+- Merge-queue/label runs cover Chromium; nightly/manual runs additionally cover the Firefox/WebKit-tagged specs.
 - CI kind config is `.github/kind.yaml`.
 - CI Helm values are `.github/values-ci.yaml`.
 - CI NodePort services use frontend `3000`, backend `9000`, and metrics `9050`.
 - `drizzle-kit check`, codegen, and db-migration validation run in the `platform-lint-and-unit-tests` job of `.github/workflows/on-pull-requests.yml`, not in the e2e workflow — a red check there is not an e2e failure.
+
+## Registering a spec
+
+`e2e-tests/playwright.config.ts` uses explicit `testMatch` lists. Add a new spec to the matching list (`uiTestMatch`, `apiTestMatch`, `apiK8sTestMatch`, or its dedicated project); naming it `*.spec.ts` alone does not register it. Confirm discovery without starting the stack:
+
+```bash
+pnpm --dir e2e-tests exec playwright test --list --project=chromium tests/your-spec.spec.ts
+```
+
+Choose the project that should run the spec and confirm it appears in the output.
 
 ## Fixtures
 
 - Use the Playwright fixtures pattern.
 - API fixtures live in `e2e-tests/tests/api-fixtures.ts` — import relative to the spec's location (`./api-fixtures` from `tests/`, `../api-fixtures` from a subdirectory like `tests/llm-proxy/`). They include `makeApiRequest`, `createAgent`, `deleteAgent`, `createApiKey`, `deleteApiKey`, `createToolInvocationPolicy`, `deleteToolInvocationPolicy`, `createTrustedDataPolicy`, and `deleteTrustedDataPolicy`.
 - UI fixtures live in `e2e-tests/fixtures.ts` — import relative to the spec's location (`../fixtures` from `tests/`). They include `goToPage` and `makeRandomString`.
-- Pure API tests (no browser needed) belong in the backend vitest suite as route tests, not in Playwright (#6155). Keep Playwright specs for flows that exercise the UI.
+- API behavior that `app.inject` + PGlite can cover belongs in backend Vitest route tests (#6155). Keep Playwright for browser flows and behavior requiring the real stack, such as host kubectl, NetworkPolicy enforcement, or Helm fixtures.
 
 Example:
 

--- a/.codex/skills/archestra-dev-interactions-migrations/SKILL.md
+++ b/.codex/skills/archestra-dev-interactions-migrations/SKILL.md
@@ -16,18 +16,23 @@ apply to any other very large, write-hot table.
 
 ## Safe vs risky operations
 
-Safe (fast, metadata-only, no table rewrite in PostgreSQL 11+):
+Fast once the required lock is acquired (metadata-only, no table rewrite in PostgreSQL 11+):
 
 - `ADD COLUMN ... DEFAULT <constant> NOT NULL` — the default is stored as
-  metadata; existing rows are not rewritten. This is instant regardless of table
-  size. (The billing_mode column was added this way.)
+  metadata; existing rows are not rewritten. This avoids a table-size-dependent
+  rewrite. (The billing_mode column was added this way.)
 - `ADD COLUMN` nullable, with no default.
+- Nonvolatile defaults such as `now()` also avoid the rewrite; `now()` is stable, not volatile.
 - `DROP DEFAULT`, `SET DEFAULT <constant>`, renaming a column.
 
-Risky (rewrites the whole table or takes a write-blocking lock — scales with
-table size):
+These operations still acquire table locks: ordinary `ADD COLUMN` requires
+`ACCESS EXCLUSIVE`, even without a rewrite. Check long-running transactions and
+use a bounded `lock_timeout` rather than assuming metadata-only means lock-free.
+See the [PostgreSQL ALTER TABLE reference](https://www.postgresql.org/docs/17/sql-altertable.html).
 
-- `ADD COLUMN ... DEFAULT <volatile expr>` (e.g. `now()`, `gen_random_uuid()`) —
+Operations with potentially table-size-dependent work:
+
+- `ADD COLUMN ... DEFAULT <volatile expr>` (e.g. `clock_timestamp()`, `gen_random_uuid()`) —
   rewrites every row.
 - `ALTER COLUMN ... TYPE ...` — usually rewrites the table.
 - `SET NOT NULL` on an existing column — full scan to validate.
@@ -125,8 +130,8 @@ below grant nothing on their own.
    ```
 
 5. Read the numbers:
-   - Metadata-only changes (safe `ADD COLUMN`) are effectively instant no matter
-     how big the table is — ship them normally.
+   - Metadata-only changes avoid a table rewrite, but can still wait for a
+     conflicting transaction. Assess lock waits as well as table size.
    - A table rewrite or a non-concurrent index build scales with heap/index size.
      As a rough order of magnitude, an index build reads the whole table, sorts,
      and writes the index — expect it to be at least as slow as a full scan of

--- a/.codex/skills/archestra-dev-llm-providers/SKILL.md
+++ b/.codex/skills/archestra-dev-llm-providers/SKILL.md
@@ -9,7 +9,7 @@ Use this skill before adding an LLM provider or changing provider translation, s
 
 ## Provider surface map
 
-One provider touches all of these (use `github-copilot` as the worked example — it is OpenAI-compatible, so it follows the default path; `microsoft-365-copilot` is the most recent full addition and shows the harder shape, with its own graph translator):
+For a chat-capable provider, check all of these (use `github-copilot` as the worked example — it is OpenAI-compatible, so it follows the default path; `microsoft-365-copilot` shows the harder shape, with its own graph translator):
 
 - `backend/src/types/llm-providers/<provider>/` — `api.ts`, `messages.ts`, `tools.ts`, `index.ts` (some also have `models.ts`). `index.ts` default-exports a namespace (e.g. `GithubCopilot`) with `API`/`Messages`/`Tools` plus a `Types` sub-namespace; register it in `types/llm-providers/index.ts`. OpenAI-compatible providers re-export OpenAI schemas with `.passthrough()`.
 - `backend/src/routes/proxy/adapters/<provider>.ts` — exports `<provider>AdapterFactory`; re-export it from `adapters/index.ts`.
@@ -20,6 +20,8 @@ One provider touches all of these (use `github-copilot` as the worked example �
 - Frontend: provider key management at `frontend/src/app/llm/model-providers/page.tsx` + `frontend/src/components/create-llm-provider-api-key-dialog.tsx`; provider icon at `frontend/public/icons/<provider>.png`; model pickers (`components/llm-model-select.tsx`, `components/chat/model-selector.tsx`) use `providerDisplayNames`.
 - Also: `backend/src/config.ts` + `.env.example` for base-URL/key env vars, `../docs/pages/platform-supported-llm-providers.md`.
 
+For embeddings-only providers, follow `voyage`: register the provider and model fetcher, wire the embedding client, and add it to `EMBEDDING_ONLY_PROVIDER_LIST` in `shared/model-constants.ts`. Chat surfaces use `providerSupportsChat` and `ChatProvider`; do not invent chat routes, adapters, or chat-matrix entries for a provider with no chat API.
+
 ## Default path: OpenAI-compatible
 
 - Most new providers are OpenAI-compatible. Do not hand-roll a translator: call `createOpenAiCompatibleAdapterFactory` from `adapters/openai-compatible-adapter.ts` with `provider`, `interactionType`, `getBaseUrl`, and `createClient` — it reuses `OpenAIRequestAdapter`/`OpenAIResponseAdapter`/`OpenAIStreamAdapter` wholesale. See `adapters/deepseek.ts` (minimal) and `adapters/github-copilot.ts` (custom auth via a fetch wrapper, since `createClient` is synchronous).
@@ -27,7 +29,7 @@ One provider touches all of these (use `github-copilot` as the worked example �
 
 ## Guard rails
 
-- `backend/src/routes/proxy/routes/provider-matrix.test.ts` — `providerConfigsByProvider` is `satisfies Record<SupportedProvider, ProviderTestConfig>`, so adding a provider to the enum without a matrix entry (route plugin + adapter factory + endpoints) fails typecheck. The suite then exercises every provider's real route with a mocked client: declared-tool persistence, execution IDs, streaming tool calls, cost-optimized model substitution, TOON compression, and limit blocking.
+- `backend/src/routes/proxy/routes/provider-matrix.test.ts` — `providerConfigsByProvider` is `satisfies Record<ChatProvider, ProviderTestConfig>`, so adding a chat-capable provider without a matrix entry (route plugin + adapter factory + endpoints) fails typecheck. The suite then exercises every chat provider's real route with a mocked client: declared-tool persistence, execution IDs, streaming tool calls, TOON compression, and limit blocking.
 - The `modelFetchers` record (above) enforces the same exhaustiveness for model listing.
 
 ## Translation gotchas (real handling, check before "fixing")

--- a/.codex/skills/archestra-dev-migrations/resolve-conflicts.md
+++ b/.codex/skills/archestra-dev-migrations/resolve-conflicts.md
@@ -6,9 +6,9 @@ after taking main's migration metadata. Never edit main's migrations, and do
 not hand-renumber a migration unless regeneration is impossible.
 
 `pnpm db:generate` emits ONLY schema DDL diffed against the latest snapshot.
-Any data-migration tail (UPDATE, INSERT, DO $$ blocks, mutating CTEs) is NOT
-regenerated. The procedure below regenerates fresh DDL against main's
-snapshot, then re-appends your saved data-migration tail.
+Data changes (including DELETE) and custom DDL not represented in the Drizzle
+schema are NOT regenerated. Back up the original SQL and preserve those
+operations when regenerating against main's snapshot.
 
 All paths below are relative to the **repo root**, not `platform/`. Run the
 shell commands from the repo root unless a step explicitly `cd`s elsewhere
@@ -24,26 +24,20 @@ shell commands from the repo root unless a step explicitly `cd`s elsewhere
 
 ## Procedure
 
-### 1. Extract your data-migration tail
+### 1. Preserve your manually authored SQL
 
 Read `platform/backend/src/database/migrations/<COLLIDING>_<your_name>.sql`.
 Copy the whole file to `/tmp/<COLLIDING>_<your_name>.original.sql` as a
-backup. Then save just the data-migration statements to
-`/tmp/<your_name>.data.sql`, each separated by `--> statement-breakpoint`.
+backup. Save operations that schema generation cannot reproduce to
+`/tmp/<your_name>.custom.sql`, separated by `--> statement-breakpoint`.
 
-Statements to save (Drizzle does NOT regenerate these):
-- `UPDATE …`
-- `INSERT INTO …` (when used for data, not as part of `CREATE TABLE`)
-- `DO $$ … END $$;` blocks
-- `WITH … (INSERT|UPDATE|DELETE) …` CTEs
+These include UPDATE, INSERT, standalone DELETE, DO blocks, mutating CTEs,
+and custom DDL such as extension creation. Do not discard an operation just
+because it starts with ALTER or CREATE: verify that the Drizzle schema and
+regenerated SQL preserve its meaning, including renames. Note ordering
+requirements, such as a backfill before a constraint or a cleanup before a drop.
 
-Statements to DISCARD (Drizzle WILL regenerate these):
-- `ALTER TABLE …`, `ALTER COLUMN …`
-- `CREATE TABLE/INDEX/TYPE/EXTENSION …`
-- `DROP TABLE/COLUMN/INDEX …`
-
-If the file has no data-migration tail, `/tmp/<your_name>.data.sql` is empty
-and step 5 is a no-op.
+If no custom operations remain, the saved file is empty.
 
 ### 2. Take main's side for the conflicted journal + snapshot
 
@@ -90,23 +84,23 @@ resolving with `git checkout --ours` or `--theirs` just-enough-to-parse is
 fine; for hand-written code, resolve properly. Run `git status` and check
 for any `UU` entries; resolve each before continuing.
 
-### 3. Delete your old generated migration artifacts
+### 3. Delete only your obsolete migration SQL
 
 ```
 git rm -f \
-  platform/backend/src/database/migrations/<COLLIDING>_<your_name>.sql \
-  platform/backend/src/database/migrations/meta/<COLLIDING>_snapshot.json
+  platform/backend/src/database/migrations/<COLLIDING>_<your_name>.sql
 ```
 
-The files are often staged from the in-progress rebase/merge; plain `git rm`
-can refuse to remove staged files, so `-f` is needed. If your branch's
+The SQL file may already be staged, so `-f` is needed. **Keep the colliding
+snapshot restored from main in step 2.** Verify main's latest snapshot still
+exists before generation; deleting it loses the schema baseline. If your branch's
 journal entry still exists in `_journal.json`, remove that entry before
 regenerating. The journal should end at main's latest migration at this point.
 
 ### 4. Regenerate the migration with your descriptive name
 
 ```
-cd platform/backend && pnpm exec drizzle-kit generate --name=<your_name>
+pnpm --dir platform/backend exec drizzle-kit generate --name=<your_name>
 ```
 
 Drizzle picks the next free `<NEW>`, emits `<NEW>_<your_name>.sql` with
@@ -116,30 +110,29 @@ schema-only DDL diffed against main's snapshot, writes
 right the first time — no journal-tag rename needed. Let Drizzle create the
 journal timestamp; do not copy the old timestamp from your collided migration.
 
-If Drizzle reports "No schema changes, nothing to migrate", your branch was
-pure-data; generate a custom empty migration instead:
+If Drizzle reports "No schema changes, nothing to migrate" but saved custom
+operations still need to run, generate a custom empty migration instead:
 
 ```
-cd platform/backend && pnpm exec drizzle-kit generate --custom --name=<your_name>
+pnpm --dir platform/backend exec drizzle-kit generate --custom --name=<your_name>
 ```
 
-### 5. Append the saved data-migration tail
+### 5. Restore custom operations in dependency order
 
-Skip this step if `/tmp/<your_name>.data.sql` is empty.
+Compare the backed-up original SQL with the regenerated migration. Restore each
+operation from `/tmp/<your_name>.custom.sql` that is not already represented,
+with `--> statement-breakpoint` separators. Put operations that reference new
+columns after their creation, backfills before constraints that depend on them,
+and cleanup before dropping the objects it reads. Append only when all saved
+operations genuinely belong after the generated DDL.
 
-```
-printf '\n--> statement-breakpoint\n' \
-  >> platform/backend/src/database/migrations/<NEW>_<your_name>.sql
-cat /tmp/<your_name>.data.sql \
-  >> platform/backend/src/database/migrations/<NEW>_<your_name>.sql
-```
-
-Schema DDL must run before the data migration so column references resolve.
+Account for every operation in the original SQL, even when the generated
+migration passes validation; schema checks cannot detect a missing data cleanup.
 
 ### 6. Verify journal/snapshot/SQL consistency
 
 ```
-cd platform/backend && pnpm exec drizzle-kit check
+pnpm --dir platform/backend exec drizzle-kit check
 ```
 
 Must print **"Everything's fine"**. Then run the same checks CI runs — journal
@@ -147,26 +140,26 @@ ordering plus the Drizzle migration linter over migrations changed relative to
 `origin/main`:
 
 ```
-cd platform/backend && pnpm check:migrations
+pnpm --dir platform/backend check:migrations
 ```
 
 The journal check must print **"Drizzle migration journal ordering is valid."**
 If it fails, your regenerated migration was not appended after main's latest
 migration, or its journal timestamp was copied/edited incorrectly. The linter
 fails separately, with `ERROR <code>` lines pointing at the migration file —
-that is a lint problem in the regenerated/edited SQL (often the re-appended
-data-migration tail), not a journal problem.
+that is a lint problem in the regenerated/edited SQL (often the restored
+custom SQL), not a journal problem.
 
 If `drizzle-kit check` reports drift, compare
 `/tmp/<COLLIDING>_<your_name>.original.sql` against the regenerated SQL and
-either (a) restore a missed data-migration statement to the tail, or
+either (a) restore a missed custom operation in dependency order, or
 (b) update your schema files so the regenerated DDL matches what your
 original SQL did.
 
 ### 7. (Optional) Apply locally to confirm it runs
 
 ```
-cd platform/backend && pnpm db:migrate
+pnpm --dir platform/backend db:migrate
 ```
 
 ### 8. Regenerate conflicted generated clients (only if hey-api files conflicted)
@@ -176,7 +169,7 @@ Skip this step unless step 2 surfaced conflicts under `platform/shared/hey-api/`
 step 9).
 
 ```
-cd platform/shared && CODEGEN=true pnpm codegen:api-client
+CODEGEN=true pnpm --dir platform/shared codegen:api-client
 ```
 
 ### 9. Stage and continue

--- a/.codex/skills/archestra-dev-testing/SKILL.md
+++ b/.codex/skills/archestra-dev-testing/SKILL.md
@@ -85,12 +85,14 @@ none.
 ### E2E tests, sparingly
 
 E2E is the most expensive level: slow, flaky-prone, and delicate to maintain.
-Add one only for a **happy path** through a flow that no cheaper level can
-cover — a real browser against a real stack, or real Kubernetes behaviour.
+Use E2E for a **happy path** that no cheaper level can cover — a real browser
+against a real stack, or real Kubernetes behaviour. Include failure/denial cases
+when only real infrastructure can establish the contract, such as NetworkPolicy
+enforcement.
 
-Do not use e2e for error branches, permission matrices, validation messages, or
-field-level behaviour. Those belong in route-level or MSW-backed integration
-tests, where they run in milliseconds and fail legibly.
+Use route-level or MSW-backed integration tests for error branches, permission
+matrices, validation messages, and field-level behaviour when those levels
+preserve the boundary under test.
 
 When a bug fix needs pinning, ask whether an integration test would catch the
 same regression. It usually would.
@@ -239,5 +241,5 @@ own way to fail".
    away the thing under test to get there.
 4. Assert observable behaviour: responses, rendered output, persisted rows,
    emitted events. Not internal shape, not styling, not that a prop arrived.
-5. E2E only for a happy path nothing cheaper can reach.
+5. E2E for happy paths or infrastructure contracts nothing cheaper can reach.
 6. If it can't be made to pass, don't commit it skipped.

--- a/ai-labs/CLAUDE.md
+++ b/ai-labs/CLAUDE.md
@@ -1,7 +1,7 @@
 # Authoring bench tasks
 
 Conventions for writing/editing a `tasks/<id>/` task. Mechanics (env-var contract, `[state].rest`,
-file layout, lifecycle) live in `../README.md` -- this file is the discipline, not the plumbing.
+file layout, lifecycle) live in `README.md` -- this file is the discipline, not the plumbing.
 
 ## The prompt is a real user's ask
 
@@ -51,14 +51,18 @@ behavior when unset:
   other container env vars — feature flags — do flow through).
 
 Gotchas: the bench resolves its Postgres from `ARCHESTRA_BENCH_DATABASE_URL` and creates its own
-per-run DB on it. The sandbox (`run_command`) is gated only by a valid Dagger host
-(`ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`); the `basic` env needs no other env to expose Agent
-Skills and Environments. The prod image runs `NODE_ENV=production`, where better-auth
+per-run DB on it. The bench supplies an explicit Dagger host
+(`ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`) for sandbox execution, but
+`ARCHESTRA_CODE_RUNTIME_ENABLED=false` disables it even when that host is set.
+Outside this explicit-host mode, `ARCHESTRA_CODE_RUNTIME_ENABLED=true` plus a configured
+orchestrator enables code-managed engines; see `platform/backend/src/config.ts` from the repo root.
+
+The prod image runs `NODE_ENV=production`, where better-auth
 hard-exits on its default secret — set `ARCHESTRA_AUTH_SECRET` (the entrypoint generates a throwaway
 one per run; the DB is fresh and dropped each run, so the value never matters).
 
 ## Skills are pinned, not live
 
-Benchmark-owned skills are imported by pinned GitHub commit SHA in `../envs/basic.toml`, not from the
-working tree. After editing a skill under `../skills/`, commit + push, then repin its `ref`. Edits do
+Benchmark-owned skills are imported by pinned GitHub commit SHA in `envs/basic.toml`, not from the
+working tree. After editing a skill under `skills/`, commit + push, then repin its `ref`. Edits do
 not take effect until repinned.

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -21,7 +21,7 @@
 
 ## Docs
 
-Docs are stored at ./docs
+Docs are stored at `../docs/`.
 Use the `archestra-docs-writer` skill before changing any docs files.
 
 ## Project Skills
@@ -76,7 +76,8 @@ pnpm dev                                # Start all workspaces
 pnpm run prepare                        # Install the husky pre-commit hook. `tilt up` does this for you;
                                         # run it by hand if you skip Tilt. `pnpm install` will NOT do it,
                                         # because ignoreScripts blocks lifecycle scripts (see below).
-pnpm lint                               # Lint and auto-fix
+pnpm lint                               # Check lint
+pnpm lint:fix                           # Lint and auto-fix
 pnpm type-check                         # Check TypeScript types
 pnpm test                               # Run tests
 pnpm test:e2e                           # Run e2e tests with Playwright (chromium, webkit, firefox)
@@ -284,7 +285,7 @@ pnpm rebuild <package-name>  # Enable scripts for specific package
 - **Backend Testing Best Practices**: Never mock database interfaces in backend tests - use the existing `backend/src/test/setup.ts` PGlite setup for real database testing, and use model methods to create/manipulate test data for integration-focused testing. For module mocking and global stubs, load the `archestra-dev-backend-tests` skill: mock-free files run in a shared-worker fast path, `@/auth`/`@/logging` mocks go through their `__mocks__` dirs (bare `vi.mock("@/auth")`), `@/config` through `configModuleMock(overrides)`, and `vi.stubGlobal` must be (re-)applied in `beforeEach` because stubs auto-revert after every test
 - **API Response Standardization**: Use `constructResponseSchema` helper for all routes to ensure consistent error responses (400, 401, 403, 404, 500)
 - **Error Handling**: Always use `throw new ApiError(statusCode, message)` for error responses - never use manual `reply.status().send({ error: ... })`. The centralized Fastify error handler formats all errors consistently as `{ error: { message, type } }` and logs appropriately.
-- **Protected Routes & Authentication**: Routes under `/api/` are protected by the auth middleware which guarantees `request.user` and `request.organizationId` exist. Never add redundant null checks like `if (!request.organizationId) throw new ApiError(401, "Unauthorized")` - just use `request.organizationId` directly. The middleware handles authentication; routes handle authorization and business logic.
+- **Protected Routes & Authentication**: Routes that pass ordinary API authentication have `request.user` and `request.organizationId`. Public, webhook, and callback routes exempted in `backend/src/auth/fastify-plugin/middleware.ts` follow their own authentication contracts; the `/api/` prefix alone is not a guarantee. On ordinarily authenticated routes, do not add redundant null checks like `if (!request.organizationId) throw new ApiError(401, "Unauthorized")` - just use `request.organizationId` directly. The middleware handles authentication; routes handle authorization and business logic.
 - **Type Organization**: Keep database schemas in `database/schemas/`, extract business types to dedicated `types/` files
 - **Pagination**: Use `PaginationQuerySchema` and `createPaginatedResponseSchema` for ordinary bounded tables that need page counts. Use `CursorQuerySchema` and `createCursorPaginatedResponseSchema` for write-hot or unbounded logs; keyset queries must fetch `limit + 1` rows and must not calculate totals.
 - **Sorting**: Use `SortingQuerySchema` or `createSortingQuerySchema` for standardized sorting parameters
@@ -345,7 +346,7 @@ pnpm rebuild <package-name>  # Enable scripts for specific package
 **MCP Server Runtime**:
 
 - Local MCP servers run in K8s pods (one pod per server) when K8s is configured
-- Feature flag `orchestratorK8sRuntime` returned by `/api/features` endpoint
+- Feature flag `orchestratorK8sRuntime` returned by `/api/config` endpoint
 - Feature enabled when EITHER ARCHESTRA_ORCHESTRATOR_KUBECONFIG or ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER is configured
 - Frontend disables local MCP server functionality when feature is off (shows tooltip explaining orchestratorK8sRuntime requirement)
 - Automatic pod lifecycle management (start/restart/stop)
@@ -358,7 +359,7 @@ pnpm rebuild <package-name>  # Enable scripts for specific package
 - K8s configuration: ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE, ARCHESTRA_ORCHESTRATOR_KUBECONFIG, ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER, ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE
 - Custom Docker images supported per MCP server (overrides ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE)
 - When using Docker image, command is optional (uses image's default CMD if not specified)
-- Runtime manager at `backend/src/mcp-server-runtime/`
+- Runtime manager at `backend/src/k8s/mcp-server-runtime/`
 
 **Configuring Transport Type**:
 


### PR DESCRIPTION
The migration-conflict recipe restored main's snapshot and then deleted it before regeneration. It also omitted standalone DELETE from the SQL to preserve. The recipe now retains main's baseline, preserves custom SQL in dependency order, and uses commands that keep the working directory stable.

Correct the other factual drift in project guidance: Docker-lite/Kubernetes/quickstart E2E environments and explicit spec registration (#6561), embeddings-only providers (#7363), cursor pagination for logs (#7635), public-route authentication exceptions, sandbox enablement (#6430), PostgreSQL lock/default behavior, and stale commands and paths. Remove the obsolete optimization-test claim and clarify retry and worker-process behavior.

Exercised disposable Drizzle migration collisions through both merge and rebase: main's SQL and snapshot remained intact, regeneration added only the branch's column, the standalone DELETE survived, and both operations completed. Also verified Playwright discovery with the documented command and validated the affected skill frontmatter and referenced paths/scripts. Product code is unchanged; no application test suite was run.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>