### PR TITLE
fix(frontend): one loading indicator through the auth surface

### DIFF
--- a/platform/e2e-tests/tests/loading-states.spec.ts
+++ b/platform/e2e-tests/tests/loading-states.spec.ts
@@ -133,6 +133,114 @@ test.describe("loading states", () => {
     await context.close();
   });
 
+  test("the sign-in surface never blanks, and its form lands in one place", async ({
+    browser,
+  }) => {
+    // One signed-out load used to run through five states: an indicator, an
+    // empty screen, the indicator again, an empty screen again, the card — and
+    // then the card shoved 55px down as the default-credentials banner landed
+    // above it in a vertically centred column. The blanks were the backend
+    // connectivity probe rendering nothing while it had no verdict, and the
+    // jump was the column painting before it knew its own shape.
+    //
+    // Hidden elements are skipped deliberately: React keeps the outgoing
+    // Suspense boundary mounted as `display: none` during a transition, so a
+    // naive query matches a loader nobody can see, at y=0.
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      const states: string[] = [];
+      (window as unknown as { __states: string[] }).__states = states;
+      const isVisible = (element: Element) =>
+        element.getClientRects().length > 0;
+      let previous = "";
+      const sample = () => {
+        const form = [...document.querySelectorAll("form")].find(isVisible);
+        const indicator = [...document.querySelectorAll("output")].find(
+          (element) =>
+            isVisible(element) && element.querySelector(".animate-spin"),
+        );
+        const state = form
+          ? `form@${Math.round(form.getBoundingClientRect().y)}`
+          : indicator
+            ? "indicator"
+            : "nothing";
+        if (state !== previous) {
+          previous = state;
+          states.push(state);
+        }
+        requestAnimationFrame(sample);
+      };
+      requestAnimationFrame(sample);
+    });
+
+    await page.goto(`${UI_BASE_URL}/auth/sign-in`);
+    await expect(
+      page.getByRole("button", { name: "Sign In", exact: true }),
+    ).toBeVisible();
+    // Give a late-arriving banner the chance to shift the form, so that a
+    // regression fails here rather than passing on timing.
+    await page.waitForTimeout(1000);
+
+    const states = await page.evaluate(
+      () => (window as unknown as { __states: string[] }).__states,
+    );
+
+    // Everything before the first paint is legitimately empty; the contract
+    // starts once the surface has shown something.
+    const painted = states.slice(states.findIndex((s) => s !== "nothing"));
+    expect(painted).not.toContain("nothing");
+
+    // The form is allowed to appear once. Appearing at two different offsets
+    // means something arrived above it after it had already painted.
+    const formOffsets = painted
+      .filter((s) => s.startsWith("form@"))
+      .map((s) => Number(s.slice("form@".length)));
+    const formSpread =
+      formOffsets.length > 1
+        ? Math.max(...formOffsets) - Math.min(...formOffsets)
+        : 0;
+    expect(formSpread).toBeLessThanOrEqual(2);
+
+    await context.close();
+  });
+
+  test("the chat page's gates draw a loader, never a stringified value", async ({
+    page,
+    goToPage,
+  }) => {
+    // The chat page holds the screen until it knows whether a provider key
+    // exists, and that gate once returned the *text* `null` where its loader
+    // used to be — an early return for the whole page, so the version footer
+    // went with it. Both queries behind the gate are pending on a cold load,
+    // so it renders for at least a frame every time; sampling each frame is
+    // what makes this deterministic rather than a race.
+    await page.addInitScript(() => {
+      const seen = new Set<string>();
+      (window as unknown as { __placeholders: Set<string> }).__placeholders =
+        seen;
+      const sample = () => {
+        for (const element of document.body?.querySelectorAll("*") ?? []) {
+          if (element.children.length > 0) continue;
+          const text = element.textContent?.trim();
+          if (text === "null" || text === "undefined") seen.add(text);
+        }
+        requestAnimationFrame(sample);
+      };
+      requestAnimationFrame(sample);
+    });
+
+    await goToPage(page, "/chat");
+    await expect(
+      page.getByPlaceholder(/What would you like to get done\?/i),
+    ).toBeVisible();
+
+    const placeholders = await page.evaluate(() => [
+      ...(window as unknown as { __placeholders: Set<string> }).__placeholders,
+    ]);
+    expect(placeholders).toEqual([]);
+  });
+
   test("an empty result is only reported once the list has actually loaded", async ({
     page,
     goToPage,

--- a/platform/frontend/src/app/_parts/with-auth-check.test.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.test.tsx
@@ -316,7 +316,7 @@ describe("WithAuthCheck", () => {
       expect(mockRouterPush).not.toHaveBeenCalled();
     });
 
-    it("keeps a centred indicator on auth pages, which have no shell to hold", () => {
+    it("shows the auth page immediately instead of waiting for the session", () => {
       vi.mocked(usePathname).mockReturnValue("/auth/sign-in");
 
       render(
@@ -325,8 +325,14 @@ describe("WithAuthCheck", () => {
         </WithAuthCheck>,
       );
 
-      const status = screen.getByRole("status", { name: "Loading…" });
-      expect(status.querySelector(".animate-spin")).not.toBeNull();
+      // The sign-in form is static and correct for everyone who is not signed
+      // in, so there is no second layout to guess at and nothing to wait for.
+      // Gating it on the session charged every real sign-in the round trip in
+      // order to spare a signed-in visitor a glimpse of a form — and that
+      // visitor is redirected either way, by the branch that fires when the
+      // session resolves.
+      expect(screen.getByTestId("protected-content")).toBeInTheDocument();
+      expect(screen.queryByRole("status", { name: "Loading…" })).toBeNull();
     });
   });
 

--- a/platform/frontend/src/app/_parts/with-auth-check.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.tsx
@@ -175,26 +175,24 @@ export const WithAuthCheck: React.FC<React.PropsWithChildren> = ({
     queryClient,
   ]);
 
-  // Auth surfaces are their own layout with no shell behind them, so a single
-  // centred indicator is still the right call while the session resolves. It
-  // draws inside the same frame the shell's auth branch will render, so the
-  // route's own loading indicator takes over at exactly this position.
-  if (inProgress && (isAuthPage || isSpecialAuth)) {
-    return (
-      <AuthSurfaceFrame>
-        <LoadingState label="Loading…" variant="fill" />
-      </AuthSurfaceFrame>
-    );
-  }
-
-  // Everywhere else, an unresolved session means we do not yet know whether
-  // this person gets the app or the sign-in page. Rendering either one's
-  // chrome now would flash the wrong layout, and a full-screen spinner is the
-  // jumpy boot loader this screen is meant to be rid of — so hold the
-  // background steady and say nothing visually. A refresh normally skips this
-  // branch entirely: the session comes back with the restored cache, already
-  // resolved.
-  if (inProgress) {
+  // An unresolved session means we do not yet know whether this person gets
+  // the app or the sign-in page. Rendering either one's chrome now would flash
+  // the wrong layout, and a full-screen spinner is the jumpy boot loader this
+  // screen is meant to be rid of — so hold the background steady and say
+  // nothing visually. A refresh normally skips this branch entirely: the
+  // session comes back with the restored cache, already resolved.
+  //
+  // Auth surfaces are deliberately exempt. They do not have a second layout to
+  // guess at: the sign-in form is static markup that is correct for every
+  // visitor who is not signed in, which on a sign-in page is very nearly all
+  // of them — and always the one arriving from sign-out, whose session was
+  // just destroyed. Holding it back bought only the certainty that a visitor
+  // who *is* signed in never glimpses a form before being redirected, and
+  // charged every real sign-in ~550ms for it. That visitor is being sent
+  // somewhere else either way; the branch below still catches them the moment
+  // the session resolves, and now they are interrupted from a form rather than
+  // from a spinner.
+  if (inProgress && !isAuthPage && !isSpecialAuth) {
     return <LoadingState label="Loading…" variant="quiet" />;
   }
 

--- a/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.tsx
+++ b/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.tsx
@@ -45,11 +45,10 @@ export function AuthPageWithInvitationCheck({ path }: { path: string }) {
   // Show loading while checking the invitation or redirecting to the
   // sign-up-with-invitation page
   if (invitationId && isSignUpPath) {
-    return (
-      <main className="h-full flex flex-col">
-        <LoadingState variant="fill" />
-      </main>
-    );
+    // No wrapper: `fill` centres in the frame slot the shell already gives
+    // this route. A `h-full` <main> around it resolves to zero height inside
+    // that flex column and drops the indicator at the top of the screen.
+    return <LoadingState variant="fill" />;
   }
 
   // Block direct sign-up without invitation
@@ -117,40 +116,52 @@ export function AuthPageWithInvitationCheck({ path }: { path: string }) {
   return (
     <BackendConnectivityStatus>
       <main className="h-full flex items-center justify-center p-4">
-        <div className="space-y-4 w-full max-w-md">
-          {showLogo && <AppLogo />}
+        {/*
+          The banner sits under the card and out of the column's flow, and the
+          column keeps its own `space-y-4` in a child so the banner's presence
+          cannot add a gap to it either. The queries it depends on answer after
+          the card has painted, and in a vertically centred column anything
+          that joins the column afterwards moves the card — which is what it
+          did, by 55px, every time someone opened sign-in on a deployment still
+          using the default credentials. Out of flow, it can arrive whenever it
+          arrives and nothing above it moves.
+        */}
+        <div className="relative w-full max-w-md">
           {showDefaultCredentialsWarning && (
-            <div className="p-0 m-0 pb-4">
+            <div className="absolute inset-x-0 top-full pt-4">
               <DefaultCredentialsWarning alwaysShow />
             </div>
           )}
-          {showExistingUserMessage && (
-            <Card className="mb-4">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base">Welcome Back!</CardTitle>
-                <CardDescription>
-                  You already have an account. Please sign in to join the new
-                  organization.
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          )}
-          {/*
+          <div className="space-y-4">
+            {showLogo && <AppLogo />}
+            {showExistingUserMessage && (
+              <Card className="mb-4">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base">Welcome Back!</CardTitle>
+                  <CardDescription>
+                    You already have an account. Please sign in to join the new
+                    organization.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            )}
+            {/*
             callbackURL behavior differs by flow:
             - Invitation flow: Points back to auth page with invitationId preserved.
               After OAuth/SSO completes, user returns here to trigger invitation acceptance.
             - Normal flow: Points to final destination (from redirectTo param or /).
               After auth completes, user goes directly to their intended page.
           */}
-          <AuthViewWithErrorHandling
-            path={path}
-            callbackURL={getAuthCallbackURL({
-              invitationId,
-              redirectTo,
-              searchParams,
-            })}
-          />
-          {isSignInOrSignUp && <CommunityLinks />}
+            <AuthViewWithErrorHandling
+              path={path}
+              callbackURL={getAuthCallbackURL({
+                invitationId,
+                redirectTo,
+                searchParams,
+              })}
+            />
+            {isSignInOrSignUp && <CommunityLinks />}
+          </div>
         </div>
       </main>
     </BackendConnectivityStatus>

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
@@ -312,13 +312,18 @@ export function AuthViewWithErrorHandling({
   // invitation, redirected to /auth/sign-up-with-invitation with one).
   const isSignInPage = path === "sign-in";
 
-  if (isLoadingPublicConfig && isSignInPage) {
-    return <LoadingState label="Loading sign-in…" variant="compact" />;
-  }
-
-  // When basic auth is disabled and SSO providers are still loading, wait (only for sign-in)
-  if (isBasicAuthDisabled && isLoadingIdentityProviders && isSignInPage) {
-    return <LoadingState label="Loading sign-in…" variant="compact" />;
+  // Both of these wait on a query that decides what goes *inside* the card —
+  // the password form, or the identity-provider list. Returning a bare
+  // indicator threw the card away to do it, collapsing a ~314px card to a
+  // ~96px box and, in a vertically centred column, moving the logo and
+  // everything else with it. The card is the one part that is known before
+  // either query answers, so it stays: only its contents wait.
+  if (
+    isSignInPage &&
+    (isLoadingPublicConfig ||
+      (isBasicAuthDisabled && isLoadingIdentityProviders))
+  ) {
+    return <SignInCardShell />;
   }
 
   // When basic auth is disabled and no SSO providers are configured, show a message
@@ -648,6 +653,35 @@ function SignInView({ callbackURL }: { callbackURL?: string }) {
         </CardContent>
       </Card>
     </>
+  );
+}
+
+/**
+ * The sign-in card with its contents still on the way.
+ *
+ * It carries the real card's header, because the title and description are
+ * true before any query answers — what is unknown is only whether the body is
+ * a password form or a list of identity providers. The body reserves roughly
+ * the height of the email/password/submit stack it is standing in for, so the
+ * card does not resize under the person reading it when the answer lands.
+ */
+function SignInCardShell() {
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="text-xl">Sign In</CardTitle>
+        <CardDescription>
+          Enter your email below to login to your account
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <LoadingState
+          label="Loading sign-in…"
+          variant="fill"
+          className="min-h-[188px]"
+        />
+      </CardContent>
+    </Card>
   );
 }
 

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
@@ -31,7 +31,11 @@ describe("BackendConnectivityStatus", () => {
   it.each([
     "initializing",
     "checking",
-  ] as const)("renders nothing while status is %s", (status) => {
+  ] as const)("keeps an indicator on screen while status is %s", (status) => {
+    // This wraps the whole auth column, and it sits between the session gate's
+    // indicator and the sign-in card. Rendering nothing here blanked the
+    // screen mid-boot — twice on one signed-out load — which reads as the page
+    // having thrown its content away rather than as a wait still in progress.
     vi.mocked(useBackendConnectivity).mockReturnValue({
       status,
       attemptCount: 0,
@@ -41,13 +45,13 @@ describe("BackendConnectivityStatus", () => {
       retry: mockRetry,
     });
 
-    const { container } = render(
+    render(
       <BackendConnectivityStatus>
         <div data-testid="child-content">Login Form</div>
       </BackendConnectivityStatus>,
     );
 
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByRole("status")).toBeInTheDocument();
     expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
   });
 

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.tsx
@@ -5,6 +5,7 @@ import { ExternalLink, LoaderCircle, RefreshCcw } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { AppLogo } from "@/components/app-logo";
+import { LoadingState } from "@/components/loading";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -61,8 +62,14 @@ export function BackendConnectivityStatus({
     return () => clearTimeout(timer);
   }, [status, redirectTo]);
 
+  // This wraps the whole auth column, so returning nothing here blanks the
+  // screen rather than showing less of it — and it lands mid-boot, between the
+  // session gate's indicator and the column it is about to hand over to. Hold
+  // that indicator in the box both of them centre in instead: the first probe
+  // is a single request, and a spinner that keeps spinning reads as one wait
+  // where a blank frame reads as the page having thrown its content away.
   if (status === "initializing" || status === "checking") {
-    return null;
+    return <LoadingState variant="fill" />;
   }
 
   if (status === "connected" && showConnectedMessage) {

--- a/platform/frontend/src/app/auth/sign-up-with-invitation/page.tsx
+++ b/platform/frontend/src/app/auth/sign-up-with-invitation/page.tsx
@@ -108,11 +108,7 @@ function SignUpWithInvitationContent() {
   };
 
   if (isCheckingInvitation && invitationId) {
-    return (
-      <main className="h-full flex flex-col">
-        <LoadingState variant="fill" />
-      </main>
-    );
+    return <LoadingState variant="fill" />;
   }
 
   return (

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -78,6 +78,7 @@ import { StreamTimeoutWarning } from "@/components/chat/stream-timeout-warning";
 import { useChatApps } from "@/components/chat/use-chat-apps";
 import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
 import { DefaultModelOnboardingStep } from "@/components/default-model-onboarding";
+import { LoadingState } from "@/components/loading";
 import MessageThread, {
   type PartialUIMessage,
 } from "@/components/message-thread";
@@ -3117,7 +3118,7 @@ export function ChatPageContent({
   //   (`isPlaywrightSetupNeeded`) reaches the composer, so the setup card
   //   appears when the check lands rather than while it runs.
   if (isLoadingApiKeyCheck) {
-    return <div className="flex items-center justify-center h-full">null</div>;
+    return <LoadingState variant="fill" />;
   }
 
   // The first keys fetch failed with no cached list (e.g. offline cold start).

--- a/platform/frontend/src/components/default-credentials-warning.test.tsx
+++ b/platform/frontend/src/components/default-credentials-warning.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseSession, mockUseDefaultCredentialsEnabled } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+  mockUseDefaultCredentialsEnabled: vi.fn(),
+}));
+
+const mockConfig = {
+  enterpriseFeatures: {
+    fullWhiteLabeling: false,
+  },
+};
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/lib/config/config", () => ({
+  default: new Proxy(
+    {},
+    {
+      get: (_target, prop) =>
+        prop in mockConfig
+          ? mockConfig[prop as keyof typeof mockConfig]
+          : undefined,
+    },
+  ),
+}));
+
+vi.mock("@/lib/auth/auth.query", () => ({
+  useSession: () => mockUseSession(),
+  useDefaultCredentialsEnabled: () => mockUseDefaultCredentialsEnabled(),
+}));
+
+import { DefaultCredentialsWarning } from "./default-credentials-warning";
+
+describe("DefaultCredentialsWarning", () => {
+  beforeEach(() => {
+    mockConfig.enterpriseFeatures.fullWhiteLabeling = false;
+    mockUseSession.mockReturnValue({ data: null });
+    mockUseDefaultCredentialsEnabled.mockReturnValue({
+      data: true,
+      isLoading: false,
+    });
+  });
+
+  it("tells an operator how to change the credentials", () => {
+    render(<DefaultCredentialsWarning alwaysShow />);
+
+    expect(screen.getByRole("link", { name: /Set ENV/ })).toBeInTheDocument();
+    // The link carries an sr-only "(opens in new tab)", so the visible phrase
+    // is split across nodes rather than contiguous.
+    expect(screen.getByRole("alert")).toHaveTextContent(/Set ENV.*to change/);
+  });
+
+  it("still says what to do when white-labeling hides the docs link", () => {
+    // The instruction used to live entirely in the link — "Set ENV" was the
+    // verb — so hiding it left the warning reading "to change" and nothing
+    // else. Whatever replaces the link has to carry the instruction itself.
+    mockConfig.enterpriseFeatures.fullWhiteLabeling = true;
+
+    render(<DefaultCredentialsWarning alwaysShow />);
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Set the admin credential environment variables to change",
+    );
+  });
+
+  it("points a signed-in admin at their account page instead of the docs", () => {
+    // No docs link and a session to act on: the account page is the whole
+    // instruction, so it must not arrive as a dangling "or Change".
+    mockConfig.enterpriseFeatures.fullWhiteLabeling = true;
+    mockUseSession.mockReturnValue({
+      data: { user: { email: "admin@example.com" } },
+    });
+
+    render(<DefaultCredentialsWarning />);
+
+    const link = screen.getByRole("link", { name: "Change password" });
+    expect(link).toHaveAttribute("href", "/account?highlight=change-password");
+    expect(screen.getByRole("alert")).not.toHaveTextContent(/\bor\s*$/);
+  });
+
+  it("keeps the slim badge readable without its link", () => {
+    mockConfig.enterpriseFeatures.fullWhiteLabeling = true;
+    mockUseSession.mockReturnValue({
+      data: { user: { email: "admin@example.com" } },
+    });
+
+    const { container } = render(<DefaultCredentialsWarning slim />);
+
+    // The separator existed only to introduce the link, so it goes with it.
+    expect(container).toHaveTextContent("Default credentials in use");
+    expect(container).not.toHaveTextContent("-");
+  });
+});

--- a/platform/frontend/src/components/default-credentials-warning.tsx
+++ b/platform/frontend/src/components/default-credentials-warning.tsx
@@ -4,7 +4,6 @@ import {
   DEFAULT_ADMIN_EMAIL,
   DEFAULT_ADMIN_PASSWORD,
   DocsPage,
-  getDocsUrl,
 } from "@archestra/shared";
 import { AlertTriangle } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
@@ -14,6 +13,7 @@ import {
   useDefaultCredentialsEnabled,
   useSession,
 } from "@/lib/auth/auth.query";
+import { getFrontendDocsUrl } from "@/lib/docs/docs";
 
 export function DefaultCredentialsWarning({
   alwaysShow = false,
@@ -26,6 +26,14 @@ export function DefaultCredentialsWarning({
   const userEmail = session?.user?.email;
   const { data: defaultCredentialsEnabled, isLoading } =
     useDefaultCredentialsEnabled();
+  // Null under full white-labeling, which hides links to the vendor's docs.
+  // Every branch below has to read as a finished sentence without them: the
+  // link used to carry the verb ("Set ENV"), so hiding it left the warning
+  // trailing off into "to change" and "or Change".
+  const deploymentDocsUrl = getFrontendDocsUrl(
+    DocsPage.PlatformDeployment,
+    "authentication--security",
+  );
 
   // Loading state - don't show anything yet
   if (isLoading || defaultCredentialsEnabled === undefined) {
@@ -43,24 +51,32 @@ export function DefaultCredentialsWarning({
   }
 
   if (slim) {
+    const fixUrl = getFrontendDocsUrl(
+      DocsPage.PlatformDeployment,
+      "authentication--security:~:text=ARCHESTRA_AUTH_ADMIN_EMAIL",
+    );
+
     return (
       <div className="rounded-lg border bg-card px-3 py-1.5 text-xs text-destructive">
         <p className="flex items-center gap-1.5 whitespace-nowrap">
           <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          <span>
-            Default credentials
-            {" - "}
-            <ExternalDocsLink
-              href={getDocsUrl(
-                DocsPage.PlatformDeployment,
-                "authentication--security:~:text=ARCHESTRA_AUTH_ADMIN_EMAIL",
-              )}
-              className="underline font-medium"
-              showIcon={false}
-            >
-              Fix
-            </ExternalDocsLink>
-          </span>
+          {fixUrl ? (
+            <span>
+              Default credentials
+              {" - "}
+              <ExternalDocsLink
+                href={fixUrl}
+                className="underline font-medium"
+                showIcon={false}
+              >
+                Fix
+              </ExternalDocsLink>
+            </span>
+          ) : (
+            // Without the link the separator has nothing to introduce, so the
+            // label stands alone rather than trailing a dangling dash.
+            <span>Default credentials in use</span>
+          )}
         </p>
       </div>
     );
@@ -93,28 +109,40 @@ export function DefaultCredentialsWarning({
           </div>
         </div>
         <p className="mt-1">
-          <ExternalDocsLink
-            href={getDocsUrl(
-              DocsPage.PlatformDeployment,
-              "authentication--security",
-            )}
-            className="underline"
-            showIcon={false}
-          >
-            Set ENV
-          </ExternalDocsLink>
-          {alwaysShow ? (
-            <span>{" to change"}</span>
-          ) : (
+          {deploymentDocsUrl ? (
             <>
-              <span>{" or "}</span>
-              <a
-                href="/account?highlight=change-password"
+              <ExternalDocsLink
+                href={deploymentDocsUrl}
                 className="underline"
+                showIcon={false}
               >
-                Change
-              </a>
+                Set ENV
+              </ExternalDocsLink>
+              {alwaysShow ? (
+                <span>{" to change"}</span>
+              ) : (
+                <>
+                  <span>{" or "}</span>
+                  <a
+                    href="/account?highlight=change-password"
+                    className="underline"
+                  >
+                    Change
+                  </a>
+                </>
+              )}
             </>
+          ) : alwaysShow ? (
+            // Nobody is signed in yet, so there is no account page to send
+            // them to — say what has to happen instead of linking to it.
+            <span>
+              Set the admin credential environment variables to change
+            </span>
+          ) : (
+            // Signed in, so the account page is the whole instruction.
+            <a href="/account?highlight=change-password" className="underline">
+              Change password
+            </a>
           )}
         </p>
       </AlertDescription>

--- a/platform/frontend/src/components/loading.test.tsx
+++ b/platform/frontend/src/components/loading.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { LoadingState } from "./loading";
 
 describe("LoadingState", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("exposes the label to assistive tech and respects reduced motion", () => {
     const { container } = render(<LoadingState label="Loading connectors…" />);
 
@@ -40,10 +44,44 @@ describe("LoadingState", () => {
     const fill = filled.querySelector("output");
     expect(fill?.className).toContain("h-full");
     expect(fill?.className).not.toContain("visual-viewport-height");
+  });
 
-    // It also takes over from an indicator already on screen, so it must not
-    // delay its own entrance and blank the area at the handover.
-    expect(fill?.className).not.toContain("animation-delay");
+  it("holds a fresh indicator back so a short wait draws nothing", () => {
+    // A wait shorter than the delay never draws: the indicator is transparent
+    // for the whole delay (`backwards` fill-mode) and unmounts before it would
+    // have appeared. That is what keeps a gate resolving in 50ms from flashing
+    // a spinner nobody could read — the sign-out route did exactly that.
+    //
+    // Fresh means nothing was on screen recently, and the previous test's
+    // teardown was milliseconds ago, so move past the handover window first.
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 10_000);
+
+    const { container } = render(<LoadingState variant="fill" />);
+    expect(container.querySelector("output")?.className).toContain(
+      "animation-delay",
+    );
+  });
+
+  it("does not delay an indicator that replaces one already on screen", () => {
+    // The same call site is a fresh wait or a handover depending only on what
+    // was on screen a moment earlier, so the component decides per mount
+    // rather than trusting a prop. Delaying at a handover would blank the area
+    // between the two indicators instead of covering a new wait.
+    const first = render(<LoadingState variant="fill" />);
+    const takingOver = render(<LoadingState variant="fill" />);
+
+    expect(
+      takingOver.container.querySelector("output")?.className,
+    ).not.toContain("animation-delay");
+
+    // Still a handover when the outgoing one leaves first, which is the order
+    // a plain conditional swap unmounts in.
+    first.unmount();
+    takingOver.unmount();
+    const afterSwap = render(<LoadingState variant="fill" />);
+    expect(
+      afterSwap.container.querySelector("output")?.className,
+    ).not.toContain("animation-delay");
   });
 
   it("keeps inline loading labels accessible-only", () => {

--- a/platform/frontend/src/components/loading.tsx
+++ b/platform/frontend/src/components/loading.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { ComponentProps, ReactNode } from "react";
+import {
+  type ComponentProps,
+  type ReactNode,
+  useEffect,
+  useState,
+} from "react";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "./ui/skeleton";
 
@@ -73,17 +78,25 @@ export function LoadingState({
   /** Compact controls can hide the visible label while retaining its accessible name. */
   showLabel?: boolean;
 }) {
+  const delayEntrance = useDelayedEntrance();
+
   return (
     <output
       aria-label={label}
       className={cn(
         "flex flex-col items-center justify-center text-center",
+        // A spinner that comes and goes inside a couple of hundred
+        // milliseconds reports nothing — the eye reads it as the page
+        // glitching, and a screen that flashes one on every gate reads as
+        // broken even when every gate is fast. Holding the entrance back means
+        // anything that resolves quickly resolves invisibly, and only a wait
+        // long enough to notice ever draws. `backwards` fill-mode keeps it
+        // transparent during the delay rather than showing then fading.
+        delayEntrance &&
+          "animate-in fade-in-0 duration-200 [animation-delay:200ms] [animation-fill-mode:backwards] motion-reduce:animate-none",
         variant === "viewport" && "min-h-app-viewport",
         variant === "page" &&
-          "min-h-[calc(var(--visual-viewport-height,100dvh)-12rem)] animate-in fade-in-0 duration-200 [animation-delay:150ms] [animation-fill-mode:backwards] motion-reduce:animate-none",
-        // No enter-delay: `fill` takes over from an indicator that is already
-        // on screen (the session gate's), so fading in late would blank the
-        // area at the handover instead of covering a fresh wait.
+          "min-h-[calc(var(--visual-viewport-height,100dvh)-12rem)]",
         variant === "fill" && "h-full min-h-0 flex-1",
         variant === "content" && "min-h-48 py-10",
         variant === "compact" && "min-h-24 py-4",
@@ -130,3 +143,57 @@ export function LoadingWrapper({
   if (error) return <>{errorFallback}</>;
   return <>{children}</>;
 }
+
+/**
+ * Whether this indicator should hold its entrance back.
+ *
+ * Two rules that pull in opposite directions, and neither is a property of the
+ * call site — which is why this is decided per mount rather than per prop:
+ *
+ * - A wait too short to read should draw nothing. Delaying the entrance means
+ *   a gate that resolves quickly resolves invisibly instead of strobing.
+ * - An indicator replacing one that was just on screen has no wait to
+ *   introduce; delaying it blanks the area across the handover, which reads as
+ *   the page dropping its content rather than as one continuous wait.
+ *
+ * The same component is both, depending on what happened immediately before
+ * it: the auth route's Suspense fallback takes over from the session gate on a
+ * first load, and opens a fresh wait on a client-side navigation. So ask the
+ * screen instead of the caller — if an indicator is up, or was up moments ago,
+ * this is a handover.
+ *
+ * SSR renders the delayed form, and so does the client at hydration (nothing
+ * can have unmounted yet), so the two agree.
+ */
+function useDelayedEntrance() {
+  const [delayEntrance] = useState(() => !isHandover());
+
+  useEffect(() => {
+    visibleIndicators += 1;
+    return () => {
+      visibleIndicators -= 1;
+      lastIndicatorHiddenAt = Date.now();
+    };
+  }, []);
+
+  return delayEntrance;
+}
+
+function isHandover() {
+  if (typeof window === "undefined") return false;
+  return (
+    visibleIndicators > 0 ||
+    Date.now() - lastIndicatorHiddenAt < HANDOVER_WINDOW_MS
+  );
+}
+
+/**
+ * How recently another indicator must have left for this one to count as
+ * taking over from it. A swap unmounts the outgoing indicator and mounts the
+ * incoming one in the same commit, so in practice this compares against a few
+ * milliseconds ago; the window only needs to be wider than a frame.
+ */
+const HANDOVER_WINDOW_MS = 150;
+
+let visibleIndicators = 0;
+let lastIndicatorHiddenAt = 0;


### PR DESCRIPTION
## Problem

Signing out and back in ran through a sequence of unrelated loading states. Sampling every frame of a signed-out `/auth/sign-in` load showed five:

```
indicator → blank → indicator → blank → form@770 → form@825
```

The form's last move was the default-credentials banner arriving above it in a vertically centred column and pushing it down 55px.

Separately, `app/chat/page.tsx` rendered the literal text `null` while the provider-keys query resolved:

```jsx
if (isLoadingApiKeyCheck) {
  return <div className="flex items-center justify-center h-full">null</div>;
}
```

It is an early return for the whole page, so the version footer went with it. Introduced in #7663, which replaced the `<LoadingState />` there and dropped the import. Only visible for the ~100ms the gate is open, which is why it survived — it takes a cold session (right after sign-in) plus throttling to catch.

## Approach

Each state had a different cause, so each is fixed where it originates rather than by layering another gate on top:

- **The blanks** were `BackendConnectivityStatus` returning `null` while probing the backend. It wraps the entire auth column and sits between the session gate and the card, so "no verdict yet" rendered as an empty screen. It now holds the same indicator the gates around it draw.
- **The jump** is gone because the banner is positioned out of the column's flow, under the card. It can arrive whenever it arrives. The two in-card gates also stop throwing the card away: they render its real header with the loader in the body, instead of collapsing a ~314px card to a ~96px box and moving the logo with it.
- **The wait itself** was `WithAuthCheck` holding every auth page until `GET /api/auth/get-session` answered, so that a signed-in visitor never glimpses a form before being redirected. Auth surfaces now render immediately — the sign-in form is static markup, correct for everyone not signed in, which on a sign-in page is nearly everyone and always the person arriving from sign-out. The branch that redirects a signed-in visitor still fires when the session resolves; they are now interrupted from a form rather than from a spinner. Non-auth pages keep the gate, which genuinely cannot know which layout comes next.
- **The flashes** are handled once, in `LoadingState`: it holds its entrance 200ms, so a gate that resolves quickly resolves invisibly.

## Tradeoffs

**A delayed indicator must not delay at a handover**, or the area blanks between the outgoing and incoming one. Whether a given mount is a fresh wait or a handover is not a property of the call site — the auth route's Suspense fallback takes over from the session gate on a first load, and opens a fresh wait on a client-side navigation. A `delayEntrance` prop got this wrong in exactly that way (a 52ms flash on the way to sign-out), so the component decides per mount from what is on screen: an indicator currently up, or one gone within 150ms, means a handover.

**Holding the column until its shape is known was tried and rejected.** Gating the sign-in card on the queries that decide it removed the jump, but during a backend restart `/api/auth/default-credentials-status` answered 500 into a retry storm and the page became a permanent spinner — a cosmetic fix that cost the ability to sign in. Positioning the banner out of flow gets the same result without making the form depend on backend health.

**A signed-in visitor landing on `/auth/sign-in` now sees the form for ~250ms before being redirected**, where previously they saw a spinner for ~250ms before being redirected. Same interruption, and the common case gets the form with no spinner at all.

## Result

Same flow, signed out and unthrottled against a dev stack:

| | before | after |
|---|---|---|
| states on screen | 5, ending in a 55px jump | indicator → complete form |
| form appears | 648ms | 435ms |
| indicator on screen | 545ms | ~375ms mounted, first 200ms invisible |

Sign-out loses a step too: the route fallback's 52ms `Loading…` no longer draws, leaving `Signing out…` and then the new document.

What remains on that path is the auth view's client JS — the sign-in card is a client component, so a static form still waits for JavaScript. Server-rendering it is the next step and is not in this PR.

## Also here

The default-credentials warning lost its instruction under full white-labeling. `getVisibleDocsUrl` hides links to the vendor's docs, and the instruction lived entirely inside one — "Set ENV" was the verb — so the sign-in page read:

```
Default Admin Credentials Enabled
- admin@example.com
- password
to change
```

All three call shapes degraded, not just that one: the signed-in banner ended at "or Change", the slim badge at "Default credentials - ". Each branch now reads as a finished sentence without a link. The white-label copy deliberately does not name the environment variables — they carry the vendor prefix, and printing them into a white-labeled UI leaks the name that mode exists to hide.

## Verification

Driven as the real flow in a browser against the dev stack — sign in, sign out, sign back in — sampling visible indicators and element offsets every frame. The numbers above are from that. A delayed indicator is in the DOM for the whole wait but transparent for the first 200ms, so measurements filter on computed opacity; a probe that only checks for the element overstates what is on screen.

`loading-states.spec.ts` gains two regression tests, both verified to fail against the code they describe: a cold `/chat` load renders no stringified value, and the sign-in surface never blanks between its gates while its form lands at a single offset.

Three existing tests changed meaning rather than being extended, each pinning behaviour this PR deliberately reverses — worth a look:

- `backend-connectivity-status.test.tsx` asserted `toBeEmptyDOMElement()` while probing; it pinned the blank screen.
- `with-auth-check.test.tsx` asserted a centred indicator on auth pages; it pinned the session gate.
- `loading.test.tsx` asserted `fill` never carries an entrance delay.

Unrelated and pre-existing on `main`: three frontend tests fail (`llm/(costs)/limits` ×2, `usage-dimension-cards`), and `pnpm lint` reports six warnings in files this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>