### PR TITLE
feat(connection): make CLI startup guards version aware

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -134078,8 +134078,16 @@
                         "ok",
                         "down"
                       ]
+                    },
+                    "guardVersion": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
                     }
                   },
+                  "required": [
+                    "guardVersion"
+                  ],
                   "additionalProperties": false
                 }
               }

--- a/docs/pages/platform-connection.md
+++ b/docs/pages/platform-connection.md
@@ -3,7 +3,7 @@ title: Connect Your Agents
 category: Archestra Platform
 order: 8
 description: How the one-command setup script connects your AI tools, and how to audit or undo it
-lastUpdated: 2026-08-24
+lastUpdated: 2026-09-07
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -71,6 +71,8 @@ A remote the platform reports down gets a "Failed to connect to …" line. After
 After an interactive client session exits, its Bash or PowerShell wrapper refreshes the Archestra marketplace and installed plugins if the last successful refresh was more than 24 hours ago. Refresh happens after the session, never in the startup path, and one-shot invocations such as `claude -p` and `codex exec` skip it.
 
 Under the checks the guard always shows its two keys: "To skip press [Space] · to reconfigure your Archestra connection press [C]". Press `Space` at any point to skip the rest of the checks and start the CLI at once — nothing is disconnected or remembered. When everything is healthy the guard waits about a second and a half for a key, then starts the CLI. Press `C` and the rows turn into a numbered menu — one per remote — so you can disconnect any of them, reachable or not, by pressing its number. The row lands on a check, later launches skip it, and removing the last connected remote uninstalls the guard. Press `Esc` to leave the menu and start the CLI.
+
+The same health request also tells the guard whether a newer version of the setup is available. The guard remembers the version it was installed at and compares it to the version the platform reports. When the platform is ahead, the guard shows an "update" line with one more key — press `U` to see the steps to re-run the setup from the Connection page. The line is advisory only: it never blocks the launch, and a non-interactive run — `codex exec` or `claude -p`, for example — just prints a one-line note on stderr instead. An older or rolled-back instance stays silent, so you are nudged only when there is genuinely a newer setup to pick up.
 
 The guard lives under `~/.archestra/`, hooked in by a marked wrapper block in your shell profile — on Windows, in each PowerShell edition's `profile.ps1`. Each client has its own file and its own disable variable:
 

--- a/docs/pages/platform-connection.md
+++ b/docs/pages/platform-connection.md
@@ -74,6 +74,8 @@ Under the checks the guard always shows its two keys: "To skip press [Space] · 
 
 The same health request also tells the guard whether a newer version of the setup is available. The guard remembers the version it was installed at and compares it to the version the platform reports. When the platform is ahead, the guard shows an "update" line with one more key — press `U` to see the steps to re-run the setup from the Connection page. The line is advisory only: it never blocks the launch, and a non-interactive run — `codex exec` or `claude -p`, for example — just prints a one-line note on stderr instead. An older or rolled-back instance stays silent, so you are nudged only when there is genuinely a newer setup to pick up.
 
+A guard installed before this version check cannot show that update line — it predates the check. The next time you run the setup, the script spots the older guard and upgrades it in place automatically, with no prompt. The replacement matches the version the platform reports, so it stays silent on the next launch instead of nudging you again.
+
 The guard lives under `~/.archestra/`, hooked in by a marked wrapper block in your shell profile — on Windows, in each PowerShell edition's `profile.ps1`. Each client has its own file and its own disable variable:
 
 | Client | macOS / Linux | Windows | Disable with |

--- a/platform/backend/src/routes/connection-setup/connection-setup.routes.ts
+++ b/platform/backend/src/routes/connection-setup/connection-setup.routes.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_APP_NAME,
   providerDisplayNames,
   RouteId,
+  STARTUP_GUARD_FORMAT_VERSION,
   type SupportedProvider,
   SupportedProvidersSchema,
   toMcpClientServerName,
@@ -209,6 +210,15 @@ const ConnectionHealthResponseSchema = z.object({
    */
   mcp: ConnectionHealthStatusSchema.optional(),
   llm: ConnectionHealthStatusSchema.optional(),
+  /**
+   * The running instance's monotonic startup-guard format version. The guard is
+   * stamped with this at connect time and, on every launch, nudges a re-connect
+   * only when this value is STRICTLY GREATER than its own — so a rollback or an
+   * older instance (equal-or-lower number) stays silent. Non-secret. Older
+   * guards ignore the field; a newer guard talking to an older backend that
+   * omits it simply skips the check.
+   */
+  guardVersion: z.number().int().nonnegative(),
 });
 
 const connectionSetupRoutes: FastifyPluginAsyncZod = async (fastify) => {
@@ -267,7 +277,11 @@ const connectionSetupRoutes: FastifyPluginAsyncZod = async (fastify) => {
           : exists
             ? ("ok" as const)
             : ("down" as const);
-      return { mcp: statusOf(mcpExists), llm: statusOf(llmExists) };
+      return {
+        mcp: statusOf(mcpExists),
+        llm: statusOf(llmExists),
+        guardVersion: STARTUP_GUARD_FORMAT_VERSION,
+      };
     },
   );
 

--- a/platform/backend/src/routes/connection-setup/get.connection-health.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/get.connection-health.route.test.ts
@@ -1,4 +1,7 @@
-import { VIRTUAL_KEY_HEADER } from "@archestra/shared";
+import {
+  STARTUP_GUARD_FORMAT_VERSION,
+  VIRTUAL_KEY_HEADER,
+} from "@archestra/shared";
 import { vi } from "vitest";
 import { AgentModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
@@ -6,6 +9,13 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 
 vi.mock("@/auth");
+
+/**
+ * Every response carries the monotonic startup-guard format version so the guard
+ * can flag a strictly-newer instance. Kept out of the per-case objects below via
+ * a shared constant.
+ */
+const GUARD_VERSION = STARTUP_GUARD_FORMAT_VERSION;
 
 // cacheManager needs a live PostgreSQL connection that PGlite tests don't
 // have; back it with the canonical Map-backed fake from
@@ -60,7 +70,26 @@ describe("GET /v1/health", () => {
       `?mcp=${gateway.slug ?? gateway.id}&llm=${proxy.id}`,
     );
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ mcp: "ok", llm: "ok" });
+    expect(res.json()).toEqual({
+      mcp: "ok",
+      llm: "ok",
+      guardVersion: GUARD_VERSION,
+    });
+  });
+
+  test("carries the guard format version on every response, params or not", async ({
+    makeAgent,
+  }) => {
+    // The startup guard stamps this at connect time and re-reads it here every
+    // launch; a bare ping (no params) still answers with it.
+    const proxy = await makeAgent({ agentType: "llm_proxy" });
+    expect((await health("")).json()).toEqual({ guardVersion: GUARD_VERSION });
+    expect((await health(`?llm=${proxy.id}`)).json()).toEqual({
+      llm: "ok",
+      guardVersion: GUARD_VERSION,
+    });
+    expect(Number.isInteger(GUARD_VERSION)).toBe(true);
+    expect(GUARD_VERSION).toBeGreaterThanOrEqual(0);
   });
 
   test("reports down for a deleted gateway — the startup-guard scenario", async ({
@@ -69,32 +98,46 @@ describe("GET /v1/health", () => {
     const gateway = await makeAgent({ agentType: "mcp_gateway" });
     const proxy = await makeAgent({ agentType: "llm_proxy" });
     const query = `?mcp=${gateway.id}&llm=${proxy.id}`;
-    expect((await health(query)).json()).toEqual({ mcp: "ok", llm: "ok" });
+    expect((await health(query)).json()).toEqual({
+      mcp: "ok",
+      llm: "ok",
+      guardVersion: GUARD_VERSION,
+    });
 
     await AgentModel.delete(gateway.id);
 
     // Freshness is the contract: a just-deleted gateway must read as down
     // immediately (no resolve-cache staleness).
-    expect((await health(query)).json()).toEqual({ mcp: "down", llm: "ok" });
+    expect((await health(query)).json()).toEqual({
+      mcp: "down",
+      llm: "ok",
+      guardVersion: GUARD_VERSION,
+    });
   });
 
   test("each param answers independently and is optional", async ({
     makeAgent,
   }) => {
     const proxy = await makeAgent({ agentType: "llm_proxy" });
-    expect((await health(`?llm=${proxy.id}`)).json()).toEqual({ llm: "ok" });
+    expect((await health(`?llm=${proxy.id}`)).json()).toEqual({
+      llm: "ok",
+      guardVersion: GUARD_VERSION,
+    });
     expect(
       (await health("?mcp=00000000-0000-0000-0000-000000000000")).json(),
-    ).toEqual({ mcp: "down" });
+    ).toEqual({ mcp: "down", guardVersion: GUARD_VERSION });
     // no params = a bare reachability ping
-    expect((await health("")).json()).toEqual({});
+    expect((await health("")).json()).toEqual({ guardVersion: GUARD_VERSION });
   });
 
   test("is kind-scoped: a proxy ref never passes as a gateway", async ({
     makeAgent,
   }) => {
     const proxy = await makeAgent({ agentType: "llm_proxy" });
-    expect((await health(`?mcp=${proxy.id}`)).json()).toEqual({ mcp: "down" });
+    expect((await health(`?mcp=${proxy.id}`)).json()).toEqual({
+      mcp: "down",
+      guardVersion: GUARD_VERSION,
+    });
   });
 
   test("heavily rate limits per requester, identified by forwarded-for", async ({

--- a/platform/backend/src/services/startup-guard.test.ts
+++ b/platform/backend/src/services/startup-guard.test.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import {
   CLAUDE_CODE_PROXY_ENV_KEYS,
+  STARTUP_GUARD_FORMAT_VERSION,
   STARTUP_GUARD_INSTALL,
 } from "@archestra/shared";
 import { describe, expect, test } from "vitest";
@@ -315,6 +316,22 @@ describe("renderStartupGuardScript", () => {
     expect(skillsAt).toBeGreaterThan(mcpAt);
   });
 
+  test("stamps the monotonic guard format version for the strict-newer update check", () => {
+    const script = renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT);
+    expect(script).toContain(
+      `GUARD_FORMAT_VERSION=${STARTUP_GUARD_FORMAT_VERSION}`,
+    );
+    // reads the live integer out of the same health body and only flags when
+    // it is strictly greater
+    expect(script).toContain("version_is_stale");
+    expect(script).toContain(`'"guardVersion":'`);
+    expect(script).toContain('-gt "$GUARD_FORMAT_VERSION"');
+    // interactive offers a timed, non-blocking [U] that prints the re-run steps
+    expect(script).toContain("[U]");
+    expect(script).toContain("/connection page and pick");
+    expect(script).toContain('read -rs -n 1 -t "$RECONFIG_WAIT" key');
+  });
+
   test("makes ONE health request for the launch; skills has no per-resource marker", () => {
     const script = renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT);
     expect(script).toContain(`HEALTH_URL='${CTX.healthUrl}'`);
@@ -611,6 +628,48 @@ describe("renderStartupGuardScript", () => {
     expect(stderr).toBe("");
   });
 
+  test("non-interactive run nudges an update only when the instance reports a strictly newer guard version", async () => {
+    // Remotes healthy; the instance reports a guard format one past the one
+    // this guard was stamped with.
+    const { stdout, stderr } = await runGuardNonInteractive({
+      script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 0,
+      curlBody: `{"mcp":"ok","llm":"ok","guardVersion":${STARTUP_GUARD_FORMAT_VERSION + 1}}`,
+    });
+    expect(stdout).toBe("");
+    expect(stderr).toContain("a newer Archestra setup for claude is available");
+    expect(stderr).toContain("/connection");
+  });
+
+  test("non-interactive run stays silent when the instance reports the same guard version", async () => {
+    const { stdout, stderr } = await runGuardNonInteractive({
+      script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 0,
+      curlBody: `{"mcp":"ok","llm":"ok","guardVersion":${STARTUP_GUARD_FORMAT_VERSION}}`,
+    });
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+  });
+
+  test("an older instance or a rollback (lower guard version) stays silent — no downgrade nag", async () => {
+    const { stdout, stderr } = await runGuardNonInteractive({
+      script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 0,
+      curlBody: `{"mcp":"ok","llm":"ok","guardVersion":${STARTUP_GUARD_FORMAT_VERSION - 1}}`,
+    });
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+  });
+
+  test("the guard version is read from the same whitespace-normalized body the down markers are", async () => {
+    const { stderr } = await runGuardNonInteractive({
+      script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 0,
+      curlBody: `{"mcp": "ok", "llm": "ok", "guardVersion": ${STARTUP_GUARD_FORMAT_VERSION + 1}}`,
+    });
+    expect(stderr).toContain("a newer Archestra setup for claude is available");
+  });
+
   test("ARCHESTRA_CLAUDE_GUARD=0 disables the guard entirely", async () => {
     const { stdout, stderr } = await runGuardNonInteractive({
       script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
@@ -766,6 +825,41 @@ describe("renderStartupGuardScript", () => {
     expect(output).not.toContain("Disconnected");
     expect(existsSync(guardHome.skipFile)).toBe(false);
     expect(existsSync(guardHome.guardFile)).toBe(true);
+  });
+
+  test("interactive, all healthy but the instance reports a newer guard version: shows the advisory and the [U] offer", async () => {
+    const { output, guardHome } = await runGuardInteractive({
+      script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 0,
+      curlBody: `{"mcp":"ok","llm":"ok","guardVersion":${STARTUP_GUARD_FORMAT_VERSION + 1}}`,
+      keys: "",
+    });
+    expect(output).toContain("a newer Archestra setup is available");
+    expect(output).toContain("[U]");
+    // the steps are only shown once [U] is pressed
+    expect(output).not.toContain("/connection page and pick");
+    // purely advisory: nothing disconnected, guard stays installed
+    expect(output).not.toContain("Disconnected");
+    expect(existsSync(guardHome.guardFile)).toBe(true);
+    expect(existsSync(guardHome.skipFile)).toBe(false);
+  });
+
+  test("interactive, stale: pressing [U] prints the /connection re-run steps and still launches", async () => {
+    const { output, guardHome } = await runGuardInteractive({
+      script: renderStartupGuardScript(CTX, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 0,
+      curlBody: `{"mcp":"ok","llm":"ok","guardVersion":${STARTUP_GUARD_FORMAT_VERSION + 1}}`,
+      keys: "U",
+    });
+    expect(output).toContain(
+      "To update, re-run the Archestra connection setup",
+    );
+    expect(output).toContain("/connection page and pick Claude Code");
+    // advisory only — the guard never disconnects or removes anything, and it
+    // still exits cleanly so the wrapper can launch the client
+    expect(output).not.toContain("Disconnected");
+    expect(existsSync(guardHome.guardFile)).toBe(true);
+    expect(existsSync(guardHome.skipFile)).toBe(false);
   });
 
   test("interactive, Bash 3.2 fallback hears Space between animation frames", async () => {

--- a/platform/backend/src/services/startup-guard.test.ts
+++ b/platform/backend/src/services/startup-guard.test.ts
@@ -257,6 +257,47 @@ async function readClaudeLog(guardHome: GuardHome): Promise<string> {
     : "";
 }
 
+/**
+ * Runs the real install section (the connect step that writes the guard) in a
+ * sandboxed $HOME, with a minimal preamble supplying the setup script's say/ok
+ * helpers. `preExistingGuard`, when given, is written to the guard path first so
+ * the section's pre-feature detection has a prior guard to inspect. Returns the
+ * install's stdout and the path of the guard it wrote.
+ */
+async function runInstallSection(params: {
+  preExistingGuard?: string;
+}): Promise<{ stdout: string; guardFile: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "archestra-guard-install-"));
+  const home = path.join(dir, "home");
+  const guardFile = path.join(home, CLAUDE_CODE_GUARD_SCRIPT_RELPATH);
+  await mkdir(path.dirname(guardFile), { recursive: true });
+  if (params.preExistingGuard !== undefined) {
+    await writeFile(guardFile, params.preExistingGuard, "utf8");
+  }
+  const preamble = [
+    "ARCH_C_RESET=''; ARCH_C_HEAD=''; ARCH_C_OK=''",
+    `say()  { printf '\\n==> %s\\n' "$1"; }`,
+    `ok()   { printf '==> %s\\n' "$1"; }`,
+    "",
+  ].join("\n");
+  const scriptFile = path.join(dir, "install.sh");
+  await writeFile(
+    scriptFile,
+    preamble + buildStartupGuardInstallSection(CTX, CLAUDE_CODE_GUARD_CLIENT),
+    "utf8",
+  );
+  const { stdout } = await execFileAsync("bash", [scriptFile], {
+    env: {
+      ...process.env,
+      HOME: home,
+      SHELL: "/bin/bash",
+    } as Record<string, string>,
+  });
+  // the sandbox $HOME (and the guard it wrote) is left on disk for the caller to
+  // read back, then reaped by the OS temp sweeper.
+  return { stdout, guardFile };
+}
+
 describe("buildStartupGuardContext", () => {
   test("derives refs and the single health URL from the connect-wired URLs", () => {
     const setupCtx: SetupScriptContext = {
@@ -1019,5 +1060,64 @@ describe("buildStartupGuardInstallSection", () => {
     expect(section).toContain('command claude "$@"');
     // strip-then-append keeps re-runs from duplicating the block
     expect(section).toContain("awk -v start=");
+  });
+
+  test("detects a pre-feature guard (no version stamp) and upgrades it without prompting", () => {
+    const section = buildStartupGuardInstallSection(
+      CTX,
+      CLAUDE_CODE_GUARD_CLIENT,
+    );
+    // a guard installed before the version check has no GUARD_FORMAT_VERSION
+    // line; the install reads the existing file before overwriting it
+    expect(section).toContain("grep -q 'GUARD_FORMAT_VERSION='");
+    expect(section).toContain("archestra_guard_pre_feature=1");
+    // and announces the automatic, prompt-free upgrade
+    expect(section).toContain(
+      "Upgraded your existing Claude Code startup guard",
+    );
+  });
+
+  test("auto-upgrades a pre-feature guard in place; a stamped or absent guard is refreshed silently", async () => {
+    // A guard from before the version-check feature: no GUARD_FORMAT_VERSION.
+    const preFeature = await runInstallSection({
+      preExistingGuard:
+        "#!/usr/bin/env bash\n# archestra guard (pre version-check)\nexit 0\n",
+    });
+    expect(preFeature.stdout).toContain(
+      "Upgraded your existing Claude Code startup guard",
+    );
+    // the replacement now carries the current version stamp
+    expect(await readFile(preFeature.guardFile, "utf8")).toContain(
+      `GUARD_FORMAT_VERSION=${STARTUP_GUARD_FORMAT_VERSION}`,
+    );
+
+    // a guard that already carries the stamp is refreshed, but NOT announced as
+    // an upgrade — a version-behind feature guard reaches connect via its own
+    // [U] launch nudge, not this pre-feature path
+    const stamped = await runInstallSection({
+      preExistingGuard: `#!/usr/bin/env bash\nGUARD_FORMAT_VERSION=${STARTUP_GUARD_FORMAT_VERSION}\nexit 0\n`,
+    });
+    expect(stamped.stdout).not.toContain("Upgraded your existing");
+
+    // first-ever connect (no guard yet) is a plain install, not an upgrade
+    const fresh = await runInstallSection({});
+    expect(fresh.stdout).not.toContain("Upgraded your existing");
+  });
+
+  test("the auto-upgraded guard is stamped current, so it does not then immediately nag to update", async () => {
+    // Reconciles with the stale-version [U] behavior: right after connect lifts
+    // a pre-feature user onto the current guard, that guard sees the instance at
+    // an EQUAL version and stays silent — no [U] nag on the very next launch.
+    const { guardFile } = await runInstallSection({
+      preExistingGuard:
+        "#!/usr/bin/env bash\n# archestra guard (pre version-check)\nexit 0\n",
+    });
+    const { stdout, stderr } = await runGuardNonInteractive({
+      script: await readFile(guardFile, "utf8"),
+      curlExitCode: 0,
+      curlBody: `{"mcp":"ok","llm":"ok","guardVersion":${STARTUP_GUARD_FORMAT_VERSION}}`,
+    });
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
   });
 });

--- a/platform/backend/src/services/startup-guard.test.ts
+++ b/platform/backend/src/services/startup-guard.test.ts
@@ -862,6 +862,38 @@ describe("renderStartupGuardScript", () => {
     expect(existsSync(guardHome.skipFile)).toBe(false);
   });
 
+  test("interactive, disconnecting the last remote uninstalls the guard: no update nag for a guard that's gone", async () => {
+    // A single-remote guard whose only remote the platform reports down, plus a
+    // strictly-newer guard version in the same body. Answering the down prompt
+    // disconnects it and uninstalls the guard — so the update notice, which
+    // would tell you to re-run connect to refresh a startup check that no longer
+    // exists, must not fire.
+    const proxyOnly: StartupGuardContext = {
+      appName: "Archestra",
+      healthUrl: "https://archestra.example.com/v1/health?llm=profile-123",
+      proxy: {
+        provider: "anthropic",
+        providerLabel: "Anthropic",
+        url: "https://archestra.example.com/v1/anthropic/profile-123",
+        ref: "profile-123",
+        proxyName: "default_proxy",
+      },
+      mcp: null,
+      skills: null,
+    };
+    const { output, guardHome } = await runGuardInteractive({
+      script: renderStartupGuardScript(proxyOnly, CLAUDE_CODE_GUARD_CLIENT),
+      curlExitCode: 0,
+      curlBody: `{"llm":"down","guardVersion":${STARTUP_GUARD_FORMAT_VERSION + 1}}`,
+      keys: "y",
+    });
+    // the down remote is disconnected and the guard removes itself…
+    expect(output).toContain("Disconnected");
+    expect(existsSync(guardHome.guardFile)).toBe(false);
+    // …and it never advertises an update for the guard it just uninstalled
+    expect(output).not.toContain("a newer Archestra setup is available");
+  });
+
   test("interactive, Bash 3.2 fallback hears Space between animation frames", async () => {
     const script = renderStartupGuardScript(
       CTX,

--- a/platform/backend/src/services/startup-guard.ts
+++ b/platform/backend/src/services/startup-guard.ts
@@ -1,5 +1,6 @@
 import {
   isDefaultBrandedAppName,
+  STARTUP_GUARD_FORMAT_VERSION,
   type StartupGuardClientId,
   type SupportedProvider,
 } from "@archestra/shared";
@@ -322,6 +323,11 @@ SKIP_FILE="$HOME/${client.skipRelpath}"
 # (an older backend 404ing the route, a 429) reads as ok — version skew and
 # rate limiting can never look like an outage.
 HEALTH_URL=${sh(ctx.healthUrl ?? "")}
+# The monotonic format version this guard was stamped with. The health response
+# above reports the running instance's current value; the guard nudges a
+# re-connect only when the instance reports a STRICTLY GREATER number, so an
+# older instance or a rollback stays silent.
+GUARD_FORMAT_VERSION=${STARTUP_GUARD_FORMAT_VERSION}
 GUARD_LABELS=(${resources.map((r) => sh(r.label)).join(" ")})
 GUARD_URLS=(${resources.map((r) => sh(r.url)).join(" ")})
 GUARD_KINDS=(${resources.map((r) => r.kind).join(" ")})
@@ -430,6 +436,26 @@ resource_down() { # $1 index; 0 = down
   return 1
 }
 
+# 0 = the instance reports a strictly greater guard format version than this
+# guard was stamped with (a newer setup is available). Reads the number out of
+# the same health body — no JSON parser: the body is already whitespace-stripped
+# and the value is a bare integer, so plain parameter expansion is safe. A body
+# with no guardVersion (an older backend), a non-numeric value, or an
+# equal-or-lower number reads as "not stale", so rollbacks and older instances
+# stay silent — matching how a missing down marker reads as ok.
+version_is_stale() {
+  case "$HEALTH_BODY" in
+    *'"guardVersion":'*) : ;;
+    *) return 1 ;;
+  esac
+  arch_ver_rest=\${HEALTH_BODY#*'"guardVersion":'}
+  arch_ver_num=\${arch_ver_rest%%[!0-9]*}
+  case "$arch_ver_num" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$arch_ver_num" -gt "$GUARD_FORMAT_VERSION" ]
+}
+
 if [ "$INTERACTIVE" = "0" ]; then
   if [ -n "$HEALTH_URL" ]; then
     fetch_health || HEALTH_STATE='down'
@@ -441,6 +467,9 @@ if [ "$INTERACTIVE" = "0" ]; then
     fi
     i=$((i+1))
   done
+  if version_is_stale; then
+    printf '%s\\n' "archestra: a newer $APP_NAME setup for ${client.binary} is available — re-run the setup from the $APP_NAME /connection page to update this startup check." >&2
+  fi
   exit 0
 fi
 
@@ -802,17 +831,58 @@ clear_reconfigure_hint() { printf '\\033[s\\n\\r\\033[2K\\033[u'; }
 # read here.
 offer_reconfigure_tail() {
   if [ "$PENDING_KEY_SET" = "1" ]; then
-    # a key typed ahead during the probes counts as the pressed key
-    key="$PENDING_KEY"; PENDING_KEY_SET=0
+    # a key typed ahead during the probes counts as the pressed key — but only
+    # for [C]; anything else (e.g. a [U] meant for the update offer below) is
+    # left in place so that beat can read it.
+    case "$PENDING_KEY" in
+      c|C) key="$PENDING_KEY"; PENDING_KEY_SET=0 ;;
+      *) key='' ;;
+    esac
   else
     key=''
     IFS= read -rs -n 1 -t "$RECONFIG_WAIT" key </dev/tty 2>/dev/null || key=''
+    # a non-[C] key pressed here belongs to the update offer below: stash it so
+    # this closing beat doesn't swallow it.
+    case "$key" in
+      c|C|'') ;;
+      *) PENDING_KEY="$key"; PENDING_KEY_SET=1; key='' ;;
+    esac
   fi
   clear_reconfigure_hint
   case "$key" in
     c|C) reconfigure_menu ;;
   esac
   return 0
+}
+
+# When the instance reports a newer guard format than this one, show a one-line
+# advisory with a timed, non-blocking [U] offer. It never blocks the launch:
+# the read has a short deadline (the same closing-beat budget as [C]), and any
+# other key — or the timeout — just lets ${client.binary} start. Pressing [U]
+# prints the concrete /connection re-run steps and dwells a beat longer so they
+# can be read. Re-connecting needs a fresh one-time link only the user can fetch
+# from the page, so [U] shows the steps rather than doing it for them.
+notify_version_update() {
+  version_is_stale || return 0
+  GUARD_DWELL=1
+  printf '%supdate:%s %sa newer %s setup is available.%s %s[U]%s%s for the steps to update this startup check%s\\n' "$C_WARN" "$C_RESET" "$C_DIM" "$APP_NAME" "$C_RESET" "$C_TITLE" "$C_RESET" "$C_DIM" "$C_RESET"
+  if [ "$PENDING_KEY_SET" = "1" ]; then
+    # a [U] typed ahead during the probes (stashed by the closing beat) answers here
+    key="$PENDING_KEY"; PENDING_KEY_SET=0
+  else
+    key=''
+    IFS= read -rs -n 1 -t "$RECONFIG_WAIT" key </dev/tty 2>/dev/null || key=''
+  fi
+  case "$key" in
+    u|U)
+      printf '%sTo update, re-run the %s connection setup:%s\\n' "$C_TITLE" "$APP_NAME" "$C_RESET"
+      printf '  1. Open the %s /connection page and pick %s.\\n' "$APP_NAME" ${sh(client.label)}
+      printf '  2. Copy the setup command it shows and run it in your terminal.\\n'
+      printf '     It reinstalls this startup check at the current version.\\n'
+      # a longer, still non-blocking beat so the steps can be read
+      IFS= read -rs -n 1 -t 6 key </dev/tty 2>/dev/null || true
+      ;;
+  esac
 }
 
 # When something is down: the quick (Y/n) reverses everything that failed in
@@ -1045,6 +1115,7 @@ elif [ "$OPEN_MENU" = "1" ]; then
 else
   offer_reconfigure_tail
 fi
+notify_version_update
 finish_guard
 `;
 }

--- a/platform/backend/src/services/startup-guard.ts
+++ b/platform/backend/src/services/startup-guard.ts
@@ -370,7 +370,12 @@ remember_disconnected() { printf '%s\\n' "$1" >> "$SKIP_FILE" 2>/dev/null || tru
 # — script, skip file, and the profile wrapper blocks. A leftover no-op hook
 # is a dependency that can only ever break a future claude launch (deleted
 # files, reconfigured shells); connect re-installs everything.
+# Set once the guard has removed itself, so later steps (e.g. the version-update
+# notice) don't advertise re-connecting to refresh a startup check that no
+# longer exists.
+GUARD_UNINSTALLED=0
 uninstall_guard() {
+  GUARD_UNINSTALLED=1
   rm -f "$GUARD_PATH" "$SKIP_FILE" 2>/dev/null || true
   for profile in "$HOME/.zshrc" "$HOME/.bashrc"; do
     [ -f "$profile" ] || continue
@@ -863,8 +868,11 @@ offer_reconfigure_tail() {
 # can be read. Re-connecting needs a fresh one-time link only the user can fetch
 # from the page, so [U] shows the steps rather than doing it for them.
 notify_version_update() {
+  # Nothing to update if the guard just removed itself (every remote was
+  # disconnected this run), and the timed reads below already hold the advisory
+  # on screen — so no extra dwell is needed.
+  [ "$GUARD_UNINSTALLED" = "1" ] && return 0
   version_is_stale || return 0
-  GUARD_DWELL=1
   printf '%supdate:%s %sa newer %s setup is available.%s %s[U]%s%s for the steps to update this startup check%s\\n' "$C_WARN" "$C_RESET" "$C_DIM" "$APP_NAME" "$C_RESET" "$C_TITLE" "$C_RESET" "$C_DIM" "$C_RESET"
   if [ "$PENDING_KEY_SET" = "1" ]; then
     # a [U] typed ahead during the probes (stashed by the closing beat) answers here

--- a/platform/backend/src/services/startup-guard.ts
+++ b/platform/backend/src/services/startup-guard.ts
@@ -1148,9 +1148,24 @@ export function buildStartupGuardInstallSection(
 
   return `say ${sh(`Installing the ${ctx.appName} startup guard for ${client.label}`)}
 mkdir -p "$(dirname "${guardPath}")"
+# A guard installed BEFORE the version-check feature has no GUARD_FORMAT_VERSION
+# stamp and no [U] update check, so at launch it can never nudge the user to
+# re-connect on its own — the [U] launch prompt only exists in version-aware
+# guards. Running connect is therefore the one moment we can lift such a user
+# onto the current guard, so we upgrade it in place, automatically, with no
+# prompt. (A guard that already carries the stamp is just refreshed silently; if
+# it was merely a version behind, its own [U] launch nudge is what sent the user
+# here.)
+archestra_guard_pre_feature=0
+if [ -f "${guardPath}" ] && ! grep -q 'GUARD_FORMAT_VERSION=' "${guardPath}" 2>/dev/null; then
+  archestra_guard_pre_feature=1
+fi
 cat > "${guardPath}" <<'${GUARD_FILE_EOF}'
 ${renderStartupGuardScript(ctx, client)}${GUARD_FILE_EOF}
 chmod +x "${guardPath}"
+if [ "$archestra_guard_pre_feature" = "1" ]; then
+  ok ${sh(`Upgraded your existing ${client.label} startup guard to the version-aware format automatically — no re-connect prompt was needed.`)}
+fi
 # A fresh connect re-arms every check: forget remotes a previous guard
 # disconnected.
 rm -f "$HOME/${client.skipRelpath}"

--- a/platform/backend/src/services/startup-guard.windows.test.ts
+++ b/platform/backend/src/services/startup-guard.windows.test.ts
@@ -1,5 +1,6 @@
 import {
   CLAUDE_CODE_PROXY_ENV_KEYS,
+  STARTUP_GUARD_FORMAT_VERSION,
   STARTUP_GUARD_INSTALL,
 } from "@archestra/shared";
 import { describe, expect, test } from "vitest";
@@ -84,6 +85,26 @@ describe("renderStartupGuardPowerShell (Claude Code)", () => {
     expect(script).toContain(
       "$_.Exception.PSObject.Properties['Response'] -and $_.Exception.Response",
     );
+  });
+
+  test("stamps the monotonic guard format version and offers the update only when the instance reports a strictly newer one", () => {
+    const script = renderStartupGuardPowerShell(CTX, CLAUDE_CODE_GUARD_CLIENT);
+    expect(script).toContain(
+      `$GuardFormatVersion = ${STARTUP_GUARD_FORMAT_VERSION}`,
+    );
+    // reads the live integer off the same health body and only flags -gt
+    expect(script).toContain(`'"guardVersion":([0-9]+)'`);
+    expect(script).toContain("[int]$Matches[1] -gt $GuardFormatVersion");
+    expect(script).toContain("Test-ArchVersionStale");
+    // both the interactive notice and the non-interactive stderr advisory
+    expect(script).toContain("Show-ArchVersionUpdate");
+    expect(script).toContain("a newer ' + $AppName + ' setup");
+    // non-interactive stays advisory-only
+    expect(script).toContain("re-run the setup from the ");
+    // interactive offers a timed, non-blocking [U] that prints the steps
+    expect(script).toContain("'[U]'");
+    expect(script).toContain("/connection page and pick");
+    expect(script).toContain("$key -eq 'u' -or $key -eq 'U'");
   });
 
   test("every down remote gets the failure copy; ONE prompt then covers them all", () => {

--- a/platform/backend/src/services/startup-guard.windows.test.ts
+++ b/platform/backend/src/services/startup-guard.windows.test.ts
@@ -110,6 +110,9 @@ describe("renderStartupGuardPowerShell (Claude Code)", () => {
     expect(script).toContain(
       "if ($key -and $key -ne 'c' -and $key -ne 'C') { $Script:PendingKey = $key; $key = '' }",
     );
+    // a guard that removed itself this run must not advertise an update for a
+    // startup check that no longer exists
+    expect(script).toContain("if ($Script:GuardUninstalled) { return }");
   });
 
   test("every down remote gets the failure copy; ONE prompt then covers them all", () => {

--- a/platform/backend/src/services/startup-guard.windows.test.ts
+++ b/platform/backend/src/services/startup-guard.windows.test.ts
@@ -366,6 +366,23 @@ describe("buildWindowsStartupGuardInstallSection (Claude Code)", () => {
     );
   });
 
+  test("detects a pre-feature guard (no version stamp) and upgrades it without prompting", () => {
+    const section = buildWindowsStartupGuardInstallSection(
+      CTX,
+      CLAUDE_CODE_GUARD_CLIENT,
+    );
+    // a guard installed before the version check has no $GuardFormatVersion
+    // line; the install inspects the existing file before overwriting it
+    expect(section).toContain(
+      "Select-String -Path $archGuardPath -Pattern 'GuardFormatVersion'",
+    );
+    expect(section).toContain("$archGuardPreFeature = $true");
+    // and announces the automatic, prompt-free upgrade
+    expect(section).toContain(
+      "Upgraded your existing Claude Code startup guard",
+    );
+  });
+
   test("defines the wrapper in the CURRENT session too, so the screen works without a new window", () => {
     const section = buildWindowsStartupGuardInstallSection(
       CTX,

--- a/platform/backend/src/services/startup-guard.windows.test.ts
+++ b/platform/backend/src/services/startup-guard.windows.test.ts
@@ -358,6 +358,12 @@ describe("buildWindowsStartupGuardInstallSection (Claude Code)", () => {
     expect(section).toContain(CLAUDE_CODE_GUARD_MARKER_START);
     expect(section).toContain(CLAUDE_CODE_GUARD_MARKER_END);
     expect(section).toContain("'WindowsPowerShell', 'PowerShell'");
+    // PowerShell on non-Windows hosts reports no MyDocuments directory. The
+    // generated installer must reach its $PROFILE fallback without passing an
+    // empty path to Join-Path first.
+    expect(section).toContain(
+      "if (-not [string]::IsNullOrWhiteSpace($archDocs)) {",
+    );
     expect(section).toContain("function claude {");
     expect(section).toContain("& $archReal.Source @args");
     // a fresh connect re-arms checks a previous guard disconnected

--- a/platform/backend/src/services/startup-guard.windows.test.ts
+++ b/platform/backend/src/services/startup-guard.windows.test.ts
@@ -105,6 +105,11 @@ describe("renderStartupGuardPowerShell (Claude Code)", () => {
     expect(script).toContain("'[U]'");
     expect(script).toContain("/connection page and pick");
     expect(script).toContain("$key -eq 'u' -or $key -eq 'U'");
+    // the [C] closing beat must leave a non-[C] queued key (an early [U]) in
+    // PendingKey so the update offer can consume it, mirroring the bash guard
+    expect(script).toContain(
+      "if ($key -and $key -ne 'c' -and $key -ne 'C') { $Script:PendingKey = $key; $key = '' }",
+    );
   });
 
   test("every down remote gets the failure copy; ONE prompt then covers them all", () => {

--- a/platform/backend/src/services/startup-guard.windows.ts
+++ b/platform/backend/src/services/startup-guard.windows.ts
@@ -912,10 +912,22 @@ export function buildWindowsStartupGuardInstallSection(
   return `Say ${psq(`Installing the ${ctx.appName} startup guard for ${client.label}`)}
 $archGuardPath = Join-Path $env:USERPROFILE ${psq(client.psScriptRelpath)}
 $null = New-Item -ItemType Directory -Force -Path (Split-Path -Parent $archGuardPath)
+# A guard installed BEFORE the version-check feature has no $GuardFormatVersion
+# stamp and no [U] update check, so at launch it can never nudge the user to
+# re-connect on its own. Running connect is the one moment we can lift such a
+# user onto the current guard, so we upgrade it in place, automatically, with no
+# prompt. (A guard already carrying the stamp is just refreshed silently.)
+$archGuardPreFeature = $false
+if ((Test-Path $archGuardPath) -and -not (Select-String -Path $archGuardPath -Pattern 'GuardFormatVersion' -Quiet -ErrorAction SilentlyContinue)) {
+  $archGuardPreFeature = $true
+}
 $archGuardBody = @'
 ${renderStartupGuardPowerShell(ctx, client)}'@
 [IO.File]::WriteAllText($archGuardPath, $archGuardBody, (New-Object System.Text.UTF8Encoding $true))
 Write-Host ('Updated ' + $archGuardPath)
+if ($archGuardPreFeature) {
+  Ok ${psq(`Upgraded your existing ${client.label} startup guard to the version-aware format automatically — no re-connect prompt was needed.`)}
+}
 # A fresh connect re-arms every check: forget remotes a previous guard
 # disconnected.
 Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path $env:USERPROFILE ${psq(client.skipRelpath)})

--- a/platform/backend/src/services/startup-guard.windows.ts
+++ b/platform/backend/src/services/startup-guard.windows.ts
@@ -960,9 +960,11 @@ ${client.markerEnd}
 '@
 $archDocs = [Environment]::GetFolderPath('MyDocuments')
 $archProfiles = @()
-foreach ($archEdition in @('WindowsPowerShell', 'PowerShell')) {
-  $archDir = Join-Path $archDocs $archEdition
-  if (Test-Path $archDir) { $archProfiles += (Join-Path $archDir 'profile.ps1') }
+if (-not [string]::IsNullOrWhiteSpace($archDocs)) {
+  foreach ($archEdition in @('WindowsPowerShell', 'PowerShell')) {
+    $archDir = Join-Path $archDocs $archEdition
+    if (Test-Path $archDir) { $archProfiles += (Join-Path $archDir 'profile.ps1') }
+  }
 }
 if ($archProfiles.Count -eq 0) { $archProfiles = @($PROFILE.CurrentUserAllHosts) }
 foreach ($archProfilePath in $archProfiles) {

--- a/platform/backend/src/services/startup-guard.windows.ts
+++ b/platform/backend/src/services/startup-guard.windows.ts
@@ -567,8 +567,11 @@ function Show-ArchReconfigureOffer {
   if (-not $UseVt) { Show-ArchReconfigureHint }
   $key = ''
   if ($null -ne $Script:PendingKey) {
-    # a key typed ahead during the probes counts as the pressed key
-    $key = $Script:PendingKey; $Script:PendingKey = $null
+    # only [C] is answered here; any other queued key (e.g. a [U] meant for the
+    # update offer below) is left in PendingKey so that beat can read it
+    if ($Script:PendingKey -eq 'c' -or $Script:PendingKey -eq 'C') {
+      $key = $Script:PendingKey; $Script:PendingKey = $null
+    }
   } else {
     $deadline = [DateTime]::UtcNow.AddMilliseconds(1500)
     while ([DateTime]::UtcNow -lt $deadline) {
@@ -576,6 +579,9 @@ function Show-ArchReconfigureOffer {
       if ($key) { break }
       Start-Sleep -Milliseconds 40
     }
+    # a non-[C] key pressed here belongs to the update offer below: stash it so
+    # this closing beat doesn't swallow it
+    if ($key -and $key -ne 'c' -and $key -ne 'C') { $Script:PendingKey = $key; $key = '' }
   }
   Clear-ArchReconfigureHint
   if ($key -eq 'c' -or $key -eq 'C') { Invoke-ArchReconfigureMenu }
@@ -596,11 +602,16 @@ function Show-ArchVersionUpdate {
   Write-Arch '[U]' Cyan -NoNewline
   Write-Arch ' for the steps to update this startup check' DarkGray
   $key = ''
-  $deadline = [DateTime]::UtcNow.AddMilliseconds(1500)
-  while ([DateTime]::UtcNow -lt $deadline) {
-    $key = Read-ArchKey
-    if ($key) { break }
-    Start-Sleep -Milliseconds 40
+  if ($null -ne $Script:PendingKey) {
+    # a [U] typed ahead during the probes (left in place by the closing beat) answers here
+    $key = $Script:PendingKey; $Script:PendingKey = $null
+  } else {
+    $deadline = [DateTime]::UtcNow.AddMilliseconds(1500)
+    while ([DateTime]::UtcNow -lt $deadline) {
+      $key = Read-ArchKey
+      if ($key) { break }
+      Start-Sleep -Milliseconds 40
+    }
   }
   if ($key -eq 'u' -or $key -eq 'U') {
     Write-Arch ('To update, re-run the ' + $AppName + ' connection setup:') Cyan

--- a/platform/backend/src/services/startup-guard.windows.ts
+++ b/platform/backend/src/services/startup-guard.windows.ts
@@ -118,11 +118,17 @@ $ActiveRemotes = @($Remotes | Where-Object { $DisconnectedKinds -notcontains $_.
 
 function Add-ArchDisconnected([string]$Kind) { try { Add-Content -Path $SkipFile -Value $Kind } catch { } }
 
+# Set once the guard has removed itself, so later steps (e.g. the version-update
+# notice) don't advertise re-connecting to refresh a startup check that no
+# longer exists.
+$Script:GuardUninstalled = $false
+
 # Once nothing connected is left to check, the guard removes itself entirely
 # — script, skip file, and the profile wrapper blocks. A leftover no-op hook
 # is a dependency that can only ever break a future claude launch (deleted
 # files, reconfigured shells); connect re-installs everything.
 function Remove-ArchGuard {
+  $Script:GuardUninstalled = $true
   Remove-Item -Force -ErrorAction SilentlyContinue $GuardPath, $SkipFile
   $profilePaths = @()
   $docs = [Environment]::GetFolderPath('MyDocuments')
@@ -594,8 +600,11 @@ function Show-ArchReconfigureOffer {
 # steps and holds a beat longer so they can be read. Re-connecting needs a fresh
 # one-time link only the user can fetch, so [U] shows the steps.
 function Show-ArchVersionUpdate {
+  # Nothing to update if the guard just removed itself (every remote was
+  # disconnected this run); the timed reads below already hold the advisory on
+  # screen, so no extra dwell is needed.
+  if ($Script:GuardUninstalled) { return }
   if (-not (Test-ArchVersionStale)) { return }
-  $Script:Dwell = $true
   Clear-ArchLine
   Write-Arch 'update:' Yellow -NoNewline
   Write-Arch (' a newer ' + $AppName + ' setup is available. ') DarkGray -NoNewline

--- a/platform/backend/src/services/startup-guard.windows.ts
+++ b/platform/backend/src/services/startup-guard.windows.ts
@@ -1,4 +1,7 @@
-import { isDefaultBrandedAppName } from "@archestra/shared";
+import {
+  isDefaultBrandedAppName,
+  STARTUP_GUARD_FORMAT_VERSION,
+} from "@archestra/shared";
 import {
   ARCHESTRA_MARK,
   ARCHESTRA_MARK_GAP,
@@ -85,6 +88,11 @@ $AppName = ${psq(ctx.appName)}
 # A response without a down marker (an older backend 404ing the route, a 429)
 # reads as ok — version skew and rate limiting can never look like an outage.
 $HealthUrl = ${psq(ctx.healthUrl ?? "")}
+# The monotonic format version this guard was stamped with. The health response
+# reports the running instance's current value; the guard nudges a re-connect
+# only when the instance reports a STRICTLY GREATER number, so an older instance
+# or a rollback stays silent.
+$GuardFormatVersion = ${STARTUP_GUARD_FORMAT_VERSION}
 $Remotes = @(
 ${remoteEntries}
 )${
@@ -221,6 +229,16 @@ function Test-ArchResourceDown($r) {
   return $Script:HealthBody.Contains($r.DownMarker)
 }
 
+# $true when the instance reports a strictly greater guard format version than
+# this guard was stamped with (a newer setup is available). Reads the bare
+# integer out of the same health body. A body with no guardVersion (an older
+# backend) or an equal-or-lower number reads as "not stale", so rollbacks and
+# older instances stay silent — matching how a missing down marker reads as ok.
+function Test-ArchVersionStale {
+  if ($Script:HealthBody -notmatch '"guardVersion":([0-9]+)') { return $false }
+  return ([int]$Matches[1] -gt $GuardFormatVersion)
+}
+
 if (-not $Interactive) {
   if ($HealthUrl) {
     if (-not (Invoke-ArchHealthFetch)) { $Script:HealthState = 'down' }
@@ -229,6 +247,9 @@ if (-not $Interactive) {
     if (Test-ArchResourceDown $r) {
       [Console]::Error.WriteLine('archestra: failed to connect to ' + $r.FailName + ' — ${client.binary} is configured to use it and may fail. Disconnect it from the ' + $AppName + ' /connection page, or run ${client.binary} interactively to be offered a disconnect.')
     }
+  }
+  if (Test-ArchVersionStale) {
+    [Console]::Error.WriteLine('archestra: a newer ' + $AppName + ' setup for ${client.binary} is available — re-run the setup from the ' + $AppName + ' /connection page to update this startup check.')
   }
   return
 }
@@ -560,6 +581,41 @@ function Show-ArchReconfigureOffer {
   if ($key -eq 'c' -or $key -eq 'C') { Invoke-ArchReconfigureMenu }
 }
 
+# When the instance reports a newer guard format than this one, show a one-line
+# advisory with a timed, non-blocking [U] offer. It never blocks the launch: the
+# key poll has a short deadline and any other key — or the timeout — lets
+# ${client.binary} start. Pressing [U] prints the concrete /connection re-run
+# steps and holds a beat longer so they can be read. Re-connecting needs a fresh
+# one-time link only the user can fetch, so [U] shows the steps.
+function Show-ArchVersionUpdate {
+  if (-not (Test-ArchVersionStale)) { return }
+  $Script:Dwell = $true
+  Clear-ArchLine
+  Write-Arch 'update:' Yellow -NoNewline
+  Write-Arch (' a newer ' + $AppName + ' setup is available. ') DarkGray -NoNewline
+  Write-Arch '[U]' Cyan -NoNewline
+  Write-Arch ' for the steps to update this startup check' DarkGray
+  $key = ''
+  $deadline = [DateTime]::UtcNow.AddMilliseconds(1500)
+  while ([DateTime]::UtcNow -lt $deadline) {
+    $key = Read-ArchKey
+    if ($key) { break }
+    Start-Sleep -Milliseconds 40
+  }
+  if ($key -eq 'u' -or $key -eq 'U') {
+    Write-Arch ('To update, re-run the ' + $AppName + ' connection setup:') Cyan
+    Write-Host ('  1. Open the ' + $AppName + ' /connection page and pick ' + ${psq(client.label)} + '.')
+    Write-Host '  2. Copy the setup command it shows and run it in your terminal.'
+    Write-Host '     It reinstalls this startup check at the current version.'
+    # a longer, still non-blocking beat so the steps can be read
+    $deadline = [DateTime]::UtcNow.AddMilliseconds(6000)
+    while ([DateTime]::UtcNow -lt $deadline) {
+      if (Read-ArchKey) { break }
+      Start-Sleep -Milliseconds 40
+    }
+  }
+}
+
 # Every down remote already got its failure line during the turn; this single
 # prompt then covers them all — disconnect everything that failed in one
 # keypress, or skip them all and go straight to claude. When every remote is
@@ -810,6 +866,7 @@ if ($DownRemotes.Count -gt 0) {
 } else {
   Show-ArchReconfigureOffer
 }
+Show-ArchVersionUpdate
 Exit-ArchGuard
 return
 `;

--- a/platform/shared/consts.ts
+++ b/platform/shared/consts.ts
@@ -284,6 +284,23 @@ export const STARTUP_GUARD_INSTALL = {
 export type StartupGuardClientId = keyof typeof STARTUP_GUARD_INSTALL;
 
 /**
+ * Monotonic format version of the installed startup guard. It is NOT the
+ * platform release version — it is a plain counter that increments by one
+ * whenever the generated guard's behavior or install layout changes in a way
+ * that warrants asking users to re-run connect.
+ *
+ * The connect setup stamps this number into the guard it installs; the public
+ * `/v1/health` endpoint reports the running instance's current value. On every
+ * launch the guard flags an update ONLY when the instance reports a STRICTLY
+ * GREATER number than the one it was stamped with. Comparing a monotonic
+ * counter — rather than release strings — is what keeps a rollback or an older
+ * instance silent: a guard from a newer deploy simply sees an equal-or-lower
+ * number and says nothing. Bump this by exactly one when, and only when, a
+ * guard change should prompt a re-connect.
+ */
+export const STARTUP_GUARD_FORMAT_VERSION = 1;
+
+/**
  * Header name for external agent ID.
  * Clients can pass this header to associate interactions with their own agent identifiers.
  */

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -36864,6 +36864,7 @@ export type GetConnectionHealthResponses = {
     200: {
         mcp?: 'ok' | 'down';
         llm?: 'ok' | 'down';
+        guardVersion: number;
     };
 };
 


### PR DESCRIPTION
## Summary

The CLI startup guard installed from `/connection` had no way to discover that its generated behavior was outdated. Existing users could therefore remain on an old guard indefinitely even as the registered Archestra instance evolved.

This change:

- adds a monotonic startup-guard format version and exposes the current value from `GET /v1/health`;
- stamps generated Bash and PowerShell guards and only reports an update when the instance has a strictly newer format, keeping equal, older, missing, and malformed versions silent;
- gives interactive launches a timed, non-blocking `[U]` action with concrete reconnection instructions while keeping non-interactive launches advisory-only;
- automatically replaces a pre-versioning guard the next time the user runs the newer connect script, without prompting;
- refreshes shell-profile wrappers idempotently and preserves queued input across the reconfigure/update prompts;
- documents the version-aware startup behavior.

A guard that removes itself after all remotes are disconnected does not subsequently advertise an update.

## Validation

The real generated Bash installer was run three times against an isolated home containing an unstamped pre-feature guard. The first run announced the automatic migration, later runs refreshed silently, the installed guard reported `GUARD_FORMAT_VERSION=1`, and the profile retained exactly one wrapper block.

The same three-run migration was exercised in PowerShell 7.4 inside an Ubuntu container. That uncovered and fixed the empty `MyDocuments` behavior on non-Windows hosts; the corrected installer fell back to `$PROFILE.CurrentUserAllHosts`, retained one wrapper block, and produced a guard that passed PowerShell syntax parsing.

The focused startup-guard suites pass all 72 Bash and PowerShell behavior/rendering tests, and generated API artifacts reproduce cleanly.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>