### PR TITLE
fix(auth): restore impersonation for owners and same-org admins

### DIFF
--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -1,6 +1,7 @@
 import {
   ADMIN_ROLE_NAME,
   MEMBER_ROLE_NAME,
+  OWNER_ROLE_NAME,
   type Permissions,
 } from "@archestra/shared";
 import { allAvailableActions } from "@archestra/shared/access-control";
@@ -93,12 +94,20 @@ function createMockContext(overrides: {
   context?: {
     newSession?: {
       user: { id: string; email: string };
-      session: { id: string; activeOrganizationId?: string | null };
+      session: {
+        id: string;
+        activeOrganizationId?: string | null;
+        impersonatedBy?: string | null;
+      };
     } | null;
     /** Present on sign-out: the session being terminated. */
     session?: {
       user: { id: string; email: string; name?: string | null };
-      session: { id: string; activeOrganizationId?: string | null };
+      session: {
+        id: string;
+        activeOrganizationId?: string | null;
+        impersonatedBy?: string | null;
+      };
     } | null;
   };
 }): HookEndpointContext {
@@ -489,15 +498,19 @@ describe("handleBeforeHook", () => {
   });
 
   describe("impersonation permission gate", () => {
-    const impersonateCtx = (user: { id: string; email: string }) =>
+    const impersonateCtx = (
+      user: { id: string; email: string },
+      targetUserId = "some-target-user",
+      session: { impersonatedBy?: string | null } = {},
+    ) =>
       createMockContext({
         path: "/admin/impersonate-user",
         method: "POST",
-        body: { userId: "some-target-user" },
+        body: { userId: targetUserId },
         context: {
           session: {
             user,
-            session: { id: "session-id" },
+            session: { id: "session-id", ...session },
           },
         },
       });
@@ -510,8 +523,26 @@ describe("handleBeforeHook", () => {
       const org = await makeOrganization();
       const adminUser = await makeUser({ role: "admin" });
       await makeMember(adminUser.id, org.id, { role: ADMIN_ROLE_NAME });
+      const adminTarget = await makeUser({ role: "admin" });
+      await makeMember(adminTarget.id, org.id, { role: ADMIN_ROLE_NAME });
 
-      const ctx = impersonateCtx(adminUser);
+      const ctx = impersonateCtx(adminUser, adminTarget.id);
+      const result = await handleBeforeHook(ctx);
+      expect(result).toBe(ctx);
+    });
+
+    test("allows callers still holding better-auth's owner creator role", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const ownerUser = await makeUser({ role: "admin" });
+      await makeMember(ownerUser.id, org.id, { role: OWNER_ROLE_NAME });
+      const target = await makeUser();
+      await makeMember(target.id, org.id, { role: MEMBER_ROLE_NAME });
+
+      const ctx = impersonateCtx(ownerUser, target.id);
       const result = await handleBeforeHook(ctx);
       expect(result).toBe(ctx);
     });
@@ -547,6 +578,74 @@ describe("handleBeforeHook", () => {
       await expect(handleBeforeHook(ctx)).rejects.toThrow(APIError);
     });
 
+    test("rejects admin and ordinary targets whose effective organization differs", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const callerOrg = await makeOrganization();
+      const otherOrg = await makeOrganization();
+      const caller = await makeUser({ role: "admin" });
+      await makeMember(caller.id, callerOrg.id, { role: ADMIN_ROLE_NAME });
+      const adminTarget = await makeUser({ role: "admin" });
+      await makeMember(adminTarget.id, otherOrg.id, { role: ADMIN_ROLE_NAME });
+      const ordinaryTarget = await makeUser();
+      await makeMember(ordinaryTarget.id, otherOrg.id, {
+        role: MEMBER_ROLE_NAME,
+      });
+      // This target also belongs to the caller's org, but its effective org is
+      // still otherOrg because that membership was created first.
+      await makeMember(ordinaryTarget.id, callerOrg.id, {
+        role: MEMBER_ROLE_NAME,
+      });
+
+      await expect(
+        handleBeforeHook(impersonateCtx(caller, adminTarget.id)),
+      ).rejects.toThrow(APIError);
+      await expect(
+        handleBeforeHook(impersonateCtx(caller, ordinaryTarget.id)),
+      ).rejects.toThrow(APIError);
+
+      const deniedTargetIds = (
+        await db
+          .select()
+          .from(schema.auditLogsTable)
+          .where(eq(schema.auditLogsTable.organizationId, callerOrg.id))
+      )
+        .filter(
+          (row) =>
+            row.action === "auth.impersonation_started" &&
+            row.outcome === "denied",
+        )
+        .map((row) => row.resourceId);
+      expect(deniedTargetIds).toEqual(
+        expect.arrayContaining([adminTarget.id, ordinaryTarget.id]),
+      );
+    });
+
+    test("rejects self and nested impersonation", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const caller = await makeUser({ role: "admin" });
+      await makeMember(caller.id, org.id, { role: ADMIN_ROLE_NAME });
+      const target = await makeUser();
+      await makeMember(target.id, org.id, { role: MEMBER_ROLE_NAME });
+
+      await expect(
+        handleBeforeHook(impersonateCtx(caller, caller.id)),
+      ).rejects.toThrow(APIError);
+      await expect(
+        handleBeforeHook(
+          impersonateCtx(caller, target.id, {
+            impersonatedBy: "original-user",
+          }),
+        ),
+      ).rejects.toThrow(APIError);
+    });
+
     test("leaves unauthenticated calls for better-auth to reject", async () => {
       const ctx = createMockContext({
         path: "/admin/impersonate-user",
@@ -577,8 +676,10 @@ describe("handleBeforeHook", () => {
       // Org admin promoted after bootstrap: no system-level role yet.
       const orgAdmin = await makeUser();
       await makeMember(orgAdmin.id, org.id, { role: ADMIN_ROLE_NAME });
+      const target = await makeUser();
+      await makeMember(target.id, org.id, { role: MEMBER_ROLE_NAME });
 
-      await handleBeforeHook(impersonateCtx(orgAdmin));
+      await handleBeforeHook(impersonateCtx(orgAdmin, target.id));
 
       const [row] = await db
         .select({ role: schema.usersTable.role })

--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -593,11 +593,6 @@ describe("handleBeforeHook", () => {
       await makeMember(ordinaryTarget.id, otherOrg.id, {
         role: MEMBER_ROLE_NAME,
       });
-      // This target also belongs to the caller's org, but its effective org is
-      // still otherOrg because that membership was created first.
-      await makeMember(ordinaryTarget.id, callerOrg.id, {
-        role: MEMBER_ROLE_NAME,
-      });
 
       await expect(
         handleBeforeHook(impersonateCtx(caller, adminTarget.id)),

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -1,5 +1,6 @@
 // This file contains Enterprise regions licensed under LICENSE_ENTERPRISE.
 import {
+  ADMIN_ROLE_NAME,
   API_KEY_MAX_EXPIRATION_DAYS,
   API_KEY_MAX_NAME_LENGTH,
   API_KEY_MIN_EXPIRATION_DAYS,
@@ -161,6 +162,9 @@ export const auth = betterAuth({
     organization({
       requireEmailVerificationOnInvitation: false,
       allowUserToCreateOrganization: false, // Disable organization creation by users
+      // better-auth defaults this to "owner", which is not one of our
+      // predefined roles and left creators with an empty permission map.
+      creatorRole: ADMIN_ROLE_NAME,
       ac,
       dynamicAccessControl: {
         enabled: true,
@@ -223,7 +227,10 @@ export const auth = betterAuth({
         },
       },
     }),
-    admin(),
+    // Anyone with member:impersonate is synced to better-auth system
+    // role "admin". Without this flag, viewing-as another admin (the
+    // role debugger's job) is rejected as YOU_CANNOT_IMPERSONATE_ADMINS.
+    admin({ allowImpersonatingAdmins: true }),
     // Developer-only auto-login endpoint (self-guards to non-production + env var).
     devAutoLoginPlugin(),
     /**
@@ -749,13 +756,18 @@ async function assertCallerCanImpersonate(
   const { request, context } = ctx;
 
   type SessionUser = { id: string };
-  let user = (context?.session as { user?: SessionUser } | undefined)?.user;
+  type SessionData = { impersonatedBy?: string | null };
+  type SessionBundle = { user: SessionUser; session: SessionData };
+  const contextSession = context?.session as Partial<SessionBundle> | undefined;
+  let user = contextSession?.user;
+  let session = contextSession?.session;
 
-  if (!user && request) {
+  if ((!user || !session) && request) {
     try {
       const headers = new Headers(request.headers as HeadersInit);
       const resolved = await auth.api.getSession({ headers });
-      user = resolved?.user as SessionUser | undefined;
+      user ??= resolved?.user as SessionUser | undefined;
+      session ??= resolved?.session as SessionData | undefined;
     } catch (err) {
       logger.debug(
         { err },
@@ -814,6 +826,35 @@ async function assertCallerCanImpersonate(
       reason: "caller lacks the member:impersonate permission",
     });
     throw forbidden();
+  }
+
+  const denyTarget = async (reason: string) => {
+    await writeImpersonationAuditLog({
+      stash,
+      action: "auth.impersonation_started",
+      outcome: "denied",
+      path: "/admin/impersonate-user",
+      request,
+      reason,
+    });
+    throw forbidden();
+  };
+
+  if (session?.impersonatedBy) {
+    await denyTarget(
+      "an impersonated session cannot start another impersonation",
+    );
+  }
+
+  if (targetUserId === user.id) {
+    await denyTarget("a user cannot impersonate themselves");
+  }
+
+  if (targetUserId) {
+    const targetUserRecord = await UserModel.getById(targetUserId);
+    if (targetUserRecord?.organizationId !== userRecord.organizationId) {
+      await denyTarget("target user is not in the caller's organization");
+    }
   }
 
   // The org-level permission is the source of truth, but better-auth's own

--- a/platform/backend/src/models/organization-role.test.ts
+++ b/platform/backend/src/models/organization-role.test.ts
@@ -2,6 +2,7 @@ import {
   ADMIN_ROLE_NAME,
   EDITOR_ROLE_NAME,
   MEMBER_ROLE_NAME,
+  OWNER_ROLE_NAME,
   PLATFORM_ADMIN_ROLE_NAME,
 } from "@archestra/shared";
 import { predefinedPermissionsMap } from "@archestra/shared/access-control";
@@ -230,6 +231,36 @@ describe("OrganizationRoleModel", () => {
         org.id,
       );
       expect(permissions).toEqual({});
+    });
+
+    test("should treat better-auth owner as admin when no custom owner role exists", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+      const permissions = await OrganizationRoleModel.getPermissions(
+        OWNER_ROLE_NAME,
+        org.id,
+      );
+      expect(permissions).toEqual(predefinedPermissionsMap[ADMIN_ROLE_NAME]);
+      expect(permissions.member).toContain("impersonate");
+    });
+
+    test("should use a custom owner role when one exists", async ({
+      makeCustomRole,
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+      await makeCustomRole(org.id, {
+        role: OWNER_ROLE_NAME,
+        name: "Owner",
+        permission: { agent: ["read"] },
+      });
+
+      const permissions = await OrganizationRoleModel.getPermissions(
+        OWNER_ROLE_NAME,
+        org.id,
+      );
+      expect(permissions).toEqual({ agent: ["read"] });
     });
 
     test("should cache custom role permissions until invalidated", async ({

--- a/platform/backend/src/models/organization-role.ts
+++ b/platform/backend/src/models/organization-role.ts
@@ -3,6 +3,7 @@ import {
   ADMIN_ROLE_NAME,
   EDITOR_ROLE_NAME,
   MEMBER_ROLE_NAME,
+  OWNER_ROLE_NAME,
   type Permissions,
   PLATFORM_ADMIN_ROLE_NAME,
   type PredefinedRoleName,
@@ -358,6 +359,15 @@ class OrganizationRoleModel {
     );
 
     if (!role) {
+      // better-auth assigns "owner" to the organization creator by default.
+      // That identifier is not one of our predefined roles and has no
+      // organization_roles row, so RBAC resolved to {} and impersonation
+      // (among everything else) failed for those members.
+      if (identifier === OWNER_ROLE_NAME) {
+        return OrganizationRoleModel.getPredefinedRolePermissions(
+          ADMIN_ROLE_NAME,
+        );
+      }
       logger.debug(
         { identifier },
         "OrganizationRoleModel.getPermissions: role not found, returning empty",

--- a/platform/backend/src/routes/user.test.ts
+++ b/platform/backend/src/routes/user.test.ts
@@ -177,7 +177,7 @@ describe("user routes", () => {
       await nonMemberApp.close();
     });
 
-    test("GET /api/user/impersonable lists org users excluding self and system admins", async ({
+    test("GET /api/user/impersonable lists org users excluding self", async ({
       makeUser: makeOtherUser,
       makeMember,
     }) => {
@@ -207,10 +207,9 @@ describe("user routes", () => {
 
       const ids = candidates.map((c) => c.id);
       expect(ids).toContain(memberUser.id);
-      // self excluded
       expect(ids).not.toContain(user.id);
-      // system admins excluded — better-auth would reject impersonating them anyway
-      expect(ids).not.toContain(adminUser.id);
+      // other admins are impersonable — viewing-as an admin is the role debugger
+      expect(ids).toContain(adminUser.id);
 
       const member = candidates.find((c) => c.id === memberUser.id);
       expect(member?.role).toBe(MEMBER_ROLE_NAME);

--- a/platform/backend/src/services/user.ts
+++ b/platform/backend/src/services/user.ts
@@ -31,11 +31,11 @@ export async function listImpersonableUsers(params: {
   const members = await MemberModel.findAllByOrganization(
     params.organizationId,
   );
-  // filtering out the current user and system admins.
-  // impersonation is a feature provided by better-auth and
-  // system admins are not impersonable in the  better-auth's adminRoles.
-  // in fact system admin is the first users bootstrapped in archestra.
+  // Exclude the caller only. System-level `user.role = "admin"` is synced
+  // onto anyone whose org role grants `member:impersonate`, so filtering
+  // those out made it impossible to view-as another admin — the role
+  // debugger's actual job. better-auth is configured to allow it.
   return members
-    .filter((m) => m.id !== params.currentUserId && m.systemRole !== "admin")
+    .filter((m) => m.id !== params.currentUserId)
     .map(({ systemRole: _systemRole, ...rest }) => rest);
 }

--- a/platform/frontend/src/lib/hooks/use-is-app-loading.test.tsx
+++ b/platform/frontend/src/lib/hooks/use-is-app-loading.test.tsx
@@ -5,7 +5,7 @@ import {
 } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { useIsAppLoading, useReportSearchInFlight } from "./use-is-app-loading";
 
 /**
@@ -48,6 +48,66 @@ describe("useIsAppLoading", () => {
     );
 
     await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("does not reschedule the shell when the pending count changes but loading does not", async () => {
+    vi.useFakeTimers();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    let finishFirst!: (value: string) => void;
+    let finishSecond!: (value: string) => void;
+    const first = client.fetchQuery({
+      queryKey: ["first"],
+      queryFn: () =>
+        new Promise<string>((resolve) => {
+          finishFirst = resolve;
+        }),
+    });
+    const second = client.fetchQuery({
+      queryKey: ["second"],
+      queryFn: () =>
+        new Promise<string>((resolve) => {
+          finishSecond = resolve;
+        }),
+    });
+    let renders = 0;
+    const { result, unmount } = renderHook(
+      () => {
+        renders += 1;
+        return useIsAppLoading();
+      },
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      },
+    );
+
+    try {
+      expect(result.current).toBe(true);
+      const loadingRenders = renders;
+      await act(async () => {
+        finishFirst("loaded");
+        await first;
+        await vi.runOnlyPendingTimersAsync();
+      });
+      expect(result.current).toBe(true);
+      // Count-only updates caused a render/observer-notification feedback loop
+      // during the cold permission load after impersonation.
+      expect(renders).toBe(loadingRenders);
+
+      await act(async () => {
+        finishSecond("loaded");
+        await second;
+        await vi.runOnlyPendingTimersAsync();
+      });
+      expect(result.current).toBe(false);
+    } finally {
+      unmount();
+      client.clear();
+      vi.useRealTimers();
+    }
   });
 
   it("stays quiet while a search is waiting, then covers the app again", async () => {

--- a/platform/frontend/src/lib/hooks/use-is-app-loading.ts
+++ b/platform/frontend/src/lib/hooks/use-is-app-loading.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useIsFetching } from "@tanstack/react-query";
-import { useEffect, useSyncExternalStore } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 
 /**
  * Whether anything on screen is still waiting for its first bytes.
@@ -17,18 +17,36 @@ import { useEffect, useSyncExternalStore } from "react";
  * exception; see {@link useReportSearchInFlight}.
  */
 export function useIsAppLoading(): boolean {
+  const client = useQueryClient();
+  const subscribe = useCallback(
+    (onChange: () => void) =>
+      client.getQueryCache().subscribe((event) => {
+        // Observer options change during rendering. Subscribing to those can
+        // repeatedly interrupt the shell before its loading state commits.
+        if (
+          event.type === "added" ||
+          event.type === "removed" ||
+          event.type === "updated"
+        ) {
+          onChange();
+        }
+      }),
+    [client],
+  );
+  const getSnapshot = useCallback(
+    () =>
+      client.isFetching({
+        predicate: (query) => query.state.data === undefined,
+      }) > 0,
+    [client],
+  );
   const searchesInFlight = useSyncExternalStore(
     searchActivity.subscribe,
     searchActivity.getSnapshot,
     searchActivity.getServerSnapshot,
   );
 
-  const isFetching =
-    useIsFetching({
-      predicate: (query) =>
-        query.state.data === undefined &&
-        query.state.fetchStatus === "fetching",
-    }) > 0;
+  const isFetching = useSyncExternalStore(subscribe, getSnapshot, () => false);
 
   // A search already accounts for its own wait twice over — the box is lit and
   // the table it filters is drawing a progress bar across its top edge. Adding

--- a/platform/frontend/src/lib/impersonation.query.test.tsx
+++ b/platform/frontend/src/lib/impersonation.query.test.tsx
@@ -1,0 +1,169 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { authQueryKeys } from "@/lib/auth/auth.query";
+import { authClient } from "@/lib/clients/auth/auth-client";
+import {
+  clearPersistedQueryCache,
+  PERSISTED_QUERY_META,
+  restorePersistedQueryCache,
+  syncPersistedQueryCacheScope,
+} from "@/lib/query-persistence";
+import {
+  useImpersonateUser,
+  useStopImpersonating,
+} from "./impersonation.query";
+
+vi.mock("@/lib/clients/auth/auth-client");
+vi.mock("sonner");
+
+const originalLocation = window.location;
+const persistedSession = {
+  user: { id: "admin-1", email: "admin@example.com" },
+  session: { id: "admin-session" },
+};
+const persistedPermissions = { member: ["impersonate"] };
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderMutation<T>(hook: () => T) {
+  const queryClient = makeClient();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return renderHook(hook, { wrapper });
+}
+
+async function seedPersistedAuthSnapshot() {
+  const client = makeClient();
+  await client.fetchQuery({
+    queryKey: authQueryKeys.session(),
+    queryFn: async () => persistedSession,
+    meta: PERSISTED_QUERY_META,
+  });
+  await client.fetchQuery({
+    queryKey: authQueryKeys.userPermissions(),
+    queryFn: async () => persistedPermissions,
+    meta: PERSISTED_QUERY_META,
+  });
+  syncPersistedQueryCacheScope(client, "admin-1:org-1");
+
+  expectRestoredAuthSnapshot(persistedSession, persistedPermissions);
+}
+
+function expectRestoredAuthSnapshot(
+  session: typeof persistedSession | undefined,
+  permissions: typeof persistedPermissions | undefined,
+) {
+  const restored = makeClient();
+  restorePersistedQueryCache(restored);
+
+  expect(restored.getQueryData(authQueryKeys.session())).toEqual(session);
+  expect(restored.getQueryData(authQueryKeys.userPermissions())).toEqual(
+    permissions,
+  );
+}
+
+function mockNavigation(onAssign?: () => void) {
+  const assign = vi.fn(onAssign);
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...originalLocation, assign },
+  });
+  return assign;
+}
+
+describe("impersonation cache boundaries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearPersistedQueryCache();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    clearPersistedQueryCache();
+    window.sessionStorage.clear();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("removes persisted auth before reloading into an impersonated session", async () => {
+    await seedPersistedAuthSnapshot();
+    const assign = mockNavigation(() => {
+      expectRestoredAuthSnapshot(undefined, undefined);
+    });
+    vi.mocked(authClient.admin.impersonateUser).mockResolvedValue({
+      data: {},
+      error: null,
+    } as Awaited<ReturnType<typeof authClient.admin.impersonateUser>>);
+
+    const { result } = renderMutation(() => useImpersonateUser());
+    await act(async () => {
+      await result.current.mutateAsync("member-1");
+    });
+
+    expect(assign).toHaveBeenCalledWith("/");
+  });
+
+  it("keeps persisted auth when impersonation fails", async () => {
+    await seedPersistedAuthSnapshot();
+    mockNavigation();
+    vi.mocked(authClient.admin.impersonateUser).mockResolvedValue({
+      data: null,
+      error: new Error("Impersonation denied"),
+    } as Awaited<ReturnType<typeof authClient.admin.impersonateUser>>);
+
+    const { result } = renderMutation(() => useImpersonateUser());
+    await act(async () => {
+      await expect(result.current.mutateAsync("member-1")).rejects.toThrow(
+        "Impersonation denied",
+      );
+    });
+
+    expectRestoredAuthSnapshot(persistedSession, persistedPermissions);
+  });
+
+  it("removes persisted auth before reloading into the admin session", async () => {
+    await seedPersistedAuthSnapshot();
+    const assign = mockNavigation(() => {
+      expectRestoredAuthSnapshot(undefined, undefined);
+    });
+    vi.mocked(authClient.admin.stopImpersonating).mockResolvedValue({
+      data: {},
+      error: null,
+    } as Awaited<ReturnType<typeof authClient.admin.stopImpersonating>>);
+
+    const { result } = renderMutation(() => useStopImpersonating());
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(assign).toHaveBeenCalledWith("/");
+  });
+
+  it("keeps persisted auth when returning to the admin session fails", async () => {
+    await seedPersistedAuthSnapshot();
+    mockNavigation();
+    vi.mocked(authClient.admin.stopImpersonating).mockResolvedValue({
+      data: null,
+      error: new Error("Return denied"),
+    } as Awaited<ReturnType<typeof authClient.admin.stopImpersonating>>);
+
+    const { result } = renderMutation(() => useStopImpersonating());
+    await act(async () => {
+      await expect(result.current.mutateAsync()).rejects.toThrow(
+        "Return denied",
+      );
+    });
+
+    expectRestoredAuthSnapshot(persistedSession, persistedPermissions);
+  });
+});

--- a/platform/frontend/src/lib/impersonation.query.ts
+++ b/platform/frontend/src/lib/impersonation.query.ts
@@ -5,6 +5,7 @@ import { useIsAuthenticated } from "@/lib/auth/auth.hook";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import { useDisableImpersonation } from "@/lib/config/config.query";
+import { clearPersistedQueryCache } from "@/lib/query-persistence";
 import { throwOnApiError } from "@/lib/utils";
 
 // The org-level RBAC permission member:impersonate is the source of truth
@@ -53,8 +54,9 @@ export function useImpersonateUser() {
     onSuccess: () => {
       // Hard reload to "/" — the impersonated session likely cannot access the
       // page the admin started from (e.g. /settings/roles requires ac:read).
-      // A full-document navigation also drops every cached admin query, so we
-      // never render with a mix of admin permissions and member data.
+      // Drop the refresh snapshot too, or navigation restores the admin's
+      // session and permissions over the newly impersonated session.
+      clearPersistedQueryCache();
       toast.success("Switched to impersonated session");
       window.location.assign("/");
     },
@@ -80,6 +82,7 @@ export function useStopImpersonating() {
     onSuccess: () => {
       // Same reasoning as impersonate — full reload restores every query
       // under the admin session and avoids the inverse permission mismatch.
+      clearPersistedQueryCache();
       toast.success("Returned to admin session");
       window.location.assign("/");
     },

--- a/platform/shared/roles.ts
+++ b/platform/shared/roles.ts
@@ -4,6 +4,12 @@ export const ADMIN_ROLE_NAME = "admin";
 export const PLATFORM_ADMIN_ROLE_NAME = "platform_admin";
 export const EDITOR_ROLE_NAME = "editor";
 export const MEMBER_ROLE_NAME = "member";
+/**
+ * better-auth's default organization creator role. It is not one of our
+ * predefined roles; legacy permissions fall back to Admin only when no custom
+ * role with this identifier exists.
+ */
+export const OWNER_ROLE_NAME = "owner";
 export const PredefinedRoleNameSchema = z.enum([
   ADMIN_ROLE_NAME,
   PLATFORM_ADMIN_ROLE_NAME,


### PR DESCRIPTION
View as user failed for organization creators still holding better-auth's default `owner` role: that identifier is not one of our predefined roles, so RBAC resolved to no permissions and the impersonation gate denied them. After a successful session switch, the shell could also restore the previous user's cached session and hang on a sidebar loading-indicator render loop.

Treat a missing `owner` role as Admin for permissions, allow viewing as another admin (the role debugger's job), and refuse self, nested, and cross-organization targets. Drop the persisted query snapshot on both impersonation transitions, and have the shell loading indicator subscribe to whether anything is still loading rather than the pending-query count.

Tried on a local stack as the org owner: View as user on a member shows that member's session and banner; Return to admin restores the original session. Five consecutive chat cycles completed without a blank page.

Origin: T-1322

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>