### PR TITLE
fix(frontend): stop dialog footer lift from glowing in dark mode

### DIFF
--- a/platform/frontend/src/components/ui/dialog.tsx
+++ b/platform/frontend/src/components/ui/dialog.tsx
@@ -235,8 +235,13 @@ function DialogStickyFooter({
         "after:absolute after:inset-0 after:rounded-b-lg after:content-['']",
         "[&>*]:relative [&>*]:z-10",
         // Soft lift separating the bar from whatever scrolls under it. The
-        // hairline above it is `border-t`, not a shadow layer.
-        "shadow-[0_-12px_24px_-24px] shadow-foreground/30",
+        // hairline above it is `border-t`, not a shadow layer. The colour must
+        // be a fixed dark shadow, not `foreground`: `foreground` inverts to
+        // near-white in dark themes, turning the lift into a glowing halo above
+        // the footer. A real drop shadow is dark in both themes — matching the
+        // black-based `--shadow-*` tokens — and just fades to near-invisible
+        // over dark backgrounds, where the `border-t` carries the separation.
+        "shadow-[0_-12px_24px_-24px] shadow-black/20",
         className,
       )}
       {...props}


### PR DESCRIPTION
## What

Fixes the "weird glow in dialog footer" reported in **T-1290**.

The shared sticky dialog footer (`DialogStickyFooter` in `frontend/src/components/ui/dialog.tsx`) applies a subtle upward "soft lift" shadow to separate the pinned action bar from content that scrolls beneath it. That shadow was coloured `shadow-foreground/30`.

`--foreground` is a **theme token that inverts**: it is dark in light themes but near-white in every dark theme (e.g. `oklch(0.92 0 0)`). Because the shadow is offset upward (`0 -12px 24px -24px`), in dark mode it rendered as a near-white halo sitting above the footer — the unintended glow. In light mode it looked fine, which is why it slipped through.

## Fix

Colour the lift with a fixed dark shadow (`shadow-black/20`) instead of the inverting foreground token, matching the design system's own black-based `--shadow-*` tokens. A real drop shadow is dark in both themes: it reads as a subtle lift in light mode and fades to near-invisible over dark backgrounds, where the existing `border-t` hairline already carries the separation. No glow in either theme.

`shadow-foreground` appeared in exactly one place in the frontend, so this is the complete fix.