### PR TITLE
fix(frontend): align identity icons with name inputs

### DIFF
--- a/platform/frontend/src/app/_parts/create-project-from-chat-dialog.tsx
+++ b/platform/frontend/src/app/_parts/create-project-from-chat-dialog.tsx
@@ -114,51 +114,49 @@ export function CreateProjectFromChatDialog({
         onIconChange={(next) => form.setValue("icon", next)}
         fallbackType="project"
       >
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="chat-project-name">Name *</Label>
-            <Input
-              autoFocus
-              id="chat-project-name"
-              maxLength={PROJECT_NAME_MAX_LENGTH}
-              aria-invalid={!!form.formState.errors.name}
-              {...form.register("name", {
-                required: "Project name is required.",
-                maxLength: {
-                  value: PROJECT_NAME_MAX_LENGTH,
-                  message: `Project name must be ${PROJECT_NAME_MAX_LENGTH} characters or fewer.`,
-                },
-              })}
-            />
-            {form.formState.errors.name?.message && (
-              <p className="text-xs text-destructive">
-                {form.formState.errors.name.message}
-              </p>
-            )}
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="chat-project-description">Description</Label>
-            <Textarea
-              id="chat-project-description"
-              placeholder="What is this project about?"
-              rows={3}
-              maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
-              aria-invalid={!!form.formState.errors.description}
-              {...form.register("description", {
-                maxLength: {
-                  value: PROJECT_DESCRIPTION_MAX_LENGTH,
-                  message: `Description must be ${PROJECT_DESCRIPTION_MAX_LENGTH} characters or fewer.`,
-                },
-              })}
-            />
-            {form.formState.errors.description?.message && (
-              <p className="text-xs text-destructive">
-                {form.formState.errors.description.message}
-              </p>
-            )}
-          </div>
+        <div className="space-y-2">
+          <Label htmlFor="chat-project-name">Name *</Label>
+          <Input
+            autoFocus
+            id="chat-project-name"
+            maxLength={PROJECT_NAME_MAX_LENGTH}
+            aria-invalid={!!form.formState.errors.name}
+            {...form.register("name", {
+              required: "Project name is required.",
+              maxLength: {
+                value: PROJECT_NAME_MAX_LENGTH,
+                message: `Project name must be ${PROJECT_NAME_MAX_LENGTH} characters or fewer.`,
+              },
+            })}
+          />
+          {form.formState.errors.name?.message && (
+            <p className="text-xs text-destructive">
+              {form.formState.errors.name.message}
+            </p>
+          )}
         </div>
       </IdentityFields>
+      <div className="space-y-2">
+        <Label htmlFor="chat-project-description">Description</Label>
+        <Textarea
+          id="chat-project-description"
+          placeholder="What is this project about?"
+          rows={3}
+          maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
+          aria-invalid={!!form.formState.errors.description}
+          {...form.register("description", {
+            maxLength: {
+              value: PROJECT_DESCRIPTION_MAX_LENGTH,
+              message: `Description must be ${PROJECT_DESCRIPTION_MAX_LENGTH} characters or fewer.`,
+            },
+          })}
+        />
+        {form.formState.errors.description?.message && (
+          <p className="text-xs text-destructive">
+            {form.formState.errors.description.message}
+          </p>
+        )}
+      </div>
       <AdvancedLabelsSection
         ref={labelsRef}
         labels={labels}

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -812,51 +812,50 @@ function CreateProjectDialog({
         }
         fallbackType="project"
       >
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="new-project-name">Name *</Label>
-            <Input
-              autoFocus
-              id="new-project-name"
-              maxLength={PROJECT_NAME_MAX_LENGTH}
-              aria-invalid={!!form.formState.errors.name}
-              {...form.register("name", {
-                required: "Project name is required.",
-                maxLength: {
-                  value: PROJECT_NAME_MAX_LENGTH,
-                  message: `Project name must be ${PROJECT_NAME_MAX_LENGTH} characters or fewer.`,
-                },
-              })}
-            />
-            {form.formState.errors.name?.message && (
-              <p className="text-xs text-destructive">
-                {form.formState.errors.name.message}
-              </p>
-            )}
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="new-project-description">Description</Label>
-            <Textarea
-              id="new-project-description"
-              placeholder="What is this project about?"
-              rows={3}
-              maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
-              aria-invalid={!!form.formState.errors.description}
-              {...form.register("description", {
-                maxLength: {
-                  value: PROJECT_DESCRIPTION_MAX_LENGTH,
-                  message: `Description must be ${PROJECT_DESCRIPTION_MAX_LENGTH} characters or fewer.`,
-                },
-              })}
-            />
-            {form.formState.errors.description?.message && (
-              <p className="text-xs text-destructive">
-                {form.formState.errors.description.message}
-              </p>
-            )}
-          </div>
+        <div className="space-y-2">
+          <Label htmlFor="new-project-name">Name *</Label>
+          <Input
+            autoFocus
+            id="new-project-name"
+            maxLength={PROJECT_NAME_MAX_LENGTH}
+            aria-invalid={!!form.formState.errors.name}
+            {...form.register("name", {
+              required: "Project name is required.",
+              maxLength: {
+                value: PROJECT_NAME_MAX_LENGTH,
+                message: `Project name must be ${PROJECT_NAME_MAX_LENGTH} characters or fewer.`,
+              },
+            })}
+          />
+          {form.formState.errors.name?.message && (
+            <p className="text-xs text-destructive">
+              {form.formState.errors.name.message}
+            </p>
+          )}
         </div>
       </IdentityFields>
+
+      <div className="space-y-2">
+        <Label htmlFor="new-project-description">Description</Label>
+        <Textarea
+          id="new-project-description"
+          placeholder="What is this project about?"
+          rows={3}
+          maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
+          aria-invalid={!!form.formState.errors.description}
+          {...form.register("description", {
+            maxLength: {
+              value: PROJECT_DESCRIPTION_MAX_LENGTH,
+              message: `Description must be ${PROJECT_DESCRIPTION_MAX_LENGTH} characters or fewer.`,
+            },
+          })}
+        />
+        {form.formState.errors.description?.message && (
+          <p className="text-xs text-destructive">
+            {form.formState.errors.description.message}
+          </p>
+        )}
+      </div>
 
       {canReadAgents === true && (
         <div className="space-y-2">

--- a/platform/frontend/src/components/identity-fields.tsx
+++ b/platform/frontend/src/components/identity-fields.tsx
@@ -4,9 +4,9 @@ import type { AgentIconPickerFallback } from "@/components/agent-icon-picker";
 import { AgentIconPicker } from "@/components/agent-icon-picker";
 
 /**
- * The block every entity form opens with: the icon picker on its own row, then
- * the labelled fields that name the thing — agents, projects, apps and MCP
- * servers all start this way.
+ * The block every entity form opens with: an icon picker beside the labelled
+ * field that names the thing — agents, projects, apps and MCP servers all
+ * start this way.
  *
  * It exists so they cannot drift apart. Choosing an emoji looked different in
  * each place (beside the name field here, above it there, labelled in one form
@@ -15,7 +15,7 @@ import { AgentIconPicker } from "@/components/agent-icon-picker";
  * they are wired to four different form libraries and abstracting that would
  * cost more than the consistency is worth.
  *
- * Pass the name/description fields as `children`, each with a real `<Label>`.
+ * Pass the name field as `children`, with a real `<Label>`.
  */
 export function IdentityFields({
   icon,
@@ -37,19 +37,20 @@ export function IdentityFields({
   showLogos?: boolean;
   /** Render the icon as orientation rather than an edit control. */
   disabled?: boolean;
-  /** The labelled fields that sit under the picker. */
+  /** The labelled name field that sits beside the picker. */
   children: React.ReactNode;
 }) {
   return (
-    <div className="space-y-4">
+    <div className="flex items-start gap-3">
       <AgentIconPicker
         value={icon}
         onChange={onIconChange}
         fallbackType={fallbackType}
         showLogos={showLogos}
         disabled={disabled}
+        className="mt-6 size-9 rounded-md"
       />
-      {children}
+      <div className="min-w-0 flex-1">{children}</div>
     </div>
   );
 }

--- a/platform/frontend/src/components/projects/edit-project-dialog.tsx
+++ b/platform/frontend/src/components/projects/edit-project-dialog.tsx
@@ -296,50 +296,49 @@ function EditProjectDialogForm({
         }
         fallbackType="project"
       >
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="edit-project-name">Name *</Label>
-            <Input
-              id="edit-project-name"
-              maxLength={PROJECT_NAME_MAX_LENGTH}
-              aria-invalid={!!form.formState.errors.name}
-              {...form.register("name", {
-                required: "Project name is required.",
-                maxLength: {
-                  value: PROJECT_NAME_MAX_LENGTH,
-                  message: `Project name must be ${PROJECT_NAME_MAX_LENGTH} characters or fewer.`,
-                },
-              })}
-            />
-            {form.formState.errors.name?.message && (
-              <p className="text-xs text-destructive">
-                {form.formState.errors.name.message}
-              </p>
-            )}
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="edit-project-description">Description</Label>
-            <Textarea
-              id="edit-project-description"
-              placeholder="What is this project about?"
-              rows={3}
-              maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
-              aria-invalid={!!form.formState.errors.description}
-              {...form.register("description", {
-                maxLength: {
-                  value: PROJECT_DESCRIPTION_MAX_LENGTH,
-                  message: `Description must be ${PROJECT_DESCRIPTION_MAX_LENGTH} characters or fewer.`,
-                },
-              })}
-            />
-            {form.formState.errors.description?.message && (
-              <p className="text-xs text-destructive">
-                {form.formState.errors.description.message}
-              </p>
-            )}
-          </div>
+        <div className="space-y-2">
+          <Label htmlFor="edit-project-name">Name *</Label>
+          <Input
+            id="edit-project-name"
+            maxLength={PROJECT_NAME_MAX_LENGTH}
+            aria-invalid={!!form.formState.errors.name}
+            {...form.register("name", {
+              required: "Project name is required.",
+              maxLength: {
+                value: PROJECT_NAME_MAX_LENGTH,
+                message: `Project name must be ${PROJECT_NAME_MAX_LENGTH} characters or fewer.`,
+              },
+            })}
+          />
+          {form.formState.errors.name?.message && (
+            <p className="text-xs text-destructive">
+              {form.formState.errors.name.message}
+            </p>
+          )}
         </div>
       </IdentityFields>
+
+      <div className="space-y-2">
+        <Label htmlFor="edit-project-description">Description</Label>
+        <Textarea
+          id="edit-project-description"
+          placeholder="What is this project about?"
+          rows={3}
+          maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
+          aria-invalid={!!form.formState.errors.description}
+          {...form.register("description", {
+            maxLength: {
+              value: PROJECT_DESCRIPTION_MAX_LENGTH,
+              message: `Description must be ${PROJECT_DESCRIPTION_MAX_LENGTH} characters or fewer.`,
+            },
+          })}
+        />
+        {form.formState.errors.description?.message && (
+          <p className="text-xs text-destructive">
+            {form.formState.errors.description.message}
+          </p>
+        )}
+      </div>
 
       <VisibilitySelector
         heading="Sharing"


### PR DESCRIPTION
## Summary

- place the shared icon/logo picker inline to the left of name fields across agent, gateway, MCP server, app, and project identity forms
- keep project descriptions and subsequent controls full width below the compact identity row
- preserve picker behavior, responsive layout, and accessible labels while reducing vertical space

## Verification

- exercised the MCP server create form in Chromium at 1440px and 390px; the picker remained vertically aligned beside the responsive name input and opened its logo/emoji/upload choices
- focused form coverage passed: 102 tests across project, app, agent, and MCP registry flows
- frontend CI check passed: 5,233 tests, TypeScript, Biome, and knip

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>