### PR TITLE
fix(chatops): reply consistently to bare bot mentions

### DIFF
--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -2308,7 +2308,10 @@ describe("ChatOpsManager.getAccessibleChatopsAgents personal agent filtering", (
 });
 
 describe("ChatOpsManager.handleIncomingMessage empty Slack mention", () => {
-  test("replies once for empty app_mention and skips processMessage on retries", async ({
+  test.for([
+    "app_mention",
+    "message",
+  ])("replies once for empty %s and skips processMessage on retries", async (eventType, {
     makeUser,
     makeOrganization,
     makeInternalAgent,
@@ -2372,7 +2375,8 @@ describe("ChatOpsManager.handleIncomingMessage empty Slack mention", () => {
       timestamp: new Date(),
       isThreadReply: false,
       metadata: {
-        eventType: "app_mention",
+        eventType,
+        botMentioned: true,
         channelType: "channel",
       },
     };

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -679,13 +679,14 @@ export class ChatOpsManager {
       binding = { ...binding, agentId };
     }
 
-    // Always reply to empty Slack app mentions so users get a response even
-    // when they only tag the bot without additional text.
-    const isEmptySlackAppMention =
+    // A bare mention can arrive as either app_mention or message; ingress
+    // dedup keeps the first, so both forms must produce the same reply.
+    const isEmptySlackMention =
       provider.providerId === "slack" &&
-      message.metadata?.eventType === "app_mention" &&
+      (message.metadata?.eventType === "app_mention" ||
+        message.metadata?.botMentioned === true) &&
       !message.text.trim();
-    if (isEmptySlackAppMention) {
+    if (isEmptySlackMention) {
       // Deduplicate this early-return path so Slack retries don't produce duplicate replies.
       const isNew = await ChatOpsProcessedMessageModel.tryMarkAsProcessed(
         message.messageId,

--- a/platform/backend/src/agents/chatops/slack-mention-replies.test.ts
+++ b/platform/backend/src/agents/chatops/slack-mention-replies.test.ts
@@ -1,0 +1,145 @@
+import { SLACK_REQUIRED_BOT_SCOPES } from "@archestra/shared";
+import { HttpResponse, http } from "msw";
+import { vi } from "vitest";
+import { ChatOpsChannelBindingModel } from "@/models";
+import { describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
+import { ChatOpsManager } from "./chatops-manager";
+import SlackProvider from "./slack-provider";
+import { EventDedupMap } from "./utils";
+
+vi.mock("@/cache-manager");
+
+// biome-ignore lint/correctness/useHookAtTopLevel: registers test lifecycle hooks, not a React hook
+const server = useMswServer();
+
+describe("mention reply delivery", () => {
+  test.for([
+    "message",
+    "app_mention",
+  ])("replies once after a mute when %s arrives first", async (firstType, {
+    makeUser,
+    makeOrganization,
+    makeInternalAgent,
+  }) => {
+    const user = await makeUser({ email: "mention-user@example.com" });
+    const org = await makeOrganization();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "slack",
+      channelId: "C_TEST",
+      workspaceId: "T_TEST",
+      agentId: agent.id,
+    });
+
+    const posts: URLSearchParams[] = [];
+    server.use(
+      http.post("https://slack.com/api/auth.test", () =>
+        HttpResponse.json(
+          { ok: true, user_id: "UBOT123", team_id: "T_TEST", team: "Test" },
+          {
+            headers: { "x-oauth-scopes": SLACK_REQUIRED_BOT_SCOPES.join(",") },
+          },
+        ),
+      ),
+      http.post("https://slack.com/api/users.info", () =>
+        HttpResponse.json({
+          ok: true,
+          user: { real_name: "Test User", profile: { email: user.email } },
+        }),
+      ),
+      http.post("https://slack.com/api/conversations.list", () =>
+        HttpResponse.json({ ok: true, channels: [] }),
+      ),
+      http.post(
+        "https://slack.com/api/chat.postMessage",
+        async ({ request }) => {
+          posts.push(new URLSearchParams(await request.text()));
+          return HttpResponse.json({ ok: true, ts: "100.000010" });
+        },
+      ),
+    );
+    const provider = new SlackProvider({
+      enabled: true,
+      connectionMode: "webhook",
+      botToken: "xoxb-test",
+      signingSecret: "test-secret",
+      appId: "A_TEST",
+    });
+    await provider.initialize();
+    const manager = new ChatOpsManager();
+    const payload = (event: { type: string; text: string; ts: string }) => ({
+      type: "event_callback",
+      team_id: "T_TEST",
+      event: {
+        channel: "C_TEST",
+        channel_type: "channel",
+        user: "U_TEST",
+        thread_ts: "100.000001",
+        ...event,
+      },
+    });
+    try {
+      await manager.handleIncomingMessage(
+        provider,
+        payload({
+          type: "app_mention",
+          text: "<@UBOT123>",
+          ts: "100.000002",
+        }),
+      );
+      expect(posts).toHaveLength(1);
+      await manager.handleIncomingMessage(
+        provider,
+        payload({
+          type: "message",
+          text: "mute",
+          ts: "100.000003",
+        }),
+      );
+      expect(posts).toHaveLength(2);
+      await manager.handleIncomingMessage(
+        provider,
+        payload({
+          type: "message",
+          text: "hello",
+          ts: "100.000004",
+        }),
+      );
+      expect(posts).toHaveLength(2);
+
+      // The ingress cache keeps only the first twin. Exercise the actual
+      // parser, manager, database claim, and HTTP reply for either order.
+      const dedup = new EventDedupMap();
+      for (const type of [
+        firstType,
+        firstType === "message" ? "app_mention" : "message",
+      ]) {
+        const body = payload({ type, text: "<@UBOT123>   ", ts: "100.000005" });
+        if (!dedup.mark(body.event.ts)) {
+          await manager.handleIncomingMessage(provider, body);
+        }
+      }
+      expect(posts).toHaveLength(3);
+      expect(posts[2].get("text")).toBe("How can I help you?");
+      expect(posts[2].get("channel")).toBe("C_TEST");
+      expect(posts[2].get("thread_ts")).toBe("100.000001");
+
+      // A retry on another process bypasses the in-memory cache but still
+      // must not post again: the database claim owns reply deduplication.
+      await manager.handleIncomingMessage(
+        provider,
+        payload({
+          type: "app_mention",
+          text: "<@UBOT123>",
+          ts: "100.000005",
+        }),
+      );
+      expect(posts).toHaveLength(3);
+    } finally {
+      await provider.cleanup();
+      await manager.cleanup();
+    }
+  });
+});

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -358,14 +358,30 @@ describe("SlackProvider.parseWebhookNotification", () => {
     expect(result).toBeNull();
   });
 
-  test("empty text after cleaning bot mention for app_mention is still processed", async () => {
+  test.each([
+    "app_mention",
+    "message",
+  ])("bare mention delivered as %s is still processed", async (type) => {
     const provider = createProvider();
-    const payload = makeEventPayload({}, { text: "<@UBOT123>" });
+    const payload = makeEventPayload({}, { type, text: "<@UBOT123>" });
 
     const result = await provider.parseWebhookNotification(payload, {});
 
     expect(result).not.toBeNull();
     expect(result?.text).toBe("");
+  });
+
+  test("empty direct message without a mention is ignored", async () => {
+    const provider = createProvider();
+    const payload = makeEventPayload(
+      {},
+      {
+        type: "message",
+        channel_type: "im",
+        text: "   ",
+      },
+    );
+    expect(await provider.parseWebhookNotification(payload, {})).toBeNull();
   });
 
   test("whitespace-only text after app_mention is still processed", async () => {

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -362,7 +362,9 @@ class SlackProvider implements ChatOpsProvider {
     // text) is kept when a file survived download OR was recorded as skipped —
     // a dropped file (too large, expired, failed) carries a model-visible note
     // so the bot can explain it rather than answering a blank turn. Only a
-    // genuinely empty, attachment-less message is dropped here.
+    // genuinely empty, attachment-less message is dropped here. A bare mention
+    // is kept in either event form: ingress dedup keeps whichever of message
+    // and app_mention arrives first.
     const outcomes = await this.downloadSlackFiles(event.files);
     const attachments = outcomes.flatMap((o) =>
       o.status === "delivered" ? [o.attachment] : [],
@@ -372,7 +374,7 @@ class SlackProvider implements ChatOpsProvider {
     );
     if (
       !cleanedText &&
-      event.type !== "app_mention" &&
+      !hasBotMention &&
       attachments.length === 0 &&
       skipped.length === 0
     ) {


### PR DESCRIPTION
Bare bot mentions could receive no reply when the generic message event arrived before its mention event: ingress deduplication retained the first event, but only the mention event reached the greeting path. Accept either event form in the parser and reply handler so delivery order produces the same response.

Regression tests reproduce the failure before the fix. An integration test exercises activation, mute, re-mentioning in both event orders, and replay after bypassing the process-local cache through the real parser, manager, database claim, and HTTP reply client. Each re-mention produces exactly one threaded reply; empty messages without a mention remain ignored.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>