### PR TITLE
fix(chat): show useful explanations in simplified error cards

### DIFF
--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -36,6 +36,13 @@ Type `/` in the prompt input to open available chat commands.
 
 When the agent has the [code sandbox](./platform-code-sandbox) available, a message starting with `!` (for example `! ls attachments/`) runs the rest of the message as a shell command in the conversation's sandbox instead of asking the model. The command and its output appear in the conversation as a regular `run_command` tool call, so the agent sees the result in later turns. Output appears when the command finishes. Requires the `sandbox: execute` permission; without a sandbox, the message is sent as normal text. User-typed commands do not trigger PreToolUse/PostToolUse hooks — the user, not the model, initiated the call.
 
+### Chat Errors
+
+Simplified chat errors explain the problem without exposing provider details or raw error output.
+Your organization's support message appears beneath the explanation.
+Copied error details include the explanation, support message, and available correlation IDs.
+These IDs help administrators find the failed request in logs.
+
 ### Message Queueing
 
 Press Enter while a response is streaming to queue your message. Queued messages appear above the prompt input and send in order as each turn finishes — you can keep typing without waiting. Remove a queued message with its X, or press ArrowUp on an empty prompt to pull the newest one back for editing.

--- a/platform/frontend/src/app/settings/appearance/page.tsx
+++ b/platform/frontend/src/app/settings/appearance/page.tsx
@@ -396,7 +396,7 @@ export default function AppearanceSettingsPage() {
           <AppearanceControlRow
             id="slimChatErrorUi"
             label="Simplified Chat Error Cards"
-            description="Hide provider, model, stack trace, and raw error details in chat. Users will only see the support message or default error text plus correlation IDs."
+            description="Hide provider, model, stack trace, and raw error details in chat. Show a brief error explanation, your support message, and correlation IDs."
           >
             <Switch
               id="slimChatErrorUi"

--- a/platform/frontend/src/components/chat/chat-error.utils.ts
+++ b/platform/frontend/src/components/chat/chat-error.utils.ts
@@ -36,6 +36,19 @@ export function parseErrorResponse(error: Error): ChatErrorResponse | null {
   return null;
 }
 
+/** Simplified cards only show curated copy, never provider or raw error text. */
+export function getSimplifiedChatErrorMessage(
+  error: ChatErrorResponse,
+  appName: string,
+): string {
+  return branded(
+    ChatErrorMessages[
+      error.usageLimitExceeded ? ChatErrorCode.UsageLimitExceeded : error.code
+    ],
+    appName,
+  );
+}
+
 /**
  * Recursively parse nested JSON strings to produce a clean object
  */

--- a/platform/frontend/src/components/chat/inline-chat-error.test.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.test.tsx
@@ -52,7 +52,7 @@ describe("InlineChatError", () => {
     vi.mocked(useFeature).mockReturnValue(false);
   });
 
-  it("shows only the support message and correlation IDs in slim mode", () => {
+  it("shows a useful explanation alongside support and correlation IDs in slim mode", () => {
     render(
       <InlineChatError
         error={
@@ -79,6 +79,10 @@ describe("InlineChatError", () => {
     expect(
       screen.getByText("Contact your administrator and include these IDs."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("The AI provider is experiencing issues."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("The provider failed")).not.toBeInTheDocument();
     expect(screen.getByText("session-12345678")).toBeInTheDocument();
     expect(screen.getByText("trace-12345678")).toBeInTheDocument();
     expect(screen.getByText("span-12345678")).toBeInTheDocument();
@@ -91,7 +95,7 @@ describe("InlineChatError", () => {
     ).toBeInTheDocument();
   });
 
-  it("falls back to the mapped error message in slim mode without a support message", () => {
+  it("shows curated error copy in slim mode without a support message", () => {
     render(
       <InlineChatError
         error={
@@ -114,7 +118,9 @@ describe("InlineChatError", () => {
       />,
     );
 
-    expect(screen.getByText("The provider failed")).toBeInTheDocument();
+    expect(
+      screen.getByText("The AI provider is experiencing issues."),
+    ).toBeInTheDocument();
     expect(screen.getByText("session-12345678")).toBeInTheDocument();
     expect(screen.getByText("trace-12345678")).toBeInTheDocument();
     expect(screen.getByText("span-12345678")).toBeInTheDocument();
@@ -122,6 +128,112 @@ describe("InlineChatError", () => {
     expect(
       screen.queryByText("secret provider detail"),
     ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["rate_limit", /Too many requests/],
+    ["context_too_long", /conversation is too long/],
+    ["content_filtered", /rephrase your request/],
+    ["usage_limit_exceeded", /configured usage limit/],
+    ["unknown", /unexpected error occurred/],
+  ])("keeps %s guidance visible with support configured", (code, message) => {
+    render(
+      <InlineChatError
+        error={
+          new Error(
+            JSON.stringify({
+              code,
+              message: "private upstream payload",
+              isRetryable: false,
+            }),
+          )
+        }
+        supportMessage="Ask your administrator for help."
+        slimChatErrorUi
+      />,
+    );
+    expect(screen.getByText(message)).toBeInTheDocument();
+    expect(
+      screen.getByText("Ask your administrator for help."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("private upstream payload"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("copies the explanation, support, and IDs without raw details in slim mode", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(
+      <InlineChatError
+        error={
+          new Error(
+            JSON.stringify({
+              code: "rate_limit",
+              message: "private upstream payload",
+              isRetryable: true,
+              traceId: "trace-example",
+              originalError: { provider: "openai", raw: "private debug data" },
+            }),
+          )
+        }
+        supportMessage="  Contact your administrator.  "
+        conversationId="session-example"
+        agentName="Private Agent"
+        selectedModel="private-model"
+        slimChatErrorUi
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Copy error details" }),
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      "Too many requests. Please wait a moment and try again.\nContact your administrator.\nSession: session-example\nTrace: trace-example",
+    );
+  });
+
+  it("uses a safe fallback for unstructured errors even with blank support", () => {
+    vi.mocked(useAppName).mockReturnValue("Example Workspace");
+    render(
+      <InlineChatError
+        error={new Error("Error: private internal failure at service.ts:42")}
+        supportMessage="   "
+        slimChatErrorUi
+      />,
+    );
+    expect(screen.getByText(/unexpected error occurred/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/private internal failure/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("brands usage-limit guidance and never duplicates it beneath support", () => {
+    vi.mocked(useAppName).mockReturnValue("Example Workspace");
+    render(
+      <InlineChatError
+        error={
+          new Error(
+            JSON.stringify({
+              code: "rate_limit",
+              message: "private limit detail",
+              usageLimitExceeded: true,
+              isRetryable: false,
+            }),
+          )
+        }
+        supportMessage="Contact your administrator."
+        slimChatErrorUi
+      />,
+    );
+    expect(
+      screen.getAllByText(/Example Workspace blocked this request/),
+    ).toHaveLength(1);
+    expect(screen.queryByText(/Too many requests/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/private limit detail/)).not.toBeInTheDocument();
   });
 
   it("still shows a copy button in slim mode when no IDs are available", () => {

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -25,6 +25,7 @@ import { copyToClipboard } from "@/lib/clipboard";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import {
   formatOriginalError,
+  getSimplifiedChatErrorMessage,
   mapClientError,
   parseErrorResponse,
 } from "./chat-error.utils";
@@ -65,6 +66,9 @@ export function InlineChatError({
   });
   const appName = useAppName();
   const chatError = parseErrorResponse(error) ?? mapClientError(error, appName);
+
+  const simplifiedMessage = getSimplifiedChatErrorMessage(chatError, appName);
+  const trimmedSupportMessage = supportMessage?.trim();
 
   // A per-user provider the user hasn't linked yet → an inline "connect your
   // account" card instead of a generic error.
@@ -115,7 +119,12 @@ export function InlineChatError({
   const copyDebugInfo = async () => {
     const lines: string[] = [];
 
-    lines.push(supportMessage?.trim() || chatError.message);
+    if (slimChatErrorUi) {
+      lines.push(simplifiedMessage);
+      if (trimmedSupportMessage) lines.push(trimmedSupportMessage);
+    } else {
+      lines.push(trimmedSupportMessage || chatError.message);
+    }
     if (!slimChatErrorUi) {
       if (agentName) lines.push(`Agent: ${agentName}`);
       if (selectedModel) lines.push(`Model: ${selectedModel}`);
@@ -181,9 +190,12 @@ export function InlineChatError({
               className={`h-4 w-4 mt-0.5 flex-shrink-0 ${iconClassName}`}
             />
             <div className="flex-1 space-y-2">
-              <p className="text-sm text-foreground">
-                {supportMessage ? supportMessage : chatError.message}
-              </p>
+              <p className="text-sm text-foreground">{simplifiedMessage}</p>
+              {trimmedSupportMessage && (
+                <p className="text-xs text-muted-foreground">
+                  {trimmedSupportMessage}
+                </p>
+              )}
 
               <div className="flex items-center gap-1.5 flex-wrap">
                 {refEntries.map((entry) => (
@@ -206,11 +218,6 @@ export function InlineChatError({
                   <Copy className="h-3 w-3" />
                 </Button>
               </div>
-              {usageLimitMessage && (
-                <p className="text-xs text-muted-foreground">
-                  {usageLimitMessage}
-                </p>
-              )}
               {retryButton}
             </div>
           </div>

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -159,7 +159,7 @@ export function InlineChatError({
       <Button
         variant="outline"
         size="sm"
-        className="h-7 gap-1.5"
+        className="h-7 gap-1.5 self-start"
         disabled={isRetrying}
         onClick={() => {
           setIsRetrying(true);
@@ -184,12 +184,14 @@ export function InlineChatError({
   if (slimChatErrorUi) {
     return (
       <Message from="assistant">
-        <MessageContent className={containerClassName}>
+        <MessageContent
+          className={`${containerClassName} group-[.is-assistant]:[&_p]:my-0`}
+        >
           <div className="flex items-start gap-2">
             <StatusIcon
               className={`h-4 w-4 mt-0.5 flex-shrink-0 ${iconClassName}`}
             />
-            <div className="flex-1 space-y-2">
+            <div className="flex flex-1 flex-col gap-2">
               <p className="text-sm text-foreground">{simplifiedMessage}</p>
               {trimmedSupportMessage && (
                 <p className="text-xs text-muted-foreground">
@@ -228,12 +230,14 @@ export function InlineChatError({
 
   return (
     <Message from="assistant">
-      <MessageContent className={containerClassName}>
+      <MessageContent
+        className={`${containerClassName} group-[.is-assistant]:[&_p]:my-0`}
+      >
         <div className="flex items-start gap-2">
           <StatusIcon
             className={`h-4 w-4 mt-0.5 flex-shrink-0 ${iconClassName}`}
           />
-          <div className="flex-1 space-y-2">
+          <div className="flex flex-1 flex-col gap-2">
             {supportMessage ? (
               <p className="text-sm text-foreground">{supportMessage}</p>
             ) : (


### PR DESCRIPTION
A configured support message currently replaces the error explanation in simplified chat cards. Show a curated explanation for the error category first, with the optional support contact message beneath it. Copied details include both messages and correlation IDs while excluding raw provider output. Unknown errors receive a readable fallback.

Verified in Chrome through the chat screen with controlled API failures: rate limits retain retry, an oversized conversation gives specific guidance without retry, and unknown errors remain readable without support text. Checked clipboard contents for raw-detail exclusion. Component regression tests cover these cases, whitespace-only support, and branded usage-limit guidance.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>