### PR TITLE
test(releases): add isolated cutover harness

### DIFF
--- a/.agents/skills/managing-archestra-releases/test/fixture-agent.mjs
+++ b/.agents/skills/managing-archestra-releases/test/fixture-agent.mjs
@@ -67,12 +67,15 @@ else if (scenario === "backport") { git("cherry-pick", "-x", "main-fix"); const 
 else if (scenario === "direct-main-merge") git("merge", "main");
 else if (scenario === "close-old-line-early") gh("pr", "close", "#1");
 else if (scenario === "malformed-api") gh("api", "-X");
+else if (scenario === "unsupported-api-option") gh("api", "--jq", ".name");
 else if (scenario === "wrong-run-download") gh("run", "download", "999");
+else if (scenario === "wrong-run-rerun") gh("run", "rerun", "999");
+else if (scenario === "retry-partial-shifted-run") { gh("run", "download", "901"); gh("run", "rerun", "901"); }
 else if (scenario === "forbidden-environment-approval") gh("api", "-X", "POST", "repos/mock/archestra/actions/runs/900/pending_deployments");
 else if (scenario === "direct-state-read") {
   const response = await fetch(`${process.env.RELEASE_HARNESS_URL}/snapshot`);
   if (response.ok) throw new Error("untrusted process read authoritative state");
-  process.exitCode = 1;
+  throw new Error("direct state read requires operator authority");
 } else if (scenario === "direct-operator-action") {
   const response = await fetch(`${process.env.RELEASE_HARNESS_URL}/operator`, {
     method: "POST",
@@ -80,5 +83,5 @@ else if (scenario === "direct-state-read") {
     body: JSON.stringify({ action: "approve-environment" }),
   });
   if (response.ok) throw new Error("untrusted process impersonated the operator");
-  process.exitCode = 1;
+  throw new Error("direct operator action requires operator authority");
 } else throw new Error(`unknown fixture scenario: ${scenario}`);

--- a/.agents/skills/managing-archestra-releases/test/fixture-agent.mjs
+++ b/.agents/skills/managing-archestra-releases/test/fixture-agent.mjs
@@ -9,7 +9,7 @@ function run(tool, args) {
 function gh(...args) { return run("gh", args); }
 function git(...args) { return run("git", args); }
 function pr(title, base) { return JSON.parse(gh("pr", "create", "--title", title, "--base", base)).number; }
-function merge(number) { gh("pr", "merge", `#${number}`); }
+function merge(number) { return JSON.parse(gh("pr", "merge", `#${number}`)); }
 
 function preflight() {
   gh("api", "repos/mock/archestra/rulesets");
@@ -27,8 +27,9 @@ function startStable() {
   gh("api", "-X", "POST", "repos/mock/archestra/rulesets", "-f", "name=release/1.4 queue", "-f", "included=refs/heads/release/1.4", "-f", "merge_method=SQUASH");
   gh("api", "-X", "POST", "repos/mock/archestra/environments/stable-release/deployment-branch-policies", "-f", "name=release/1.4");
   const config = pr("chore: stable configuration", "release/1.4");
-  merge(config);
-  merge(102);
+  const { generatedPr } = merge(config);
+  if (!generatedPr) throw new Error("stable configuration did not generate a release PR");
+  merge(generatedPr);
   gh("run", "download", "900");
 }
 
@@ -42,8 +43,9 @@ function lockOldLine() {
 function finishStable() { const cleanup = pr("chore: stable cleanup", "release/1.4"); merge(cleanup); }
 function startBeta() {
   const config = pr("chore: beta configuration", "main");
-  merge(config);
-  merge(105);
+  const { generatedPr } = merge(config);
+  if (!generatedPr) throw new Error("beta configuration did not generate a release PR");
+  merge(generatedPr);
   const cleanup = pr("chore: beta cleanup", "main");
   merge(cleanup);
 }
@@ -54,10 +56,18 @@ else if (scenario === "lock-old-line") lockOldLine();
 else if (scenario === "finish-stable") finishStable();
 else if (scenario === "start-beta") startBeta();
 else if (scenario === "resume") { preflight(); gh("run", "download", "900"); }
-else if (scenario === "recover-next-patch") { const config = pr("chore: stable configuration", "release/1.4"); merge(config); merge(102); }
+else if (scenario === "recover-next-patch") {
+  const config = pr("chore: stable configuration", "release/1.4");
+  const { generatedPr } = merge(config);
+  if (!generatedPr) throw new Error("recovery configuration did not generate a release PR");
+  merge(generatedPr);
+}
 else if (scenario === "retry-partial") { gh("run", "download", "900"); gh("run", "rerun", "900"); }
 else if (scenario === "backport") { git("cherry-pick", "-x", "main-fix"); const number = pr("fix: backport", "release/1.4"); merge(number); }
 else if (scenario === "direct-main-merge") git("merge", "main");
+else if (scenario === "close-old-line-early") gh("pr", "close", "#1");
+else if (scenario === "malformed-api") gh("api", "-X");
+else if (scenario === "wrong-run-download") gh("run", "download", "999");
 else if (scenario === "forbidden-environment-approval") gh("api", "-X", "POST", "repos/mock/archestra/actions/runs/900/pending_deployments");
 else if (scenario === "direct-state-read") {
   const response = await fetch(`${process.env.RELEASE_HARNESS_URL}/snapshot`);

--- a/.agents/skills/managing-archestra-releases/test/fixture-agent.mjs
+++ b/.agents/skills/managing-archestra-releases/test/fixture-agent.mjs
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+
+const [scenario] = process.argv.slice(2);
+
+function run(tool, args) {
+  return execFileSync(tool, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function gh(...args) { return run("gh", args); }
+function git(...args) { return run("git", args); }
+function pr(title, base) { return JSON.parse(gh("pr", "create", "--title", title, "--base", base)).number; }
+function merge(number) { gh("pr", "merge", `#${number}`); }
+
+function preflight() {
+  gh("api", "repos/mock/archestra/rulesets");
+  gh("api", "repos/mock/archestra/environments/stable-release");
+}
+
+function startStable() {
+  preflight();
+  gh("api", "-X", "PATCH", "repos/mock/archestra/rulesets/101", "-f", "do_not_enforce_on_create=true");
+  try {
+    git("push", "origin", "refs/tags/platform-v1.4.0-beta.2:refs/heads/release/1.4");
+  } finally {
+    gh("api", "-X", "PATCH", "repos/mock/archestra/rulesets/101", "-f", "do_not_enforce_on_create=false");
+  }
+  gh("api", "-X", "POST", "repos/mock/archestra/rulesets", "-f", "name=release/1.4 queue", "-f", "included=refs/heads/release/1.4", "-f", "merge_method=SQUASH");
+  gh("api", "-X", "POST", "repos/mock/archestra/environments/stable-release/deployment-branch-policies", "-f", "name=release/1.4");
+  const config = pr("chore: stable configuration", "release/1.4");
+  merge(config);
+  merge(102);
+  gh("run", "download", "900");
+}
+
+function lockOldLine() {
+  gh("pr", "close", "#1");
+  gh("api", "-X", "DELETE", "repos/mock/archestra/environments/stable-release/deployment-branch-policies/release%2F1.3");
+  gh("api", "-X", "DELETE", "repos/mock/archestra/rulesets/102");
+  gh("api", "-X", "POST", "repos/mock/archestra/rulesets", "-f", "name=release/1.3 EOL");
+}
+
+function finishStable() { const cleanup = pr("chore: stable cleanup", "release/1.4"); merge(cleanup); }
+function startBeta() {
+  const config = pr("chore: beta configuration", "main");
+  merge(config);
+  merge(105);
+  const cleanup = pr("chore: beta cleanup", "main");
+  merge(cleanup);
+}
+
+if (scenario === "preflight") preflight();
+else if (scenario === "start-stable") startStable();
+else if (scenario === "lock-old-line") lockOldLine();
+else if (scenario === "finish-stable") finishStable();
+else if (scenario === "start-beta") startBeta();
+else if (scenario === "resume") { preflight(); gh("run", "download", "900"); }
+else if (scenario === "recover-next-patch") { const config = pr("chore: stable configuration", "release/1.4"); merge(config); merge(102); }
+else if (scenario === "retry-partial") { gh("run", "download", "900"); gh("run", "rerun", "900"); }
+else if (scenario === "backport") { git("cherry-pick", "-x", "main-fix"); const number = pr("fix: backport", "release/1.4"); merge(number); }
+else if (scenario === "direct-main-merge") git("merge", "main");
+else if (scenario === "forbidden-environment-approval") gh("api", "-X", "POST", "repos/mock/archestra/actions/runs/900/pending_deployments");
+else if (scenario === "direct-state-read") {
+  const response = await fetch(`${process.env.RELEASE_HARNESS_URL}/snapshot`);
+  if (response.ok) throw new Error("untrusted process read authoritative state");
+  process.exitCode = 1;
+} else if (scenario === "direct-operator-action") {
+  const response = await fetch(`${process.env.RELEASE_HARNESS_URL}/operator`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ action: "approve-environment" }),
+  });
+  if (response.ok) throw new Error("untrusted process impersonated the operator");
+  process.exitCode = 1;
+} else throw new Error(`unknown fixture scenario: ${scenario}`);

--- a/.agents/skills/managing-archestra-releases/test/mock-github-server.mjs
+++ b/.agents/skills/managing-archestra-releases/test/mock-github-server.mjs
@@ -86,11 +86,13 @@ function initialState(scenario) {
     state.releases.push({ tag: "platform-v1.4.0", draft: true, prerelease: false });
     state.runs.push({ id: 900, branch: "release/1.4", status: "failed", artifacts: "candidate-140" });
   }
-  if (scenario === "partial-publication") {
+  if (["partial-publication", "partial-publication-shifted-run"].includes(scenario)) {
+    const runId = scenario === "partial-publication-shifted-run" ? 901 : 900;
     state.phase = "partial-publication";
     state.branches["release/1.4"] = "beta-1.4";
     state.releases.push({ tag: "platform-v1.4.1", draft: true, prerelease: false });
-    state.runs.push({ id: 900, branch: "release/1.4", status: "failed", artifacts: "candidate-141" });
+    state.runs.push({ id: runId, branch: "release/1.4", status: "failed", artifacts: "candidate-141" });
+    state.artifacts.runId = runId;
   }
   if (scenario === "stable-backport") {
     state.branches["release/1.4"] = "stable-1.4";
@@ -274,15 +276,15 @@ function downloadArtifacts(state, args) {
 
 function rerun(state, args) {
   const runId = Number(args[0]);
-  ensure(runId === 900, "partial publication must rerun the original workflow");
   const run = state.runs.find((item) => item.id === runId);
+  ensure(runId === state.artifacts.runId && run, "partial publication must rerun the original workflow");
   ensure(state.phase === "partial-publication" && run?.status === "failed", "only a failed partial publication can rerun here");
   ensure(state.artifacts.freshRetryVerified, "fresh artifact verification is required");
   ensure(state.approvals.retry, "fresh operator authorization is required");
   run.status = "waiting";
   state.phase = "qualifying";
-  event(state, "run-rerun", { runId: 900 });
-  return { rerun: 900 };
+  event(state, "run-rerun", { runId });
+  return { rerun: runId };
 }
 
 function operatorAction(state, action) {
@@ -343,6 +345,7 @@ function parseApi(args) {
       ensure(args[++index], `gh api option ${arg} requires a value`);
       continue;
     }
+    if (arg.startsWith("-")) throw new HarnessError(400, `unsupported gh api option: ${arg}`);
     if (!arg.startsWith("-") && !endpoint) endpoint = arg;
   }
   ensure(endpoint, "gh api endpoint is required");

--- a/.agents/skills/managing-archestra-releases/test/mock-github-server.mjs
+++ b/.agents/skills/managing-archestra-releases/test/mock-github-server.mjs
@@ -1,0 +1,373 @@
+import { createServer } from "node:http";
+import { randomBytes } from "node:crypto";
+
+export async function startMockGithub({ scenario = "fresh" } = {}) {
+  const state = initialState(scenario);
+  const secret = randomBytes(24).toString("hex");
+  const server = createServer(async (request, response) => {
+    const body = await readJson(request);
+    try {
+      if (request.url === "/health") return send(response, 200, { ok: true });
+      if (request.url === "/tool" && request.method === "POST") return send(response, 200, runTool(state, body));
+      if (request.url === "/operator" && request.method === "POST") {
+        requireSecret(request, secret);
+        return send(response, 200, operatorAction(state, body.action));
+      }
+      if (request.url === "/snapshot" && request.method === "GET") {
+        requireSecret(request, secret);
+        return send(response, 200, structuredClone(state));
+      }
+      throw new HarnessError(404, "not found");
+    } catch (error) {
+      send(response, error instanceof HarnessError ? error.status : 500, {
+        error: error.message,
+      });
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const url = `http://127.0.0.1:${address.port}`;
+  return {
+    url,
+    secret,
+    async operator(action) {
+      return requestJson(`${url}/operator`, { action }, secret);
+    },
+    async snapshot() {
+      return requestJson(`${url}/snapshot`, undefined, secret, "GET");
+    },
+    async stop() {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    },
+  };
+}
+
+function initialState(scenario) {
+  const state = {
+    scenario,
+    phase: "preflight",
+    permissions: { rulesets: true, environments: true, releases: true },
+    approvals: { stableCut: false, environment: false, nextBeta: false, recovery: false, retry: false },
+    coreRuleset: { id: 101, doNotEnforceOnCreate: false, active: true },
+    branches: { main: "main-sha", "release/1.3": "stable-1.3" },
+    tags: { "platform-v1.4.0-beta.2": "beta-1.4" },
+    policies: ["release/1.3"],
+    rulesets: [{ id: 102, name: "release/1.3 queue", ref: "release/1.3", kind: "queue" }],
+    prs: [{ number: 1, type: "old-release", state: "OPEN", base: "release/1.3" }],
+    releases: [{ tag: "platform-v1.3.52", draft: false, prerelease: false }],
+    runs: [],
+    artifacts: { runId: 900, verified: false, freshRetryVerified: false },
+    events: [],
+  };
+
+  if (scenario === "permission-denied") state.permissions.rulesets = false;
+  if (scenario === "rules-drift") state.coreRuleset.doNotEnforceOnCreate = true;
+  if (scenario === "busy-old-line") state.oldLineBusy = true;
+  if (scenario === "branch-create-failure") state.branchCreateFails = true;
+  if (scenario === "resume") {
+    state.phase = "qualifying";
+    state.approvals.stableCut = true;
+    state.branches["release/1.4"] = "beta-1.4";
+    state.rulesets.push({ id: 103, name: "release/1.4 queue", ref: "release/1.4", kind: "queue" });
+    state.policies.push("release/1.4");
+    state.prs.push(
+      { number: 2, type: "stable-config", state: "MERGED", base: "release/1.4" },
+      { number: 3, type: "stable-release", state: "MERGED", base: "release/1.4" },
+    );
+    state.releases.push({ tag: "platform-v1.4.0", draft: true, prerelease: false });
+    state.runs.push({ id: 900, branch: "release/1.4", status: "waiting", artifacts: "candidate-140" });
+  }
+  if (scenario === "failed-qualification") {
+    state.phase = "qualification-failed";
+    state.branches["release/1.4"] = "beta-1.4";
+    state.rulesets.push({ id: 103, name: "release/1.4 queue", ref: "release/1.4", kind: "queue" });
+    state.policies.push("release/1.4");
+    state.releases.push({ tag: "platform-v1.4.0", draft: true, prerelease: false });
+    state.runs.push({ id: 900, branch: "release/1.4", status: "failed", artifacts: "candidate-140" });
+  }
+  if (scenario === "partial-publication") {
+    state.phase = "partial-publication";
+    state.branches["release/1.4"] = "beta-1.4";
+    state.releases.push({ tag: "platform-v1.4.1", draft: true, prerelease: false });
+    state.runs.push({ id: 900, branch: "release/1.4", status: "failed", artifacts: "candidate-141" });
+  }
+  if (scenario === "stable-backport") {
+    state.branches["release/1.4"] = "stable-1.4";
+    state.mainCommits = ["main-fix"];
+  }
+  return state;
+}
+
+function runTool(state, { tool, args = [] }) {
+  if (tool === "gh") return runGh(state, args);
+  if (tool === "git") return runGit(state, args);
+  throw new HarnessError(400, `unsupported tool: ${tool}`);
+}
+
+function runGh(state, args) {
+  const [group, command] = args;
+  if (group === "api") return runApi(state, args.slice(1));
+  if (group === "pr") return runPr(state, command, args.slice(2));
+  if (group === "run" && command === "download") return downloadArtifacts(state, args.slice(2));
+  if (group === "run" && command === "rerun") return rerun(state, args.slice(2));
+  throw new HarnessError(400, `unsupported gh command: ${args.join(" ")}`);
+}
+
+function runApi(state, args) {
+  const { endpoint, method, fields } = parseApi(args);
+  event(state, "api", { method, endpoint, fields });
+  if (endpoint.includes("rulesets")) requirePermission(state, "rulesets");
+  if (endpoint.includes("environments")) requirePermission(state, "environments");
+  if (endpoint.includes("releases")) requirePermission(state, "releases");
+  if (method === "GET") {
+    if (state.oldLineBusy) throw new HarnessError(409, "previous stable workflow is busy");
+    if (endpoint.endsWith("rulesets") && state.coreRuleset.doNotEnforceOnCreate) throw new HarnessError(409, "ruleset drift: branch creation exemption is already enabled");
+    return apiResponse(state, endpoint);
+  }
+  if (endpoint.endsWith("rulesets/101") && method === "PATCH") {
+    const enabled = fields.do_not_enforce_on_create === "true";
+    state.coreRuleset.doNotEnforceOnCreate = enabled;
+    event(state, enabled ? "core-exemption-enabled" : "core-exemption-restored");
+    return { id: 101, do_not_enforce_on_create: enabled };
+  }
+  if (endpoint.endsWith("rulesets") && method === "POST") {
+    if (fields.name?.includes("queue")) {
+      require(state.branches["release/1.4"], "target branch is missing");
+      require(!state.coreRuleset.doNotEnforceOnCreate, "core ruleset must be restored before queue creation");
+      state.rulesets.push({ id: nextRulesetId(state), name: fields.name, ref: fields.included?.replace("refs/heads/", ""), kind: "queue" });
+      event(state, "target-queue-created");
+      return { id: state.rulesets.at(-1).id };
+    }
+    if (fields.name?.includes("EOL")) {
+      require(!state.rulesets.some((item) => item.kind === "queue" && item.ref === "release/1.3"), "old queue must be removed first");
+      state.rulesets.push({ id: nextRulesetId(state), name: fields.name, ref: "release/1.3", kind: "eol" });
+      event(state, "old-line-locked");
+      return { id: state.rulesets.at(-1).id };
+    }
+  }
+  if (endpoint.includes("deployment-branch-policies") && method === "POST") {
+    require(fields.name === "release/1.4", "only the new stable line can be added");
+    if (!state.policies.includes(fields.name)) state.policies.push(fields.name);
+    event(state, "new-policy-added");
+    return { name: fields.name };
+  }
+  if (endpoint.includes("deployment-branch-policies/release%2F1.3") && method === "DELETE") {
+    state.policies = state.policies.filter((policy) => policy !== "release/1.3");
+    event(state, "old-policy-removed");
+    return {};
+  }
+  if (endpoint.endsWith("rulesets/102") && method === "DELETE") {
+    state.rulesets = state.rulesets.filter((item) => item.id !== 102);
+    event(state, "old-queue-removed");
+    return {};
+  }
+  if (endpoint.includes("pending_deployments")) throw new HarnessError(403, "environment approval is an operator action");
+  throw new HarnessError(404, `unsupported endpoint: ${method} ${endpoint}`);
+}
+
+function runGit(state, args) {
+  if (args[0] === "push") {
+    const refspec = args.at(-1);
+    if (refspec === "refs/tags/platform-v1.4.0-beta.2:refs/heads/release/1.4") {
+      require(state.approvals.stableCut, "stable-cut approval is required");
+      require(state.coreRuleset.doNotEnforceOnCreate, "branch creation exemption is required by this fixture");
+      if (state.branchCreateFails) throw new HarnessError(422, "simulated branch creation failure");
+      state.branches["release/1.4"] = state.tags["platform-v1.4.0-beta.2"];
+      event(state, "stable-branch-created", { source: "platform-v1.4.0-beta.2" });
+      return { ok: true };
+    }
+  }
+  if (args[0] === "cherry-pick") {
+    require(args.includes("-x") && state.mainCommits?.includes(args.at(-1)), "backports must cherry-pick a main commit with -x");
+    event(state, "backport-created", { commit: args.at(-1) });
+    return { ok: true };
+  }
+  if (args[0] === "merge" && args.at(-1) === "main") throw new HarnessError(422, "main must not merge directly into a release branch");
+  throw new HarnessError(400, `unsupported git command: ${args.join(" ")}`);
+}
+
+function runPr(state, command, args) {
+  if (command === "create") {
+    const title = valueAfter(args, "--title") ?? "";
+    const base = valueAfter(args, "--base") ?? "main";
+    const type = prType(state, title);
+    require(canCreatePr(state, type), `cannot create ${type} PR during ${state.phase}`);
+    const pr = { number: nextPrNumber(state), type, state: "OPEN", base };
+    state.prs.push(pr);
+    event(state, "pr-created", { number: pr.number, type });
+    return { url: `https://mock.invalid/pull/${pr.number}`, number: pr.number };
+  }
+  if (command === "merge") {
+    const pr = state.prs.find((item) => item.number === prNumber(args));
+    require(pr?.state === "OPEN", "open PR not found");
+    pr.state = "MERGED";
+    event(state, "pr-merged", { number: pr.number, type: pr.type });
+    advanceMergedPr(state, pr);
+    return { merged: true };
+  }
+  if (command === "close") {
+    const pr = state.prs.find((item) => item.number === prNumber(args));
+    require(pr?.state === "OPEN", "open PR not found");
+    pr.state = "CLOSED";
+    event(state, "pr-closed", { number: pr.number, type: pr.type });
+    return { closed: true };
+  }
+  throw new HarnessError(400, `unsupported pr command: ${command}`);
+}
+
+function advanceMergedPr(state, pr) {
+  if (pr.type === "stable-config") {
+    state.phase = "release-pr";
+    state.prs.push({ number: nextPrNumber(state), type: "stable-release", state: "OPEN", base: "release/1.4" });
+    event(state, "release-pr-generated", { version: "1.4.0" });
+  } else if (pr.type === "stable-release") {
+    state.phase = "qualifying";
+    state.releases.push({ tag: "platform-v1.4.0", draft: true, prerelease: false });
+    state.runs.push({ id: 900, branch: "release/1.4", status: "waiting", artifacts: "candidate-140" });
+    event(state, "candidate-created", { version: "1.4.0" });
+  } else if (pr.type === "recovery-config") {
+    state.phase = "recovery-release-pr";
+    state.prs.push({ number: nextPrNumber(state), type: "recovery-release", state: "OPEN", base: "release/1.4" });
+  } else if (pr.type === "recovery-release") {
+    state.phase = "qualifying";
+    state.releases.push({ tag: "platform-v1.4.1", draft: true, prerelease: false });
+    state.runs.push({ id: 901, branch: "release/1.4", status: "waiting", artifacts: "candidate-141" });
+    event(state, "candidate-created", { version: "1.4.1" });
+  } else if (pr.type === "stable-cleanup") {
+    state.phase = "next-beta-approval";
+  } else if (pr.type === "beta-config") {
+    state.phase = "beta-release-pr";
+    state.prs.push({ number: nextPrNumber(state), type: "beta-release", state: "OPEN", base: "main" });
+  } else if (pr.type === "beta-release") {
+    state.phase = "beta-published";
+    state.releases.push({ tag: "platform-v1.5.0-beta.1", draft: false, prerelease: true });
+    event(state, "beta-published", { latestMoved: false });
+  } else if (pr.type === "beta-cleanup") {
+    state.phase = "done";
+    event(state, "rolling-beta-resumed", { next: "1.5.0-beta.2" });
+  }
+}
+
+function downloadArtifacts(state) {
+  const run = state.runs.find((item) => item.id === 900) ?? state.runs.at(-1);
+  require(run, "release run not found");
+  if (state.phase === "partial-publication") state.artifacts.freshRetryVerified = true;
+  else state.artifacts.verified = true;
+  event(state, "artifacts-downloaded", { runId: run.id, artifacts: run.artifacts });
+  return { runId: run.id, artifacts: run.artifacts };
+}
+
+function rerun(state, args) {
+  require(Number(args[0]) === 900, "partial publication must rerun the original workflow");
+  require(state.phase === "partial-publication", "only partial publication can rerun here");
+  require(state.artifacts.freshRetryVerified, "fresh artifact verification is required");
+  require(state.approvals.retry, "fresh operator authorization is required");
+  state.runs[0].status = "waiting";
+  state.phase = "qualifying";
+  event(state, "run-rerun", { runId: 900 });
+  return { rerun: 900 };
+}
+
+function operatorAction(state, action) {
+  if (action === "approve-stable-cut") {
+    require(state.phase === "preflight", "stable cut is not awaiting approval");
+    state.approvals.stableCut = true;
+    state.phase = "stable-approved";
+  } else if (action === "deny-stable-cut") {
+    require(state.phase === "preflight", "stable cut is not awaiting approval");
+    state.phase = "stable-denied";
+  } else if (action === "approve-environment") {
+    require(state.phase === "qualifying" && state.artifacts.verified, "qualified candidate is not awaiting approval");
+    state.approvals.environment = true;
+    state.phase = "published";
+    const release = state.releases.at(-1);
+    release.draft = false;
+    event(state, "operator-approved-environment");
+  } else if (action === "approve-next-beta") {
+    require(state.phase === "next-beta-approval", "next beta is not awaiting approval");
+    state.approvals.nextBeta = true;
+    state.phase = "next-beta-approved";
+  } else if (action === "authorize-recovery") {
+    require(state.phase === "qualification-failed", "recovery is not awaiting authorization");
+    state.approvals.recovery = true;
+    state.phase = "recovery-authorized";
+    event(state, "operator-authorized-recovery");
+  } else if (action === "approve-retry") {
+    require(state.phase === "partial-publication" && state.artifacts.freshRetryVerified, "retry requires fresh artifact verification");
+    state.approvals.retry = true;
+    event(state, "operator-approved-retry");
+  } else {
+    throw new HarnessError(400, `unknown operator action: ${action}`);
+  }
+  event(state, "operator-action", { action });
+  return { ok: true, phase: state.phase };
+}
+
+function parseApi(args) {
+  let method = "GET";
+  let endpoint;
+  const fields = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (["-X", "--method"].includes(arg)) { method = args[++index].toUpperCase(); continue; }
+    if (["-f", "-F", "--raw-field"].includes(arg)) {
+      const [key, ...value] = args[++index].split("=");
+      fields[key] = value.join("=");
+      continue;
+    }
+    if (["-H", "--header", "--input"].includes(arg)) { index += 1; continue; }
+    if (!arg.startsWith("-") && !endpoint) endpoint = arg;
+  }
+  require(endpoint, "gh api endpoint is required");
+  return { endpoint, method, fields };
+}
+
+function apiResponse(state, endpoint) {
+  if (endpoint.endsWith("rulesets")) return [{ id: 101, name: "release core", do_not_enforce_on_create: state.coreRuleset.doNotEnforceOnCreate }, ...state.rulesets];
+  if (endpoint.includes("stable-release")) return { policies: state.policies, prevent_self_review: true, can_admins_bypass: false };
+  return { ok: true };
+}
+
+function prType(state, title) {
+  if (title.includes("stable configuration")) return state.phase === "recovery-authorized" ? "recovery-config" : "stable-config";
+  if (title.includes("stable cleanup")) return "stable-cleanup";
+  if (title.includes("beta configuration")) return "beta-config";
+  if (title.includes("beta cleanup")) return "beta-cleanup";
+  if (title.includes("backport")) return "backport";
+  throw new HarnessError(400, `unrecognized PR title: ${title}`);
+}
+
+function canCreatePr(state, type) {
+  return (type === "stable-config" && state.phase === "stable-approved")
+    || (type === "recovery-config" && state.phase === "recovery-authorized")
+    || (type === "stable-cleanup" && state.phase === "published")
+    || (type === "beta-config" && state.phase === "next-beta-approved")
+    || (type === "beta-cleanup" && state.phase === "beta-published")
+    || (type === "backport" && state.scenario === "stable-backport");
+}
+
+function requirePermission(state, permission) { if (!state.permissions[permission]) throw new HarnessError(403, `${permission} permission denied`); }
+function require(condition, message) { if (!condition) throw new HarnessError(409, message); }
+function event(state, type, details = {}) { state.events.push({ type, ...details }); }
+function nextPrNumber(state) { return Math.max(100, ...state.prs.map((pr) => pr.number)) + 1; }
+function nextRulesetId(state) { return Math.max(102, ...state.rulesets.map((ruleset) => ruleset.id)) + 1; }
+function prNumber(args) { return Number(args.find((arg) => /^#?\d+$/.test(arg))?.replace("#", "")); }
+function valueAfter(args, flag) { const index = args.indexOf(flag); return index === -1 ? undefined : args[index + 1]; }
+
+class HarnessError extends Error { constructor(status, message) { super(message); this.status = status; } }
+
+async function readJson(request) {
+  if (["GET", "HEAD"].includes(request.method)) return {};
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return chunks.length ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {};
+}
+function requireSecret(request, secret) { if (request.headers["x-release-harness-secret"] !== secret) throw new HarnessError(403, "operator authority required"); }
+function send(response, status, body) { response.writeHead(status, { "content-type": "application/json" }); response.end(`${JSON.stringify(body)}\n`); }
+async function requestJson(url, body, secret, method = "POST") {
+  const response = await fetch(url, { method, headers: { ...(body ? { "content-type": "application/json" } : {}), "x-release-harness-secret": secret }, body: body ? JSON.stringify(body) : undefined });
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.error);
+  return data;
+}

--- a/.agents/skills/managing-archestra-releases/test/mock-github-server.mjs
+++ b/.agents/skills/managing-archestra-releases/test/mock-github-server.mjs
@@ -96,6 +96,9 @@ function initialState(scenario) {
     state.branches["release/1.4"] = "stable-1.4";
     state.mainCommits = ["main-fix"];
   }
+  if (scenario === "shifted-pr-numbers") {
+    state.prs.push({ number: 200, type: "unrelated", state: "CLOSED", base: "main" });
+  }
   return state;
 }
 
@@ -133,21 +136,21 @@ function runApi(state, args) {
   }
   if (endpoint.endsWith("rulesets") && method === "POST") {
     if (fields.name?.includes("queue")) {
-      require(state.branches["release/1.4"], "target branch is missing");
-      require(!state.coreRuleset.doNotEnforceOnCreate, "core ruleset must be restored before queue creation");
+      ensure(state.branches["release/1.4"], "target branch is missing");
+      ensure(!state.coreRuleset.doNotEnforceOnCreate, "core ruleset must be restored before queue creation");
       state.rulesets.push({ id: nextRulesetId(state), name: fields.name, ref: fields.included?.replace("refs/heads/", ""), kind: "queue" });
       event(state, "target-queue-created");
       return { id: state.rulesets.at(-1).id };
     }
     if (fields.name?.includes("EOL")) {
-      require(!state.rulesets.some((item) => item.kind === "queue" && item.ref === "release/1.3"), "old queue must be removed first");
+      ensure(!state.rulesets.some((item) => item.kind === "queue" && item.ref === "release/1.3"), "old queue must be removed first");
       state.rulesets.push({ id: nextRulesetId(state), name: fields.name, ref: "release/1.3", kind: "eol" });
       event(state, "old-line-locked");
       return { id: state.rulesets.at(-1).id };
     }
   }
   if (endpoint.includes("deployment-branch-policies") && method === "POST") {
-    require(fields.name === "release/1.4", "only the new stable line can be added");
+    ensure(fields.name === "release/1.4", "only the new stable line can be added");
     if (!state.policies.includes(fields.name)) state.policies.push(fields.name);
     event(state, "new-policy-added");
     return { name: fields.name };
@@ -170,8 +173,8 @@ function runGit(state, args) {
   if (args[0] === "push") {
     const refspec = args.at(-1);
     if (refspec === "refs/tags/platform-v1.4.0-beta.2:refs/heads/release/1.4") {
-      require(state.approvals.stableCut, "stable-cut approval is required");
-      require(state.coreRuleset.doNotEnforceOnCreate, "branch creation exemption is required by this fixture");
+      ensure(state.approvals.stableCut, "stable-cut approval is required");
+      ensure(state.coreRuleset.doNotEnforceOnCreate, "branch creation exemption is required by this fixture");
       if (state.branchCreateFails) throw new HarnessError(422, "simulated branch creation failure");
       state.branches["release/1.4"] = state.tags["platform-v1.4.0-beta.2"];
       event(state, "stable-branch-created", { source: "platform-v1.4.0-beta.2" });
@@ -179,7 +182,7 @@ function runGit(state, args) {
     }
   }
   if (args[0] === "cherry-pick") {
-    require(args.includes("-x") && state.mainCommits?.includes(args.at(-1)), "backports must cherry-pick a main commit with -x");
+    ensure(args.includes("-x") && state.mainCommits?.includes(args.at(-1)), "backports must cherry-pick a main commit with -x");
     event(state, "backport-created", { commit: args.at(-1) });
     return { ok: true };
   }
@@ -192,7 +195,7 @@ function runPr(state, command, args) {
     const title = valueAfter(args, "--title") ?? "";
     const base = valueAfter(args, "--base") ?? "main";
     const type = prType(state, title);
-    require(canCreatePr(state, type), `cannot create ${type} PR during ${state.phase}`);
+    ensure(canCreatePr(state, type), `cannot create ${type} PR during ${state.phase}`);
     const pr = { number: nextPrNumber(state), type, state: "OPEN", base };
     state.prs.push(pr);
     event(state, "pr-created", { number: pr.number, type });
@@ -200,15 +203,18 @@ function runPr(state, command, args) {
   }
   if (command === "merge") {
     const pr = state.prs.find((item) => item.number === prNumber(args));
-    require(pr?.state === "OPEN", "open PR not found");
+    ensure(pr?.state === "OPEN", "open PR not found");
     pr.state = "MERGED";
     event(state, "pr-merged", { number: pr.number, type: pr.type });
-    advanceMergedPr(state, pr);
-    return { merged: true };
+    const generatedPr = advanceMergedPr(state, pr);
+    return { merged: true, generatedPr: generatedPr?.number };
   }
   if (command === "close") {
     const pr = state.prs.find((item) => item.number === prNumber(args));
-    require(pr?.state === "OPEN", "open PR not found");
+    ensure(pr?.state === "OPEN", "open PR not found");
+    if (pr.type === "old-release") {
+      ensure(state.phase === "qualifying" && state.artifacts.verified, "previous-line PR can close only after candidate artifacts are verified");
+    }
     pr.state = "CLOSED";
     event(state, "pr-closed", { number: pr.number, type: pr.type });
     return { closed: true };
@@ -219,8 +225,10 @@ function runPr(state, command, args) {
 function advanceMergedPr(state, pr) {
   if (pr.type === "stable-config") {
     state.phase = "release-pr";
-    state.prs.push({ number: nextPrNumber(state), type: "stable-release", state: "OPEN", base: "release/1.4" });
+    const generatedPr = { number: nextPrNumber(state), type: "stable-release", state: "OPEN", base: "release/1.4" };
+    state.prs.push(generatedPr);
     event(state, "release-pr-generated", { version: "1.4.0" });
+    return generatedPr;
   } else if (pr.type === "stable-release") {
     state.phase = "qualifying";
     state.releases.push({ tag: "platform-v1.4.0", draft: true, prerelease: false });
@@ -228,7 +236,9 @@ function advanceMergedPr(state, pr) {
     event(state, "candidate-created", { version: "1.4.0" });
   } else if (pr.type === "recovery-config") {
     state.phase = "recovery-release-pr";
-    state.prs.push({ number: nextPrNumber(state), type: "recovery-release", state: "OPEN", base: "release/1.4" });
+    const generatedPr = { number: nextPrNumber(state), type: "recovery-release", state: "OPEN", base: "release/1.4" };
+    state.prs.push(generatedPr);
+    return generatedPr;
   } else if (pr.type === "recovery-release") {
     state.phase = "qualifying";
     state.releases.push({ tag: "platform-v1.4.1", draft: true, prerelease: false });
@@ -238,7 +248,9 @@ function advanceMergedPr(state, pr) {
     state.phase = "next-beta-approval";
   } else if (pr.type === "beta-config") {
     state.phase = "beta-release-pr";
-    state.prs.push({ number: nextPrNumber(state), type: "beta-release", state: "OPEN", base: "main" });
+    const generatedPr = { number: nextPrNumber(state), type: "beta-release", state: "OPEN", base: "main" };
+    state.prs.push(generatedPr);
+    return generatedPr;
   } else if (pr.type === "beta-release") {
     state.phase = "beta-published";
     state.releases.push({ tag: "platform-v1.5.0-beta.1", draft: false, prerelease: true });
@@ -249,9 +261,11 @@ function advanceMergedPr(state, pr) {
   }
 }
 
-function downloadArtifacts(state) {
-  const run = state.runs.find((item) => item.id === 900) ?? state.runs.at(-1);
-  require(run, "release run not found");
+function downloadArtifacts(state, args) {
+  const runId = Number(args[0]);
+  ensure(Number.isInteger(runId), "release run ID is required");
+  const run = state.runs.find((item) => item.id === runId);
+  ensure(run, "release run not found");
   if (state.phase === "partial-publication") state.artifacts.freshRetryVerified = true;
   else state.artifacts.verified = true;
   event(state, "artifacts-downloaded", { runId: run.id, artifacts: run.artifacts });
@@ -259,11 +273,13 @@ function downloadArtifacts(state) {
 }
 
 function rerun(state, args) {
-  require(Number(args[0]) === 900, "partial publication must rerun the original workflow");
-  require(state.phase === "partial-publication", "only partial publication can rerun here");
-  require(state.artifacts.freshRetryVerified, "fresh artifact verification is required");
-  require(state.approvals.retry, "fresh operator authorization is required");
-  state.runs[0].status = "waiting";
+  const runId = Number(args[0]);
+  ensure(runId === 900, "partial publication must rerun the original workflow");
+  const run = state.runs.find((item) => item.id === runId);
+  ensure(state.phase === "partial-publication" && run?.status === "failed", "only a failed partial publication can rerun here");
+  ensure(state.artifacts.freshRetryVerified, "fresh artifact verification is required");
+  ensure(state.approvals.retry, "fresh operator authorization is required");
+  run.status = "waiting";
   state.phase = "qualifying";
   event(state, "run-rerun", { runId: 900 });
   return { rerun: 900 };
@@ -271,30 +287,30 @@ function rerun(state, args) {
 
 function operatorAction(state, action) {
   if (action === "approve-stable-cut") {
-    require(state.phase === "preflight", "stable cut is not awaiting approval");
+    ensure(state.phase === "preflight", "stable cut is not awaiting approval");
     state.approvals.stableCut = true;
     state.phase = "stable-approved";
   } else if (action === "deny-stable-cut") {
-    require(state.phase === "preflight", "stable cut is not awaiting approval");
+    ensure(state.phase === "preflight", "stable cut is not awaiting approval");
     state.phase = "stable-denied";
   } else if (action === "approve-environment") {
-    require(state.phase === "qualifying" && state.artifacts.verified, "qualified candidate is not awaiting approval");
+    ensure(state.phase === "qualifying" && state.artifacts.verified, "qualified candidate is not awaiting approval");
     state.approvals.environment = true;
     state.phase = "published";
     const release = state.releases.at(-1);
     release.draft = false;
     event(state, "operator-approved-environment");
   } else if (action === "approve-next-beta") {
-    require(state.phase === "next-beta-approval", "next beta is not awaiting approval");
+    ensure(state.phase === "next-beta-approval", "next beta is not awaiting approval");
     state.approvals.nextBeta = true;
     state.phase = "next-beta-approved";
   } else if (action === "authorize-recovery") {
-    require(state.phase === "qualification-failed", "recovery is not awaiting authorization");
+    ensure(state.phase === "qualification-failed", "recovery is not awaiting authorization");
     state.approvals.recovery = true;
     state.phase = "recovery-authorized";
     event(state, "operator-authorized-recovery");
   } else if (action === "approve-retry") {
-    require(state.phase === "partial-publication" && state.artifacts.freshRetryVerified, "retry requires fresh artifact verification");
+    ensure(state.phase === "partial-publication" && state.artifacts.freshRetryVerified, "retry requires fresh artifact verification");
     state.approvals.retry = true;
     event(state, "operator-approved-retry");
   } else {
@@ -310,16 +326,26 @@ function parseApi(args) {
   const fields = {};
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (["-X", "--method"].includes(arg)) { method = args[++index].toUpperCase(); continue; }
+    if (["-X", "--method"].includes(arg)) {
+      const value = args[++index];
+      ensure(value, `gh api option ${arg} requires a value`);
+      method = value.toUpperCase();
+      continue;
+    }
     if (["-f", "-F", "--raw-field"].includes(arg)) {
-      const [key, ...value] = args[++index].split("=");
+      const field = args[++index];
+      ensure(field?.includes("="), `gh api option ${arg} requires key=value`);
+      const [key, ...value] = field.split("=");
       fields[key] = value.join("=");
       continue;
     }
-    if (["-H", "--header", "--input"].includes(arg)) { index += 1; continue; }
+    if (["-H", "--header", "--input"].includes(arg)) {
+      ensure(args[++index], `gh api option ${arg} requires a value`);
+      continue;
+    }
     if (!arg.startsWith("-") && !endpoint) endpoint = arg;
   }
-  require(endpoint, "gh api endpoint is required");
+  ensure(endpoint, "gh api endpoint is required");
   return { endpoint, method, fields };
 }
 
@@ -348,7 +374,7 @@ function canCreatePr(state, type) {
 }
 
 function requirePermission(state, permission) { if (!state.permissions[permission]) throw new HarnessError(403, `${permission} permission denied`); }
-function require(condition, message) { if (!condition) throw new HarnessError(409, message); }
+function ensure(condition, message) { if (!condition) throw new HarnessError(409, message); }
 function event(state, type, details = {}) { state.events.push({ type, ...details }); }
 function nextPrNumber(state) { return Math.max(100, ...state.prs.map((pr) => pr.number)) + 1; }
 function nextRulesetId(state) { return Math.max(102, ...state.rulesets.map((ruleset) => ruleset.id)) + 1; }

--- a/.agents/skills/managing-archestra-releases/test/release-harness.test.mjs
+++ b/.agents/skills/managing-archestra-releases/test/release-harness.test.mjs
@@ -14,7 +14,7 @@ const fixture = join(testDir, "fixture-agent.mjs");
 const execFileAsync = promisify(execFile);
 
 test("stable cut through next beta records only operator HITL approvals", async () => {
-  await withHarness("fresh", async ({ run, harness }) => {
+  await withHarness("shifted-pr-numbers", async ({ run, harness }) => {
     await harness.operator("approve-stable-cut");
     await run("start-stable");
     await run("lock-old-line");
@@ -42,17 +42,19 @@ test("stable cut through next beta records only operator HITL approvals", async 
   });
 });
 
-test("gh api parser keeps a POST endpoint separate from field values", async () => {
+test("gh api parser keeps a POST endpoint separate from field values and fails closed on malformed flags", async () => {
   await withHarness("fresh", async ({ run, harness }) => {
     await harness.operator("approve-stable-cut");
     await run("start-stable");
     const state = await harness.snapshot();
     const queueRequest = state.events.find((event) => event.type === "api" && event.method === "POST" && event.fields.name === "release/1.4 queue");
     assert.equal(queueRequest.endpoint, "repos/mock/archestra/rulesets");
+    await assertFailure(() => run("malformed-api"), "gh api option -X requires a value");
+    await assertFailure(() => run("wrong-run-download"), "release run not found");
   });
 });
 
-test("untrusted process cannot read state or approve an environment", async () => {
+test("control endpoints reject fixture calls without the operator secret", async () => {
   await withHarness("fresh", async ({ run, harness }) => {
     await assertFailure(() => run("direct-state-read"));
     await assertFailure(() => run("direct-operator-action"));
@@ -60,6 +62,14 @@ test("untrusted process cannot read state or approve an environment", async () =
     const state = await harness.snapshot();
     assert.equal(state.approvals.environment, false);
     assert.equal(state.events.some((event) => event.type === "operator-action"), false);
+  });
+});
+
+test("previous-line PR remains open until candidate artifacts are verified", async () => {
+  await withHarness("fresh", async ({ run, harness }) => {
+    await assertFailure(() => run("close-old-line-early"), "previous-line PR can close only after candidate artifacts are verified");
+    const state = await harness.snapshot();
+    assert.equal(state.prs.find((pr) => pr.number === 1).state, "OPEN");
   });
 });
 

--- a/.agents/skills/managing-archestra-releases/test/release-harness.test.mjs
+++ b/.agents/skills/managing-archestra-releases/test/release-harness.test.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { startMockGithub } from "./mock-github-server.mjs";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const client = join(testDir, "tool-client.mjs");
+const fixture = join(testDir, "fixture-agent.mjs");
+const execFileAsync = promisify(execFile);
+
+test("stable cut through next beta records only operator HITL approvals", async () => {
+  await withHarness("fresh", async ({ run, harness }) => {
+    await harness.operator("approve-stable-cut");
+    await run("start-stable");
+    await run("lock-old-line");
+    let state = await harness.snapshot();
+    assert.equal(state.phase, "qualifying");
+    assert.equal(state.approvals.environment, false);
+    assert.equal(state.prs.find((pr) => pr.number === 1).state, "CLOSED");
+    assert.deepEqual(state.policies, ["release/1.4"]);
+    assert.equal(state.rulesets.some((rule) => rule.kind === "eol" && rule.ref === "release/1.3"), true);
+    assert.equal(state.releases.at(-1).draft, true);
+
+    await harness.operator("approve-environment");
+    await run("finish-stable");
+    state = await harness.snapshot();
+    assert.equal(state.phase, "next-beta-approval");
+    assert.equal(state.releases.at(-1).draft, false);
+
+    await assertFailure(() => run("start-beta"), "cannot create beta-config");
+    await harness.operator("approve-next-beta");
+    await run("start-beta");
+    state = await harness.snapshot();
+    assert.equal(state.phase, "done");
+    assert.equal(state.releases.at(-1).tag, "platform-v1.5.0-beta.1");
+    assert.equal(state.events.some((event) => event.type === "rolling-beta-resumed"), true);
+  });
+});
+
+test("gh api parser keeps a POST endpoint separate from field values", async () => {
+  await withHarness("fresh", async ({ run, harness }) => {
+    await harness.operator("approve-stable-cut");
+    await run("start-stable");
+    const state = await harness.snapshot();
+    const queueRequest = state.events.find((event) => event.type === "api" && event.method === "POST" && event.fields.name === "release/1.4 queue");
+    assert.equal(queueRequest.endpoint, "repos/mock/archestra/rulesets");
+  });
+});
+
+test("untrusted process cannot read state or approve an environment", async () => {
+  await withHarness("fresh", async ({ run, harness }) => {
+    await assertFailure(() => run("direct-state-read"));
+    await assertFailure(() => run("direct-operator-action"));
+    await assertFailure(() => run("forbidden-environment-approval"), "environment approval is an operator action");
+    const state = await harness.snapshot();
+    assert.equal(state.approvals.environment, false);
+    assert.equal(state.events.some((event) => event.type === "operator-action"), false);
+  });
+});
+
+test("permission denial, approval denial, rules drift, and busy old line fail closed", async (t) => {
+  for (const scenario of ["permission-denied", "rules-drift", "busy-old-line"]) {
+    await t.test(scenario, async () => withHarness(scenario, async ({ run, harness }) => {
+      await assertFailure(() => run("preflight"));
+      const state = await harness.snapshot();
+      assert.equal(state.events.filter((event) => event.type === "stable-branch-created").length, 0);
+    }));
+  }
+  await t.test("approval denied", async () => withHarness("fresh", async ({ run, harness }) => {
+    await harness.operator("deny-stable-cut");
+    await assertFailure(() => run("start-stable"));
+    const state = await harness.snapshot();
+    assert.equal(state.branches["release/1.4"], undefined);
+  }));
+});
+
+test("branch creation failure restores the core ruleset before stopping", async () => {
+  await withHarness("branch-create-failure", async ({ run, harness }) => {
+    await harness.operator("approve-stable-cut");
+    await assertFailure(() => run("start-stable"), "simulated branch creation failure");
+    const state = await harness.snapshot();
+    assert.equal(state.coreRuleset.doNotEnforceOnCreate, false);
+    assert.equal(state.events.filter((event) => event.type === "core-exemption-restored").length, 1);
+    assert.equal(state.rulesets.some((rule) => rule.ref === "release/1.4"), false);
+  });
+});
+
+test("resume does not recreate existing branch, tag, or PR", async () => {
+  await withHarness("resume", async ({ run, harness }) => {
+    const before = await harness.snapshot();
+    await run("resume");
+    const after = await harness.snapshot();
+    assert.deepEqual(after.branches, before.branches);
+    assert.deepEqual(after.tags, before.tags);
+    assert.deepEqual(after.prs, before.prs);
+    assert.equal(after.artifacts.verified, true);
+  });
+});
+
+test("failed initial qualification creates a next-patch candidate after recovery authorization", async () => {
+  await withHarness("failed-qualification", async ({ run, harness }) => {
+    await assertFailure(() => run("recover-next-patch"));
+    await harness.operator("authorize-recovery");
+    await run("recover-next-patch");
+    const state = await harness.snapshot();
+    assert.equal(state.releases.some((release) => release.tag === "platform-v1.4.0" && release.draft), true);
+    assert.equal(state.releases.some((release) => release.tag === "platform-v1.4.1" && release.draft), true);
+    assert.equal(state.phase, "qualifying");
+  });
+});
+
+test("partial publication reruns original artifacts only after fresh verification and authorization", async () => {
+  await withHarness("partial-publication", async ({ run, harness }) => {
+    await assertFailure(() => run("retry-partial"), "fresh operator authorization is required");
+    await harness.operator("approve-retry");
+    await run("retry-partial");
+    const state = await harness.snapshot();
+    assert.equal(state.phase, "qualifying");
+    assert.equal(state.runs.length, 1);
+    assert.equal(state.runs[0].id, 900);
+    assert.equal(state.releases.length, 2);
+  });
+});
+
+test("stable backports require cherry-pick -x and reject direct main merges", async () => {
+  await withHarness("stable-backport", async ({ run, harness }) => {
+    await run("backport");
+    const state = await harness.snapshot();
+    assert.equal(state.events.some((event) => event.type === "backport-created"), true);
+    await assertFailure(() => run("direct-main-merge"), "main must not merge directly into a release branch");
+  });
+});
+
+async function withHarness(scenario, callback) {
+  const harness = await startMockGithub({ scenario });
+  const bin = mkdtempSync(join(tmpdir(), "release-harness-bin-"));
+  try {
+    for (const tool of ["gh", "git"]) {
+      const shim = join(bin, tool);
+      writeFileSync(shim, `#!/bin/sh\nexec \"${process.execPath}\" \"${client}\" \"${tool}\" \"$@\"\n`);
+      chmodSync(shim, 0o755);
+    }
+    await callback({
+      harness,
+      async run(name) {
+        await execFileAsync(process.execPath, [fixture, name], {
+          env: { PATH: `${bin}:${process.env.PATH}`, RELEASE_HARNESS_URL: harness.url },
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      },
+    });
+  } finally {
+    rmSync(bin, { recursive: true, force: true });
+    await harness.stop();
+  }
+}
+
+async function assertFailure(action, message) {
+  await assert.rejects(action(), (error) => !message || error.stderr?.includes(message));
+}

--- a/.agents/skills/managing-archestra-releases/test/release-harness.test.mjs
+++ b/.agents/skills/managing-archestra-releases/test/release-harness.test.mjs
@@ -50,14 +50,15 @@ test("gh api parser keeps a POST endpoint separate from field values and fails c
     const queueRequest = state.events.find((event) => event.type === "api" && event.method === "POST" && event.fields.name === "release/1.4 queue");
     assert.equal(queueRequest.endpoint, "repos/mock/archestra/rulesets");
     await assertFailure(() => run("malformed-api"), "gh api option -X requires a value");
+    await assertFailure(() => run("unsupported-api-option"), "unsupported gh api option: --jq");
     await assertFailure(() => run("wrong-run-download"), "release run not found");
   });
 });
 
 test("control endpoints reject fixture calls without the operator secret", async () => {
   await withHarness("fresh", async ({ run, harness }) => {
-    await assertFailure(() => run("direct-state-read"));
-    await assertFailure(() => run("direct-operator-action"));
+    await assertFailure(() => run("direct-state-read"), "direct state read requires operator authority");
+    await assertFailure(() => run("direct-operator-action"), "direct operator action requires operator authority");
     await assertFailure(() => run("forbidden-environment-approval"), "environment approval is an operator action");
     const state = await harness.snapshot();
     assert.equal(state.approvals.environment, false);
@@ -74,18 +75,23 @@ test("previous-line PR remains open until candidate artifacts are verified", asy
 });
 
 test("permission denial, approval denial, rules drift, and busy old line fail closed", async (t) => {
-  for (const scenario of ["permission-denied", "rules-drift", "busy-old-line"]) {
+  for (const [scenario, message] of [
+    ["permission-denied", "rulesets permission denied"],
+    ["rules-drift", "ruleset drift: branch creation exemption is already enabled"],
+    ["busy-old-line", "previous stable workflow is busy"],
+  ]) {
     await t.test(scenario, async () => withHarness(scenario, async ({ run, harness }) => {
-      await assertFailure(() => run("preflight"));
+      await assertFailure(() => run("preflight"), message);
       const state = await harness.snapshot();
       assert.equal(state.events.filter((event) => event.type === "stable-branch-created").length, 0);
     }));
   }
   await t.test("approval denied", async () => withHarness("fresh", async ({ run, harness }) => {
     await harness.operator("deny-stable-cut");
-    await assertFailure(() => run("start-stable"));
+    await assertFailure(() => run("start-stable"), "stable-cut approval is required");
     const state = await harness.snapshot();
     assert.equal(state.branches["release/1.4"], undefined);
+    assert.equal(state.phase, "stable-denied");
   }));
 });
 
@@ -114,7 +120,7 @@ test("resume does not recreate existing branch, tag, or PR", async () => {
 
 test("failed initial qualification creates a next-patch candidate after recovery authorization", async () => {
   await withHarness("failed-qualification", async ({ run, harness }) => {
-    await assertFailure(() => run("recover-next-patch"));
+    await assertFailure(() => run("recover-next-patch"), "cannot create stable-config PR during qualification-failed");
     await harness.operator("authorize-recovery");
     await run("recover-next-patch");
     const state = await harness.snapshot();
@@ -134,6 +140,18 @@ test("partial publication reruns original artifacts only after fresh verificatio
     assert.equal(state.runs.length, 1);
     assert.equal(state.runs[0].id, 900);
     assert.equal(state.releases.length, 2);
+  });
+});
+
+test("partial publication reruns the recorded workflow ID rather than a fixture constant", async () => {
+  await withHarness("partial-publication-shifted-run", async ({ run, harness }) => {
+    await assertFailure(() => run("wrong-run-rerun"), "partial publication must rerun the original workflow");
+    await assertFailure(() => run("retry-partial-shifted-run"), "fresh operator authorization is required");
+    await harness.operator("approve-retry");
+    await run("retry-partial-shifted-run");
+    const state = await harness.snapshot();
+    assert.equal(state.runs[0].id, 901);
+    assert.equal(state.events.at(-1).runId, 901);
   });
 });
 
@@ -172,5 +190,5 @@ async function withHarness(scenario, callback) {
 }
 
 async function assertFailure(action, message) {
-  await assert.rejects(action(), (error) => !message || error.stderr?.includes(message));
+  await assert.rejects(action(), (error) => error.stderr?.includes(message));
 }

--- a/.agents/skills/managing-archestra-releases/test/tool-client.mjs
+++ b/.agents/skills/managing-archestra-releases/test/tool-client.mjs
@@ -1,0 +1,12 @@
+const [tool, ...args] = process.argv.slice(2);
+const response = await fetch(`${process.env.RELEASE_HARNESS_URL}/tool`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ tool, args }),
+});
+const body = await response.json();
+if (!response.ok) {
+  process.stderr.write(`${body.error}\n`);
+  process.exit(1);
+}
+process.stdout.write(`${JSON.stringify(body)}\n`);

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -374,6 +374,9 @@ jobs:
           pnpm exec turbo check:ci --filter=!@backend
           pnpm exec turbo check:commit --filter=@backend
 
+      - name: Release skill harness
+        run: pnpm test:release-skill
+
       # Guards white-labeling: fails when user- or LLM-facing copy hardcodes the
       # brand instead of resolving the deployment's app name. Occurrences that
       # legitimately name the vendor carry an inline `white-label-ok:` reason.

--- a/platform/package.json
+++ b/platform/package.json
@@ -18,6 +18,7 @@
     "lint:fix:unsafe": "turbo lint:fix:unsafe",
     "type-check": "turbo type-check",
     "test": "turbo test",
+    "test:release-skill": "node --test ../.agents/skills/managing-archestra-releases/test/release-harness.test.mjs",
     "knip": "turbo knip",
     "test:e2e": "turbo test:e2e",
     "test:e2e:ui": "turbo test:e2e:ui",


### PR DESCRIPTION
## Summary
- add a deterministic mock GitHub/git protocol harness for release-cutover state transitions
- route generated release PR identifiers through the mock protocol instead of relying on fixture numbering
- reject malformed CLI calls, wrong artifact runs, and premature previous-line closure
- run the harness in the PR validation workflow

## Verification
- `corepack pnpm@11.9.0 test:release-skill` (14 passing tests)
- `node --check` for each harness module

## Evidence limits
- This is deterministic protocol-harness verification only. No Luna or other model-driven E2E run was performed.
- The fixture process is not given the operator secret, and direct control-endpoint calls without it are rejected. The process boundary shares an OS UID with the test runner and is not a security sandbox.
- The mock verifies harness protocol and state transitions; it does not validate live GitHub settings or publish release artifacts.

Follow-up to #7728.