### PR TITLE
fix(chat): defer Bedrock IAM authentication to the proxy

### DIFF
--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -1208,6 +1208,41 @@ describe("createDirectLLMModel", () => {
 });
 
 describe("createLLMModel", () => {
+  test("sends keyless Bedrock chat to the proxy without signing or a placeholder credential", async () => {
+    vi.stubEnv("AWS_ACCESS_KEY_ID", undefined);
+    vi.stubEnv("AWS_SECRET_ACCESS_KEY", undefined);
+    vi.stubEnv("AWS_BEARER_TOKEN_BEDROCK", undefined);
+    const mockFetch = vi.fn().mockResolvedValue(
+      Response.json({
+        output: {
+          message: { role: "assistant", content: [{ text: "Hello" }] },
+        },
+        stopReason: "end_turn",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        metrics: { latencyMs: 1 },
+      }),
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    const model = createLLMModel({
+      provider: "bedrock",
+      apiKey: undefined,
+      agentId: "agent-1",
+      modelName: "amazon.nova-lite-v1:0",
+      baseUrl: null,
+      chatApiKeyId: "keyless-bedrock-key",
+    });
+    const result = await generateText({ model, prompt: "Hi", maxRetries: 0 });
+
+    expect(result.text).toBe("Hello");
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain("/v1/bedrock/agent-1/model/");
+    const headers = new Headers(init.headers);
+    expect(headers.has("authorization")).toBe(false);
+    expect(headers.has("x-amz-date")).toBe(false);
+    expect(headers.get(CHAT_API_KEY_ID_HEADER)).toBe("keyless-bedrock-key");
+  });
+
   test("forwards Bedrock SigV4 credentials through the local proxy as a bearer marker", () => {
     const marker = encodeBedrockSigV4Marker({
       accessKeyId: "test-access-key",

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -1080,11 +1080,23 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
       (direct
         ? buildBedrockProvider({ apiKey, baseUrl: baseURL, headers, fetch })
         : createAmazonBedrock({
-            apiKey,
+            // The proxy resolves AWS credentials. Keep the SDK from trying
+            // SigV4 on the loopback hop when chat uses a secretless IAM key.
+            apiKey: apiKey || KEYLESS_PROVIDER_API_KEY_PLACEHOLDER,
             region: getBedrockRegion(),
             baseURL,
             headers,
-            fetch,
+            fetch: apiKey
+              ? fetch
+              : (input, init) => {
+                  const proxyHeaders = new Headers(init?.headers);
+                  // Preserve keyless auth so the proxy selects its IAM chain.
+                  proxyHeaders.delete("authorization");
+                  return (fetch ?? globalThis.fetch)(input, {
+                    ...init,
+                    headers: proxyHeaders,
+                  });
+                },
           }))(modelName),
     defaultBaseUrl: config.llm.bedrock.baseUrl,
     apiKeyRequiredMessage: isBedrockIamAuthEnabled()


### PR DESCRIPTION
Bedrock chat in 1.3.50 fails immediately with `AWS SigV4 authentication requires AWS credentials` when using a secretless IAM credential. The chat SDK attempts to sign the loopback request before it reaches the proxy that resolves the AWS credential chain.

Force bearer mode for this local SDK hop, then remove the placeholder authorization header before sending the request so the proxy retains keyless IAM behavior. Explicit credentials and direct provider calls keep their existing authentication paths.

Added a regression test exercising the real SDK with a stubbed Bedrock response and checking that the proxy request contains neither authorization nor signing headers. A standalone reproduction using the installed SDK and the original/updated model factories reproduced the exact error before the fix and returned the stubbed response afterward. This does not validate a live AWS request or end-to-end streaming chat. The chat test suite and typecheck are blocked locally by the missing `@cantoo/pdf-lib` dependency; the existing Bedrock credential tests pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>