### PR TITLE
docs(apps): clarify who can edit shared MCP Apps

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -80789,7 +80789,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Update an app's metadata and/or html (forks a new version).\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps, their tools, and their team assignments",
+        "description": "Update an app's metadata and/or html (forks a new version).\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
         "requestBody": {
           "required": true,
           "content": {
@@ -81631,7 +81631,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Update several apps in one request. Today the only bulk-editable surface is visibility — `scope` with the `teamIds` or `userIds` it reaches — and every app in the batch is moved to the same one. Content is deliberately not editable here: replacing html forks a version and is authorized more strictly than re-scoping. Per-app problems are reported in `failed` and leave the rest applied.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps, their tools, and their team assignments",
+        "description": "Update several apps in one request. Today the only bulk-editable surface is visibility — `scope` with the `teamIds` or `userIds` it reaches — and every app in the batch is moved to the same one. Content is deliberately not editable here: replacing html forks a version and is authorized more strictly than re-scoping. Per-app problems are reported in `failed` and leave the rest applied.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
         "requestBody": {
           "required": true,
           "content": {
@@ -82317,7 +82317,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Enable a disabled app, making it live at its scope.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps, their tools, and their team assignments",
+        "description": "Enable a disabled app, making it live at its scope.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
         "parameters": [
           {
             "schema": {
@@ -82840,7 +82840,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Disable an app, pulling it back to an author-only state.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps, their tools, and their team assignments",
+        "description": "Disable an app, pulling it back to an author-only state.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
         "parameters": [
           {
             "schema": {
@@ -83363,7 +83363,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Lock an app, refusing all chat-driven modification (and REST html replacement/deletion) until unlocked.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps, their tools, and their team assignments",
+        "description": "Lock an app, refusing all chat-driven modification (and REST html replacement/deletion) until unlocked.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
         "parameters": [
           {
             "schema": {
@@ -83886,7 +83886,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Unlock a locked app, making it editable again.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps, their tools, and their team assignments",
+        "description": "Unlock a locked app, making it editable again.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
         "parameters": [
           {
             "schema": {
@@ -85467,7 +85467,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Restore an immutable app version by copying its artifact forward as a new head version. History is never rewritten.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps, their tools, and their team assignments",
+        "description": "Restore an immutable app version by copying its artifact forward as a new head version. History is never rewritten.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
         "requestBody": {
           "required": true,
           "content": {
@@ -86966,7 +86966,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Assign an upstream tool to an app.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps, their tools, and their team assignments",
+        "description": "Assign an upstream tool to an app.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
         "requestBody": {
           "required": true,
           "content": {
@@ -87276,7 +87276,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Unassign a tool from an app.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps, their tools, and their team assignments",
+        "description": "Unassign a tool from an app.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
         "parameters": [
           {
             "schema": {

--- a/docs/pages/platform-access-control.md
+++ b/docs/pages/platform-access-control.md
@@ -173,7 +173,7 @@ The following table lists all available permissions that can be assigned to cust
 | `apiKey:delete` | Delete API keys |
 | `app:read` | View and run MCP Apps within your scope (org, your teams, your own) |
 | `app:create` | Create new MCP Apps |
-| `app:update` | Modify MCP Apps and their tools within your scope (your own apps; team apps with `app:team-admin`; org apps with `app:admin`) |
+| `app:update` | Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin) |
 | `app:delete` | Delete MCP Apps |
 | `app:team-admin` | Manage team-scoped MCP Apps, including their team assignments, in teams you belong to |
 | `app:admin` | Full administrative control over all MCP Apps, bypassing team restrictions |

--- a/docs/pages/platform-access-control.md
+++ b/docs/pages/platform-access-control.md
@@ -173,9 +173,9 @@ The following table lists all available permissions that can be assigned to cust
 | `apiKey:delete` | Delete API keys |
 | `app:read` | View and run MCP Apps within your scope (org, your teams, your own) |
 | `app:create` | Create new MCP Apps |
-| `app:update` | Modify MCP Apps, their tools, and their team assignments |
+| `app:update` | Modify MCP Apps and their tools within your scope (your own apps; team apps with `app:team-admin`; org apps with `app:admin`) |
 | `app:delete` | Delete MCP Apps |
-| `app:team-admin` | Manage team assignments for MCP Apps |
+| `app:team-admin` | Manage team-scoped MCP Apps, including their team assignments, in teams you belong to |
 | `app:admin` | Full administrative control over all MCP Apps, bypassing team restrictions |
 | `app:deploy-to-restricted` | Assign MCP Apps to restricted deployment environments |
 | `auditLog:read` | View audit log records of your own administrative actions |
@@ -381,9 +381,9 @@ Hierarchy expands resource visibility and inherits organization roles assigned t
 
 External group sync continues to create direct memberships on the mapped team. Those members receive inherited resource access from its ancestors; see [SSO Team Sync](/docs/platform-sso-team-sync).
 
-### Agents and MCP Gateways
+### Agents, MCP Gateways, and Apps
 
-`agent` and `mcpGateway` share the same scope model:
+`agent`, `mcpGateway`, and `app` share the same scope model:
 
 - `personal`: the author can manage their own records
 - `team`: requires `<resource>:team-admin` and membership in at least one assigned team
@@ -394,6 +394,7 @@ Examples:
 - `agent:delete` alone does **not** allow deleting every agent
 - `agent:team-admin` allows managing team-scoped agents only in teams the user belongs to
 - `agent:admin` bypasses those scope restrictions
+- sharing an MCP App with named users grants use only; the app stays personal and only its author can edit it
 
 ### Visibility-Scoped Credentials
 

--- a/docs/pages/platform-apps.md
+++ b/docs/pages/platform-apps.md
@@ -3,7 +3,7 @@ title: MCP Apps
 category: Apps
 order: 1
 description: User-authored MCP Apps — sandboxed HTML interfaces with their own data store and tools
-lastUpdated: 2026-09-03
+lastUpdated: 2026-09-08
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -32,7 +32,7 @@ Run or author an app at `/a/:slug` (no chat chrome, no sidebar), or run it from 
 
 App settings offers four choices under "Who can use this app". **Personal** keeps it to you. **Users** shares it with people you name — a colleague, for example. **Teams** shares it with whole teams. **Organization** opens it to everyone.
 
-Visibility grants use access, not edit access. Team members can use a team app, but membership alone does not let them change it. App management follows the platform's [scoped resource permissions](./platform-access-control#scoped-resources).
+Visibility grants use access, not edit access. People you share a personal app with can use it, but only you can edit it. Team members can use a team app, but membership alone does not let them change it — that takes `app:team-admin`. App management follows the platform's [scoped resource permissions](./platform-access-control#scoped-resources).
 
 Sharing a chat does not share the apps it renders. Each viewer resolves an app against that app's own visibility. An app you have not shared with someone shows an access message in their view — a personal app in a chat you shared, for example. The chat's share dialog warns you when this will happen, and names the apps, so you can share them with the same people first.
 

--- a/platform/backend/src/standalone-scripts/codegen-access-control-docs.ts
+++ b/platform/backend/src/standalone-scripts/codegen-access-control-docs.ts
@@ -155,9 +155,9 @@ Hierarchy expands resource visibility and inherits organization roles assigned t
 
 External group sync continues to create direct memberships on the mapped team. Those members receive inherited resource access from its ancestors; see [SSO Team Sync](/docs/platform-sso-team-sync).
 
-### Agents and MCP Gateways
+### Agents, MCP Gateways, and Apps
 
-\`agent\` and \`mcpGateway\` share the same scope model:
+\`agent\`, \`mcpGateway\`, and \`app\` share the same scope model:
 
 - \`personal\`: the author can manage their own records
 - \`team\`: requires \`<resource>:team-admin\` and membership in at least one assigned team
@@ -168,6 +168,7 @@ Examples:
 - \`agent:delete\` alone does **not** allow deleting every agent
 - \`agent:team-admin\` allows managing team-scoped agents only in teams the user belongs to
 - \`agent:admin\` bypasses those scope restrictions
+- sharing an MCP App with named users grants use only; the app stays personal and only its author can edit it
 
 ### Visibility-Scoped Credentials
 

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -454,9 +454,11 @@ export const permissionDescriptions: Record<string, string> = {
   "app:read":
     "View and run MCP Apps within your scope (org, your teams, your own)",
   "app:create": "Create new MCP Apps",
-  "app:update": "Modify MCP Apps, their tools, and their team assignments",
+  "app:update":
+    "Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)",
   "app:delete": "Delete MCP Apps",
-  "app:team-admin": "Manage team assignments for MCP Apps",
+  "app:team-admin":
+    "Manage team-scoped MCP Apps, including their team assignments, in teams you belong to",
   "app:admin":
     "Full administrative control over all MCP Apps, bypassing team restrictions",
   "app:deploy-to-restricted":

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -1460,7 +1460,7 @@ export const getApp = <ThrowOnError extends boolean = false>(options: Options<Ge
  *
  * Authorization:
  *
- * `app:update`: Modify MCP Apps, their tools, and their team assignments
+ * `app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)
  */
 export const updateApp = <ThrowOnError extends boolean = false>(options: Options<UpdateAppData, ThrowOnError>) => (options.client ?? client).patch<UpdateAppResponses, UpdateAppErrors, ThrowOnError>({
     url: '/api/apps/{appId}',
@@ -1500,7 +1500,7 @@ export const bulkDeleteApps = <ThrowOnError extends boolean = false>(options: Op
  *
  * Authorization:
  *
- * `app:update`: Modify MCP Apps, their tools, and their team assignments
+ * `app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)
  */
 export const bulkUpdateApps = <ThrowOnError extends boolean = false>(options: Options<BulkUpdateAppsData, ThrowOnError>) => (options.client ?? client).patch<BulkUpdateAppsResponses, BulkUpdateAppsErrors, ThrowOnError>({
     url: '/api/apps/bulk',
@@ -1520,7 +1520,7 @@ export const bulkUpdateApps = <ThrowOnError extends boolean = false>(options: Op
  *
  * Authorization:
  *
- * `app:update`: Modify MCP Apps, their tools, and their team assignments
+ * `app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)
  */
 export const enableApp = <ThrowOnError extends boolean = false>(options: Options<EnableAppData, ThrowOnError>) => (options.client ?? client).post<EnableAppResponses, EnableAppErrors, ThrowOnError>({ url: '/api/apps/{appId}/enable', ...options });
 
@@ -1533,7 +1533,7 @@ export const enableApp = <ThrowOnError extends boolean = false>(options: Options
  *
  * Authorization:
  *
- * `app:update`: Modify MCP Apps, their tools, and their team assignments
+ * `app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)
  */
 export const disableApp = <ThrowOnError extends boolean = false>(options: Options<DisableAppData, ThrowOnError>) => (options.client ?? client).post<DisableAppResponses, DisableAppErrors, ThrowOnError>({ url: '/api/apps/{appId}/disable', ...options });
 
@@ -1546,7 +1546,7 @@ export const disableApp = <ThrowOnError extends boolean = false>(options: Option
  *
  * Authorization:
  *
- * `app:update`: Modify MCP Apps, their tools, and their team assignments
+ * `app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)
  */
 export const lockApp = <ThrowOnError extends boolean = false>(options: Options<LockAppData, ThrowOnError>) => (options.client ?? client).post<LockAppResponses, LockAppErrors, ThrowOnError>({ url: '/api/apps/{appId}/lock', ...options });
 
@@ -1559,7 +1559,7 @@ export const lockApp = <ThrowOnError extends boolean = false>(options: Options<L
  *
  * Authorization:
  *
- * `app:update`: Modify MCP Apps, their tools, and their team assignments
+ * `app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)
  */
 export const unlockApp = <ThrowOnError extends boolean = false>(options: Options<UnlockAppData, ThrowOnError>) => (options.client ?? client).post<UnlockAppResponses, UnlockAppErrors, ThrowOnError>({ url: '/api/apps/{appId}/unlock', ...options });
 
@@ -1611,7 +1611,7 @@ export const getAppVersion = <ThrowOnError extends boolean = false>(options: Opt
  *
  * Authorization:
  *
- * `app:update`: Modify MCP Apps, their tools, and their team assignments
+ * `app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)
  */
 export const restoreAppVersion = <ThrowOnError extends boolean = false>(options: Options<RestoreAppVersionData, ThrowOnError>) => (options.client ?? client).post<RestoreAppVersionResponses, RestoreAppVersionErrors, ThrowOnError>({
     url: '/api/apps/{appId}/versions/{version}/restore',
@@ -1684,7 +1684,7 @@ export const postAppRenderScreenshot = <ThrowOnError extends boolean = false>(op
  *
  * Authorization:
  *
- * `app:update`: Modify MCP Apps, their tools, and their team assignments
+ * `app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)
  */
 export const unassignToolFromApp = <ThrowOnError extends boolean = false>(options: Options<UnassignToolFromAppData, ThrowOnError>) => (options.client ?? client).delete<UnassignToolFromAppResponses, UnassignToolFromAppErrors, ThrowOnError>({ url: '/api/apps/{appId}/tools/{toolId}', ...options });
 
@@ -1697,7 +1697,7 @@ export const unassignToolFromApp = <ThrowOnError extends boolean = false>(option
  *
  * Authorization:
  *
- * `app:update`: Modify MCP Apps, their tools, and their team assignments
+ * `app:update`: Modify MCP Apps and their tools within your scope (your own apps; team apps with app:team-admin; org apps with app:admin)
  */
 export const assignToolToApp = <ThrowOnError extends boolean = false>(options: Options<AssignToolToAppData, ThrowOnError>) => (options.client ?? client).post<AssignToolToAppResponses, AssignToolToAppErrors, ThrowOnError>({
     url: '/api/apps/{appId}/tools/{toolId}',


### PR DESCRIPTION
## Problem

A customer shared a personal MCP App with named users and expected them to be able to edit it. The editing user held `app:update`, and the permissions table described `app:update` as "Modify MCP Apps, their tools, and their team assignments", so both the customer and support read it as sufficient. It is not: every app mutation runs the scoped modify rule (`services/apps/app-authorization.ts` → `requireScopedModifyPermission`), under which a personal app is author-only, a team app needs `app:team-admin` plus team membership, and an org app needs `app:admin`. Sharing with named users is a visibility grant on a still-personal app.

## Change

Wording only, no behavior change.

- `platform/shared/access-control.ts`: `app:update` now states it applies within the caller's scope and names the elevated permission each scope needs. `app:team-admin` now says it manages team-scoped apps in the holder's teams, not only "team assignments". These strings feed the generated access-control docs page, the OpenAPI route descriptions, and the SDK doc comments, so those regenerated files are included.
- `codegen-access-control-docs.ts`: the agent/gateway scope-model section now lists `app` too, with an example that per-user sharing grants use only.
- Apps page, "Who Can Use an App": one sentence each for shared personal apps (only the author edits) and team apps (editing takes `app:team-admin`).

## Verification

Read the authorization chain in `platform/backend/src/services/apps/app-authorization.ts`, `archestra-mcp-server/rbac.ts`, and `auth/agent-type-permissions.ts` against the wording. Ran `pnpm codegen && pnpm lint:fix` against a throwaway Postgres and committed the output.

https://claude.ai/code/session_01MvA2A1c4wN1dyRrokXUA6r