### PR TITLE
refactor(apps): align settings with team dialogs and move creator into header

### DIFF
--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -101,12 +101,16 @@ vi.mock("@/lib/app-session-recording/app-recording.query", () => ({
 
 // Stub the inline settings form: it pulls the environment/teams/auth query
 // chains, which aren't this suite's concern (covered by their own tests). Here
-// we only assert the panel chrome toggles it from the gear. The form owns its
-// own Cancel/Save footer, so the stub mirrors that.
+// we only assert the panel chrome toggles it from the gear. The form owns the
+// whole (left-nav) dialog and its Cancel/Save footer, so the stub mirrors that.
 vi.mock("@/components/mcp-app/app-settings-form", () => ({
-  AppSettingsForm: ({ onBack }: { onBack: () => void }) => (
+  AppSettingsForm: ({
+    onOpenChange,
+  }: {
+    onOpenChange: (open: boolean) => void;
+  }) => (
     <div data-testid="settings-form">
-      <button type="button" onClick={onBack}>
+      <button type="button" onClick={() => onOpenChange(false)}>
         Cancel
       </button>
       <button type="submit">Save</button>

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -101,13 +101,15 @@ vi.mock("@/lib/app-session-recording/app-recording.query", () => ({
 
 // Stub the inline settings form: it pulls the environment/teams/auth query
 // chains, which aren't this suite's concern (covered by their own tests). Here
-// we only assert the panel chrome toggles it from the gear.
+// we only assert the panel chrome toggles it from the gear. The form owns its
+// own Cancel/Save footer, so the stub mirrors that.
 vi.mock("@/components/mcp-app/app-settings-form", () => ({
   AppSettingsForm: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="settings-form">
       <button type="button" onClick={onBack}>
-        mock back
+        Cancel
       </button>
+      <button type="submit">Save</button>
     </div>
   ),
 }));

--- a/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
@@ -1,30 +1,22 @@
 "use client";
 
-import { useState } from "react";
-import { CreatedByCell } from "@/components/created-by-cell";
+import { FormDialog } from "@/components/form-dialog";
 import { LoadingState } from "@/components/loading";
 import { AppSettingsForm } from "@/components/mcp-app/app-settings-form";
 import { QueryLoadError } from "@/components/query-load-error";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogBody, DialogStickyFooter } from "@/components/ui/dialog";
 import { useApp } from "@/lib/app.query";
-import { useAppAccess } from "@/lib/apps/use-app-access";
-
-// Ties the footer's Save button to the settings form via the HTML `form` attr.
-// Only one settings dialog is open at a time, so a single id is safe.
-const APP_SETTINGS_FORM_ID = "app-settings-form";
 
 /**
  * The one app-settings surface, opened from both the apps-page cards and the
- * chat side-panel header. Loads the full app by id and hosts {@link AppSettingsForm}
- * with a Save button wired to it; delete is intentionally not here (each host
- * owns its own separate delete action).
+ * chat side-panel header. Loads the full app by id and hosts {@link AppSettingsForm},
+ * which renders the settings fields plus the Cancel/Save footer. Delete is
+ * intentionally not here (each host owns its own separate delete action).
+ *
+ * Uses the shared {@link FormDialog} shell so it matches the identity-provider
+ * and roles create/edit dialogs: a title + description header, a scrollable
+ * body, and a sticky footer.
  */
 export function AppSettingsDialog({
   appId,
@@ -43,69 +35,65 @@ export function AppSettingsDialog({
     isLoadingError,
     refetch,
   } = useApp(open ? appId : null, { toastOnError: false });
-  const access = useAppAccess(app);
-  const [status, setStatus] = useState({ saving: false, disabled: false });
+
+  const close = () => onOpenChange(false);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-w-2xl flex-col gap-0 p-0 pt-0">
-        <DialogHeader className="px-4 py-4">
-          <DialogTitle className="flex min-w-0 flex-wrap items-center justify-between gap-x-4 gap-y-1 pr-5">
-            <span>App settings</span>
-            {app?.createdBy ? (
-              <span className="flex items-center gap-1.5 text-xs font-normal text-muted-foreground">
-                <span>Created by</span>
-                <CreatedByCell createdBy={app.createdBy} />
-              </span>
-            ) : null}
-          </DialogTitle>
-        </DialogHeader>
-        {isPending ? (
-          <LoadingState
-            className="min-h-40 flex-1"
-            label="Loading app settings…"
-            variant="compact"
-          />
-        ) : isLoadingError ? (
-          <QueryLoadError
-            title="Couldn't load app settings"
-            onRetry={() => refetch()}
-            className="min-h-40 flex-1"
-          />
-        ) : app ? (
-          <AppSettingsForm
-            app={app}
-            formId={APP_SETTINGS_FORM_ID}
-            onBack={() => onOpenChange(false)}
-            onStatusChange={setStatus}
-          />
-        ) : (
-          <output
-            aria-label="App settings unavailable"
-            className="flex min-h-40 flex-1 items-center justify-center text-sm text-muted-foreground"
-          >
-            App settings are unavailable.
-          </output>
-        )}
-        <DialogFooter className="px-4 py-3">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-          >
-            {app && !access.isPending && !access.canEdit ? "Close" : "Cancel"}
-          </Button>
-          {app && !access.isPending && access.canEdit ? (
-            <Button
-              type="submit"
-              form={APP_SETTINGS_FORM_ID}
-              disabled={status.disabled}
-            >
-              {status.saving ? "Saving…" : "Save"}
+    <FormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="App settings"
+      description="Manage this app's details, tools, and who can use it."
+    >
+      {isPending ? (
+        <>
+          <DialogBody>
+            <LoadingState
+              className="min-h-40 flex-1"
+              label="Loading app settings…"
+              variant="compact"
+            />
+          </DialogBody>
+          <DialogStickyFooter className="mt-0">
+            <Button type="button" variant="outline" onClick={close}>
+              Cancel
             </Button>
-          ) : null}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          </DialogStickyFooter>
+        </>
+      ) : isLoadingError ? (
+        <>
+          <DialogBody>
+            <QueryLoadError
+              title="Couldn't load app settings"
+              onRetry={() => refetch()}
+              className="min-h-40 flex-1"
+            />
+          </DialogBody>
+          <DialogStickyFooter className="mt-0">
+            <Button type="button" variant="outline" onClick={close}>
+              Cancel
+            </Button>
+          </DialogStickyFooter>
+        </>
+      ) : app ? (
+        <AppSettingsForm app={app} onBack={close} />
+      ) : (
+        <>
+          <DialogBody>
+            <output
+              aria-label="App settings unavailable"
+              className="flex min-h-40 flex-1 items-center justify-center text-sm text-muted-foreground"
+            >
+              App settings are unavailable.
+            </output>
+          </DialogBody>
+          <DialogStickyFooter className="mt-0">
+            <Button type="button" variant="outline" onClick={close}>
+              Cancel
+            </Button>
+          </DialogStickyFooter>
+        </>
+      )}
+    </FormDialog>
   );
 }

--- a/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
@@ -1,22 +1,31 @@
 "use client";
 
-import { FormDialog } from "@/components/form-dialog";
 import { LoadingState } from "@/components/loading";
 import { AppSettingsForm } from "@/components/mcp-app/app-settings-form";
 import { QueryLoadError } from "@/components/query-load-error";
 import { Button } from "@/components/ui/button";
-import { DialogBody, DialogStickyFooter } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useApp } from "@/lib/app.query";
 
 /**
  * The one app-settings surface, opened from both the apps-page cards and the
  * chat side-panel header. Loads the full app by id and hosts {@link AppSettingsForm},
- * which renders the settings fields plus the Cancel/Save footer. Delete is
- * intentionally not here (each host owns its own separate delete action).
+ * which renders the left-nav settings dialog (General/Tools/Access) plus the
+ * Cancel/Save footer. Delete is intentionally not here (each host owns its own
+ * separate delete action).
  *
- * Uses the shared {@link FormDialog} shell so it matches the identity-provider
- * and roles create/edit dialogs: a title + description header, a scrollable
- * body, and a sticky footer.
+ * {@link AppSettingsForm} owns the {@link TabbedDialogShell} — the same left-nav
+ * dialog used by the identity-provider and team dialogs — so once the app is
+ * loaded this component just mounts it. The transient load/error/unavailable
+ * states render a small dialog with a Cancel button instead, since there is no
+ * form to show yet.
  */
 export function AppSettingsDialog({
   appId,
@@ -38,62 +47,48 @@ export function AppSettingsDialog({
 
   const close = () => onOpenChange(false);
 
+  // Once the app resolves, the form owns the whole (left-nav) dialog.
+  if (open && app) {
+    return (
+      <AppSettingsForm app={app} open={open} onOpenChange={onOpenChange} />
+    );
+  }
+
   return (
-    <FormDialog
-      open={open}
-      onOpenChange={onOpenChange}
-      title="App settings"
-      description="Manage this app's details, tools, and who can use it."
-    >
-      {isPending ? (
-        <>
-          <DialogBody>
-            <LoadingState
-              className="min-h-40 flex-1"
-              label="Loading app settings…"
-              variant="compact"
-            />
-          </DialogBody>
-          <DialogStickyFooter className="mt-0">
-            <Button type="button" variant="outline" onClick={close}>
-              Cancel
-            </Button>
-          </DialogStickyFooter>
-        </>
-      ) : isLoadingError ? (
-        <>
-          <DialogBody>
-            <QueryLoadError
-              title="Couldn't load app settings"
-              onRetry={() => refetch()}
-              className="min-h-40 flex-1"
-            />
-          </DialogBody>
-          <DialogStickyFooter className="mt-0">
-            <Button type="button" variant="outline" onClick={close}>
-              Cancel
-            </Button>
-          </DialogStickyFooter>
-        </>
-      ) : app ? (
-        <AppSettingsForm app={app} onBack={close} />
-      ) : (
-        <>
-          <DialogBody>
-            <output
-              aria-label="App settings unavailable"
-              className="flex min-h-40 flex-1 items-center justify-center text-sm text-muted-foreground"
-            >
-              App settings are unavailable.
-            </output>
-          </DialogBody>
-          <DialogStickyFooter className="mt-0">
-            <Button type="button" variant="outline" onClick={close}>
-              Cancel
-            </Button>
-          </DialogStickyFooter>
-        </>
-      )}
-    </FormDialog>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>App settings</DialogTitle>
+          <DialogDescription>
+            Manage this app's details, tools, and who can use it.
+          </DialogDescription>
+        </DialogHeader>
+        {isPending ? (
+          <LoadingState
+            className="min-h-40 flex-1"
+            label="Loading app settings…"
+            variant="compact"
+          />
+        ) : isLoadingError ? (
+          <QueryLoadError
+            title="Couldn't load app settings"
+            onRetry={() => refetch()}
+            className="min-h-40 flex-1"
+          />
+        ) : (
+          <output
+            aria-label="App settings unavailable"
+            className="flex min-h-40 flex-1 items-center justify-center text-sm text-muted-foreground"
+          >
+            App settings are unavailable.
+          </output>
+        )}
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={close}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
@@ -152,17 +152,8 @@ function toolsQuery(over: Record<string, unknown> = {}) {
 
 function renderForm(over: Partial<Parameters<typeof AppSettingsForm>[0]> = {}) {
   const onBack = vi.fn();
-  const onStatusChange = vi.fn();
-  const utils = render(
-    <AppSettingsForm
-      app={APP}
-      onBack={onBack}
-      formId="settings-form"
-      onStatusChange={onStatusChange}
-      {...over}
-    />,
-  );
-  return { onBack, onStatusChange, ...utils };
+  const utils = render(<AppSettingsForm app={APP} onBack={onBack} {...over} />);
+  return { onBack, ...utils };
 }
 
 function submitForm(container: HTMLElement) {
@@ -399,10 +390,11 @@ describe("AppSettingsForm save", () => {
     useAppToolsMock.mockReturnValue(
       toolsQuery({ data: undefined, isError: true }),
     );
-    const { container, onBack, onStatusChange } = renderForm();
+    const { container, onBack } = renderForm();
 
-    const lastStatus = onStatusChange.mock.calls.at(-1)?.[0];
-    expect(lastStatus).toEqual({ saving: false, disabled: false });
+    // Save stays enabled: identity/visibility still commit even though the tool
+    // diff is skipped while the assignments couldn't load.
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
     // The editor is not rendered unseeded — it would show every assigned tool
     // unchecked and let the user stage edits the save would drop.
     expect(screen.queryByTestId("stage-tool-t2")).not.toBeInTheDocument();
@@ -416,7 +408,7 @@ describe("AppSettingsForm save", () => {
   });
 
   test("a background refetch does not overwrite the staged selection", async () => {
-    const { container, onBack, rerender, onStatusChange } = renderForm();
+    const { container, onBack, rerender } = renderForm();
 
     fireEvent.click(screen.getByTestId("stage-tool-t2"));
     // Refetch lands a changed server set while tool-2 is staged.
@@ -428,14 +420,7 @@ describe("AppSettingsForm save", () => {
         ],
       }),
     );
-    rerender(
-      <AppSettingsForm
-        app={APP}
-        onBack={onBack}
-        formId="settings-form"
-        onStatusChange={onStatusChange}
-      />,
-    );
+    rerender(<AppSettingsForm app={APP} onBack={onBack} />);
     submitForm(container);
 
     await waitFor(() => expect(onBack).toHaveBeenCalled());

--- a/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
@@ -242,6 +242,28 @@ describe("AppSettingsForm save", () => {
     );
   });
 
+  test("flushes an in-progress label when switching away from General before Save", async () => {
+    // The labels editor lives in General and unmounts on section switch; a
+    // valid draft must survive a Save issued from another section.
+    const user = userEvent.setup();
+    const { onOpenChange } = renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Advanced" }));
+    await user.type(screen.getByLabelText("Label key"), "region");
+    await user.type(screen.getByLabelText("Label value"), "eu");
+    goToSection("Access");
+    submitForm();
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(updateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          labels: [{ key: "region", value: "eu" }],
+        }),
+      }),
+    );
+  });
+
   test("saves trimmed identity fields and closes; unchanged tools fire no mutations", async () => {
     const { onOpenChange } = renderForm();
 

--- a/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.test.tsx
@@ -151,15 +151,25 @@ function toolsQuery(over: Record<string, unknown> = {}) {
 }
 
 function renderForm(over: Partial<Parameters<typeof AppSettingsForm>[0]> = {}) {
-  const onBack = vi.fn();
-  const utils = render(<AppSettingsForm app={APP} onBack={onBack} {...over} />);
-  return { onBack, ...utils };
+  const onOpenChange = vi.fn();
+  const utils = render(
+    <AppSettingsForm app={APP} open onOpenChange={onOpenChange} {...over} />,
+  );
+  return { onOpenChange, ...utils };
 }
 
-function submitForm(container: HTMLElement) {
-  const form = container.querySelector("form");
+// The dialog now renders through the shared left-nav shell (a Radix dialog in a
+// portal), so the form lives on document, not inside the render container.
+function submitForm() {
+  const form = document.querySelector("form");
   expect(form).not.toBeNull();
   fireEvent.submit(form as HTMLFormElement);
+}
+
+// Fields are split across General/Tools/Access sidebar sections; interacting
+// with a non-General field means clicking its nav item first.
+function goToSection(label: "General" | "Tools" | "Access") {
+  fireEvent.click(screen.getByRole("button", { name: label }));
 }
 
 beforeEach(() => {
@@ -202,6 +212,7 @@ describe("AppSettingsForm save", () => {
       },
     });
 
+    goToSection("Access");
     expect(
       screen.getByText("You are not a member of the selected teams."),
     ).toBeVisible();
@@ -212,16 +223,16 @@ describe("AppSettingsForm save", () => {
 
   test("keeps labels under Advanced and saves an in-progress label", async () => {
     const user = userEvent.setup();
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
     expect(screen.queryByLabelText("Label key")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Advanced" }));
     await user.type(screen.getByLabelText("Label key"), "region");
     await user.type(screen.getByLabelText("Label value"), "eu");
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({
@@ -232,14 +243,14 @@ describe("AppSettingsForm save", () => {
   });
 
   test("saves trimmed identity fields and closes; unchanged tools fire no mutations", async () => {
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
     fireEvent.change(screen.getByLabelText("Name *"), {
       target: { value: "  Budget v2  " },
     });
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith({
       appId: "app-1",
       body: {
@@ -264,13 +275,13 @@ describe("AppSettingsForm save", () => {
 
   test("switches the app to opening fullscreen", async () => {
     const user = userEvent.setup();
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
     await user.click(screen.getByRole("combobox", { name: "Opens in" }));
     await user.click(screen.getByRole("option", { name: /fullscreen/i }));
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({ openInFullscreen: true }),
@@ -279,7 +290,7 @@ describe("AppSettingsForm save", () => {
   });
 
   test("seeds from the app's saved display default and re-sends it on an unrelated save", async () => {
-    const { container, onBack } = renderForm({
+    const { onOpenChange } = renderForm({
       app: { ...APP, openInFullscreen: true } as typeof APP,
     });
     expect(
@@ -289,9 +300,9 @@ describe("AppSettingsForm save", () => {
     fireEvent.change(screen.getByLabelText("Name *"), {
       target: { value: "Budget v2" },
     });
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({ openInFullscreen: true }),
@@ -300,12 +311,12 @@ describe("AppSettingsForm save", () => {
   });
 
   test("sends a picked icon", async () => {
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
     fireEvent.click(screen.getByTestId("pick-icon"));
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({ icon: "🚀" }),
@@ -314,7 +325,7 @@ describe("AppSettingsForm save", () => {
   });
 
   test("seeds from the app's icon and re-sends it on an unrelated save", async () => {
-    const { container, onBack, getByTestId } = renderForm({
+    const { onOpenChange, getByTestId } = renderForm({
       app: { ...APP, icon: "🚀" } as typeof APP,
     });
     expect(getByTestId("icon-value")).toHaveTextContent("🚀");
@@ -322,9 +333,9 @@ describe("AppSettingsForm save", () => {
     fireEvent.change(screen.getByLabelText("Name *"), {
       target: { value: "Budget v2" },
     });
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({ name: "Budget v2", icon: "🚀" }),
@@ -333,14 +344,14 @@ describe("AppSettingsForm save", () => {
   });
 
   test("clearing the icon sends null so it goes back to the generic glyph", async () => {
-    const { container, onBack } = renderForm({
+    const { onOpenChange } = renderForm({
       app: { ...APP, icon: "🚀" } as typeof APP,
     });
 
     fireEvent.click(screen.getByTestId("clear-icon"));
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({ icon: null }),
@@ -349,12 +360,13 @@ describe("AppSettingsForm save", () => {
   });
 
   test("assigns a staged tool with dynamic credential resolution on save", async () => {
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
+    goToSection("Tools");
     fireEvent.click(screen.getByTestId("stage-tool-t2"));
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(assignMutateAsync).toHaveBeenCalledWith({
       appId: "app-1",
       toolId: "tool-2",
@@ -365,51 +377,58 @@ describe("AppSettingsForm save", () => {
 
   test("a failed update leaves the form open", async () => {
     updateMutateAsync.mockResolvedValue(null);
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
-    submitForm(container);
+    submitForm();
 
     await waitFor(() => expect(updateMutateAsync).toHaveBeenCalled());
-    expect(onBack).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
     expect(assignMutateAsync).not.toHaveBeenCalled();
   });
 
   test("a failed tool change keeps the form open with the selection staged", async () => {
     assignMutateAsync.mockResolvedValue(null);
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
+    goToSection("Tools");
     fireEvent.click(screen.getByTestId("stage-tool-t2"));
-    submitForm(container);
+    submitForm();
 
     await waitFor(() => expect(assignMutateAsync).toHaveBeenCalled());
     expect(updateMutateAsync).toHaveBeenCalled();
-    expect(onBack).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   test("a failed tools query still allows saving identity, skipping tool changes", async () => {
     useAppToolsMock.mockReturnValue(
       toolsQuery({ data: undefined, isError: true }),
     );
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
     // Save stays enabled: identity/visibility still commit even though the tool
     // diff is skipped while the assignments couldn't load.
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
     // The editor is not rendered unseeded — it would show every assigned tool
-    // unchecked and let the user stage edits the save would drop.
+    // unchecked and let the user stage edits the save would drop. The Tools
+    // section shows the couldn't-load note in its place.
+    goToSection("Tools");
     expect(screen.queryByTestId("stage-tool-t2")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Tool assignments couldn't be loaded/i),
+    ).toBeInTheDocument();
 
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalled();
     expect(assignMutateAsync).not.toHaveBeenCalled();
     expect(unassignMutateAsync).not.toHaveBeenCalled();
   });
 
   test("a background refetch does not overwrite the staged selection", async () => {
-    const { container, onBack, rerender } = renderForm();
+    const { onOpenChange, rerender } = renderForm();
 
+    goToSection("Tools");
     fireEvent.click(screen.getByTestId("stage-tool-t2"));
     // Refetch lands a changed server set while tool-2 is staged.
     useAppToolsMock.mockReturnValue(
@@ -420,10 +439,10 @@ describe("AppSettingsForm save", () => {
         ],
       }),
     );
-    rerender(<AppSettingsForm app={APP} onBack={onBack} />);
-    submitForm(container);
+    rerender(<AppSettingsForm app={APP} open onOpenChange={onOpenChange} />);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     // The staged selection {tool-1, tool-2} survives the refetch: tool-2 is
     // assigned. tool-3 — assigned concurrently by someone else after this
     // dialog seeded — is untouched: the diff runs against the seeded
@@ -440,19 +459,20 @@ describe("AppSettingsForm save", () => {
     // First save carries two changes: the unassign of tool-1 succeeds, the
     // assign of tool-2 fails.
     assignMutateAsync.mockResolvedValueOnce(null);
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
+    goToSection("Tools");
     fireEvent.click(screen.getByTestId("stage-tool-t2"));
     fireEvent.click(screen.getByTestId("unstage-tool-t1"));
-    submitForm(container);
+    submitForm();
     await waitFor(() => expect(assignMutateAsync).toHaveBeenCalledTimes(1));
     expect(unassignMutateAsync).toHaveBeenCalledTimes(1);
-    expect(onBack).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
 
     // Retry: only the failed assign is left in the diff — the applied
     // unassign was folded into the snapshot and must not be re-sent.
-    submitForm(container);
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    submitForm();
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(assignMutateAsync).toHaveBeenCalledTimes(2);
     expect(assignMutateAsync).toHaveBeenLastCalledWith({
       appId: "app-1",
@@ -463,18 +483,18 @@ describe("AppSettingsForm save", () => {
   });
 
   test("an empty name blocks submit and shows a validation message", async () => {
-    const { container, onBack } = renderForm();
+    const { onOpenChange } = renderForm();
 
     fireEvent.change(screen.getByLabelText("Name *"), {
       target: { value: "   " },
     });
-    submitForm(container);
+    submitForm();
 
     await waitFor(() =>
       expect(screen.getByText("Name is required.")).toBeInTheDocument(),
     );
     expect(updateMutateAsync).not.toHaveBeenCalled();
-    expect(onBack).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 });
 
@@ -491,14 +511,14 @@ describe("AppSettingsForm URL field", () => {
   });
 
   test("sends a changed slug", async () => {
-    const { container, onBack } = renderForm({ app: SLUGGED });
+    const { onOpenChange } = renderForm({ app: SLUGGED });
 
     fireEvent.change(screen.getByLabelText("URL"), {
       target: { value: "  team-budget  " },
     });
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({ slug: "team-budget" }),
@@ -507,14 +527,14 @@ describe("AppSettingsForm URL field", () => {
   });
 
   test("omits an unchanged slug so a save cannot 409 against its own row", async () => {
-    const { container, onBack } = renderForm({ app: SLUGGED });
+    const { onOpenChange } = renderForm({ app: SLUGGED });
 
     fireEvent.change(screen.getByLabelText("Name *"), {
       target: { value: "Budget v2" },
     });
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.not.objectContaining({ slug: expect.anything() }),
@@ -525,12 +545,12 @@ describe("AppSettingsForm URL field", () => {
   test("treats a cleared field as leave-alone, not as an empty slug", async () => {
     // The API has no way to unset a URL, so an empty field must not be sent —
     // it would come back a 400 rather than clearing anything.
-    const { container, onBack } = renderForm({ app: SLUGGED });
+    const { onOpenChange } = renderForm({ app: SLUGGED });
 
     fireEvent.change(screen.getByLabelText("URL"), { target: { value: "" } });
-    submitForm(container);
+    submitForm();
 
-    await waitFor(() => expect(onBack).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(updateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.not.objectContaining({ slug: expect.anything() }),
@@ -543,10 +563,10 @@ describe("AppSettingsForm URL field", () => {
     ["an underscore", "team_budget"],
     ["a space", "team budget"],
   ])("blocks the save on %s and never calls the API", async (_label, value) => {
-    const { container, onBack } = renderForm({ app: SLUGGED });
+    const { onOpenChange } = renderForm({ app: SLUGGED });
 
     fireEvent.change(screen.getByLabelText("URL"), { target: { value } });
-    submitForm(container);
+    submitForm();
 
     await waitFor(() =>
       expect(
@@ -554,6 +574,6 @@ describe("AppSettingsForm URL field", () => {
       ).toBeInTheDocument(),
     );
     expect(updateMutateAsync).not.toHaveBeenCalled();
-    expect(onBack).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 });

--- a/platform/frontend/src/components/mcp-app/app-settings-form.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.tsx
@@ -459,6 +459,14 @@ export function AppSettingsForm({
       className="max-w-5xl"
       contentClassName="px-5 py-5"
       sidebarClassName="w-[220px]"
+      headerExtra={
+        app.createdBy ? (
+          <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="shrink-0">Created by</span>
+            <CreatedByCell createdBy={app.createdBy} className="max-w-48" />
+          </div>
+        ) : null
+      }
       footer={
         <>
           <Button type="button" variant="outline" onClick={onBack}>
@@ -473,15 +481,6 @@ export function AppSettingsForm({
       }
     >
       <div className="space-y-4">
-        {app.createdBy ? (
-          <div className="flex justify-end">
-            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <span>Created by</span>
-              <CreatedByCell createdBy={app.createdBy} />
-            </span>
-          </div>
-        ) : null}
-
         {!isAccessPending && !canEdit ? (
           <Alert variant="info">
             <AlertTriangle />

--- a/platform/frontend/src/components/mcp-app/app-settings-form.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.tsx
@@ -4,7 +4,14 @@ import type {
   archestraApiTypes,
   ResourceVisibilityScope,
 } from "@archestra/shared";
-import { AlertTriangle, Globe, User, UserRound, Users } from "lucide-react";
+import {
+  AlertTriangle,
+  AppWindow,
+  Globe,
+  User,
+  UserRound,
+  Users,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { AppToolsEditor } from "@/app/apps/_parts/app-tools-editor";
@@ -14,13 +21,9 @@ import { CreatedByCell } from "@/components/created-by-cell";
 import { EnvironmentSelector } from "@/components/environment-selector";
 import { IdentityFields } from "@/components/identity-fields";
 import { AppTeamAccessWarning } from "@/components/mcp-app/app-team-access-warning";
+import { TabbedDialogShell } from "@/components/tabbed-dialog-shell";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import {
-  DialogBody,
-  DialogForm,
-  DialogStickyFooter,
-} from "@/components/ui/dialog";
 import { FieldDescription } from "@/components/ui/field-description";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -61,6 +64,16 @@ type FormValues = {
   icon: string | null;
 };
 
+// The sidebar sections the fields are grouped into, mirroring the Team and
+// identity-provider dialogs' left-nav layout.
+type AppSettingsSection = "general" | "tools" | "access";
+
+const NAV_ITEMS: Array<{ id: AppSettingsSection; label: string }> = [
+  { id: "general", label: "General" },
+  { id: "tools", label: "Tools" },
+  { id: "access", label: "Access" },
+];
+
 // Mirrors the backend's AppSlugSchema so a malformed URL is caught before the
 // round-trip. Uniqueness is only knowable server-side and comes back as a 409.
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -72,21 +85,24 @@ const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
  */
 type AppVisibilityChoice = ResourceVisibilityScope | "user";
 
-// The whole-app settings fields, hosted by `AppSettingsDialog` (apps-page cards
+// The whole-app settings dialog, hosted by `AppSettingsDialog` (apps-page cards
 // and the side panel both open that dialog). It folds the previously separate
 // rename dialog, manage-tools dialog, and publish popover into one staged form
 // committed by a single Save: identity (name/description), the bound environment
-// + assigned tools, and visibility (scope + teams). It renders its own dialog
-// body and sticky footer (Cancel/Save), matching the identity-provider and roles
-// dialogs; `onBack` closes the host dialog. Delete is intentionally NOT here —
-// it's a separate destructive action owned by each host.
+// + assigned tools, and visibility (scope + teams). It renders the shared
+// `TabbedDialogShell` — the same left-nav dialog as the identity-provider and
+// team dialogs — with the fields split across General/Tools/Access sections and
+// a sticky Cancel/Save footer. Delete is intentionally NOT here — it's a
+// separate destructive action owned by each host.
 export function AppSettingsForm({
   app,
-  onBack,
+  open,
+  onOpenChange,
 }: {
   app: App;
-  /** Closes the host dialog — called by Cancel and after a successful save. */
-  onBack: () => void;
+  open: boolean;
+  /** Controls the host dialog; `false` closes it (Cancel and after a save). */
+  onOpenChange: (open: boolean) => void;
 }) {
   const {
     canEdit,
@@ -106,6 +122,9 @@ export function AppSettingsForm({
   const unassignTool = useUnassignToolFromApp();
   const appToolsQuery = useAppTools(app.id);
   const assignedTools = appToolsQuery.data;
+
+  const [activeSection, setActiveSection] =
+    useState<AppSettingsSection>("general");
 
   const form = useForm<FormValues>({
     defaultValues: {
@@ -298,16 +317,23 @@ export function AppSettingsForm({
   // resend already-applied mutations.
   const submitInFlight = useRef(false);
 
-  const onSubmit = form.handleSubmit(async (values) => {
-    if (submitInFlight.current) return;
-    if (readOnly || saving || toolsLoading || selectionMissing) return;
-    submitInFlight.current = true;
-    try {
-      await submitSettings(values);
-    } finally {
-      submitInFlight.current = false;
-    }
-  });
+  const onBack = () => onOpenChange(false);
+
+  const onSubmit = form.handleSubmit(
+    async (values) => {
+      if (submitInFlight.current) return;
+      if (readOnly || saving || toolsLoading || selectionMissing) return;
+      submitInFlight.current = true;
+      try {
+        await submitSettings(values);
+      } finally {
+        submitInFlight.current = false;
+      }
+    },
+    // The only validated fields (name, URL) live in General, so surface the
+    // section holding the error rather than failing silently on another tab.
+    () => setActiveSection("general"),
+  );
 
   async function submitSettings(values: FormValues) {
     // Enable/disable is a distinct lifecycle transition on the backend (its
@@ -406,8 +432,35 @@ export function AppSettingsForm({
   }
 
   return (
-    <DialogForm onSubmit={onSubmit} className="flex min-h-0 flex-1 flex-col">
-      <DialogBody className="space-y-4">
+    <TabbedDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title="App settings"
+      description="Manage this app's details, tools, and who can use it."
+      sidebarLabel={form.watch("name")?.trim() || app.name || "App"}
+      sidebarDescription="App"
+      sidebarIcon={<AppWindow className="h-4 w-4 text-muted-foreground" />}
+      activeSection={activeSection}
+      navItems={NAV_ITEMS}
+      onActiveSectionChange={setActiveSection}
+      onSubmit={onSubmit}
+      className="max-w-5xl"
+      contentClassName="px-5 py-5"
+      sidebarClassName="w-[220px]"
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={onBack}>
+            {!isAccessPending && !canEdit ? "Close" : "Cancel"}
+          </Button>
+          {!isAccessPending && canEdit ? (
+            <Button type="submit" disabled={saveDisabled}>
+              {saving ? "Saving…" : "Save"}
+            </Button>
+          ) : null}
+        </>
+      }
+    >
+      <div className="space-y-4">
         {app.createdBy ? (
           <div className="flex justify-end">
             <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -427,278 +480,283 @@ export function AppSettingsForm({
           </Alert>
         ) : null}
 
-        <IdentityFields
-          icon={form.watch("icon")}
-          onIconChange={(icon) =>
-            form.setValue("icon", icon, { shouldDirty: true })
-          }
-          fallbackType="app"
-          disabled={readOnly}
-        >
-          <div className="space-y-2">
-            <Label htmlFor="app-settings-name">Name *</Label>
-            <Input
-              id="app-settings-name"
-              disabled={readOnly}
-              aria-invalid={!!form.formState.errors.name}
-              {...form.register("name", {
-                required: "Name is required.",
-                maxLength: {
-                  value: 100,
-                  message: "Name must be 100 characters or fewer.",
-                },
-                validate: (value) =>
-                  value.trim().length > 0 || "Name is required.",
-              })}
-            />
-            {form.formState.errors.name?.message ? (
-              <p className="text-xs text-destructive">
-                {form.formState.errors.name.message}
-              </p>
-            ) : null}
-          </div>
-        </IdentityFields>
-
-        <div className="space-y-2">
-          <Label htmlFor="app-settings-slug">URL</Label>
-          <FieldDescription id="app-settings-slug-help">
-            Where this app opens. Changing it breaks links that used the old
-            URL.
-          </FieldDescription>
-          <div className="flex items-center gap-1">
-            <span className="shrink-0 text-sm text-muted-foreground">/a/</span>
-            <Input
-              id="app-settings-slug"
-              disabled={readOnly}
-              placeholder="sales-dashboard"
-              aria-invalid={!!form.formState.errors.slug}
-              // Only one of the two is rendered at a time, so point at
-              // whichever is actually in the DOM or the message goes
-              // unannounced (same wiring as components/ui/form.tsx).
-              aria-describedby={
-                form.formState.errors.slug
-                  ? "app-settings-slug-help app-settings-slug-error"
-                  : "app-settings-slug-help"
+        {activeSection === "general" ? (
+          <div className="space-y-4">
+            <IdentityFields
+              icon={form.watch("icon")}
+              onIconChange={(icon) =>
+                form.setValue("icon", icon, { shouldDirty: true })
               }
-              {...form.register("slug", {
-                maxLength: {
-                  value: 100,
-                  message: "URL must be 100 characters or fewer.",
-                },
-                validate: (value) =>
-                  value.trim() === "" ||
-                  SLUG_PATTERN.test(value.trim()) ||
-                  "Use lowercase letters, numbers and single hyphens.",
-              })}
-            />
-          </div>
-          {form.formState.errors.slug?.message ? (
-            <p
-              id="app-settings-slug-error"
-              className="text-xs text-destructive"
+              fallbackType="app"
+              disabled={readOnly}
             >
-              {form.formState.errors.slug.message}
-            </p>
-          ) : null}
-        </div>
+              <div className="space-y-2">
+                <Label htmlFor="app-settings-name">Name *</Label>
+                <Input
+                  id="app-settings-name"
+                  disabled={readOnly}
+                  aria-invalid={!!form.formState.errors.name}
+                  {...form.register("name", {
+                    required: "Name is required.",
+                    maxLength: {
+                      value: 100,
+                      message: "Name must be 100 characters or fewer.",
+                    },
+                    validate: (value) =>
+                      value.trim().length > 0 || "Name is required.",
+                  })}
+                />
+                {form.formState.errors.name?.message ? (
+                  <p className="text-xs text-destructive">
+                    {form.formState.errors.name.message}
+                  </p>
+                ) : null}
+              </div>
+            </IdentityFields>
 
-        <div className="space-y-2">
-          <Label htmlFor="app-settings-description">Description</Label>
-          <Textarea
-            id="app-settings-description"
-            disabled={readOnly}
-            aria-invalid={!!form.formState.errors.description}
-            {...form.register("description", {
-              maxLength: {
-                value: 500,
-                message: "Description must be 500 characters or fewer.",
-              },
-            })}
-          />
-          {form.formState.errors.description?.message ? (
-            <p className="text-xs text-destructive">
-              {form.formState.errors.description.message}
-            </p>
-          ) : null}
-        </div>
-
-        <EnvironmentSelector
-          value={environmentId}
-          onChange={setEnvironmentId}
-          resource="app"
-          disabled={readOnly}
-          helpText="The app can be assigned and call MCP tools from this environment plus the Default environment."
-        />
-
-        <div className="space-y-2">
-          <h3 className="text-sm font-semibold">Tools</h3>
-          {toolsSeeded ? (
-            <AppToolsEditor
-              appId={app.id}
-              environmentId={environmentId}
-              selectedToolIds={selectedToolIds}
-              onSelectionChange={setSelectedToolIds}
-              readOnly={readOnly}
-            />
-          ) : (
-            // Unseeded selection: the checklist would misrepresent every
-            // assigned tool as unchecked, and staged edits would be
-            // dropped by the save's unseeded-diff skip.
-            <p className="text-sm text-muted-foreground">
-              {appToolsQuery.isPending
-                ? "Loading tools…"
-                : "Tool assignments couldn't be loaded. Saving keeps the app's current tools."}
-            </p>
-          )}
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="app-settings-open-mode">Opens in</Label>
-          {selectedOpenModeDescription ? (
-            <FieldDescription>{selectedOpenModeDescription}</FieldDescription>
-          ) : null}
-          <Select
-            value={openMode}
-            disabled={readOnly}
-            onValueChange={(next) =>
-              setOpenMode(next as "inline" | "fullscreen")
-            }
-          >
-            <SelectTrigger id="app-settings-open-mode" className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent position="popper">
-              {openModeOptions.map((option) => (
-                <SelectItem
-                  key={option.value}
-                  value={option.value}
-                  description={option.description}
+            <div className="space-y-2">
+              <Label htmlFor="app-settings-slug">URL</Label>
+              <FieldDescription id="app-settings-slug-help">
+                Where this app opens. Changing it breaks links that used the old
+                URL.
+              </FieldDescription>
+              <div className="flex items-center gap-1">
+                <span className="shrink-0 text-sm text-muted-foreground">
+                  /a/
+                </span>
+                <Input
+                  id="app-settings-slug"
+                  disabled={readOnly}
+                  placeholder="sales-dashboard"
+                  aria-invalid={!!form.formState.errors.slug}
+                  // Only one of the two is rendered at a time, so point at
+                  // whichever is actually in the DOM or the message goes
+                  // unannounced (same wiring as components/ui/form.tsx).
+                  aria-describedby={
+                    form.formState.errors.slug
+                      ? "app-settings-slug-help app-settings-slug-error"
+                      : "app-settings-slug-help"
+                  }
+                  {...form.register("slug", {
+                    maxLength: {
+                      value: 100,
+                      message: "URL must be 100 characters or fewer.",
+                    },
+                    validate: (value) =>
+                      value.trim() === "" ||
+                      SLUG_PATTERN.test(value.trim()) ||
+                      "Use lowercase letters, numbers and single hyphens.",
+                  })}
+                />
+              </div>
+              {form.formState.errors.slug?.message ? (
+                <p
+                  id="app-settings-slug-error"
+                  className="text-xs text-destructive"
                 >
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+                  {form.formState.errors.slug.message}
+                </p>
+              ) : null}
+            </div>
 
-        <VisibilitySelector
-          heading="Who can use this app"
-          value={scope}
-          options={options}
-          onValueChange={setScope}
-          readOnly={readOnly}
-        >
-          {scope === "user" && (
             <div className="space-y-2">
-              <Label>Users</Label>
-              <UserSearchableMultiSelect
-                value={userIds}
-                onValueChange={setUserIds}
-                users={memberOptions}
-                placeholder="Select users"
-                searchPlaceholder="Search users..."
-                emptyMessage="No users found."
-                className="w-full"
+              <Label htmlFor="app-settings-description">Description</Label>
+              <Textarea
+                id="app-settings-description"
                 disabled={readOnly}
+                aria-invalid={!!form.formState.errors.description}
+                {...form.register("description", {
+                  maxLength: {
+                    value: 500,
+                    message: "Description must be 500 characters or fewer.",
+                  },
+                })}
               />
+              {form.formState.errors.description?.message ? (
+                <p className="text-xs text-destructive">
+                  {form.formState.errors.description.message}
+                </p>
+              ) : null}
             </div>
-          )}
 
-          {scope === "team" && (
             <div className="space-y-2">
-              <TeamVisibilityPicker
-                disabled={readOnly || !canShareTeams || hasNoTeams}
-                teams={teams ?? []}
-                value={teamIds}
-                onChange={setTeamIds}
-              />
-              <AppTeamAccessWarning
-                scope={scope}
-                selectedTeamIds={teamIds}
-                isAppAdmin={!!isAppAdmin}
-                userTeamIds={userTeamIds}
-              />
+              <Label htmlFor="app-settings-open-mode">Opens in</Label>
+              {selectedOpenModeDescription ? (
+                <FieldDescription>
+                  {selectedOpenModeDescription}
+                </FieldDescription>
+              ) : null}
+              <Select
+                value={openMode}
+                disabled={readOnly}
+                onValueChange={(next) =>
+                  setOpenMode(next as "inline" | "fullscreen")
+                }
+              >
+                <SelectTrigger id="app-settings-open-mode" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {openModeOptions.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      description={option.description}
+                    >
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
-          )}
 
-          <div className="space-y-2">
-            <Label>App status</Label>
-            {selectedEnabledDescription ? (
-              <FieldDescription>{selectedEnabledDescription}</FieldDescription>
-            ) : null}
-            <Select
-              value={enabledStatus}
-              disabled={readOnly}
-              onValueChange={(next) =>
-                setEnabledStatus(next as "disabled" | "enabled")
-              }
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent position="popper">
-                {enabledOptions.map((option) => (
-                  <SelectItem
-                    key={option.value}
-                    value={option.value}
-                    description={option.description}
-                  >
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            {canEdit && (
+              <AdvancedLabelsSection
+                ref={labelsRef}
+                labels={labels}
+                onLabelsChange={setLabels}
+              />
+            )}
           </div>
-
-          <div className="space-y-2">
-            <Label>Modification</Label>
-            {selectedLockedDescription ? (
-              <FieldDescription>{selectedLockedDescription}</FieldDescription>
-            ) : null}
-            <Select
-              value={lockedStatus}
-              disabled={readOnly}
-              onValueChange={(next) =>
-                setLockedStatus(next as "unlocked" | "locked")
-              }
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent position="popper">
-                {lockedOptions.map((option) => (
-                  <SelectItem
-                    key={option.value}
-                    value={option.value}
-                    description={option.description}
-                  >
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </VisibilitySelector>
-
-        {canEdit && (
-          <AdvancedLabelsSection
-            ref={labelsRef}
-            labels={labels}
-            onLabelsChange={setLabels}
-          />
-        )}
-      </DialogBody>
-
-      <DialogStickyFooter className="mt-0">
-        <Button type="button" variant="outline" onClick={onBack}>
-          {!isAccessPending && !canEdit ? "Close" : "Cancel"}
-        </Button>
-        {!isAccessPending && canEdit ? (
-          <Button type="submit" disabled={saveDisabled}>
-            {saving ? "Saving…" : "Save"}
-          </Button>
         ) : null}
-      </DialogStickyFooter>
-    </DialogForm>
+
+        {activeSection === "tools" ? (
+          <div className="space-y-4">
+            <EnvironmentSelector
+              value={environmentId}
+              onChange={setEnvironmentId}
+              resource="app"
+              disabled={readOnly}
+              helpText="The app can be assigned and call MCP tools from this environment plus the Default environment."
+            />
+
+            <div className="space-y-2">
+              <Label>Tools</Label>
+              {toolsSeeded ? (
+                <AppToolsEditor
+                  appId={app.id}
+                  environmentId={environmentId}
+                  selectedToolIds={selectedToolIds}
+                  onSelectionChange={setSelectedToolIds}
+                  readOnly={readOnly}
+                />
+              ) : (
+                // Unseeded selection: the checklist would misrepresent every
+                // assigned tool as unchecked, and staged edits would be
+                // dropped by the save's unseeded-diff skip.
+                <p className="text-sm text-muted-foreground">
+                  {appToolsQuery.isPending
+                    ? "Loading tools…"
+                    : "Tool assignments couldn't be loaded. Saving keeps the app's current tools."}
+                </p>
+              )}
+            </div>
+          </div>
+        ) : null}
+
+        {activeSection === "access" ? (
+          <VisibilitySelector
+            heading="Who can use this app"
+            value={scope}
+            options={options}
+            onValueChange={setScope}
+            readOnly={readOnly}
+          >
+            {scope === "user" && (
+              <div className="space-y-2">
+                <Label>Users</Label>
+                <UserSearchableMultiSelect
+                  value={userIds}
+                  onValueChange={setUserIds}
+                  users={memberOptions}
+                  placeholder="Select users"
+                  searchPlaceholder="Search users..."
+                  emptyMessage="No users found."
+                  className="w-full"
+                  disabled={readOnly}
+                />
+              </div>
+            )}
+
+            {scope === "team" && (
+              <div className="space-y-2">
+                <TeamVisibilityPicker
+                  disabled={readOnly || !canShareTeams || hasNoTeams}
+                  teams={teams ?? []}
+                  value={teamIds}
+                  onChange={setTeamIds}
+                />
+                <AppTeamAccessWarning
+                  scope={scope}
+                  selectedTeamIds={teamIds}
+                  isAppAdmin={!!isAppAdmin}
+                  userTeamIds={userTeamIds}
+                />
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label>App status</Label>
+              {selectedEnabledDescription ? (
+                <FieldDescription>
+                  {selectedEnabledDescription}
+                </FieldDescription>
+              ) : null}
+              <Select
+                value={enabledStatus}
+                disabled={readOnly}
+                onValueChange={(next) =>
+                  setEnabledStatus(next as "disabled" | "enabled")
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {enabledOptions.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      description={option.description}
+                    >
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Modification</Label>
+              {selectedLockedDescription ? (
+                <FieldDescription>{selectedLockedDescription}</FieldDescription>
+              ) : null}
+              <Select
+                value={lockedStatus}
+                disabled={readOnly}
+                onValueChange={(next) =>
+                  setLockedStatus(next as "unlocked" | "locked")
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {lockedOptions.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      description={option.description}
+                    >
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </VisibilitySelector>
+        ) : null}
+      </div>
+    </TabbedDialogShell>
   );
 }

--- a/platform/frontend/src/components/mcp-app/app-settings-form.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.tsx
@@ -319,6 +319,18 @@ export function AppSettingsForm({
 
   const onBack = () => onOpenChange(false);
 
+  // Leaving General unmounts the labels editor, which holds any not-yet-added
+  // label draft in its own state; flush a valid draft into committed labels
+  // first so a Save from another section doesn't silently drop it. Invalid or
+  // empty drafts return null and are left untouched — the same rule Save uses.
+  const changeSection = (next: AppSettingsSection) => {
+    if (activeSection === "general") {
+      const flushed = labelsRef.current?.saveUnsavedLabel();
+      if (flushed) setLabels(flushed);
+    }
+    setActiveSection(next);
+  };
+
   const onSubmit = form.handleSubmit(
     async (values) => {
       if (submitInFlight.current) return;
@@ -442,7 +454,7 @@ export function AppSettingsForm({
       sidebarIcon={<AppWindow className="h-4 w-4 text-muted-foreground" />}
       activeSection={activeSection}
       navItems={NAV_ITEMS}
-      onActiveSectionChange={setActiveSection}
+      onActiveSectionChange={changeSection}
       onSubmit={onSubmit}
       className="max-w-5xl"
       contentClassName="px-5 py-5"

--- a/platform/frontend/src/components/mcp-app/app-settings-form.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.tsx
@@ -10,10 +10,17 @@ import { useForm } from "react-hook-form";
 import { AppToolsEditor } from "@/app/apps/_parts/app-tools-editor";
 import { AdvancedLabelsSection } from "@/components/advanced-labels-section";
 import type { ProfileLabel, ProfileLabelsRef } from "@/components/agent-labels";
+import { CreatedByCell } from "@/components/created-by-cell";
 import { EnvironmentSelector } from "@/components/environment-selector";
 import { IdentityFields } from "@/components/identity-fields";
 import { AppTeamAccessWarning } from "@/components/mcp-app/app-team-access-warning";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  DialogBody,
+  DialogForm,
+  DialogStickyFooter,
+} from "@/components/ui/dialog";
 import { FieldDescription } from "@/components/ui/field-description";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -69,22 +76,17 @@ type AppVisibilityChoice = ResourceVisibilityScope | "user";
 // and the side panel both open that dialog). It folds the previously separate
 // rename dialog, manage-tools dialog, and publish popover into one staged form
 // committed by a single Save: identity (name/description), the bound environment
-// + assigned tools, and visibility (scope + teams). The dialog owns the Save
-// button (wired to this form via `formId`) and Cancel; `onStatusChange` reports
-// saving/validity up so that button can disable/spin. Delete is intentionally
-// NOT here — it's a separate destructive action owned by each host.
+// + assigned tools, and visibility (scope + teams). It renders its own dialog
+// body and sticky footer (Cancel/Save), matching the identity-provider and roles
+// dialogs; `onBack` closes the host dialog. Delete is intentionally NOT here —
+// it's a separate destructive action owned by each host.
 export function AppSettingsForm({
   app,
   onBack,
-  formId,
-  onStatusChange,
 }: {
   app: App;
+  /** Closes the host dialog — called by Cancel and after a successful save. */
   onBack: () => void;
-  /** Ties the host's submit button to this form via the HTML `form` attr. */
-  formId: string;
-  /** Reports save button state (must be a stable callback, e.g. a setState). */
-  onStatusChange?: (status: { saving: boolean; disabled: boolean }) => void;
 }) {
   const {
     canEdit,
@@ -287,13 +289,9 @@ export function AppSettingsForm({
     assignTool.isPending ||
     unassignTool.isPending;
 
-  // Drive the top bar's save button (it lives outside this form).
-  useEffect(() => {
-    onStatusChange?.({
-      saving,
-      disabled: readOnly || saving || toolsLoading || selectionMissing,
-    });
-  }, [readOnly, saving, toolsLoading, selectionMissing, onStatusChange]);
+  // Save is blocked while access is resolving, for view-only users, mid-save,
+  // while tool assignments load, or when a shared scope has no recipients.
+  const saveDisabled = readOnly || saving || toolsLoading || selectionMissing;
 
   // Serializes the handler itself: the state-based `saving` guard lags a
   // render, so a rapid resubmit could reread a stale tool-diff snapshot and
@@ -408,12 +406,17 @@ export function AppSettingsForm({
   }
 
   return (
-    <form
-      id={formId}
-      onSubmit={onSubmit}
-      className="flex min-h-0 flex-1 flex-col"
-    >
-      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
+    <DialogForm onSubmit={onSubmit} className="flex min-h-0 flex-1 flex-col">
+      <DialogBody className="space-y-4">
+        {app.createdBy ? (
+          <div className="flex justify-end">
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span>Created by</span>
+              <CreatedByCell createdBy={app.createdBy} />
+            </span>
+          </div>
+        ) : null}
+
         {!isAccessPending && !canEdit ? (
           <Alert variant="info">
             <AlertTriangle />
@@ -684,7 +687,18 @@ export function AppSettingsForm({
             onLabelsChange={setLabels}
           />
         )}
-      </div>
-    </form>
+      </DialogBody>
+
+      <DialogStickyFooter className="mt-0">
+        <Button type="button" variant="outline" onClick={onBack}>
+          {!isAccessPending && !canEdit ? "Close" : "Cancel"}
+        </Button>
+        {!isAccessPending && canEdit ? (
+          <Button type="submit" disabled={saveDisabled}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        ) : null}
+      </DialogStickyFooter>
+    </DialogForm>
   );
 }

--- a/platform/frontend/src/components/tabbed-dialog-shell.tsx
+++ b/platform/frontend/src/components/tabbed-dialog-shell.tsx
@@ -33,6 +33,7 @@ interface TabbedDialogShellProps<TSection extends string> {
   children: ReactNode;
   footer: ReactNode;
   sidebarFooter?: ReactNode;
+  headerExtra?: ReactNode;
   className?: string;
   contentClassName?: string;
   sidebarClassName?: string;
@@ -55,6 +56,7 @@ export function TabbedDialogShell<TSection extends string>({
   children,
   footer,
   sidebarFooter,
+  headerExtra,
   className,
   contentClassName,
   sidebarClassName,
@@ -110,20 +112,23 @@ export function TabbedDialogShell<TSection extends string>({
       </nav>
 
       <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
-        <div className="flex min-h-[72px] shrink-0 items-center justify-between border-b px-4 py-4">
+        <div className="flex min-h-[72px] shrink-0 items-center justify-between gap-4 border-b px-4 py-4">
           <div className="min-w-0">
             <h2 className="text-lg font-semibold truncate">{title}</h2>
           </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 rounded-xs opacity-70 hover:opacity-100"
-            onClick={() => onOpenChange(false)}
-          >
-            <XIcon className="h-4 w-4" />
-            <span className="sr-only">Close</span>
-          </Button>
+          <div className="flex min-w-0 items-center justify-end gap-3">
+            {headerExtra}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 rounded-xs opacity-70 hover:opacity-100"
+              onClick={() => onOpenChange(false)}
+            >
+              <XIcon className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </Button>
+          </div>
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">


### PR DESCRIPTION
App settings now uses the same left-navigation dialog as teams and identity providers, with General, Tools, and Access sections and a shared Save footer. Creator attribution sits in the header immediately left of the close button.

The dialog remains available from app cards and chat. Existing save, view-only, loading, and error behavior is preserved; valid label drafts survive switching sections before saving.

Verified in Chrome against the worktree preview: opened settings from an app card, visited all three sections, and confirmed creator attribution stays in the header. Focused tests cover saving, section navigation, label draft preservation, and the chat entry point.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>