### PR TITLE
fix(agent-runtime): reject incompatible models before accepting runs

### DIFF
--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -22,6 +22,7 @@ import {
 } from "@/models";
 import { RouteCategory, startActiveChatSpan } from "@/observability/tracing";
 import { validateMCPGatewayToken } from "@/routes/mcp-gateway/utils";
+import { preflightAgentRuntimeModelCompatibility } from "@/services/agent-runtime/model-compatibility";
 import {
   resolveAgentRuntime,
   resumeAgentRun,
@@ -419,6 +420,24 @@ export class A2AManager {
         throw new A2AError(A2AErrorKind.NothingToExecute);
       }
 
+      // A detached run returns its task handle before execution. Reject an
+      // incompatible model before compaction, context creation, or turn writes.
+      const runtime = resolveAgentRuntime(agent);
+      if (
+        fullTaskMode &&
+        params.taskRun?.createTask &&
+        params.taskRun.detached &&
+        !task &&
+        runtime
+      ) {
+        await preflightAgentRuntimeModelCompatibility({
+          runtime,
+          agent,
+          organizationId: actor.organizationId,
+          userId: actor.kind === "user" ? actor.id : "system",
+        });
+      }
+
       // Fetch history messages from the db
       let contextDbMessages =
         !this.config.stateless && context
@@ -573,8 +592,6 @@ export class A2AManager {
       // Agent Runtime belongs to the Agent itself and is selected only
       // for a durable task. Invocation surfaces decide whether a plain send
       // should remain a Message or be promoted to that task lifecycle.
-      const runtime = resolveAgentRuntime(agent);
-
       const executeRun = (runOpts: {
         abortSignal?: AbortSignal;
         onTextDelta?: (delta: string) => void;

--- a/platform/backend/src/routes/a2a/v2.tasks.route.test.ts
+++ b/platform/backend/src/routes/a2a/v2.tasks.route.test.ts
@@ -2,6 +2,11 @@ import type { AddressInfo } from "node:net";
 import { vi } from "vitest";
 import type { A2AExecuteParams } from "@/agents/a2a-executor";
 import config from "@/config";
+import {
+  AgentModel,
+  LlmProviderApiKeyModelLinkModel,
+  ModelModel,
+} from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
@@ -253,6 +258,63 @@ describe("a2a v2 task methods", () => {
       },
     ]);
     expect(settled.status.timestamp).toEqual(expect.any(String));
+  });
+
+  test("rejects an incompatible streaming runtime model before opening SSE", async ({
+    makeLlmProviderApiKey,
+    makeSecret,
+  }) => {
+    config.agentRuntime.enabled = true;
+    const secret = await makeSecret({ secret: { apiKey: "gemini-test-key" } });
+    const providerKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+      provider: "gemini",
+    });
+    const model = await ModelModel.create({
+      externalId: "gemini/gemini-a2a-preflight-test",
+      provider: "gemini",
+      modelId: "gemini-a2a-preflight-test",
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      lastSyncedAt: new Date(),
+    });
+    await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(providerKey.id, [
+      model.id,
+    ]);
+    await AgentModel.update(agentId, {
+      modelId: model.id,
+      llmApiKeyId: providerKey.id,
+      runtime: {
+        image: "example.invalid/runtime-agent:test",
+        command: null,
+        inferenceProtocol: "anthropic",
+        backend: "kubernetes",
+        steerMode: "pipe",
+        privileged: false,
+        resources: null,
+        environment: null,
+        credentials: null,
+        ttlHours: null,
+        maxCostUsd: null,
+        idleTimeoutMinutes: null,
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v2/a2a/${agentId}`,
+      headers: { authorization: "Bearer test-token" },
+      payload: jsonRpc(91, "SendStreamingMessage", {
+        message: userMessage("start incompatible runtime"),
+      }),
+    });
+
+    expect(response.headers["content-type"]).not.toContain("text/event-stream");
+    expect(response.json().error).toMatchObject({
+      code: -32602,
+      message: expect.stringContaining("expects the Anthropic API"),
+    });
+    expect(mockRunTaskInAgentRuntime).not.toHaveBeenCalled();
   });
 
   test("SendMessage returns a durable Task when the Agent uses Agent Runtime", async ({

--- a/platform/backend/src/routes/a2a/v2.ts
+++ b/platform/backend/src/routes/a2a/v2.ts
@@ -40,6 +40,7 @@ import {
   resolveTokenOrganizationId,
   validateMCPGatewayToken,
 } from "@/routes/mcp-gateway/utils";
+import { preflightAgentRuntimeModelCompatibility } from "@/services/agent-runtime/model-compatibility";
 import { resolveAgentRuntime } from "@/services/agent-runtime/pod-run";
 import { type Agent, ApiError, UuidIdSchema } from "@/types";
 import { isTerminalA2ATaskState } from "@/types/a2a-task";
@@ -893,6 +894,7 @@ enum A2AV2RouterErrorKind {
   AgentNotInternal,
   FailedToResolveActor,
   VersionNotSupported,
+  InvalidAgentRuntimeModel,
 }
 
 const A2A_V2_ROUTER_ERRORS = {
@@ -909,6 +911,10 @@ const A2A_V2_ROUTER_ERRORS = {
   [A2AV2RouterErrorKind.VersionNotSupported]: {
     code: -32009,
     message: `Unsupported A2A-Version. This endpoint serves: ${SUPPORTED_A2A_VERSION_LIST.join(", ")}`,
+  },
+  [A2AV2RouterErrorKind.InvalidAgentRuntimeModel]: {
+    code: -32602,
+    message: "Agent Runtime model is incompatible",
   },
   [A2AV2RouterErrorKind.AgentNotInternal]: {
     code: -32602,
@@ -995,6 +1001,17 @@ class A2AV2Router {
     // (a generated `messageId`) reaches them — the streaming path below has
     // always worked this way.
     const parsed = schema.parse(params) as A2ARouteRequest;
+    if (method === "SendMessage") {
+      await this.preflightDetachedAgentRuntime({
+        agent,
+        actor,
+        request: parsed as A2AProtocolSendMessageRequest,
+        detached: Boolean(
+          (parsed as A2AProtocolSendMessageRequest).configuration
+            ?.returnImmediately,
+        ),
+      });
+    }
 
     return await func({ actor, agentId: agent.id, request: parsed });
   }
@@ -1029,6 +1046,12 @@ class A2AV2Router {
     }
 
     const parsed = A2AProtocolSendMessageRequestSchema.parse(params);
+    await this.preflightDetachedAgentRuntime({
+      agent,
+      actor,
+      request: parsed,
+      detached: true,
+    });
     return { kind: "send", actor, agentId: agent.id, request: parsed };
   }
 
@@ -1068,6 +1091,34 @@ class A2AV2Router {
       agentId: params.agentId,
       request: { id: params.taskId },
     });
+  }
+
+  private async preflightDetachedAgentRuntime(params: {
+    agent: Agent;
+    actor: A2AActor;
+    request: A2AProtocolSendMessageRequest;
+    detached: boolean;
+  }): Promise<void> {
+    if (!params.detached || params.request.message.taskId) return;
+    const runtime = resolveAgentRuntime(params.agent);
+    if (!runtime) return;
+
+    try {
+      await preflightAgentRuntimeModelCompatibility({
+        runtime,
+        agent: params.agent,
+        organizationId: params.actor.organizationId,
+        userId: params.actor.kind === "user" ? params.actor.id : "system",
+      });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw new A2AV2RouterError(
+          A2AV2RouterErrorKind.InvalidAgentRuntimeModel,
+          error.message,
+        );
+      }
+      throw error;
+    }
   }
 
   private getRouteForMethod(method: string, usesAgentRuntime = false) {

--- a/platform/backend/src/services/agent-runtime/launch-spec.ts
+++ b/platform/backend/src/services/agent-runtime/launch-spec.ts
@@ -1,11 +1,8 @@
 import {
   CLAUDE_CODE_CUSTOM_HEADERS_ENV_KEY,
   isDefaultBrandedAppName,
-  MODEL_ROUTER_SUPPORTED_PROVIDERS,
   providerDisplayNames,
   RUN_ID_HEADER,
-  requiresOpenAiResponsesApi,
-  requiresResponsesApi,
   resolveClaudeContextVariant,
   SESSION_ID_HEADER,
   SUBSCRIPTION_CREDENTIALS,
@@ -33,10 +30,10 @@ import type {
 } from "@/types";
 import { AGENT_RUNTIME_CREDENTIALS_REQUIRED_CODE, ApiError } from "@/types";
 import { resolveProviderApiKey } from "@/utils/llm-api-key-resolution";
-import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
 import type { AgentRunLaunchSpec } from "./backends";
 import { resolveAgentRuntimeCredentials } from "./credentials";
 import { taskWithAgentRunInputs } from "./input-files";
+import { preflightAgentRuntimeModelCompatibility } from "./model-compatibility";
 import {
   AGENT_RUNTIME_STEER_FIFO,
   constructStableRunName,
@@ -142,20 +139,11 @@ export async function buildAgentRunLaunchSpec(params: {
       "The Agent for this Agent Runtime run no longer exists",
     );
   }
-  const llm = await resolveConversationLlmSelectionForAgent({
+  const { llm, selectedModel } = await preflightAgentRuntimeModelCompatibility({
+    runtime: params.runtime,
     agent,
     organizationId: params.organizationId,
     userId: actorUserId ?? "system",
-    includeMemberChatDefault: false,
-  });
-  const selectedModel = llm.modelId
-    ? await ModelModel.findById(llm.modelId)
-    : null;
-  assertInferenceProtocolSupported({
-    protocol: params.runtime.inferenceProtocol,
-    provider: llm.selectedProvider,
-    model: llm.selectedModel,
-    supportedEndpoints: selectedModel?.supportedEndpoints,
   });
 
   const claudeCodeSubscriptionToken =
@@ -533,40 +521,4 @@ function withNativeClientCredentialAliases(
   return credentials.GITHUB_TOKEN && !credentials.GH_TOKEN
     ? { ...credentials, GH_TOKEN: credentials.GITHUB_TOKEN }
     : credentials;
-}
-
-function assertInferenceProtocolSupported(params: {
-  protocol: ResolvedAgentRuntime["inferenceProtocol"];
-  provider: SupportedProvider;
-  model: string;
-  supportedEndpoints: string[] | null | undefined;
-}): void {
-  if (params.protocol === "anthropic" && params.provider !== "anthropic") {
-    throw new ApiError(
-      409,
-      `This Agent Runtime image expects the Anthropic API, but the Agent's selected model uses ${providerDisplayNames[params.provider]}. Choose an Anthropic model or use an OpenAI-compatible Agent Runtime image.`,
-    );
-  }
-  if (
-    params.protocol !== "anthropic" &&
-    !new Set<SupportedProvider>(MODEL_ROUTER_SUPPORTED_PROVIDERS).has(
-      params.provider,
-    )
-  ) {
-    throw new ApiError(
-      409,
-      `${providerDisplayNames[params.provider]} models are not available through the OpenAI-compatible model router used by this Agent Runtime image.`,
-    );
-  }
-  if (
-    params.protocol === "openai_chat" &&
-    (requiresResponsesApi(params.supportedEndpoints) ||
-      (params.provider === "openai" &&
-        requiresOpenAiResponsesApi(params.model)))
-  ) {
-    throw new ApiError(
-      409,
-      `This Agent Runtime image uses Chat Completions, but model "${params.model}" requires the Responses API. Choose a Chat Completions model or an image that uses OpenAI Responses.`,
-    );
-  }
 }

--- a/platform/backend/src/services/agent-runtime/model-compatibility.test.ts
+++ b/platform/backend/src/services/agent-runtime/model-compatibility.test.ts
@@ -1,0 +1,240 @@
+import type { SupportedProvider } from "@archestra/shared";
+import { A2AManager } from "@/agents/a2a/a2a-manager";
+import { A2AProtocolRole } from "@/agents/a2a/a2a-protocol";
+import config from "@/config";
+import {
+  A2AContextModel,
+  A2AMessageModel,
+  A2ATaskModel,
+  LlmProviderApiKeyModelLinkModel,
+  ModelModel,
+  OrganizationModel,
+} from "@/models";
+import { expect, test } from "@/test";
+import type { Agent, ResolvedAgentRuntime } from "@/types";
+import { preflightAgentRuntimeModelCompatibility } from "./model-compatibility";
+
+test("refuses an incompatible Gemini runtime before creating a detached task", async ({
+  makeAgent,
+  makeAdmin,
+  makeLlmProviderApiKey,
+  makeMember,
+  makeOrganization,
+  makeSecret,
+}) => {
+  const organization = await makeOrganization();
+  const user = await makeAdmin();
+  await makeMember(user.id, organization.id, { role: "admin" });
+  const { model, providerKey } = await createModelSelection({
+    organizationId: organization.id,
+    provider: "gemini",
+    modelId: "gemini-preflight-test",
+    makeSecret,
+    makeLlmProviderApiKey,
+  });
+  const agent = await makeAgent({
+    organizationId: organization.id,
+    authorId: user.id,
+    agentType: "agent",
+    modelId: model.id,
+    llmApiKeyId: providerKey.id,
+    runtime: agentRuntime("anthropic"),
+  });
+  const previousRuntimeEnabled = config.agentRuntime.enabled;
+  config.agentRuntime.enabled = true;
+  const actor = {
+    id: user.id,
+    kind: "user" as const,
+    organizationId: organization.id,
+  };
+  const originalContextCount = await A2AContextModel.getTotalCount();
+  const originalMessageCount = await A2AMessageModel.getTotalCount();
+
+  try {
+    await expect(
+      new A2AManager({ taskMode: "full" }).sendMessage({
+        actor,
+        agentId: agent.id,
+        request: {
+          message: {
+            messageId: crypto.randomUUID(),
+            role: A2AProtocolRole.User,
+            parts: [{ text: "Start a task" }],
+          },
+        },
+        taskRun: { createTask: true, detached: true },
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message: expect.stringContaining("Anthropic API"),
+    });
+    await expect(
+      A2ATaskModel.listForActor({
+        actorKind: "user",
+        actorId: user.id,
+        agentId: agent.id,
+        pageSize: 10,
+      }),
+    ).resolves.toMatchObject({ totalSize: 0 });
+    expect(await A2AContextModel.getTotalCount()).toBe(originalContextCount);
+    expect(await A2AMessageModel.getTotalCount()).toBe(originalMessageCount);
+
+    const context = await A2AContextModel.create({
+      actorKind: actor.kind,
+      actorId: actor.id,
+    });
+    await expect(
+      new A2AManager({ taskMode: "full" }).sendMessage({
+        actor,
+        agentId: agent.id,
+        request: {
+          message: {
+            messageId: crypto.randomUUID(),
+            contextId: context.id,
+            role: A2AProtocolRole.User,
+            parts: [{ text: "Reject without appending" }],
+          },
+        },
+        taskRun: { createTask: true, detached: true },
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    expect(await A2AMessageModel.findByContextId(context.id)).toEqual([]);
+  } finally {
+    config.agentRuntime.enabled = previousRuntimeEnabled;
+  }
+});
+
+test("rejects a Bedrock model for an Anthropic runtime image", async ({
+  makeAgent,
+  makeAdmin,
+  makeLlmProviderApiKey,
+  makeMember,
+  makeOrganization,
+  makeSecret,
+}) => {
+  const organization = await makeOrganization();
+  const user = await makeAdmin();
+  await makeMember(user.id, organization.id, { role: "admin" });
+  const { model, providerKey } = await createModelSelection({
+    organizationId: organization.id,
+    provider: "bedrock",
+    modelId: "anthropic.claude-preflight-test",
+    makeSecret,
+    makeLlmProviderApiKey,
+  });
+  const agent = await makeAgent({
+    organizationId: organization.id,
+    authorId: user.id,
+    agentType: "agent",
+    modelId: model.id,
+    llmApiKeyId: providerKey.id,
+  });
+
+  await expect(
+    preflightAgentRuntimeModelCompatibility({
+      runtime: { inferenceProtocol: "anthropic" },
+      agent,
+      organizationId: organization.id,
+      userId: user.id,
+    }),
+  ).rejects.toMatchObject({
+    statusCode: 409,
+    message: expect.stringContaining("Anthropic API"),
+  });
+});
+
+test("accepts an inherited compatible organization default model", async ({
+  makeAgent,
+  makeAdmin,
+  makeLlmProviderApiKey,
+  makeMember,
+  makeOrganization,
+  makeSecret,
+}) => {
+  const organization = await makeOrganization();
+  const user = await makeAdmin();
+  await makeMember(user.id, organization.id, { role: "admin" });
+  const { model, providerKey } = await createModelSelection({
+    organizationId: organization.id,
+    provider: "anthropic",
+    modelId: "claude-preflight-test",
+    makeSecret,
+    makeLlmProviderApiKey,
+  });
+  await OrganizationModel.patch(organization.id, {
+    defaultModelId: model.id,
+    defaultLlmApiKeyId: providerKey.id,
+  });
+  const agent = await makeAgent({
+    organizationId: organization.id,
+    authorId: user.id,
+    agentType: "agent",
+    modelId: null,
+    llmApiKeyId: null,
+  });
+
+  await expect(
+    preflightAgentRuntimeModelCompatibility({
+      runtime: { inferenceProtocol: "anthropic" },
+      agent,
+      organizationId: organization.id,
+      userId: user.id,
+    }),
+  ).resolves.toMatchObject({
+    llm: { selectedProvider: "anthropic", selectedModel: model.modelId },
+    selectedModel: { id: model.id },
+  });
+});
+
+async function createModelSelection(params: {
+  organizationId: string;
+  provider: SupportedProvider;
+  modelId: string;
+  makeSecret: (params: {
+    secret: Record<string, unknown>;
+  }) => Promise<{ id: string }>;
+  makeLlmProviderApiKey: (
+    organizationId: string,
+    secretId: string,
+    overrides: { provider: SupportedProvider },
+  ) => Promise<{ id: string }>;
+}) {
+  const secret = await params.makeSecret({ secret: { apiKey: "test-key" } });
+  const providerKey = await params.makeLlmProviderApiKey(
+    params.organizationId,
+    secret.id,
+    { provider: params.provider },
+  );
+  const model = await ModelModel.create({
+    externalId: `${params.provider}/${params.modelId}`,
+    provider: params.provider,
+    modelId: params.modelId,
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    supportsToolCalling: true,
+    lastSyncedAt: new Date(),
+  });
+  await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(providerKey.id, [
+    model.id,
+  ]);
+  return { model, providerKey };
+}
+
+function agentRuntime(
+  inferenceProtocol: ResolvedAgentRuntime["inferenceProtocol"],
+): Agent["runtime"] {
+  return {
+    image: "example.invalid/runtime-agent:test",
+    command: null,
+    inferenceProtocol,
+    backend: "kubernetes",
+    steerMode: "pipe",
+    privileged: false,
+    resources: null,
+    environment: null,
+    credentials: null,
+    ttlHours: null,
+    maxCostUsd: null,
+    idleTimeoutMinutes: null,
+  };
+}

--- a/platform/backend/src/services/agent-runtime/model-compatibility.ts
+++ b/platform/backend/src/services/agent-runtime/model-compatibility.ts
@@ -1,0 +1,77 @@
+import {
+  MODEL_ROUTER_SUPPORTED_PROVIDERS,
+  providerDisplayNames,
+  requiresOpenAiResponsesApi,
+  requiresResponsesApi,
+  type SupportedProvider,
+} from "@archestra/shared";
+import { ModelModel } from "@/models";
+import type { Agent, ResolvedAgentRuntime } from "@/types";
+import { ApiError } from "@/types";
+import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
+
+/**
+ * Resolve the model an Agent Runtime run would receive and reject an image
+ * protocol that cannot serve it. This only reads model configuration, so task
+ * callers can use it before creating a detached task.
+ */
+export async function preflightAgentRuntimeModelCompatibility(params: {
+  runtime: Pick<ResolvedAgentRuntime, "inferenceProtocol">;
+  agent: Pick<Agent, "llmApiKeyId" | "modelId">;
+  organizationId: string;
+  userId: string;
+}) {
+  const llm = await resolveConversationLlmSelectionForAgent({
+    agent: params.agent,
+    organizationId: params.organizationId,
+    userId: params.userId,
+    includeMemberChatDefault: false,
+  });
+  const selectedModel = llm.modelId
+    ? await ModelModel.findById(llm.modelId)
+    : null;
+  assertInferenceProtocolSupported({
+    protocol: params.runtime.inferenceProtocol,
+    provider: llm.selectedProvider,
+    model: llm.selectedModel,
+    supportedEndpoints: selectedModel?.supportedEndpoints,
+  });
+
+  return { llm, selectedModel };
+}
+
+function assertInferenceProtocolSupported(params: {
+  protocol: ResolvedAgentRuntime["inferenceProtocol"];
+  provider: SupportedProvider;
+  model: string;
+  supportedEndpoints: string[] | null | undefined;
+}): void {
+  if (params.protocol === "anthropic" && params.provider !== "anthropic") {
+    throw new ApiError(
+      409,
+      `This Agent Runtime image expects the Anthropic API, but the Agent's selected model uses ${providerDisplayNames[params.provider]}. Choose an Anthropic model or use an OpenAI-compatible Agent Runtime image.`,
+    );
+  }
+  if (
+    params.protocol !== "anthropic" &&
+    !new Set<SupportedProvider>(MODEL_ROUTER_SUPPORTED_PROVIDERS).has(
+      params.provider,
+    )
+  ) {
+    throw new ApiError(
+      409,
+      `${providerDisplayNames[params.provider]} models are not available through the OpenAI-compatible model router used by this Agent Runtime image.`,
+    );
+  }
+  if (
+    params.protocol === "openai_chat" &&
+    (requiresResponsesApi(params.supportedEndpoints) ||
+      (params.provider === "openai" &&
+        requiresOpenAiResponsesApi(params.model)))
+  ) {
+    throw new ApiError(
+      409,
+      `This Agent Runtime image uses Chat Completions, but model "${params.model}" requires the Responses API. Choose a Chat Completions model or an image that uses OpenAI Responses.`,
+    );
+  }
+}


### PR DESCRIPTION
## What changed
An incompatible runtime/model pairing previously accepted a detached task, then failed before creating a run. Chat navigated to a run page that could not load.

Validate the effective model before saving a context, message, or task so the existing chat error toast shows the compatibility error and the draft stays in the composer. Keep the launch-time guard, and reject incompatible streaming A2A requests before opening SSE with an actionable JSON-RPC error.

## Verification
Exercised a Claude-protocol runtime with a Gemini model: launch returned HTTP 409 with the compatibility message and no task ID. Regression coverage verifies rejected requests leave no context or message behind, including when reusing an existing context, and that streaming rejection is a normal JSON response rather than an SSE failure.

## Scope
This PR only fixes failure handling. Model/runtime picker filtering, form validation, and pre-submission readiness changes are deferred to a separate follow-up.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>