### PR TITLE
fix(agent-runtime): support Claude Code with Bedrock and Vertex AI

### DIFF
--- a/docs/pages/platform-agent-runtime.md
+++ b/docs/pages/platform-agent-runtime.md
@@ -266,6 +266,8 @@ accept useful follow-up instructions.
 
 ### Runtime environment
 
+Archestra supplies the applicable variables below when launching a run. You do not need to set them manually for the maintained runtime images. For Claude Code with Bedrock or Vertex AI, configure the platform provider and select a supported Claude model. Archestra handles the runtime connection and authentication automatically.
+
 | Variable | Purpose |
 | --- | --- |
 | `ARCHESTRA_AGENT_RUNTIME_AGENT_ID`, `ARCHESTRA_AGENT_RUNTIME_AGENT_NAME` | Durable Agent identity. |

--- a/docs/pages/platform-agent-runtime.md
+++ b/docs/pages/platform-agent-runtime.md
@@ -133,12 +133,12 @@ starts the same Agent uses their own connected account; Archestra never shares
 one user's subscription credential with another user.
 
 Claude Code subscriptions are deliberately narrower. The **Claude Code**
-catalog option declares a per-user `CLAUDE_CODE_OAUTH_TOKEN` for Anthropic models. Each
+catalog option declares a per-user `CLAUDE_CODE_OAUTH_TOKEN` for direct Anthropic access. Each
 user generates it with `claude setup-token` and saves it from the Agent's
 Overview after the Agent is created. Archestra injects it only into the
 official Claude Code Agent Runtime image. It is not registered as a general
 Anthropic provider credential and cannot be used by Archestra Chat, Hermes,
-OpenClaw, or a custom runtime. Anthropic-backed runs require that token.
+OpenClaw, or a custom runtime. Direct Anthropic runs require that token.
 They never fall back to a metered Anthropic API key.
 
 Claude Code also supports Claude models hosted on **AWS Bedrock**.
@@ -147,6 +147,13 @@ These runs use Bedrock billing and require no Claude subscription token.
 Archestra configures Claude Code's native Bedrock transport through the Agent-scoped proxy.
 AWS credentials stay in the backend; the runtime receives a temporary virtual key.
 Non-Claude Bedrock models remain incompatible with Claude Code.
+
+Claude Code also supports **Anthropic on Vertex AI** when configured on the platform.
+Select the Anthropic provider and a Claude model available through Vertex AI.
+These runs use Google Cloud billing and require no Claude subscription token.
+The runtime uses the Anthropic proxy; the backend authenticates to Vertex through Google ADC.
+Google credentials stay in the backend.
+See [Anthropic on Vertex AI](/docs/platform-supported-llm-providers#anthropic-on-vertex-ai) for setup.
 
 The **Codex** catalog option requires the initiating user's connected ChatGPT
 subscription. If that person has already signed in with ChatGPT under Model

--- a/docs/pages/platform-agent-runtime.md
+++ b/docs/pages/platform-agent-runtime.md
@@ -132,28 +132,11 @@ person in both Archestra Chat and the Codex Agent Runtime image. A teammate who
 starts the same Agent uses their own connected account; Archestra never shares
 one user's subscription credential with another user.
 
-Claude Code subscriptions are deliberately narrower. The **Claude Code**
-catalog option declares a per-user `CLAUDE_CODE_OAUTH_TOKEN` for direct Anthropic access. Each
-user generates it with `claude setup-token` and saves it from the Agent's
-Overview after the Agent is created. Archestra injects it only into the
-official Claude Code Agent Runtime image. It is not registered as a general
-Anthropic provider credential and cannot be used by Archestra Chat, Hermes,
-OpenClaw, or a custom runtime. Direct Anthropic runs require that token.
-They never fall back to a metered Anthropic API key.
+Claude Code subscriptions are deliberately narrower. The **Claude Code** catalog option declares a per-user `CLAUDE_CODE_OAUTH_TOKEN` for direct Anthropic access. Each user generates it with `claude setup-token` and saves it from the Agent's Overview after the Agent is created. Archestra injects it only into the official Claude Code Agent Runtime image. It is not registered as a general Anthropic provider credential and cannot be used by Archestra Chat, Hermes, OpenClaw, or a custom runtime. Direct Anthropic runs require that token. They never fall back to a metered Anthropic API key.
 
-Claude Code also supports Claude models hosted on **AWS Bedrock**.
-Select a Bedrock provider credential and Claude model on the Agent.
-These runs use Bedrock billing and require no Claude subscription token.
-Archestra configures Claude Code's native Bedrock transport through the Agent-scoped proxy.
-AWS credentials stay in the backend; the runtime receives a temporary virtual key.
-Non-Claude Bedrock models remain incompatible with Claude Code.
+Claude Code also supports Claude models hosted on **AWS Bedrock**. Select a Bedrock provider credential and Claude model on the Agent. These runs use Bedrock billing and require no Claude subscription token. Archestra configures Claude Code's native Bedrock transport through the Agent-scoped proxy. AWS credentials stay in the backend; the runtime receives a temporary virtual key. Non-Claude Bedrock models remain incompatible with Claude Code.
 
-Claude Code also supports **Anthropic on Vertex AI** when configured on the platform.
-Select the Anthropic provider and a Claude model available through Vertex AI.
-These runs use Google Cloud billing and require no Claude subscription token.
-The runtime uses the Anthropic proxy; the backend authenticates to Vertex through Google ADC.
-Google credentials stay in the backend.
-See [Anthropic on Vertex AI](/docs/platform-supported-llm-providers#anthropic-on-vertex-ai) for setup.
+Claude Code also supports **Anthropic on Vertex AI** when configured on the platform. Select the Anthropic provider and a Claude model available through Vertex AI. These runs use Google Cloud billing and require no Claude subscription token. The runtime uses the Anthropic proxy; the backend authenticates to Vertex through Google ADC. Google credentials stay in the backend. See [Anthropic on Vertex AI](/docs/platform-supported-llm-providers#anthropic-on-vertex-ai) for setup.
 
 The **Codex** catalog option requires the initiating user's connected ChatGPT
 subscription. If that person has already signed in with ChatGPT under Model
@@ -163,11 +146,7 @@ run does not start with an ordinary OpenAI API key, so selecting the
 maintained runtime cannot silently switch from subscription access to metered
 API billing.
 
-The **Inference API** setting describes the wire protocol expected by the
-image. Choose **OpenAI Responses** for clients such as Codex and OpenCode. Choose **OpenAI
-Chat Completions** for clients such as Hermes and OpenClaw. Choose
-**Anthropic Messages** for clients such as Claude Code, including its Bedrock mode. Archestra rejects an
-incompatible model and image before creating a pod.
+The **Inference API** setting describes the wire protocol expected by the image. Choose **OpenAI Responses** for clients such as Codex and OpenCode. Choose **OpenAI Chat Completions** for clients such as Hermes and OpenClaw. Choose **Anthropic Messages** for clients such as Claude Code, including its Bedrock mode. Archestra rejects an incompatible model and image before creating a pod.
 
 The runtime also supplies the pod with the invoking user's Agent-scoped MCP
 gateway URL and token. A maintained catalog image configures its native client

--- a/docs/pages/platform-agent-runtime.md
+++ b/docs/pages/platform-agent-runtime.md
@@ -3,7 +3,7 @@ title: Agent Runtime (Beta)
 category: Agents
 order: 7
 description: Run delegated Agent tasks in an isolated runtime
-lastUpdated: 2026-09-07
+lastUpdated: "2026-09-08"
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -133,13 +133,20 @@ starts the same Agent uses their own connected account; Archestra never shares
 one user's subscription credential with another user.
 
 Claude Code subscriptions are deliberately narrower. The **Claude Code**
-catalog option declares a required per-user `CLAUDE_CODE_OAUTH_TOKEN`. Each
+catalog option declares a per-user `CLAUDE_CODE_OAUTH_TOKEN` for Anthropic models. Each
 user generates it with `claude setup-token` and saves it from the Agent's
 Overview after the Agent is created. Archestra injects it only into the
 official Claude Code Agent Runtime image. It is not registered as a general
 Anthropic provider credential and cannot be used by Archestra Chat, Hermes,
-OpenClaw, or a custom runtime. A Claude Code run does not start without
-that token and never falls back to a metered Anthropic API key.
+OpenClaw, or a custom runtime. Anthropic-backed runs require that token.
+They never fall back to a metered Anthropic API key.
+
+Claude Code also supports Claude models hosted on **AWS Bedrock**.
+Select a Bedrock provider credential and Claude model on the Agent.
+These runs use Bedrock billing and require no Claude subscription token.
+Archestra configures Claude Code's native Bedrock transport through the Agent-scoped proxy.
+AWS credentials stay in the backend; the runtime receives a temporary virtual key.
+Non-Claude Bedrock models remain incompatible with Claude Code.
 
 The **Codex** catalog option requires the initiating user's connected ChatGPT
 subscription. If that person has already signed in with ChatGPT under Model
@@ -152,7 +159,7 @@ API billing.
 The **Inference API** setting describes the wire protocol expected by the
 image. Choose **OpenAI Responses** for clients such as Codex and OpenCode. Choose **OpenAI
 Chat Completions** for clients such as Hermes and OpenClaw. Choose
-**Anthropic Messages** for clients such as Claude Code. Archestra rejects an
+**Anthropic Messages** for clients such as Claude Code, including its Bedrock mode. Archestra rejects an
 incompatible model and image before creating a pod.
 
 The runtime also supplies the pod with the invoking user's Agent-scoped MCP
@@ -287,6 +294,8 @@ accept useful follow-up instructions.
 | `ARCHESTRA_AGENT_RUNTIME_MODEL_CONTEXT_LENGTH`, `ARCHESTRA_AGENT_RUNTIME_MODEL_OUTPUT_LENGTH` | Known context and output limits for native client configuration. |
 | `ARCHESTRA_LLM_PROXY_URL`, `ARCHESTRA_LLM_PROXY_PROTOCOL` | Agent-scoped inference endpoint and its `openai_responses`, `openai_chat`, or `anthropic` protocol. |
 | `ARCHESTRA_VIRTUAL_KEY` | Personal virtual key for the run. |
+| `ANTHROPIC_BEDROCK_BASE_URL`, `CLAUDE_CODE_USE_BEDROCK`, `AWS_REGION` | Configure native Bedrock transport for Claude Code using a Bedrock model. |
+| `AWS_BEARER_TOKEN_BEDROCK` | The run’s virtual key for the Bedrock proxy. AWS credentials remain server-side. |
 | `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL` | Native client aliases for the Agent-scoped proxy. |
 | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` | Native client aliases for the virtual key on the standard provider path. These are omitted when the official Claude Code image uses its run-scoped subscription token. |
 | `ARCHESTRA_MCP_GATEWAY_URL`, `ARCHESTRA_MCP_GATEWAY_TOKEN` | Agent-scoped MCP endpoint and the initiating user's bearer token. |

--- a/platform/backend/src/clients/anthropic-vertex-request.test.ts
+++ b/platform/backend/src/clients/anthropic-vertex-request.test.ts
@@ -11,12 +11,15 @@ describe("buildAnthropicVertexRequest", () => {
           Authorization: "Bearer caller-token",
           "x-api-key": "caller-key",
           "anthropic-version": "2023-06-01",
-          "anthropic-beta": "prompt-caching-2024-07-31",
+          "anthropic-beta": "context-management-2025-06-27",
           "x-custom-header": "preserved",
         },
         body: JSON.stringify({
           model: "claude-sonnet-5",
           max_tokens: 32,
+          context_management: {
+            edits: [{ type: "clear_thinking_20251015", keep: "all" }],
+          },
           messages: [{ role: "user", content: "Hello" }],
         }),
       },
@@ -33,13 +36,18 @@ describe("buildAnthropicVertexRequest", () => {
     );
     expect(await request.json()).toEqual({
       anthropic_version: "vertex-2023-10-16",
+      context_management: {
+        edits: [{ type: "clear_thinking_20251015", keep: "all" }],
+      },
       max_tokens: 32,
       messages: [{ role: "user", content: "Hello" }],
     });
     expect(request.headers.get("Authorization")).toBe("Bearer google-token");
     expect(request.headers.get("x-api-key")).toBeNull();
     expect(request.headers.get("anthropic-version")).toBeNull();
-    expect(request.headers.get("anthropic-beta")).toBeNull();
+    expect(request.headers.get("anthropic-beta")).toBe(
+      "context-management-2025-06-27",
+    );
     expect(request.headers.get("x-custom-header")).toBe("preserved");
     expect(request.headers.get("x-goog-user-project")).toBe("test-project");
   });

--- a/platform/backend/src/clients/anthropic-vertex-request.ts
+++ b/platform/backend/src/clients/anthropic-vertex-request.ts
@@ -79,7 +79,6 @@ function buildVertexHeaders(
   headers.delete("authorization");
   headers.delete("x-api-key");
   headers.delete("anthropic-version");
-  headers.delete("anthropic-beta");
   headers.delete("content-length");
 
   new Headers(authHeaders).forEach((value, name) => {

--- a/platform/backend/src/services/agent-runtime/credentials.ts
+++ b/platform/backend/src/services/agent-runtime/credentials.ts
@@ -17,6 +17,8 @@ import type {
   ResolvedAgentRuntime,
 } from "@/types";
 import { ApiError } from "@/types";
+import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
+import { usesClaudeCodeBedrock } from "./model-compatibility";
 
 /**
  * Outcome of resolving one Agent Runtime run's declared credentials for one user.
@@ -39,11 +41,14 @@ type AgentRuntimeCredentialResolution = {
  * blank value — an agent handed an empty token fails far from the cause.
  */
 export async function resolveAgentRuntimeCredentials(params: {
-  runtime: Pick<ResolvedAgentRuntime, "agentId" | "credentials" | "secretId">;
+  runtime: Pick<ResolvedAgentRuntime, "agentId" | "credentials" | "secretId"> &
+    Partial<Pick<ResolvedAgentRuntime, "command">>;
   organizationId: string;
   userId: string | null;
 }): Promise<AgentRuntimeCredentialResolution> {
-  const { shared, perUser } = splitDeclarations(params.runtime.credentials);
+  const { shared, perUser } = splitDeclarations(
+    await applicableCredentials(params),
+  );
   const env: Record<string, string> = {};
   const missing: MissingAgentRuntimeCredential[] = [];
   const misconfigured: MissingAgentRuntimeCredential[] = [];
@@ -110,7 +115,8 @@ export async function resolveAgentRuntimeCredentials(params: {
  * rather than failing on click.
  */
 export async function preflightAgentRuntimeCredentials(params: {
-  runtime: Pick<ResolvedAgentRuntime, "agentId" | "credentials" | "secretId">;
+  runtime: Pick<ResolvedAgentRuntime, "agentId" | "credentials" | "secretId"> &
+    Partial<Pick<ResolvedAgentRuntime, "command">>;
   organizationId: string;
   userId: string | null;
 }): Promise<{
@@ -118,7 +124,9 @@ export async function preflightAgentRuntimeCredentials(params: {
   missing: MissingAgentRuntimeCredential[];
   misconfigured: MissingAgentRuntimeCredential[];
 }> {
-  const { shared, perUser } = splitDeclarations(params.runtime.credentials);
+  const { shared, perUser } = splitDeclarations(
+    await applicableCredentials(params),
+  );
   const configured: string[] = [];
   const missing: MissingAgentRuntimeCredential[] = [];
   const misconfigured: MissingAgentRuntimeCredential[] = [];
@@ -409,4 +417,38 @@ async function deleteSecretQuietly(secretId: string): Promise<void> {
       "Failed to delete replaced Agent Runtime credential secret",
     );
   }
+}
+
+// Bedrock uses the selected provider credential; a saved Anthropic subscription
+// declaration must neither block the run nor inject an unrelated OAuth token.
+async function applicableCredentials(params: {
+  runtime: Pick<ResolvedAgentRuntime, "agentId" | "credentials"> &
+    Partial<Pick<ResolvedAgentRuntime, "command">>;
+  organizationId: string;
+  userId: string | null;
+}) {
+  if (
+    params.runtime.command?.[0] !== "archestra-claude-code" ||
+    !params.runtime.credentials?.some(
+      ({ key }) => key === "CLAUDE_CODE_OAUTH_TOKEN",
+    )
+  ) {
+    return params.runtime.credentials;
+  }
+  const agent = await AgentModel.findById(params.runtime.agentId);
+  if (!agent) return params.runtime.credentials;
+  const llm = await resolveConversationLlmSelectionForAgent({
+    agent,
+    organizationId: params.organizationId,
+    userId: params.userId ?? "system",
+    includeMemberChatDefault: false,
+  });
+  return usesClaudeCodeBedrock({
+    runtime: params.runtime,
+    provider: llm.selectedProvider,
+  })
+    ? params.runtime.credentials.filter(
+        ({ key }) => key !== "CLAUDE_CODE_OAUTH_TOKEN",
+      )
+    : params.runtime.credentials;
 }

--- a/platform/backend/src/services/agent-runtime/credentials.ts
+++ b/platform/backend/src/services/agent-runtime/credentials.ts
@@ -18,7 +18,7 @@ import type {
 } from "@/types";
 import { ApiError } from "@/types";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
-import { usesClaudeCodeBedrock } from "./model-compatibility";
+import { getClaudeCodeCloudProvider } from "./model-compatibility";
 
 /**
  * Outcome of resolving one Agent Runtime run's declared credentials for one user.
@@ -419,7 +419,7 @@ async function deleteSecretQuietly(secretId: string): Promise<void> {
   }
 }
 
-// Bedrock uses the selected provider credential; a saved Anthropic subscription
+// Cloud-hosted Claude uses the selected provider credential; a saved subscription
 // declaration must neither block the run nor inject an unrelated OAuth token.
 async function applicableCredentials(params: {
   runtime: Pick<ResolvedAgentRuntime, "agentId" | "credentials"> &
@@ -443,7 +443,7 @@ async function applicableCredentials(params: {
     userId: params.userId ?? "system",
     includeMemberChatDefault: false,
   });
-  return usesClaudeCodeBedrock({
+  return getClaudeCodeCloudProvider({
     runtime: params.runtime,
     provider: llm.selectedProvider,
   })

--- a/platform/backend/src/services/agent-runtime/launch-spec.test.ts
+++ b/platform/backend/src/services/agent-runtime/launch-spec.test.ts
@@ -591,6 +591,103 @@ describe("buildAgentRunLaunchSpec", () => {
     ]);
   });
 
+  test.for([
+    false,
+    true,
+  ])("runs Claude Code on Vertex without a subscription (connected: %s)", async (connected, {
+    makeOrganization,
+    makeAdmin,
+    makeMember,
+    makeSecret,
+    makeLlmProviderApiKey,
+    makeAgent,
+  }) => {
+    config.llm.anthropic.vertexAi.enabled = true;
+    config.llm.anthropic.vertexAi.project = "test-project";
+    const setup = await makeConfiguredAgent({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      contextLength: 1_000_000,
+      apiKey: "",
+      makeOrganization,
+      makeAdmin,
+      makeMember,
+      makeSecret,
+      makeLlmProviderApiKey,
+      makeAgent,
+    });
+    const configuredRuntime = runtime(setup.agent, "anthropic");
+    configuredRuntime.command = ["archestra-claude-code"];
+    configuredRuntime.credentials = [
+      {
+        key: "CLAUDE_CODE_OAUTH_TOKEN",
+        scope: "per_user",
+        label: "Claude subscription",
+        required: true,
+      },
+    ];
+    if (connected)
+      await UserCredentialModel.upsert({
+        organizationId: setup.agent.organizationId,
+        userId: setup.user.id,
+        agentId: setup.agent.id,
+        key: "CLAUDE_CODE_OAUTH_TOKEN",
+        value: "unused-subscription-token",
+      });
+    await expect(
+      preflightAgentRuntimeCredentials({
+        runtime: configuredRuntime,
+        organizationId: setup.agent.organizationId,
+        userId: setup.user.id,
+      }),
+    ).resolves.toEqual({ configured: [], missing: [], misconfigured: [] });
+    const taskId = crypto.randomUUID();
+    const { spec, virtualApiKeyId } = await buildAgentRunLaunchSpec({
+      runtime: configuredRuntime,
+      taskId,
+      runId: crypto.randomUUID(),
+      agentId: setup.agent.id,
+      actor: {
+        id: setup.user.id,
+        kind: "user",
+        organizationId: setup.agent.organizationId,
+      },
+      organizationId: setup.agent.organizationId,
+      runtimeScope: "agent-tests",
+      effectiveNetworkPolicy: { source: "built_in", policy: null },
+      appName: "Archestra",
+      runMode: "one_shot",
+    });
+    expect(spec.env).toMatchObject({
+      ANTHROPIC_BASE_URL: `https://platform.example.test/v1/anthropic/${setup.agent.id}`,
+      ARCHESTRA_LLM_PROXY_URL: `https://platform.example.test/v1/anthropic/${setup.agent.id}`,
+      ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL: "claude-sonnet-4-6",
+    });
+    expect(spec.env).not.toHaveProperty("CLAUDE_CODE_USE_BEDROCK");
+    expect(spec.env).not.toHaveProperty("GOOGLE_APPLICATION_CREDENTIALS");
+    expect(spec.secretEnv.ANTHROPIC_AUTH_TOKEN).toBe(
+      spec.secretEnv.ARCHESTRA_VIRTUAL_KEY,
+    );
+    expect(spec.secretEnv.ANTHROPIC_AUTH_TOKEN).toMatch(/^arch_/);
+    expect(spec.secretEnv).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(spec.secretEnv.ANTHROPIC_CUSTOM_HEADERS).toContain(
+      `X-Archestra-Run-Id: ${taskId}`,
+    );
+    expect(await VirtualApiKeyModel.findById(virtualApiKeyId)).toMatchObject({
+      keyType: "standard",
+      scope: "personal",
+      authorId: setup.user.id,
+    });
+    expect(
+      await VirtualApiKeyModel.getProviderApiKeys(virtualApiKeyId),
+    ).toEqual([
+      expect.objectContaining({
+        provider: "anthropic",
+        providerApiKeyId: setup.agent.llmApiKeyId,
+      }),
+    ]);
+  });
+
   test("never falls back to Anthropic API billing for Claude Code", async ({
     makeOrganization,
     makeAdmin,
@@ -793,6 +890,7 @@ describe("buildAgentRunLaunchSpec", () => {
 });
 
 async function makeConfiguredAgent(params: {
+  apiKey?: string;
   provider: SupportedProvider;
   modelId?: string;
   contextLength?: number;
@@ -823,7 +921,7 @@ async function makeConfiguredAgent(params: {
   const user = await params.makeAdmin();
   await params.makeMember(user.id, organization.id, { role: "admin" });
   const secret = await params.makeSecret({
-    secret: { apiKey: "upstream-secret" },
+    secret: { apiKey: params.apiKey ?? "upstream-secret" },
   });
   const providerKey = await params.makeLlmProviderApiKey(
     organization.id,

--- a/platform/backend/src/services/agent-runtime/launch-spec.test.ts
+++ b/platform/backend/src/services/agent-runtime/launch-spec.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@/models";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { Agent, ResolvedAgentRuntime, User } from "@/types";
+import { preflightAgentRuntimeCredentials } from "./credentials";
 import { buildAgentRunLaunchSpec } from "./launch-spec";
 
 describe("buildAgentRunLaunchSpec", () => {
@@ -482,6 +483,112 @@ describe("buildAgentRunLaunchSpec", () => {
     expect(virtualKey?.keyType).toBe("passthrough");
     expect(virtualKey?.scope).toBe("personal");
     expect(virtualKey?.authorId).toBe(setup.user.id);
+  });
+
+  test.for([
+    false,
+    true,
+  ])("runs Claude Code on Bedrock with a provider key (subscription connected: %s)", async (connected, {
+    makeOrganization,
+    makeAdmin,
+    makeMember,
+    makeSecret,
+    makeLlmProviderApiKey,
+    makeAgent,
+  }) => {
+    const setup = await makeConfiguredAgent({
+      provider: "bedrock",
+      modelId: "us.anthropic.claude-sonnet-4-6",
+      contextLength: 1_000_000,
+      makeOrganization,
+      makeAdmin,
+      makeMember,
+      makeSecret,
+      makeLlmProviderApiKey,
+      makeAgent,
+    });
+    const configuredRuntime = runtime(setup.agent, "anthropic");
+    configuredRuntime.command = ["archestra-claude-code"];
+    configuredRuntime.credentials = [
+      {
+        key: "CLAUDE_CODE_OAUTH_TOKEN",
+        scope: "per_user",
+        label: "Claude subscription",
+        required: true,
+      },
+    ];
+    configuredRuntime.environment = [
+      { key: "ANTHROPIC_BEDROCK_BASE_URL", value: "https://bypass.invalid" },
+      { key: "AWS_BEARER_TOKEN_BEDROCK", value: "bypass-token" },
+      { key: "CLAUDE_CODE_USE_BEDROCK", value: "0" },
+      { key: "CLAUDE_CODE_SKIP_BEDROCK_AUTH", value: "1" },
+    ];
+    if (connected)
+      await UserCredentialModel.upsert({
+        organizationId: setup.agent.organizationId,
+        userId: setup.user.id,
+        agentId: setup.agent.id,
+        key: "CLAUDE_CODE_OAUTH_TOKEN",
+        value: "unused-subscription-token",
+      });
+    const preflight = await preflightAgentRuntimeCredentials({
+      runtime: configuredRuntime,
+      organizationId: setup.agent.organizationId,
+      userId: setup.user.id,
+    });
+    expect(preflight).toEqual({
+      configured: [],
+      missing: [],
+      misconfigured: [],
+    });
+    const taskId = crypto.randomUUID();
+    const { spec, virtualApiKeyId } = await buildAgentRunLaunchSpec({
+      runtime: configuredRuntime,
+      taskId,
+      runId: crypto.randomUUID(),
+      agentId: setup.agent.id,
+      actor: {
+        id: setup.user.id,
+        kind: "user",
+        organizationId: setup.agent.organizationId,
+      },
+      organizationId: setup.agent.organizationId,
+      runtimeScope: "agent-tests",
+      effectiveNetworkPolicy: { source: "built_in", policy: null },
+      appName: "Archestra",
+      runMode: "one_shot",
+    });
+    expect(spec.env).toMatchObject({
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      ANTHROPIC_BEDROCK_BASE_URL: `https://platform.example.test/v1/bedrock/${setup.agent.id}`,
+      ARCHESTRA_LLM_PROXY_URL: `https://platform.example.test/v1/bedrock/${setup.agent.id}`,
+      ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL: "us.anthropic.claude-sonnet-4-6",
+    });
+    expect(spec.env).not.toHaveProperty("AWS_BEARER_TOKEN_BEDROCK");
+    expect(spec.env).not.toHaveProperty("CLAUDE_CODE_SKIP_BEDROCK_AUTH");
+    expect(spec.secretEnv.AWS_BEARER_TOKEN_BEDROCK).toBe(
+      spec.secretEnv.ARCHESTRA_VIRTUAL_KEY,
+    );
+    expect(spec.secretEnv.AWS_BEARER_TOKEN_BEDROCK).toMatch(/^arch_/);
+    expect(spec.secretEnv).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(spec.secretEnv).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
+    expect(spec.secretEnv.ANTHROPIC_CUSTOM_HEADERS).toContain(
+      `X-Archestra-Run-Id: ${taskId}`,
+    );
+    const key = await VirtualApiKeyModel.findById(virtualApiKeyId);
+    expect(key).toMatchObject({
+      keyType: "standard",
+      scope: "personal",
+      authorId: setup.user.id,
+    });
+    expect(
+      await VirtualApiKeyModel.getProviderApiKeys(virtualApiKeyId),
+    ).toEqual([
+      expect.objectContaining({
+        provider: "bedrock",
+        providerApiKeyId: setup.agent.llmApiKeyId,
+      }),
+    ]);
   });
 
   test("never falls back to Anthropic API billing for Claude Code", async ({

--- a/platform/backend/src/services/agent-runtime/launch-spec.ts
+++ b/platform/backend/src/services/agent-runtime/launch-spec.ts
@@ -35,8 +35,8 @@ import type { AgentRunLaunchSpec } from "./backends";
 import { resolveAgentRuntimeCredentials } from "./credentials";
 import { taskWithAgentRunInputs } from "./input-files";
 import {
+  getClaudeCodeCloudProvider,
   preflightAgentRuntimeModelCompatibility,
-  usesClaudeCodeBedrock,
 } from "./model-compatibility";
 import {
   AGENT_RUNTIME_STEER_FIFO,
@@ -150,10 +150,11 @@ export async function buildAgentRunLaunchSpec(params: {
     userId: actorUserId ?? "system",
   });
 
-  const isClaudeCodeBedrock = usesClaudeCodeBedrock({
+  const claudeCodeCloudProvider = getClaudeCodeCloudProvider({
     runtime: params.runtime,
     provider: llm.selectedProvider,
   });
+  const isClaudeCodeBedrock = claudeCodeCloudProvider === "bedrock";
   const claudeCodeSubscriptionToken =
     credentials.env.CLAUDE_CODE_OAUTH_TOKEN?.trim();
   const usesClaudeCodeSubscription = Boolean(claudeCodeSubscriptionToken);
@@ -162,7 +163,7 @@ export async function buildAgentRunLaunchSpec(params: {
   const isCodexRuntime = params.runtime.command?.[0] === "archestra-codex";
   if (
     isClaudeCodeRuntime &&
-    !isClaudeCodeBedrock &&
+    !claudeCodeCloudProvider &&
     !usesClaudeCodeSubscription
   ) {
     throw new ApiError(
@@ -237,7 +238,7 @@ export async function buildAgentRunLaunchSpec(params: {
       ? `${llm.selectedProvider}:${llm.selectedModel}`
       : llm.selectedModel;
   const nativeModel =
-    isClaudeCodeRuntime && !isClaudeCodeBedrock
+    isClaudeCodeRuntime && !claudeCodeCloudProvider
       ? resolveClaudeContextVariant({
           modelId: llm.selectedModel,
           contextLength: selectedModel

--- a/platform/backend/src/services/agent-runtime/launch-spec.ts
+++ b/platform/backend/src/services/agent-runtime/launch-spec.ts
@@ -11,6 +11,7 @@ import {
   VIRTUAL_KEY_HEADER,
 } from "@archestra/shared";
 import type { A2AActor } from "@/agents/a2a/a2a-base";
+import { getBedrockRegion } from "@/clients/bedrock-credentials";
 import { selectMCPGatewayToken } from "@/clients/chat-mcp-client";
 import config from "@/config";
 import {
@@ -33,7 +34,10 @@ import { resolveProviderApiKey } from "@/utils/llm-api-key-resolution";
 import type { AgentRunLaunchSpec } from "./backends";
 import { resolveAgentRuntimeCredentials } from "./credentials";
 import { taskWithAgentRunInputs } from "./input-files";
-import { preflightAgentRuntimeModelCompatibility } from "./model-compatibility";
+import {
+  preflightAgentRuntimeModelCompatibility,
+  usesClaudeCodeBedrock,
+} from "./model-compatibility";
 import {
   AGENT_RUNTIME_STEER_FIFO,
   constructStableRunName,
@@ -146,13 +150,21 @@ export async function buildAgentRunLaunchSpec(params: {
     userId: actorUserId ?? "system",
   });
 
+  const isClaudeCodeBedrock = usesClaudeCodeBedrock({
+    runtime: params.runtime,
+    provider: llm.selectedProvider,
+  });
   const claudeCodeSubscriptionToken =
     credentials.env.CLAUDE_CODE_OAUTH_TOKEN?.trim();
   const usesClaudeCodeSubscription = Boolean(claudeCodeSubscriptionToken);
   const isClaudeCodeRuntime =
     params.runtime.command?.[0] === "archestra-claude-code";
   const isCodexRuntime = params.runtime.command?.[0] === "archestra-codex";
-  if (isClaudeCodeRuntime && !usesClaudeCodeSubscription) {
+  if (
+    isClaudeCodeRuntime &&
+    !isClaudeCodeBedrock &&
+    !usesClaudeCodeSubscription
+  ) {
     throw new ApiError(
       409,
       "Connect your Claude Code subscription before starting this Agent. The maintained Claude Code runtime never falls back to usage-based API billing.",
@@ -214,22 +226,25 @@ export async function buildAgentRunLaunchSpec(params: {
 
   const modelRouterUrl = `${platformBaseUrl}/v1/model-router/${params.agentId}`;
   const anthropicUrl = `${platformBaseUrl}/v1/anthropic/${params.agentId}`;
-  const proxyUrl =
-    params.runtime.inferenceProtocol === "anthropic"
+  const bedrockUrl = `${platformBaseUrl}/v1/bedrock/${params.agentId}`;
+  const proxyUrl = isClaudeCodeBedrock
+    ? bedrockUrl
+    : params.runtime.inferenceProtocol === "anthropic"
       ? anthropicUrl
       : modelRouterUrl;
   const runtimeModel =
     params.runtime.inferenceProtocol !== "anthropic"
       ? `${llm.selectedProvider}:${llm.selectedModel}`
       : llm.selectedModel;
-  const nativeModel = isClaudeCodeRuntime
-    ? resolveClaudeContextVariant({
-        modelId: llm.selectedModel,
-        contextLength: selectedModel
-          ? ModelModel.resolveArchitecturalContextLength(selectedModel)
-          : null,
-      })
-    : llm.selectedModel;
+  const nativeModel =
+    isClaudeCodeRuntime && !isClaudeCodeBedrock
+      ? resolveClaudeContextVariant({
+          modelId: llm.selectedModel,
+          contextLength: selectedModel
+            ? ModelModel.resolveArchitecturalContextLength(selectedModel)
+            : null,
+        })
+      : llm.selectedModel;
   const modelContextLength = selectedModel
     ? ModelModel.resolveEffectiveContextLength(selectedModel)
     : null;
@@ -281,6 +296,13 @@ export async function buildAgentRunLaunchSpec(params: {
     ARCHESTRA_LLM_PROXY_PROTOCOL: params.runtime.inferenceProtocol,
     OPENAI_BASE_URL: modelRouterUrl,
     ANTHROPIC_BASE_URL: anthropicUrl,
+    ...(isClaudeCodeBedrock
+      ? {
+          CLAUDE_CODE_USE_BEDROCK: "1",
+          ANTHROPIC_BEDROCK_BASE_URL: bedrockUrl,
+          AWS_REGION: getBedrockRegion(),
+        }
+      : {}),
     ARCHESTRA_MCP_GATEWAY_URL: `${platformBaseUrl}/v1/mcp/${params.agentId}`,
   };
 
@@ -291,7 +313,7 @@ export async function buildAgentRunLaunchSpec(params: {
   const secretEnv: Record<string, string> = {
     ARCHESTRA_MCP_GATEWAY_TOKEN: gatewayToken,
     ARCHESTRA_VIRTUAL_KEY: virtualKey.value,
-    ...(!usesClaudeCodeSubscription
+    ...(!isClaudeCodeBedrock && !usesClaudeCodeSubscription
       ? {
           // Both the Archestra runtime-agent and bring-your-own CLIs read the
           // provider variables, so the standard virtual key is presented in
@@ -308,6 +330,9 @@ export async function buildAgentRunLaunchSpec(params: {
       : {}),
     ...(task ? { ARCHESTRA_AGENT_RUNTIME_TASK: task } : {}),
     ...withNativeClientCredentialAliases(credentials.env),
+    ...(isClaudeCodeBedrock
+      ? { AWS_BEARER_TOKEN_BEDROCK: virtualKey.value }
+      : {}),
     ...(params.runtime.command?.[0] === "archestra-claude-code"
       ? {
           // Claude Code accepts only one custom-header variable. Keep run
@@ -371,6 +396,10 @@ const RESERVED_RUNTIME_ENV_KEYS = new Set([
   "ANTHROPIC_API_KEY",
   "ANTHROPIC_AUTH_TOKEN",
   "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_BEDROCK_BASE_URL",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
   "CLAUDE_CODE_OAUTH_TOKEN",
   "OPENAI_API_KEY",
   "OPENAI_BASE_URL",

--- a/platform/backend/src/services/agent-runtime/model-compatibility.test.ts
+++ b/platform/backend/src/services/agent-runtime/model-compatibility.test.ts
@@ -143,6 +143,58 @@ test("rejects a Bedrock model for an Anthropic runtime image", async ({
   });
 });
 
+test.for([
+  ["us.anthropic.claude-sonnet-4-6", true],
+  ["anthropic.claude-sonnet-4-6", true],
+  ["amazon.nova-pro-v1:0", false],
+] as const)("checks Claude Code compatibility for Bedrock model %s", async ([
+  modelId,
+  compatible,
+], {
+  makeAgent,
+  makeAdmin,
+  makeLlmProviderApiKey,
+  makeMember,
+  makeOrganization,
+  makeSecret,
+}) => {
+  const organization = await makeOrganization();
+  const user = await makeAdmin();
+  await makeMember(user.id, organization.id, { role: "admin" });
+  const { model, providerKey } = await createModelSelection({
+    organizationId: organization.id,
+    provider: "bedrock",
+    modelId,
+    makeSecret,
+    makeLlmProviderApiKey,
+  });
+  const agent = await makeAgent({
+    organizationId: organization.id,
+    authorId: user.id,
+    agentType: "agent",
+    modelId: model.id,
+    llmApiKeyId: providerKey.id,
+  });
+  const result = preflightAgentRuntimeModelCompatibility({
+    runtime: {
+      inferenceProtocol: "anthropic",
+      command: ["archestra-claude-code"],
+    },
+    agent,
+    organizationId: organization.id,
+    userId: user.id,
+  });
+  if (compatible)
+    await expect(result).resolves.toMatchObject({
+      llm: { selectedProvider: "bedrock", selectedModel: modelId },
+    });
+  else
+    await expect(result).rejects.toMatchObject({
+      statusCode: 409,
+      message: expect.stringContaining("requires a Claude model"),
+    });
+});
+
 test("accepts an inherited compatible organization default model", async ({
   makeAgent,
   makeAdmin,

--- a/platform/backend/src/services/agent-runtime/model-compatibility.ts
+++ b/platform/backend/src/services/agent-runtime/model-compatibility.ts
@@ -16,7 +16,8 @@ import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution"
  * callers can use it before creating a detached task.
  */
 export async function preflightAgentRuntimeModelCompatibility(params: {
-  runtime: Pick<ResolvedAgentRuntime, "inferenceProtocol">;
+  runtime: Pick<ResolvedAgentRuntime, "inferenceProtocol"> &
+    Partial<Pick<ResolvedAgentRuntime, "command">>;
   agent: Pick<Agent, "llmApiKeyId" | "modelId">;
   organizationId: string;
   userId: string;
@@ -32,6 +33,7 @@ export async function preflightAgentRuntimeModelCompatibility(params: {
     : null;
   assertInferenceProtocolSupported({
     protocol: params.runtime.inferenceProtocol,
+    command: params.runtime.command,
     provider: llm.selectedProvider,
     model: llm.selectedModel,
     supportedEndpoints: selectedModel?.supportedEndpoints,
@@ -40,13 +42,39 @@ export async function preflightAgentRuntimeModelCompatibility(params: {
   return { llm, selectedModel };
 }
 
+/** Claude Code can speak Bedrock's native Anthropic InvokeModel transport. */
+export function usesClaudeCodeBedrock(params: {
+  runtime: Partial<Pick<ResolvedAgentRuntime, "command">>;
+  provider: SupportedProvider;
+}): boolean {
+  return (
+    params.runtime.command?.[0] === "archestra-claude-code" &&
+    params.provider === "bedrock"
+  );
+}
+
 function assertInferenceProtocolSupported(params: {
   protocol: ResolvedAgentRuntime["inferenceProtocol"];
+  command: ResolvedAgentRuntime["command"] | undefined;
   provider: SupportedProvider;
   model: string;
   supportedEndpoints: string[] | null | undefined;
 }): void {
-  if (params.protocol === "anthropic" && params.provider !== "anthropic") {
+  const claudeCodeBedrock = usesClaudeCodeBedrock({
+    runtime: { command: params.command },
+    provider: params.provider,
+  });
+  if (claudeCodeBedrock && !/(?:^|[./])anthropic\.claude-/.test(params.model)) {
+    throw new ApiError(
+      409,
+      "The Claude Code runtime requires a Claude model when using AWS Bedrock.",
+    );
+  }
+  if (
+    params.protocol === "anthropic" &&
+    params.provider !== "anthropic" &&
+    !claudeCodeBedrock
+  ) {
     throw new ApiError(
       409,
       `This Agent Runtime image expects the Anthropic API, but the Agent's selected model uses ${providerDisplayNames[params.provider]}. Choose an Anthropic model or use an OpenAI-compatible Agent Runtime image.`,

--- a/platform/backend/src/services/agent-runtime/model-compatibility.ts
+++ b/platform/backend/src/services/agent-runtime/model-compatibility.ts
@@ -5,6 +5,7 @@ import {
   requiresResponsesApi,
   type SupportedProvider,
 } from "@archestra/shared";
+import config from "@/config";
 import { ModelModel } from "@/models";
 import type { Agent, ResolvedAgentRuntime } from "@/types";
 import { ApiError } from "@/types";
@@ -42,15 +43,20 @@ export async function preflightAgentRuntimeModelCompatibility(params: {
   return { llm, selectedModel };
 }
 
-/** Claude Code can speak Bedrock's native Anthropic InvokeModel transport. */
-export function usesClaudeCodeBedrock(params: {
+/** Cloud-hosted Claude uses provider billing instead of a Claude subscription. */
+export function getClaudeCodeCloudProvider(params: {
   runtime: Partial<Pick<ResolvedAgentRuntime, "command">>;
   provider: SupportedProvider;
-}): boolean {
-  return (
-    params.runtime.command?.[0] === "archestra-claude-code" &&
-    params.provider === "bedrock"
-  );
+}): "bedrock" | "vertex" | null {
+  if (params.runtime.command?.[0] !== "archestra-claude-code") return null;
+  if (params.provider === "bedrock") return "bedrock";
+  if (
+    params.provider === "anthropic" &&
+    config.llm.anthropic.vertexAi.enabled
+  ) {
+    return "vertex";
+  }
+  return null;
 }
 
 function assertInferenceProtocolSupported(params: {
@@ -60,10 +66,11 @@ function assertInferenceProtocolSupported(params: {
   model: string;
   supportedEndpoints: string[] | null | undefined;
 }): void {
-  const claudeCodeBedrock = usesClaudeCodeBedrock({
-    runtime: { command: params.command },
-    provider: params.provider,
-  });
+  const claudeCodeBedrock =
+    getClaudeCodeCloudProvider({
+      runtime: { command: params.command },
+      provider: params.provider,
+    }) === "bedrock";
   if (claudeCodeBedrock && !/(?:^|[./])anthropic\.claude-/.test(params.model)) {
     throw new ApiError(
       409,


### PR DESCRIPTION
Claude Code Agent Runtime runs reject Claude models hosted on Bedrock and require a Claude subscription when Anthropic is configured through Vertex AI. Allow both cloud-hosted paths to use provider billing without requiring or injecting a Claude subscription token.

Bedrock uses the existing InvokeModel proxy with a personal provider-backed virtual key. Vertex uses the existing Anthropic proxy and backend Google authentication. Preserve native cloud model IDs and keep cloud credentials in the backend. Direct Anthropic access still requires the user's Claude subscription; non-Claude Bedrock models remain incompatible.

Validation:
- Regression tests reproduce the previous failures and cover credential preflight, connected and unconnected subscriptions, launch configuration, and virtual-key scoping.
- Agent Runtime and provider regression suites pass; full repository commit checks pass, including types, lint, and backend knip.
- Live AWS Bedrock: the maintained Claude Code container completed a Bash → Read → final-answer round trip through the Agent-scoped proxy. Verified streaming responses and persisted user/session attribution with metered billing.
- Live Vertex AI: the maintained Claude Code container completed a Bash → Read → final-answer round trip with Sonnet 5 in the global region, using local Google ADC through the Agent-scoped proxy. Verified successful streaming requests, the written file, and persisted user/session attribution with metered billing.

Live testing also exposed dropped Anthropic beta headers on the Vertex path. Preserve those headers so Claude Code's context-management requests are accepted, with regression coverage for the header and request body.
