### PR TITLE
fix(releases): resume rolling beta release PRs

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -68,7 +68,6 @@
       "release-type": "node",
       "versioning": "prerelease",
       "prerelease-type": "beta",
-      "release-as": "1.4.0-beta.1",
       "prerelease": true,
       "initial-version": "0.0.1",
       "draft": true,


### PR DESCRIPTION
The initial `1.4.0-beta.1` release has published, but its `release-as` override still matches the manifest. The release workflow therefore skips creating subsequent release PRs even as features and fixes merge into main.

Remove the consumed override so Release Please can open the next rolling beta release PR. The manifest remains at `1.4.0-beta.1`; merging the generated release PR will trigger publication.

Validation: executed the workflow’s actual branch-policy script against the edited configuration and confirmed `requested=1.4.0-beta.1` and `create_pr=true`. No permanent test added for this temporary configuration value. Existing release-channel documentation remains accurate.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>