### PR TITLE
fix(subscriptions): add Astra and simplify credential dialogs

### DIFF
--- a/platform/backend/src/routes/chat/model-fetchers/openai-codex-models.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openai-codex-models.test.ts
@@ -32,6 +32,13 @@ describe("fetchOpenAiModels with a ChatGPT-subscription credential", () => {
       OPENAI_CODEX_MODELS.map((model) => model.id),
     );
     expect(models.every((model) => model.provider === "openai")).toBe(true);
+    // Subscription discovery must expose the current model using the upstream
+    // request ID, so it can be selected and sent through the Codex adapter.
+    expect(models).toContainEqual({
+      id: "gpt-6-astra",
+      displayName: "GPT-6 Astra",
+      provider: "openai",
+    });
     // The only network call is the OAuth redemption — never a models listing.
     expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
     expect(String(vi.mocked(fetch).mock.calls[0][0])).toContain("/oauth/token");

--- a/platform/backend/src/services/openai-codex-credentials.ts
+++ b/platform/backend/src/services/openai-codex-credentials.ts
@@ -132,7 +132,7 @@ export function extractChatgptAccountId(jwt: string): string | undefined {
  * These are subscription-billed, so their token price is treated as zero.
  *
  * Manually curated — update when OpenAI adds or removes Codex models.
- * Last synchronized: 2026-07 (Codex CLI model set).
+ * Last synchronized: 2026-09 (Codex CLI model set).
  */
 /**
  * The Codex backend exposes no /models endpoint, so this list is maintained by
@@ -145,6 +145,7 @@ export function extractChatgptAccountId(jwt: string): string | undefined {
  * newest-first; the picker shows them in this order.
  */
 export const OPENAI_CODEX_MODELS = [
+  { id: "gpt-6-astra", displayName: "GPT-6 Astra" },
   { id: "gpt-5.6-sol", displayName: "GPT-5.6 Sol" },
   { id: "gpt-5.6-terra", displayName: "GPT-5.6 Terra" },
   { id: "gpt-5.6-luna", displayName: "GPT-5.6 Luna" },

--- a/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
@@ -59,6 +59,7 @@ function Harness({
   progressive,
   allowPersonalSubscriptions,
   requiresExactSubscriptionCredential,
+  withLabels,
 }: {
   existingKeys?: LlmProviderApiKeyResponse[];
   existingKey?: LlmProviderApiKeyResponse;
@@ -67,6 +68,7 @@ function Harness({
   progressive?: boolean;
   allowPersonalSubscriptions?: boolean;
   requiresExactSubscriptionCredential?: boolean;
+  withLabels?: boolean;
 }) {
   form = useForm<LlmProviderApiKeyFormValues>({
     defaultValues: { ...DEFAULTS, ...defaults },
@@ -82,6 +84,8 @@ function Harness({
       progressive={progressive}
       allowPersonalSubscriptions={allowPersonalSubscriptions}
       requiresExactSubscriptionCredential={requiresExactSubscriptionCredential}
+      labels={withLabels ? [] : undefined}
+      onLabelsChange={withLabels ? () => {} : undefined}
     />
   );
 }
@@ -94,6 +98,7 @@ function renderForm(options?: {
   progressive?: boolean;
   allowPersonalSubscriptions?: boolean;
   requiresExactSubscriptionCredential?: boolean;
+  withLabels?: boolean;
 }) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -106,6 +111,7 @@ function renderForm(options?: {
         defaults={options?.defaults}
         credentialMode={options?.credentialMode}
         progressive={options?.progressive}
+        withLabels={options?.withLabels}
         allowPersonalSubscriptions={options?.allowPersonalSubscriptions}
         requiresExactSubscriptionCredential={
           options?.requiresExactSubscriptionCredential
@@ -136,6 +142,27 @@ beforeEach(() => {
 });
 
 describe("LlmProviderApiKeyForm", () => {
+  it.each([
+    "openai",
+    "github-copilot",
+    "microsoft-365-copilot",
+    "xai",
+  ] as const)("hides advanced settings and labels in the %s subscription dialog", (provider) => {
+    renderForm({
+      defaults: { provider, authMethod: "subscription" },
+      credentialMode: "subscription",
+      progressive: true,
+      withLabels: true,
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Advanced settings" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Labels", { exact: true }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows only sign-in content for a focused subscription flow", () => {
     renderForm({
       credentialMode: "subscription",
@@ -419,11 +446,19 @@ describe("LlmProviderApiKeyForm", () => {
     renderForm({
       existingKey,
       defaults: { authMethod: "subscription" },
+      progressive: true,
+      withLabels: true,
     });
 
     await waitFor(() => {
       expect(screen.getByText("ChatGPT account connected")).toBeInTheDocument();
     });
+    expect(
+      screen.queryByRole("button", { name: "Advanced settings" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Labels", { exact: true }),
+    ).not.toBeInTheDocument();
   });
 
   it("does not show the connected card when editing a plain OpenAI key on the subscription tab", async () => {

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -510,7 +510,6 @@ export function LlmProviderApiKeyForm({
   const isSubscriptionFlow = credentialMode === "subscription";
   const hasLabelsEditor = labels !== undefined && onLabelsChange !== undefined;
   const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
-  const showAdvancedSettings = !progressive || advancedSettingsOpen;
 
   const provider = form.watch("provider");
   const apiKey = form.watch("apiKey");
@@ -791,6 +790,9 @@ export function LlmProviderApiKeyForm({
   // OpenAI "ChatGPT subscription" auth mode is the same shape.
   const isPerUserProvider = providerRequiresPerUserCredential(provider);
   const isPerUserCredential = isPerUserProvider || isCredentialSubscriptionMode;
+  const hasAdvancedSettings = !isSubscriptionFlow && !isPerUserCredential;
+  const showAdvancedSettings =
+    hasAdvancedSettings && (!progressive || advancedSettingsOpen);
   // The subscription this form is currently connecting, if any: implied by the
   // provider when it is per-user outright, chosen by the auth-method tabs when
   // the provider also accepts API keys. Drives every piece of vendor copy below.
@@ -1602,7 +1604,7 @@ export function LlmProviderApiKeyForm({
 
         {!isSubscriptionFlow && showBaseUrlUpFront && baseUrlField}
 
-        {progressive && (!isSubscriptionFlow || hasLabelsEditor) && (
+        {progressive && hasAdvancedSettings && (
           <Button
             type="button"
             variant="ghost"


### PR DESCRIPTION
ChatGPT subscription credentials used a maintained model catalog that omitted `gpt-6-astra`, so Astra was available with API keys but missing from subscription model pickers. Add the upstream model ID to that catalog; existing connections pick it up on the next model refresh.

Hide Advanced settings and labels in personal subscription sign-in and management dialogs. Standard API-key dialogs retain their advanced controls.

Verified locally in Chrome against a separate database: refreshed an existing ChatGPT connection’s models, selected GPT-6 Astra, and received a successful live response with subscription billing recorded. Checked the subscription dialogs and the standard API-key dialog. Regression coverage pins model discovery and hides advanced controls across all four subscription providers.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>