### PR TITLE
feat(frontend): backport personal settings improvements to 1.3

### DIFF
--- a/platform/frontend/src/app/account/_components/my-teams-card.test.tsx
+++ b/platform/frontend/src/app/account/_components/my-teams-card.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useMyTeams } from "@/lib/teams/team.query";
+import { MyTeamsCard } from "./my-teams-card";
+
+vi.mock("@/lib/teams/team.query");
+
+function mockMyTeams(overrides: Partial<ReturnType<typeof useMyTeams>>) {
+  vi.mocked(useMyTeams).mockReturnValue({
+    data: [],
+    isPending: false,
+    isLoadingError: false,
+    refetch: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useMyTeams>);
+}
+
+describe("MyTeamsCard", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("lists each team with its role and member count", () => {
+    mockMyTeams({
+      data: [
+        {
+          id: "t1",
+          name: "Platform",
+          description: "Core platform team",
+          myRole: "admin",
+          members: [{ userId: "u1" }, { userId: "u2" }],
+        },
+        {
+          id: "t2",
+          name: "Design",
+          myRole: "member",
+          members: [{ userId: "u1" }],
+        },
+      ] as unknown as ReturnType<typeof useMyTeams>["data"],
+    });
+
+    render(<MyTeamsCard />);
+
+    const platform = screen.getByText("Platform").closest("li");
+    expect(platform).toHaveTextContent("admin");
+    expect(platform).toHaveTextContent("2 members");
+    expect(platform).toHaveTextContent("Core platform team");
+
+    const design = screen.getByText("Design").closest("li");
+    expect(design).toHaveTextContent("member");
+    expect(design).toHaveTextContent("1 member");
+  });
+
+  it("shows an empty state when the user has no teams", () => {
+    mockMyTeams({ data: [] });
+
+    render(<MyTeamsCard />);
+
+    expect(screen.getByText("You're not in any teams yet")).toBeInTheDocument();
+  });
+
+  it("offers a retry when the teams fail to load", async () => {
+    const refetch = vi.fn();
+    mockMyTeams({ data: undefined, isLoadingError: true, refetch });
+
+    render(<MyTeamsCard />);
+
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/platform/frontend/src/app/account/_components/my-teams-card.tsx
+++ b/platform/frontend/src/app/account/_components/my-teams-card.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Users } from "lucide-react";
+import { QueryLoadError } from "@/components/query-load-error";
+import { SettingsBlock } from "@/components/settings/settings-block";
+import { Badge } from "@/components/ui/badge";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Skeleton } from "@/components/ui/skeleton";
+import { type Team, useMyTeams } from "@/lib/teams/team.query";
+
+/**
+ * Read-only list of the teams the signed-in user belongs to. Teams are often
+ * created and managed from chat, so members had no place in the UI to see which
+ * teams they're in — the admin-only team settings aren't reachable to them.
+ * This section closes that gap without granting any management ability.
+ */
+export function MyTeamsCard() {
+  // isLoadingError, not isError: a failed background refetch keeps the last
+  // good list on screen rather than replacing it with an error panel.
+  const { data: teams, isPending, isLoadingError, refetch } = useMyTeams();
+
+  return (
+    <SettingsBlock
+      title="My Teams"
+      description="Teams you belong to. Membership controls which resources you can access."
+      control={null}
+      // Kept to the same column width as the profile fields above it, so the
+      // two sections read as one stacked list rather than a full-width table.
+      contentClassName="max-w-xl"
+    >
+      {isLoadingError ? (
+        <QueryLoadError
+          className="py-6"
+          title="Couldn't load your teams"
+          onRetry={() => refetch()}
+        />
+      ) : isPending ? (
+        <div className="space-y-2">
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      ) : teams.length === 0 ? (
+        <Empty className="py-6">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Users />
+            </EmptyMedia>
+            <EmptyTitle>You're not in any teams yet</EmptyTitle>
+            <EmptyDescription>
+              When you're added to a team, or create one from chat, it shows up
+              here.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <ul className="divide-y overflow-hidden rounded-lg border">
+          {teams.map((team) => (
+            <TeamRow key={team.id} team={team} />
+          ))}
+        </ul>
+      )}
+    </SettingsBlock>
+  );
+}
+
+function TeamRow({ team }: { team: Team }) {
+  const memberCount = team.members?.length ?? 0;
+
+  return (
+    <li className="flex flex-col gap-1 p-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      <div className="min-w-0 space-y-0.5">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium">{team.name}</span>
+          {team.myRole && (
+            <Badge
+              variant="outline"
+              className="rounded-md px-1.5 py-0 text-[10px] font-normal leading-4 text-muted-foreground capitalize"
+            >
+              {team.myRole}
+            </Badge>
+          )}
+        </div>
+        {team.description && (
+          <p className="truncate text-sm text-muted-foreground">
+            {team.description}
+          </p>
+        )}
+      </div>
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {memberCount === 1 ? "1 member" : `${memberCount} members`}
+      </span>
+    </li>
+  );
+}

--- a/platform/frontend/src/app/account/_components/sessions-card.tsx
+++ b/platform/frontend/src/app/account/_components/sessions-card.tsx
@@ -163,8 +163,8 @@ export function SessionsCard() {
   ];
 
   return (
-    <section className="w-full space-y-5">
-      <div className={isLoadingError ? "space-y-1" : "space-y-1 !mb-3"}>
+    <section className="w-full space-y-4">
+      <div className="space-y-1">
         <h2 className="text-sm font-medium leading-5">Sessions</h2>
         <p className="text-sm leading-5 text-muted-foreground">
           Manage where your account is signed in.
@@ -203,6 +203,7 @@ export function SessionsCard() {
       ) : (
         <>
           <BulkActions
+            reserveSpace={false}
             count={selectedSessions.length}
             noun="session"
             onClear={clearSelection}

--- a/platform/frontend/src/app/account/page.test.tsx
+++ b/platform/frontend/src/app/account/page.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSession } from "@/lib/auth/auth.query";
+import { useActiveMemberRole } from "@/lib/organization.query";
+import { useMyTeams } from "@/lib/teams/team.query";
+import AccountProfilePage from "./page";
+
+vi.mock("next/navigation");
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/organization.query");
+vi.mock("@/lib/teams/team.query");
+vi.mock("@/lib/auth/account.query", () => ({
+  useUpdateAccountNameMutation: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+describe("AccountProfilePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({
+      replace: vi.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
+    );
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: { id: "u1", name: "Ada", email: "ada@example.com" },
+        session: { activeOrganizationId: "org-1" },
+      },
+      isPending: false,
+    } as unknown as ReturnType<typeof useSession>);
+    vi.mocked(useActiveMemberRole).mockReturnValue({
+      data: "member",
+      isPending: false,
+    } as unknown as ReturnType<typeof useActiveMemberRole>);
+    vi.mocked(useMyTeams).mockReturnValue({
+      data: [
+        {
+          id: "t1",
+          name: "Platform",
+          myRole: "member",
+          members: [{ userId: "u1" }, { userId: "u2" }],
+        },
+      ],
+      isPending: false,
+      isLoadingError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMyTeams>);
+  });
+
+  it("shows the My Teams list on the profile page, below the profile fields", () => {
+    render(<AccountProfilePage />);
+
+    // The profile fields and the My Teams section share the one page — there is
+    // no separate route to visit.
+    expect(screen.getByLabelText("Name")).toHaveValue("Ada");
+
+    const teamsHeading = screen.getByRole("heading", { name: "My Teams" });
+    expect(teamsHeading).toBeInTheDocument();
+    // My Teams follows Profile in document order.
+    const profileHeading = screen.getByRole("heading", { name: "Profile" });
+    expect(
+      profileHeading.compareDocumentPosition(teamsHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(screen.getByText("Platform")).toBeInTheDocument();
+    expect(screen.getByText("Platform").closest("li")).toHaveTextContent(
+      "2 members",
+    );
+  });
+});

--- a/platform/frontend/src/app/account/page.tsx
+++ b/platform/frontend/src/app/account/page.tsx
@@ -3,12 +3,18 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { resolveLegacyAccountHref } from "@/app/account/_components/account-sections";
+import { MyTeamsCard } from "@/app/account/_components/my-teams-card";
 import { ProfileCard } from "@/components/settings/profile-card";
+import { SettingsSectionStack } from "@/components/settings/settings-block";
 
 /**
  * The Profile section, and the landing spot for the `/account?section=…` URLs
  * that predate these routes. Those are bookmarked and printed in docs, so they
  * are redirected rather than broken; anything else just renders Profile.
+ *
+ * My Teams sits directly below the profile fields here rather than in its own
+ * route: it is a short, read-only list every user wants beside the rest of
+ * their personal details, not a section worth a separate page.
  */
 export default function AccountProfilePage() {
   const router = useRouter();
@@ -27,5 +33,10 @@ export default function AccountProfilePage() {
 
   if (legacyHref && legacyHref !== "/account") return null;
 
-  return <ProfileCard />;
+  return (
+    <SettingsSectionStack className="space-y-5">
+      <ProfileCard />
+      <MyTeamsCard />
+    </SettingsSectionStack>
+  );
 }

--- a/platform/frontend/src/components/settings/profile-card.test.tsx
+++ b/platform/frontend/src/components/settings/profile-card.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProfileCard } from "@/components/settings/profile-card";
-import { useSession } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useActiveMemberRole } from "@/lib/organization.query";
 
 const mockUpdateNameMutateAsync = vi.fn();
@@ -21,6 +21,11 @@ describe("ProfileCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUpdateNameMutateAsync.mockResolvedValue(true);
+    // The save bar's button runs through PermissionButton; the profile edit has
+    // no RBAC gate ({} permissions), so it is always granted.
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as unknown as ReturnType<typeof useHasPermissions>);
     vi.mocked(useActiveMemberRole).mockReturnValue({
       data: "admin",
       isPending: false,
@@ -101,48 +106,60 @@ describe("ProfileCard", () => {
     expect(screen.queryByText("Original Name")).toBeNull();
   });
 
-  it("keeps email and role as read-only fields", () => {
+  it("shows email and individual assigned roles without editable controls", () => {
+    vi.mocked(useActiveMemberRole).mockReturnValue({
+      data: "admin, platform_admin,custom_reviewer",
+      isPending: false,
+    } as unknown as ReturnType<typeof useActiveMemberRole>);
+
     render(<ProfileCard />);
 
-    const email = screen.getByLabelText("Email");
-    expect(email).toHaveValue("admin@example.com");
-    expect(email).toHaveAttribute("readonly");
-
-    const role = screen.getByLabelText("Role");
-    expect(role).toHaveValue("admin");
-    expect(role).toHaveAttribute("readonly");
-
+    expect(screen.getByText("admin@example.com")).toBeVisible();
+    const roles = screen.getByRole("list", { name: "Assigned roles" });
+    expect(roles).toHaveTextContent("Admin");
+    expect(roles).toHaveTextContent("Platform Admin");
+    expect(roles).toHaveTextContent("custom reviewer");
+    expect(roles.querySelectorAll("li")).toHaveLength(3);
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.getAllByRole("textbox")).toHaveLength(1);
     expect(screen.getByLabelText("Name")).not.toHaveAttribute("readonly");
   });
 
-  it("says why each locked field is locked", () => {
+  it("hides the save bar until the name changes, then saves through it", async () => {
     render(<ProfileCard />);
 
-    expect(
-      screen.getByText("The address you sign in with. It can't be changed."),
-    ).toBeVisible();
-    expect(
-      screen.getByText(
-        "Set by an organization admin. You can't change your own role.",
-      ),
-    ).toBeVisible();
-  });
-
-  it("submits a changed name and keeps the button idle until it changes", async () => {
-    render(<ProfileCard />);
-
-    const submit = screen.getByRole("button", { name: "Update profile" });
-    expect(submit).toBeDisabled();
+    // The footer save bar stays out of the way until there is something to
+    // save — no Save control on first paint.
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
 
     fireEvent.change(screen.getByLabelText("Name"), {
       target: { value: "Updated Name" },
     });
-    await waitFor(() => expect(submit).toBeEnabled());
 
-    fireEvent.click(submit);
+    const save = await screen.findByRole("button", { name: "Save" });
+    expect(save).toBeEnabled();
+
+    fireEvent.click(save);
 
     await waitFor(() => {
       expect(mockUpdateNameMutateAsync).toHaveBeenCalledWith("Updated Name");
     });
+  });
+
+  it("drops the change and hides the save bar again on cancel", async () => {
+    render(<ProfileCard />);
+
+    const nameField = screen.getByLabelText("Name");
+    fireEvent.change(nameField, { target: { value: "Half-typed" } });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    // Cancel reverts to the saved name and pulls the bar back down without
+    // calling the mutation.
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Save" })).toBeNull(),
+    );
+    expect(nameField).toHaveValue("Original Name");
+    expect(mockUpdateNameMutateAsync).not.toHaveBeenCalled();
   });
 });

--- a/platform/frontend/src/components/settings/profile-card.tsx
+++ b/platform/frontend/src/components/settings/profile-card.tsx
@@ -1,24 +1,27 @@
 "use client";
 
+import {
+  getRoleDisplayName,
+  PredefinedRoleNameSchema,
+} from "@archestra/shared";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Loader2 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { SettingsBlock } from "@/components/settings/settings-block";
+import { RoleOptionLabel } from "@/components/role-type-icon";
+import {
+  SettingsBlock,
+  SettingsSaveBar,
+} from "@/components/settings/settings-block";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
-import { FieldDescription } from "@/components/ui/field-description";
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUpdateAccountNameMutation } from "@/lib/auth/account.query";
 import { useSession } from "@/lib/auth/auth.query";
@@ -47,10 +50,7 @@ export function ProfileCard() {
   const image = session?.user?.image ?? null;
 
   return (
-    <SettingsBlock
-      title="Profile"
-      description="Your personal details and organization role."
-    >
+    <SettingsBlock title="Profile">
       <div className="max-w-xl">
         <ProfileForm
           name={name}
@@ -91,16 +91,11 @@ function ProfileForm({
 
   return (
     <Form {...form}>
-      <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
-        {/* The avatar takes the gutter beside the first field only; the name
-            input flexes into what is left, so every input in the form still
-            ends on the same right edge. Display-only — there is no
-            self-service upload endpoint — and the name is not printed beside
-            it, since this field already holds it. */}
-        <div className="flex items-start gap-4">
-          <Avatar className="size-16 shrink-0">
+      <form className="space-y-5" onSubmit={form.handleSubmit(onSubmit)}>
+        <div className="flex items-center gap-3">
+          <Avatar className="size-12 shrink-0">
             {image && <AvatarImage src={image} alt="" />}
-            <AvatarFallback className="text-base">
+            <AvatarFallback>
               {(name || email).slice(0, 2).toUpperCase()}
             </AvatarFallback>
           </Avatar>
@@ -110,9 +105,6 @@ function ProfileForm({
             render={({ field }) => (
               <FormItem className="min-w-0 flex-1 gap-2">
                 <FormLabel>Name</FormLabel>
-                <FormDescription className="text-pretty">
-                  Shown next to you across the app.
-                </FormDescription>
                 <FormControl>
                   <Input
                     {...field}
@@ -126,91 +118,63 @@ function ProfileForm({
           />
         </div>
 
-        <ReadOnlyField
-          id="account-email"
-          label="Email"
-          value={email}
-          note="The address you sign in with. It can't be changed."
-        />
-
-        <ReadOnlyField
-          id="account-role"
-          label="Role"
-          value={role}
-          valueClassName="capitalize"
-          note="Set by an organization admin. You can't change your own role."
-        />
-
-        <Button
-          type="submit"
-          disabled={updateName.isPending || !form.formState.isDirty}
-        >
-          {updateName.isPending && <Loader2 className="size-4 animate-spin" />}
-          <span>Update profile</span>
-        </Button>
+        <dl className="divide-y text-sm">
+          <div className="grid gap-2 py-3 sm:grid-cols-[6rem_minmax(0,1fr)]">
+            <dt className="text-muted-foreground">Email</dt>
+            <dd className="min-w-0 break-all select-text">{email || "—"}</dd>
+          </div>
+          <div className="grid gap-2 py-3 sm:grid-cols-[6rem_minmax(0,1fr)]">
+            <dt className="text-muted-foreground">Roles</dt>
+            <dd className="space-y-2">
+              <ul aria-label="Assigned roles" className="flex flex-wrap gap-2">
+                {role
+                  .split(",")
+                  .map((value) => value.trim())
+                  .filter(Boolean)
+                  .map((value) => (
+                    <li key={value} className="rounded-md border px-2.5 py-1.5">
+                      <RoleOptionLabel
+                        predefined={
+                          PredefinedRoleNameSchema.safeParse(value).success
+                        }
+                        label={getRoleDisplayName(value)}
+                      />
+                    </li>
+                  ))}
+                {!role.trim() && <li>—</li>}
+              </ul>
+              <p className="text-xs text-muted-foreground">
+                Managed by your organization admin.
+              </p>
+            </dd>
+          </div>
+        </dl>
       </form>
-    </Form>
-  );
-}
 
-/**
- * A value with no self-service endpoint behind it. It stays a real input so
- * the block matches the editable fields around it and the value can still be
- * selected and copied, but it keeps full-contrast text — muted text on a
- * muted fill drops under the contrast floor (WCAG AA 4.5:1) — and says why it
- * is locked.
- */
-function ReadOnlyField({
-  id,
-  label,
-  value,
-  note,
-  valueClassName,
-}: {
-  id: string;
-  label: string;
-  value: string;
-  note: string;
-  valueClassName?: string;
-}) {
-  return (
-    <div className="grid gap-2">
-      <Label htmlFor={id}>{label}</Label>
-      <FieldDescription className="text-pretty">{note}</FieldDescription>
-      <Input
-        id={id}
-        value={value || "—"}
-        readOnly
-        aria-readonly
-        className={`cursor-default bg-muted ${valueClassName ?? ""}`}
+      <SettingsSaveBar
+        hasChanges={form.formState.isDirty}
+        isSaving={updateName.isPending}
+        permissions={{}}
+        onSave={form.handleSubmit(onSubmit)}
+        onCancel={() => form.reset()}
       />
-    </div>
+    </Form>
   );
 }
 
 function ProfileSkeleton() {
   return (
-    <SettingsBlock
-      title="Profile"
-      description="Your personal details and organization role."
-    >
-      <div className="max-w-xl space-y-6">
-        <div className="flex items-start gap-4">
-          <Skeleton className="size-16 shrink-0 rounded-full" />
+    <SettingsBlock title="Profile">
+      <div className="max-w-xl space-y-5">
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-12 shrink-0 rounded-full" />
           <div className="grid min-w-0 flex-1 gap-2">
             <Skeleton className="h-4 w-16" />
             <Skeleton className="h-9 w-full" />
-            <Skeleton className="h-4 w-2/3" />
           </div>
         </div>
-        {["email", "role"].map((field) => (
-          <div key={field} className="grid gap-2">
-            <Skeleton className="h-4 w-16" />
-            <Skeleton className="h-9 w-full" />
-            <Skeleton className="h-4 w-2/3" />
-          </div>
-        ))}
-        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-16 w-full" />
       </div>
     </SettingsBlock>
   );


### PR DESCRIPTION
Backports #7760 to `release/1.3` without conflicts or release-specific changes.

Adds My Teams to Profile, compacts account details with individual read-only role labels, and uses the sticky Save/Cancel bar for name edits. Includes the smaller team badges, tighter section spacing, broader resource-access copy, and removal of the empty bulk-action gap above the Sessions table.

The changed files match the reviewed frontend implementation. On the release branch, focused tests pass for team list/empty/retry states, multiple read-only roles, profile saving/cancellation, and session management. The source implementation was also verified in Chrome against the local backend.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>