### PR TITLE
feat(frontend): backport model table and URL filters to release/1.3

### DIFF
--- a/platform/e2e-tests/tests/agents.spec.ts
+++ b/platform/e2e-tests/tests/agents.spec.ts
@@ -171,20 +171,19 @@ test("can create and delete an agent", {
     checkEnabled: false,
   });
 
-  // The whole row opens the detail page, not just the name link: click the
-  // icon cell, which carries no control of its own. Retried until the URL
-  // changes, for the same pre-hydration reason as the wizard steps above.
+  // Click the name cell's padding, outside its link, to exercise whole-row
+  // navigation. Retry until the URL changes for the same pre-hydration
+  // reason as the wizard steps above.
   const agentDetailUrl = new RegExp(`/agents/${agentId}$`);
   // The name cell truncates long names in the DOM and carries the full
   // name as its title, so find the row by that title, not by text.
-  const rowIconCell = page
+  const rowNameCell = page
     .getByTestId(E2eTestId.AgentsTable)
-    .locator("tr")
-    .filter({ has: page.getByTitle(AGENT_NAME) })
-    .locator('td[data-column-id="icon"]');
+    .getByRole("cell")
+    .filter({ has: page.getByTitle(AGENT_NAME) });
   await expect(async () => {
     if (!page.url().match(agentDetailUrl)) {
-      await rowIconCell.click();
+      await rowNameCell.click({ position: { x: 4, y: 4 } });
     }
     await expect(page).toHaveURL(agentDetailUrl, { timeout: 3_000 });
   }).toPass({ timeout: 20_000 });

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -468,17 +468,6 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
           }),
         ]),
     {
-      id: "icon",
-      size: 40,
-      enableSorting: false,
-      header: "",
-      cell: ({ row }) => (
-        <div className="flex items-center justify-center">
-          <AgentIcon icon={row.original.icon} size={20} />
-        </div>
-      ),
-    },
-    {
       id: "name",
       accessorKey: "name",
       size: 240,
@@ -497,6 +486,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
         return (
           <AgentNameCell
             name={agent.name}
+            icon={<AgentIcon icon={agent.icon} size={20} />}
             // A trashed agent has no detail page: `GET /api/agents/:id`
             // filters deleted rows, so the link would land on "not found".
             href={

--- a/platform/frontend/src/app/llm/models/page.test.tsx
+++ b/platform/frontend/src/app/llm/models/page.test.tsx
@@ -280,6 +280,49 @@ describe("ModelsPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders the provider icon inline before the model ID", async () => {
+    keyCreated = true;
+    renderPage();
+
+    expect(await screen.findByText(model.modelId)).toBeVisible();
+    // The icon moved out of its own column and now sits in the Model ID cell.
+    expect(screen.getByRole("img", { name: "Anthropic" })).toBeVisible();
+  });
+
+  it("hydrates filter state from the URL query params", async () => {
+    keyCreated = true;
+    // A chat model filtered to embedding-only should drop out entirely.
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("modelType=embedding") as unknown as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+    renderPage();
+
+    expect(
+      await screen.findByText("No models match your filters"),
+    ).toBeVisible();
+    expect(screen.queryByText(model.modelId)).not.toBeInTheDocument();
+  });
+
+  it("syncs the search filter to the URL query params", async () => {
+    keyCreated = true;
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(
+      await screen.findByPlaceholderText(/search models/i),
+      "claude",
+    );
+
+    await waitFor(() =>
+      expect(routerPush).toHaveBeenCalledWith(
+        expect.stringContaining("search=claude"),
+        { scroll: false },
+      ),
+    );
+  });
+
   it("clears an active label filter from the model collection", async () => {
     keyCreated = true;
     vi.mocked(useSearchParams).mockReturnValue(

--- a/platform/frontend/src/app/llm/models/page.test.tsx
+++ b/platform/frontend/src/app/llm/models/page.test.tsx
@@ -289,6 +289,18 @@ describe("ModelsPage", () => {
     expect(screen.getByRole("img", { name: "Anthropic" })).toBeVisible();
   });
 
+  it("shows input and output prices in one combined column", async () => {
+    keyCreated = true;
+    renderPage();
+
+    expect(await screen.findByText(model.modelId)).toBeVisible();
+    // Input ($3) and output ($15) share a single cell, like Cache R/W.
+    expect(screen.getByText("$3.00 / $15.00")).toBeVisible();
+    expect(screen.getByText("$/M In/Out")).toBeVisible();
+    expect(screen.queryByText("$/M Input")).not.toBeInTheDocument();
+    expect(screen.queryByText("$/M Output")).not.toBeInTheDocument();
+  });
+
   it("hydrates filter state from the URL query params", async () => {
     keyCreated = true;
     // A chat model filtered to embedding-only should drop out entirely.

--- a/platform/frontend/src/app/llm/models/page.test.tsx
+++ b/platform/frontend/src/app/llm/models/page.test.tsx
@@ -335,6 +335,32 @@ describe("ModelsPage", () => {
     );
   });
 
+  it("keeps a free-only deep link while the provider keys load", async () => {
+    keyCreated = true;
+    // An OpenRouter key makes the free-only filter valid — but it resolves
+    // after first render, when apiKeys is still empty.
+    server.use(
+      http.get(`${API_ORIGIN}/api/llm-provider-api-keys`, () =>
+        HttpResponse.json([
+          { ...providerKey, provider: "openrouter", name: "OpenRouter" },
+        ]),
+      ),
+    );
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("freeOnly=true") as unknown as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+
+    renderPage();
+
+    // The toggle hydrates from the URL and stays on once keys resolve...
+    const toggle = await screen.findByRole("switch", { name: /free only/i });
+    await waitFor(() => expect(toggle).toBeChecked());
+    // ...and the deep link is never stripped while keys were loading.
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
   it("clears an active label filter from the model collection", async () => {
     keyCreated = true;
     vi.mocked(useSearchParams).mockReturnValue(

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -110,12 +110,17 @@ export default function ModelsPage() {
   const selectedLabels = useSelectedLabels();
   const [isCreateApiKeyDialogOpen, setIsCreateApiKeyDialogOpen] =
     useState(false);
-  const [search, setSearch] = useState("");
-  const [apiKeyFilter, setApiKeyFilter] = useState<string>("all");
   const [apiKeyFilterOpen, setApiKeyFilterOpen] = useState(false);
-  const [modelTypeFilter, setModelTypeFilter] =
-    useState<ModelsPageModelTypeFilter>("all");
-  const [freeOnly, setFreeOnly] = useState(false);
+  // Filters live in the URL so they survive reloads and are shareable, like the
+  // other list pages' table filters.
+  const search = searchParams.get("search") ?? "";
+  const apiKeyFilter = searchParams.get("apiKey") ?? "all";
+  const modelTypeParam = searchParams.get("modelType");
+  const modelTypeFilter: ModelsPageModelTypeFilter =
+    modelTypeParam === "chat" || modelTypeParam === "embedding"
+      ? modelTypeParam
+      : "all";
+  const freeOnly = searchParams.get("freeOnly") === "true";
   const labelsFilter = searchParams.get("labels") ?? "";
   const editId = searchParams.get("edit");
   const modelFromUrl = useMemo(
@@ -136,9 +141,9 @@ export default function ModelsPage() {
 
   useEffect(() => {
     if (!canFilterFreeModels && freeOnly) {
-      setFreeOnly(false);
+      updateQueryParams({ freeOnly: null });
     }
-  }, [canFilterFreeModels, freeOnly]);
+  }, [canFilterFreeModels, freeOnly, updateQueryParams]);
 
   const bulkVisibility = useBulkUpdateModelVisibility();
 
@@ -209,11 +214,13 @@ export default function ModelsPage() {
       labelsFilter,
   );
   const clearFilters = useCallback(() => {
-    setSearch("");
-    setApiKeyFilter("all");
-    setModelTypeFilter("all");
-    setFreeOnly(false);
-    updateQueryParams({ labels: null });
+    updateQueryParams({
+      search: null,
+      apiKey: null,
+      modelType: null,
+      freeOnly: null,
+      labels: null,
+    });
   }, [updateQueryParams]);
 
   // Hiding keeps a model out of the pickers without deleting anything, so the
@@ -256,96 +263,91 @@ export default function ModelsPage() {
         allLabel: "Select all models on this page",
       }),
       {
-        id: "providerIcon",
-        size: 40,
-        header: "",
-        cell: ({ row }) => {
-          const config = PROVIDER_CONFIG[row.original.provider];
-          if (!config) return null;
-          return (
-            <div className="flex items-center justify-center">
-              <Image
-                src={config.icon}
-                alt={config.name}
-                width={20}
-                height={20}
-                className="rounded dark:invert"
-              />
-            </div>
-          );
-        },
-      },
-      {
         accessorKey: "modelId",
         size: 280,
         header: "Model ID",
         cell: ({ row }) => {
           const { modelId, provider, isFree } = row.original;
           const isLatestAlias = isOpenRouterLatestAlias(provider, modelId);
+          // The provider icon sits inline before the model ID (as the knowledge
+          // connectors table does) rather than in its own column, saving the
+          // table a fixed slot of horizontal space.
+          const config = PROVIDER_CONFIG[provider];
           return (
-            <div className="min-w-0 space-y-2">
-              <span className="flex items-center gap-2 font-mono text-sm">
-                <span className="truncate">{modelId}</span>
-                <LabelTags labels={row.original.labels} />
-              </span>
-              <div className="mt-0.5 flex flex-wrap items-center gap-2">
-                {isFree && <FreeModelBadge />}
-                {isLatestAlias && <LatestModelBadge />}
-                {row.original.isBest && <BestModelBadge />}
-                {providerRequiresPerUserCredential(provider) && (
-                  <PerUserModelBadge />
-                )}
-                {row.original.embeddingDimensions !== null && (
-                  <EmbeddingModelBadge />
-                )}
-                {row.original.teams.length > 0 && (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Badge variant="outline" className="text-xs gap-1">
-                          <Users className="h-3 w-3 shrink-0" />
-                          <span>
-                            {row.original.teams.length === 1
-                              ? "1 team"
-                              : `${row.original.teams.length} teams`}
-                          </span>
-                        </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-xs">
-                        <p>
-                          Limited to:{" "}
-                          {row.original.teams
-                            .map((team) => team.name)
-                            .join(", ")}
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
-                {row.original.users.length > 0 && (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Badge variant="outline" className="text-xs gap-1">
-                          <UserRoundCheck className="h-3 w-3 shrink-0" />
-                          <span>
-                            {row.original.users.length === 1
-                              ? "1 person"
-                              : `${row.original.users.length} people`}
-                          </span>
-                        </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-xs">
-                        <p>
-                          Limited to:{" "}
-                          {row.original.users
-                            .map((user) => user.name)
-                            .join(", ")}
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
+            <div className="flex min-w-0 items-center gap-3">
+              {config && (
+                <Image
+                  src={config.icon}
+                  alt={config.name}
+                  width={20}
+                  height={20}
+                  className="shrink-0 rounded dark:invert"
+                />
+              )}
+              <div className="min-w-0 space-y-2">
+                <span className="flex items-center gap-2 font-mono text-sm">
+                  <span className="truncate">{modelId}</span>
+                  <LabelTags labels={row.original.labels} />
+                </span>
+                <div className="mt-0.5 flex flex-wrap items-center gap-2">
+                  {isFree && <FreeModelBadge />}
+                  {isLatestAlias && <LatestModelBadge />}
+                  {row.original.isBest && <BestModelBadge />}
+                  {providerRequiresPerUserCredential(provider) && (
+                    <PerUserModelBadge />
+                  )}
+                  {row.original.embeddingDimensions !== null && (
+                    <EmbeddingModelBadge />
+                  )}
+                  {row.original.teams.length > 0 && (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge variant="outline" className="text-xs gap-1">
+                            <Users className="h-3 w-3 shrink-0" />
+                            <span>
+                              {row.original.teams.length === 1
+                                ? "1 team"
+                                : `${row.original.teams.length} teams`}
+                            </span>
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-xs">
+                          <p>
+                            Limited to:{" "}
+                            {row.original.teams
+                              .map((team) => team.name)
+                              .join(", ")}
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
+                  {row.original.users.length > 0 && (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge variant="outline" className="text-xs gap-1">
+                            <UserRoundCheck className="h-3 w-3 shrink-0" />
+                            <span>
+                              {row.original.users.length === 1
+                                ? "1 person"
+                                : `${row.original.users.length} people`}
+                            </span>
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-xs">
+                          <p>
+                            Limited to:{" "}
+                            {row.original.users
+                              .map((user) => user.name)
+                              .join(", ")}
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
+                </div>
               </div>
             </div>
           );
@@ -600,9 +602,7 @@ export default function ModelsPage() {
               <SearchInput
                 objectNamePlural="models"
                 searchFields={["model ID"]}
-                value={search}
-                onSearchChange={setSearch}
-                syncQueryParams={false}
+                paramName="search"
                 className={filterSearchClass}
               />
               <LlmProviderApiKeyDropdown
@@ -611,7 +611,7 @@ export default function ModelsPage() {
                 open={apiKeyFilterOpen}
                 onOpenChange={setApiKeyFilterOpen}
                 onSelectKey={(value) => {
-                  setApiKeyFilter(value);
+                  updateQueryParams({ apiKey: value });
                   setApiKeyFilterOpen(false);
                 }}
                 triggerVariant="select"
@@ -622,14 +622,14 @@ export default function ModelsPage() {
                 allOptionLabel="All provider API keys"
                 allOptionSelected={apiKeyFilter === "all"}
                 onSelectAllOption={() => {
-                  setApiKeyFilter("all");
+                  updateQueryParams({ apiKey: null });
                   setApiKeyFilterOpen(false);
                 }}
               />
               <FilterSelect
                 value={modelTypeFilter}
                 onValueChange={(v) =>
-                  setModelTypeFilter(v as "all" | "chat" | "embedding")
+                  updateQueryParams({ modelType: v === "all" ? null : v })
                 }
                 placeholder="Model type"
                 items={[
@@ -688,7 +688,9 @@ export default function ModelsPage() {
                   <Switch
                     id="models-free-only"
                     checked={freeOnly}
-                    onCheckedChange={setFreeOnly}
+                    onCheckedChange={(checked) =>
+                      updateQueryParams({ freeOnly: checked ? "true" : null })
+                    }
                   />
                   <Label
                     htmlFor="models-free-only"

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -103,7 +103,8 @@ export default function ModelsPage() {
     isLoadingError: isModelsLoadError,
     refetch,
   } = useModelsWithApiKeys({ toastOnError: false });
-  const { data: apiKeys = [] } = useLlmProviderApiKeys();
+  const { data: apiKeys = [], isLoading: isApiKeysLoading } =
+    useLlmProviderApiKeys();
   const syncModelsMutation = useSyncLlmModels();
   const updateModel = useUpdateModel();
   const [isRefreshingModels, setIsRefreshingModels] = useState(false);
@@ -140,10 +141,13 @@ export default function ModelsPage() {
   );
 
   useEffect(() => {
-    if (!canFilterFreeModels && freeOnly) {
+    // Wait for the provider-key query to settle before clearing: on a cold
+    // cache `apiKeys` starts empty, so acting while it loads would strip a
+    // `?freeOnly=true` deep link before an OpenRouter key had a chance to load.
+    if (!isApiKeysLoading && !canFilterFreeModels && freeOnly) {
       updateQueryParams({ freeOnly: null });
     }
-  }, [canFilterFreeModels, freeOnly, updateQueryParams]);
+  }, [isApiKeysLoading, canFilterFreeModels, freeOnly, updateQueryParams]);
 
   const bulkVisibility = useBulkUpdateModelVisibility();
 

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -403,34 +403,26 @@ export default function ModelsPage() {
         },
       },
       {
-        id: "pricingInput",
-        size: 104,
-        header: "$/M Input",
+        id: "pricingInputOutput",
+        size: 132,
+        // Input and output prices share one column (like Cache R/W) to save
+        // horizontal space, shown "$input / $output" and free to wrap onto two
+        // lines when the column is narrow.
+        header: "$/M In/Out",
         cell: ({ row }) => {
-          const price = row.original.pricePerMillionInput;
+          const { pricePerMillionInput, pricePerMillionOutput } = row.original;
           if (hasUnknownCapabilities(row.original)) return null;
-          return price ? (
-            <span className="text-sm font-mono">
-              ${formatPricePerMillion(price)}
-            </span>
-          ) : (
-            <span className="text-sm text-muted-foreground">-</span>
-          );
-        },
-      },
-      {
-        id: "pricingOutput",
-        size: 104,
-        header: "$/M Output",
-        cell: ({ row }) => {
-          const price = row.original.pricePerMillionOutput;
-          if (hasUnknownCapabilities(row.original)) return null;
-          return price ? (
-            <span className="text-sm font-mono">
-              ${formatPricePerMillion(price)}
-            </span>
-          ) : (
-            <span className="text-sm text-muted-foreground">-</span>
+          if (!pricePerMillionInput && !pricePerMillionOutput) {
+            return <span className="text-sm text-muted-foreground">-</span>;
+          }
+          const input = pricePerMillionInput
+            ? `$${formatPricePerMillion(pricePerMillionInput)}`
+            : "-";
+          const output = pricePerMillionOutput
+            ? `$${formatPricePerMillion(pricePerMillionOutput)}`
+            : "-";
+          return (
+            <span className="text-sm font-mono">{`${input} / ${output}`}</span>
           );
         },
       },

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -447,21 +447,6 @@ function McpGateways({
           }),
         ]),
     {
-      id: "icon",
-      size: 40,
-      enableSorting: false,
-      header: "",
-      cell: ({ row }) => (
-        <div className="flex items-center justify-center">
-          <AgentIcon
-            icon={row.original.icon}
-            size={20}
-            fallbackType="mcp_gateway"
-          />
-        </div>
-      ),
-    },
-    {
       id: "name",
       accessorKey: "name",
       size: 240,
@@ -480,6 +465,13 @@ function McpGateways({
         return (
           <AgentNameCell
             name={agent.name}
+            icon={
+              <AgentIcon
+                icon={agent.icon}
+                size={20}
+                fallbackType="mcp_gateway"
+              />
+            }
             // A trashed gateway has no detail page: `GET /api/agents/:id`
             // filters deleted rows, so the link would land on "not found".
             href={

--- a/platform/frontend/src/components/agent-name-cell.test.tsx
+++ b/platform/frontend/src/components/agent-name-cell.test.tsx
@@ -17,4 +17,16 @@ describe("AgentNameCell", () => {
 
     expect(screen.getByText("Built-in")).toBeInTheDocument();
   });
+
+  it("renders a leading icon inline before the name when provided", () => {
+    render(
+      <AgentNameCell
+        name="Iconic Agent"
+        icon={<span data-testid="agent-icon" />}
+      />,
+    );
+
+    expect(screen.getByTestId("agent-icon")).toBeInTheDocument();
+    expect(screen.getByText("Iconic Agent")).toBeInTheDocument();
+  });
 });

--- a/platform/frontend/src/components/agent-name-cell.tsx
+++ b/platform/frontend/src/components/agent-name-cell.tsx
@@ -19,6 +19,7 @@ export function AgentNameCell({
   description,
   labels,
   extraBadges,
+  icon,
 }: {
   name: string;
   /**
@@ -30,11 +31,17 @@ export function AgentNameCell({
   description?: string | null;
   labels?: AgentLabels;
   extraBadges?: ReactNode;
+  /**
+   * The entity's icon, rendered inline before the name (as the knowledge
+   * connectors table does) rather than in its own column, so the table isn't
+   * spending a fixed slot of horizontal space on it.
+   */
+  icon?: ReactNode;
 }) {
   const hasMetadata = !!extraBadges || !!labels?.length || builtIn;
   const displayName = truncateName(name);
 
-  return (
+  const content = (
     <div className="font-medium">
       <div className="flex flex-col gap-1">
         <div className="flex flex-wrap items-center gap-2">
@@ -71,6 +78,15 @@ export function AgentNameCell({
           </div>
         )}
       </div>
+    </div>
+  );
+
+  if (!icon) return content;
+
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <span className="flex shrink-0 items-center justify-center">{icon}</span>
+      <div className="min-w-0">{content}</div>
     </div>
   );
 }


### PR DESCRIPTION
Backports #7762 (model table and URL-filter improvements) to `release/1.3`.

The models table uses less horizontal space by placing provider icons beside model IDs and combining input/output prices into `$/M In/Out`. Agent and MCP gateway icons likewise move into their name cells.

Model search, provider API key, model type, and free-only filters now persist in URL parameters, so filtered views survive reloads and can be shared. Clearing filters removes those parameters; free-only links remain intact while provider keys load.

Validation: the focused frontend tests pass, covering URL hydration, search URL updates, delayed provider-key loading, and combined pricing. Frontend type-checking reports the same existing `llmProviderApiKey.updated` audit-event type error on the unchanged base branch.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>