### PR TITLE
feat(frontend): add responsive table filters and widen model IDs

### DIFF
--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -616,14 +616,16 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
               <FilterBar
                 leading
                 actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
+                search={
+                  <SearchInput
+                    isLoading={isFetching}
+                    objectNamePlural="agents"
+                    searchFields={["name"]}
+                    paramName="name"
+                    className={filterSearchClass}
+                  />
+                }
               >
-                <SearchInput
-                  isLoading={isFetching}
-                  objectNamePlural="agents"
-                  searchFields={["name"]}
-                  paramName="name"
-                  className={filterSearchClass}
-                />
                 <ResourceScopeFilter
                   showBuiltIn
                   showLabels

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -189,13 +189,18 @@ export default function AppsPage() {
     >
       <TableCardView storageKey="archestra-apps-view">
         <CollectionFilters>
-          <FilterBar leading actions={<TableCardViewToggle />}>
-            <SearchInput
-              isLoading={isFetching}
-              paramName="search"
-              placeholder="Search apps"
-              className={filterSearchClass}
-            />
+          <FilterBar
+            leading
+            actions={<TableCardViewToggle />}
+            search={
+              <SearchInput
+                isLoading={isFetching}
+                paramName="search"
+                placeholder="Search apps"
+                className={filterSearchClass}
+              />
+            }
+          >
             <Select
               value={kind}
               onValueChange={(value) =>

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.tsx
@@ -284,20 +284,23 @@ export function ConnectorDocumentsTable({
   return (
     <BulkActionsScope>
       <CollectionFilters>
-        <FilterBar>
-          <SearchInput
-            isLoading={isFetching}
-            value={search}
-            syncQueryParams={false}
-            placeholder="Search documents by title"
-            className={filterSearchClass}
-            onSearchChange={(nextValue) =>
-              updateQueryParams({
-                search: nextValue || null,
-                page: "1",
-              })
-            }
-          />
+        <FilterBar
+          search={
+            <SearchInput
+              isLoading={isFetching}
+              value={search}
+              syncQueryParams={false}
+              placeholder="Search documents by title"
+              className={filterSearchClass}
+              onSearchChange={(nextValue) =>
+                updateQueryParams({
+                  search: nextValue || null,
+                  page: "1",
+                })
+              }
+            />
+          }
+        >
           {showGroupFilter && (
             <Select
               value={group || "all"}

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-members-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-members-table.tsx
@@ -302,14 +302,17 @@ export function ConnectorMembersTable({
     <div>
       {members.length > 0 && (
         <CollectionFilters>
-          <FilterBar>
-            <SearchInput
-              value={search}
-              syncQueryParams={false}
-              placeholder={`Search by ID, email, name, or ${noun.singular}`}
-              className={filterSearchClass}
-              onSearchChange={setSearch}
-            />
+          <FilterBar
+            search={
+              <SearchInput
+                value={search}
+                syncQueryParams={false}
+                placeholder={`Search by ID, email, name, or ${noun.singular}`}
+                className={filterSearchClass}
+                onSearchChange={setSearch}
+              />
+            }
+          >
             <Select
               value={filter}
               onValueChange={(value) => setFilter(value as MemberFilter)}

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-user-groups-table.tsx
@@ -213,14 +213,17 @@ export function ConnectorUserGroupsTable({
     <div>
       {groups.length > 0 && (
         <CollectionFilters>
-          <FilterBar>
-            <SearchInput
-              value={search}
-              syncQueryParams={false}
-              placeholder={`Search by ${noun.singular} or member name`}
-              className={filterSearchClass}
-              onSearchChange={setSearch}
-            />
+          <FilterBar
+            search={
+              <SearchInput
+                value={search}
+                syncQueryParams={false}
+                placeholder={`Search by ${noun.singular} or member name`}
+                className={filterSearchClass}
+                onSearchChange={setSearch}
+              />
+            }
+          >
             <Select
               value={filter}
               onValueChange={(value) => setFilter(value as GroupFilter)}

--- a/platform/frontend/src/app/knowledge/connectors/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/page.client.tsx
@@ -438,12 +438,14 @@ function ConnectorsList() {
               leading
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
               onClearFilters={hasActiveFilters ? clearFilters : undefined}
+              search={
+                <SearchInput
+                  paramName="search"
+                  className={filterSearchClass}
+                  isLoading={isFetching}
+                />
+              }
             >
-              <SearchInput
-                paramName="search"
-                className={filterSearchClass}
-                isLoading={isFetching}
-              />
               <Select
                 value={connectorTypeFilter}
                 onValueChange={handleConnectorTypeChange}

--- a/platform/frontend/src/app/knowledge/files/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/files/page.client.tsx
@@ -544,6 +544,22 @@ export default function KnowledgeFilesPage() {
           <FilterBar
             leading
             onClearFilters={hasActiveFilters ? clearFilters : undefined}
+            search={
+              <SearchInput
+                isLoading={isLoading}
+                value={search}
+                onSearchChange={(value) => {
+                  setSearch(value);
+                  updateQueryParams({ page: "1" });
+                }}
+                // The term lives in local state and the page reset is handled just
+                // above, so the component's own query-param sync would only add a
+                // second router push per keystroke.
+                syncQueryParams={false}
+                placeholder="Search documents…"
+                className={filterSearchClass}
+              />
+            }
           >
             {openDirectory ? (
               <Button
@@ -564,20 +580,6 @@ export default function KnowledgeFilesPage() {
               <span className="font-medium text-sm">{openDirectory.name}</span>
             )}
 
-            <SearchInput
-              isLoading={isLoading}
-              value={search}
-              onSearchChange={(value) => {
-                setSearch(value);
-                updateQueryParams({ page: "1" });
-              }}
-              // The term lives in local state and the page reset is handled just
-              // above, so the component's own query-param sync would only add a
-              // second router push per keystroke.
-              syncQueryParams={false}
-              placeholder="Search documents…"
-              className={filterSearchClass}
-            />
             <EntityLabelFilter
               useLabelKeys={useKnowledgeFileLabelKeys}
               useLabelValues={useKnowledgeFileLabelValues}

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -501,12 +501,14 @@ function KnowledgeBasesList() {
               leading
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
               onClearFilters={hasActiveFilters ? clearFilters : undefined}
+              search={
+                <SearchInput
+                  paramName="search"
+                  className={filterSearchClass}
+                  isLoading={isFetching}
+                />
+              }
             >
-              <SearchInput
-                paramName="search"
-                className={filterSearchClass}
-                isLoading={isFetching}
-              />
               <ResourceScopeFilter
                 adminPermission={{ knowledgeSource: ["admin"] }}
                 ownerLabelPlural="knowledge bases"

--- a/platform/frontend/src/app/llm/logs/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.tsx
@@ -518,26 +518,26 @@ function SessionsTable() {
         <FilterBar
           leading
           onClearFilters={hasFilters ? clearFilters : undefined}
+          search={
+            <div className={filterSearchClass}>
+              <SearchInput
+                isLoading={isFetching}
+                objectNamePlural="logs"
+                searchFields={["session ID"]}
+                paramName="search"
+                className="relative w-full"
+                paginationMode="cursor"
+                onSearchChange={cursorPagination.goNewest}
+              />
+              {/* Keep validation below search without moving the table. */}
+              {searchIsNotSessionId && (
+                <output className="absolute left-0 top-full z-20 mt-1 w-full rounded-md border bg-popover px-2 py-1 text-xs text-muted-foreground shadow-md">
+                  Enter a valid session UUID
+                </output>
+              )}
+            </div>
+          }
         >
-          {/* Anchor the "not a session ID" hint as a floating overlay under the
-            input so toggling it never reflows the filter bar or the table. */}
-          <div className={filterSearchClass}>
-            <SearchInput
-              isLoading={isFetching}
-              objectNamePlural="logs"
-              searchFields={["session ID"]}
-              paramName="search"
-              className="relative w-full"
-              paginationMode="cursor"
-              onSearchChange={cursorPagination.goNewest}
-            />
-            {searchIsNotSessionId && (
-              <output className="absolute left-0 top-full z-20 mt-1 w-full rounded-md border bg-popover px-2 py-1 text-xs text-muted-foreground shadow-md">
-                Enter a valid session UUID
-              </output>
-            )}
-          </div>
-
           {/* Two people's personal agents can both be called "My Agent", so the
             picker carries each one's scope and owner email rather than a bare
             name. */}

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -741,14 +741,16 @@ export default function ApiKeysPage() {
                       })
                   : undefined
               }
+              search={
+                <SearchInput
+                  isLoading={isFetching}
+                  objectNamePlural="credentials"
+                  searchFields={["name"]}
+                  paramName="search"
+                  className={filterSearchClass}
+                />
+              }
             >
-              <SearchInput
-                isLoading={isFetching}
-                objectNamePlural="credentials"
-                searchFields={["name"]}
-                paramName="search"
-                className={filterSearchClass}
-              />
               <Select
                 value={providerFilter}
                 onValueChange={(value) =>

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -268,7 +268,6 @@ export default function ModelsPage() {
       }),
       {
         accessorKey: "modelId",
-        size: 280,
         header: "Model ID",
         cell: ({ row }) => {
           const { modelId, provider, isFree } = row.original;
@@ -359,6 +358,7 @@ export default function ModelsPage() {
       },
       {
         accessorKey: "apiKeys",
+        size: 160,
         header: "Source",
         cell: ({ row }) => {
           const apiKeys = row.original.apiKeys;
@@ -408,7 +408,7 @@ export default function ModelsPage() {
       },
       {
         id: "pricingInputOutput",
-        size: 132,
+        size: 160,
         // Input and output prices share one column (like Cache R/W) to save
         // horizontal space, shown "$input / $output" and free to wrap onto two
         // lines when the column is narrow.
@@ -432,7 +432,7 @@ export default function ModelsPage() {
       },
       {
         id: "pricingCache",
-        size: 132,
+        size: 160,
         header: "$/M Cache R/W",
         cell: ({ row }) => {
           const { pricePerMillionCacheRead, pricePerMillionCacheWrite } =
@@ -455,7 +455,7 @@ export default function ModelsPage() {
         id: "contextLength",
         // Sorting must follow what the cell shows, not the architectural column.
         accessorFn: (row) => resolveDisplayContextLength(row).display,
-        size: 100,
+        size: 88,
         header: "Context",
         cell: ({ row }) => {
           if (hasUnknownCapabilities(row.original)) {
@@ -735,6 +735,15 @@ export default function ModelsPage() {
 
         <DataTable
           columns={columns}
+          flexibleColumnIds={["modelId"]}
+          fixedWidthColumnIds={[
+            "apiKeys",
+            "pricingInputOutput",
+            "pricingCache",
+            "contextLength",
+            "outputLength",
+          ]}
+          tableClassName="min-w-[1000px]"
           data={filteredModels}
           getRowId={(row) => row.id}
           rowSelection={rowSelection}

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -594,13 +594,15 @@ export default function ModelsPage() {
             <FilterBar
               leading
               onClearFilters={hasActiveFilters ? clearFilters : undefined}
+              search={
+                <SearchInput
+                  objectNamePlural="models"
+                  searchFields={["model ID"]}
+                  paramName="search"
+                  className={filterSearchClass}
+                />
+              }
             >
-              <SearchInput
-                objectNamePlural="models"
-                searchFields={["model ID"]}
-                paramName="search"
-                className={filterSearchClass}
-              />
               <LlmProviderApiKeyDropdown
                 availableKeys={apiKeys}
                 selectedApiKeyId={apiKeyFilter === "all" ? null : apiKeyFilter}

--- a/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/proxy/virtual-keys/page.tsx
@@ -353,14 +353,19 @@ function VirtualKeysTable() {
     <TableCardView storageKey="archestra-llm-virtual-keys-view">
       <div>
         <CollectionFilters>
-          <FilterBar leading actions={<TableCardViewToggle />}>
-            <SearchInput
-              isLoading={query.isFetching}
-              objectNamePlural="keys"
-              searchFields={["name"]}
-              paramName="search"
-              className={filterSearchClass}
-            />
+          <FilterBar
+            leading
+            actions={<TableCardViewToggle />}
+            search={
+              <SearchInput
+                isLoading={query.isFetching}
+                objectNamePlural="keys"
+                searchFields={["name"]}
+                paramName="search"
+                className={filterSearchClass}
+              />
+            }
+          >
             <FilterSelect
               value={keyTypeFilter ?? "all"}
               onValueChange={(value) =>

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -687,14 +687,16 @@ function McpGateways({
               <FilterBar
                 leading
                 actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
+                search={
+                  <SearchInput
+                    isLoading={isFetching}
+                    objectNamePlural="gateways"
+                    searchFields={["name"]}
+                    paramName="name"
+                    className={filterSearchClass}
+                  />
+                }
               >
-                <SearchInput
-                  isLoading={isFetching}
-                  objectNamePlural="gateways"
-                  searchFields={["name"]}
-                  paramName="name"
-                  className={filterSearchClass}
-                />
                 <ResourceScopeFilter
                   showLabels
                   ownerLabelPlural="MCP gateways"

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1177,17 +1177,19 @@ export function InternalMCPCatalog({
                 )}
               </>
             }
+            search={
+              <SearchInput
+                objectNamePlural="MCP servers"
+                searchFields={["name"]}
+                value={searchQueryFromUrl}
+                onSearchChange={handleSearchChange}
+                syncQueryParams={false}
+                debounceMs={0}
+                className={filterSearchClass}
+                inputClassName="w-full bg-background/50 backdrop-blur-sm border-border/50 focus:border-primary/50 transition-colors pl-9"
+              />
+            }
           >
-            <SearchInput
-              objectNamePlural="MCP servers"
-              searchFields={["name"]}
-              value={searchQueryFromUrl}
-              onSearchChange={handleSearchChange}
-              syncQueryParams={false}
-              debounceMs={0}
-              className={filterSearchClass}
-              inputClassName="w-full bg-background/50 backdrop-blur-sm border-border/50 focus:border-primary/50 transition-colors pl-9"
-            />
             <McpCatalogLabelFilter active={Boolean(hasLabelFilters)} />
             {!selectedFacet && (
               <ResourceScopeFilter

--- a/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
@@ -159,14 +159,16 @@ export function ArchestraCatalogTab({
                 }
               : undefined
           }
+          search={
+            <SearchInput
+              placeholder="Search servers by name..."
+              value={searchQuery}
+              onSearchChange={setSearchQuery}
+              syncQueryParams={false}
+              className={filterSearchClass}
+            />
+          }
         >
-          <SearchInput
-            placeholder="Search servers by name..."
-            value={searchQuery}
-            onSearchChange={setSearchQuery}
-            syncQueryParams={false}
-            className={filterSearchClass}
-          />
           <Select
             value={filters.type}
             onValueChange={(value) =>

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.test.tsx
@@ -55,13 +55,16 @@ vi.mock("@/components/filter-bar", () => ({
     <div>{children}</div>
   ),
   FilterBar: ({
+    search,
     children,
     onClearFilters,
   }: {
+    search?: React.ReactNode;
     children: React.ReactNode;
     onClearFilters?: () => void;
   }) => (
     <div>
+      {search}
       {children}
       {onClearFilters ? (
         <button type="button" onClick={onClearFilters}>

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -392,14 +392,16 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
         <FilterBar
           leading
           onClearFilters={hasActiveFilters ? clearFilters : undefined}
+          search={
+            <SearchInput
+              placeholder="Search by name or namespace"
+              value={search}
+              onSearchChange={setSearch}
+              syncQueryParams={false}
+              className={filterSearchClass}
+            />
+          }
         >
-          <SearchInput
-            placeholder="Search by name or namespace"
-            value={search}
-            onSearchChange={setSearch}
-            syncQueryParams={false}
-            className={filterSearchClass}
-          />
           <FilterSelect
             value={egressModeFilter}
             onValueChange={(value) =>

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.test.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.test.tsx
@@ -12,7 +12,18 @@ vi.mock("@/components/filter-bar", () => ({
   CollectionFilters: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
-  FilterBar: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  FilterBar: ({
+    search,
+    children,
+  }: {
+    search?: ReactNode;
+    children: ReactNode;
+  }) => (
+    <div>
+      {search}
+      {children}
+    </div>
+  ),
   FilterSelect: () => <button type="button">All Sources</button>,
   filterSearchClass: "",
 }));

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
@@ -637,16 +637,19 @@ export function AssignedToolsTable({
   return (
     <BulkActionsScope>
       <CollectionFilters>
-        <FilterBar leading>
-          <SearchInput
-            isLoading={isLoading}
-            objectNamePlural="tools"
-            searchFields={["name"]}
-            paramName="search"
-            onSearchChange={handleSearchChange}
-            className={filterSearchClass}
-          />
-
+        <FilterBar
+          leading
+          search={
+            <SearchInput
+              isLoading={isLoading}
+              objectNamePlural="tools"
+              searchFields={["name"]}
+              paramName="search"
+              onSearchChange={handleSearchChange}
+              className={filterSearchClass}
+            />
+          }
+        >
           <FilterSelect
             value={originFilter}
             onValueChange={handleOriginFilterChange}

--- a/platform/frontend/src/app/plugins/new/page.client.tsx
+++ b/platform/frontend/src/app/plugins/new/page.client.tsx
@@ -194,15 +194,16 @@ function NewPluginWizard() {
                   </div>
                   <FilterBar
                     onClearFilters={search ? () => setSearch("") : undefined}
-                  >
-                    <SearchInput
-                      value={search}
-                      onSearchChange={setSearch}
-                      syncQueryParams={false}
-                      placeholder="Search marketplaces by name or use case..."
-                      className="w-full flex-1"
-                    />
-                  </FilterBar>
+                    search={
+                      <SearchInput
+                        value={search}
+                        onSearchChange={setSearch}
+                        syncQueryParams={false}
+                        placeholder="Search marketplaces by name or use case..."
+                        className="w-full flex-1"
+                      />
+                    }
+                  />
                 </CardHeader>
                 <CardContent className="p-0">
                   {filteredMarketplaces.length === 0 ? (

--- a/platform/frontend/src/app/plugins/page.client.tsx
+++ b/platform/frontend/src/app/plugins/page.client.tsx
@@ -753,11 +753,13 @@ function PluginsList() {
                       : []),
                   ]}
                   actions={<TableCardViewToggle />}
+                  search={
+                    <SearchInput
+                      paramName="search"
+                      className={filterSearchClass}
+                    />
+                  }
                 >
-                  <SearchInput
-                    paramName="search"
-                    className={filterSearchClass}
-                  />
                   <FacetSelect
                     label="Filter by client"
                     value={client}

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -269,6 +269,16 @@ function ProjectsList() {
         <div>
           <CollectionFilters>
             <FilterBar
+              search={
+                !isDeletedView ? (
+                  <SearchInput
+                    isLoading={isFetching}
+                    placeholder="Search projects"
+                    paramName="search"
+                    className={filterSearchClass}
+                  />
+                ) : null
+              }
               leading
               actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
             >
@@ -276,12 +286,6 @@ function ProjectsList() {
               search and scope, so live controls would read as broken filters. */}
               {!isDeletedView && (
                 <>
-                  <SearchInput
-                    isLoading={isFetching}
-                    placeholder="Search projects"
-                    paramName="search"
-                    className={filterSearchClass}
-                  />
                   <ResourceScopeFilter
                     ownerLabelPlural="projects"
                     allLabel="All projects"

--- a/platform/frontend/src/app/settings/llm/_parts/model-providers-section.tsx
+++ b/platform/frontend/src/app/settings/llm/_parts/model-providers-section.tsx
@@ -119,15 +119,16 @@ export function ModelProvidersSection() {
                 <CollectionFilters>
                   <FilterBar
                     onClearFilters={search ? () => setSearch("") : undefined}
-                  >
-                    <SearchInput
-                      value={search}
-                      onSearchChange={setSearch}
-                      syncQueryParams={false}
-                      placeholder="Search providers…"
-                      className={filterSearchClass}
-                    />
-                  </FilterBar>
+                    search={
+                      <SearchInput
+                        value={search}
+                        onSearchChange={setSearch}
+                        syncQueryParams={false}
+                        placeholder="Search providers…"
+                        className={filterSearchClass}
+                      />
+                    }
+                  />
                 </CollectionFilters>
 
                 {visible.length === 0 ? (

--- a/platform/frontend/src/app/settings/messaging-channels/_components/channels-section.tsx
+++ b/platform/frontend/src/app/settings/messaging-channels/_components/channels-section.tsx
@@ -522,16 +522,17 @@ export function ChannelsSection({
                   onAssign={handleBulkAssign}
                 />
               }
+              search={
+                <SearchInput
+                  isLoading={isFetching}
+                  placeholder="Search channels..."
+                  paramName="search"
+                  className={filterSearchClass}
+                  debounceMs={300}
+                  onSearchChange={handleSearchChange}
+                />
+              }
             >
-              <SearchInput
-                isLoading={isFetching}
-                placeholder="Search channels..."
-                paramName="search"
-                className={filterSearchClass}
-                debounceMs={300}
-                onSearchChange={handleSearchChange}
-              />
-
               <Button
                 variant="ghost"
                 size="sm"

--- a/platform/frontend/src/app/settings/oauth-clients/page.tsx
+++ b/platform/frontend/src/app/settings/oauth-clients/page.tsx
@@ -366,14 +366,17 @@ function OauthClientsTable() {
   return (
     <div>
       <CollectionFilters>
-        <FilterBar>
-          <SearchInput
-            isLoading={llmQuery.isFetching || mcpQuery.isFetching}
-            objectNamePlural="OAuth clients"
-            searchFields={["name"]}
-            paramName="search"
-            className={filterSearchClass}
-          />
+        <FilterBar
+          search={
+            <SearchInput
+              isLoading={llmQuery.isFetching || mcpQuery.isFetching}
+              objectNamePlural="OAuth clients"
+              searchFields={["name"]}
+              paramName="search"
+              className={filterSearchClass}
+            />
+          }
+        >
           <FilterSelect
             value={typeFilter ?? "all"}
             onValueChange={(value) =>

--- a/platform/frontend/src/app/settings/service-accounts/page.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/page.tsx
@@ -395,12 +395,14 @@ export default function ServiceAccountsSettingsPage() {
               <FilterBar
                 actions={<TableCardViewToggle />}
                 onClearFilters={hasActiveFilters ? clearFilters : undefined}
+                search={
+                  <SearchInput
+                    objectNamePlural="service accounts"
+                    searchFields={["name"]}
+                    className={filterSearchClass}
+                  />
+                }
               >
-                <SearchInput
-                  objectNamePlural="service accounts"
-                  searchFields={["name"]}
-                  className={filterSearchClass}
-                />
                 <RoleSelect
                   mode="filter"
                   value={roleFilter}

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -603,14 +603,16 @@ function MembersTab({
           actions={
             <TabButtons activeTab={activeTab} onTabChange={onTabChange} />
           }
+          search={
+            <SearchInput
+              isLoading={isFetching}
+              objectNamePlural="users"
+              searchFields={["name", "email"]}
+              paramName="name"
+              className={filterSearchClass}
+            />
+          }
         >
-          <SearchInput
-            isLoading={isFetching}
-            objectNamePlural="users"
-            searchFields={["name", "email"]}
-            paramName="name"
-            className={filterSearchClass}
-          />
           <RoleFilterDropdown />
         </FilterBar>
       </CollectionFilters>

--- a/platform/frontend/src/app/skills/new/page.client.tsx
+++ b/platform/frontend/src/app/skills/new/page.client.tsx
@@ -203,15 +203,16 @@ function NewSkillWizard() {
                         onClearFilters={
                           search ? () => setSearch("") : undefined
                         }
-                      >
-                        <SearchInput
-                          value={search}
-                          onSearchChange={setSearch}
-                          syncQueryParams={false}
-                          placeholder="Search skills by name, repo, or use case..."
-                          className="w-full flex-1"
-                        />
-                      </FilterBar>
+                        search={
+                          <SearchInput
+                            value={search}
+                            onSearchChange={setSearch}
+                            syncQueryParams={false}
+                            placeholder="Search skills by name, repo, or use case..."
+                            className="w-full flex-1"
+                          />
+                        }
+                      />
                     </CardHeader>
                     <CardContent className="p-0">
                       {isSearchingSkills ? (

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -837,12 +837,14 @@ function SkillsList() {
                   leading
                   onClearFilters={hasActiveFilters ? clearFilters : undefined}
                   actions={!isDeletedView ? <TableCardViewToggle /> : undefined}
+                  search={
+                    <SearchInput
+                      isLoading={isFetching}
+                      paramName="search"
+                      className={filterSearchClass}
+                    />
+                  }
                 >
-                  <SearchInput
-                    isLoading={isFetching}
-                    paramName="search"
-                    className={filterSearchClass}
-                  />
                   {(mcpSkillsEnabled || pluginSkillsEnabled) &&
                     !isDeletedView && (
                       <Select value={kind} onValueChange={setKindFilter}>

--- a/platform/frontend/src/components/filter-bar.test.tsx
+++ b/platform/frontend/src/components/filter-bar.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   FilterBar,
   FilterBarContextualActions,
@@ -141,5 +142,124 @@ describe("FilterSelect", () => {
     expect(
       screen.getByRole("combobox", { name: "Audit action" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("compact filters", () => {
+  let compact: boolean;
+  let listeners: Set<() => void>;
+
+  beforeEach(() => {
+    compact = true;
+    listeners = new Set();
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(max-width: 1023px)" && compact,
+      media: query,
+      addEventListener: (_event: string, listener: () => void) =>
+        listeners.add(listener),
+      removeEventListener: (_event: string, listener: () => void) =>
+        listeners.delete(listener),
+    }));
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  function FilteredList() {
+    const [action, setAction] = useState("all");
+    return (
+      <>
+        <FilterBar
+          search={<input aria-label="Search entries" />}
+          onClearFilters={action !== "all" ? () => setAction("all") : undefined}
+          moreFilters={[
+            {
+              key: "actor",
+              label: "Actor",
+              active: false,
+              control: <button type="button">All actors</button>,
+            },
+          ]}
+        >
+          <FilterSelect
+            value={action}
+            onValueChange={setAction}
+            placeholder="Filter by action"
+            items={ITEMS}
+          />
+        </FilterBar>
+        <ul>
+          {(action === "all"
+            ? ["Created entry", "Deleted entry"]
+            : ["Created entry"]
+          ).map((entry) => (
+            <li key={entry}>{entry}</li>
+          ))}
+        </ul>
+      </>
+    );
+  }
+
+  it("keeps search visible and applies and clears a filter inside the popover", async () => {
+    render(<FilteredList />);
+    expect(
+      screen.getByRole("textbox", { name: "Search entries" }),
+    ).toBeVisible();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Filters" }));
+    expect(screen.getByRole("button", { name: "All actors" })).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /More filters/ }),
+    ).not.toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("combobox", { name: "Filter by action" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(screen.queryByText("Deleted entry")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Filters (active)" }),
+    ).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(screen.getByText("Deleted entry")).toBeVisible();
+  });
+
+  it("retains search and selected filters when resizing between compact and desktop layouts", async () => {
+    render(<FilteredList />);
+    await userEvent.type(screen.getByRole("textbox"), "entry");
+    await userEvent.click(screen.getByRole("button", { name: "Filters" }));
+    await userEvent.click(
+      screen.getByRole("combobox", { name: "Filter by action" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    act(() => {
+      compact = false;
+      listeners.forEach((listener) => {
+        listener();
+      });
+    });
+    expect(
+      screen.queryByRole("button", { name: "Filters (active)" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "Filter by action" }),
+    ).toHaveTextContent("Create");
+    expect(screen.getByRole("textbox")).toHaveValue("entry");
+    act(() => {
+      compact = true;
+      listeners.forEach((listener) => {
+        listener();
+      });
+    });
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Filters (active)" }),
+    ).toBeVisible();
+    expect(screen.queryByText("Deleted entry")).not.toBeInTheDocument();
+  });
+
+  it("does not show a filter button on search-only lists", () => {
+    render(<FilterBar search={<input aria-label="Search" />} />);
+    expect(screen.getByRole("textbox")).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Filters" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/filter-bar.tsx
+++ b/platform/frontend/src/components/filter-bar.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { ChevronDown, SlidersHorizontal, X } from "lucide-react";
-import { type ComponentProps, Fragment, type ReactNode } from "react";
+import { ChevronDown, Funnel, SlidersHorizontal, X } from "lucide-react";
+import {
+  Children,
+  type ComponentProps,
+  Fragment,
+  type ReactNode,
+  useSyncExternalStore,
+} from "react";
 import {
   ContextualActionsPortal,
   useBulkActionsScope,
@@ -72,11 +78,15 @@ export function CollectionFilters({
  * and truncated their labels ("All Agents & LLM Pr…") while leaving dead space
  * inside the shorter ones.
  *
+ * Below the lg breakpoint, search stays inline and all filters share a funnel
+ * popover. Desktop keeps the primary controls and active secondary filters inline.
+ *
+ * @param search - The search input (or its hint wrapper), kept outside the popover.
  * @param onClearFilters - When provided, a "Clear" button is appended after the
  * filters. Pass it only while some filter is actually applied; the button is
  * the bar's only affordance for resetting them all at once.
  * @param moreFilters - Secondary filters, for pages with more of them than fit
- * a row. An entry is shown inline while it is `active` and tucked into a "More
+ * a row. On desktop, an entry is inline while `active` and tucked into a "More
  * filters" popover while it is not, so the bar always states every filter
  * currently narrowing the table — a hidden active filter reads as an empty
  * table with no explanation.
@@ -99,6 +109,7 @@ export function CollectionFilters({
  */
 export function FilterBar({
   children,
+  search,
   className,
   contextualActions,
   contextualActionsClassName,
@@ -109,6 +120,8 @@ export function FilterBar({
   leading = false,
 }: {
   children?: ReactNode;
+  /** Search stays visible beside the filter popover on compact screens. */
+  search?: ReactNode;
   className?: string;
   contextualActions?: ReactNode;
   contextualActionsClassName?: string;
@@ -118,6 +131,15 @@ export function FilterBar({
   actions?: ReactNode;
   leading?: boolean;
 }) {
+  const compact = useSyncExternalStore(
+    subscribeToCompactFilters,
+    getCompactFiltersSnapshot,
+    () => false,
+  );
+  const hasFilters =
+    Children.toArray(children).length > 0 || !!moreFilters?.length;
+  const hasActiveFilters =
+    !!onClearFilters || !!moreFilters?.some((filter) => filter.active);
   const bulkActionsScope = useBulkActionsScope();
   const actionsTargetId =
     contextualActionsTargetId ?? bulkActionsScope?.targetId;
@@ -146,36 +168,42 @@ export function FilterBar({
           className,
         )}
       >
-        {children}
-        {appliedOverflow.map((filter) => (
-          // Fragment rather than a wrapper element: the control has to be the
-          // bar's own flex item for its sizing to behave like the inline ones'.
-          <Fragment key={filter.key}>{filter.control}</Fragment>
-        ))}
-        {tuckedAway.length > 0 && (
+        {search && (
+          <div className="min-w-0 flex-1 max-lg:max-w-[20rem] lg:contents max-lg:[&>*]:min-w-0 max-lg:[&>*]:w-full max-lg:[&>*]:basis-auto">
+            {search}
+          </div>
+        )}
+        {compact && hasFilters ? (
           <Popover>
             <PopoverTrigger asChild>
-              <Button variant="outline" className={filterControlClass()}>
-                <SlidersHorizontal aria-hidden className="h-3.5 w-3.5" />
-                <span>More filters</span>
-                <ChevronDown
-                  aria-hidden
-                  className="h-4 w-4 text-muted-foreground"
-                />
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label={hasActiveFilters ? "Filters (active)" : "Filters"}
+                className={filterControlClass({
+                  active: hasActiveFilters,
+                  className: "relative size-8 shrink-0 px-0",
+                })}
+              >
+                <Funnel aria-hidden className="size-4" />
+                {hasActiveFilters && (
+                  <span
+                    aria-hidden
+                    className="absolute right-1 top-1 size-1.5 rounded-full bg-primary"
+                  />
+                )}
               </Button>
             </PopoverTrigger>
-            <PopoverContent align="start" className="w-72 space-y-3">
-              {tuckedAway.map((filter) => (
+            <PopoverContent
+              align={search ? "end" : "start"}
+              aria-label="Table filters"
+              className="flex max-h-[var(--radix-popover-content-available-height)] w-80 max-w-[calc(100vw-2rem)] flex-col gap-3 overflow-y-auto [&>button]:w-full [&>button]:max-w-none"
+            >
+              <span className="text-sm font-medium">Filters</span>
+              {children}
+              {moreFilters?.map((filter) => (
                 <div
                   key={filter.key}
-                  // The control is the same compact trigger used in the bar,
-                  // stretched to the popover width so this reads as a small form
-                  // rather than a second filter bar. Scoped to the row's direct
-                  // child so a control that renders buttons of its own inside
-                  // itself keeps their widths, and matched by element rather than
-                  // by `[data-slot=button]`: a trigger reaches its <button>
-                  // through a Radix `asChild` wrapper, which overwrites Button's
-                  // `data-slot` with its own (`popover-trigger`/`select-trigger`).
                   className="space-y-1.5 [&>button]:w-full [&>button]:max-w-none"
                 >
                   <span className="block text-xs font-medium">
@@ -184,19 +212,69 @@ export function FilterBar({
                   {filter.control}
                 </div>
               ))}
+              {onClearFilters && (
+                <Button variant="ghost" size="sm" onClick={onClearFilters}>
+                  <X aria-hidden className="size-3.5" />
+                  <span>Clear</span>
+                </Button>
+              )}
             </PopoverContent>
           </Popover>
-        )}
-        {onClearFilters && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onClearFilters}
-            className="h-8 gap-1.5 px-2"
-          >
-            <X className="h-3.5 w-3.5" />
-            <span>Clear</span>
-          </Button>
+        ) : (
+          <>
+            {children}
+            {appliedOverflow.map((filter) => (
+              // Fragment rather than a wrapper element: the control has to be the
+              // bar's own flex item for its sizing to behave like the inline ones'.
+              <Fragment key={filter.key}>{filter.control}</Fragment>
+            ))}
+            {tuckedAway.length > 0 && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" className={filterControlClass()}>
+                    <SlidersHorizontal aria-hidden className="h-3.5 w-3.5" />
+                    <span>More filters</span>
+                    <ChevronDown
+                      aria-hidden
+                      className="h-4 w-4 text-muted-foreground"
+                    />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-72 space-y-3">
+                  {tuckedAway.map((filter) => (
+                    <div
+                      key={filter.key}
+                      // The control is the same compact trigger used in the bar,
+                      // stretched to the popover width so this reads as a small form
+                      // rather than a second filter bar. Scoped to the row's direct
+                      // child so a control that renders buttons of its own inside
+                      // itself keeps their widths, and matched by element rather than
+                      // by `[data-slot=button]`: a trigger reaches its <button>
+                      // through a Radix `asChild` wrapper, which overwrites Button's
+                      // `data-slot` with its own (`popover-trigger`/`select-trigger`).
+                      className="space-y-1.5 [&>button]:w-full [&>button]:max-w-none"
+                    >
+                      <span className="block text-xs font-medium">
+                        {filter.label}
+                      </span>
+                      {filter.control}
+                    </div>
+                  ))}
+                </PopoverContent>
+              </Popover>
+            )}
+            {onClearFilters && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onClearFilters}
+                className="h-8 gap-1.5 px-2"
+              >
+                <X className="h-3.5 w-3.5" />
+                <span>Clear</span>
+              </Button>
+            )}
+          </>
         )}
         {actions && (
           <div className="flex basis-full items-center justify-start gap-1.5 md:ml-auto md:basis-auto">
@@ -317,5 +395,20 @@ export function FilterSelect({
         contentClassName,
       )}
     />
+  );
+}
+
+// Keep this breakpoint aligned with Tailwind's lg layout.
+function subscribeToCompactFilters(onChange: () => void) {
+  if (typeof window.matchMedia !== "function") return () => {};
+  const query = window.matchMedia("(max-width: 1023px)");
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function getCompactFiltersSnapshot() {
+  return (
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(max-width: 1023px)").matches
   );
 }

--- a/platform/frontend/src/components/roles/roles-list.ee.tsx
+++ b/platform/frontend/src/components/roles/roles-list.ee.tsx
@@ -433,15 +433,16 @@ export function RolesList({ headerAction }: { headerAction?: ReactNode }) {
                 : undefined
             }
             actions={headerAction}
-          >
-            <SearchInput
-              isLoading={isLoading}
-              objectNamePlural="roles"
-              searchFields={["name"]}
-              paramName="name"
-              className={filterSearchClass}
-            />
-          </FilterBar>
+            search={
+              <SearchInput
+                isLoading={isLoading}
+                objectNamePlural="roles"
+                searchFields={["name"]}
+                paramName="name"
+                className={filterSearchClass}
+              />
+            }
+          />
         </CollectionFilters>
 
         {isLoadingError ? (

--- a/platform/frontend/src/components/settings/api-keys-card.tsx
+++ b/platform/frontend/src/components/settings/api-keys-card.tsx
@@ -332,13 +332,14 @@ function ApiKeysCardContent() {
                     ? () => updateQueryParams({ search: null, page: "1" })
                     : undefined
                 }
-              >
-                <SearchInput
-                  objectNamePlural="API keys"
-                  searchFields={["key name"]}
-                  className={filterSearchClass}
-                />
-              </FilterBar>
+                search={
+                  <SearchInput
+                    objectNamePlural="API keys"
+                    searchFields={["key name"]}
+                    className={filterSearchClass}
+                  />
+                }
+              />
             </CollectionFilters>
             {isApiKeysLoadError ? (
               <QueryLoadError

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -324,13 +324,16 @@ export function TeamsList() {
     <>
       <BulkActionsScope>
         <CollectionFilters>
-          <FilterBar>
-            <SearchInput
-              isLoading={isLoading}
-              objectNamePlural="teams"
-              searchFields={["name"]}
-              className={filterSearchClass}
-            />
+          <FilterBar
+            search={
+              <SearchInput
+                isLoading={isLoading}
+                objectNamePlural="teams"
+                searchFields={["name"]}
+                className={filterSearchClass}
+              />
+            }
+          >
             <LabelSelect
               labelKeys={labelKeys}
               LabelKeyRowComponent={TeamLabelKeyRow}


### PR DESCRIPTION
Table filters wrapped into several rows on tablet and phone screens, while the Models table reserved excess space for short token limits and truncated model IDs.

The shared FilterBar now keeps search beside a funnel button below 1024px and moves the remaining filters into a popover. Search inputs use an explicit slot across list pages; desktop retains inline filters and its existing More filters behavior. The compact popover includes secondary filters and Clear, indicates applied filters, and avoids an empty trigger on search-only lists.

The Models table gives Model ID the remaining width and bounds metadata columns, with horizontal scrolling below 1000px.

Verified in Chrome at phone, tablet, and desktop widths, including selecting and clearing a model filter and opening the audit-log filters. Regression tests cover selection and search persistence across resizing, clearing filters, and search-only lists.
