### PR TITLE
fix(mcp): align registry view toggle order

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1172,9 +1172,7 @@ export function InternalMCPCatalog({
                   onChange={setSort}
                   options={sortOptions}
                 />
-                {!selectedFacet && (
-                  <TableCardViewToggle order={["table", "cards"]} />
-                )}
+                {!selectedFacet && <TableCardViewToggle />}
               </>
             }
             search={


### PR DESCRIPTION
The MCP Registry presented its list-view toggle before its card-view toggle, unlike the other customizable collection pages.

This removes the Registry-specific ordering override so it uses the shared card-first, list-second control order while preserving the existing default list layout and stored view preference.

Verified in the running application by signing in, opening the MCP Registry, confirming the card control renders to the left of the list control, and switching between both layouts. The complete frontend check passed (5,286 tests, type-check, knip, and Biome).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>