### PR TITLE
feat(frontend): backport floating edit-page save bars to release/1.3

### DIFF
--- a/platform/frontend/src/app/plugins/[id]/page.client.tsx
+++ b/platform/frontend/src/app/plugins/[id]/page.client.tsx
@@ -24,6 +24,7 @@ import { CreatedByCell } from "@/components/created-by-cell";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { PageLayout } from "@/components/page-layout";
 import { QueryLoadError } from "@/components/query-load-error";
+import { FloatingActionBar } from "@/components/settings/settings-block";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -41,7 +42,6 @@ import {
   useGuardedInAppNavigation,
   useUnsavedChangesGuard,
 } from "@/components/unsaved-changes-guard";
-import { WizardFooter } from "@/components/wizard-footer";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { formatPermissionConstraint } from "@/lib/auth/auth.utils";
 import { useFeature } from "@/lib/config/config.query";
@@ -508,36 +508,32 @@ function PluginDetailView({
           githubAppConfigs={githubAppConfigOptions}
         />
 
-        {/* A reader who cannot change the plugin has no save row at all — the
-            alert above already says why. */}
+        {/* The save row floats at the foot of the form so it is in reach
+            without scrolling to the bottom of a long plugin, the same bar the
+            settings pages use. A reader who cannot change the plugin has no
+            save row at all — the alert above already says why. */}
         {!isReadOnly && (
-          <WizardFooter className="border-t-0 sm:justify-end">
-            <div className="flex items-center gap-2">
-              {isDirty && !isSaving && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={discardChanges}
-                >
-                  Discard changes
-                </Button>
+          <FloatingActionBar>
+            <PermissionButton
+              permissions={{ plugin: ["update", "admin"] }}
+              disabled={!isDirty || !isComplete || isGone || isSaving}
+              onClick={handleSave}
+            >
+              {isSaving ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span>Saving...</span>
+                </>
+              ) : (
+                <span>Save changes</span>
               )}
-              <PermissionButton
-                permissions={{ plugin: ["update", "admin"] }}
-                disabled={!isDirty || !isComplete || isGone || isSaving}
-                onClick={handleSave}
-              >
-                {isSaving ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <span>Saving...</span>
-                  </>
-                ) : (
-                  <span>Save changes</span>
-                )}
-              </PermissionButton>
-            </div>
-          </WizardFooter>
+            </PermissionButton>
+            {isDirty && !isSaving && (
+              <Button type="button" variant="outline" onClick={discardChanges}>
+                Discard changes
+              </Button>
+            )}
+          </FloatingActionBar>
         )}
       </div>
 

--- a/platform/frontend/src/app/skills/[id]/page.client.tsx
+++ b/platform/frontend/src/app/skills/[id]/page.client.tsx
@@ -15,6 +15,7 @@ import { AgentBadge } from "@/components/agent-badge";
 import type { ProfileLabelsRef } from "@/components/agent-labels";
 import { CreatedByCell } from "@/components/created-by-cell";
 import { PageLayout } from "@/components/page-layout";
+import { FloatingActionBar } from "@/components/settings/settings-block";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -32,7 +33,6 @@ import {
   useGuardedInAppNavigation,
   useUnsavedChangesGuard,
 } from "@/components/unsaved-changes-guard";
-import { WizardFooter } from "@/components/wizard-footer";
 import { formatPermissionConstraint } from "@/lib/auth/auth.utils";
 import {
   backToListLabel,
@@ -454,38 +454,36 @@ function SkillDetailView({
             }
           />
 
-          {/* A reader who cannot change the skill has no save row at all — the
-              alert above already says why. No rule above it either: the panel
-              is already ruled off, and a second line right under it read as a
-              stray divider. */}
+          {/* The save row floats at the foot of the form so it is in reach
+              without scrolling to the bottom of a long skill, the same bar the
+              settings pages use. A reader who cannot change the skill has no
+              save row at all — the alert above already says why. */}
           {!isReadOnly && (
-            <WizardFooter className="border-t-0 sm:justify-end">
-              <div className="flex items-center gap-2">
-                {isDirty && !isSaving && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={discardChanges}
-                  >
-                    Discard changes
-                  </Button>
+            <FloatingActionBar>
+              <PermissionButton
+                permissions={{ skill: ["update"] }}
+                disabled={!isDirty || !contentComplete || isGone || isSaving}
+                onClick={handleSave}
+              >
+                {isSaving ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span>Saving...</span>
+                  </>
+                ) : (
+                  <span>Save changes</span>
                 )}
-                <PermissionButton
-                  permissions={{ skill: ["update"] }}
-                  disabled={!isDirty || !contentComplete || isGone || isSaving}
-                  onClick={handleSave}
+              </PermissionButton>
+              {isDirty && !isSaving && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={discardChanges}
                 >
-                  {isSaving ? (
-                    <>
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                      <span>Saving...</span>
-                    </>
-                  ) : (
-                    <span>Save changes</span>
-                  )}
-                </PermissionButton>
-              </div>
-            </WizardFooter>
+                  Discard changes
+                </Button>
+              )}
+            </FloatingActionBar>
           )}
         </div>
       )}

--- a/platform/frontend/src/components/agent-form.tsx
+++ b/platform/frontend/src/components/agent-form.tsx
@@ -45,6 +45,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -820,6 +821,12 @@ const AGENT_FORM_SECTIONS: readonly AgentFormSection[] = [
 
 /** What a caller-rendered footer gets to build its buttons from. */
 export interface AgentFormFooterState {
+  /**
+   * The form element's `id`. A footer rendered into a floating bar is portaled
+   * out of the `<form>`, so its submit button carries `form={formId}` to stay
+   * wired to the form it no longer sits inside.
+   */
+  formId: string;
   /** Create mode (no agent yet) vs. edit mode. */
   isCreate: boolean;
   /** A save is in flight — disable everything that would start another. */
@@ -924,6 +931,9 @@ export function AgentForm({
   openToolsCombobox = false,
 }: AgentFormProps) {
   const appName = useAppName();
+  // Given to the footer so a submit button portaled out of this form (into a
+  // floating save bar) stays associated with it via `form={formId}`.
+  const formId = useId();
   const mountedSections = new Set<AgentFormSection>(sections);
   const showConfigurationSections = mountedSections.has("configuration");
   const showMessagingSection = mountedSections.has("messaging");
@@ -2729,6 +2739,7 @@ export function AgentForm({
     !environmentConflicts.blocksSave &&
     !(scope === "team" && hasNoAvailableTeams);
   const footerState: AgentFormFooterState = {
+    formId,
     isCreate: !agent,
     isSaving: isSaving || createAgent.isPending || updateAgent.isPending,
     isDirty,
@@ -2737,6 +2748,7 @@ export function AgentForm({
   };
   return (
     <form
+      id={formId}
       className="flex flex-col"
       autoComplete="off"
       onSubmit={(event) => {

--- a/platform/frontend/src/components/agent-pages/agent-create-page.test.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-create-page.test.tsx
@@ -44,6 +44,7 @@ vi.mock("@/components/agent-form", () => ({
           fire created
         </button>
         {props.footer?.({
+          formId: "agent-form",
           isCreate: true,
           isSaving: false,
           isDirty: false,

--- a/platform/frontend/src/components/agent-pages/agent-detail-page.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-detail-page.tsx
@@ -29,6 +29,7 @@ import { ExternalDocsLink } from "@/components/external-docs-link";
 import { PageBackLink } from "@/components/page-back-link";
 import { PageLayout } from "@/components/page-layout";
 import { QueryLoadError } from "@/components/query-load-error";
+import { FloatingActionBar } from "@/components/settings/settings-block";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -53,7 +54,6 @@ import {
   useGuardedInAppNavigation,
   useUnsavedChangesGuard,
 } from "@/components/unsaved-changes-guard";
-import { WizardFooter } from "@/components/wizard-footer";
 import {
   useDeleteProfile,
   useExportAgent,
@@ -630,21 +630,25 @@ function AgentDetails({
                 openToolsCombobox={openToolsCombobox}
                 onDirtyChange={setIsDirty}
                 footer={({
+                  formId,
                   isSaving,
                   isDirty: formDirty,
                   canSubmit,
                   readOnly,
                 }) =>
+                  // The save row floats at the foot of the form so it is in
+                  // reach without scrolling to the bottom of a long
+                  // configuration, the same bar the settings pages use. The bar
+                  // portals out of the form, so the submit button carries
+                  // `form={formId}` to stay wired to it.
                   // Nothing to save onto once the record is gone; the PUT would
                   // only come back 404. A reader who cannot change it has no
                   // save row at all — the alert above already says why.
-                  // No rule above the save row either: the panel's sections
-                  // are already ruled apart, and a second line right under the
-                  // last of them read as a stray divider.
                   readOnly ? null : (
-                    <WizardFooter className="border-t-0 sm:justify-end">
+                    <FloatingActionBar>
                       <Button
                         type="submit"
+                        form={formId}
                         disabled={
                           !canSubmit || isGone || isSaving || !formDirty
                         }
@@ -659,7 +663,7 @@ function AgentDetails({
                           <span>Save changes</span>
                         )}
                       </Button>
-                    </WizardFooter>
+                    </FloatingActionBar>
                   )
                 }
               />

--- a/platform/frontend/src/components/settings/settings-block.test.tsx
+++ b/platform/frontend/src/components/settings/settings-block.test.tsx
@@ -3,12 +3,46 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import {
+  FloatingActionBar,
   SettingsBlock,
   SettingsSaveBar,
   SettingsSectionStack,
 } from "./settings-block";
 
 vi.mock("@/lib/auth/auth.query");
+
+describe("FloatingActionBar", () => {
+  it("floats its actions in a sticky bar when there is no stack to portal into", () => {
+    // The shape the agent, skill and plugin detail pages render it in: on their
+    // own, not inside a SettingsSectionStack, so the bar sticks from where it
+    // stands instead of riding away at the foot of a long form.
+    render(
+      <FloatingActionBar>
+        <button type="button">Save changes</button>
+      </FloatingActionBar>,
+    );
+
+    const save = screen.getByRole("button", { name: "Save changes" });
+    expect(save.closest(".sticky")).not.toBeNull();
+  });
+
+  it("moves into the stack's slot when rendered inside one", () => {
+    const { container } = render(
+      <SettingsSectionStack>
+        <FloatingActionBar>
+          <button type="button">Save changes</button>
+        </FloatingActionBar>
+      </SettingsSectionStack>,
+    );
+
+    const stack = container.firstElementChild as HTMLElement;
+    const slot = stack.lastElementChild as HTMLElement;
+    expect(slot.className).toContain("sticky");
+    expect(slot).toContainElement(
+      screen.getByRole("button", { name: "Save changes" }),
+    );
+  });
+});
 
 describe("SettingsBlock", () => {
   it("renders a semantic section with an accessible heading", () => {

--- a/platform/frontend/src/components/settings/settings-block.tsx
+++ b/platform/frontend/src/components/settings/settings-block.tsx
@@ -2,7 +2,7 @@
 
 import type { Permissions } from "@archestra/shared";
 import type { ReactNode } from "react";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { PermissionButton } from "@/components/ui/permission-button";
@@ -61,6 +61,124 @@ export function SettingsBlock({
   );
 }
 
+/**
+ * The floating card the save rows across the app ride in: a settings page's
+ * Save/Cancel, and the Save/Discard rows on the agent, MCP gateway, skill and
+ * plugin detail pages. It keeps the actions in reach at the foot of a long
+ * form without the reader scrolling to the bottom for them.
+ *
+ * Inside a {@link SettingsSectionStack} the card belongs to the stack's slot,
+ * not to wherever the page declared it (see that component for why).
+ *
+ * Outside a stack it has to float on its own. A plain `position: sticky` bar
+ * declared in the page content is enough on a settings page, but a detail page
+ * asks {@link PageLayout} for a `min-width` floor, which wraps its content in
+ * an `overflow-x` box — and that box is itself a scroll container, so a sticky
+ * bar inside it pins to the foot of the *content* (scrolled past with it)
+ * rather than to the viewport. To float for the whole page regardless, the bar
+ * portals up to the page's real scroll container and borrows the content
+ * column's horizontal box from an in-flow anchor left where it was declared.
+ * With no such container to find (a bare unit test, or a surface that never
+ * sets one) it falls back to sticking from where it stands.
+ */
+export function FloatingActionBar({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const slot = useContext(SaveBarSlotContext);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  // The scroll container to portal into, plus the content column's offset and
+  // width within it, so the floating card lines up with the form above it.
+  const [portal, setPortal] = useState<{
+    target: HTMLElement;
+    left: number;
+    width: number;
+  } | null>(null);
+
+  useEffect(() => {
+    // A stack owns placement through its slot; nothing to measure or portal.
+    if (slot) return;
+    const anchor = anchorRef.current;
+    const target = anchor?.closest<HTMLElement>("[data-page-scroll-container]");
+    if (!anchor || !target) return;
+
+    const measure = () => {
+      const box = anchor.getBoundingClientRect();
+      // Hidden (display:none ancestor) — keep the last good measurement rather
+      // than snapping the bar to the top-left corner.
+      if (box.width === 0) return;
+      const targetBox = target.getBoundingClientRect();
+      const left = box.left - targetBox.left;
+      const width = box.width;
+      // Skip no-op updates: this also runs on every scroll (below), and a fresh
+      // object each time would re-render the card on plain vertical scroll.
+      setPortal((prev) =>
+        prev && prev.left === left && prev.width === width
+          ? prev
+          : { target, left, width },
+      );
+    };
+
+    measure();
+    // Re-measure when the column reflows: a sidebar collapse/expand, a window
+    // resize, the content growing a scrollbar.
+    const observer =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(measure);
+    observer?.observe(anchor);
+    observer?.observe(target);
+    window.addEventListener("resize", measure);
+    // On a viewport narrower than the content column, PageLayout's `overflow-x`
+    // box scrolls the form sideways under the bar; that moves the anchor's left
+    // edge without resizing anything, so track scroll too. Capture phase, since
+    // scroll does not bubble from the inner container.
+    document.addEventListener("scroll", measure, true);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", measure);
+      document.removeEventListener("scroll", measure, true);
+    };
+  }, [slot]);
+
+  const bar = (
+    <div
+      className={cn(
+        "flex flex-wrap gap-3 bg-background p-4 rounded-lg border border-border shadow-lg",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+
+  if (slot) return createPortal(bar, slot);
+
+  return (
+    <>
+      {/* Left where the bar was declared, so its geometry tracks the content
+          column even as the portaled card floats elsewhere. */}
+      <div ref={anchorRef} aria-hidden className="h-0" />
+      {portal ? (
+        createPortal(
+          <div
+            className="sticky bottom-4 z-10"
+            style={{ marginLeft: portal.left, width: portal.width }}
+          >
+            {bar}
+          </div>,
+          portal.target,
+        )
+      ) : (
+        <div className="sticky bottom-4 z-10">{bar}</div>
+      )}
+    </>
+  );
+}
+
 interface SettingsSaveBarProps {
   hasChanges: boolean;
   isSaving: boolean;
@@ -78,12 +196,10 @@ export function SettingsSaveBar({
   onCancel,
   disabledSave,
 }: SettingsSaveBarProps) {
-  const slot = useContext(SaveBarSlotContext);
-
   if (!hasChanges) return null;
 
-  const bar = (
-    <div className="flex gap-3 bg-background p-4 rounded-lg border border-border shadow-lg">
+  return (
+    <FloatingActionBar>
       <PermissionButton
         permissions={permissions}
         onClick={onSave}
@@ -94,16 +210,7 @@ export function SettingsSaveBar({
       <Button variant="outline" onClick={onCancel} disabled={isSaving}>
         Cancel
       </Button>
-    </div>
-  );
-
-  // Inside a stack the bar belongs to the stack's slot, not to wherever the
-  // page declared it. Outside one there is nothing to move it into, so it
-  // sticks from where it stands.
-  return slot ? (
-    createPortal(bar, slot)
-  ) : (
-    <div className="sticky bottom-4 z-10">{bar}</div>
+    </FloatingActionBar>
   );
 }
 


### PR DESCRIPTION
Backports #7769 to `release/1.3` so Save stays within reach on long agent, MCP gateway, skill, and plugin edit pages. The shared floating action bar escapes the content scroll wrapper, and agent/gateway submit buttons retain their form association when portaled.

Clean cherry-pick of b187f9d73cd7468ce84c10a46c31ac7a820e7e38, including its tests; no conflict resolutions or additional changes. The source PR is still open.

Validated on the release branch with the affected settings, agent form/page, skill, and plugin tests, covering existing save/discard behavior and floating-bar fallback/slot placement. Browser verification was performed on the source PR; it was not repeated for this backport.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>