### PR TITLE
fix(mcp): align registry view toggle order on release/1.3

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1172,9 +1172,7 @@ export function InternalMCPCatalog({
                   onChange={setSort}
                   options={sortOptions}
                 />
-                {!selectedFacet && (
-                  <TableCardViewToggle order={["table", "cards"]} />
-                )}
+                {!selectedFacet && <TableCardViewToggle />}
               </>
             }
             search={


### PR DESCRIPTION
Backports #7768 to `release/1.3`.

The MCP Registry now uses the shared card-first, list-second view toggle order. This removes its ordering override while preserving the default list layout and saved view preference.

The cherry-pick applied without conflicts. Existing view tests pass, covering layout switching and persisted preferences. The original PR also verified the toggle order and both layouts in the running application.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>