### PR TITLE
fix(frontend): update browser titles for chat and connect pages

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -194,6 +194,7 @@ import {
 } from "@/lib/config/connectivity";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
+import { usePageTitle } from "@/lib/hooks/use-page-title";
 import { useLlmModels, useLlmModelsByProvider } from "@/lib/llm-models.query";
 import {
   type SupportedProvider,
@@ -830,6 +831,11 @@ export function ChatPageContent({
   // Fetch conversation with messages
   const { data: conversation, isLoading: isLoadingConversation } =
     useConversation(conversationId);
+  usePageTitle(
+    conversation
+      ? getConversationDisplayTitle(conversation.title, conversation.messages)
+      : "Chat",
+  );
   const canManageShare =
     !!conversationId &&
     !!conversation &&

--- a/platform/frontend/src/app/chat/runs/page.client.tsx
+++ b/platform/frontend/src/app/chat/runs/page.client.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useCancelAgentRun, useMyAgentRun } from "@/lib/agent-runtime.query";
 import { copyToClipboard } from "@/lib/clipboard";
+import { usePageTitle } from "@/lib/hooks/use-page-title";
 
 export function AgentRunChatSession({ taskId }: { taskId: string }) {
   const query = useMyAgentRun(taskId);
@@ -41,6 +42,7 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
   );
   const [commandCopied, setCommandCopied] = useState(false);
   const run = query.data;
+  usePageTitle(run?.title ?? "Agent Runtime");
 
   // Metadata and the log stream are readable by shared viewers, but attaching
   // to the live terminal runs a shell under the owner's own credentials — so it

--- a/platform/frontend/src/app/connection/page.tsx
+++ b/platform/frontend/src/app/connection/page.tsx
@@ -5,12 +5,14 @@ import { LoadingState } from "@/components/loading";
 import { PageLayout } from "@/components/page-layout";
 import { QueryLoadError } from "@/components/query-load-error";
 import { useDefaultMcpGateway } from "@/lib/agent.query";
+import { usePageTitle } from "@/lib/hooks/use-page-title";
 import { useLlmProxy } from "@/lib/llm-proxy.query";
 import { useOrganization } from "@/lib/organization.query";
 import { ConnectionFlow } from "./connection-flow";
 import { getConnectableProviders } from "./connection-flow.utils";
 
 export default function ConnectionPage() {
+  usePageTitle("Connect");
   const { data: defaultMcpGateway } = useDefaultMcpGateway();
   const organizationQuery = useOrganization(true, { fresh: true });
   useEffect(() => {

--- a/platform/frontend/src/app/layout.tsx
+++ b/platform/frontend/src/app/layout.tsx
@@ -15,6 +15,7 @@ import { DynamicHead } from "@/components/dynamic-head";
 import { OrgThemeLoader } from "@/components/org-theme-loader";
 import { ChatProvider } from "@/lib/chat/global-chat.context";
 import { getDeploymentFavicon } from "@/lib/favicon.server";
+import { PageTitleProvider } from "@/lib/hooks/use-page-title";
 import { WebsocketInitializer } from "./_parts/websocket-initializer";
 import { WithAuthCheck } from "./_parts/with-auth-check";
 import { WithPagePermissions } from "./_parts/with-page-permissions";
@@ -258,15 +259,17 @@ export default async function RootLayout({
                 disableTransitionOnChange
               >
                 <PostHogProviderWrapper>
-                  <OrgThemeLoader />
-                  <DynamicHead />
-                  <WithAuthCheck>
-                    <WebsocketInitializer />
-                    <RumTracker />
-                    <AppShell>
-                      <WithPagePermissions>{children}</WithPagePermissions>
-                    </AppShell>
-                  </WithAuthCheck>
+                  <PageTitleProvider>
+                    <OrgThemeLoader />
+                    <DynamicHead />
+                    <WithAuthCheck>
+                      <WebsocketInitializer />
+                      <RumTracker />
+                      <AppShell>
+                        <WithPagePermissions>{children}</WithPagePermissions>
+                      </AppShell>
+                    </WithAuthCheck>
+                  </PageTitleProvider>
                 </PostHogProviderWrapper>
               </ThemeProvider>
             </ChatProvider>

--- a/platform/frontend/src/components/dynamic-head.tsx
+++ b/platform/frontend/src/components/dynamic-head.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_APP_FULL_NAME,
 } from "@archestra/shared";
 import { useEffect } from "react";
+import { useCurrentPageTitle } from "@/lib/hooks/use-page-title";
 import { useAppearanceSettings } from "@/lib/organization.query";
 
 const DEFAULT_FAVICON_PATH = "/default-favicon.ico";
@@ -18,12 +19,14 @@ const PNG_DATA_URI_PREFIX = "data:image/png;base64,";
  */
 export function DynamicHead() {
   const { data: appearance, isFetched } = useAppearanceSettings();
+  const pageTitle = useCurrentPageTitle();
 
   // Update document title only after data has loaded to avoid flashing default
   useEffect(() => {
     if (!isFetched) return;
-    document.title = appearance?.appName || DEFAULT_APP_FULL_NAME;
-  }, [appearance?.appName, isFetched]);
+    const appName = appearance?.appName || DEFAULT_APP_FULL_NAME;
+    document.title = pageTitle ? `${pageTitle} - ${appName}` : appName;
+  }, [appearance?.appName, isFetched, pageTitle]);
 
   // The server-rendered layout already contains the current content-versioned
   // favicon. Avoid replacing that stable candidate when the same appearance

--- a/platform/frontend/src/lib/hooks/use-page-title.test.tsx
+++ b/platform/frontend/src/lib/hooks/use-page-title.test.tsx
@@ -1,0 +1,42 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/organization.query", () => ({
+  useAppearanceSettings: () => ({
+    data: { appName: "Example App" },
+    isFetched: true,
+  }),
+}));
+
+import { DynamicHead } from "@/components/dynamic-head";
+import { PageTitleProvider, usePageTitle } from "./use-page-title";
+
+function PageTitle({ title }: { title: string }) {
+  usePageTitle(title);
+  return null;
+}
+
+describe("usePageTitle", () => {
+  afterEach(() => {
+    document.title = "";
+  });
+
+  it("updates the tab when the page title changes and restores the app title on exit", async () => {
+    const renderTitle = (title: string) => (
+      <PageTitleProvider>
+        <DynamicHead />
+        <PageTitle title={title} />
+      </PageTitleProvider>
+    );
+    const { rerender, unmount } = render(renderTitle("Chat"));
+
+    await waitFor(() => expect(document.title).toBe("Chat - Example App"));
+
+    rerender(renderTitle("Incident review"));
+    await waitFor(() =>
+      expect(document.title).toBe("Incident review - Example App"),
+    );
+
+    unmount();
+  });
+});

--- a/platform/frontend/src/lib/hooks/use-page-title.test.tsx
+++ b/platform/frontend/src/lib/hooks/use-page-title.test.tsx
@@ -1,34 +1,47 @@
-import { render, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("@/lib/organization.query", () => ({
-  useAppearanceSettings: () => ({
-    data: { appName: "Example App" },
-    isFetched: true,
-  }),
-}));
-
+import { archestraApiClient } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { DynamicHead } from "@/components/dynamic-head";
 import { PageTitleProvider, usePageTitle } from "./use-page-title";
 
-function PageTitle({ title }: { title: string }) {
-  usePageTitle(title);
-  return null;
-}
+const server = setupServer(
+  http.get("http://localhost:9000/api/organization/appearance-settings", () =>
+    HttpResponse.json({ appName: "Example App" }),
+  ),
+);
+
+beforeAll(() => {
+  archestraApiClient.setConfig({ baseUrl: "http://localhost:9000" });
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  cleanup();
+  document.title = "";
+});
+
+afterAll(() => {
+  server.close();
+  archestraApiClient.setConfig({ baseUrl: "" });
+});
 
 describe("usePageTitle", () => {
-  afterEach(() => {
-    document.title = "";
-  });
-
   it("updates the tab when the page title changes and restores the app title on exit", async () => {
-    const renderTitle = (title: string) => (
-      <PageTitleProvider>
-        <DynamicHead />
-        <PageTitle title={title} />
-      </PageTitleProvider>
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const renderTitle = (title: string | null) => (
+      <QueryClientProvider client={client}>
+        <PageTitleProvider>
+          <DynamicHead />
+          {title !== null && <PageTitle title={title} />}
+        </PageTitleProvider>
+      </QueryClientProvider>
     );
-    const { rerender, unmount } = render(renderTitle("Chat"));
+    const { rerender } = render(renderTitle("Chat"));
 
     await waitFor(() => expect(document.title).toBe("Chat - Example App"));
 
@@ -37,6 +50,12 @@ describe("usePageTitle", () => {
       expect(document.title).toBe("Incident review - Example App"),
     );
 
-    unmount();
+    rerender(renderTitle(null));
+    await waitFor(() => expect(document.title).toBe("Example App"));
   });
 });
+
+function PageTitle({ title }: { title: string }) {
+  usePageTitle(title);
+  return null;
+}

--- a/platform/frontend/src/lib/hooks/use-page-title.tsx
+++ b/platform/frontend/src/lib/hooks/use-page-title.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+const PageTitleContext = createContext<{
+  pageTitle: string | null;
+  setPageTitle: (title: string | null) => void;
+} | null>(null);
+
+export function PageTitleProvider({ children }: { children: ReactNode }) {
+  const [pageTitle, setPageTitle] = useState<string | null>(null);
+
+  return (
+    <PageTitleContext.Provider value={{ pageTitle, setPageTitle }}>
+      {children}
+    </PageTitleContext.Provider>
+  );
+}
+
+export function useCurrentPageTitle() {
+  return useContext(PageTitleContext)?.pageTitle ?? null;
+}
+
+/** Keeps the browser tab aligned with the page currently shown in the app. */
+export function usePageTitle(pageTitle: string) {
+  const setPageTitle = useContext(PageTitleContext)?.setPageTitle;
+
+  useEffect(() => {
+    setPageTitle?.(pageTitle);
+
+    return () => {
+      setPageTitle?.(null);
+    };
+  }, [pageTitle, setPageTitle]);
+}


### PR DESCRIPTION
Connect, Chat, and Agent Runtime sessions could retain a previous page’s browser-tab title, making multiple tabs difficult to distinguish.

Adds page-title context to the existing dynamic head component. Connect and Chat set their page names, while conversations and runtime sessions update the title when their names load. The configured deployment name remains the suffix.

Verified in Chrome against the local Tilt preview: navigating Projects → Connect → Chat displays `Connect - Archestra.AI` and then `Chat - Archestra.AI`. An MSW-backed integration test exercises the real appearance query and dynamic head, covering a loaded conversation title and restoration of the deployment name when the page exits.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>