### PR TITLE
fix(frontend): keep environment warnings visible below page tabs (1.3)

### DIFF
--- a/platform/frontend/src/components/agent-form.tsx
+++ b/platform/frontend/src/components/agent-form.tsx
@@ -91,6 +91,8 @@ import {
   KnowledgeSourcesEditor,
 } from "@/components/knowledge-sources-editor";
 import { LlmProviderApiKeyDropdown } from "@/components/llm-provider-api-key-dropdown";
+import { McpConflictServerList } from "@/components/mcp-conflict-server-list";
+import { PageHeaderBanner } from "@/components/page-header-banner";
 import {
   formatPermissionRequirement,
   PermissionRequirementHint,
@@ -113,6 +115,10 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import {
+  CompactWarning,
+  CompactWarningText,
+} from "@/components/ui/compact-warning";
 import { ExpandableText } from "@/components/ui/expandable-text";
 import { FieldDescription } from "@/components/ui/field-description";
 import { Input } from "@/components/ui/input";
@@ -4069,80 +4075,84 @@ export function AgentForm({
           )}
         </div>
       </fieldset>
-      {!readOnly && environmentConflicts.conflicts.length > 0 && (
-        <Alert variant="warning" className="mt-4">
-          <AlertTriangle className="h-4 w-4" />
-          <AlertTitle>
-            {environmentConflicts.conflicts.length} MCP server
-            {environmentConflicts.conflicts.length === 1 ? null : (
-              <span>s</span>
-            )}{" "}
-            not in this environment
-          </AlertTitle>
-          <AlertDescription>
-            <p>
-              This agent&apos;s tools from{" "}
-              <span className="font-medium text-foreground">
-                {environmentConflicts.conflicts.map((c) => c.name).join(", ")}
-              </span>{" "}
-              stop working once it moves. Remove them or put the environment
-              back before saving.
-            </p>
+      {/* Environment warnings appear above the form, below the page tabs. */}
+      <PageHeaderBanner>
+        {!readOnly && environmentConflicts.conflicts.length > 0 && (
+          <CompactWarning className="flex-nowrap items-start gap-x-3 bg-amber-50/90 shadow-sm backdrop-blur-md dark:bg-amber-950/60">
+            <AlertTriangle className="mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <span className="block font-medium">
+                {environmentConflicts.conflicts.length} MCP server
+                {environmentConflicts.conflicts.length === 1 ? null : (
+                  <span>s</span>
+                )}{" "}
+                not in this environment
+              </span>
+              <CompactWarningText className="mt-1 block">
+                Tools from{" "}
+                <McpConflictServerList
+                  names={environmentConflicts.conflicts.map((c) => c.name)}
+                />{" "}
+                stop working once it moves.
+              </CompactWarningText>
+            </div>
             <Button
               type="button"
               variant="outline"
               size="sm"
-              className="mt-2"
+              className="h-7 shrink-0 self-center bg-background/80 px-2 text-xs"
               disabled={environmentConflicts.isRemoving || isSaving}
               onClick={() => void handleRemoveEnvironmentConflicts()}
             >
               <span>{removeConflictingToolsLabel}</span>
             </Button>
-          </AlertDescription>
-        </Alert>
-      )}
-      {!readOnly &&
-        environmentConflicts.blocksSave &&
-        environmentConflicts.conflicts.length === 0 && (
-          <Alert variant="warning" className="mt-4">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertDescription>
-              {environmentConflicts.isVerifying
-                ? "Checking which of this agent's tools work in the new environment…"
-                : "Could not check which of this agent's tools work in the new environment, so the change cannot be saved yet."}
-            </AlertDescription>
-          </Alert>
+          </CompactWarning>
         )}
-      {!readOnly && mcpEnvConflicts.length > 0 && (
-        <Alert variant="warning" className="mt-4">
-          <AlertTriangle className="h-4 w-4" />
-          <AlertTitle>
-            {mcpEnvConflicts.length} MCP server
-            {mcpEnvConflicts.length === 1 ? null : <span>s</span>} not in this
-            environment
-          </AlertTitle>
-          <AlertDescription>
-            <p>
-              Remove {mcpEnvConflicts.length === 1 ? "it" : "them"} or change
-              the environment before saving:{" "}
-              <span className="font-medium text-foreground">
-                {mcpEnvConflicts.map((c) => c.name).join(", ")}
+        {!readOnly &&
+          environmentConflicts.blocksSave &&
+          environmentConflicts.conflicts.length === 0 && (
+            <CompactWarning className="flex-nowrap items-start gap-x-3 bg-amber-50/90 shadow-sm backdrop-blur-md dark:bg-amber-950/60">
+              <AlertTriangle className="mt-0.5" />
+              <div className="min-w-0 flex-1">
+                <CompactWarningText className="text-amber-900 dark:text-amber-200">
+                  {environmentConflicts.isVerifying
+                    ? "Checking which of this agent's tools work in the new environment…"
+                    : "Could not check which of this agent's tools work in the new environment, so the change cannot be saved yet."}
+                </CompactWarningText>
+              </div>
+            </CompactWarning>
+          )}
+        {!readOnly && mcpEnvConflicts.length > 0 && (
+          <CompactWarning className="flex-nowrap items-start gap-x-3 bg-amber-50/90 shadow-sm backdrop-blur-md dark:bg-amber-950/60">
+            <AlertTriangle className="mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <span className="block font-medium">
+                {mcpEnvConflicts.length} MCP server
+                {mcpEnvConflicts.length === 1 ? null : <span>s</span>} not in
+                this environment
               </span>
-            </p>
+              <CompactWarningText className="mt-1 block">
+                Remove {mcpEnvConflicts.length === 1 ? "it" : "them"} or change
+                the environment before saving:{" "}
+                <McpConflictServerList
+                  names={mcpEnvConflicts.map((c) => c.name)}
+                />
+              </CompactWarningText>
+            </div>
             <Button
               type="button"
               variant="outline"
               size="sm"
-              className="mt-2"
+              className="h-7 shrink-0 self-center bg-background/80 px-2 text-xs"
               onClick={() =>
                 agentToolsEditorRef.current?.removeIncompatibleTools()
               }
             >
               Remove incompatible
             </Button>
-          </AlertDescription>
-        </Alert>
-      )}
+          </CompactWarning>
+        )}
+      </PageHeaderBanner>
       {!readOnly &&
         runtimeModelIncompatibility &&
         (!showConfigurationSections || !isActiveSection("configuration")) && (

--- a/platform/frontend/src/components/mcp-conflict-server-list.test.tsx
+++ b/platform/frontend/src/components/mcp-conflict-server-list.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { McpConflictServerList } from "./mcp-conflict-server-list";
+
+describe("McpConflictServerList", () => {
+  it("shows up to three names without an overflow control", () => {
+    render(<McpConflictServerList names={["Files", "Search", "Database"]} />);
+    expect(screen.getByText("Files, Search, Database")).toBeVisible();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("reveals only the remaining servers when the overflow control is focused", async () => {
+    const user = userEvent.setup();
+    render(
+      <McpConflictServerList
+        names={["Files", "Search", "Database", "Calendar", "Documents"]}
+      />,
+    );
+    expect(screen.queryByText("Calendar")).not.toBeInTheDocument();
+    await user.tab();
+    expect(screen.getByRole("button", { name: "2 more" })).toHaveFocus();
+    const tooltip = await screen.findByRole("tooltip");
+    expect(within(tooltip).getByText("Calendar")).toBeInTheDocument();
+    expect(within(tooltip).getByText("Documents")).toBeInTheDocument();
+    expect(within(tooltip).queryByText("Files")).not.toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/mcp-conflict-server-list.tsx
+++ b/platform/frontend/src/components/mcp-conflict-server-list.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export function McpConflictServerList({ names }: { names: string[] }) {
+  const remaining = names.slice(3);
+  return (
+    <span className="font-medium text-foreground">
+      <span>{names.slice(0, 3).join(", ")}</span>
+      {remaining.length > 0 && (
+        <>
+          <span>, and </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="link"
+                className="h-auto p-0 text-xs font-medium text-inherit underline decoration-dotted underline-offset-4"
+              >
+                <span>{remaining.length} more</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent
+              side="bottom"
+              align="start"
+              className="max-w-80 px-3 py-2.5"
+            >
+              <p className="mb-2 font-medium">Other incompatible MCP servers</p>
+              <ul className="space-y-1 text-muted-foreground">
+                {remaining.map((name) => (
+                  <li key={name} className="break-words">
+                    {name}
+                  </li>
+                ))}
+              </ul>
+            </TooltipContent>
+          </Tooltip>
+        </>
+      )}
+    </span>
+  );
+}

--- a/platform/frontend/src/components/page-header-banner.test.tsx
+++ b/platform/frontend/src/components/page-header-banner.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  PageHeaderBanner,
+  PageHeaderBannerSlotContext,
+} from "@/components/page-header-banner";
+
+describe("PageHeaderBanner", () => {
+  it("renders in place when there is no host content slot", () => {
+    // The fallback the clone/create surfaces and the unit tests rely on: with
+    // no PageLayout to pin into, the notice still shows where it stands.
+    render(
+      <PageHeaderBanner>
+        <span>1 MCP server not in this environment</span>
+      </PageHeaderBanner>,
+    );
+
+    expect(
+      screen.getByText("1 MCP server not in this environment"),
+    ).toBeInTheDocument();
+  });
+
+  it("portals its children into the content slot the layout provides", () => {
+    const slot = document.createElement("div");
+    document.body.appendChild(slot);
+
+    render(
+      <PageHeaderBannerSlotContext.Provider value={slot}>
+        <PageHeaderBanner>
+          <span>1 MCP server not in this environment</span>
+        </PageHeaderBanner>
+      </PageHeaderBannerSlotContext.Provider>,
+    );
+
+    // The notice lands in the content slot, not beside where it was declared.
+    expect(slot).toHaveTextContent("1 MCP server not in this environment");
+
+    slot.remove();
+  });
+});

--- a/platform/frontend/src/components/page-header-banner.tsx
+++ b/platform/frontend/src/components/page-header-banner.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { createContext, type ReactNode, useContext } from "react";
+import { createPortal } from "react-dom";
+
+/** The notice slot at the top of PageLayout's content area. */
+export const PageHeaderBannerSlotContext = createContext<HTMLElement | null>(
+  null,
+);
+
+/**
+ * Keeps page-level notices sticky above the form, below the page header and tabs.
+ * Without a layout slot (for example in a dialog), renders in place.
+ */
+export function PageHeaderBanner({ children }: { children: ReactNode }) {
+  const slot = useContext(PageHeaderBannerSlotContext);
+  if (slot) return createPortal(children, slot);
+  return <>{children}</>;
+}

--- a/platform/frontend/src/components/page-layout.test.tsx
+++ b/platform/frontend/src/components/page-layout.test.tsx
@@ -13,14 +13,6 @@ vi.mock("@/lib/hooks/use-app-name", () => ({
 
 describe("PageLayout tabs", () => {
   beforeEach(() => {
-    vi.stubGlobal(
-      "ResizeObserver",
-      class {
-        observe() {}
-        unobserve() {}
-        disconnect() {}
-      },
-    );
     vi.mocked(usePathname).mockReturnValue("/mcp/registry/abc");
     vi.mocked(useSearchParams).mockReturnValue(
       new URLSearchParams() as ReturnType<typeof useSearchParams>,

--- a/platform/frontend/src/components/page-layout.test.tsx
+++ b/platform/frontend/src/components/page-layout.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { usePathname, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PageHeaderBanner } from "@/components/page-header-banner";
 import { PageLayout } from "@/components/page-layout";
 
 vi.mock("next/navigation");
@@ -12,6 +13,14 @@ vi.mock("@/lib/hooks/use-app-name", () => ({
 
 describe("PageLayout tabs", () => {
   beforeEach(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
     vi.mocked(usePathname).mockReturnValue("/mcp/registry/abc");
     vi.mocked(useSearchParams).mockReturnValue(
       new URLSearchParams() as ReturnType<typeof useSearchParams>,
@@ -369,7 +378,9 @@ describe("PageLayout header", () => {
     ).toBeGreaterThan(0);
     const header = container.querySelector("[data-page-header]");
     expect(header?.parentElement).not.toHaveClass("overflow-x-auto");
-    expect(header?.nextElementSibling).toHaveClass("overflow-x-auto");
+    expect(container.querySelector("[data-page-content]")).toHaveClass(
+      "overflow-x-auto",
+    );
   });
 
   it("gives every wizard-width detail page the safe phone floor by default", () => {
@@ -382,6 +393,39 @@ describe("PageLayout header", () => {
     expect(
       container.querySelectorAll(".min-w-\\[20rem\\]").length,
     ).toBeGreaterThan(0);
+  });
+
+  it("places a page warning below the header and before the form", () => {
+    const { container } = render(
+      <PageLayout maxWidth="wizard" title="Edit agent">
+        <PageHeaderBanner>
+          <span>1 MCP server not in this environment</span>
+        </PageHeaderBanner>
+        <button type="button">Form action</button>
+      </PageLayout>,
+    );
+
+    const header = container.querySelector("[data-page-header]");
+    const banner = screen.getByText("1 MCP server not in this environment");
+    expect(header?.contains(banner)).toBe(false);
+    expect(
+      banner.compareDocumentPosition(
+        screen.getByRole("button", { name: "Form action" }),
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("gives the content banner slot no footprint until a banner rides in", () => {
+    // `empty:hidden` keeps a page with no banner reading exactly as before.
+    const { container } = render(
+      <PageLayout maxWidth="wizard" title="Edit agent">
+        <div>form</div>
+      </PageLayout>,
+    );
+
+    const slot = container.querySelector("[data-page-banner]");
+    expect(slot).not.toBeNull();
+    expect(slot?.children).toHaveLength(0);
   });
 
   it("keeps wizard and detail header copy within one shared height contract", () => {

--- a/platform/frontend/src/components/page-layout.tsx
+++ b/platform/frontend/src/components/page-layout.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
+import { PageHeaderBannerSlotContext } from "@/components/page-header-banner";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -139,6 +140,23 @@ export function PageLayout({
     minWidthKey === "none" && maxWidthKey === "wizard" ? "phone" : minWidthKey;
   const minWidth = MIN_WIDTH_CLASSES[resolvedMinWidthKey];
   const [overflowOpen, setOverflowOpen] = useState(false);
+  // The top of the content area, into which PageHeaderBanner portals a
+  // page-level notice without changing the header or tab layout.
+  const [bannerSlot, setBannerSlot] = useState<HTMLDivElement | null>(null);
+  const [headerElement, setHeaderElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  useEffect(() => {
+    if (!headerElement) return;
+    const measure = () =>
+      setHeaderHeight(headerElement.getBoundingClientRect().height);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(headerElement);
+    return () => observer.disconnect();
+  }, [headerElement]);
 
   // Split tabs for mobile: visible vs overflow
   const mobileVisibleTabs = tabs.slice(0, mobileVisibleCount);
@@ -157,29 +175,34 @@ export function PageLayout({
       : undefined;
 
   return (
-    <div className="flex min-h-full w-full min-w-0 flex-col">
-      <div
-        data-page-header
-        className="border-b border-border bg-background md:sticky md:top-0 md:z-20"
-      >
-        <div className={cn("mx-auto", minWidth, maxWidth, "px-6 pt-6 md:px-6")}>
-          {backLink && <div className="mb-2">{backLink}</div>}
-          {/* Below sm the action buttons drop under the title/description
-              instead of squeezing them into a sliver beside the buttons. */}
+    <PageHeaderBannerSlotContext.Provider value={bannerSlot}>
+      <div className="flex min-h-full w-full min-w-0 flex-col">
+        <div
+          ref={setHeaderElement}
+          data-page-header
+          className="border-b border-border bg-background md:sticky md:top-0 md:z-20"
+        >
           <div
-            className={cn(
-              "mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6",
-              maxWidthKey === "wizard" && "min-h-[5.75rem] sm:min-h-[3.75rem]",
-            )}
+            className={cn("mx-auto", minWidth, maxWidth, "px-6 pt-6 md:px-6")}
           >
+            {backLink && <div className="mb-2">{backLink}</div>}
+            {/* Below sm the action buttons drop under the title/description
+              instead of squeezing them into a sliver beside the buttons. */}
             <div
               className={cn(
-                "min-w-0 sm:flex-1",
+                "mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6",
                 maxWidthKey === "wizard" &&
-                  "min-h-10 sm:relative sm:h-[3.75rem] sm:min-h-0",
+                  "min-h-[5.75rem] sm:min-h-[3.75rem]",
               )}
             >
-              {/* Sibling pages of a tabbed section render PageLayout at the
+              <div
+                className={cn(
+                  "min-w-0 sm:flex-1",
+                  maxWidthKey === "wizard" &&
+                    "min-h-10 sm:relative sm:h-[3.75rem] sm:min-h-0",
+                )}
+              >
+                {/* Sibling pages of a tabbed section render PageLayout at the
                   same tree position, so React reconciles it across
                   client-side navigations instead of remounting. A rich
                   description (text mixed with links, like the Costs page)
@@ -188,182 +211,200 @@ export function PageLayout({
                   page-translate has re-parented them into <font> wrappers
                   (facebook/react#11538). Keying the wrappers by pathname
                   swaps a whole element per page instead. */}
-              {/* The status pill is a sibling of the heading, not part of it:
+                {/* The status pill is a sibling of the heading, not part of it:
                   detail titles already compose an icon, a name and badges
                   inside `title`, and folding a live state into the accessible
                   heading name would make the heading change every time the
                   probe does. */}
-              <div
-                className={cn(
-                  "flex min-w-0 items-center gap-2",
-                  maxWidthKey === "wizard"
-                    ? "flex-nowrap overflow-hidden"
-                    : "flex-wrap",
-                  description && maxWidthKey !== "wizard" && "mb-2",
-                )}
-              >
-                <h1
-                  className={cn(
-                    "min-w-0 text-2xl font-semibold tracking-tight",
-                    maxWidthKey === "wizard" && "max-h-10 overflow-hidden",
-                  )}
-                >
-                  <span key={pathname}>{title}</span>
-                </h1>
-                {status && <div className="shrink-0">{status}</div>}
-              </div>
-              {description && (
                 <div
-                  data-page-description
                   className={cn(
-                    "text-sm text-muted-foreground",
-                    maxWidthKey === "wizard" &&
-                      "hidden sm:absolute sm:inset-x-0 sm:bottom-0 sm:line-clamp-1",
+                    "flex min-w-0 items-center gap-2",
+                    maxWidthKey === "wizard"
+                      ? "flex-nowrap overflow-hidden"
+                      : "flex-wrap",
+                    description && maxWidthKey !== "wizard" && "mb-2",
                   )}
                 >
-                  <span key={pathname}>{description}</span>
+                  <h1
+                    className={cn(
+                      "min-w-0 text-2xl font-semibold tracking-tight",
+                      maxWidthKey === "wizard" && "max-h-10 overflow-hidden",
+                    )}
+                  >
+                    <span key={pathname}>{title}</span>
+                  </h1>
+                  {status && <div className="shrink-0">{status}</div>}
                 </div>
-              )}
-            </div>
-            {actionButton && <div className="shrink-0">{actionButton}</div>}
-          </div>
-          {tabs.length > 0 && (
-            <>
-              {/* Desktop: Show all tabs */}
-              <div className="hidden md:flex gap-4 mb-0 overflow-x-auto whitespace-nowrap">
-                {tabs.map((tab) => {
-                  const isSelected = tab === selectedTab;
-                  return (
-                    <Link
-                      key={tab.href}
-                      href={tab.href}
-                      aria-current={isSelected ? "page" : undefined}
-                      // Only this copy carries the test id — see the `tabs` prop.
-                      data-testid={tab.testId}
-                      className={cn(
-                        "relative cursor-pointer pb-3 text-sm font-medium transition-colors hover:text-foreground",
-                        isSelected
-                          ? "text-foreground"
-                          : "text-muted-foreground",
-                      )}
-                    >
-                      {tab.label}
-                      {isSelected && (
-                        <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </Link>
-                  );
-                })}
+                {description && (
+                  <div
+                    data-page-description
+                    className={cn(
+                      "text-sm text-muted-foreground",
+                      maxWidthKey === "wizard" &&
+                        "hidden sm:absolute sm:inset-x-0 sm:bottom-0 sm:line-clamp-1",
+                    )}
+                  >
+                    <span key={pathname}>{description}</span>
+                  </div>
+                )}
               </div>
+              {actionButton && <div className="shrink-0">{actionButton}</div>}
+            </div>
+            {tabs.length > 0 && (
+              <>
+                {/* Desktop: Show all tabs */}
+                <div className="hidden md:flex gap-4 mb-0 overflow-x-auto whitespace-nowrap">
+                  {tabs.map((tab) => {
+                    const isSelected = tab === selectedTab;
+                    return (
+                      <Link
+                        key={tab.href}
+                        href={tab.href}
+                        aria-current={isSelected ? "page" : undefined}
+                        // Only this copy carries the test id — see the `tabs` prop.
+                        data-testid={tab.testId}
+                        className={cn(
+                          "relative cursor-pointer pb-3 text-sm font-medium transition-colors hover:text-foreground",
+                          isSelected
+                            ? "text-foreground"
+                            : "text-muted-foreground",
+                        )}
+                      >
+                        {tab.label}
+                        {isSelected && (
+                          <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+                        )}
+                      </Link>
+                    );
+                  })}
+                </div>
 
-              {/* Mobile: Show first N tabs + overflow dropdown */}
-              <div className="flex md:hidden gap-3 mb-0 items-center whitespace-nowrap overflow-x-auto">
-                {mobileVisibleTabs.map((tab) => {
-                  const isSelected = tab === selectedTab;
-                  return (
-                    <Link
-                      key={tab.href}
-                      href={tab.href}
-                      aria-current={isSelected ? "page" : undefined}
-                      className={cn(
-                        "relative cursor-pointer pb-1 text-sm font-medium transition-colors hover:text-foreground",
-                        isSelected
-                          ? "text-foreground"
-                          : "text-muted-foreground",
-                      )}
-                    >
-                      {tab.label}
-                      {isSelected && (
-                        <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </Link>
-                  );
-                })}
+                {/* Mobile: Show first N tabs + overflow dropdown */}
+                <div className="flex md:hidden gap-3 mb-0 items-center whitespace-nowrap overflow-x-auto">
+                  {mobileVisibleTabs.map((tab) => {
+                    const isSelected = tab === selectedTab;
+                    return (
+                      <Link
+                        key={tab.href}
+                        href={tab.href}
+                        aria-current={isSelected ? "page" : undefined}
+                        className={cn(
+                          "relative cursor-pointer pb-1 text-sm font-medium transition-colors hover:text-foreground",
+                          isSelected
+                            ? "text-foreground"
+                            : "text-muted-foreground",
+                        )}
+                      >
+                        {tab.label}
+                        {isSelected && (
+                          <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+                        )}
+                      </Link>
+                    );
+                  })}
 
-                {mobileOverflowTabs.length > 0 && (
-                  <>
-                    <div className="h-5 w-px bg-border shrink-0" />
-                    <Popover open={overflowOpen} onOpenChange={setOverflowOpen}>
-                      <PopoverTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          className={cn(
-                            "relative h-auto cursor-pointer rounded-none px-1 pb-3 text-sm font-medium transition-colors hover:bg-transparent hover:text-foreground flex items-center gap-1",
-                            selectedOverflowTab
-                              ? "text-foreground"
-                              : "text-muted-foreground",
-                          )}
-                        >
-                          {/* Distinct keyed spans so switching between the
+                  {mobileOverflowTabs.length > 0 && (
+                    <>
+                      <div className="h-5 w-px bg-border shrink-0" />
+                      <Popover
+                        open={overflowOpen}
+                        onOpenChange={setOverflowOpen}
+                      >
+                        <PopoverTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            className={cn(
+                              "relative h-auto cursor-pointer rounded-none px-1 pb-3 text-sm font-medium transition-colors hover:bg-transparent hover:text-foreground flex items-center gap-1",
+                              selectedOverflowTab
+                                ? "text-foreground"
+                                : "text-muted-foreground",
+                            )}
+                          >
+                            {/* Distinct keyed spans so switching between the
                               label (an element) and "More" (a string) swaps
                               elements instead of deleting a bare text node —
                               Chrome page-translate re-parents text nodes into
                               <font> wrappers and React crashes removing a
                               re-parented text node (facebook/react#11538). */}
-                          {selectedOverflowTab ? (
-                            <span key="selected-tab">
-                              {selectedOverflowTab.label}
-                            </span>
-                          ) : (
-                            <span key="more">More</span>
-                          )}
-                          <ChevronDown className="h-3.5 w-3.5" />
-                          {selectedOverflowTab && (
-                            <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                          )}
-                        </Button>
-                      </PopoverTrigger>
-                      <PopoverContent
-                        className="w-auto p-1 flex flex-col"
-                        align="end"
-                      >
-                        {mobileOverflowTabs.map((tab) => {
-                          const isSelected = tab === selectedTab;
-                          return (
-                            <Link
-                              key={tab.href}
-                              href={tab.href}
-                              aria-current={isSelected ? "page" : undefined}
-                              onClick={() => setOverflowOpen(false)}
-                              className={cn(
-                                "cursor-pointer rounded-md px-3 py-2 text-sm transition-colors hover:bg-muted",
-                                isSelected
-                                  ? "font-medium text-foreground bg-muted"
-                                  : "text-muted-foreground",
-                              )}
-                            >
-                              {tab.label}
-                            </Link>
-                          );
-                        })}
-                      </PopoverContent>
-                    </Popover>
-                  </>
-                )}
-              </div>
-            </>
-          )}
-          {!tabs.length && <div className="mb-6" />}
+                            {selectedOverflowTab ? (
+                              <span key="selected-tab">
+                                {selectedOverflowTab.label}
+                              </span>
+                            ) : (
+                              <span key="more">More</span>
+                            )}
+                            <ChevronDown className="h-3.5 w-3.5" />
+                            {selectedOverflowTab && (
+                              <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+                            )}
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent
+                          className="w-auto p-1 flex flex-col"
+                          align="end"
+                        >
+                          {mobileOverflowTabs.map((tab) => {
+                            const isSelected = tab === selectedTab;
+                            return (
+                              <Link
+                                key={tab.href}
+                                href={tab.href}
+                                aria-current={isSelected ? "page" : undefined}
+                                onClick={() => setOverflowOpen(false)}
+                                className={cn(
+                                  "cursor-pointer rounded-md px-3 py-2 text-sm transition-colors hover:bg-muted",
+                                  isSelected
+                                    ? "font-medium text-foreground bg-muted"
+                                    : "text-muted-foreground",
+                                )}
+                              >
+                                {tab.label}
+                              </Link>
+                            );
+                          })}
+                        </PopoverContent>
+                      </Popover>
+                    </>
+                  )}
+                </div>
+              </>
+            )}
+            {!tabs.length && <div className="mb-6" />}
+          </div>
         </div>
-      </div>
-      {/* `flex-1`, not `min-h-full`: a full viewport *below* a header that is
+        <div
+          ref={setBannerSlot}
+          data-page-banner
+          style={
+            {
+              "--page-banner-top": `${headerHeight + 12}px`,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "sticky top-3 z-10 mx-auto mt-6 w-full space-y-2 px-6 empty:hidden md:top-[var(--page-banner-top)]",
+            maxWidth,
+          )}
+        />
+        {/* `flex-1`, not `min-h-full`: a full viewport *below* a header that is
           already on screen made every page scroll by the header's height, so
           the bottom of even a short one had a band of nothing under it. */}
-      <div
-        className={cn("w-full flex-1", minWidth && "min-w-0 overflow-x-auto")}
-      >
         <div
-          className={cn(
-            "mx-auto w-full",
-            minWidth || "min-w-0",
-            maxWidth,
-            "px-6 py-6 md:px-6",
-          )}
+          data-page-content
+          className={cn("w-full flex-1", minWidth && "min-w-0 overflow-x-auto")}
         >
-          {children}
+          <div
+            className={cn(
+              "mx-auto w-full",
+              minWidth || "min-w-0",
+              maxWidth,
+              "px-6 py-6 md:px-6",
+            )}
+          >
+            {children}
+          </div>
         </div>
       </div>
-    </div>
+    </PageHeaderBannerSlotContext.Provider>
   );
 }
 

--- a/platform/frontend/vitest-setup.ts
+++ b/platform/frontend/vitest-setup.ts
@@ -2,6 +2,14 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
+// JSDOM has no layout engine or ResizeObserver. Components can subscribe to
+// size changes; tests that exercise resizing supply their own observer callback.
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 // Disable Sentry for tests - prevent sending test data to Sentry
 process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN = "";
 


### PR DESCRIPTION
Backport of #7784 to `release/1.3`.

Keep cross-environment tool warnings visible in a compact, slightly translucent banner below the agent and MCP gateway tabs, sticky while the form scrolls. The removal action stays beside the message. Show the first three server names and expose the remainder in a keyboard-accessible hover/focus tooltip; existing save blocking and removal behavior are preserved.

The change applies cleanly. Agent form, banner placement, and tooltip tests pass on this branch. The main implementation was verified in Chrome with a 12-server preview and scrolling; temporary preview code is excluded.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>