### PR TITLE
fix(agents): prompt for all missing runtime credentials from setup links

### DIFF
--- a/docs/pages/platform-runtime-credentials.md
+++ b/docs/pages/platform-runtime-credentials.md
@@ -3,7 +3,7 @@ title: Runtime Credentials
 category: Administration
 description: Manage reusable secrets for Agent Runtime
 order: 5
-lastUpdated: 2026-09-03
+lastUpdated: 2026-09-10
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -31,6 +31,8 @@ Definitions describe the credential but do not contain its secret value.
 Connect organization values from **Settings → Agents → Runtime credentials**.
 
 Connect personal values under **Personal settings → Connections**. Archestra prompts for a missing personal value when a run starts.
+
+Credential setup links from conversations open a dialog for all missing credentials. After saving, return to the conversation and retry your request.
 
 Saved values are never displayed again. They use the configured [secrets manager](/docs/platform-secrets-management).
 

--- a/platform/backend/src/archestra-mcp-server/tasks.test.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.test.ts
@@ -4,10 +4,11 @@ import {
   TOOL_POST_RUN_FILE_FULL_NAME,
   TOOL_START_RUN_FULL_NAME,
 } from "@archestra/shared";
-import { vi } from "vitest";
+import { onTestFinished, vi } from "vitest";
 import { A2AManager } from "@/agents/a2a/a2a-manager";
 import * as a2aExecutor from "@/agents/a2a-executor";
 import { chatOpsManager } from "@/agents/chatops/chatops-manager";
+import config from "@/config";
 import { agentRuntimeManager } from "@/k8s/agent-runtime";
 import {
   A2AContextModel,
@@ -84,6 +85,64 @@ describe("run tools", () => {
     expect((result.content[0] as { text: string }).text).toContain(
       "Agent not found",
     );
+  });
+
+  test("returns a setup link and every missing credential before starting a run", async ({
+    makeAgent,
+  }) => {
+    const originalEnabled = config.agentRuntime.enabled;
+    config.agentRuntime.enabled = true;
+    onTestFinished(() => {
+      config.agentRuntime.enabled = originalEnabled;
+    });
+    const target = await makeAgent({
+      organizationId,
+      authorId: actorId,
+      agentType: "agent",
+      scope: "org",
+      runtime: {
+        image: "example.com/coding-agent:latest",
+        command: null,
+        inferenceProtocol: "openai_responses",
+        backend: "kubernetes",
+        steerMode: "pipe",
+        privileged: false,
+        resources: null,
+        environment: null,
+        credentials: [
+          {
+            key: "GITHUB_TOKEN",
+            label: "GitHub token",
+            scope: "per_user",
+            required: true,
+          },
+          {
+            key: "CLAUDE_CODE_OAUTH_TOKEN",
+            label: "Claude Code token",
+            scope: "per_user",
+            required: true,
+          },
+        ],
+        ttlHours: null,
+        maxCostUsd: null,
+        idleTimeoutMinutes: null,
+      },
+    });
+    const result = await executeArchestraTool(
+      TOOL_START_RUN_FULL_NAME,
+      { agent_id: target.id, message: "Review the example repository" },
+      context,
+    );
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("GITHUB_TOKEN");
+    expect(text).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(text).toContain(
+      `/agents/${target.id}?section=advanced&setup=credentials`,
+    );
+    expect(
+      await AgentRunModel.listForAgent({ agentId: target.id, organizationId }),
+    ).toEqual([]);
   });
 
   test("run controls remain callable without individual assignment", async ({

--- a/platform/backend/src/archestra-mcp-server/tasks.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.ts
@@ -818,7 +818,7 @@ function credentialsNeededResult(
   agentId: string,
   missing: Array<{ key: string; label: string; description?: string }>,
 ) {
-  const url = `${config.frontendBaseUrl}/agents/${agentId}?tab=overview#runtime-credentials`;
+  const url = `${config.frontendBaseUrl}/agents/${agentId}?section=advanced&setup=credentials`;
   return errorResult(
     `This Agent's Agent Runtime needs credentials you have not set up yet:\n${missing
       .map(

--- a/platform/frontend/src/app/_parts/with-auth-check.test.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.test.tsx
@@ -63,11 +63,13 @@ const MockChild = () => (
 
 // Helper to set window.location for tests
 const setWindowLocation = (pathname: string, search = "") => {
+  const url = new URL(`http://localhost${pathname}${search}`);
   Object.defineProperty(window, "location", {
     value: {
-      pathname,
-      search,
-      href: `http://localhost${pathname}${search}`,
+      pathname: url.pathname,
+      search: url.search,
+      hash: url.hash,
+      href: url.href,
     },
     writable: true,
   });
@@ -136,6 +138,22 @@ describe("WithAuthCheck", () => {
 
       expect(mockRouterPush).toHaveBeenCalledWith(
         "/auth/sign-in?redirectTo=%2Fsearch%3Fq%3Dhello%26filter%3Dactive",
+      );
+    });
+
+    it("preserves a credential setup link through sign-in", () => {
+      vi.mocked(usePathname).mockReturnValue("/agents/example-agent");
+      setWindowLocation(
+        "/agents/example-agent",
+        "?tab=overview#runtime-credentials",
+      );
+      render(
+        <WithAuthCheck>
+          <MockChild />
+        </WithAuthCheck>,
+      );
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        "/auth/sign-in?redirectTo=%2Fagents%2Fexample-agent%3Ftab%3Doverview%23runtime-credentials",
       );
     });
 

--- a/platform/frontend/src/app/_parts/with-auth-check.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.tsx
@@ -135,7 +135,7 @@ export const WithAuthCheck: React.FC<React.PropsWithChildren> = ({
       router.push(getValidatedRedirectPath(redirectTo));
     } else if (!isAuthPage && !isLoggedIn) {
       const queryString = searchParams.toString();
-      const fullPath = queryString ? `${pathname}?${queryString}` : pathname;
+      const fullPath = `${pathname}${queryString ? `?${queryString}` : ""}${window.location.hash}`;
       // Developer-only: mint a session server-side instead of showing the login
       // form. On any failure, fall back to the normal sign-in redirect.
       if (devAutoLoginEnabled && !devAutoLoginAttemptedRef.current) {

--- a/platform/frontend/src/components/agent-pages/agent-detail-page.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-detail-page.tsx
@@ -21,6 +21,7 @@ import { ConvertToSkillDialog } from "@/app/agents/convert-to-skill-dialog";
 import { AgentBadge } from "@/components/agent-badge";
 import { AgentForm, type AgentFormSection } from "@/components/agent-form";
 import { AgentIcon } from "@/components/agent-icon";
+import { AgentRuntimeCredentialsDeepLink } from "@/components/agent-runtime-credentials-dialog";
 import { AgentVersionHistoryDialog } from "@/components/agent-version-history-dialog";
 import { CloneAgentDialog } from "@/components/clone-agent-dialog";
 import { CreatedByCell } from "@/components/created-by-cell";
@@ -672,6 +673,14 @@ function AgentDetails({
         )}
       </div>
 
+      {hasAgentRuntime && !isGone && (
+        <AgentRuntimeCredentialsDeepLink
+          key={agent.id}
+          agentId={agent.id}
+          declarations={agent.runtime?.credentials ?? []}
+          canEditAgent={canEdit}
+        />
+      )}
       <UnsavedChangesDialog
         open={guard.confirmOpen}
         onKeepEditing={() => {

--- a/platform/frontend/src/components/agent-run-credential-prompt.tsx
+++ b/platform/frontend/src/components/agent-run-credential-prompt.tsx
@@ -115,7 +115,9 @@ export function AgentRuntimeCredentialPrompt({
             variant="outline"
             className="ml-auto h-6 shrink-0 px-2 text-xs"
           >
-            <Link href={`/agents/${agentId}?tab=overview#runtime-credentials`}>
+            <Link
+              href={`/agents/${agentId}?section=advanced&setup=credentials`}
+            >
               Agent details
             </Link>
           </Button>

--- a/platform/frontend/src/components/agent-runtime-credentials-dialog.test.tsx
+++ b/platform/frontend/src/components/agent-runtime-credentials-dialog.test.tsx
@@ -1,0 +1,459 @@
+import { archestraApiClient } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { delay, HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { makeSession } from "@/mocks/data/auth";
+import { makeConfig } from "@/mocks/data/config";
+import { AgentRuntimeCredentialsDeepLink } from "./agent-runtime-credentials-dialog";
+
+vi.mock("next/navigation");
+vi.mock("sonner");
+
+const origin = "http://localhost:9000";
+const declarations = [
+  {
+    key: "GITHUB_TOKEN",
+    credentialId: "github",
+    label: "GitHub token",
+    scope: "per_user" as const,
+    required: true,
+  },
+  {
+    key: "CLAUDE_CODE_OAUTH_TOKEN",
+    label: "Claude Code token",
+    scope: "per_user" as const,
+    required: true,
+  },
+  {
+    key: "OPTIONAL_TOKEN",
+    label: "Optional token",
+    scope: "per_user" as const,
+    required: false,
+  },
+];
+const server = setupServer();
+let configured: string[];
+let writes: Array<{ key: string; value: string }>;
+let failKey: string | null;
+let permissions: Record<string, string[]>;
+let queryClient: QueryClient;
+const replace = vi.fn();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => {
+  server.close();
+  archestraApiClient.setConfig({ baseUrl: "" });
+});
+afterEach(() => {
+  server.resetHandlers();
+  queryClient.clear();
+  window.history.replaceState(null, "", "/");
+});
+beforeEach(() => {
+  configured = [];
+  writes = [];
+  failKey = null;
+  permissions = { agent: ["read"], agentSettings: [] };
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  queryClient.setQueryData(["auth", "session"], makeSession());
+  archestraApiClient.setConfig({ baseUrl: origin });
+  window.history.replaceState(
+    null,
+    "",
+    "/agents/agent-1?section=advanced&setup=credentials",
+  );
+  vi.mocked(usePathname).mockReturnValue("/agents/agent-1");
+  vi.mocked(useSearchParams).mockImplementation(
+    () =>
+      new URLSearchParams(window.location.search) as ReturnType<
+        typeof useSearchParams
+      >,
+  );
+  vi.mocked(useRouter).mockReturnValue({ replace } as unknown as ReturnType<
+    typeof useRouter
+  >);
+  server.use(
+    http.get("http://localhost:3000/api/auth/get-session", () =>
+      HttpResponse.json(makeSession()),
+    ),
+    http.get(`${origin}/api/user/permissions`, () =>
+      HttpResponse.json(permissions),
+    ),
+    http.get(`${origin}/api/config`, () => HttpResponse.json(makeConfig())),
+    http.get(`${origin}/api/runtime-credentials`, () =>
+      HttpResponse.json([
+        {
+          key: "github",
+          name: "GitHub",
+          description: "Repository access",
+          icon: null,
+          builtIn: true,
+          allowPersonal: true,
+          allowOrganization: false,
+          personalConfigured: configured.includes("GITHUB_TOKEN"),
+          organizationConfigured: false,
+        },
+      ]),
+    ),
+    http.get(`${origin}/api/agents/agent-1/runtime/preflight`, () =>
+      HttpResponse.json({
+        configured,
+        missing: declarations.filter(
+          ({ key, required }) => required && !configured.includes(key),
+        ),
+        misconfigured: [],
+        incompatible: null,
+        ready: configured.length === 2,
+      }),
+    ),
+    http.put(
+      `${origin}/api/agents/agent-1/runtime/credentials/:key`,
+      async ({ params, request }) => {
+        const key = String(params.key);
+        const { value } = (await request.json()) as { value: string };
+        writes.push({ key, value });
+        if (key === failKey)
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Connection unavailable",
+                type: "api_internal_server_error",
+              },
+            },
+            { status: 500 },
+          );
+        configured.push(key);
+        return HttpResponse.json({ configured: true });
+      },
+    ),
+  );
+});
+
+function show(
+  props: Partial<Parameters<typeof AgentRuntimeCredentialsDeepLink>[0]> = {},
+) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentRuntimeCredentialsDeepLink
+        agentId="agent-1"
+        declarations={declarations}
+        canEditAgent={false}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("credential setup deep links", () => {
+  it.each([
+    "?section=advanced&setup=credentials",
+    "?tab=overview#runtime-credentials",
+  ])("prompts for every missing credential from %s and saves both", async (query) => {
+    window.history.replaceState(null, "", `/agents/agent-1${query}`);
+    const user = userEvent.setup();
+    show();
+    await user.type(
+      await screen.findByLabelText("GitHub token"),
+      "example-github-secret",
+    );
+    await user.type(
+      screen.getByLabelText("Claude Code token"),
+      "example-claude-secret",
+    );
+    expect(screen.queryByLabelText("Optional token")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Save credentials" }));
+    expect(
+      await screen.findByText(/All required credentials are configured/),
+    ).toBeVisible();
+    expect(writes).toEqual(
+      expect.arrayContaining([
+        { key: "GITHUB_TOKEN", value: "example-github-secret" },
+        { key: "CLAUDE_CODE_OAUTH_TOKEN", value: "example-claude-secret" },
+      ]),
+    );
+    expect(writes).toHaveLength(2);
+    await user.click(screen.getByRole("button", { name: "Done" }));
+    expect(replace).toHaveBeenCalledWith(
+      query.includes("section")
+        ? "/agents/agent-1?section=advanced"
+        : "/agents/agent-1",
+      { scroll: false },
+    );
+  });
+
+  it("only retries failed credentials after a partial save", async () => {
+    failKey = "CLAUDE_CODE_OAUTH_TOKEN";
+    const user = userEvent.setup();
+    show();
+    await user.type(
+      await screen.findByLabelText("GitHub token"),
+      "example-github-secret",
+    );
+    await user.type(
+      screen.getByLabelText("Claude Code token"),
+      "example-claude-secret",
+    );
+    await user.click(screen.getByRole("button", { name: "Save credentials" }));
+    await screen.findByText("Could not save this credential. Try again.");
+    expect(screen.queryByLabelText("GitHub token")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Claude Code token")).toHaveValue(
+      "example-claude-secret",
+    );
+    failKey = null;
+    await user.click(screen.getByRole("button", { name: "Save credentials" }));
+    await screen.findByText(/All required credentials are configured/);
+    expect(writes.filter(({ key }) => key === "GITHUB_TOKEN")).toHaveLength(1);
+    expect(
+      writes.filter(({ key }) => key === "CLAUDE_CODE_OAUTH_TOKEN"),
+    ).toHaveLength(2);
+  });
+
+  it("does not request already configured or optional credentials", async () => {
+    configured = ["GITHUB_TOKEN"];
+    show();
+    await screen.findByLabelText("Claude Code token");
+    expect(screen.queryByLabelText("GitHub token")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Optional token")).not.toBeInTheDocument();
+  });
+
+  it("keeps unavailable shared credentials visible while allowing a reader to save personal credentials", async () => {
+    const shared = {
+      key: "SHARED_TOKEN",
+      credentialId: "shared",
+      label: "Organization token",
+      scope: "shared" as const,
+      required: true,
+    };
+    server.use(
+      http.get(`${origin}/api/agents/agent-1/runtime/preflight`, () =>
+        HttpResponse.json({
+          configured,
+          missing: declarations.filter(
+            ({ required, key }) => required && !configured.includes(key),
+          ),
+          misconfigured: [shared],
+          incompatible: null,
+          ready: false,
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    show({ declarations: [...declarations, shared] });
+    await user.type(
+      await screen.findByLabelText("GitHub token"),
+      "example-github-secret",
+    );
+    await user.type(
+      screen.getByLabelText("Claude Code token"),
+      "example-claude-secret",
+    );
+    expect(
+      screen.getByText(
+        "An administrator must configure this organization credential.",
+      ),
+    ).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Save credentials" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Save credentials" }),
+      ).toBeDisabled(),
+    );
+    expect(writes).toHaveLength(2);
+    expect(
+      screen.queryByText(/All required credentials are configured/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("retries a preflight failure instead of claiming credentials are configured", async () => {
+    server.use(
+      http.get(
+        `${origin}/api/agents/agent-1/runtime/preflight`,
+        () =>
+          HttpResponse.json(
+            {
+              error: {
+                message: "Unavailable",
+                type: "api_internal_server_error",
+              },
+            },
+            { status: 500 },
+          ),
+        { once: true },
+      ),
+    );
+    const user = userEvent.setup();
+    show();
+    await screen.findByText("Could not load runtime credentials");
+    expect(
+      screen.queryByText(/All required credentials are configured/),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByLabelText("GitHub token")).toBeVisible();
+  });
+
+  it("requires a value for every editable missing credential", async () => {
+    const user = userEvent.setup();
+    show();
+    await screen.findByLabelText("GitHub token");
+    await user.click(screen.getByRole("button", { name: "Save credentials" }));
+    expect(await screen.findAllByText("Secret value is required")).toHaveLength(
+      2,
+    );
+    expect(writes).toEqual([]);
+  });
+
+  it("uses Vault selection for every credential when external secrets are enabled", async () => {
+    server.use(
+      http.get(`${origin}/api/config`, () =>
+        HttpResponse.json(makeConfig({ features: { byosEnabled: true } })),
+      ),
+    );
+    show();
+    expect(
+      await screen.findByRole("button", { name: "GitHub token" }),
+    ).toHaveTextContent("Select Vault secret");
+    expect(
+      screen.getByRole("button", { name: "Claude Code token" }),
+    ).toHaveTextContent("Select Vault secret");
+    expect(
+      screen.queryByPlaceholderText("Paste secret"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lets an administrator configure a missing organization connection", async () => {
+    permissions = { agent: ["read"], agentSettings: ["update"] };
+    const shared = { ...declarations[0], scope: "shared" as const };
+    server.use(
+      http.get(`${origin}/api/agents/agent-1/runtime/preflight`, () =>
+        HttpResponse.json({
+          configured,
+          missing: [],
+          misconfigured: configured.length ? [] : [shared],
+          incompatible: null,
+          ready: configured.length > 0,
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    show({ declarations: [shared] });
+    await user.type(
+      await screen.findByLabelText("GitHub token"),
+      "example-organization-secret",
+    );
+    await user.click(screen.getByRole("button", { name: "Save credentials" }));
+    await screen.findByText(/All required credentials are configured/);
+    expect(writes).toEqual([
+      { key: "GITHUB_TOKEN", value: "example-organization-secret" },
+    ]);
+  });
+
+  it("saves agent-specific shared secrets without overlapping updates to their shared bag", async () => {
+    const shared = declarations.slice(0, 2).map((credential) => ({
+      ...credential,
+      credentialId: undefined,
+      scope: "shared" as const,
+    }));
+    let bag: Record<string, string> = {};
+    server.use(
+      http.get(`${origin}/api/agents/agent-1/runtime/preflight`, () =>
+        HttpResponse.json({
+          configured: Object.keys(bag),
+          missing: [],
+          misconfigured: shared.filter(({ key }) => !bag[key]),
+          incompatible: null,
+          ready: Object.keys(bag).length === 2,
+        }),
+      ),
+      http.put(
+        `${origin}/api/agents/agent-1/runtime/credentials/:key`,
+        async ({ params, request }) => {
+          const snapshot = { ...bag };
+          const { value } = (await request.json()) as { value: string };
+          await delay(20);
+          bag = { ...snapshot, [String(params.key)]: value };
+          return HttpResponse.json({ configured: true });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    show({ declarations: shared, canEditAgent: true });
+    await user.type(
+      await screen.findByLabelText("GitHub token"),
+      "example-github-secret",
+    );
+    await user.type(
+      screen.getByLabelText("Claude Code token"),
+      "example-claude-secret",
+    );
+    await user.click(screen.getByRole("button", { name: "Save credentials" }));
+    await screen.findByText(/All required credentials are configured/);
+    expect(bag).toEqual({
+      GITHUB_TOKEN: "example-github-secret",
+      CLAUDE_CODE_OAUTH_TOKEN: "example-claude-secret",
+    });
+  });
+
+  it("shows full multiline definition and agent-specific instructions for every missing credential", async () => {
+    const githubDescription =
+      "Create a token for the example repository.\nChoose the repository permissions required by your workflow.\nKeep the token private and paste it below.";
+    const claudeDescription =
+      "Run claude setup-token on your own machine.\nComplete the sign-in flow in your browser.\nCopy the resulting subscription token and paste it below.";
+    server.use(
+      http.get(`${origin}/api/runtime-credentials`, () =>
+        HttpResponse.json([
+          {
+            key: "github",
+            name: "GitHub",
+            description: githubDescription,
+            icon: null,
+          },
+          {
+            key: "claude-code",
+            name: "Claude Code",
+            description: claudeDescription,
+            icon: null,
+          },
+        ]),
+      ),
+    );
+    const instructions =
+      "This Agent needs access to the example project and its dependencies.";
+    show({
+      declarations: declarations.map((credential) => ({
+        ...credential,
+        credentialId:
+          credential.key === "GITHUB_TOKEN" ? "github" : "claude-code",
+        description: instructions,
+      })),
+    });
+    await screen.findByLabelText("GitHub token");
+    expect(
+      screen.getByText(githubDescription, { normalizer: (text) => text }),
+    ).toBeVisible();
+    expect(
+      screen.getByText(claudeDescription, { normalizer: (text) => text }),
+    ).toBeVisible();
+    expect(screen.getAllByText(instructions)).toHaveLength(2);
+  });
+
+  it("does not open for ordinary agent navigation", () => {
+    window.history.replaceState(null, "", "/agents/agent-1?section=advanced");
+    show();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/agent-runtime-credentials-dialog.tsx
+++ b/platform/frontend/src/components/agent-runtime-credentials-dialog.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import type { AgentRuntimeConfig } from "@/components/agent-runtime-fields";
+import { ExternalSecretReferenceDialog } from "@/components/external-secret-reference-dialog";
+import { QueryLoadError } from "@/components/query-load-error";
+import { StandardFormDialog } from "@/components/standard-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { SecretInput } from "@/components/ui/secret-input";
+import {
+  useAgentRuntimePreflight,
+  useSetMissingAgentRuntimeCredentials,
+} from "@/lib/agent-runtime.query";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useConfig } from "@/lib/config/config.query";
+import { useRuntimeCredentials } from "@/lib/runtime-credentials.query";
+
+/** Accept both new setup links and credential anchors already sent to users. */
+export function AgentRuntimeCredentialsDeepLink(props: {
+  agentId: string;
+  declarations: NonNullable<AgentRuntimeConfig["credentials"]>;
+  canEditAgent: boolean;
+}) {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const [legacyLink, setLegacyLink] = useState(false);
+  useEffect(() => {
+    const readHash = () =>
+      setLegacyLink(window.location.hash === "#runtime-credentials");
+    readHash();
+    window.addEventListener("hashchange", readHash);
+    return () => window.removeEventListener("hashchange", readHash);
+  }, []);
+
+  if (searchParams.get("setup") !== "credentials" && !legacyLink) return null;
+
+  return (
+    <MissingCredentialsDialog
+      {...props}
+      onClose={() => {
+        setLegacyLink(false);
+        const params = new URLSearchParams(searchParams.toString());
+        params.delete("setup");
+        params.delete("tab");
+        const query = params.toString();
+        router.replace(`${pathname}${query ? `?${query}` : ""}`, {
+          scroll: false,
+        });
+      }}
+    />
+  );
+}
+
+function MissingCredentialsDialog({
+  agentId,
+  declarations,
+  canEditAgent,
+  onClose,
+}: {
+  agentId: string;
+  declarations: NonNullable<AgentRuntimeConfig["credentials"]>;
+  canEditAgent: boolean;
+  onClose: () => void;
+}) {
+  const preflight = useAgentRuntimePreflight(agentId);
+  const definitions = useRuntimeCredentials();
+  const { data: canManageOrganization, isPending: permissionsPending } =
+    useHasPermissions({ agentSettings: ["update"] });
+  const config = useConfig();
+  const byosEnabled = config.data?.features.byosEnabled;
+  const save = useSetMissingAgentRuntimeCredentials(agentId);
+  const form = useForm<{ values: Record<string, string> }>({
+    defaultValues: { values: {} },
+  });
+  const [externalKey, setExternalKey] = useState<string | null>(null);
+  const [failedKeys, setFailedKeys] = useState<string[]>([]);
+  const missingKeys = new Set(
+    [
+      ...(preflight.data?.missing ?? []),
+      ...(preflight.data?.misconfigured ?? []),
+    ].map(({ key }) => key),
+  );
+  const missing = declarations.filter((credential) =>
+    missingKeys.has(credential.key),
+  );
+  const canSet = (credential: (typeof declarations)[number]) =>
+    credential.scope === "per_user" ||
+    (credential.credentialId ? canManageOrganization : canEditAgent);
+  const editable = missing.filter(canSet);
+  const loading =
+    preflight.isPending ||
+    definitions.isPending ||
+    config.isPending ||
+    permissionsPending;
+  const loadFailed = preflight.isError || definitions.isError || config.isError;
+  const complete = !loading && !loadFailed && missing.length === 0;
+
+  return (
+    <StandardFormDialog
+      open
+      title="Set up runtime credentials"
+      description="Add the missing credentials for this Agent. Personal credentials belong to your account."
+      size="medium"
+      isDirty={form.formState.isDirty}
+      onOpenChange={(open) => {
+        if (!open && !save.isPending) onClose();
+      }}
+      onSubmit={form.handleSubmit(({ values }) => {
+        save.mutate(
+          editable.map(({ key }) => ({ key, value: values[key].trim() })),
+          {
+            onSuccess: ({ saved, failed }) => {
+              setFailedKeys(failed);
+              for (const key of saved)
+                form.resetField(`values.${key}`, { defaultValue: "" });
+            },
+          },
+        );
+      })}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={save.isPending}
+            onClick={onClose}
+          >
+            {complete ? "Done" : "Cancel"}
+          </Button>
+          {!complete && (
+            <Button
+              type="submit"
+              disabled={
+                loading || loadFailed || save.isPending || editable.length === 0
+              }
+            >
+              {save.isPending ? "Saving…" : "Save credentials"}
+            </Button>
+          )}
+        </>
+      }
+    >
+      {loading ? (
+        <output>Checking missing credentials…</output>
+      ) : loadFailed ? (
+        <QueryLoadError
+          title="Could not load runtime credentials"
+          onRetry={() => {
+            void preflight.refetch();
+            void definitions.refetch();
+            void config.refetch();
+          }}
+        />
+      ) : complete ? (
+        <output>
+          All required credentials are configured. Return to your conversation
+          and retry the request.
+        </output>
+      ) : (
+        <Form {...form}>
+          <div className="space-y-6">
+            {missing.map((credential) => {
+              const definition = definitions.data?.find(
+                ({ key }) => key === credential.credentialId,
+              );
+              return (
+                <FormField
+                  key={credential.key}
+                  control={form.control}
+                  name={`values.${credential.key}`}
+                  defaultValue=""
+                  rules={{
+                    validate: (value) =>
+                      !canSet(credential) ||
+                      !!value?.trim() ||
+                      "Secret value is required",
+                    maxLength: {
+                      value: 20_000,
+                      message: "Secret value is too long",
+                    },
+                  }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{credential.label}</FormLabel>
+                      <p className="text-xs text-muted-foreground">
+                        {credential.key} ·{" "}
+                        {credential.scope === "per_user"
+                          ? "Personal"
+                          : "Organization"}
+                      </p>
+                      {[
+                        ...new Set([
+                          credential.description?.trim(),
+                          definition?.description.trim(),
+                        ]),
+                      ]
+                        .filter(Boolean)
+                        .map((description) => (
+                          <p
+                            key={description}
+                            className="whitespace-pre-wrap break-words text-sm text-muted-foreground"
+                          >
+                            {description}
+                          </p>
+                        ))}
+                      {!canSet(credential) ? (
+                        <p className="text-sm text-muted-foreground">
+                          An administrator must configure this organization
+                          credential.
+                        </p>
+                      ) : byosEnabled ? (
+                        <FormControl>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            disabled={save.isPending}
+                            onClick={() => setExternalKey(credential.key)}
+                          >
+                            {field.value
+                              ? "Change Vault secret"
+                              : "Select Vault secret"}
+                          </Button>
+                        </FormControl>
+                      ) : (
+                        <FormControl>
+                          <SecretInput
+                            {...field}
+                            disabled={save.isPending}
+                            autoFocus={credential.key === editable[0]?.key}
+                            autoComplete="off"
+                            revealable
+                            placeholder="Paste secret"
+                          />
+                        </FormControl>
+                      )}
+                      <FormMessage />
+                      {failedKeys.includes(credential.key) && (
+                        <p role="alert" className="text-sm text-destructive">
+                          Could not save this credential. Try again.
+                        </p>
+                      )}
+                    </FormItem>
+                  )}
+                />
+              );
+            })}
+          </div>
+        </Form>
+      )}
+      {preflight.data?.incompatible && (
+        <p role="alert" className="mt-4 text-sm text-muted-foreground">
+          {preflight.data.incompatible}
+        </p>
+      )}
+      {externalKey && (
+        <ExternalSecretReferenceDialog
+          fieldLabel={
+            declarations.find(({ key }) => key === externalKey)?.label ??
+            externalKey
+          }
+          initialValue={form.getValues(`values.${externalKey}`)}
+          onClose={() => setExternalKey(null)}
+          onConfirm={(reference) => {
+            form.setValue(`values.${externalKey}`, reference, {
+              shouldDirty: true,
+              shouldValidate: true,
+            });
+            setExternalKey(null);
+          }}
+        />
+      )}
+    </StandardFormDialog>
+  );
+}

--- a/platform/frontend/src/components/agent-runtime-credentials-dialog.tsx
+++ b/platform/frontend/src/components/agent-runtime-credentials-dialog.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -193,27 +194,29 @@ function MissingCredentialsDialog({
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>{credential.label}</FormLabel>
-                      <p className="text-xs text-muted-foreground">
-                        {credential.key} ·{" "}
-                        {credential.scope === "per_user"
-                          ? "Personal"
-                          : "Organization"}
-                      </p>
-                      {[
-                        ...new Set([
-                          credential.description?.trim(),
-                          definition?.description.trim(),
-                        ]),
-                      ]
-                        .filter(Boolean)
-                        .map((description) => (
-                          <p
-                            key={description}
-                            className="whitespace-pre-wrap break-words text-sm text-muted-foreground"
-                          >
-                            {description}
-                          </p>
-                        ))}
+                      <FormDescription className="space-y-2">
+                        <span className="block">
+                          {credential.key} ·{" "}
+                          {credential.scope === "per_user"
+                            ? "Personal"
+                            : "Organization"}
+                        </span>
+                        {[
+                          ...new Set([
+                            credential.description?.trim(),
+                            definition?.description.trim(),
+                          ]),
+                        ]
+                          .filter(Boolean)
+                          .map((description) => (
+                            <span
+                              key={description}
+                              className="block whitespace-pre-wrap break-words"
+                            >
+                              {description}
+                            </span>
+                          ))}
+                      </FormDescription>
                       {!canSet(credential) ? (
                         <p className="text-sm text-muted-foreground">
                           An administrator must configure this organization

--- a/platform/frontend/src/lib/agent-runtime.query.ts
+++ b/platform/frontend/src/lib/agent-runtime.query.ts
@@ -337,6 +337,51 @@ export function useSetAgentRuntimeCredential(agentId: string) {
   });
 }
 
+/** Save independently so a failed connection does not discard successful ones. */
+export function useSetMissingAgentRuntimeCredentials(agentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (credentials: Array<{ key: string; value: string }>) => {
+      const saved: string[] = [];
+      const failed: string[] = [];
+      // Agent-specific shared secrets update one bag. Concurrent writes could
+      // each read the old bag and overwrite another credential's value.
+      for (const { key, value } of credentials) {
+        try {
+          const { error } = await setAgentRuntimeCredential({
+            path: { id: agentId, key },
+            body: { value },
+          });
+          if (error) throw reportApiError(error);
+          saved.push(key);
+        } catch {
+          failed.push(key);
+        }
+      }
+      return { saved, failed };
+    },
+    onSuccess: async ({ saved, failed }) => {
+      if (failed.length > 0) {
+        toast.error(
+          "Some credentials could not be saved. Retry the remaining fields.",
+        );
+      } else if (saved.length > 0) {
+        toast.success("Credentials saved");
+      }
+      // Reusable connections may also satisfy other Agents' preflights.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["runtime-credentials"] }),
+        queryClient.invalidateQueries({
+          predicate: (query) =>
+            query.queryKey[0] === "agents" &&
+            query.queryKey[2] === "runtime" &&
+            query.queryKey[3] === "preflight",
+        }),
+      ]);
+    },
+  });
+}
+
 export function useDeleteAgentRuntimeCredential(agentId: string) {
   const queryClient = useQueryClient();
   return useMutation({


### PR DESCRIPTION
When a run needs multiple credentials, its setup link currently lands on the Agent’s General tab without prompting for them. The link now opens one dialog containing every missing credential, with full credential and Agent-specific descriptions. Existing credential-anchor links remain supported, including through sign-in.

The dialog uses the existing credential APIs and permission checks, supports Vault references, and retries failed saves without re-entering successful ones. Saves run sequentially because Agent-specific organization secrets share a storage bag. After setup, users return to their conversation and retry the request.

Verified both link formats in the local UI. Integration tests cover multiple credentials, partial failures, personal and organization access, Vault mode, multiline instructions, and shared-secret writes. A backend test verifies that the task tool returns the setup link and both missing keys before creating a run.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>