### PR TITLE
fix(agent-runtime): preserve session identity and history across continuations

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -64492,6 +64492,11 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "sessionId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
                     "taskId": {
                       "type": "string",
                       "format": "uuid",
@@ -64953,6 +64958,11 @@
                             "type": "string",
                             "format": "date-time"
                           },
+                          "sessionId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
                           "prompt": {
                             "type": "string"
                           },
@@ -65011,6 +65021,7 @@
                           "stateChangedAt",
                           "hardDeadlineAt",
                           "lastModelActivityAt",
+                          "sessionId",
                           "prompt",
                           "agent",
                           "projectName",
@@ -65458,6 +65469,11 @@
                       "type": "string",
                       "format": "date-time"
                     },
+                    "sessionId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
                     "prompt": {
                       "type": "string"
                     },
@@ -65611,6 +65627,7 @@
                     "stateChangedAt",
                     "hardDeadlineAt",
                     "lastModelActivityAt",
+                    "sessionId",
                     "prompt",
                     "agent",
                     "projectName",
@@ -66038,6 +66055,11 @@
                       "type": "string",
                       "format": "date-time"
                     },
+                    "sessionId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
                     "prompt": {
                       "type": "string"
                     },
@@ -66096,6 +66118,7 @@
                     "stateChangedAt",
                     "hardDeadlineAt",
                     "lastModelActivityAt",
+                    "sessionId",
                     "prompt",
                     "agent",
                     "projectName",
@@ -66695,6 +66718,11 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "sessionId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
                     "taskId": {
                       "type": "string",
                       "format": "uuid",
@@ -349401,6 +349429,11 @@
                         "type": "string",
                         "format": "date-time"
                       },
+                      "sessionId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                      },
                       "prompt": {
                         "type": "string"
                       },
@@ -349554,6 +349587,7 @@
                       "stateChangedAt",
                       "hardDeadlineAt",
                       "lastModelActivityAt",
+                      "sessionId",
                       "prompt",
                       "agent",
                       "projectName",

--- a/docs/pages/platform-agent-runtime.md
+++ b/docs/pages/platform-agent-runtime.md
@@ -281,7 +281,9 @@ interactive mode, but they will not provide a useful Chat terminal.
 
 A completed task can retain its interactive session. Reattaching preserves that
 process, terminal history, and conversation. When the process has ended, resuming
-creates a new run in the same workspace. The completed A2A task stays completed.
+creates a new turn in the same workspace. The completed A2A task stays completed.
+The session keeps its original URL across turns. Its history includes earlier terminal recordings.
+Sharing a turn does not automatically share later turns.
 Only the workspace's original actor can continue it, and only one turn can own it
 at a time.
 
@@ -430,6 +432,7 @@ Archestra supplies the applicable variables below when launching a run. You do n
 | `ARCHESTRA_AGENT_RUNTIME_ATTACHMENTS_DIR` | Parent directory containing each turn's attached files. |
 | `ARCHESTRA_AGENT_RUNTIME_ATTACHMENTS_MANIFEST` | JSON manifest containing each input file's name, path, media type, and size. |
 | `ARCHESTRA_AGENT_RUNTIME_MODEL` | Provider-qualified model ID for generic clients. |
+| `ARCHESTRA_AGENT_RUNTIME_NATIVE_STATE_DIR` | Optional image-wrapper override for isolated Codex, Hermes, or OpenClaw conversation state. Control files and terminal recording remain in the runtime directory. |
 | `ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL` | Provider-native model slug for clients that configure their provider separately. |
 | `ARCHESTRA_AGENT_RUNTIME_MODEL_CONTEXT_LENGTH`, `ARCHESTRA_AGENT_RUNTIME_MODEL_OUTPUT_LENGTH` | Known context and output limits for native client configuration. |
 | `ARCHESTRA_LLM_PROXY_URL`, `ARCHESTRA_LLM_PROXY_PROTOCOL` | Agent-scoped inference endpoint and its `openai_responses`, `openai_chat`, or `anthropic` protocol. |

--- a/platform/agent_images/bin/archestra-agent-init
+++ b/platform/agent_images/bin/archestra-agent-init
@@ -42,7 +42,7 @@ if [ -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ] && command -v gh >/dev/null 2>&1; the
   # Coding agents commonly prefer the SSH clone URL shown by GitHub. The
   # catalog credential is an HTTPS token, so normalize either SSH spelling to
   # the authenticated HTTPS transport instead of requiring a second SSH key.
-  git config --global url."https://github.com/".insteadOf "git@github.com:"
+  git config --global --replace-all url."https://github.com/".insteadOf "git@github.com:"
   git config --global --add url."https://github.com/".insteadOf \
     "ssh://git@github.com/"
   unset github_token

--- a/platform/agent_images/bin/archestra-codex
+++ b/platform/agent_images/bin/archestra-codex
@@ -8,8 +8,8 @@ fi
 
 runtime_dir="${ARCHESTRA_AGENT_RUNTIME_DIR:-/var/run/archestra}"
 runtime_mode="${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}"
-export CODEX_HOME="${runtime_dir}/codex"
-mkdir -p "${CODEX_HOME}"
+export CODEX_HOME="${ARCHESTRA_AGENT_RUNTIME_NATIVE_STATE_DIR:-${runtime_dir}}/codex"
+mkdir -p "${runtime_dir}" "${CODEX_HOME}"
 attention_hook="${runtime_dir}/codex-attention-hook.sh"
 cat > "${attention_hook}" <<'HOOK'
 #!/usr/bin/env bash

--- a/platform/agent_images/bin/archestra-hermes
+++ b/platform/agent_images/bin/archestra-hermes
@@ -8,8 +8,8 @@ fi
 
 runtime_dir="${ARCHESTRA_AGENT_RUNTIME_DIR:-/var/run/archestra}"
 runtime_mode="${ARCHESTRA_AGENT_RUNTIME_MODE:-one_shot}"
-export HERMES_HOME="${runtime_dir}/hermes"
-mkdir -p "${HERMES_HOME}"
+export HERMES_HOME="${ARCHESTRA_AGENT_RUNTIME_NATIVE_STATE_DIR:-${runtime_dir}}/hermes"
+mkdir -p "${runtime_dir}" "${HERMES_HOME}"
 attention_plugin_dir="${HERMES_HOME}/plugins/archestra-attention"
 mkdir -p "${attention_plugin_dir}"
 cat > "${attention_plugin_dir}/plugin.yaml" <<'PLUGIN_MANIFEST'

--- a/platform/agent_images/bin/archestra-openclaw
+++ b/platform/agent_images/bin/archestra-openclaw
@@ -41,7 +41,7 @@ attention_plugin_dir="${runtime_dir}/openclaw-attention"
 attention_plugin="${attention_plugin_dir}/index.cjs"
 model="${ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL:?}"
 runtime_instructions="${ARCHESTRA_AGENT_RUNTIME_SYSTEM_PROMPT:-}"
-export OPENCLAW_STATE_DIR="${runtime_dir}/openclaw-state"
+export OPENCLAW_STATE_DIR="${ARCHESTRA_AGENT_RUNTIME_NATIVE_STATE_DIR:-${runtime_dir}}/openclaw-state"
 export OPENCLAW_CONFIG_PATH="${config_file}"
 mkdir -p "${OPENCLAW_STATE_DIR}" "${attention_plugin_dir}"
 

--- a/platform/backend/src/archestra-mcp-server/tasks.test.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.test.ts
@@ -275,6 +275,55 @@ describe("run tools", () => {
     return task;
   }
 
+  test("get_run resolves the current turn from the original session ID", async () => {
+    const first = await seedChatopsTask({
+      actorUserId: actorId,
+      withTarget: false,
+    });
+    const firstRun = await AgentRunModel.findByTaskId(first.id);
+    if (!firstRun) throw new Error("Run fixture missing");
+    await AgentRunModel.close({ id: firstRun.id, logs: "first answer" });
+    const next = await A2ATaskModel.create({
+      contextId: first.contextId,
+      agentId: callingAgent.id,
+      state: "TASK_STATE_WORKING",
+    });
+    await AgentRunModel.create({
+      organizationId,
+      taskId: next.id,
+      agentId: callingAgent.id,
+      actorKind: "user",
+      actorId,
+      actorUserId: actorId,
+      workloadName: firstRun.workloadName,
+      backend: "kubernetes",
+      runtimeScope: "test",
+    });
+    await AgentWorkspaceModel.create({
+      id: first.id,
+      organizationId,
+      agentId: callingAgent.id,
+      actorKind: "user",
+      actorId,
+      backend: "kubernetes",
+      runtimeScope: "test",
+      workloadName: firstRun.workloadName,
+      state: "active",
+      lastTaskId: next.id,
+      activeTaskId: next.id,
+      expiresAt: new Date(Date.now() + 3600_000),
+    });
+    const result = await executeArchestraTool(
+      TOOL_GET_RUN_FULL_NAME,
+      { task_id: first.id },
+      context,
+    );
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      run: { task_id: next.id, state: "working" },
+    });
+  });
+
   test("workspace file tools accept the task ID and enforce original ownership", async ({
     makeUser,
     makeMember,

--- a/platform/backend/src/archestra-mcp-server/tasks.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.ts
@@ -421,7 +421,11 @@ const registry = defineArchestraTools([
     handler: async ({ args, context }) => {
       try {
         const actor = requireActor(context);
-        const task = await requireAccessibleTask(args.task_id, actor);
+        const task = await requireAccessibleTask({
+          taskId: args.task_id,
+          actor,
+          currentSession: true,
+        });
         if ("error" in task) return errorResult(task.error);
 
         const artifacts = await A2AArtifactModel.findByTaskId(task.row.id);
@@ -627,7 +631,11 @@ const registry = defineArchestraTools([
     handler: async ({ args, context }) => {
       try {
         const actor = requireActor(context);
-        const task = await requireAccessibleTask(args.task_id, actor);
+        const task = await requireAccessibleTask({
+          taskId: args.task_id,
+          actor,
+          currentSession: true,
+        });
         if ("error" in task) return errorResult(task.error);
 
         const session = await AgentRunModel.findByTaskId(task.row.id);
@@ -649,6 +657,9 @@ const registry = defineArchestraTools([
           );
         }
 
+        const workspace = await AgentWorkspaceModel.findByWorkloadName(
+          session.workloadName,
+        );
         if (session.endedAt) {
           const continuation = await startDetachedAgentTask({
             actor,
@@ -665,6 +676,7 @@ const registry = defineArchestraTools([
               success: true,
               task_id: continuation.id,
               previous_task_id: session.taskId,
+              session_id: workspace?.id ?? session.taskId,
             },
             "Continuation started in the retained workspace using the same Agent.",
           );
@@ -676,7 +688,11 @@ const registry = defineArchestraTools([
           message: args.message,
         });
         return structuredSuccessResult(
-          { success: true, task_id: task.row.id },
+          {
+            success: true,
+            task_id: task.row.id,
+            session_id: workspace?.id ?? session.taskId,
+          },
           "Steer delivered. It lands at the loop's next turn boundary (pipe) or is typed into the session (tmux keys).",
         );
       } catch (error) {
@@ -696,7 +712,11 @@ const registry = defineArchestraTools([
     handler: async ({ args, context }) => {
       try {
         const actor = requireActor(context);
-        const task = await requireAccessibleTask(args.task_id, actor);
+        const task = await requireAccessibleTask({
+          taskId: args.task_id,
+          actor,
+          currentSession: true,
+        });
         if ("error" in task) return errorResult(task.error);
         if (!task.row.agentId) {
           return errorResult("This run has no agent to cancel against.");
@@ -747,7 +767,10 @@ const registry = defineArchestraTools([
     handler: async ({ args, context }) => {
       try {
         const actor = requireActor(context);
-        const task = await requireAccessibleTask(args.task_id, actor);
+        const task = await requireAccessibleTask({
+          taskId: args.task_id,
+          actor,
+        });
         if ("error" in task) return errorResult(task.error);
 
         const session = await AgentRunModel.findByTaskId(task.row.id);
@@ -894,15 +917,28 @@ function requireActor(context: ArchestraContext): A2AActor {
  * hold agent:admin. Missing and inaccessible return the same message so run
  * ids cannot be probed.
  */
-async function requireAccessibleTask(
-  taskId: string,
-  actor: A2AActor,
-): Promise<
+async function requireAccessibleTask({
+  taskId,
+  actor,
+  currentSession = false,
+}: {
+  taskId: string;
+  actor: A2AActor;
+  currentSession?: boolean;
+}): Promise<
   | { row: Awaited<ReturnType<typeof A2ATaskModel.findById>> & object }
   | { error: string }
 > {
   const notFound = { error: "Run not found" };
-  const row = await A2ATaskModel.findById(taskId);
+  const current = currentSession
+    ? await AgentRunModel.findCurrentSessionForActor({
+        taskId,
+        actorUserId: actor.id,
+        organizationId: actor.organizationId,
+      })
+    : null;
+  const resolvedTaskId = current?.taskId ?? taskId;
+  const row = await A2ATaskModel.findById(resolvedTaskId);
   if (!row) return notFound;
 
   // Contexts carry no organization; the task's agent does. A task without an
@@ -914,7 +950,7 @@ async function requireAccessibleTask(
     }
   }
 
-  const context = await A2ATaskModel.findActorForTask(taskId);
+  const context = await A2ATaskModel.findActorForTask(resolvedTaskId);
   const isOwn =
     context !== null &&
     context.actorKind === actor.kind &&

--- a/platform/backend/src/models/agent-run.test.ts
+++ b/platform/backend/src/models/agent-run.test.ts
@@ -187,3 +187,96 @@ describe("AgentRunModel completion notifications", () => {
     );
   });
 });
+
+test("continuations keep one owner session and ordered history without exposing it to another user", async ({
+  makeOrganization,
+  makeUser,
+  makeAgent,
+}) => {
+  const org = await makeOrganization();
+  const owner = await makeUser();
+  const other = await makeUser();
+  const agent = await makeAgent({ organizationId: org.id });
+  const context = await A2AContextModel.create({
+    actorKind: "user",
+    actorId: owner.id,
+  });
+  const first = await A2ATaskModel.createForRun({
+    contextId: context.id,
+    agentId: agent.id,
+  });
+  const workloadName = `session-${first.id}`;
+  const common = {
+    organizationId: org.id,
+    agentId: agent.id,
+    actorKind: "user" as const,
+    actorId: owner.id,
+    actorUserId: owner.id,
+    workloadName,
+    backend: "kubernetes" as const,
+    runtimeScope: "test",
+  };
+  const firstRun = await AgentRunModel.create({ ...common, taskId: first.id });
+  await AgentRunModel.close({ id: firstRun.id, logs: "first turn" });
+  const workspace = await AgentWorkspaceModel.create({
+    ...common,
+    id: first.id,
+    state: "idle",
+    lastTaskId: first.id,
+    expiresAt: new Date(Date.now() + 3600_000),
+  });
+  const second = await A2ATaskModel.createForRun({
+    contextId: context.id,
+    agentId: agent.id,
+  });
+  const secondRun = await AgentRunModel.create({
+    ...common,
+    taskId: second.id,
+  });
+  expect(
+    await AgentWorkspaceModel.claim({
+      id: workspace.id,
+      organizationId: org.id,
+      actorKind: "user",
+      actorId: owner.id,
+      agentId: agent.id,
+      taskId: second.id,
+    }),
+  ).not.toBeNull();
+  const lookup = { actorUserId: owner.id, organizationId: org.id };
+  for (const taskId of [first.id, second.id, workspace.id]) {
+    expect(
+      await AgentRunModel.findCurrentSessionForActor({ ...lookup, taskId }),
+    ).toMatchObject({
+      taskId: second.id,
+      sessionId: first.id,
+    });
+    expect(
+      await AgentRunModel.findCurrentSessionForActor({
+        ...lookup,
+        taskId,
+        actorUserId: other.id,
+      }),
+    ).toBeNull();
+  }
+  const listed = await AgentRunModel.listForActor({
+    ...lookup,
+    pagination: { limit: 10, offset: 0 },
+  });
+  expect(listed.data.map((run) => run.taskId)).toEqual([second.id]);
+  const history = await AgentRunModel.listPreviousTurns({ run: secondRun });
+  expect(history.map((run) => run.id)).toEqual([firstRun.id]);
+  expect(
+    await AgentRunModel.listPreviousTurns({
+      run: secondRun,
+      afterId: firstRun.id,
+    }),
+  ).toEqual([]);
+  // Explicit per-turn sharing must still resolve the requested record.
+  expect(
+    await AgentRunModel.findSessionByTaskId({
+      taskId: first.id,
+      organizationId: org.id,
+    }),
+  ).toMatchObject({ taskId: first.id });
+});

--- a/platform/backend/src/models/agent-run.ts
+++ b/platform/backend/src/models/agent-run.ts
@@ -1,6 +1,7 @@
 import type { PaginationQuery } from "@archestra/shared";
 import {
   and,
+  asc,
   desc,
   eq,
   getTableColumns,
@@ -46,6 +47,69 @@ class AgentRunModel {
       .where(eq(schema.agentRunsTable.taskId, taskId))
       .limit(1);
     return run ?? null;
+  }
+
+  /** Resolve an owned session URL (or any of its task aliases) to its current turn. */
+  static async findCurrentSessionForActor(params: {
+    taskId: string;
+    actorUserId: string;
+    organizationId: string;
+  }): Promise<AgentRunSession | null> {
+    const workspaces = schema.agentWorkspacesTable;
+    const [workspace] = await db
+      .select()
+      .from(workspaces)
+      .where(
+        and(
+          eq(workspaces.organizationId, params.organizationId),
+          eq(workspaces.actorKind, "user"),
+          eq(workspaces.actorId, params.actorUserId),
+          or(
+            eq(workspaces.id, params.taskId),
+            sql`${workspaces.workloadName} IN (
+          SELECT workload_name FROM agent_runs WHERE task_id = ${params.taskId}::uuid
+          AND organization_id = ${params.organizationId}
+          AND actor_kind = 'user' AND actor_id = ${params.actorUserId}
+        )`,
+          ),
+        ),
+      )
+      .limit(1);
+    const run = await AgentRunModel.findForActorByTaskId({
+      ...params,
+      taskId: workspace?.lastTaskId ?? params.taskId,
+    });
+    return run && (!workspace || run.workloadName === workspace.workloadName)
+      ? run
+      : null;
+  }
+
+  /** Stream history metadata in bounded pages; cursor comparisons stay in PostgreSQL. */
+  static async listPreviousTurns(params: {
+    run: AgentRunRecord;
+    afterId?: string;
+  }) {
+    const table = schema.agentRunsTable;
+    return db
+      .select()
+      .from(table)
+      .where(
+        and(
+          eq(table.workloadName, params.run.workloadName),
+          eq(table.organizationId, params.run.organizationId),
+          eq(table.actorKind, params.run.actorKind),
+          eq(table.actorId, params.run.actorId),
+          sql`${table.id} <> ${params.run.id}::uuid`,
+          isNotNull(table.endedAt),
+          sql`${table.startedAt} <= (SELECT started_at FROM agent_runs WHERE id = ${params.run.id}::uuid)`,
+          params.afterId
+            ? sql`(${table.startedAt}, ${table.id}) >
+        (SELECT started_at, id FROM agent_runs WHERE id = ${params.afterId}::uuid)`
+            : undefined,
+        ),
+      )
+      .orderBy(asc(table.startedAt), asc(table.id))
+      .limit(100);
   }
 
   /** A new protocol task in an existing context continues its owner's latest
@@ -271,6 +335,9 @@ class AgentRunModel {
       eq(schema.agentRunsTable.actorKind, "user"),
       eq(schema.agentRunsTable.actorId, params.actorUserId),
       eq(schema.agentRunsTable.organizationId, params.organizationId),
+      sql`NOT EXISTS (SELECT 1 FROM agent_workspaces w
+        WHERE w.workload_name = ${schema.agentRunsTable.workloadName}
+        AND w.last_task_id <> ${schema.agentRunsTable.taskId})`,
     ];
     const [rows, [{ total }]] = await Promise.all([
       AgentRunModel.selectRunSessionsWhere({
@@ -498,6 +565,7 @@ class AgentRunModel {
         stateChangedAt: schema.a2aTasksTable.stateChangedAt,
         hardDeadlineAt: hardDeadlineAtExpression(),
         lastModelActivityAt: lastModelActivityAtExpression(),
+        sessionId: sql<string>`COALESCE(${schema.agentWorkspacesTable.id}, ${schema.agentRunsTable.taskId})`,
         agent: {
           id: schema.agentsTable.id,
           name: schema.agentsTable.name,
@@ -514,6 +582,13 @@ class AgentRunModel {
       .innerJoin(
         schema.agentsTable,
         eq(schema.agentRunsTable.agentId, schema.agentsTable.id),
+      )
+      .leftJoin(
+        schema.agentWorkspacesTable,
+        eq(
+          schema.agentWorkspacesTable.workloadName,
+          schema.agentRunsTable.workloadName,
+        ),
       )
       .leftJoin(
         schema.projectsTable,

--- a/platform/backend/src/routes/agent-runtime/agent-runtime.routes.ts
+++ b/platform/backend/src/routes/agent-runtime/agent-runtime.routes.ts
@@ -472,7 +472,7 @@ const agentRuntimeRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async (request, reply) => {
-      const owned = await AgentRunModel.findForActorByTaskId({
+      const owned = await AgentRunModel.findCurrentSessionForActor({
         taskId: request.params.taskId,
         actorUserId: request.user.id,
         organizationId: request.organizationId,
@@ -600,6 +600,7 @@ const agentRuntimeRoutes: FastifyPluginAsyncZod = async (fastify) => {
         attachmentCount: request.body.attachments?.length ?? 0,
       };
       return reply.send({
+        sessionId: workspace.id,
         taskId: task.id,
         state: task.state,
         agentId: run.agentId,
@@ -927,7 +928,7 @@ async function inspectStartupProgress(
 }
 
 async function requireOwnedRun(request: OwnedRunRequest) {
-  const run = await AgentRunModel.findForActorByTaskId({
+  const run = await AgentRunModel.findCurrentSessionForActor({
     taskId: request.params.taskId,
     actorUserId: request.user.id,
     organizationId: request.organizationId,

--- a/platform/backend/src/services/agent-runtime/agent-init.test.ts
+++ b/platform/backend/src/services/agent-runtime/agent-init.test.ts
@@ -1,0 +1,77 @@
+import { execFile } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { expect, test } from "vitest";
+
+const exec = promisify(execFile);
+
+test("reinitializing a retained workspace refreshes Git auth without duplicating URL rewrites", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-init-"));
+  try {
+    const bin = path.join(root, "bin");
+    await mkdir(bin);
+    const gh = path.join(bin, "gh");
+    await writeFile(
+      gh,
+      `#!/bin/sh
+if [ "$1 $2" = "auth login" ]; then cat > "$HOME/current-token"; fi
+`,
+    );
+    await chmod(gh, 0o755);
+    const env = {
+      ...process.env,
+      HOME: root,
+      GIT_CONFIG_GLOBAL: path.join(root, ".gitconfig"),
+      PATH: `${bin}:${process.env.PATH}`,
+      OPENAI_BASE_URL: "",
+      OPENAI_API_KEY: "",
+      GH_TOKEN: "",
+    };
+    for (const token of [
+      "first-synthetic-token",
+      "refreshed-synthetic-token",
+      "third-synthetic-token",
+    ]) {
+      await exec(
+        "sh",
+        [
+          path.resolve(
+            import.meta.dirname,
+            "../../../../agent_images/bin/archestra-agent-init",
+          ),
+        ],
+        {
+          env: { ...env, GITHUB_TOKEN: token },
+        },
+      );
+      expect(
+        (await readFile(path.join(root, "current-token"), "utf8")).trim(),
+      ).toBe(token);
+      const rewrites = await exec(
+        "git",
+        [
+          "config",
+          "--global",
+          "--get-all",
+          "url.https://github.com/.insteadOf",
+        ],
+        { env },
+      );
+      expect(rewrites.stdout.trim().split("\n")).toEqual([
+        "git@github.com:",
+        "ssh://git@github.com/",
+      ]);
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/platform/backend/src/services/agent-runtime/codex-entrypoint.test.ts
+++ b/platform/backend/src/services/agent-runtime/codex-entrypoint.test.ts
@@ -22,11 +22,14 @@ describe("Codex image entrypoint", () => {
   test.each([
     "one_shot",
     "interactive",
+    "isolated",
   ] as const)("configures and starts %s run in the native TUI", async (mode) => {
     const root = await mkdtemp(path.join(tmpdir(), "archestra-codex-"));
     try {
       const bin = path.join(root, "bin");
       const runtime = path.join(root, "runtime");
+      const stateDir =
+        mode === "isolated" ? path.join(root, "separate-state") : runtime;
       const workspace = path.join(root, 'workspace "quoted" \\ folder');
       await Promise.all([
         mkdir(bin, { recursive: true }),
@@ -78,7 +81,9 @@ printf '%s\n' "$*" >> "$ARCHESTRA_AGENT_RUNTIME_DIR/attention-calls"
         ARCHESTRA_AGENT_RUNTIME_TASK: "Run the task.",
         ARCHESTRA_AGENT_RUNTIME_SYSTEM_PROMPT:
           "Follow the configured Agent instructions.",
-        ARCHESTRA_AGENT_RUNTIME_MODE: mode,
+        ARCHESTRA_AGENT_RUNTIME_MODE:
+          mode === "isolated" ? "interactive" : mode,
+        ARCHESTRA_AGENT_RUNTIME_NATIVE_STATE_DIR: stateDir,
         ARCHESTRA_MCP_GATEWAY_URL: "http://localhost:9000/v1/mcp/test",
         ARCHESTRA_MCP_GATEWAY_TOKEN: "test-token",
         ARCHESTRA_AGENT_ATTENTION_COMMAND: attentionCommand,
@@ -92,7 +97,7 @@ printf '%s\n' "$*" >> "$ARCHESTRA_AGENT_RUNTIME_DIR/attention-calls"
       });
 
       const config = await readFile(
-        path.join(runtime, "codex", "config.toml"),
+        path.join(stateDir, "codex", "config.toml"),
         "utf8",
       );
       expect(config).toContain('wire_api = "responses"');
@@ -101,7 +106,7 @@ printf '%s\n' "$*" >> "$ARCHESTRA_AGENT_RUNTIME_DIR/attention-calls"
           await execFileAsync("python3", [
             "-c",
             "import json, sys, tomllib; print(json.dumps(tomllib.load(open(sys.argv[1], 'rb'))))",
-            path.join(runtime, "codex", "config.toml"),
+            path.join(stateDir, "codex", "config.toml"),
           ])
         ).stdout,
       );
@@ -118,7 +123,7 @@ printf '%s\n' "$*" >> "$ARCHESTRA_AGENT_RUNTIME_DIR/attention-calls"
       );
       expect(config.includes("notify = [")).toBe(mode === "one_shot");
       const hooks = JSON.parse(
-        await readFile(path.join(runtime, "codex", "hooks.json"), "utf8"),
+        await readFile(path.join(stateDir, "codex", "hooks.json"), "utf8"),
       );
       expect(hooks.hooks.PreToolUse[0].matcher).toBe("^request_user_input$");
 

--- a/platform/backend/src/services/agent-runtime/hermes-entrypoint.test.ts
+++ b/platform/backend/src/services/agent-runtime/hermes-entrypoint.test.ts
@@ -23,11 +23,14 @@ describe("Hermes image entrypoint", () => {
     "one_shot",
     "interactive",
     "continuation",
+    "isolated",
   ] as const)("configures and starts %s run in the native TUI", async (mode) => {
     const root = await mkdtemp(path.join(tmpdir(), "archestra-hermes-"));
     try {
       const bin = path.join(root, "bin");
       const runtime = path.join(root, "runtime");
+      const stateDir =
+        mode === "isolated" ? path.join(root, "separate-state") : runtime;
       const workspace = path.join(root, "workspace");
       const home = path.join(root, "home");
       await Promise.all([
@@ -122,6 +125,7 @@ printf '%s\n' "$*" >> "$ARCHESTRA_AGENT_RUNTIME_DIR/attention-calls"
         ARCHESTRA_AGENT_RUNTIME_MODE:
           mode === "interactive" ? mode : "one_shot",
         ARCHESTRA_AGENT_RUNTIME_CONTINUE: mode === "continuation" ? "1" : "0",
+        ARCHESTRA_AGENT_RUNTIME_NATIVE_STATE_DIR: stateDir,
         ARCHESTRA_MCP_GATEWAY_URL: "http://localhost:9000/v1/mcp/test",
         ARCHESTRA_MCP_GATEWAY_TOKEN: "test-token",
         ARCHESTRA_AGENT_ATTENTION_COMMAND: attentionCommand,
@@ -135,7 +139,7 @@ printf '%s\n' "$*" >> "$ARCHESTRA_AGENT_RUNTIME_DIR/attention-calls"
       });
 
       const config = JSON.parse(
-        await readFile(path.join(runtime, "hermes", "config.yaml"), "utf8"),
+        await readFile(path.join(stateDir, "hermes", "config.yaml"), "utf8"),
       );
       expect(config.plugins.enabled).toEqual(["archestra-attention"]);
       expect(config.providers.archestra.transport).toBe("openai_chat");

--- a/platform/backend/src/services/agent-runtime/openclaw-entrypoint.test.ts
+++ b/platform/backend/src/services/agent-runtime/openclaw-entrypoint.test.ts
@@ -33,6 +33,7 @@ describe("OpenClaw image entrypoint", () => {
       baseUrl: "http://localhost:9000/v1/model-router/test",
       expectedBaseUrl: "http://localhost:9000/v1/model-router/test",
       workspaceId: undefined,
+      separateState: true,
     },
   ])("configures the $protocol transport as $expectedApi", async (testCase) => {
     const { protocol, expectedApi, baseUrl, expectedBaseUrl } = testCase;
@@ -50,6 +51,7 @@ describe("OpenClaw image entrypoint", () => {
         `#!/bin/sh
 cp "$PWD/SOUL.md" "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-soul.md"
 printf '%s\n' "$@" > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-args"
+printf '%s' "$OPENCLAW_STATE_DIR" > "$ARCHESTRA_AGENT_RUNTIME_DIR/captured-state-dir"
 plugin_dir="$(jq -r '.plugins.load.paths[] | select(contains("openclaw-transcript"))' "$OPENCLAW_CONFIG_PATH")"
 PLUGIN_PATH="$plugin_dir/index.mjs" node --input-type=module <<'JS'
 const plugin = await import("file://" + process.env.PLUGIN_PATH);
@@ -118,6 +120,9 @@ printf '%s\n' "$*" >> "$ARCHESTRA_AGENT_RUNTIME_DIR/attention-calls"
         PATH: `${bin}:${process.env.PATH}`,
         ARCHESTRA_LLM_PROXY_PROTOCOL: protocol,
         ARCHESTRA_AGENT_RUNTIME_DIR: runtime,
+        ARCHESTRA_AGENT_RUNTIME_NATIVE_STATE_DIR: testCase.separateState
+          ? path.join(root, "separate-state")
+          : undefined,
         ARCHESTRA_AGENT_RUNTIME_NATIVE_MODEL: "test-model",
         ARCHESTRA_AGENT_RUNTIME_TASK_ID: "12345678-abcd-4000-8000-123456789abc",
         ARCHESTRA_AGENT_RUNTIME_WORKSPACE_ID: testCase.workspaceId,
@@ -177,6 +182,14 @@ printf '%s\n' "$*" >> "$ARCHESTRA_AGENT_RUNTIME_DIR/attention-calls"
         id: "archestra-runtime-attention",
         configSchema: { type: "object", additionalProperties: false },
       });
+      expect(
+        await readFile(path.join(runtime, "captured-state-dir"), "utf8"),
+      ).toBe(
+        path.join(
+          testCase.separateState ? path.join(root, "separate-state") : runtime,
+          "openclaw-state",
+        ),
+      );
       const args = (await readFile(path.join(runtime, "captured-args"), "utf8"))
         .trim()
         .split("\n");

--- a/platform/backend/src/services/agent-runtime/pod-run.ts
+++ b/platform/backend/src/services/agent-runtime/pod-run.ts
@@ -196,6 +196,8 @@ async function startAgentRunSession(params: {
       await backend.continueRun({ session, spec });
     } else {
       createdWorkspace = await AgentWorkspaceModel.create({
+        // The initial public run URL is the permanent session URL.
+        id: params.taskId,
         organizationId: params.organizationId,
         agentId: params.agentId,
         actorKind: params.actor.kind,

--- a/platform/backend/src/types/agent-runtime.ts
+++ b/platform/backend/src/types/agent-runtime.ts
@@ -242,6 +242,7 @@ export const SelectAgentRunSchema = SelectAgentRunRecordSchema.omit({
 
 /** A user's durable run session as rendered in Chat and its sidebar. */
 export const SelectAgentRunSessionSchema = SelectAgentRunSchema.extend({
+  sessionId: z.string().uuid(),
   prompt: z.string(),
   agent: z.object({
     id: z.string().uuid(),
@@ -303,6 +304,7 @@ export const UpdateAgentRunSchema = createUpdateSchema(schema.agentRunsTable)
   );
 
 export const StartAgentRunResponseSchema = z.object({
+  sessionId: z.string().uuid().optional(),
   taskId: z.string().uuid(),
   state: A2ATaskStateSchema,
   agentId: z.string().uuid(),

--- a/platform/backend/src/websocket.test.ts
+++ b/platform/backend/src/websocket.test.ts
@@ -21,6 +21,7 @@ import {
   A2ATaskModel,
   AgentRunModel,
   AgentRunShareModel,
+  AgentWorkspaceModel,
 } from "@/models";
 import AgentModel from "@/models/agent";
 import { agentRunTranscriptStore } from "@/services/agent-runtime/transcript-store";
@@ -750,6 +751,115 @@ describe("websocket Agent run authorization and cleanup", () => {
         .map((message) => message.payload.logs)
         .join(""),
     ).toBe(readableTranscript);
+  });
+
+  test("owner session history includes earlier turns while shared access remains per turn", async ({
+    makeOrganization,
+    makeUser,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const owner = await makeUser();
+    const other = await makeUser();
+    const agent = await makeAgent({ organizationId: org.id });
+    const context = await A2AContextModel.create({
+      actorKind: "user",
+      actorId: owner.id,
+    });
+    const turns = [];
+    const workloadName = `history-${crypto.randomUUID()}`;
+    for (const text of ["first turn ✓", "second turn ✓"]) {
+      const task = await A2ATaskModel.create({
+        contextId: context.id,
+        agentId: agent.id,
+        state: "TASK_STATE_COMPLETED",
+      });
+      const run = await AgentRunModel.create({
+        organizationId: org.id,
+        taskId: task.id,
+        agentId: agent.id,
+        actorKind: "user",
+        actorId: owner.id,
+        actorUserId: owner.id,
+        workloadName,
+        backend: "kubernetes",
+        runtimeScope: "test",
+        virtualApiKeyId: null,
+      });
+      await AgentRunModel.close({ id: run.id });
+      await agentRunTranscriptStore.persist({
+        runId: run.id,
+        transcript: text,
+        observedBytes: Buffer.byteLength(text),
+      });
+      turns.push(task);
+    }
+    await AgentWorkspaceModel.create({
+      id: turns[0].id,
+      organizationId: org.id,
+      agentId: agent.id,
+      actorKind: "user",
+      actorId: owner.id,
+      workloadName,
+      backend: "kubernetes",
+      runtimeScope: "test",
+      state: "idle",
+      lastTaskId: turns[1].id,
+      expiresAt: new Date(Date.now() + 3600_000),
+    });
+    const ws = {
+      readyState: WS.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+    } as unknown as WS;
+    service.clientContexts.set(ws, {
+      userId: owner.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: false,
+    });
+    await service.handleMessage(
+      {
+        type: "subscribe_agent_run_logs",
+        payload: { runId: turns[0].id, includeSessionHistory: true },
+      },
+      ws,
+    );
+    const messages = vi
+      .mocked(ws.send)
+      .mock.calls.map(([value]) => JSON.parse(String(value)));
+    expect(
+      messages
+        .filter(
+          (message) =>
+            message.type === "agent_run_logs" && !message.payload.channel,
+        )
+        .map((message) => message.payload.logs)
+        .join(""),
+    ).toBe("first turn ✓\r\n\u001b[0msecond turn ✓");
+    expect(
+      messages.find((message) => message.type === "agent_run_logs_ended")
+        .payload.truncated,
+    ).toBe(false);
+    vi.mocked(ws.send).mockClear();
+    // Requesting the same session ID never grants another user the owner's accumulated history.
+    service.clientContexts.set(ws, {
+      userId: other.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: false,
+    });
+    await service.handleMessage(
+      {
+        type: "subscribe_agent_run_logs",
+        payload: { runId: turns[0].id, includeSessionHistory: true },
+      },
+      ws,
+    );
+    expect(
+      vi
+        .mocked(ws.send)
+        .mock.calls.map(([value]) => JSON.parse(String(value)))
+        .map((message) => message.type),
+    ).toEqual(["agent_run_logs_error"]);
   });
 
   test("does not let an Agent administrator attach to another user's run", async ({

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -35,6 +35,7 @@ import {
 } from "@/services/agent-runtime/output-capture";
 import { agentRunTranscriptStore } from "@/services/agent-runtime/transcript-store";
 import { isPredefinedAdmin } from "@/services/agent-tool-assignment";
+import type { AgentRunRecord } from "@/types";
 
 interface McpLogsSubscription {
   serverId: string;
@@ -254,6 +255,7 @@ class WebSocketService {
         message.payload.runId,
         message.payload.lines ?? MCP_DEFAULT_LOG_LINES,
         clientContext,
+        message.payload.includeSessionHistory ?? false,
       );
     },
     unsubscribe_agent_run_logs: (ws) => {
@@ -669,13 +671,24 @@ class WebSocketService {
     runId: string,
     lines: number,
     clientContext: WebSocketClientContext,
+    includeSessionHistory = false,
   ): Promise<void> {
     this.unsubscribeAgentRunLogs(ws);
     const abortController = new AbortController();
     const stream = new PassThrough();
     this.agentRunLogsSubscriptions.set(ws, { runId, stream, abortController });
 
-    const session = await AgentRunModel.findByTaskId(runId);
+    const owned = includeSessionHistory
+      ? await AgentRunModel.findCurrentSessionForActor({
+          taskId: runId,
+          actorUserId: clientContext.userId,
+          organizationId: clientContext.organizationId,
+        })
+      : null;
+    const resolvedTaskId = includeSessionHistory ? owned?.taskId : runId;
+    const session = resolvedTaskId
+      ? await AgentRunModel.findByTaskId(resolvedTaskId)
+      : null;
     if (abortController.signal.aborted) return;
     if (!session || session.organizationId !== clientContext.organizationId) {
       this.sendToClient(ws, {
@@ -698,6 +711,31 @@ class WebSocketService {
       this.unsubscribeAgentRunLogs(ws);
       return;
     }
+
+    let history = { complete: true, bytes: 0 };
+    try {
+      if (includeSessionHistory) {
+        history = await this.streamAgentSessionHistory({
+          ws,
+          runId,
+          session,
+          signal: abortController.signal,
+        });
+      }
+    } catch (error) {
+      if (abortController.signal.aborted) return;
+      logger.error(
+        { error, taskId: session.taskId },
+        "Could not read session history",
+      );
+      this.sendToClient(ws, {
+        type: "agent_run_logs_error",
+        payload: { runId, error: "Could not read session history" },
+      });
+      this.unsubscribeAgentRunLogs(ws);
+      return;
+    }
+    if (abortController.signal.aborted) return;
 
     if (session.endedAt) {
       if (session.virtualApiKeyId) {
@@ -763,8 +801,8 @@ class WebSocketService {
           payload: {
             runId,
             source: "full",
-            truncated: false,
-            totalBytes: transcript.uncompressedBytes,
+            truncated: !history.complete,
+            totalBytes: transcript.uncompressedBytes + history.bytes,
             ...(readable ? { readable } : {}),
           },
         });
@@ -792,6 +830,7 @@ class WebSocketService {
           runId,
           source: "tail",
           truncated:
+            !history.complete ||
             transcript?.isComplete === false ||
             Buffer.byteLength(session.logs ?? "", "utf8") >= RETAINED_LOG_BYTES,
           totalBytes: transcript?.uncompressedBytes,
@@ -836,6 +875,50 @@ class WebSocketService {
       });
       this.unsubscribeAgentRunLogs(ws);
     }
+  }
+
+  private async streamAgentSessionHistory(params: {
+    ws: WebSocket;
+    runId: string;
+    session: AgentRunRecord;
+    signal: AbortSignal;
+  }): Promise<{ complete: boolean; bytes: number }> {
+    let afterId: string | undefined;
+    let complete = true;
+    let bytes = 0;
+    while (!params.signal.aborted) {
+      const turns = await AgentRunModel.listPreviousTurns({
+        run: params.session,
+        afterId,
+      });
+      if (!turns.length) break;
+      for (const turn of turns) {
+        if (params.signal.aborted) return { complete, bytes };
+        const decoder = new StringDecoder("utf8");
+        const send = (logs: string) => {
+          if (logs && !params.signal.aborted)
+            this.sendToClient(params.ws, {
+              type: "agent_run_logs",
+              payload: { runId: params.runId, logs },
+            });
+        };
+        const transcript = await agentRunTranscriptStore.stream({
+          runId: turn.id,
+          onChunk: (chunk) => send(decoder.write(chunk)),
+        });
+        send(decoder.end());
+        if (!transcript?.isComplete) {
+          complete = false;
+          send(turn.logs ?? "");
+        }
+        bytes +=
+          transcript?.uncompressedBytes ??
+          Buffer.byteLength(turn.logs ?? "", "utf8");
+        send("\r\n\u001b[0m");
+      }
+      afterId = turns.at(-1)?.id;
+    }
+    return { complete, bytes };
   }
 
   private async streamReadableAgentRunTranscript(params: {

--- a/platform/dev/run-backend-dev.sh
+++ b/platform/dev/run-backend-dev.sh
@@ -7,7 +7,7 @@ export ARCHESTRA_LOGGING_LEVEL=debug
 export ARCHESTRA_ANALYTICS=disabled
 
 backend_pid=""
-backend_ports="$(node --env-file=.env -e 'let port = "9000"; try { port = new URL(process.env.ARCHESTRA_INTERNAL_API_BASE_URL).port || port; } catch {} process.stdout.write(port + " " + (process.env.ARCHESTRA_METRICS_PORT || "9050"));')"
+backend_ports="$(node --env-file-if-exists=.env -e 'let port = "9000"; try { port = new URL(process.env.ARCHESTRA_INTERNAL_API_BASE_URL).port || port; } catch {} process.stdout.write(port + " " + (process.env.ARCHESTRA_METRICS_PORT || "9050"));')"
 
 # The node server is a grandchild of $backend_pid (pnpm → tsdown --watch →
 # node), so the TERM to $backend_pid and its direct children can miss it. A

--- a/platform/dev/run-backend-dev.sh
+++ b/platform/dev/run-backend-dev.sh
@@ -7,6 +7,7 @@ export ARCHESTRA_LOGGING_LEVEL=debug
 export ARCHESTRA_ANALYTICS=disabled
 
 backend_pid=""
+backend_ports="$(node --env-file=.env -e 'let port = "9000"; try { port = new URL(process.env.ARCHESTRA_INTERNAL_API_BASE_URL).port || port; } catch {} process.stdout.write(port + " " + (process.env.ARCHESTRA_METRICS_PORT || "9050"));')"
 
 # The node server is a grandchild of $backend_pid (pnpm → tsdown --watch →
 # node), so the TERM to $backend_pid and its direct children can miss it. A
@@ -14,7 +15,7 @@ backend_pid=""
 # is why `tilt trigger pnpm-dev-backend` used to leave the old server running.
 # Sweep the dev ports on both stop and start.
 free_backend_ports() {
-  for port in 9000 "${ARCHESTRA_METRICS_PORT:-9050}"; do
+  for port in $backend_ports; do
     pids="$(lsof -t -i "tcp:$port" -s tcp:LISTEN 2>/dev/null || true)"
     [ -n "$pids" ] || continue
     echo "killing stale backend listener(s) on port $port: $pids" >&2

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -694,7 +694,7 @@ export function ChatSidebarSection({
   };
 
   const renderRunItem = (run: (typeof runs)[number]) => {
-    const active = currentRunTaskId === run.taskId;
+    const active = currentRunTaskId === (run.sessionId ?? run.taskId);
     const menuKey = `run:${run.taskId}`;
     const isMenuOpen = openMenuId === menuKey;
     const isEditing = editingRunId === run.taskId;
@@ -724,7 +724,7 @@ export function ChatSidebarSection({
             <SidebarMenuButton
               onClick={() => {
                 if (isMobile) setOpenMobile(false);
-                router.push(`/chat/runs/${run.taskId}`);
+                router.push(`/chat/runs/${run.sessionId ?? run.taskId}`);
               }}
               isActive={active}
               className="cursor-pointer flex-1"

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -694,7 +694,8 @@ export function ChatSidebarSection({
   };
 
   const renderRunItem = (run: (typeof runs)[number]) => {
-    const active = currentRunTaskId === (run.sessionId ?? run.taskId);
+    const active =
+      currentRunTaskId === run.sessionId || currentRunTaskId === run.taskId;
     const menuKey = `run:${run.taskId}`;
     const isMenuOpen = openMenuId === menuKey;
     const isEditing = editingRunId === run.taskId;

--- a/platform/frontend/src/app/chat/runs/page.client.tsx
+++ b/platform/frontend/src/app/chat/runs/page.client.tsx
@@ -50,6 +50,7 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
   const [continueDialogOpen, setContinueDialogOpen] = useState(false);
   const [reattachedTaskId, setReattachedTaskId] = useState<string | null>(null);
   const reattached = reattachedTaskId === taskId;
+  const [showHistory, setShowHistory] = useState(false);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [connectionDialogOpen, setConnectionDialogOpen] = useState(false);
   const [connectionCommand, setConnectionCommand] = useState<string | null>(
@@ -88,7 +89,7 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
   const canReattach = Boolean(isOwner && run?.workspace?.terminalAvailable);
   const showLiveTerminal =
     (!run && query.isPending) ||
-    (isOwner && (live || (reattached && canReattach)));
+    (isOwner && !showHistory && (live || (reattached && canReattach)));
   const canContinue =
     isOwner &&
     !live &&
@@ -131,6 +132,15 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
+              {isOwner && (live || (reattached && canReattach)) && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowHistory(!showHistory)}
+                >
+                  {showHistory ? "Live terminal" : "Session history"}
+                </Button>
+              )}
               {canContinue && !showLiveTerminal && (
                 <Button
                   size="sm"
@@ -238,7 +248,7 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
         )}
         {showLiveTerminal ? (
           <AgentRunTerminal
-            taskId={taskId}
+            taskId={run?.taskId ?? taskId}
             active
             title={live ? "Live terminal" : "Output"}
             showManualCommand={false}
@@ -255,7 +265,7 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
           />
         ) : run ? (
           <>
-            {live && (
+            {live && !isOwner && (
               <div className="shrink-0 overflow-hidden rounded-md border bg-slate-950">
                 <ExecTerminalStatus
                   title="Read-only terminal"
@@ -264,7 +274,11 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
                 />
               </div>
             )}
-            <AgentRunLogs run={run} />
+            <AgentRunLogs
+              key={run.taskId}
+              run={run}
+              sessionId={isOwner ? run.sessionId : undefined}
+            />
           </>
         ) : null}
       </section>

--- a/platform/frontend/src/app/chat/runs/page.client.tsx
+++ b/platform/frontend/src/app/chat/runs/page.client.tsx
@@ -315,7 +315,7 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
         }
       />
       <ShareAgentRunDialog
-        taskId={taskId}
+        taskId={run?.taskId ?? taskId}
         open={shareDialogOpen}
         onOpenChange={setShareDialogOpen}
       />

--- a/platform/frontend/src/components/agent-run-logs.test.tsx
+++ b/platform/frontend/src/components/agent-run-logs.test.tsx
@@ -62,6 +62,28 @@ describe("AgentRunLogs", () => {
     expect(screen.getByText("Complete terminal recording")).toBeInTheDocument();
   });
 
+  it("renders session history delivered to the stable URL after a continuation", () => {
+    render(<AgentRunLogs run={completedRun} sessionId="original-session" />);
+    emit({
+      type: "agent_run_logs",
+      payload: { runId: "original-session", logs: "Earlier turn output\n" },
+    });
+    emit({
+      type: "agent_run_logs",
+      payload: { runId: "unrelated-session", logs: "Private unrelated output" },
+    });
+    emit({
+      type: "agent_run_logs",
+      payload: { runId: "original-session", logs: "Continuation output\n" },
+    });
+    expect(screen.getByTestId("terminal-playback")).toHaveTextContent(
+      "Earlier turn output Continuation output",
+    );
+    expect(
+      screen.queryByText(/Private unrelated output/),
+    ).not.toBeInTheDocument();
+  });
+
   it("warns when only the bounded tail could be retained", () => {
     render(<AgentRunLogs run={completedRun} />);
 

--- a/platform/frontend/src/components/agent-run-logs.tsx
+++ b/platform/frontend/src/components/agent-run-logs.tsx
@@ -15,10 +15,14 @@ import websocketService from "@/lib/websocket/websocket";
 export function AgentRunLogs({
   run,
   title = "Output",
+  sessionId,
 }: {
   run: AgentRun;
   title?: string;
+  sessionId?: string;
 }) {
+  const includeSessionHistory = Boolean(sessionId);
+  const logId = sessionId ?? run.taskId;
   const [terminalContent, setTerminalContent] = useState("");
   const [error, setError] = useState<string>();
   const [isStreaming, setIsStreaming] = useState(!run.endedAt);
@@ -34,7 +38,10 @@ export function AgentRunLogs({
     const subscribeToLogs = () => {
       websocketService.send({
         type: "subscribe_agent_run_logs",
-        payload: { runId: run.taskId },
+        payload: {
+          runId: logId,
+          ...(includeSessionHistory ? { includeSessionHistory: true } : {}),
+        },
       });
     };
     setTerminalContent("");
@@ -47,7 +54,7 @@ export function AgentRunLogs({
         "agent_run_logs",
         (message: AgentRunLogsMessage) => {
           if (
-            message.payload.runId === run.taskId &&
+            message.payload.runId === logId &&
             message.payload.channel !== "readable"
           ) {
             receivedOutput = true;
@@ -58,7 +65,7 @@ export function AgentRunLogs({
       websocketService.subscribe(
         "agent_run_logs_error",
         (message: AgentRunLogsErrorMessage) => {
-          if (message.payload.runId === run.taskId) {
+          if (message.payload.runId === logId) {
             setError(message.payload.error);
             setIsStreaming(false);
           }
@@ -67,7 +74,7 @@ export function AgentRunLogs({
       websocketService.subscribe(
         "agent_run_logs_ended",
         (message: AgentRunLogsEndedMessage) => {
-          if (message.payload.runId === run.taskId) {
+          if (message.payload.runId === logId) {
             if (!receivedOutput && emptyRetryCount < EMPTY_LOG_RETRY_LIMIT) {
               emptyRetryCount += 1;
               setIsStreaming(true);
@@ -94,10 +101,10 @@ export function AgentRunLogs({
       for (const unsubscribe of subscriptions) unsubscribe();
       websocketService.send({
         type: "unsubscribe_agent_run_logs",
-        payload: { runId: run.taskId },
+        payload: { runId: logId },
       });
     };
-  }, [run.endedAt, run.taskId]);
+  }, [run.endedAt, logId, includeSessionHistory]);
 
   return (
     <DeploymentLogPanel

--- a/platform/frontend/src/components/continue-agent-run-dialog.tsx
+++ b/platform/frontend/src/components/continue-agent-run-dialog.tsx
@@ -34,7 +34,7 @@ export function ContinueAgentRunDialog({
               if (!result) return;
               form.reset();
               onOpenChange(false);
-              router.push(`/chat/runs/${result.taskId}`);
+              router.push(`/chat/runs/${result.sessionId ?? taskId}`);
             },
           },
         ),

--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -571,7 +571,7 @@ export function ConversationSearchPalette({
       key={`exec-${run.taskId}`}
       value={`exec-${run.taskId}`}
       onSelect={() => {
-        router.push(`/chat/runs/${run.taskId}`);
+        router.push(`/chat/runs/${run.sessionId ?? run.taskId}`);
         onOpenChange(false);
       }}
       className="flex items-center gap-2 px-3 py-2.5 cursor-pointer aria-selected:bg-accent rounded-sm w-full"

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -18325,6 +18325,7 @@ export type StartAgentRunResponses = {
      * Default Response
      */
     200: {
+        sessionId?: string;
         taskId: string;
         state: 'TASK_STATE_UNSPECIFIED' | 'TASK_STATE_SUBMITTED' | 'TASK_STATE_WORKING' | 'TASK_STATE_COMPLETED' | 'TASK_STATE_FAILED' | 'TASK_STATE_CANCELED' | 'TASK_STATE_INPUT_REQUIRED' | 'TASK_STATE_REJECTED' | 'TASK_STATE_AUTH_REQUIRED';
         agentId: string;
@@ -18440,6 +18441,7 @@ export type GetMyAgentRunsResponses = {
             stateChangedAt: string | null;
             hardDeadlineAt: string;
             lastModelActivityAt: string | null;
+            sessionId: string;
             prompt: string;
             agent: {
                 id: string;
@@ -18648,6 +18650,7 @@ export type GetMyAgentRunResponses = {
         stateChangedAt: string | null;
         hardDeadlineAt: string;
         lastModelActivityAt: string | null;
+        sessionId: string;
         prompt: string;
         agent: {
             id: string;
@@ -18783,6 +18786,7 @@ export type UpdateAgentRunResponses = {
         stateChangedAt: string | null;
         hardDeadlineAt: string;
         lastModelActivityAt: string | null;
+        sessionId: string;
         prompt: string;
         agent: {
             id: string;
@@ -18882,6 +18886,7 @@ export type ContinueAgentRunResponses = {
      * Default Response
      */
     200: {
+        sessionId?: string;
         taskId: string;
         state: 'TASK_STATE_UNSPECIFIED' | 'TASK_STATE_SUBMITTED' | 'TASK_STATE_WORKING' | 'TASK_STATE_COMPLETED' | 'TASK_STATE_FAILED' | 'TASK_STATE_CANCELED' | 'TASK_STATE_INPUT_REQUIRED' | 'TASK_STATE_REJECTED' | 'TASK_STATE_AUTH_REQUIRED';
         agentId: string;
@@ -89838,6 +89843,7 @@ export type GetProjectRunsResponses = {
         stateChangedAt: string | null;
         hardDeadlineAt: string;
         lastModelActivityAt: string | null;
+        sessionId: string;
         prompt: string;
         agent: {
             id: string;

--- a/platform/shared/websocket.ts
+++ b/platform/shared/websocket.ts
@@ -103,6 +103,7 @@ const AgentRunAttachResizePayloadSchema = z.object({
   rows: z.number().int().min(1),
 });
 const SubscribeAgentRunLogsPayloadSchema = z.object({
+  includeSessionHistory: z.boolean().optional(),
   runId: z.string().uuid(),
   lines: z.number().int().min(1).max(10_000).optional(),
 });


### PR DESCRIPTION
Continuing a retained Agent workspace previously moved the owner to a new run URL and split its recorded history. Keep the original session URL pointed at the current turn, show one owner-sidebar session, and stream earlier turn recordings into session history. Shared links still grant access to a specific turn rather than future continuations.

Also make Git initialization repeatable for retained workspaces, allow runtime wrappers to isolate native publishing conversations, and respect configured backend ports when restarting an isolated development stack.

Validated through the local Slack app and Chrome: a local commit and uncommitted files survived suspension and Pod replacement; Slack and browser continuations kept the original URL; Continue reattached to the retained native terminal; and a shared current-turn link opened for another user without exposing earlier turns. Regression coverage checks session lookup, history ownership, native state isolation, and repeatable Git initialization.

Companion Lobster changes: https://github.com/archestra-ai/infra/pull/262. Existing recordings without terminal resize metadata can still render incorrectly after geometry changes; this change preserves their recorded bytes but does not reconstruct missing geometry.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>