### PR TITLE
docs: add branch layout diagram to release checklist

### DIFF
--- a/platform/dev/RELEASE.md
+++ b/platform/dev/RELEASE.md
@@ -6,6 +6,25 @@ Archestra uses two release pipelines:
 
 [Release-please](https://github.com/googleapis/release-please-action#supporting-multiple-release-branches) manages versions and changelogs. GitHub Actions builds the artifacts. Only approved stable releases update `latest`.
 
+```mermaid
+gitGraph
+   commit id: "1.3 cut point"
+   branch release/1.3
+   checkout main
+   commit id: "fix B"
+   commit id: "feat C"
+   commit id: "beta" tag: "v1.4.0-beta.1"
+   checkout release/1.3
+   cherry-pick id: "fix B" tag: ""
+   commit id: "patch" tag: "v1.3.52"
+   checkout main
+   commit id: "beta again" tag: "v1.4.0-beta.2"
+   branch release/1.4
+   commit id: "stable cut" tag: "v1.4.0"
+   checkout main
+   commit id: "Feat" tag: "v1.5.0-beta.1"
+```
+
 ## Release A Beta
 
 1. [ ] Open the release-please PR on `main` (for example, `1.4.0-beta.2`).


### PR DESCRIPTION
Adds a mermaid gitGraph to platform/dev/RELEASE.md showing how main, release/1.3, and release/1.4 relate: rolling beta tags on main, stable patches via cherry-pick on release/1.3, and the new stable line branched from a qualified beta tag.

https://claude.ai/code/session_01YT5Uyzis51sU1D7BxVKLYD

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>