### PR TITLE
feat(apps): add card quick actions

### DIFF
--- a/docs/pages/platform-apps.md
+++ b/docs/pages/platform-apps.md
@@ -3,7 +3,7 @@ title: MCP Apps
 category: Apps
 order: 1
 description: User-authored MCP Apps — sandboxed HTML interfaces with their own data store and tools
-lastUpdated: 2026-09-08
+lastUpdated: 2026-09-10
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -38,7 +38,9 @@ Sharing a chat does not share the apps it renders. Each viewer resolves an app a
 
 Disabling an app (in App settings) pulls it back without deleting it. It leaves everyone else's gallery, and its launch tool leaves every agent surface. To chat, a disabled app does not exist: it is not listed, and no conversation can read, edit, publish, or delete it — not even yours. You still see it in your own gallery, marked Disabled; enable it there to keep building.
 
-The `/apps` gallery lists everything the viewer can reach in two sections: apps you own, and the interactive apps exposed by your installed external [MCP servers](./platform-mcp). Each `ui://` resource is its own card, titled by the server's display name (*Task Tracker*); when one server exposes several UIs, the title carries the tool — *Task Tracker / show_board*. A card opens the app in a new chat. That chat stays out of your conversation list until you write into it. An owned card carries **Open in new tab** and **Delete** in its overflow menu; an external card carries **Open in new tab** (the standalone runtime) and a link to the backing **MCP server** page (where the server — and its uninstall — lives).
+The `/apps` gallery lists apps you own and apps exposed by installed [MCP servers](./platform-mcp). Each `ui://` resource has its own card. The card uses the server's display name, such as *Task Tracker*. When a server exposes several apps, the title also includes the tool name — *Task Tracker / show_board*.
+
+Choose **Chat** to open an app in a new conversation. That chat stays out of your conversation list until you write into it. Owned cards also offer quick access to **Settings**. Their overflow menu includes version history, standalone launch, pinning, and deletion. External cards link to the backing MCP server and offer standalone launch when the tool needs no input.
 
 While the feature is enabled, newly created agents get the full app tool set assigned by default — the staged flow (`refine_app`, `scaffold_app`, `read_app`, `edit_app`, `validate_app`, `publish_app`) plus the supporting `list_app_versions`, `restore_app_version`, `preview_app_tool`, `get_app_diagnostics`, `render_app`, `list_apps`, and `delete_app` — so "build me an app" works in chat without per-agent setup. The tools can be unassigned per agent like any other; agents created before the feature was enabled need them assigned manually.
 

--- a/docs/pages/platform-apps.md
+++ b/docs/pages/platform-apps.md
@@ -40,7 +40,7 @@ Disabling an app (in App settings) pulls it back without deleting it. It leaves 
 
 The `/apps` gallery lists apps you own and apps exposed by installed [MCP servers](./platform-mcp). Each `ui://` resource has its own card. The card uses the server's display name, such as *Task Tracker*. When a server exposes several apps, the title also includes the tool name — *Task Tracker / show_board*.
 
-Choose **Chat** to open an app in a new conversation. That chat stays out of your conversation list until you write into it. Owned cards also offer quick access to **Settings**. Their overflow menu includes version history, standalone launch, pinning, and deletion. External cards link to the backing MCP server and offer standalone launch when the tool needs no input.
+Click a card to open its app in a new conversation. That chat stays out of your conversation list until you write into it. Owned cards also offer quick access to **Settings**. Their overflow menu includes version history, standalone launch, pinning, and deletion. External cards link to the backing MCP server and offer standalone launch when the tool needs no input.
 
 While the feature is enabled, newly created agents get the full app tool set assigned by default — the staged flow (`refine_app`, `scaffold_app`, `read_app`, `edit_app`, `validate_app`, `publish_app`) plus the supporting `list_app_versions`, `restore_app_version`, `preview_app_tool`, `get_app_diagnostics`, `render_app`, `list_apps`, and `delete_app` — so "build me an app" works in chat without per-agent setup. The tools can be unassigned per agent like any other; agents created before the feature was enabled need them assigned manually.
 

--- a/platform/frontend/src/app/apps/_parts/app-card.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.test.tsx
@@ -244,6 +244,12 @@ describe("ExternalAppCard", () => {
   it("links 'Open in new tab' to the install-pinned run page and 'Manage MCP server'", () => {
     render(<AppCard app={externalApp} />);
 
+    expect(
+      screen.queryByRole("button", {
+        name: "Chat Archestra PM / show_board",
+      }),
+    ).not.toBeInTheDocument();
+
     const expectedRun =
       "/a/catalog/cat-1?install=srv-1&resource=ui%3A%2F%2Fpm%2Fboard.html";
 
@@ -288,33 +294,19 @@ describe("OwnedAppCard", () => {
     openOwnedMutate.mockReset();
   });
 
-  it("offers Chat and Settings as quick card actions", () => {
+  it("offers Settings without duplicating the card's chat action", () => {
     const onOpenSettings = vi.fn();
     render(<AppCard app={ownedApp} onOpenSettings={onOpenSettings} />);
 
     expect(
-      screen.getByRole("button", { name: "Chat My Owned App" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Chat My Owned App" }),
+    ).not.toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("button", { name: "Settings My Owned App" }),
     );
+    expect(onOpenSettings).toHaveBeenCalledOnce();
     expect(onOpenSettings).toHaveBeenCalledWith(ownedApp);
-  });
-
-  it("disables the Chat action while an app is opening", async () => {
-    openOwnedMutate.mockReturnValue(new Promise(() => undefined));
-    render(<AppCard app={ownedApp} />);
-
-    const chat = screen.getByRole("button", { name: "Chat My Owned App" });
-    fireEvent.click(chat);
-
-    await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: "Chat My Owned App" }),
-      ).toBeDisabled(),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Chat My Owned App" }));
-    expect(openOwnedMutate).toHaveBeenCalledTimes(1);
+    expect(openOwnedMutate).not.toHaveBeenCalled();
   });
 
   it("exposes a standalone link and a delete action", () => {

--- a/platform/frontend/src/app/apps/_parts/app-card.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.test.tsx
@@ -4,13 +4,15 @@ import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppAccess } from "@/lib/apps/use-app-access";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { takePendingProjectChatHandoff } from "@/lib/chat/pending-project-chat-handoff";
 import { AppCard } from "./app-card";
 
 type AppListItem = archestraApiTypes.GetAppsResponses["200"]["data"][number];
 
-const { pushMock, openExternalMutate } = vi.hoisted(() => ({
+const { pushMock, openOwnedMutate, openExternalMutate } = vi.hoisted(() => ({
   pushMock: vi.fn(),
+  openOwnedMutate: vi.fn(),
   openExternalMutate: vi.fn(),
 }));
 
@@ -21,9 +23,10 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("next/navigation");
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/app.query", () => ({
-  useOpenAppInChat: () => ({ mutateAsync: vi.fn() }),
+  useOpenAppInChat: () => ({ mutateAsync: openOwnedMutate }),
   useOpenExternalAppInChat: () => ({ mutateAsync: openExternalMutate }),
   usePinApp: () => ({ mutate: vi.fn() }),
   // The card hosts the shared AppSettingsDialog, which reads the app by id.
@@ -81,11 +84,13 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuItem: ({
     children,
     onSelect,
+    onClick,
     variant,
     ...props
   }: {
     children: ReactNode;
     onSelect?: (e: { preventDefault: () => void }) => void;
+    onClick?: React.MouseEventHandler<HTMLDivElement>;
     variant?: string;
   } & React.HTMLAttributes<HTMLDivElement>) => (
     <div
@@ -93,7 +98,10 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
       role="menuitem"
       data-variant={variant}
       tabIndex={0}
-      onClick={(e) => onSelect?.(e)}
+      onClick={(e) => {
+        onSelect?.(e);
+        onClick?.(e);
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           onSelect?.(e);
@@ -106,6 +114,9 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 }));
 
 beforeEach(() => {
+  vi.mocked(useHasPermissions).mockReturnValue({ data: true } as ReturnType<
+    typeof useHasPermissions
+  >);
   vi.mocked(useRouter).mockReturnValue({
     push: pushMock,
   } as unknown as ReturnType<typeof useRouter>);
@@ -273,6 +284,39 @@ describe("ExternalAppCard", () => {
 });
 
 describe("OwnedAppCard", () => {
+  beforeEach(() => {
+    openOwnedMutate.mockReset();
+  });
+
+  it("offers Chat and Settings as quick card actions", () => {
+    const onOpenSettings = vi.fn();
+    render(<AppCard app={ownedApp} onOpenSettings={onOpenSettings} />);
+
+    expect(
+      screen.getByRole("button", { name: "Chat My Owned App" }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Settings My Owned App" }),
+    );
+    expect(onOpenSettings).toHaveBeenCalledWith(ownedApp);
+  });
+
+  it("disables the Chat action while an app is opening", async () => {
+    openOwnedMutate.mockReturnValue(new Promise(() => undefined));
+    render(<AppCard app={ownedApp} />);
+
+    const chat = screen.getByRole("button", { name: "Chat My Owned App" });
+    fireEvent.click(chat);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Chat My Owned App" }),
+      ).toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Chat My Owned App" }));
+    expect(openOwnedMutate).toHaveBeenCalledTimes(1);
+  });
+
   it("exposes a standalone link and a delete action", () => {
     render(<AppCard app={ownedApp} />);
 
@@ -325,7 +369,9 @@ describe("OwnedAppCard", () => {
 
     render(<AppCard app={ownedApp} onOpenSettings={onOpenSettings} />);
 
-    const settings = screen.getByRole("menuitem", { name: "Settings" });
+    const settings = screen.getByRole("button", {
+      name: "Settings My Owned App",
+    });
     const versionHistory = screen.getByRole("menuitem", {
       name: "Version history",
     });

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -5,7 +5,7 @@ import {
   AppWindow,
   History,
   Loader2,
-  MoreHorizontal,
+  MessageSquare,
   Pin,
   PinOff,
   Server,
@@ -13,9 +13,8 @@ import {
   SquareArrowOutUpRight,
   Trash2,
 } from "lucide-react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useId, useState } from "react";
+import { useState } from "react";
 import { LockedChatIcon } from "@/components/chat/locked-chat-icon";
 import { CreatedByCell } from "@/components/created-by-cell";
 import { LabelTags } from "@/components/label-tags";
@@ -23,15 +22,12 @@ import { AppVersionHistoryDialog } from "@/components/mcp-app/app-version-histor
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { ScopeBadge } from "@/components/scope-badge";
 import { TableCard } from "@/components/table-card-view";
-import { Badge } from "@/components/ui/badge";
-import { Button, buttonVariants } from "@/components/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  type TableRowAction,
+  TableRowActions,
+} from "@/components/table-row-actions";
+import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
@@ -78,55 +74,6 @@ export function AppCard({
     />
   ) : (
     <ExternalAppCard app={app} showDisabledSelection={selection === null} />
-  );
-}
-
-// Shared card chrome: the scope pill / owner badge / overflow menu cluster that
-// sits at the right of the card's header row (mirroring the project card).
-function CardOverflowMenu({
-  leading,
-  children,
-}: {
-  leading?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex shrink-0 items-center gap-1.5">
-      {leading}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7 text-muted-foreground"
-            aria-label="More actions"
-          >
-            <MoreHorizontal className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">{children}</DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
-}
-
-// Pin/Unpin menu item (mirrors the project card's): pins are per-user and
-// toggle from the same overflow menu on both card kinds.
-function PinMenuItem({
-  pinned,
-  target,
-}: {
-  pinned: boolean;
-  target: PinAppTarget;
-}) {
-  const pinAppMutation = usePinApp();
-  return (
-    <DropdownMenuItem
-      onSelect={() => pinAppMutation.mutate({ pinned: !pinned, target })}
-    >
-      {pinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
-      <span>{pinned ? "Unpin" : "Pin"}</span>
-    </DropdownMenuItem>
   );
 }
 
@@ -197,6 +144,7 @@ function OwnedAppCard({
 }) {
   const router = useRouter();
   const openApp = useOpenAppInChat();
+  const pinApp = usePinApp();
   const lockedChatEnabled = useFeature("lockedChatEnabled") ?? false;
   const access = useAppAccess(app);
   // A personal app the caller only reaches through app:admin oversight
@@ -225,6 +173,7 @@ function OwnedAppCard({
   });
 
   const handleOpen = async (lockedChat = false) => {
+    if (isOpening) return;
     setIsOpening(true);
     const result = await openApp.mutateAsync({ appId: app.id, lockedChat });
     if (result?.conversationId) {
@@ -233,6 +182,69 @@ function OwnedAppCard({
       setIsOpening(false);
     }
   };
+  const actions: TableRowAction[] = [
+    {
+      icon: <MessageSquare className="h-4 w-4" />,
+      label: "Chat",
+      disabled: isOpening,
+      onClick: () => void handleOpen(),
+    },
+    {
+      icon: <Settings className="h-4 w-4" />,
+      label: "Settings",
+      permissions: { app: ["update"] },
+      disabled: !!settingsDisabledReason,
+      disabledTooltip: settingsDisabledReason,
+      onClick: () => onOpenSettings?.(app),
+    },
+  ];
+  const dropdownActions: TableRowAction[] = [
+    {
+      icon: app.pinnedAt ? (
+        <PinOff className="h-4 w-4" />
+      ) : (
+        <Pin className="h-4 w-4" />
+      ),
+      label: app.pinnedAt ? "Unpin" : "Pin",
+      onClick: () =>
+        pinApp.mutate({
+          pinned: !app.pinnedAt,
+          target: { source: "owned", appId: app.id } satisfies PinAppTarget,
+        }),
+    },
+    {
+      icon: <History className="h-4 w-4" />,
+      label: "Version history",
+      permissions: { app: ["update"] },
+      disabled: !!settingsDisabledReason,
+      disabledTooltip: settingsDisabledReason,
+      onClick: () => setHistoryOpen(true),
+    },
+    {
+      icon: <SquareArrowOutUpRight className="h-4 w-4" />,
+      label: "Open in new tab",
+      href: appRunUrl(app),
+      external: true,
+    },
+    ...(lockedChatEnabled
+      ? [
+          {
+            icon: <LockedChatIcon className="h-4 w-4" />,
+            label: "Open as locked chat",
+            onClick: () => void handleOpen(true),
+          } satisfies TableRowAction,
+        ]
+      : []),
+    {
+      icon: <Trash2 className="h-4 w-4" />,
+      label: "Delete",
+      variant: "destructive",
+      permissions: { app: ["delete"] },
+      disabled: !!deleteDisabledReason,
+      disabledTooltip: deleteDisabledReason,
+      onClick: () => setDeleteOpen(true),
+    },
+  ];
   return (
     <>
       <TableCard
@@ -254,44 +266,11 @@ function OwnedAppCard({
         }
         description={app.description}
         actions={
-          <CardOverflowMenu>
-            <PinMenuItem
-              pinned={!!app.pinnedAt}
-              target={{ source: "owned", appId: app.id }}
-            />
-            <AppMenuItem
-              icon={<Settings className="h-4 w-4" />}
-              label="Settings"
-              disabledReason={settingsDisabledReason}
-              onSelect={() => onOpenSettings?.(app)}
-            />
-            <AppMenuItem
-              icon={<History className="h-4 w-4" />}
-              label="Version history"
-              disabledReason={settingsDisabledReason}
-              onSelect={() => setHistoryOpen(true)}
-            />
-            <DropdownMenuItem asChild>
-              <Link href={appRunUrl(app)} target="_blank" rel="noreferrer">
-                <SquareArrowOutUpRight className="h-4 w-4" />
-                Open in new tab
-              </Link>
-            </DropdownMenuItem>
-            {lockedChatEnabled ? (
-              <DropdownMenuItem onSelect={() => void handleOpen(true)}>
-                <LockedChatIcon className="h-4 w-4" />
-                Open as locked chat
-              </DropdownMenuItem>
-            ) : null}
-            <DropdownMenuSeparator />
-            <AppMenuItem
-              icon={<Trash2 className="h-4 w-4" />}
-              label="Delete"
-              variant="destructive"
-              disabledReason={deleteDisabledReason}
-              onSelect={() => setDeleteOpen(true)}
-            />
-          </CardOverflowMenu>
+          <TableRowActions
+            actions={actions}
+            dropdownActions={dropdownActions}
+            itemName={app.name}
+          />
         }
         selected={selection?.selected}
         selectionDisabled={selection?.selectionDisabled || !access.canEdit}
@@ -360,6 +339,7 @@ function ExternalAppCard({
 }) {
   const router = useRouter();
   const openApp = useOpenExternalAppInChat();
+  const pinApp = usePinApp();
   // Stays true from click through the redirect; see OwnedAppCard for the same
   // reasoning. Only a failure resets it (the card unmounts on success).
   const [isOpening, setIsOpening] = useState(false);
@@ -371,6 +351,7 @@ function ExternalAppCard({
   const serverHref = `/mcp/registry/${app.catalogId}`;
 
   const handleOpen = async (lockedChat = false) => {
+    if (isOpening) return;
     setIsOpening(true);
     const result = await openApp.mutateAsync({
       mcpServerId: app.mcpServerId,
@@ -389,6 +370,58 @@ function ExternalAppCard({
       setIsOpening(false);
     }
   };
+  const actions: TableRowAction[] = [
+    {
+      icon: <MessageSquare className="h-4 w-4" />,
+      label: "Chat",
+      disabled: isOpening,
+      onClick: () => void handleOpen(),
+    },
+    {
+      icon: <Server className="h-4 w-4" />,
+      label: "Manage MCP server",
+      href: serverHref,
+    },
+  ];
+  const dropdownActions: TableRowAction[] = [
+    {
+      icon: app.pinnedAt ? (
+        <PinOff className="h-4 w-4" />
+      ) : (
+        <Pin className="h-4 w-4" />
+      ),
+      label: app.pinnedAt ? "Unpin" : "Pin",
+      onClick: () =>
+        pinApp.mutate({
+          pinned: !app.pinnedAt,
+          target: {
+            source: "external",
+            mcpServerId: app.mcpServerId,
+            resourceUri: app.resourceUri,
+            toolName: app.toolName,
+          } satisfies PinAppTarget,
+        }),
+    },
+    ...(app.requiresInput
+      ? []
+      : [
+          {
+            icon: <SquareArrowOutUpRight className="h-4 w-4" />,
+            label: "Open in new tab",
+            href: runHref,
+            external: true,
+          } satisfies TableRowAction,
+        ]),
+    ...(lockedChatEnabled
+      ? [
+          {
+            icon: <LockedChatIcon className="h-4 w-4" />,
+            label: "Open as locked chat",
+            onClick: () => void handleOpen(true),
+          } satisfies TableRowAction,
+        ]
+      : []),
+  ];
   return (
     <TableCard
       className="relative"
@@ -409,37 +442,11 @@ function ExternalAppCard({
       }
       description={app.description}
       actions={
-        <CardOverflowMenu>
-          <PinMenuItem
-            pinned={!!app.pinnedAt}
-            target={{
-              source: "external",
-              mcpServerId: app.mcpServerId,
-              resourceUri: app.resourceUri,
-              toolName: app.toolName,
-            }}
-          />
-          {app.requiresInput ? null : (
-            <DropdownMenuItem asChild>
-              <Link href={runHref} target="_blank" rel="noreferrer">
-                <SquareArrowOutUpRight className="h-4 w-4" />
-                Open in new tab
-              </Link>
-            </DropdownMenuItem>
-          )}
-          {lockedChatEnabled ? (
-            <DropdownMenuItem onSelect={() => void handleOpen(true)}>
-              <LockedChatIcon className="h-4 w-4" />
-              Open as locked chat
-            </DropdownMenuItem>
-          ) : null}
-          <DropdownMenuItem asChild>
-            <Link href={serverHref}>
-              <Server className="h-4 w-4" />
-              Manage MCP server
-            </Link>
-          </DropdownMenuItem>
-        </CardOverflowMenu>
+        <TableRowActions
+          actions={actions}
+          dropdownActions={dropdownActions}
+          itemName={app.name}
+        />
       }
       selected={false}
       selectionDisabled={showDisabledSelection}
@@ -453,63 +460,5 @@ function ExternalAppCard({
         <ScopeBadge scope={app.scope} />
       </div>
     </TableCard>
-  );
-}
-
-/**
- * A refused menu item stays in the menu so the action remains discoverable.
- * `aria-disabled` keeps it focusable, while the guarded select handler and the
- * visible/screen-reader reason explain why it cannot run.
- */
-function AppMenuItem({
-  icon,
-  label,
-  onSelect,
-  disabledReason,
-  variant,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  onSelect: () => void;
-  disabledReason?: string;
-  variant?: "default" | "destructive";
-}) {
-  const reasonId = useId();
-  const isDisabled = !!disabledReason;
-  const content = (
-    <DropdownMenuItem
-      aria-disabled={isDisabled || undefined}
-      aria-describedby={isDisabled ? reasonId : undefined}
-      className={isDisabled ? "cursor-not-allowed opacity-50" : undefined}
-      variant={variant}
-      onSelect={(event) => {
-        if (isDisabled) {
-          event.preventDefault();
-          return;
-        }
-        onSelect();
-      }}
-    >
-      {icon}
-      <span>{label}</span>
-      {disabledReason ? (
-        <span id={reasonId} aria-hidden="true" className="sr-only">
-          {disabledReason}
-        </span>
-      ) : null}
-    </DropdownMenuItem>
-  );
-
-  if (!disabledReason) return content;
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="cursor-not-allowed">{content}</div>
-      </TooltipTrigger>
-      <TooltipContent side="left" className="max-w-64">
-        {disabledReason}
-      </TooltipContent>
-    </Tooltip>
   );
 }

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -5,7 +5,6 @@ import {
   AppWindow,
   History,
   Loader2,
-  MessageSquare,
   Pin,
   PinOff,
   Server,
@@ -183,12 +182,6 @@ function OwnedAppCard({
     }
   };
   const actions: TableRowAction[] = [
-    {
-      icon: <MessageSquare className="h-4 w-4" />,
-      label: "Chat",
-      disabled: isOpening,
-      onClick: () => void handleOpen(),
-    },
     {
       icon: <Settings className="h-4 w-4" />,
       label: "Settings",
@@ -371,12 +364,6 @@ function ExternalAppCard({
     }
   };
   const actions: TableRowAction[] = [
-    {
-      icon: <MessageSquare className="h-4 w-4" />,
-      label: "Chat",
-      disabled: isOpening,
-      onClick: () => void handleOpen(),
-    },
     {
       icon: <Server className="h-4 w-4" />,
       label: "Manage MCP server",

--- a/platform/frontend/src/components/mcp-app/app-settings-dialog.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-dialog.test.tsx
@@ -125,12 +125,14 @@ describe("AppSettingsDialog", () => {
     expect(
       await screen.findByRole("status", { name: "Loading app settings…" }),
     ).toBeInTheDocument();
+    const pendingDialog = screen.getByRole("dialog");
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
 
     await act(async () => releaseRequest());
     expect(
       await screen.findByRole("textbox", { name: "Name *" }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBe(pendingDialog);
   });
 
   it("retries an initial query failure without showing Save", async () => {

--- a/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
@@ -21,11 +21,9 @@ import { useApp } from "@/lib/app.query";
  * Cancel/Save footer. Delete is intentionally not here (each host owns its own
  * separate delete action).
  *
- * {@link AppSettingsForm} owns the {@link TabbedDialogShell} — the same left-nav
- * dialog used by the identity-provider and team dialogs — so once the app is
- * loaded this component just mounts it. The transient load/error/unavailable
- * states render a small dialog with a Cancel button instead, since there is no
- * form to show yet.
+ * This component keeps one dialog mounted while the app loads. Once resolved,
+ * {@link AppSettingsForm} fills that same modal with the left-nav settings
+ * layout, avoiding a second modal entrance and focus cycle.
  */
 export function AppSettingsDialog({
   appId,
@@ -47,47 +45,54 @@ export function AppSettingsDialog({
 
   const close = () => onOpenChange(false);
 
-  // Once the app resolves, the form owns the whole (left-nav) dialog.
-  if (open && app) {
-    return (
-      <AppSettingsForm app={app} open={open} onOpenChange={onOpenChange} />
-    );
-  }
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>App settings</DialogTitle>
-          <DialogDescription>
-            Manage this app's details, tools, and who can use it.
-          </DialogDescription>
-        </DialogHeader>
-        {isPending ? (
-          <LoadingState
-            className="min-h-40 flex-1"
-            label="Loading app settings…"
-            variant="compact"
-          />
-        ) : isLoadingError ? (
-          <QueryLoadError
-            title="Couldn't load app settings"
-            onRetry={() => refetch()}
-            className="min-h-40 flex-1"
+      <DialogContent
+        className={app ? "h-[85vh] max-w-5xl flex-row gap-0 p-0" : "max-w-lg"}
+        showCloseButton={!app}
+      >
+        {app ? (
+          <AppSettingsForm
+            app={app}
+            open={open}
+            onOpenChange={onOpenChange}
+            contentOnly
           />
         ) : (
-          <output
-            aria-label="App settings unavailable"
-            className="flex min-h-40 flex-1 items-center justify-center text-sm text-muted-foreground"
-          >
-            App settings are unavailable.
-          </output>
+          <>
+            <DialogHeader>
+              <DialogTitle>App settings</DialogTitle>
+              <DialogDescription>
+                Manage this app's details, tools, and who can use it.
+              </DialogDescription>
+            </DialogHeader>
+            {isPending ? (
+              <LoadingState
+                className="min-h-40 flex-1"
+                label="Loading app settings…"
+                variant="compact"
+              />
+            ) : isLoadingError ? (
+              <QueryLoadError
+                title="Couldn't load app settings"
+                onRetry={() => refetch()}
+                className="min-h-40 flex-1"
+              />
+            ) : (
+              <output
+                aria-label="App settings unavailable"
+                className="flex min-h-40 flex-1 items-center justify-center text-sm text-muted-foreground"
+              >
+                App settings are unavailable.
+              </output>
+            )}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={close}>
+                Cancel
+              </Button>
+            </DialogFooter>
+          </>
         )}
-        <DialogFooter>
-          <Button type="button" variant="outline" onClick={close}>
-            Cancel
-          </Button>
-        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/platform/frontend/src/components/mcp-app/app-settings-form.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.tsx
@@ -98,11 +98,14 @@ export function AppSettingsForm({
   app,
   open,
   onOpenChange,
+  contentOnly = false,
 }: {
   app: App;
   open: boolean;
   /** Controls the host dialog; `false` closes it (Cancel and after a save). */
   onOpenChange: (open: boolean) => void;
+  /** Render inside AppSettingsDialog's existing modal content. */
+  contentOnly?: boolean;
 }) {
   const {
     canEdit,
@@ -447,6 +450,7 @@ export function AppSettingsForm({
     <TabbedDialogShell
       open={open}
       onOpenChange={onOpenChange}
+      contentOnly={contentOnly}
       title="App settings"
       description="Manage this app's details, tools, and who can use it."
       sidebarLabel={form.watch("name")?.trim() || app.name || "App"}

--- a/platform/frontend/src/components/tabbed-dialog-shell.tsx
+++ b/platform/frontend/src/components/tabbed-dialog-shell.tsx
@@ -21,6 +21,8 @@ export interface TabbedDialogNavItem<TSection extends string> {
 interface TabbedDialogShellProps<TSection extends string> {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Render inside a DialogContent already owned by the caller. */
+  contentOnly?: boolean;
   title: string;
   description: string;
   sidebarLabel: string;
@@ -44,6 +46,7 @@ interface TabbedDialogShellProps<TSection extends string> {
 export function TabbedDialogShell<TSection extends string>({
   open,
   onOpenChange,
+  contentOnly = false,
   title,
   description,
   sidebarLabel,
@@ -146,6 +149,16 @@ export function TabbedDialogShell<TSection extends string>({
     </DialogForm>
   );
 
+  const content = (
+    <>
+      <DialogTitle className="sr-only">{title}</DialogTitle>
+      <DialogDescription className="sr-only">{description}</DialogDescription>
+      {wrapForm ? wrapForm(formContent) : formContent}
+    </>
+  );
+
+  if (contentOnly) return content;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -155,9 +168,7 @@ export function TabbedDialogShell<TSection extends string>({
         )}
         showCloseButton={false}
       >
-        <DialogTitle className="sr-only">{title}</DialogTitle>
-        <DialogDescription className="sr-only">{description}</DialogDescription>
-        {wrapForm ? wrapForm(formContent) : formContent}
+        {content}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

Apps cards now use the shared `TableRowActions` treatment for quick actions and overflow controls. Owned apps expose Settings, while external apps link to their backing MCP server. Clicking the card remains the single way to open an app in chat.

App settings now preserves one modal while the app loads instead of replacing the loading dialog with a second dialog. This avoids replaying the entrance animation and focus cycle. Pinning, version history, standalone launch, locked chat, and deletion remain in overflow.

The Apps documentation reflects the final quick-action behavior.

## Validation

- Live browser validation: Chat quick actions are absent; Settings opens one modal and closes cleanly
- AppCard and app-settings suites: 45 tests passed
- Full frontend suite: 600 files / 5,397 tests passed
- Frontend type-check, Knip, and Biome passed
- Repository pre-commit checks passed

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>