### PR TITLE
perf(frontend): reuse navigation data and prefetch Apps on intent

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   GITHUB_REPO_URL,
 } from "@archestra/shared";
 import { requiredPagePermissionsMap } from "@archestra/shared/access-control";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   AppWindow,
   BookOpen,
@@ -73,6 +74,7 @@ import {
   SidebarMenuSubItem,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { prefetchApps } from "@/lib/app.query";
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
 import { useHasPermissions, usePermissionMap } from "@/lib/auth/auth.query";
 import config from "@/lib/config/config";
@@ -694,19 +696,27 @@ function SidebarPrefetchLink({
   ...props
 }: React.ComponentProps<typeof Link>) {
   const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const prefetch = () => {
+    const prefetchHref = getPrefetchHref(href);
+    if (!prefetchHref) return;
+    router.prefetch(prefetchHref);
+    // Route prefetch doesn't mount client query hooks. Start the matching
+    // first page alongside it, not after the destination's JavaScript loads.
+    if (prefetchHref === "/apps") void prefetchApps(queryClient);
+  };
 
   return (
     <Link
       href={href}
       prefetch={false}
       onFocus={(event) => {
-        const prefetchHref = getPrefetchHref(href);
-        if (prefetchHref) router.prefetch(prefetchHref);
+        prefetch();
         onFocus?.(event);
       }}
       onMouseEnter={(event) => {
-        const prefetchHref = getPrefetchHref(href);
-        if (prefetchHref) router.prefetch(prefetchHref);
+        prefetch();
         onMouseEnter?.(event);
       }}
       {...props}

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -212,6 +212,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
     limit: pageSize,
     offset,
     initialData: initialData?.agents ?? undefined,
+    initialDataExcludeOtherPersonalAgents: true,
     ...listFilters,
   });
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });

--- a/platform/frontend/src/app/agents/page.tsx
+++ b/platform/frontend/src/app/agents/page.tsx
@@ -49,6 +49,7 @@ export default async function AgentsPageServer() {
           sortBy: DEFAULT_SORT_BY,
           sortDirection: DEFAULT_SORT_DIRECTION,
           agentTypes: ["agent"],
+          excludeOtherPersonalAgents: true,
         },
       }),
       canReadTeams

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -47,6 +47,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  APPS_FIRST_PAGE,
   useAppLabelKeys,
   useAppLabelValues,
   useApps,
@@ -65,8 +66,6 @@ import { useDialogUrlParam } from "@/lib/hooks/use-dialog-url-param";
 import { AppCard } from "./_parts/app-card";
 import { AppCreateDialog } from "./_parts/app-create-dialog";
 import { AppsTable, getAppRowKey } from "./_parts/apps-table";
-
-const PAGE_SIZE = 100;
 
 type AppListItem = archestraApiTypes.GetAppsResponses["200"]["data"][number];
 type OwnedApp = Extract<AppListItem, { source: "owned" }>;
@@ -90,8 +89,7 @@ export default function AppsPage() {
 
   const { data, isPending, isFetching, isLoadingError, refetch } = useApps(
     {
-      limit: PAGE_SIZE,
-      offset: 0,
+      ...APPS_FIRST_PAGE,
       search: search || undefined,
       scope,
       authorIds,

--- a/platform/frontend/src/lib/agent.query.ts
+++ b/platform/frontend/src/lib/agent.query.ts
@@ -218,10 +218,13 @@ export function useSuggestSkillDescription() {
 export function useProfilesPaginated(
   params?: archestraApiTypes.GetAgentsData["query"] & {
     initialData?: archestraApiTypes.GetAgentsResponses["200"];
+    /** Scope of the server seed; never reuse it for a different visibility filter. */
+    initialDataExcludeOtherPersonalAgents?: boolean;
   },
 ) {
   const {
     initialData,
+    initialDataExcludeOtherPersonalAgents,
     limit,
     offset,
     sortBy,
@@ -250,7 +253,7 @@ export function useProfilesPaginated(
     teamIds === undefined &&
     authorIds === undefined &&
     excludeAuthorIds === undefined &&
-    excludeOtherPersonalAgents === undefined &&
+    excludeOtherPersonalAgents === initialDataExcludeOtherPersonalAgents &&
     labels === undefined &&
     status === undefined &&
     (limit === undefined || limit === DEFAULT_TABLE_LIMIT);

--- a/platform/frontend/src/lib/app.query.ts
+++ b/platform/frontend/src/lib/app.query.ts
@@ -1,11 +1,23 @@
 import {
   archestraApiSdk,
   type archestraApiTypes,
+  type Permissions,
   type ResourceVisibilityScope,
 } from "@archestra/shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import {
+  authQueryKeys,
+  useHasPermissions,
+  type useSession,
+} from "@/lib/auth/auth.query";
+import { hasPermissions } from "@/lib/auth/auth.utils";
 import { toBulkOutcome } from "@/lib/bulk-action";
 import {
   generateLockedChatKey,
@@ -57,23 +69,31 @@ type AppDetailQueryOptions = { toastOnError?: boolean };
 
 // ===== Query hooks =====
 
+export const APPS_FIRST_PAGE = { limit: 100, offset: 0 } as const;
+
+/** Warm only the bounded initial list, after authenticated navigation intent. */
+export function prefetchApps(queryClient: QueryClient) {
+  const session = queryClient.getQueryData<
+    ReturnType<typeof useSession>["data"]
+  >(authQueryKeys.session());
+  const permissions = queryClient.getQueryData<Permissions>(
+    authQueryKeys.userPermissions(),
+  );
+  if (!session?.user || !hasPermissions(permissions, { app: ["read"] })) return;
+  return queryClient.prefetchQuery(appsQueryOptions(APPS_FIRST_PAGE, false));
+}
+
 export function useApps(
   params: AppsParams,
   options?: { enabled?: boolean; toastOnError?: boolean },
 ) {
-  const toastOnError = options?.toastOnError;
   // The endpoint requires app:read; skip the request for users whose role
   // lacks it (e.g. the chat sidebar mounts this for everyone) instead of 403ing.
   const { data: canReadApps } = useHasPermissions({ app: ["read"] });
   return useQuery({
-    queryKey: ["apps", "paginated", params],
+    ...appsQueryOptions(params, options?.toastOnError),
     enabled: (options?.enabled ?? true) && !!canReadApps,
     placeholderData: (previousData) => previousData,
-    queryFn: async () => {
-      const { data, error } = await getApps({ query: params });
-      throwOnApiError(error, { toastOnError });
-      return data;
-    },
   });
 }
 
@@ -603,6 +623,17 @@ export function useAssignToolToApp() {
       queryClient.invalidateQueries({
         queryKey: ["apps", variables.appId, "tools"],
       });
+    },
+  });
+}
+
+function appsQueryOptions(params: AppsParams, toastOnError?: boolean) {
+  return queryOptions({
+    queryKey: ["apps", "paginated", params],
+    queryFn: async ({ signal }) => {
+      const { data, error } = await getApps({ query: params, signal });
+      throwOnApiError(error, { toastOnError });
+      return data;
     },
   });
 }

--- a/platform/frontend/src/lib/auth/auth.server.ts
+++ b/platform/frontend/src/lib/auth/auth.server.ts
@@ -1,5 +1,6 @@
 import { archestraApiSdk, type Permissions } from "@archestra/shared";
 import { requiredPagePermissionsMap } from "@archestra/shared/access-control";
+import { cache } from "react";
 import { hasPermissions } from "@/lib/auth/auth.utils";
 import { getServerApiHeaders } from "@/lib/utils/server";
 
@@ -10,6 +11,12 @@ export async function serverCanAccessPage(pathname: string): Promise<boolean> {
 export async function serverHasPermissions(
   permissionsToCheck: Permissions,
 ): Promise<boolean> {
+  return hasPermissions(await getServerPermissions(), permissionsToCheck);
+}
+
+// React cache is scoped to one server render, not shared between users or
+// requests. Page access and optional sections can reuse the same lookup.
+const getServerPermissions = cache(async () => {
   const headers = await getServerApiHeaders();
   const {
     data: userPermissions,
@@ -34,5 +41,5 @@ export async function serverHasPermissions(
     );
   }
 
-  return hasPermissions(userPermissions ?? undefined, permissionsToCheck);
-}
+  return userPermissions ?? undefined;
+});

--- a/platform/frontend/src/lib/navigation-data.test.tsx
+++ b/platform/frontend/src/lib/navigation-data.test.tsx
@@ -1,0 +1,159 @@
+import { archestraApiClient } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import type { ReactNode } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { DEFAULT_TABLE_LIMIT } from "@/consts";
+import { useProfilesPaginated } from "@/lib/agent.query";
+import { prefetchApps, useApps } from "@/lib/app.query";
+import { authQueryKeys } from "@/lib/auth/auth.query";
+import { makeAgent, makeAgentsList } from "@/mocks/data/agents";
+
+const origin = "http://localhost:9000";
+const server = setupServer();
+const clients: QueryClient[] = [];
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+beforeEach(() => archestraApiClient.setConfig({ baseUrl: origin }));
+afterEach(() => {
+  for (const client of clients.splice(0)) client.clear();
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
+  });
+  clients.push(client);
+  return {
+    client,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+describe("navigation data reuse", () => {
+  it("renders the server's default agent list without a second fetch", () => {
+    const { wrapper } = setup();
+    const seed = makeAgentsList({
+      agents: [makeAgent({ name: "Visible agent" })],
+    });
+    const { result } = renderHook(
+      () =>
+        useProfilesPaginated({
+          offset: 0,
+          limit: DEFAULT_TABLE_LIMIT,
+          agentTypes: ["agent"],
+          excludeOtherPersonalAgents: true,
+          initialData: seed,
+          initialDataExcludeOtherPersonalAgents: true,
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isFetching).toBe(false);
+    expect(result.current.data?.data[0].name).toBe("Visible agent");
+  });
+
+  it.each([
+    { excludeOtherPersonalAgents: undefined },
+    { offset: DEFAULT_TABLE_LIMIT },
+    { name: "different" },
+    { scope: "personal" as const },
+  ])("does not seed a different agent view: %j", async (overrides) => {
+    const { wrapper } = setup();
+    server.use(
+      http.get(`${origin}/api/agents`, () =>
+        HttpResponse.json(
+          makeAgentsList({ agents: [makeAgent({ name: "Requested view" })] }),
+        ),
+      ),
+    );
+    const { result } = renderHook(
+      () =>
+        useProfilesPaginated({
+          offset: 0,
+          limit: DEFAULT_TABLE_LIMIT,
+          agentTypes: ["agent"],
+          excludeOtherPersonalAgents: true,
+          initialData: makeAgentsList({
+            agents: [makeAgent({ name: "Wrong seed" })],
+          }),
+          initialDataExcludeOtherPersonalAgents: true,
+          ...overrides,
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.data).toBeUndefined();
+    await waitFor(() =>
+      expect(result.current.data?.data[0].name).toBe("Requested view"),
+    );
+  });
+
+  it("shares the intent-prefetched Apps page with the mounted query", async () => {
+    const { client, wrapper } = setup();
+    client.setQueryData(authQueryKeys.session(), { user: { id: "user-1" } });
+    client.setQueryData(authQueryKeys.userPermissions(), { app: ["read"] });
+    const requests: string[] = [];
+    server.use(
+      http.get(`${origin}/api/apps`, ({ request }) => {
+        requests.push(new URL(request.url).search);
+        return HttpResponse.json({
+          data: [{ id: "app-1", name: "Prefetched app" }],
+          pagination: { total: 1 },
+        });
+      }),
+    );
+
+    await Promise.all([prefetchApps(client), prefetchApps(client)]);
+    const { result } = renderHook(
+      () =>
+        useApps({
+          limit: 100,
+          offset: 0,
+          search: undefined,
+          scope: undefined,
+          authorIds: undefined,
+          excludeAuthorIds: undefined,
+          labels: undefined,
+        }),
+      { wrapper },
+    );
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.data?.data[0].name).toBe("Prefetched app");
+    expect(requests).toEqual(["?limit=100&offset=0"]);
+
+    const filtered = renderHook(
+      () => useApps({ limit: 100, offset: 0, search: "other" }),
+      { wrapper },
+    );
+    expect(filtered.result.current.data).toBeUndefined();
+    await waitFor(() => expect(requests).toHaveLength(2));
+  });
+
+  it("does not prefetch without both a session and permission", async () => {
+    const { client } = setup();
+    client.setQueryData(authQueryKeys.userPermissions(), { app: ["read"] });
+    await prefetchApps(client);
+    client.setQueryData(authQueryKeys.session(), { user: { id: "user-1" } });
+    client.setQueryData(authQueryKeys.userPermissions(), {});
+    await prefetchApps(client);
+    expect(client.getQueryCache().findAll({ queryKey: ["apps"] })).toHaveLength(
+      0,
+    );
+  });
+});

--- a/platform/frontend/tests-integration/navigation-data.spec.ts
+++ b/platform/frontend/tests-integration/navigation-data.spec.ts
@@ -1,0 +1,29 @@
+import { makeAgent, makeAgentsList } from "../src/mocks/data/agents";
+import { expect, test } from "./fixtures";
+
+test("the default Agents view uses its server list through hydration", async ({
+  page,
+  mswControl,
+}) => {
+  await mswControl.use({
+    method: "get",
+    url: "/api/agents",
+    body: makeAgentsList({
+      agents: [makeAgent({ name: "Server-rendered agent" })],
+    }),
+  });
+  const clientListRequests: string[] = [];
+  page.on("request", (request) => {
+    if (new URL(request.url()).pathname === "/api/agents")
+      clientListRequests.push(request.url());
+  });
+  await page.goto("/agents");
+  await expect(
+    page.getByText("Server-rendered agent", { exact: true }),
+  ).toBeVisible();
+  // A real interaction establishes that hydration finished. Before the fix,
+  // mounting the default visibility filter issued a redundant client GET.
+  await page.getByRole("button", { name: "View as table" }).click();
+  await expect(page.getByRole("table")).toBeVisible();
+  expect(clientListRequests).toEqual([]);
+});


### PR DESCRIPTION
Agents discarded its server-rendered list because the client default visibility filter differed from the server seed, producing a second request and loading transition. Align the seed scope and reuse it only for the matching first-page view. Reuse permission lookups within a server render through React cache, without caching authorization across requests.

Sidebar hover/focus now warms the bounded first Apps page alongside the existing route prefetch. It uses the same TanStack key/options as the destination, checks the cached session and read permission, and suppresses speculative error toasts. No cache freshness settings change.

Verified in a local MSW-backed browser: Agents remains populated through hydration and a table-view switch without a client list request. Query regressions exercise changed filters, prefetched data reuse, request deduplication, and absent permissions. Production latency budgets have not been remeasured.

Stack 1/3, based on main. Followed by deferred optional libraries, then standalone Skills pagination.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>

Verification note: the full frontend suite exposed three existing assertion failures, reproduced on the unchanged main baseline: two reset-date labels in the cost-limits page and compact-number capitalization in usage-dimension cards. These are outside this stack. The lazy-loading-specific multiline-code assertion was updated to verify immediately available raw code, and the affected tests pass.

Complete stack: #7800 → #7801 → #7802.