### PR TITLE
perf(frontend): paginate standalone Skills without fetching every page

### DIFF
--- a/platform/frontend/src/app/skills/page.client.test.tsx
+++ b/platform/frontend/src/app/skills/page.client.test.tsx
@@ -367,6 +367,66 @@ describe("SkillsPage rows", () => {
     );
   });
 
+  it("uses one server page and its total for a standalone-only active view", () => {
+    mockUseFeature.mockImplementation(
+      (name: string) => name === "mcpGatewaySkillsEnabled",
+    );
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("kind=standalone&pageSize=10") as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+    vi.mocked(useSkillsPaginated).mockReturnValue({
+      data: { data: [MINE], pagination: { total: 250 } },
+      isPending: false,
+      isFetching: false,
+      isLoadingError: false,
+      refetch: vi.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: partial query result is enough
+    } as any);
+
+    render(<SkillsPage />);
+
+    expect(screen.getByText("pdf-tools")).toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 25")).toBeInTheDocument();
+    expect(vi.mocked(useSkillsPaginated)).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10, offset: 0 }),
+      expect.objectContaining({ enabled: true }),
+    );
+    expect(vi.mocked(useSkillsList)).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it("keeps the complete standalone list for name-based edit links", () => {
+    const replace = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+      replace,
+    } as unknown as ReturnType<typeof useRouter>);
+    mockUseFeature.mockImplementation(
+      (name: string) => name === "mcpGatewaySkillsEnabled",
+    );
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("kind=standalone&openEdit=pdf-tools") as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+
+    render(<SkillsPage />);
+
+    expect(vi.mocked(useSkillsList)).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ enabled: true }),
+    );
+    expect(vi.mocked(useSkillsPaginated)).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(replace).toHaveBeenCalledWith(`/skills/${MINE.id}`);
+  });
+
   it("clamps a stale card page after filters shrink the collection", async () => {
     const push = vi.fn();
     vi.mocked(useRouter).mockReturnValue({
@@ -403,9 +463,7 @@ describe("SkillsPage rows", () => {
 
     render(<SkillsPage />);
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Clear filters" }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Clear" }));
     expect(push).toHaveBeenCalledWith("/skills?page=1", { scroll: false });
   });
 

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -214,6 +214,12 @@ function SkillsList() {
     pluginSkillsEnabled &&
     !isDeletedView &&
     (kind === "all" || kind === "plugin");
+  // Name-based edit links may target a skill beyond the visible page, so keep
+  // their existing complete standalone list until the name has resolved.
+  const openEdit = searchParams.get("openEdit");
+  const isStandalonePaginatedView =
+    !isDeletedView && kind === "standalone" && !openEdit;
+  const usesPaginatedSkills = isDeletedView || isStandalonePaginatedView;
 
   /**
    * Everything that narrows the table, with the page itself left out — the
@@ -245,7 +251,7 @@ function SkillsList() {
       offset: pageIndex * pageSize,
       ...listFilters,
     },
-    { enabled: isDeletedView, toastOnError: false },
+    { enabled: usesPaginatedSkills, toastOnError: false },
   );
   const {
     data: activeSkills = [],
@@ -254,13 +260,14 @@ function SkillsList() {
     isLoadingError: isActiveSkillsLoadError,
     refetch: refetchActiveSkills,
   } = useSkillsList(listFilters, {
-    enabled: !isDeletedView && showStandaloneSkills,
+    enabled:
+      !isDeletedView && showStandaloneSkills && !isStandalonePaginatedView,
     toastOnError: false,
   });
-  const isFetching = isDeletedView
+  const isFetching = usesPaginatedSkills
     ? isDeletedSkillsFetching
     : isActiveSkillsFetching;
-  const isSkillsLoadError = isDeletedView
+  const isSkillsLoadError = usesPaginatedSkills
     ? isDeletedSkillsLoadError
     : isActiveSkillsLoadError;
   const { data: sourceReposData } = useSkillSourceRepos();
@@ -383,7 +390,9 @@ function SkillsList() {
   const { data: userTeams } = useMyTeams({ enabled: !!canReadTeams });
   const userTeamIdSet = new Set((userTeams ?? []).map((team) => team.id));
 
-  const standaloneSkills = isDeletedView ? (skills?.data ?? []) : activeSkills;
+  const standaloneSkills = usesPaginatedSkills
+    ? (skills?.data ?? [])
+    : activeSkills;
   const items: ListedSkill[] = [
     ...(showStandaloneSkills
       ? standaloneSkills.map((skill) => ({
@@ -450,7 +459,6 @@ function SkillsList() {
   // Deep-link support: /skills?openEdit=<name> opens the matching skill's page
   // (e.g. from the chat SkillPill). The name resolves to an id once the items
   // it was searched by have loaded.
-  const openEdit = searchParams.get("openEdit");
   useEffect(() => {
     if (!openEdit || standaloneSkills.length === 0) return;
     const match = standaloneSkills.find((skill) => skill.name === openEdit);
@@ -458,10 +466,12 @@ function SkillsList() {
     router.replace(`/skills/${match.id}`);
   }, [openEdit, standaloneSkills, router]);
   const pagination = skills?.pagination;
-  const totalStandaloneSkills = isDeletedView
+  const totalStandaloneSkills = usesPaginatedSkills
     ? (pagination?.total ?? 0)
     : activeSkills.length;
-  const totalSkills = isDeletedView ? totalStandaloneSkills : items.length;
+  const totalSkills = usesPaginatedSkills
+    ? totalStandaloneSkills
+    : items.length;
   const hasActiveFilters =
     !!search ||
     !!sourceRepo ||
@@ -490,7 +500,7 @@ function SkillsList() {
    * which is only true during a first load of a query that is switched on.
    */
   const isInitialSkillsLoad =
-    ((isDeletedView ? isDeletedSkillsPending : isActiveSkillsPending) &&
+    ((usesPaginatedSkills ? isDeletedSkillsPending : isActiveSkillsPending) &&
       isFetching) ||
     (showMcpSkills && isExternalSkillsPending && isExternalSkillsFetching) ||
     (showPluginSkills && isPluginSkillsPending && isPluginSkillsFetching);
@@ -803,7 +813,7 @@ function SkillsList() {
         <QueryLoadError
           title="Couldn't load your skills"
           onRetry={() =>
-            isDeletedView ? refetchSkills() : refetchActiveSkills()
+            usesPaginatedSkills ? refetchSkills() : refetchActiveSkills()
           }
         />
       </PageLayout>
@@ -1068,8 +1078,8 @@ function SkillsList() {
                       : "No skills match the current filters."
                   }
                   onClearFilters={clearFilters}
-                  manualPagination={isDeletedView}
-                  manualSorting={isDeletedView}
+                  manualPagination={usesPaginatedSkills}
+                  manualSorting={usesPaginatedSkills}
                   sorting={sorting}
                   onSortingChange={handleSortingChange}
                   pagination={{ pageIndex, pageSize, total: totalSkills }}

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -83,10 +83,14 @@ import {
 } from "@/lib/entity-labels.query";
 import { useAppIconLogo, useAppName } from "@/lib/hooks/use-app-name";
 import { useBulkCardSelection } from "@/lib/hooks/use-bulk-card-selection";
-import { useBulkSelection } from "@/lib/hooks/use-bulk-selection";
+import {
+  useBulkSelection,
+  useControlledRowSelection,
+} from "@/lib/hooks/use-bulk-selection";
 import { useIsGlobalAdmin } from "@/lib/organization.query";
 import {
   type SkillUsageReference,
+  useAllMatchingSkills,
   useBulkDeleteSkills,
   useExternalMcpSkills,
   usePermanentlyDeleteSkill,
@@ -430,7 +434,15 @@ function SkillsList() {
    * the whole matching set fits in one bulk request, so an escalation that
    * survived a filter change could otherwise claim more than it can act on.
    */
-  const filterSignature = JSON.stringify(listFilters);
+  const filterSignature = JSON.stringify({ kind, ...listFilters });
+  const [escalatedFor, setEscalatedFor] = useState<string | null>(null);
+  const allMatchingSelected =
+    usesPaginatedSkills && escalatedFor === filterSignature;
+  const {
+    data: allMatchingSkills,
+    isFetching: isAllMatchingFetching,
+    isError: isAllMatchingError,
+  } = useAllMatchingSkills(listFilters, { enabled: allMatchingSelected });
   const selection = useBulkSelection({
     rows: items,
     getId: (row) => row.key,
@@ -440,21 +452,37 @@ function SkillsList() {
       ? "match this search query"
       : "match the current filters",
   });
+  const { effectiveRowSelection, onRowSelectionChange, rangeSelection } =
+    useControlledRowSelection({
+      rowSelection: selection.rowSelection,
+      setRowSelection: selection.setRowSelection,
+      rows: items,
+      getRowId: (row) => row.key,
+      canSelect: canBulkActOnSkill,
+      allMatchingSelected,
+      clearEscalation: () => setEscalatedFor(null),
+    });
   const visibleRows = items.filter((item) =>
     selection.pageRowIds.includes(item.key),
   );
   const cardSelection = useBulkCardSelection({
     rows: visibleRows,
     getRowId: (row) => row.key,
-    rowSelection: selection.rowSelection,
-    setRowSelection: selection.setRowSelection,
+    rowSelection: effectiveRowSelection,
+    setRowSelection: onRowSelectionChange,
     canSelect: canBulkActOnSkill,
-    rangeSelection: selection.rangeSelection,
+    rangeSelection,
   });
-  const selectedSkills = selection.selected
+  const pageSelectedSkills = selection.selected
     .filter((item) => item.source === "standalone")
     .map((item) => item.skill);
-  const clearSelection = selection.clearSelection;
+  const selectedSkills = allMatchingSelected
+    ? (allMatchingSkills ?? pageSelectedSkills)
+    : pageSelectedSkills;
+  const clearSelection = () => {
+    selection.clearSelection();
+    setEscalatedFor(null);
+  };
 
   // Deep-link support: /skills?openEdit=<name> opens the matching skill's page
   // (e.g. from the chat SkillPill). The name resolves to an id once the items
@@ -962,7 +990,20 @@ function SkillsList() {
                   noun="skill"
                   countTestId={E2eTestId.SkillsBulkSelectionCount}
                   onClear={clearSelection}
-                  selectAllMatching={selection.selectAllMatching}
+                  busy={
+                    allMatchingSelected &&
+                    (isAllMatchingFetching || isAllMatchingError)
+                  }
+                  selectAllMatching={
+                    usesPaginatedSkills
+                      ? {
+                          ...selection.selectAllMatching,
+                          total: skills?.pagination.total ?? 0,
+                          active: allMatchingSelected,
+                          onSelectAll: () => setEscalatedFor(filterSignature),
+                        }
+                      : selection.selectAllMatching
+                  }
                 >
                   <PermissionButton
                     permissions={{ skill: ["update"] }}
@@ -1089,10 +1130,10 @@ function SkillsList() {
                       ? undefined
                       : (item) => router.push(listedSkillHref(item))
                   }
-                  rowSelection={selection.rowSelection}
-                  onRowSelectionChange={selection.setRowSelection}
+                  rowSelection={effectiveRowSelection}
+                  onRowSelectionChange={onRowSelectionChange}
                   onPageRowIdsChange={selection.onPageRowIdsChange}
-                  rangeSelection={selection.rangeSelection}
+                  rangeSelection={rangeSelection}
                   fixedWidthColumnIds={["visibility", "files", "usageCount"]}
                   flexibleColumnIds={["name"]}
                 />

--- a/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
+++ b/platform/frontend/tests-integration/bulk-actions-bar.spec.ts
@@ -139,6 +139,43 @@ test.describe("Bulk actions bar", () => {
       url: "/api/skills",
       body: {
         ...shareableSkillsSeed,
+        data: matchingSkills.slice(0, 2),
+        pagination: {
+          ...shareableSkillsSeed.pagination,
+          limit: 2,
+          total: 7,
+          totalPages: 4,
+          hasNext: true,
+        },
+      },
+    });
+    const listRequests: URL[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (url.pathname === "/api/skills") listRequests.push(url);
+    });
+    await page.goto("/skills?kind=standalone&pageSize=2");
+
+    await page
+      .getByRole("checkbox", { name: "Select all skills on this page" })
+      .click();
+    await expect(page.getByTestId("skills-bulk-selection-count")).toHaveText(
+      "2 skills selected",
+    );
+    expect(listRequests).toHaveLength(1);
+    expect(listRequests[0].searchParams.get("limit")).toBe("2");
+
+    const offer = page.getByRole("button", { name: /^Select all/ });
+    await expect(offer).toHaveText(
+      "Select all 7 skills that match the current filters.",
+    );
+
+    // Only explicit escalation may load the rows beyond the visible page.
+    await mswControl.use({
+      method: "get",
+      url: "/api/skills",
+      body: {
+        ...shareableSkillsSeed,
         data: matchingSkills,
         pagination: {
           ...shareableSkillsSeed.pagination,
@@ -149,25 +186,33 @@ test.describe("Bulk actions bar", () => {
         },
       },
     });
-    // The collection loads all sources once, then applies its shared page size.
-    await page.goto("/skills?pageSize=2");
-
-    await page
-      .getByRole("checkbox", { name: "Select all skills on this page" })
-      .click();
-
-    const offer = page.getByRole("button", { name: /^Select all/ });
-    await expect(offer).toHaveText(
-      "Select all 7 skills that match the current filters.",
-    );
-
     await offer.click();
 
     await expect(page.getByTestId("skills-bulk-selection-count")).toHaveText(
       "All 7 skills selected",
     );
+    const deleteButton = page.getByRole("button", {
+      name: "Delete",
+      exact: true,
+    });
+    await expect(deleteButton).toBeEnabled();
+    expect(listRequests).toHaveLength(2);
+    expect(listRequests[1].searchParams.get("limit")).toBe("100");
+    await deleteButton.click();
+    await expect(page.getByRole("dialog")).toContainText("Delete 7 skills?");
+    await page.getByRole("button", { name: "Cancel", exact: true }).click();
     // The offer has nothing left to escalate to.
     await expect(offer).toBeHidden();
+    await page
+      .getByRole("checkbox", { name: "Select skill-1", exact: true })
+      .click();
+    await expect(page.getByTestId("skills-bulk-selection-count")).toHaveText(
+      "1 skill selected",
+    );
+    await page.getByRole("button", { name: "Clear", exact: true }).click();
+    await expect(page.getByTestId("skills-bulk-selection-count")).toHaveText(
+      "0 skills selected",
+    );
   });
 
   test("ticking a row selects it instead of opening the row's editor", async ({

--- a/platform/frontend/tests-integration/skills-pagination.spec.ts
+++ b/platform/frontend/tests-integration/skills-pagination.spec.ts
@@ -1,0 +1,34 @@
+import { skillsListSeed } from "../src/mocks/data/skills";
+import { expect, test } from "./fixtures";
+
+test("standalone Skills loads one page and preserves the server total", async ({
+  page,
+  mswControl,
+}) => {
+  await mswControl.use({
+    method: "get",
+    url: "/api/skills",
+    once: true,
+    body: {
+      ...skillsListSeed,
+      pagination: {
+        currentPage: 1,
+        limit: 10,
+        total: 250,
+        totalPages: 25,
+        hasNext: true,
+        hasPrev: false,
+      },
+    },
+  });
+  const listRequests: URL[] = [];
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/api/skills") listRequests.push(url);
+  });
+  await page.goto("/skills?kind=standalone&pageSize=10");
+  await expect(page.getByText("Page 1 of 25", { exact: true })).toBeVisible();
+  expect(listRequests).toHaveLength(1);
+  expect(listRequests[0].searchParams.get("limit")).toBe("10");
+  expect(listRequests[0].searchParams.get("offset")).toBe("0");
+});


### PR DESCRIPTION
The standalone-only Skills view fetched all active skills in sequential batches before rendering a client-side page. Use the existing paginated endpoint for this view, including its server total, sorting, loading, and retry state.

The mixed MCP/plugin/standalone collection still uses its complete lists so combined sorting, filtering, and totals stay correct. Name-based openEdit links also retain complete-list resolution to reach skills beyond the current page. This deliberately avoids a new aggregation endpoint or client merge engine.

Verified with an MSW-backed browser response advertising 250 skills: the standalone view makes one request with limit=10 and offset=0 and displays Page 1 of 25, rather than fetching subsequent batches. Component regressions also cover name-based edit navigation and the existing mixed/deleted views. This reduces unnecessary work; it does not establish a universal sub-100ms navigation guarantee.

Stack 3/3, based on #7801, which follows #7800. Merge predecessors first and retarget to main.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>

Verification note: the full frontend suite exposed three existing assertion failures, reproduced on the unchanged main baseline: two reset-date labels in the cost-limits page and compact-number capitalization in usage-dimension cards. These are outside this stack. The lazy-loading-specific multiline-code assertion was updated to verify immediately available raw code, and the affected tests pass.

Complete stack: #7800 → #7801 → #7802.