### PR TITLE
fix(frontend): label app and project visibility badges

### DIFF
--- a/platform/frontend/src/app/apps/_parts/app-card.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.test.tsx
@@ -178,9 +178,7 @@ describe("ExternalAppCard", () => {
     expect(screen.getByText("Shows the project board")).toBeInTheDocument();
     expect(screen.queryByText(/archestra_pm/)).not.toBeInTheDocument();
     expect(screen.getByLabelText("MCP server app")).toBeInTheDocument();
-    // Per-install card carries an icon-only scope pill (label in aria/tooltip)
-    // to disambiguate sibling installs.
-    expect(screen.getByLabelText("Organization")).toBeInTheDocument();
+    expect(screen.getByText("Organization")).toBeVisible();
   });
 
   it("opens the install in chat and navigates to the seeded conversation", async () => {
@@ -359,6 +357,7 @@ describe("OwnedAppCard", () => {
     );
 
     expect(screen.getByLabelText("Team: London HQ")).toBeInTheDocument();
+    expect(screen.getByText("Team")).toBeVisible();
   });
 
   it("shows the personal pill (no owner badge) for the viewer's own personal app", () => {
@@ -377,6 +376,7 @@ describe("OwnedAppCard", () => {
     );
 
     expect(screen.getByLabelText("Personal")).toBeInTheDocument();
+    expect(screen.getByText("Personal")).toBeVisible();
     expect(screen.queryByText(/owned by/i)).not.toBeInTheDocument();
   });
 
@@ -399,6 +399,23 @@ describe("OwnedAppCard", () => {
 
     expect(screen.getByLabelText("Personal")).toBeInTheDocument();
     expect(screen.getByText("Owned by Grace Hopper")).toBeInTheDocument();
+  });
+
+  it("labels a personal app shared directly with users as shared", () => {
+    render(
+      <AppCard
+        app={{
+          ...ownedApp,
+          scope: "personal",
+          viewerRole: "owner",
+          users: [{ id: "user-2", name: "Grace Hopper" }],
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Shared with: Grace Hopper")).toBeVisible();
+    expect(screen.getByText("Shared")).toBeVisible();
+    expect(screen.queryByText("Personal")).not.toBeInTheDocument();
   });
 
   it("shows a 'Disabled' badge for a disabled app", () => {

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -316,6 +316,7 @@ function OwnedAppCard({
             scope={app.scope}
             teamNames={app.teams?.map((team) => team.name)}
             userNames={app.users?.map((user) => user.name)}
+            showLabel
           />
           {!app.enabled ? <Badge variant="outline">Disabled</Badge> : null}
           {app.locked ? <Badge variant="outline">Locked</Badge> : null}
@@ -450,7 +451,7 @@ function ExternalAppCard({
     >
       {isOpening ? <CardOpeningOverlay /> : null}
       <div className="flex flex-wrap items-center gap-2">
-        <ScopeBadge scope={app.scope} />
+        <ScopeBadge scope={app.scope} showLabel />
       </div>
     </TableCard>
   );

--- a/platform/frontend/src/app/projects/page.client.test.tsx
+++ b/platform/frontend/src/app/projects/page.client.test.tsx
@@ -39,6 +39,8 @@ type ProjectFixture = {
   ownerName: string | null;
   conversationCount: number;
   visibility: "organization" | "team" | null;
+  shareTeamNames?: string[] | null;
+  shareUserNames?: string[] | null;
   pinnedAt: string | null;
   createdAt: string;
   deletedAt: string | null;
@@ -416,6 +418,31 @@ describe("ProjectsPageClient", () => {
     expect(screen.queryByText("All projects")).not.toBeInTheDocument();
     expect(screen.getByText("Plain project")).toBeInTheDocument();
     expect(screen.getByText("Other project")).toBeInTheDocument();
+  });
+
+  it("shows visibility labels on project cards", () => {
+    mockProjects = [
+      makeProject({ id: "personal", name: "Personal project" }),
+      makeProject({
+        id: "team",
+        name: "Team project",
+        visibility: "team",
+        shareTeamNames: ["Design"],
+      }),
+      makeProject({
+        id: "organization",
+        name: "Organization project",
+        visibility: "organization",
+      }),
+    ];
+
+    render(<ProjectsPageClient />);
+
+    expect(screen.getByText("Personal", { selector: "span" })).toBeVisible();
+    expect(screen.getByText("Team", { selector: "span" })).toBeVisible();
+    expect(
+      screen.getByText("Organization", { selector: "span" }),
+    ).toBeVisible();
   });
 
   it("shows pin, edit details, and delete in owner card menus", () => {

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -673,6 +673,7 @@ function ProjectCard({
           scope={projectVisibilityToScope(project.visibility)}
           teamNames={project.shareTeamNames}
           userNames={project.shareUserNames}
+          showLabel
         />
         {project.viewerRole === "admin" && project.visibility === null ? (
           <Badge variant="secondary">

--- a/platform/frontend/src/components/scope-badge.tsx
+++ b/platform/frontend/src/components/scope-badge.tsx
@@ -22,6 +22,7 @@ export function ScopeBadge({
   teamNames,
   userNames,
   hidePersonal = false,
+  showLabel = false,
 }: {
   scope: ResourceVisibilityScope;
   teamNames?: string[] | null;
@@ -33,6 +34,8 @@ export function ScopeBadge({
    */
   userNames?: string[] | null;
   hidePersonal?: boolean;
+  /** Show the scope type beside the icon on surfaces where space allows. */
+  showLabel?: boolean;
 }) {
   const sharedWith = userNames?.filter(Boolean) ?? [];
   const sharedWithUsers = scope === "personal" && sharedWith.length > 0;
@@ -50,6 +53,7 @@ export function ScopeBadge({
     : scope === "team" && names.length > 0
       ? `Team: ${names.join(", ")}`
       : scopeLabel(scope);
+  const visibleLabel = sharedWithUsers ? "Shared" : scopeLabel(scope);
 
   return (
     <Tooltip>
@@ -67,6 +71,7 @@ export function ScopeBadge({
           )}
         >
           <Icon className="h-3 w-3" />
+          {showLabel ? <span>{visibleLabel}</span> : null}
         </Badge>
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>


### PR DESCRIPTION
## Summary

Apps and Projects cards showed only visibility icons, making Personal, Team, or Organization scope less clear than equivalent Skills cards. The shared compact scope badge now supports an optional visible type label, enabled for Apps and Projects cards while table and other compact consumers retain their existing icon-only presentation. Directly shared personal-scope resources are labeled Shared to avoid misrepresenting their effective visibility.

Card-level tests assert that Personal, Team, Organization, and direct-sharing labels are visibly rendered while detailed sharing context remains available through the accessible badge label.

## Validation

- Focused Apps, Projects, and scope badge suites passed
- Full frontend gate: 600 files / 5,398 tests, type-check, knip, and Biome passed
- Browser verification and demo recording were unavailable because this runner cannot start the nested container runtime required by the local development stack.
- Private CI status could not be queried with the available token.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>