### PR TITLE
fix(rbac): one rule set for role writes, so duplicating a role works

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -11,7 +11,6 @@ import {
   getEmailDomain,
   OAUTH_PAGES,
   OAUTH_SCOPES,
-  PredefinedRoleNameSchema,
 } from "@archestra/shared";
 import {
   allAvailableActions,
@@ -151,9 +150,12 @@ export const auth = betterAuth({
     // same table as `/api/roles`, and they skip everything that surface adds:
     // the enterprise licence gate, the permissions-cache invalidation, the
     // `member:impersonate` system-role resync, and the audit trail. Close the
-    // door — `disabledPaths` is enforced in better-auth's HTTP router only,
-    // so `betterAuth.api.createOrgRole()` and friends keep working for the
-    // `/api/roles` handlers that call them server-side.
+    // door. Role writes go through `/api/roles`, which owns authorization
+    // (the no-privilege-escalation rule in `findUngrantablePermissions`) and
+    // writes the row itself; the plugin's own role CRUD is unused. Reads stay
+    // mounted, and `dynamicAccessControl.enabled` must stay on so
+    // better-auth's `hasPermission` still resolves custom roles from the
+    // database.
     "/organization/create-role",
     "/organization/update-role",
     "/organization/delete-role",
@@ -175,25 +177,6 @@ export const auth = betterAuth({
          * https://better-auth.com/docs/plugins/organization#maximumrolesperorganization
          */
         // maximumRolesPerOrganization: 50,
-        validateRoleName: async (roleName: string) => {
-          // Role names must be lowercase alphanumeric with underscores
-          if (!/^[a-z0-9_]+$/.test(roleName)) {
-            throw new Error(
-              "Role name must be lowercase letters, numbers, and underscores only",
-            );
-          }
-          if (roleName.length < 2) {
-            throw new Error("Role name must be at least 2 characters");
-          }
-          if (roleName.length > 50) {
-            throw new Error("Role name must be less than 50 characters");
-          }
-          if (PredefinedRoleNameSchema.safeParse(roleName).success) {
-            throw new Error(
-              `"${roleName}" is a predefined role name and cannot be used for a custom role`,
-            );
-          }
-        },
       },
       roles: {
         admin: adminRole,

--- a/platform/backend/src/models/organization-role.ts
+++ b/platform/backend/src/models/organization-role.ts
@@ -628,33 +628,117 @@ class OrganizationRoleModel {
   }
 
   /**
-   * @deprecated Do not use directly. Routes should use betterAuth.api.createOrgRole() instead.
-   * This method exists only for test fixtures.
+   * Create a custom role.
+   *
+   * Authorization (the no-privilege-escalation rule), the enterprise licence
+   * gate, and name validation belong to the route; this only writes the row.
+   * Permissions are sanitized on the way in so the stored set never carries a
+   * resource or action outside the permission universe — reads sanitize too,
+   * so an unsanitized write would silently vanish on the way back out.
    */
-  static async create(): Promise<OrganizationRole> {
-    throw new Error(
-      "OrganizationRoleModel.create() should not be called directly. Use betterAuth.api.createOrgRole() in routes, or direct DB operations in test fixtures.",
+  static async create(params: {
+    organizationId: string;
+    role: string;
+    name: string;
+    description?: string | null;
+    permission: Permissions;
+  }): Promise<OrganizationRole> {
+    const permission = OrganizationRoleModel.sanitizePermissions(
+      params.permission,
     );
+    logger.debug(
+      { role: params.role, organizationId: params.organizationId },
+      "OrganizationRoleModel.create: inserting",
+    );
+
+    const [result] = await db
+      .insert(schema.organizationRolesTable)
+      .values({
+        id: crypto.randomUUID(),
+        organizationId: params.organizationId,
+        role: params.role,
+        name: params.name,
+        description: params.description ?? null,
+        permission: JSON.stringify(permission),
+      })
+      .returning();
+
+    return { ...result, permission, predefined: false };
   }
 
   /**
-   * @deprecated Do not use directly. Routes should use betterAuth.api.updateOrgRole() instead.
-   * This method exists only for test fixtures.
+   * Update a custom role's display name, description, and/or permissions.
+   * The `role` identifier is immutable. Returns null when no row matches.
    */
-  static async update(): Promise<OrganizationRole> {
-    throw new Error(
-      "OrganizationRoleModel.update() should not be called directly. Use betterAuth.api.updateOrgRole() in routes, or direct DB operations in test fixtures.",
+  static async update(params: {
+    id: string;
+    organizationId: string;
+    name?: string;
+    description?: string | null;
+    permission?: Permissions;
+  }): Promise<OrganizationRole | null> {
+    const updates: Partial<typeof schema.organizationRolesTable.$inferInsert> =
+      {};
+    if (params.name !== undefined) updates.name = params.name;
+    if (params.description !== undefined)
+      updates.description = params.description;
+    if (params.permission !== undefined) {
+      updates.permission = JSON.stringify(
+        OrganizationRoleModel.sanitizePermissions(params.permission),
+      );
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return OrganizationRoleModel.getById(params.id, params.organizationId);
+    }
+
+    logger.debug(
+      { roleId: params.id, organizationId: params.organizationId },
+      "OrganizationRoleModel.update: updating",
     );
+
+    const [result] = await db
+      .update(schema.organizationRolesTable)
+      .set(updates)
+      .where(
+        and(
+          eq(schema.organizationRolesTable.id, params.id),
+          eq(
+            schema.organizationRolesTable.organizationId,
+            params.organizationId,
+          ),
+        ),
+      )
+      .returning();
+
+    if (!result) return null;
+
+    return {
+      ...result,
+      permission: OrganizationRoleModel.sanitizePermissions(result.permission),
+      predefined: false,
+    };
   }
 
   /**
-   * @deprecated Do not use directly. Routes should use betterAuth.api.deleteOrgRole() instead.
-   * This method exists only for test fixtures.
+   * Delete a custom role. Returns false when no row matched.
    */
-  static async delete(): Promise<boolean> {
-    throw new Error(
-      "OrganizationRoleModel.delete() should not be called directly. Use betterAuth.api.deleteOrgRole() in routes, or direct DB operations in test fixtures.",
+  static async delete(id: string, organizationId: string): Promise<boolean> {
+    logger.debug(
+      { roleId: id, organizationId },
+      "OrganizationRoleModel.delete: deleting",
     );
+    const deleted = await db
+      .delete(schema.organizationRolesTable)
+      .where(
+        and(
+          eq(schema.organizationRolesTable.id, id),
+          eq(schema.organizationRolesTable.organizationId, organizationId),
+        ),
+      )
+      .returning({ id: schema.organizationRolesTable.id });
+
+    return deleted.length > 0;
   }
 
   static async findByIdForAudit(

--- a/platform/backend/src/routes/custom-role.bulk.ee.test.ts
+++ b/platform/backend/src/routes/custom-role.bulk.ee.test.ts
@@ -1,14 +1,10 @@
 import { vi } from "vitest";
-import { betterAuth, hasPermission } from "@/auth";
+import { hasPermission } from "@/auth";
 import OrganizationRoleModel from "@/models/organization-role";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
-
-const { deleteOrgRoleMock } = vi.hoisted(() => ({
-  deleteOrgRoleMock: vi.fn(),
-}));
 
 vi.mock("@/auth");
 
@@ -21,11 +17,6 @@ describe("DELETE /api/roles/bulk", () => {
 
   beforeEach(async ({ makeAdmin, makeMember, makeOrganization }) => {
     vi.clearAllMocks();
-
-    // Not part of the canonical @/auth mock surface — see custom-role.ee.test.ts.
-    const api = betterAuth.api as unknown as Record<string, unknown>;
-    api.deleteOrgRole = deleteOrgRoleMock;
-    deleteOrgRoleMock.mockResolvedValue({ success: true });
 
     user = await makeAdmin();
     organizationId = (await makeOrganization()).id;
@@ -64,7 +55,12 @@ describe("DELETE /api/roles/bulk", () => {
       ],
       failed: [],
     });
-    expect(deleteOrgRoleMock).toHaveBeenCalledTimes(2);
+    expect(
+      await OrganizationRoleModel.getById(first.id, organizationId),
+    ).toBeNull();
+    expect(
+      await OrganizationRoleModel.getById(second.id, organizationId),
+    ).toBeNull();
   });
 
   /**
@@ -110,7 +106,6 @@ describe("DELETE /api/roles/bulk", () => {
     expect(response.json().failed).toEqual([
       { id: foreign.id, name: null, error: "Role not found" },
     ]);
-    expect(deleteOrgRoleMock).not.toHaveBeenCalled();
     expect(
       await OrganizationRoleModel.getById(foreign.id, otherOrgId),
     ).not.toBeNull();
@@ -118,6 +113,5 @@ describe("DELETE /api/roles/bulk", () => {
 
   test("rejects an empty batch", async () => {
     expect((await bulkDelete([])).statusCode).toBe(400);
-    expect(deleteOrgRoleMock).not.toHaveBeenCalled();
   });
 });

--- a/platform/backend/src/routes/custom-role.ee.test.ts
+++ b/platform/backend/src/routes/custom-role.ee.test.ts
@@ -1,6 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { vi } from "vitest";
-import { betterAuth, hasPermission } from "@/auth";
+import { hasPermission } from "@/auth";
 import db, { schema } from "@/database";
 import { enterpriseTier } from "@/enterprise-tier";
 import OrganizationRoleModel from "@/models/organization-role";
@@ -9,14 +9,6 @@ import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
-
-const { createOrgRoleMock, updateOrgRoleMock, deleteOrgRoleMock } = vi.hoisted(
-  () => ({
-    createOrgRoleMock: vi.fn(),
-    updateOrgRoleMock: vi.fn(),
-    deleteOrgRoleMock: vi.fn(),
-  }),
-);
 
 vi.mock("@/auth");
 
@@ -35,15 +27,6 @@ describe("custom role routes", () => {
     // the clean project's module registry; this mocked-project file has to
     // seed the instance its own route imports.
     enterpriseTier.setUserCountForTesting(0);
-
-    // These better-auth org-role API methods are not part of the canonical
-    // @/auth mock surface, so wire them onto betterAuth.api here. The casts
-    // are needed because the mocks don't carry better-auth's strict endpoint
-    // types; the routes only ever call them as plain functions.
-    const api = betterAuth.api as unknown as Record<string, unknown>;
-    api.createOrgRole = createOrgRoleMock;
-    api.updateOrgRole = updateOrgRoleMock;
-    api.deleteOrgRole = deleteOrgRoleMock;
 
     user = await makeAdmin();
     authenticatedUser = user;
@@ -82,36 +65,69 @@ describe("custom role routes", () => {
     await app.close();
   });
 
-  test("gracefully normalizes malformed permission JSON from the auth layer", async () => {
-    createOrgRoleMock.mockResolvedValue({
-      roleData: {
-        id: "role-1",
-        organizationId,
-        role: "ops_admin",
-        name: "Ops Admin",
-        description: "Operations access",
-        permission: "{not-json}",
-        createdAt: new Date("2026-03-15T00:00:00.000Z"),
-        updatedAt: new Date("2026-03-15T00:00:00.000Z"),
+  /**
+   * Regression: role creation used to be delegated to better-auth's
+   * `createOrgRole`, which re-checked every `resource:action` pair against
+   * the author's role with rules of its own — no exemption for the UI-only
+   * resources, and no tolerance for the vestigial actions the predefined sets
+   * still carry. Duplicating a role carried those pairs along in the payload
+   * and the write was refused ("You are not allowed to create a role") even
+   * though `/api/roles` had already cleared it. Authorization now lives in
+   * one place: `findUngrantablePermissions`.
+   */
+  test("accepts a vestigial action the predefined editor role still lists", async () => {
+    // `invitation: ["read"]` is not in the permission universe — it grants
+    // nothing, and it rides along whenever the Editor role is duplicated.
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/roles",
+      payload: {
+        name: "Editor Copy",
+        permission: { invitation: ["read"], agent: ["read"] },
       },
     });
+
+    expect(response.statusCode).toBe(200);
+    // Stored sanitized: the pair grants nothing, so it does not survive.
+    expect(response.json().permission).toEqual({ agent: ["read"] });
+  });
+
+  test("accepts a UI-only permission the author's own role does not hold", async ({
+    makeCustomRole,
+    makeUser,
+  }) => {
+    // `simpleView:enable` is a display preference, not a privilege: admin
+    // deliberately holds less of it than member, so granting it is exempt
+    // from the no-escalation rule. An author without it must still be able to
+    // hand it to a role.
+    const author = await makeUser();
+    const authorRole = await makeCustomRole(organizationId, {
+      role: "role_maker",
+      name: "Role Maker",
+      permission: { ac: ["create"], agent: ["read"] },
+    });
+    await db.insert(schema.membersTable).values({
+      id: crypto.randomUUID(),
+      organizationId,
+      userId: author.id,
+      role: authorRole.role,
+      createdAt: new Date(),
+    });
+    authenticatedUser = author;
 
     const response = await app.inject({
       method: "POST",
       url: "/api/roles",
       payload: {
-        name: "Ops Admin",
-        description: "Operations access",
-        permission: {},
+        name: "Collapsed Sidebar",
+        permission: { agent: ["read"], simpleView: ["enable"] },
       },
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toMatchObject({
-      id: "role-1",
-      name: "Ops Admin",
-      permission: {},
-      predefined: false,
+    expect(response.json().permission).toEqual({
+      agent: ["read"],
+      simpleView: ["enable"],
     });
   });
 
@@ -148,7 +164,12 @@ describe("custom role routes", () => {
     });
 
     expect(response.statusCode).toBe(403);
-    expect(createOrgRoleMock).not.toHaveBeenCalled();
+    expect(
+      await OrganizationRoleModel.getByIdentifier(
+        "too_powerful",
+        organizationId,
+      ),
+    ).toBeNull();
   });
 
   test("rejects updating a role to grant permissions the user does not have", async ({
@@ -179,7 +200,10 @@ describe("custom role routes", () => {
 
     expect(response.statusCode).toBe(403);
     expect(response.json().error.message).toContain("auditLog:read");
-    expect(updateOrgRoleMock).not.toHaveBeenCalled();
+    expect(
+      (await OrganizationRoleModel.getById(targetRole.id, organizationId))
+        ?.permission,
+    ).toEqual({ ac: ["read"] });
   });
 
   test("rejects updates to predefined roles", async () => {
@@ -192,25 +216,9 @@ describe("custom role routes", () => {
     });
 
     expect(response.statusCode).toBe(403);
-    expect(updateOrgRoleMock).not.toHaveBeenCalled();
   });
 
-  test("supports the custom role create, update, and delete lifecycle", async ({
-    makeCustomRole,
-  }) => {
-    createOrgRoleMock.mockResolvedValue({
-      roleData: {
-        id: "role-1",
-        organizationId,
-        role: "ops_admin",
-        name: "Ops Admin",
-        description: "Operations access",
-        permission: { ac: ["read"] },
-        createdAt: new Date("2026-03-15T00:00:00.000Z"),
-        updatedAt: new Date("2026-03-15T00:00:00.000Z"),
-      },
-    });
-
+  test("supports the custom role create, update, and delete lifecycle", async () => {
     const createResponse = await app.inject({
       method: "POST",
       url: "/api/roles",
@@ -223,32 +231,19 @@ describe("custom role routes", () => {
 
     expect(createResponse.statusCode).toBe(200);
     expect(createResponse.json()).toMatchObject({
-      id: "role-1",
       role: "ops_admin",
       name: "Ops Admin",
-    });
-
-    const existingRole = await makeCustomRole(organizationId, {
-      role: "reader",
-      name: "Reader",
+      description: "Operations access",
       permission: { ac: ["read"] },
+      predefined: false,
     });
-
-    updateOrgRoleMock.mockResolvedValue({
-      roleData: {
-        ...existingRole,
-        name: "Reader Plus",
-        description: "Updated description",
-        permission: JSON.stringify({ ac: ["read", "update"] }),
-        updatedAt: new Date("2026-03-16T00:00:00.000Z"),
-      },
-    });
+    const roleId = createResponse.json().id;
 
     const updateResponse = await app.inject({
       method: "PUT",
-      url: `/api/roles/${existingRole.id}`,
+      url: `/api/roles/${roleId}`,
       payload: {
-        name: "Reader Plus",
+        name: "Ops Admin Plus",
         description: "Updated description",
         permission: { ac: ["read", "update"] },
       },
@@ -256,20 +251,23 @@ describe("custom role routes", () => {
 
     expect(updateResponse.statusCode).toBe(200);
     expect(updateResponse.json()).toMatchObject({
-      id: existingRole.id,
-      name: "Reader Plus",
+      id: roleId,
+      // The identifier is immutable; only the display name changes.
+      role: "ops_admin",
+      name: "Ops Admin Plus",
       permission: { ac: ["read", "update"] },
     });
 
-    deleteOrgRoleMock.mockResolvedValue({ success: true, error: null });
-
     const deleteResponse = await app.inject({
       method: "DELETE",
-      url: `/api/roles/${existingRole.id}`,
+      url: `/api/roles/${roleId}`,
     });
 
     expect(deleteResponse.statusCode).toBe(200);
     expect(deleteResponse.json()).toEqual({ success: true });
+    expect(
+      await OrganizationRoleModel.getById(roleId, organizationId),
+    ).toBeNull();
   });
 
   test.for([
@@ -304,28 +302,6 @@ describe("custom role routes", () => {
       });
       await TeamModel.addMember(child.id, holder.id);
     }
-
-    // The route delegates the write to better-auth; mirror it onto the DB row
-    // so the post-update resync (which reads the row) sees the new grant.
-    updateOrgRoleMock.mockImplementation(
-      async ({ body }: { body: { data: { permission: unknown } } }) => {
-        await db
-          .update(schema.organizationRolesTable)
-          .set({ permission: JSON.stringify(body.data.permission) })
-          .where(
-            and(
-              eq(schema.organizationRolesTable.organizationId, organizationId),
-              eq(schema.organizationRolesTable.role, role.role),
-            ),
-          );
-        return {
-          roleData: {
-            ...role,
-            permission: JSON.stringify(body.data.permission),
-          },
-        };
-      },
-    );
 
     const grantResponse = await app.inject({
       method: "PUT",
@@ -367,34 +343,6 @@ describe("custom role routes", () => {
       OrganizationRoleModel.getPermissions(existingRole.role, organizationId),
     ).resolves.toEqual({ ac: ["read"] });
 
-    updateOrgRoleMock.mockImplementation(async () => {
-      const updatedAt = new Date("2026-03-16T00:00:00.000Z");
-      await db
-        .update(schema.organizationRolesTable)
-        .set({
-          name: "Reader Plus",
-          description: "Updated description",
-          permission: JSON.stringify({ ac: ["read", "update"] }),
-          updatedAt,
-        })
-        .where(
-          and(
-            eq(schema.organizationRolesTable.id, existingRole.id),
-            eq(schema.organizationRolesTable.organizationId, organizationId),
-          ),
-        );
-
-      return {
-        roleData: {
-          ...existingRole,
-          name: "Reader Plus",
-          description: "Updated description",
-          permission: JSON.stringify({ ac: ["read", "update"] }),
-          updatedAt,
-        },
-      };
-    });
-
     const updateResponse = await app.inject({
       method: "PUT",
       url: `/api/roles/${existingRole.id}`,
@@ -429,19 +377,6 @@ describe("custom role routes", () => {
     await expect(
       OrganizationRoleModel.getPermissions(existingRole.role, organizationId),
     ).resolves.toEqual({ ac: ["read"] });
-
-    deleteOrgRoleMock.mockImplementation(async () => {
-      await db
-        .delete(schema.organizationRolesTable)
-        .where(
-          and(
-            eq(schema.organizationRolesTable.id, existingRole.id),
-            eq(schema.organizationRolesTable.organizationId, organizationId),
-          ),
-        );
-
-      return { success: true };
-    });
 
     const deleteResponse = await app.inject({
       method: "DELETE",
@@ -593,19 +528,6 @@ describe("custom role routes", () => {
   // === POST /api/roles - Create ===
 
   test("POST /api/roles creates a new custom role", async () => {
-    createOrgRoleMock.mockResolvedValue({
-      roleData: {
-        id: "role-new",
-        organizationId,
-        role: "test_role",
-        name: "Test Role",
-        description: null,
-        permission: { agent: ["read"], toolPolicy: ["read", "create"] },
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
-
     const response = await app.inject({
       method: "POST",
       url: "/api/roles",
@@ -617,41 +539,41 @@ describe("custom role routes", () => {
 
     expect(response.statusCode).toBe(200);
     const role = response.json();
-    expect(role.id).toBe("role-new");
+    expect(role.role).toBe("test_role");
     expect(role.name).toBe("Test Role");
     expect(role.permission).toEqual({
       agent: ["read"],
       toolPolicy: ["read", "create"],
     });
     expect(role.predefined).toBe(false);
+    expect(
+      (await OrganizationRoleModel.getById(role.id, organizationId))?.name,
+    ).toBe("Test Role");
   });
 
-  test("POST /api/roles rejects duplicate name via betterAuth error", async () => {
-    createOrgRoleMock.mockRejectedValue({
-      statusCode: 400,
-      body: { message: "That role name is already taken" },
+  test("POST /api/roles rejects a name whose identifier is already taken", async ({
+    makeCustomRole,
+  }) => {
+    await makeCustomRole(organizationId, {
+      role: "duplicate_role",
+      name: "Duplicate Role",
     });
 
     const response = await app.inject({
       method: "POST",
       url: "/api/roles",
       payload: {
-        name: "Duplicate Role",
+        // Different display name, same derived identifier.
+        name: "Duplicate role",
         permission: { agent: ["read"] },
       },
     });
 
     expect(response.statusCode).toBe(400);
-    const error = response.json();
-    expect(error.error.message).toContain("That role name is already taken");
+    expect(response.json().error.message).toContain("already taken");
   });
 
-  test("POST /api/roles rejects reserved predefined name via betterAuth error", async () => {
-    createOrgRoleMock.mockRejectedValue({
-      statusCode: 400,
-      body: { message: "That role name is already taken" },
-    });
-
+  test("POST /api/roles rejects a reserved predefined name", async () => {
     const response = await app.inject({
       method: "POST",
       url: "/api/roles",
@@ -662,24 +584,23 @@ describe("custom role routes", () => {
     });
 
     expect(response.statusCode).toBe(400);
-    const error = response.json();
-    expect(error.error.message).toContain("That role name is already taken");
+    expect(response.json().error.message).toContain("predefined role name");
+  });
+
+  test("POST /api/roles rejects a name with no letters or numbers", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/roles",
+      payload: { name: "***", permission: { agent: ["read"] } },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toContain(
+      "must contain at least one letter or number",
+    );
   });
 
   test("POST /api/roles creates role with empty permissions", async () => {
-    createOrgRoleMock.mockResolvedValue({
-      roleData: {
-        id: "role-empty",
-        organizationId,
-        role: "empty_perms",
-        name: "Empty Perms",
-        description: null,
-        permission: {},
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
-
     const response = await app.inject({
       method: "POST",
       url: "/api/roles",
@@ -690,8 +611,7 @@ describe("custom role routes", () => {
     });
 
     expect(response.statusCode).toBe(200);
-    const role = response.json();
-    expect(role.permission).toEqual({});
+    expect(response.json().permission).toEqual({});
   });
 
   test("POST /api/roles creates role with multiple complex permissions", async () => {
@@ -701,19 +621,6 @@ describe("custom role routes", () => {
       log: ["read"],
       mcpServerInstallation: ["read", "create", "delete"],
     };
-
-    createOrgRoleMock.mockResolvedValue({
-      roleData: {
-        id: "role-complex",
-        organizationId,
-        role: "complex_role",
-        name: "Complex Role",
-        description: null,
-        permission: complexPermissions,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
 
     const response = await app.inject({
       method: "POST",
@@ -738,15 +645,6 @@ describe("custom role routes", () => {
       role: "updatable",
       name: "Updatable",
       permission: { agent: ["read"] },
-    });
-
-    updateOrgRoleMock.mockResolvedValue({
-      roleData: {
-        ...existingRole,
-        name: "Updated Name",
-        permission: JSON.stringify({ agent: ["read"] }),
-        updatedAt: new Date(),
-      },
     });
 
     const response = await app.inject({
@@ -776,14 +674,6 @@ describe("custom role routes", () => {
       toolPolicy: ["read"],
     };
 
-    updateOrgRoleMock.mockResolvedValue({
-      roleData: {
-        ...existingRole,
-        permission: JSON.stringify(newPermissions),
-        updatedAt: new Date(),
-      },
-    });
-
     const response = await app.inject({
       method: "PUT",
       url: `/api/roles/${existingRole.id}`,
@@ -796,6 +686,51 @@ describe("custom role routes", () => {
     expect(role.permission).toEqual(newPermissions);
   });
 
+  test("PUT /api/roles/:roleId accepts pairs the no-escalation rule exempts", async ({
+    makeCustomRole,
+    makeUser,
+  }) => {
+    // Same divergence as on create: editing a role to switch on a UI-only
+    // preference, or leaving a vestigial action in place, is not escalation.
+    const author = await makeUser();
+    const authorRole = await makeCustomRole(organizationId, {
+      role: "role_editor",
+      name: "Role Editor",
+      permission: { ac: ["read", "update"], agent: ["read"] },
+    });
+    await db.insert(schema.membersTable).values({
+      id: crypto.randomUUID(),
+      organizationId,
+      userId: author.id,
+      role: authorRole.role,
+      createdAt: new Date(),
+    });
+    const target = await makeCustomRole(organizationId, {
+      role: "target_role",
+      name: "Target Role",
+      permission: { agent: ["read"] },
+    });
+    authenticatedUser = author;
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/roles/${target.id}`,
+      payload: {
+        permission: {
+          agent: ["read"],
+          simpleView: ["enable"],
+          invitation: ["read"],
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().permission).toEqual({
+      agent: ["read"],
+      simpleView: ["enable"],
+    });
+  });
+
   test("PUT /api/roles/admin rejects update to predefined role", async () => {
     const response = await app.inject({
       method: "PUT",
@@ -806,7 +741,6 @@ describe("custom role routes", () => {
     expect(response.statusCode).toBe(403);
     const error = response.json();
     expect(error.error.message).toContain("Cannot update predefined roles");
-    expect(updateOrgRoleMock).not.toHaveBeenCalled();
   });
 
   // === DELETE /api/roles/:roleId ===
@@ -820,8 +754,6 @@ describe("custom role routes", () => {
       permission: { agent: ["read"] },
     });
 
-    deleteOrgRoleMock.mockResolvedValue({ success: true, error: null });
-
     const deleteResponse = await app.inject({
       method: "DELETE",
       url: `/api/roles/${existingRole.id}`,
@@ -830,14 +762,11 @@ describe("custom role routes", () => {
     expect(deleteResponse.statusCode).toBe(200);
     expect(deleteResponse.json()).toEqual({ success: true });
 
-    // Verify role is now 404
-    const _getResponse = await app.inject({
+    const getResponse = await app.inject({
       method: "GET",
       url: `/api/roles/${existingRole.id}`,
     });
-    // The role still exists in DB since deleteOrgRoleMock is a mock,
-    // but in a real scenario it would return 404.
-    // We test the delete route response is correct.
+    expect(getResponse.statusCode).toBe(404);
   });
 
   test("DELETE /api/roles/:roleId returns 404 for non-existent role", async () => {
@@ -847,114 +776,8 @@ describe("custom role routes", () => {
     });
 
     expect(response.statusCode).toBe(404);
-    expect(deleteOrgRoleMock).not.toHaveBeenCalled();
   });
 
-  // === Full lifecycle ===
-
-  test("complete role lifecycle: create, list, get, update, delete", async ({
-    makeCustomRole,
-  }) => {
-    // 1. Create via betterAuth mock
-    createOrgRoleMock.mockResolvedValue({
-      roleData: {
-        id: "lifecycle-id",
-        organizationId,
-        role: "lifecycle_role",
-        name: "Lifecycle Role",
-        description: null,
-        permission: { agent: ["read"] },
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
-
-    const createResponse = await app.inject({
-      method: "POST",
-      url: "/api/roles",
-      payload: {
-        name: "Lifecycle Role",
-        permission: { agent: ["read"] },
-      },
-    });
-
-    expect(createResponse.statusCode).toBe(200);
-    expect(createResponse.json().name).toBe("Lifecycle Role");
-
-    // 2. List roles includes predefined
-    const listResponse = await app.inject({
-      method: "GET",
-      url: "/api/roles",
-    });
-    expect(listResponse.statusCode).toBe(200);
-    const roles = listResponse.json().data;
-    expect(roles.length).toBeGreaterThanOrEqual(3);
-    const adminRole = roles.find((r: { role: string }) => r.role === "admin");
-    expect(adminRole).toBeDefined();
-    expect(adminRole.predefined).toBe(true);
-
-    // 3. Get predefined role by name
-    const getAdminResponse = await app.inject({
-      method: "GET",
-      url: "/api/roles/admin",
-    });
-    expect(getAdminResponse.statusCode).toBe(200);
-    expect(getAdminResponse.json().id).toBe("admin");
-    expect(getAdminResponse.json().predefined).toBe(true);
-
-    // 4. Create a real DB role for update/delete testing
-    const dbRole = await makeCustomRole(organizationId, {
-      role: "lifecycle_db",
-      name: "Lifecycle DB",
-      permission: { agent: ["read"] },
-    });
-
-    // 5. Update
-    updateOrgRoleMock.mockResolvedValue({
-      roleData: {
-        ...dbRole,
-        permission: JSON.stringify({ agent: ["read", "create"] }),
-        updatedAt: new Date(),
-      },
-    });
-
-    const updateResponse = await app.inject({
-      method: "PUT",
-      url: `/api/roles/${dbRole.id}`,
-      payload: { permission: { agent: ["read", "create"] } },
-    });
-    expect(updateResponse.statusCode).toBe(200);
-    expect(updateResponse.json().permission).toEqual({
-      agent: ["read", "create"],
-    });
-
-    // 6. Delete
-    deleteOrgRoleMock.mockImplementation(async () => {
-      await db
-        .delete(schema.organizationRolesTable)
-        .where(
-          and(
-            eq(schema.organizationRolesTable.id, dbRole.id),
-            eq(schema.organizationRolesTable.organizationId, organizationId),
-          ),
-        );
-      return { success: true };
-    });
-
-    const deleteResponse = await app.inject({
-      method: "DELETE",
-      url: `/api/roles/${dbRole.id}`,
-    });
-    expect(deleteResponse.statusCode).toBe(200);
-    expect(deleteResponse.json()).toEqual({ success: true });
-
-    // 7. Verify deletion
-    const getDeletedResponse = await app.inject({
-      method: "GET",
-      url: `/api/roles/${dbRole.id}`,
-    });
-    expect(getDeletedResponse.statusCode).toBe(404);
-  });
   // === Enterprise licence gate ===
 
   describe("without an enterprise licence", () => {
@@ -972,7 +795,12 @@ describe("custom role routes", () => {
 
       expect(response.statusCode).toBe(403);
       expect(response.json().error.message).toContain("enterprise feature");
-      expect(createOrgRoleMock).not.toHaveBeenCalled();
+      expect(
+        await OrganizationRoleModel.getByIdentifier(
+          "ops_admin",
+          organizationId,
+        ),
+      ).toBeNull();
     });
 
     test("refuses to update a custom role", async ({ makeCustomRole }) => {
@@ -993,7 +821,6 @@ describe("custom role routes", () => {
 
       expect(response.statusCode).toBe(403);
       expect(response.json().error.message).toContain("enterprise feature");
-      expect(updateOrgRoleMock).not.toHaveBeenCalled();
       expect(
         (await OrganizationRoleModel.getById(role.id, organizationId))?.name,
       ).toBe("Ops Admin");
@@ -1007,15 +834,15 @@ describe("custom role routes", () => {
         name: "Ops Admin",
         permission: { agent: ["read"] },
       });
-      deleteOrgRoleMock.mockResolvedValue({ success: true, error: null });
-
       const response = await app.inject({
         method: "DELETE",
         url: `/api/roles/${role.id}`,
       });
 
       expect(response.statusCode).toBe(200);
-      expect(deleteOrgRoleMock).toHaveBeenCalledTimes(1);
+      expect(
+        await OrganizationRoleModel.getById(role.id, organizationId),
+      ).toBeNull();
     });
 
     test("still lists roles, so the page renders its list dimmed rather than empty", async ({

--- a/platform/backend/src/routes/custom-role.ee.ts
+++ b/platform/backend/src/routes/custom-role.ee.ts
@@ -5,7 +5,6 @@ import {
 } from "@archestra/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
-import { betterAuth } from "@/auth";
 import { syncSystemRoleForRoleHolders } from "@/auth/system-role-sync";
 import { enterpriseTier } from "@/enterprise-tier";
 import logger from "@/logging";
@@ -92,6 +91,7 @@ const customRoleRoutes: FastifyPluginAsyncZod = async (fastify) => {
       }
 
       const roleIdentifier = generateRoleIdentifier(name);
+      await assertRoleIdentifierIsFree(roleIdentifier, organizationId);
 
       logger.info(
         {
@@ -103,44 +103,21 @@ const customRoleRoutes: FastifyPluginAsyncZod = async (fastify) => {
         "Creating role",
       );
 
-      try {
-        const result = await betterAuth.api.createOrgRole({
-          headers: request.headers as HeadersInit,
-          body: {
-            role: roleIdentifier,
-            permission,
-            additionalFields: {
-              name,
-              description,
-            },
-            organizationId,
-          },
-        });
+      const created = await OrganizationRoleModel.create({
+        organizationId,
+        role: roleIdentifier,
+        name,
+        description,
+        permission,
+      }).catch(rethrowDuplicateRoleName);
 
-        if (!result.roleData) {
-          throw new ApiError(500, "Role created but data not returned");
-        }
+      OrganizationRoleModel.invalidatePermissionsCacheForRole(
+        organizationId,
+        created.role,
+      );
 
-        OrganizationRoleModel.invalidatePermissionsCacheForRole(
-          organizationId,
-          result.roleData.role,
-        );
-
-        logger.info({ role: result.roleData }, "Role created successfully");
-        return reply.send(normalizeRoleResponse(result.roleData));
-      } catch (error) {
-        const err = error as {
-          status?: string;
-          statusCode?: number;
-          message?: string;
-          body?: { message?: string };
-        };
-        logger.error({ error }, "Failed to create role");
-        throw new ApiError(
-          err.statusCode || 400,
-          err.body?.message || err.message || "Failed to create role",
-        );
-      }
+      logger.info({ roleId: created.id }, "Role created successfully");
+      return reply.send(normalizeRoleResponse(created));
     },
   );
 
@@ -168,7 +145,6 @@ const customRoleRoutes: FastifyPluginAsyncZod = async (fastify) => {
         body: { name, description, permission },
         user,
         organizationId,
-        headers,
       },
       reply,
     ) => {
@@ -209,45 +185,31 @@ const customRoleRoutes: FastifyPluginAsyncZod = async (fastify) => {
         }
       }
 
-      // Build update data
-      const updateData: Record<string, unknown> = {};
-      if (name) updateData.name = name;
-      if (description !== undefined) updateData.description = description;
-      if (permission) updateData.permission = permission;
-
-      const result = await betterAuth.api.updateOrgRole({
-        headers: headers as HeadersInit,
-        body: {
-          roleId,
-          organizationId,
-          data: updateData,
-        },
+      const updated = await OrganizationRoleModel.update({
+        id: roleId,
+        organizationId,
+        name,
+        description,
+        permission,
       });
 
-      if (!result.roleData) {
-        throw new ApiError(500, "Role updated but data not returned");
+      if (!updated) {
+        throw new ApiError(404, "Role not found");
       }
 
       OrganizationRoleModel.invalidatePermissionsCacheForRole(
         organizationId,
-        existingRole.role,
-      );
-      OrganizationRoleModel.invalidatePermissionsCacheForRole(
-        organizationId,
-        result.roleData.role,
+        updated.role,
       );
 
       // The role's member:impersonate grant may have appeared or vanished;
       // resync the system-level user.role of everyone holding it (the
       // better-auth admin plugin gates impersonation on that column).
       if (permission) {
-        await syncSystemRoleForRoleHolders(
-          result.roleData.role,
-          organizationId,
-        );
+        await syncSystemRoleForRoleHolders(updated.role, organizationId);
       }
 
-      return reply.send(normalizeRoleResponse(result.roleData));
+      return reply.send(normalizeRoleResponse(updated));
     },
   );
 
@@ -267,7 +229,7 @@ const customRoleRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async (request, reply) => {
-      const { organizationId, headers } = request;
+      const { organizationId } = request;
       const snapshot = async (ids: string[]) => {
         const roles = await Promise.all(
           ids.map((id) => OrganizationRoleModel.getById(id, organizationId)),
@@ -306,10 +268,7 @@ const customRoleRoutes: FastifyPluginAsyncZod = async (fastify) => {
           }
         },
         applyEach: async (role) => {
-          await betterAuth.api.deleteOrgRole({
-            headers: headers as HeadersInit,
-            body: { roleId: role.id, organizationId },
-          });
+          await OrganizationRoleModel.delete(role.id, organizationId);
           OrganizationRoleModel.invalidatePermissionsCacheForRole(
             organizationId,
             role.role,
@@ -335,7 +294,7 @@ const customRoleRoutes: FastifyPluginAsyncZod = async (fastify) => {
         response: constructResponseSchema(DeleteObjectResponseSchema),
       },
     },
-    async ({ params: { roleId }, organizationId, headers }, reply) => {
+    async ({ params: { roleId }, organizationId }, reply) => {
       // Check if role exists first
       const role = await OrganizationRoleModel.getById(roleId, organizationId);
       if (!role) {
@@ -352,13 +311,7 @@ const customRoleRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(400, deleteCheck.reason || "Cannot delete role");
       }
 
-      await betterAuth.api.deleteOrgRole({
-        headers: headers as HeadersInit,
-        body: {
-          roleId,
-          organizationId,
-        },
-      });
+      await OrganizationRoleModel.delete(roleId, organizationId);
 
       OrganizationRoleModel.invalidatePermissionsCacheForRole(
         organizationId,
@@ -398,6 +351,53 @@ function assertCustomRolesLicensed(): void {
     );
   }
 }
+
+/**
+ * A custom role's identifier must not collide with a predefined role name or
+ * with another custom role in the same organization. The unique index on
+ * (organization_id, role) is the real guard — this check exists to return a
+ * useful message instead of a constraint violation in the common case.
+ */
+async function assertRoleIdentifierIsFree(
+  roleIdentifier: string,
+  organizationId: string,
+): Promise<void> {
+  if (!roleIdentifier) {
+    throw new ApiError(
+      400,
+      "Role name must contain at least one letter or number",
+    );
+  }
+
+  if (OrganizationRoleModel.isPredefinedRole(roleIdentifier)) {
+    throw new ApiError(
+      400,
+      `"${roleIdentifier}" is a predefined role name and cannot be used for a custom role`,
+    );
+  }
+
+  const existing = await OrganizationRoleModel.getByIdentifier(
+    roleIdentifier,
+    organizationId,
+  );
+  if (existing) {
+    throw new ApiError(400, "That role name is already taken");
+  }
+}
+
+/** Two creates racing on the same name land here rather than as a 500. */
+function rethrowDuplicateRoleName(error: unknown): never {
+  const err = error as { code?: string; cause?: { code?: string } };
+  if (
+    err.code === POSTGRES_UNIQUE_VIOLATION ||
+    err.cause?.code === POSTGRES_UNIQUE_VIOLATION
+  ) {
+    throw new ApiError(400, "That role name is already taken");
+  }
+  throw error;
+}
+
+const POSTGRES_UNIQUE_VIOLATION = "23505";
 
 function normalizeRoleResponse(roleData: {
   id: string;


### PR DESCRIPTION
## The bug

Duplicating a role can fail with **"You are not allowed to create a role"** even for an author who is allowed to create roles, and even though the same request has already passed the platform's own permission check. The role list ends up showing the error toast next to a success toast from an earlier attempt.

## Why

Role writes were validated twice, by two rule sets that disagree.

1. `POST /api/roles` checks the no-privilege-escalation rule with `findUngrantablePermissions`, which:
   - **exempts the UI-only resources** (`simpleView`, `chatAgentPicker`, `chatProviderSettings`) — predefined admin deliberately holds *less* of those than member, so treating them as privileges would make ordinary grants impossible;
   - **skips actions outside the permission universe** — the predefined editor set still lists `invitation:read`, which is not in `allAvailableActions.invitation` and grants nothing.
2. The handler then delegated the write to better-auth's `createOrgRole` / `updateOrgRole`, whose `checkIfMemberHasPermission` re-checks **every** `resource:action` pair against the author's role with none of those exemptions, and refuses with `YOU_ARE_NOT_ALLOWED_TO_CREATE_A_ROLE`.

Duplicating is where the divergence surfaces: the dialog copies the source role's permission set wholesale, and the builder leaves an already-checked box enabled (`shouldDisableAction = readOnly || (!canGrantAction && !isSelected)`), so a pair the author cannot grant rides along invisibly.

Checked against the real role maps (`ac.newRole(...).authorize()`, one pair at a time, the way better-auth does it):

| author | duplicating | `/api/roles` check | better-auth check |
|---|---|---|---|
| admin | editor | ok | **missing `invitation:read`** |
| platform_admin | member | ok | **missing `simpleView:enable`** |
| admin | member / admin / platform_admin | ok | ok |

Not a regression — the same code shipped in 1.3.45 and is unchanged on main.

## Repro on main

As a predefined **admin**: Settings → Roles → duplicate **Editor** → Create → refused.

For the custom-role shape: as admin create `role_maker` (`ac: create`, "Show agent picker in chat" **off**) and `with_picker` (that toggle **on**); assign `role_maker` to a user; as that user, duplicate `with_picker` → refused, while duplicating a predefined role whose toggles match theirs succeeds.

## The fix

Role writes go through `OrganizationRoleModel` and `/api/roles` becomes the single authority. It already owns everything that matters — the enterprise licence gate, the escalation rule, the permissions-cache invalidation, the `member:impersonate` system-role resync, and the audit trail — and the plugin's own role CRUD was already closed in `disabledPaths`, so nothing else could reach that second rule set anyway.

Also in here:

- `dynamicAccessControl.enabled` **stays on** — better-auth's own `hasPermission` needs it to resolve custom roles from the database.
- Its `validateRoleName` hook is removed: the option does not exist in better-auth 1.6.22 (no reference anywhere in the shipped bundle) and never ran. The rules it described are now enforced in the route — non-empty identifier, no predefined-name collision, no duplicate in the organization — and a create that loses the race to the unique index returns 400 instead of 500.
- Permissions are sanitized on write as well as on read, so a stored set can no longer carry a pair that silently vanishes on the way back out.

## Tests

`custom-role.ee.test.ts` and `custom-role.bulk.ee.test.ts` exercise the real write path instead of mocking the better-auth endpoints — which is what let this through, since the mocks could not disagree with the route. New regression tests cover both divergences on create and on update: a vestigial action (`invitation:read`), and a UI-only permission the author's own role does not hold (`simpleView:enable`).

Note for reviewers: the two `without an enterprise licence` tests fail locally when `ARCHESTRA_ENTERPRISE_LICENSE_ACTIVATED=true` is set in `.env` (pre-existing, unrelated to this change — they fail the same way on main). With it unset, all 35 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>