### PR TITLE
fix(proxy): keep SSE streams alive while tool calls are withheld (backport #7810)

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -2,7 +2,7 @@
 title: Deployment
 category: Archestra Platform
 order: 3
-lastUpdated: 2026-09-07
+lastUpdated: 2026-09-10
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -1337,6 +1337,12 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Opt-in: raise it when an upstream can take more than 5 minutes to send headers or the next stream chunk
   - Keep it below the load balancer's request or idle timeout. For a 600-second load balancer timeout, use `540000` so Archestra can report the upstream timeout before the load balancer closes the connection
   - Keep it finite so genuinely-dead upstreams still surface as errors
+
+- **`ARCHESTRA_LLM_PROXY_STREAM_KEEPALIVE_INTERVAL_MS`** - Longest a streaming proxy response goes without a byte before Archestra writes an SSE keep-alive comment.
+  - Default: `10000` (10 seconds). Set `0` to turn the keep-alive off.
+  - Archestra holds back tool calls until the model turn ends and tool invocation policies have run. A large tool call — a long file write, for example — is a silent stream for the client until then. Streaming clients treat silence as a stalled connection and retry; Claude Code flags a stall after 20 seconds. The keep-alive comment is a valid SSE line that clients ignore, so the connection stays busy without changing the response.
+  - Only applies to `text/event-stream` responses. Bedrock's binary event stream and Ollama's NDJSON stream have no comment syntax and get no keep-alive.
+  - Keep it below the shortest stall timeout of your clients.
 
 - **`ARCHESTRA_LLM_COST_SUBSCRIPTION_AUTODETECT`** - Automatically classify subscription credentials as subscription usage.
   - Default: `true`

--- a/docs/pages/platform-observability.md
+++ b/docs/pages/platform-observability.md
@@ -2,7 +2,7 @@
 title: Observability
 category: Archestra Platform
 order: 4
-lastUpdated: 2026-09-03
+lastUpdated: 2026-09-10
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -30,7 +30,8 @@ Combined, these endpoints expose metrics including:
 - `llm_cache_cost_total` - Estimated cost in USD attributable to prompt-cache tokens (reads plus writes, including the higher 1-hour-TTL write surcharge), by provider, model, agent_id, agent_name, agent_type, and source. Lets you chart caching spend separately from total cost.
 - `llm_cache_savings_total` - Gross estimated USD saved by cache reads being billed at a discount versus the full input price, by provider, model, agent_id, agent_name, agent_type, and source. Read-side only (always non-negative); the signed net-of-write-surcharge savings is persisted per interaction rather than as a counter.
 - `llm_blocked_tools_total` - Counter of tool calls blocked by tool invocation policies, grouped by provider, model, agent_id, agent_name, agent_type, and source
-- `llm_time_to_first_token_seconds` - Time to first token (TTFT) for streaming requests, by provider, agent_id, agent_name, agent_type, source, and model. Helps developers choose models with lower initial response latency.
+- `llm_time_to_first_token_seconds` - Time from the upstream call to the first chunk the provider returns, by provider, agent_id, agent_name, agent_type, source, and model. Helps developers choose models with lower initial response latency. Buckets run to 300 seconds, so a stalled upstream is visible rather than folded into the top bucket.
+- `llm_time_to_first_byte_seconds` - Time from receiving a streaming request to the first byte written to the client, by the same labels. Includes everything before the upstream call — agent lookup, authentication, guardrails, tool policies. Compare it with `llm_time_to_first_token_seconds` to see how much of the client's wait is Archestra's own preflight.
 - `llm_tokens_per_second` - Output tokens per second throughput, by provider, agent_id, agent_name, agent_type, source, and model. Allows comparing model response speeds for latency-sensitive applications.
 - `llm_active_users` - Distinct users who made at least one attributed LLM request, by `window` (`24h` or `7d`). An org-wide adoption signal. The value is read from the database, so every replica reports the same number — aggregate it with `max()`, not `sum()`. Set `ARCHESTRA_METRICS_ACTIVE_USERS_REFRESH_INTERVAL_MS` to change how often it refreshes, or to `0` to turn it off.
 

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -41,6 +41,9 @@ ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai
 # Opt-in: unset = undici defaults (5 min headers/body timeout). Raise it for slow
 # upstreams such as CPU Ollama whose first token can take longer than 5 min.
 # ARCHESTRA_LLM_PROXY_UPSTREAM_TIMEOUT_MS=600000
+# Longest an SSE proxy stream may go without a byte before the proxy writes an
+# SSE comment to keep client stall watchdogs quiet (default 10000, 0 = disable).
+# ARCHESTRA_LLM_PROXY_STREAM_KEEPALIVE_INTERVAL_MS=10000
 # Maximum number of virtual API keys per LLM API key (default 10)
 # ARCHESTRA_LLM_PROXY_MAX_VIRTUAL_KEYS=10
 # Default expiration for new virtual API keys in seconds (default 2592000 = 30 days, 0 = never)

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -501,6 +501,19 @@ const DEFAULT_BODY_LIMIT = 70 * 1024 * 1024;
  */
 const DEFAULT_KEEP_ALIVE_TIMEOUT_MS = 620_000;
 
+/**
+ * Longest the LLM proxy lets an already-committed `text/event-stream`
+ * response go without a byte before it writes an SSE comment. The proxy
+ * withholds client tool-call events until the turn ends and tool-invocation
+ * policy has run, so a large tool payload is a stretch of upstream traffic the
+ * client hears nothing of. Streaming clients run byte-clock watchdogs against
+ * exactly that: Claude Code flags a stream as stalled after ~20s of silence
+ * and aborts and retries it after a few minutes. 10s keeps at least one
+ * keep-alive inside the 20s window with margin for scheduling jitter. 0
+ * disables the keep-alive.
+ */
+const DEFAULT_LLM_PROXY_STREAM_KEEPALIVE_INTERVAL_MS = 10_000;
+
 const DEFAULT_DATABASE_POOL_MAX = 50;
 const MAX_DATABASE_POOL_MAX = 500;
 
@@ -3388,6 +3401,10 @@ const config = {
           300000,
         )
       : undefined,
+    streamKeepAliveIntervalMs: parseNonNegativeInt(
+      process.env.ARCHESTRA_LLM_PROXY_STREAM_KEEPALIVE_INTERVAL_MS,
+      DEFAULT_LLM_PROXY_STREAM_KEEPALIVE_INTERVAL_MS,
+    ),
   },
   kb: {
     // BETA gate for the auto-sync-permissions connector visibility: the

--- a/platform/backend/src/observability/metrics/llm.ts
+++ b/platform/backend/src/observability/metrics/llm.ts
@@ -114,6 +114,15 @@ type Fetch = (
   init?: RequestInit,
 ) => Promise<Response>;
 
+/**
+ * Shared by the two first-token/first-byte histograms. Dense below 10s where
+ * healthy latency lives, then 20s and 180s bracket the silence a streaming
+ * client treats as a stall and as grounds to abort and retry.
+ */
+const FIRST_BYTE_BUCKETS = [
+  0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120, 180, 300,
+] as const;
+
 // LLM-specific metrics matching fastify-metrics format for consistency.
 // You can monitor request count, duration and error rate with these.
 let llmRequestDuration: client.Histogram<string>;
@@ -124,6 +133,7 @@ let llmCostTotal: client.Counter<string>;
 let llmCacheCostTotal: client.Counter<string>;
 let llmCacheSavingsTotal: client.Counter<string>;
 let llmTimeToFirstToken: client.Histogram<string>;
+let llmTimeToFirstByte: client.Histogram<string>;
 let llmTokensPerSecond: client.Histogram<string>;
 let llmTokenUsage: client.Histogram<string>;
 
@@ -151,6 +161,7 @@ export function initializeMetrics(labelKeys: string[]): void {
     llmCacheCostTotal &&
     llmCacheSavingsTotal &&
     llmTimeToFirstToken &&
+    llmTimeToFirstByte &&
     llmTokensPerSecond &&
     llmTokenUsage
   ) {
@@ -187,6 +198,9 @@ export function initializeMetrics(labelKeys: string[]): void {
     }
     if (llmTimeToFirstToken) {
       client.register.removeSingleMetric("llm_time_to_first_token_seconds");
+    }
+    if (llmTimeToFirstByte) {
+      client.register.removeSingleMetric("llm_time_to_first_byte_seconds");
     }
     if (llmTokensPerSecond) {
       client.register.removeSingleMetric("llm_tokens_per_second");
@@ -278,10 +292,24 @@ export function initializeMetrics(labelKeys: string[]): void {
 
   llmTimeToFirstToken = new client.Histogram({
     name: "llm_time_to_first_token_seconds",
-    help: "Time to first token in seconds (streaming latency)",
+    help: "Time from upstream call to first upstream chunk in seconds (streaming latency)",
     labelNames: [...baseLabelNames, ...nextLabelKeys],
-    // Buckets optimized for TTFT - typically faster than full response
-    buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+    // Dense below 10s where healthy TTFT lives, then sparse up to the
+    // 20s / 180s marks streaming clients use as stall and abort thresholds.
+    // With the old 10s ceiling every stall landed in +Inf next to a 12s TTFT.
+    buckets: [...FIRST_BYTE_BUCKETS],
+    enableExemplars: true,
+  });
+
+  // Client-visible latency: from the proxy receiving the request to the first
+  // byte it writes, so preflight (auth, agent resolution, guardrails) counts.
+  // llm_time_to_first_token_seconds starts its clock at the upstream call and
+  // never sees that window.
+  llmTimeToFirstByte = new client.Histogram({
+    name: "llm_time_to_first_byte_seconds",
+    help: "Time from request receipt to the first byte written to the client in seconds (streaming)",
+    labelNames: [...baseLabelNames, ...nextLabelKeys],
+    buckets: [...FIRST_BYTE_BUCKETS],
     enableExemplars: true,
   });
 
@@ -531,6 +559,32 @@ export function reportLLMCacheCost(
  * @param ttftSeconds Time to first token in seconds
  * @param source Interaction source (e.g. "api", "chat", "knowledge:embedding")
  */
+/**
+ * Reports client-visible time to first byte for streaming requests: request
+ * receipt to first write, preflight included.
+ */
+export function reportTimeToFirstByte(
+  provider: SupportedProvider,
+  profile: GatewayAgent,
+  model: string,
+  ttfbSeconds: number,
+  source: InteractionSource,
+): void {
+  if (!llmTimeToFirstByte) {
+    logger.warn("LLM metrics not initialized, skipping TTFB reporting");
+    return;
+  }
+  if (ttfbSeconds <= 0) {
+    logger.warn("Invalid TTFB value, must be positive");
+    return;
+  }
+  llmTimeToFirstByte.observe({
+    labels: buildMetricLabels(profile, { provider }, model, source),
+    value: ttfbSeconds,
+    exemplarLabels: getExemplarLabels(),
+  });
+}
+
 export function reportTimeToFirstToken(
   provider: SupportedProvider,
   profile: GatewayAgent,

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -122,6 +122,7 @@ import {
   toToolCallBlock,
   withSessionContext,
 } from "./llm-proxy-helpers";
+import { StreamKeepAlive } from "./stream-keepalive";
 import * as utils from "./utils";
 import type { SessionSource } from "./utils/headers/session-id";
 import {
@@ -200,6 +201,18 @@ export interface LLMProxyContext<TRequest> {
   teamIds?: string[];
   teams?: SpanTeamInfo[];
   userTeams?: SpanTeamInfo[];
+  /**
+   * Client-visible latency clock. `requestReceivedAt` is stamped on entry to
+   * the handler; `firstByteAt` is set by `ensureStreamHeaders` the moment the
+   * response is committed — which, on a lazily committed stream, is also the
+   * first byte the client sees, wherever in preflight or streaming it happens.
+   */
+  streamTiming: StreamTiming;
+}
+
+export interface StreamTiming {
+  requestReceivedAt: number;
+  firstByteAt?: number;
 }
 
 export type LLMProxyAuthOverride = {
@@ -264,6 +277,7 @@ export async function handleLLMProxy<
   reply: FastifyReply,
   provider: LLMProvider<TRequest, TResponse, TMessages, TChunk, THeaders>,
 ): Promise<FastifyReply> {
+  const streamTiming: StreamTiming = { requestReceivedAt: Date.now() };
   const headers = request.headers as unknown as THeaders;
   const agentId = (request.params as { agentId?: string }).agentId;
   const providerName = provider.provider;
@@ -874,6 +888,7 @@ export async function handleLLMProxy<
     const ensureStreamHeaders = () => {
       if (sseHeaders && !reply.raw.headersSent) {
         reply.raw.writeHead(200, sseHeaders);
+        streamTiming.firstByteAt = Date.now();
       }
     };
 
@@ -1317,6 +1332,7 @@ export async function handleLLMProxy<
       teamIds,
       teams,
       userTeams,
+      streamTiming,
     };
 
     // handleStreaming is self-contained: it persists its own failed-interaction
@@ -1450,6 +1466,7 @@ async function handleStreaming<
     teamIds,
     teams,
     userTeams,
+    streamTiming,
   } = ctx;
 
   const providerName = provider.provider;
@@ -1457,6 +1474,26 @@ async function handleStreaming<
   const streamStartTime = Date.now();
   let firstChunkTime: number | undefined;
   let streamCompleted = false;
+
+  // Every byte to the client goes through here so the keep-alive knows when
+  // the stream last spoke. The keep-alive itself only ever writes to a stream
+  // that is already committed and idle (see StreamKeepAlive) — it is armed
+  // now, before the upstream call, so it also covers a stream the dual-LLM
+  // keep-alive committed during preflight and a slow post-stream policy
+  // evaluation, but it cannot itself turn a pending upstream error into a 200.
+  const keepAlive = new StreamKeepAlive(
+    reply.raw,
+    config.llmProxy.streamKeepAliveIntervalMs,
+    streamAdapter
+      .getSSEHeaders()
+      ["Content-Type"]?.startsWith("text/event-stream") ?? false,
+  );
+  keepAlive.start();
+  const writeToClient = (data: string | Uint8Array) => {
+    ensureStreamHeaders();
+    reply.raw.write(data);
+    keepAlive.touch();
+  };
   // Providers whose transport can't self-instrument duration (Bedrock) rely on
   // us to record llm_request_duration_seconds. Guard against a second (error-path)
   // observation once the stream has been established.
@@ -1597,8 +1634,7 @@ async function handleStreaming<
           // branch still do; zhipuai.ts guards it), as does one whose terminal
           // frame echoes the turn's calls (the Responses adapters).
           if (result.sseData) {
-            ensureStreamHeaders();
-            reply.raw.write(result.sseData);
+            writeToClient(result.sseData);
           }
 
           if (result.isFinal) {
@@ -1763,10 +1799,9 @@ async function handleStreaming<
 
       // The tool-call events were held back, so they are simply dropped and
       // the client is sent the refusal alone.
-      ensureStreamHeaders();
       const refusalEvents = streamAdapter.formatCompleteTextSSE(contentMessage);
       for (const event of refusalEvents) {
-        reply.raw.write(event);
+        writeToClient(event);
       }
 
       recordBlockedToolCallMetrics({
@@ -1808,18 +1843,14 @@ async function handleStreaming<
             ...rewrittenToolCalls,
           );
         }
-        if (allEvents.length > 0) {
-          ensureStreamHeaders();
-          for (const event of allEvents) {
-            reply.raw.write(event);
-          }
+        for (const event of allEvents) {
+          writeToClient(event);
         }
       }
     }
 
     // Stream end events
-    ensureStreamHeaders();
-    reply.raw.write(streamAdapter.formatEndSSE());
+    writeToClient(streamAdapter.formatEndSSE());
     reply.raw.end();
 
     streamCompleted = true;
@@ -1862,10 +1893,25 @@ async function handleStreaming<
       provider.formatStreamErrorFrame,
     );
   } finally {
+    keepAlive.stop();
+
     // Always record interaction (whether stream completed or was aborted)
     if (!streamCompleted) {
       logger.info(
         "Stream was aborted before completion, recording partial interaction",
+      );
+    }
+
+    // Client-visible first byte, preflight included. Observed here rather
+    // than at commit time because the commit can happen during preflight
+    // (dual-LLM keep-alive), before the handler has the labels in hand.
+    if (streamTiming.firstByteAt !== undefined) {
+      metrics.llm.reportTimeToFirstByte(
+        providerName,
+        agent,
+        actualModel,
+        (streamTiming.firstByteAt - streamTiming.requestReceivedAt) / 1000,
+        source,
       );
     }
 

--- a/platform/backend/src/routes/proxy/llm-proxy-stream-keepalive.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-stream-keepalive.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Byte-level liveness of a proxied stream.
+ *
+ * Streaming clients (Claude Code among them) run a byte-clock watchdog: if no
+ * byte arrives for ~20s the turn is flagged as stalled, and after a few
+ * minutes of silence the stream is aborted and retried. The proxy withholds
+ * client tool-call events until the whole turn has streamed and tool-invocation
+ * policy has run, so a large tool payload generated token-by-token is, from
+ * the client's side, a dead stream for exactly that long.
+ *
+ * These tests drive the real routes over a real TCP socket (not `app.inject`,
+ * which buffers the whole body) and timestamp every chunk the client receives,
+ * so they measure the property the client actually cares about: the longest
+ * gap between successive bytes.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+import { Stream } from "@anthropic-ai/sdk/streaming";
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { vi } from "vitest";
+import { ModelModel } from "@/models";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { Agent } from "@/types";
+import { anthropicAdapterFactory, bedrockAdapterFactory } from "./adapters";
+import anthropicProxyRoutes from "./routes/anthropic";
+import bedrockProxyRoutes from "./routes/bedrock";
+import { STREAM_KEEPALIVE_SSE_COMMENT } from "./stream-keepalive";
+
+/** Short enough to keep the suite fast, long enough to be unambiguous. */
+const { KEEPALIVE_INTERVAL_MS } = vi.hoisted(() => ({
+  KEEPALIVE_INTERVAL_MS: 40,
+}));
+/** Upstream delta cadence; the withheld window is DELTA_COUNT × this. */
+const DELTA_GAP_MS = 25;
+const DELTA_COUNT = 12;
+const WITHHELD_WINDOW_MS = DELTA_COUNT * DELTA_GAP_MS;
+
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    llmProxy: { streamKeepAliveIntervalMs: KEEPALIVE_INTERVAL_MS },
+  }),
+);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+type StreamEvent = Anthropic.Messages.MessageStreamEvent;
+
+const messageStart: StreamEvent = {
+  type: "message_start",
+  message: {
+    id: "msg-keepalive",
+    type: "message",
+    container: null,
+    role: "assistant",
+    content: [],
+    model: "claude-3-5-sonnet-20241022",
+    stop_reason: null,
+    stop_sequence: null,
+    usage: {
+      input_tokens: 12,
+      output_tokens: 1,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    } as unknown as Anthropic.Messages.Usage,
+  },
+};
+
+/**
+ * An upstream turn that is one long tool call: `message_start`, then a
+ * `tool_use` block whose input JSON arrives in DELTA_COUNT slow fragments.
+ * Every fragment is a withheld chunk, so nothing the adapter emits reaches
+ * the client between `message_start` and the post-policy flush.
+ */
+async function* slowAnthropicToolCall(): AsyncGenerator<StreamEvent> {
+  yield messageStart;
+  yield {
+    type: "content_block_start",
+    index: 0,
+    content_block: {
+      type: "tool_use",
+      id: "toolu_write",
+      caller: { type: "direct" },
+      name: "write_file",
+      input: {},
+    },
+  };
+  yield {
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "input_json_delta", partial_json: '{"content":"' },
+  };
+  for (let i = 0; i < DELTA_COUNT; i++) {
+    await sleep(DELTA_GAP_MS);
+    yield {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: `line ${i}\\n` },
+    };
+  }
+  yield {
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "input_json_delta", partial_json: '"}' },
+  };
+  yield { type: "content_block_stop", index: 0 };
+  yield {
+    type: "message_delta",
+    delta: { stop_reason: "tool_use", stop_sequence: null },
+    usage: {
+      output_tokens: 40,
+    } as unknown as Anthropic.Messages.MessageDeltaUsage,
+  } as StreamEvent;
+  yield { type: "message_stop" };
+}
+
+/** The same turn in Bedrock Converse shape, for the binary event-stream route. */
+async function* slowBedrockToolCall(): AsyncGenerator<unknown> {
+  yield { messageStart: { role: "assistant" } };
+  yield {
+    contentBlockStart: {
+      contentBlockIndex: 0,
+      start: { toolUse: { toolUseId: "toolu_write", name: "write_file" } },
+    },
+  };
+  for (let i = 0; i < DELTA_COUNT; i++) {
+    await sleep(DELTA_GAP_MS);
+    yield {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { toolUse: { input: i === 0 ? '{"content":"' : `line ${i}` } },
+      },
+    };
+  }
+  yield {
+    contentBlockDelta: {
+      contentBlockIndex: 0,
+      delta: { toolUse: { input: '"}' } },
+    },
+  };
+  yield { contentBlockStop: { contentBlockIndex: 0 } };
+  yield { messageStop: { stopReason: "tool_use" } };
+  yield { metadata: { usage: { inputTokens: 12, outputTokens: 40 } } };
+}
+
+type TimedChunk = { at: number; bytes: Uint8Array };
+
+/** Read the whole body, timestamping each chunk as it arrives. */
+async function readTimedChunks(response: Response): Promise<TimedChunk[]> {
+  const chunks: TimedChunk[] = [];
+  const reader = response.body!.getReader();
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    chunks.push({ at: Date.now(), bytes: value });
+  }
+  return chunks;
+}
+
+function maxGapMs(chunks: TimedChunk[]): number {
+  let max = 0;
+  for (let i = 1; i < chunks.length; i++) {
+    max = Math.max(max, chunks[i].at - chunks[i - 1].at);
+  }
+  return max;
+}
+
+function concatText(chunks: TimedChunk[]): string {
+  return chunks.map((c) => new TextDecoder().decode(c.bytes)).join("");
+}
+
+function newApp() {
+  const app = Fastify().withTypeProvider<ZodTypeProvider>();
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  return app;
+}
+
+describe("LLM proxy stream keep-alive", () => {
+  let app: FastifyInstance;
+  let testAgent: Agent;
+  let baseUrl: string;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  describe("Anthropic (text/event-stream)", () => {
+    let createStream: () => Promise<unknown>;
+
+    beforeEach(async ({ makeAgent }) => {
+      app = newApp();
+      createStream = async () => slowAnthropicToolCall();
+      vi.spyOn(anthropicAdapterFactory, "createClient").mockImplementation(
+        () =>
+          ({
+            messages: {
+              create: async (params: { stream?: boolean }) => {
+                if (!params.stream) {
+                  throw new Error("test stub only serves streaming requests");
+                }
+                return createStream();
+              },
+            },
+          }) as never,
+      );
+
+      testAgent = await makeAgent({ name: "Keep-alive Agent" });
+      await ModelModel.upsert({
+        externalId: "anthropic/claude-3-5-sonnet-20241022",
+        provider: "anthropic",
+        modelId: "claude-3-5-sonnet-20241022",
+        inputModalities: null,
+        outputModalities: null,
+        customPricePerMillionInput: "3.00",
+        customPricePerMillionOutput: "15.00",
+        lastSyncedAt: new Date(),
+      });
+
+      await app.register(anthropicProxyRoutes);
+      baseUrl = await app.listen({ port: 0, host: "127.0.0.1" });
+    });
+
+    const postMessages = () =>
+      fetch(`${baseUrl}/v1/anthropic/${testAgent.id}/v1/messages`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "Write the file" }],
+          tools: [
+            {
+              name: "write_file",
+              description: "Write a file",
+              input_schema: {
+                type: "object",
+                properties: { content: { type: "string" } },
+              },
+            },
+          ],
+          stream: true,
+        }),
+      });
+
+    test("a withheld tool call never leaves the client without bytes for longer than the keep-alive interval", async () => {
+      const response = await postMessages();
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("text/event-stream");
+
+      const chunks = await readTimedChunks(response);
+      const body = concatText(chunks);
+
+      // Without the keep-alive the client sees `message_start` and then
+      // nothing until the flush: two chunks, one gap the size of the window.
+      expect(body).toContain(STREAM_KEEPALIVE_SSE_COMMENT);
+      // Leave slack for event-loop scheduling: the bound that matters is
+      // "well inside the withheld window", not the exact interval.
+      expect(maxGapMs(chunks)).toBeLessThan(WITHHELD_WINDOW_MS / 2);
+      expect(maxGapMs(chunks)).toBeLessThan(KEEPALIVE_INTERVAL_MS * 3);
+    });
+
+    test("the SDK's own SSE parser reads through the keep-alive comments to the released tool call", async () => {
+      const response = await postMessages();
+      expect(response.status).toBe(200);
+
+      // Not a hand-rolled parser: this is the code path a real Anthropic
+      // client runs on our bytes, so a comment it did not tolerate would
+      // throw or drop events here.
+      const events: StreamEvent[] = [];
+      for await (const event of Stream.fromSSEResponse<StreamEvent>(
+        response,
+        new AbortController(),
+      )) {
+        events.push(event);
+      }
+
+      const toolStart = events.find(
+        (e) =>
+          e.type === "content_block_start" &&
+          e.content_block.type === "tool_use",
+      );
+      expect(toolStart).toBeDefined();
+      expect(
+        toolStart?.type === "content_block_start" &&
+          toolStart.content_block.type === "tool_use" &&
+          toolStart.content_block.name,
+      ).toBe("write_file");
+      const input = events
+        .flatMap((e) =>
+          e.type === "content_block_delta" &&
+          e.delta.type === "input_json_delta"
+            ? [e.delta.partial_json]
+            : [],
+        )
+        .join("");
+      expect(JSON.parse(input)).toEqual({
+        content: Array.from(
+          { length: DELTA_COUNT },
+          (_, i) => `line ${i}\n`,
+        ).join(""),
+      });
+      expect(events.at(-1)?.type).toBe("message_stop");
+    });
+
+    // The keep-alive must not defeat lazy header commitment. A provider
+    // failure before the first upstream byte has to reach the client as the
+    // provider's HTTP status (clients retry on 429/529 and give up on 400),
+    // which is impossible once a 200 has been written.
+    test("an upstream failure after a silence longer than the interval still returns the provider's status", async () => {
+      createStream = async () => {
+        await sleep(KEEPALIVE_INTERVAL_MS * 3);
+        throw Object.assign(new Error("rate limited upstream"), {
+          status: 429,
+        });
+      };
+
+      const response = await postMessages();
+      expect(response.status).toBe(429);
+      const body = await response.text();
+      expect(body).not.toContain(STREAM_KEEPALIVE_SSE_COMMENT);
+    });
+  });
+
+  // Bedrock's stream is `application/vnd.amazon.eventstream`: a binary
+  // framing with no notion of a comment, where a stray `:` line is a parse
+  // error at the client. The keep-alive must stay off it.
+  describe("Bedrock (binary event stream)", () => {
+    const BEDROCK_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    beforeEach(async ({ makeAgent }) => {
+      app = newApp();
+      vi.spyOn(bedrockAdapterFactory, "createClient").mockReturnValue({
+        converseStream: async () => slowBedrockToolCall(),
+      } as never);
+
+      testAgent = await makeAgent({ name: "Keep-alive Bedrock Agent" });
+      await ModelModel.upsert({
+        externalId: `bedrock/${BEDROCK_MODEL}`,
+        provider: "bedrock",
+        modelId: BEDROCK_MODEL,
+        inputModalities: null,
+        outputModalities: null,
+        customPricePerMillionInput: "3.00",
+        customPricePerMillionOutput: "15.00",
+        lastSyncedAt: new Date(),
+      });
+
+      await app.register(bedrockProxyRoutes);
+      baseUrl = await app.listen({ port: 0, host: "127.0.0.1" });
+    });
+
+    test("no SSE comment is written into a non-SSE stream, even across a long withheld tool call", async () => {
+      const response = await fetch(
+        `${baseUrl}/v1/bedrock/${testAgent.id}/converse-stream`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer test-key",
+          },
+          body: JSON.stringify({
+            modelId: BEDROCK_MODEL,
+            messages: [{ role: "user", content: [{ text: "Write the file" }] }],
+            toolConfig: {
+              tools: [
+                {
+                  toolSpec: {
+                    name: "write_file",
+                    inputSchema: { json: { type: "object" } },
+                  },
+                },
+              ],
+            },
+          }),
+        },
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe(
+        "application/vnd.amazon.eventstream",
+      );
+
+      const chunks = await readTimedChunks(response);
+      const body = concatText(chunks);
+
+      // The withheld window went by in silence — the transport cannot carry
+      // a keep-alive — but the tool call still arrived once policy ran.
+      expect(body).not.toContain(STREAM_KEEPALIVE_SSE_COMMENT);
+      expect(body).toContain("write_file");
+      expect(maxGapMs(chunks)).toBeGreaterThanOrEqual(WITHHELD_WINDOW_MS / 2);
+    });
+  });
+});

--- a/platform/backend/src/routes/proxy/stream-keepalive.ts
+++ b/platform/backend/src/routes/proxy/stream-keepalive.ts
@@ -1,0 +1,79 @@
+import type { ServerResponse } from "node:http";
+
+/**
+ * Keep-alive frame written to an idle `text/event-stream` response. A
+ * `:`-prefixed line is a comment under the event-stream spec, so a compliant
+ * SSE parser drops it without touching message content — which is also why it
+ * is only safe on `text/event-stream`, not on the NDJSON or binary event
+ * streams some providers speak.
+ */
+export const STREAM_KEEPALIVE_SSE_COMMENT = ": archestra keep-alive\n\n";
+
+/**
+ * Keeps bytes flowing on an SSE response the proxy has committed but is not
+ * currently writing to.
+ *
+ * The proxy withholds client tool-call events until the turn has fully
+ * streamed and tool-invocation policy has run, so a large tool payload
+ * generated token-by-token is, from the client's side, a silent stream for
+ * that whole stretch. Streaming clients run byte-clock watchdogs against
+ * exactly that (Claude Code flags a stall after ~20s and aborts after a few
+ * minutes), and the upstream `ping` events that would otherwise cover it never
+ * reach us: the Anthropic SDK drops them inside its SSE parser.
+ *
+ * This never commits headers. Writing anything before the upstream call has
+ * produced a byte would force a 200 and foreclose the provider's real status
+ * (a 429, an overload 529, a 400) that clients key their retry logic on. It
+ * only fires on a stream that is already open and has been quiet for the
+ * configured interval; every real write is reported through {@link touch} so
+ * an active stream is never interrupted.
+ */
+export class StreamKeepAlive {
+  private timer: NodeJS.Timeout | undefined;
+
+  constructor(
+    private readonly raw: Pick<
+      ServerResponse,
+      "headersSent" | "writableEnded" | "destroyed" | "write"
+    >,
+    /** Silence tolerated before a keep-alive is written. `0` disables. */
+    private readonly intervalMs: number,
+    /** Whether the response is `text/event-stream`; nothing else can carry a comment. */
+    private readonly isEventStream: boolean,
+  ) {}
+
+  /** Arm the idle timer. A disabled or non-SSE keep-alive stays inert. */
+  start(): void {
+    if (this.timer || this.intervalMs <= 0 || !this.isEventStream) {
+      return;
+    }
+    this.timer = setTimeout(() => this.onIdle(), this.intervalMs);
+    this.timer.unref();
+  }
+
+  /** Report that a real byte just went out, so the idle clock restarts. */
+  touch(): void {
+    this.timer?.refresh();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private onIdle(): void {
+    if (!this.timer) {
+      return;
+    }
+    if (
+      this.raw.headersSent &&
+      !this.raw.writableEnded &&
+      !this.raw.destroyed
+    ) {
+      this.raw.write(STREAM_KEEPALIVE_SSE_COMMENT);
+    }
+    this.timer.refresh();
+  }
+}


### PR DESCRIPTION
Backport of #7810 to the `release/1.3` stable line (`cherry-pick -x` of main commit 494b3639e33ee1af63207ac05d1f56b76fef6b80).

Claude Code sessions proxied through Archestra intermittently see `Waiting for API response · check your network` and retry. The proxy withholds client tool-call events until the model turn ends and tool-invocation policy has run, so a large tool payload is a silent stream for the client long enough to trip Claude Code's ~20 s stall watchdog. This adds a periodic SSE keep-alive comment on idle `text/event-stream` responses (`ARCHESTRA_LLM_PROXY_STREAM_KEEPALIVE_INTERVAL_MS`, default 10 s, `0` disables), never before headers are committed so provider error statuses still propagate. Also extends `llm_time_to_first_token_seconds` buckets and adds `llm_time_to_first_byte_seconds`. Bug fix only; no schema or feature changes.

The only manual resolution was the `lastUpdated` frontmatter line in `docs/pages/platform-observability.md`. Proxy handler, keep-alive and metrics test suites and `tsc` pass on the 1.3 tree.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>