### PR TITLE
fix(connect): discover Desktop models and remove deprecated MCP configuration

### DIFF
--- a/platform/backend/src/services/connection-setup-script.claude-desktop.test.ts
+++ b/platform/backend/src/services/connection-setup-script.claude-desktop.test.ts
@@ -119,6 +119,8 @@ with patch('sys.platform', target_os), patch.dict(os.environ, {'LOCALAPPDATA': s
             assert profile['inferenceCustomHeaders'].get('X-Archestra-Virtual-Key') == ${auth === "provider-key" ? "'archestra-test-user'" : "None"}
         else:
             assert 'inferenceProvider' not in profile
+        assert 'source' not in profile['managedMcpServers'][0]
+        assert profile['managedMcpServers'][0]['oauth'] == {'mode': 'dcr'}
         assert profile['managedMcpServers'][0]['url'] == 'https://proxy.example/v1/mcp/test'
         assert profile_path.stat().st_mode & 0o777 == 0o600
         assert json.loads((library / '_meta.json.before-archestra').read_text()) == original
@@ -128,6 +130,7 @@ with patch('sys.platform', target_os), patch.dict(os.environ, {'LOCALAPPDATA': s
         legacy_id = str(uuid.uuid5(uuid.NAMESPACE_URL, 'archestra-desktop:https://proxy.example/v1/mcp/test'))
         legacy_path = library / (legacy_id + '.json')
         legacy_profile = {**profile, 'inferenceModels': [{'name': 'claude-haiku-4-5-20251001'}], 'modelDiscoveryEnabled': False} if ${auth === "none" ? "False" : "True"} else profile
+        legacy_profile = {**legacy_profile, 'managedMcpServers': [{**server, 'source': 'user'} for server in profile['managedMcpServers']]}
         legacy_path.write_text(json.dumps(legacy_profile))
         old_metadata = {**metadata, 'appliedId': legacy_id, 'entries': metadata['entries'] + [{'id': legacy_id, 'name': 'Old deployment'}]}
         (library / '_meta.json').write_text(json.dumps(old_metadata))
@@ -143,6 +146,8 @@ with patch('sys.platform', target_os), patch.dict(os.environ, {'LOCALAPPDATA': s
         if ${auth === "none" ? "False" : "True"}:
             assert replaced_profile['modelDiscoveryEnabled'] is True
             assert 'inferenceModels' not in replaced_profile
+        assert 'source' not in replaced_profile['managedMcpServers'][0]
+        assert replaced_profile['managedMcpServers'][0]['oauth'] == {'mode': 'dcr'}
         assert replaced_profile['managedMcpServers'][0]['url'] == 'https://replacement.example/v1/mcp/test'
         assert 'proxy.example' not in json.dumps(replaced_profile)
         assert sum('setup-token' in args for args in calls) == ${auth === "provider-key" ? 1 : 0}

--- a/platform/backend/src/services/connection-setup-script.claude-desktop.test.ts
+++ b/platform/backend/src/services/connection-setup-script.claude-desktop.test.ts
@@ -114,6 +114,8 @@ with patch('sys.platform', target_os), patch.dict(os.environ, {'LOCALAPPDATA': s
         profile = json.loads(profile_path.read_text())
         if ${auth === "none" ? "False" : "True"}:
             assert profile['inferenceGatewayApiKey'] == token
+            assert profile['modelDiscoveryEnabled'] is True
+            assert 'inferenceModels' not in profile
             assert profile['inferenceCustomHeaders'].get('X-Archestra-Virtual-Key') == ${auth === "provider-key" ? "'archestra-test-user'" : "None"}
         else:
             assert 'inferenceProvider' not in profile
@@ -125,7 +127,8 @@ with patch('sys.platform', target_os), patch.dict(os.environ, {'LOCALAPPDATA': s
         # Migrate a profile made by the older per-deployment installer.
         legacy_id = str(uuid.uuid5(uuid.NAMESPACE_URL, 'archestra-desktop:https://proxy.example/v1/mcp/test'))
         legacy_path = library / (legacy_id + '.json')
-        legacy_path.write_text(json.dumps(profile))
+        legacy_profile = {**profile, 'inferenceModels': [{'name': 'claude-haiku-4-5-20251001'}], 'modelDiscoveryEnabled': False} if ${auth === "none" ? "False" : "True"} else profile
+        legacy_path.write_text(json.dumps(legacy_profile))
         old_metadata = {**metadata, 'appliedId': legacy_id, 'entries': metadata['entries'] + [{'id': legacy_id, 'name': 'Old deployment'}]}
         (library / '_meta.json').write_text(json.dumps(old_metadata))
         # A different deployment replaces the managed connection without duplicating it.
@@ -135,8 +138,11 @@ with patch('sys.platform', target_os), patch.dict(os.environ, {'LOCALAPPDATA': s
         replaced_metadata = json.loads((library / '_meta.json').read_text())
         assert replaced_metadata == metadata
         assert not legacy_path.exists()
-        assert json.loads(legacy_path.with_name(legacy_path.name + '.before-archestra').read_text()) == profile
+        assert json.loads(legacy_path.with_name(legacy_path.name + '.before-archestra').read_text()) == legacy_profile
         replaced_profile = json.loads(profile_path.read_text())
+        if ${auth === "none" ? "False" : "True"}:
+            assert replaced_profile['modelDiscoveryEnabled'] is True
+            assert 'inferenceModels' not in replaced_profile
         assert replaced_profile['managedMcpServers'][0]['url'] == 'https://replacement.example/v1/mcp/test'
         assert 'proxy.example' not in json.dumps(replaced_profile)
         assert sum('setup-token' in args for args in calls) == ${auth === "provider-key" ? 1 : 0}

--- a/platform/backend/src/services/connection-setup-script.claude-desktop.ts
+++ b/platform/backend/src/services/connection-setup-script.claude-desktop.ts
@@ -236,7 +236,7 @@ def main():
     if SETUP.get('mcp'):
         mcp = SETUP['mcp']
         profile['managedMcpServers'] = [{'name': mcp['serverName'], 'transport': 'http',
-                                       'url': mcp['url'], 'oauth': {'mode': 'dcr'}, 'source': 'user'}]
+                                       'url': mcp['url'], 'oauth': {'mode': 'dcr'}}]
     if SETUP.get('skills'):
         skills = SETUP['skills']
         profile['allowedPluginMarketplaces'] = [{'source': 'git', 'url': skills['cloneUrl'],

--- a/platform/backend/src/services/connection-setup-script.claude-desktop.ts
+++ b/platform/backend/src/services/connection-setup-script.claude-desktop.ts
@@ -229,7 +229,9 @@ def main():
             'inferenceProvider': 'gateway', 'inferenceCredentialKind': 'static',
             'inferenceGatewayBaseUrl': proxy['url'], 'inferenceGatewayApiKey': token,
             'inferenceGatewayAuthScheme': 'bearer', 'inferenceCustomHeaders': headers,
-            'inferenceModels': [{'name': model}],
+            # An explicit inferenceModels list overrides discovery and would
+            # restrict the picker to the model used for the connection check.
+            'modelDiscoveryEnabled': True,
         })
     if SETUP.get('mcp'):
         mcp = SETUP['mcp']


### PR DESCRIPTION
Claude Desktop setup saved the inference probe model as the entire `inferenceModels` list, leaving the picker with only Haiku by default. It also wrote the deprecated `managedMcpServers[].source` field, triggering a configuration warning.

Enable native gateway model discovery and omit the explicit list, which [overrides discovered models](https://claude.com/docs/third-party/claude-desktop/configuration#models). The selected setup model still drives the inference check. Omit the obsolete MCP source field; Desktop assigns connector provenance itself. Rerunning setup removes both obsolete settings from the managed profile while preserving MCP URLs and OAuth configuration.

A read-only check of an existing installation confirmed one configured model while its authenticated proxy returned 17 models spanning Haiku, Sonnet, and Opus. Generated-script tests execute the installer against real temporary files across macOS, Windows, and Linux with native processes and HTTP mocked. They verify discovery is enabled, older model restrictions and MCP source fields are removed during profile replacement, and the original profile is backed up. All eight cases pass.

Existing installations must rerun setup after deployment. The native app was inspected but not restarted to validate the updated picker. Audited the Connect and Desktop docs; no documentation changes are needed.
