### PR TITLE
fix(agents): preserve final task reports in Slack

### DIFF
--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -71,7 +71,6 @@ import {
   type A2AProtocolListTasksRequest,
   type A2AProtocolListTasksResponse,
   type A2AProtocolMessage,
-  type A2AProtocolPart,
   A2AProtocolRole,
   type A2AProtocolSendMessageRequest,
   type A2AProtocolSendMessageResponse,
@@ -81,6 +80,7 @@ import {
   type A2AProtocolTaskPushNotificationConfig,
   A2AProtocolTaskState,
 } from "./a2a-protocol";
+import { extractProtocolPartsFromUIMessage } from "./a2a-response-parts";
 import { a2aTaskRunService } from "./a2a-task-run-service";
 
 /** Wire name of the single text artifact carrying a tasked run's answer. */
@@ -1843,19 +1843,6 @@ function buildStatusReasonMessage(params: {
     role: A2AProtocolRole.Agent,
     parts: [{ text: params.reason }],
   };
-}
-
-function extractProtocolPartsFromUIMessage(
-  uiMessage: UIMessage,
-): A2AProtocolPart[] {
-  const protocolParts: A2AProtocolPart[] = [];
-  const parts = uiMessage.parts;
-  for (const part of parts) {
-    if (part.type === "text") {
-      protocolParts.push({ text: part.text });
-    }
-  }
-  return protocolParts;
 }
 
 function extractApprovalRequestsFromUiMessage(

--- a/platform/backend/src/agents/a2a/a2a-response-parts.test.ts
+++ b/platform/backend/src/agents/a2a/a2a-response-parts.test.ts
@@ -1,0 +1,59 @@
+import type { UIMessage } from "ai";
+import { describe, expect, test } from "vitest";
+import { extractProtocolPartsFromUIMessage } from "./a2a-response-parts";
+
+describe("A2A final response parts", () => {
+  test("excludes tool-retry commentary while retaining the complete transcript", () => {
+    const message: UIMessage = {
+      id: "response",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        {
+          type: "text",
+          text: "I used the wrong arguments. Retrying the tool.",
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "start_run",
+          toolCallId: "call",
+          state: "output-available",
+          input: {},
+          output: { success: true },
+        },
+        { type: "step-start" },
+        { type: "reasoning", text: "execution notes" },
+        { type: "text", text: "Run started. " },
+        { type: "text", text: "Reply in this thread to continue." },
+      ],
+    };
+    expect(extractProtocolPartsFromUIMessage(message)).toEqual([
+      { text: "Run started. " },
+      { text: "Reply in this thread to continue." },
+    ]);
+    expect(message.parts).toHaveLength(7);
+  });
+
+  test("does not reuse earlier commentary when the last step has no answer", () => {
+    expect(
+      extractProtocolPartsFromUIMessage({
+        id: "response",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "I will investigate." },
+          { type: "step-start" },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  test("keeps text from legacy responses without step boundaries", () => {
+    expect(
+      extractProtocolPartsFromUIMessage({
+        id: "response",
+        role: "assistant",
+        parts: [{ type: "text", text: "Research complete." }],
+      }),
+    ).toEqual([{ text: "Research complete." }]);
+  });
+});

--- a/platform/backend/src/agents/a2a/a2a-response-parts.ts
+++ b/platform/backend/src/agents/a2a/a2a-response-parts.ts
@@ -1,0 +1,14 @@
+import type { UIMessage } from "ai";
+import type { A2AProtocolPart } from "./a2a-protocol";
+
+/** The final response excludes commentary from earlier tool execution steps. */
+export function extractProtocolPartsFromUIMessage(
+  message: UIMessage,
+): A2AProtocolPart[] {
+  const lastStep = message.parts.findLastIndex(
+    (part) => part.type === "step-start",
+  );
+  return message.parts
+    .slice(Math.max(0, lastStep))
+    .flatMap((part) => (part.type === "text" ? [{ text: part.text }] : []));
+}

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -1318,6 +1318,33 @@ describe("SlackProvider.sendReply", () => {
     });
   });
 
+  test("delimits bare PR URLs without changing existing links or code", async () => {
+    const provider = createProvider();
+    const postMessage = vi.fn().mockResolvedValue({ ts: "2222222222.000000" });
+    // biome-ignore lint/suspicious/noExplicitAny: test-only Slack network boundary
+    (provider as any).client = { chat: { postMessage } };
+    const url = "https://github.com/example/project/pull/42";
+    const unchanged = `Inline ${url} stays inline.\n[PR](${url})\n<${url}>\n\`${url}\`\n\`\`\`sh\ncurl ${url}\n\`\`\``;
+    await provider.sendReply({
+      originalMessage: {
+        messageId: "1234567890.123456",
+        channelId: "C12345",
+        workspaceId: "T12345",
+        threadId: "1111111111.000000",
+        senderId: "U_SENDER",
+        senderName: "Test User",
+        text: "hello",
+        rawText: "hello",
+        timestamp: new Date(),
+        isThreadReply: true,
+      },
+      text: `PR: ${url}\nNext: review.\nReport: ${url}.\n${unchanged}`,
+    });
+    expect(postMessage.mock.calls[0][0].blocks[0].text).toBe(
+      `PR: <${url}>\nNext: review.\nReport: <${url}>.\n${unchanged}`,
+    );
+  });
+
   test("renders the mute hint as its own subtle context block above the footer", async () => {
     const provider = createProvider();
     const postMessage = vi.fn().mockResolvedValue({ ts: "2222222222.000000" });

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -460,7 +460,7 @@ class SlackProvider implements ChatOpsProvider {
     // we post one message per chunk and thread the follow-ups so the user sees
     // the full reply. Non-final messages reserve their footer slot for a
     // "continued in a message below" hint.
-    const chunks = splitSlackMarkdownText(body);
+    const chunks = splitSlackMarkdownText(protectSlackUrlBoundaries(body));
 
     let firstTs = "";
     for (let i = 0; i < chunks.length; i++) {
@@ -2599,4 +2599,19 @@ interface SlackInteractivePayload {
   team?: { id: string };
   message?: { ts: string; thread_ts?: string };
   response_url?: string;
+}
+
+/** Slack's markdown converter can absorb the next line into a bare URL. */
+function protectSlackUrlBoundaries(text: string): string {
+  // Leave fenced/inline code, explicit links and autolinks alone. Delimit bare
+  // URLs before handing them to Slack's server-side Markdown converter.
+  return text.replace(
+    /(`{3,}[\s\S]*?`{3,}|~{3,}[\s\S]*?~{3,}|`+[^`]*`+|<[^>\n]*>|\[[^\]\n]*\]\([^\n]*?\))|(https?:\/\/[^\s<>`]+)(?=[ \t]*\r?\n)/g,
+    (match, protectedText: string | undefined, url: string | undefined) => {
+      if (protectedText || !url) return match;
+      const trailing = url.match(/[.,;:!?]+$/)?.[0] ?? "";
+      const address = trailing ? url.slice(0, -trailing.length) : url;
+      return `<${address}>${trailing}`;
+    },
+  );
 }

--- a/platform/backend/src/agents/task-completion-notification.test.ts
+++ b/platform/backend/src/agents/task-completion-notification.test.ts
@@ -40,7 +40,7 @@ describe("buildTaskCompletionNotification", () => {
     ).toBe(output);
   });
 
-  test("reduces a verbose PR completion report to its review link", () => {
+  test("preserves a final report including its review link and caveats", () => {
     const output = [
       "The implementation is complete, but here is a long internal chronology.",
       "The policy gate required an audience-narrowing remedy before one operation.",
@@ -58,10 +58,10 @@ describe("buildTaskCompletionNotification", () => {
         statusReason: null,
         output,
       }),
-    ).toBe("PR ready: https://github.com/example/project/pull/42");
+    ).toBe(output);
   });
 
-  test("enforces the four-line worker completion contract", () => {
+  test("preserves the five-line worker report including demo status", () => {
     const output = [
       "CI is fully green and the implementation is complete.",
       "Done — the setting now explains the selected behavior inline.",
@@ -76,7 +76,38 @@ describe("buildTaskCompletionNotification", () => {
         statusReason: null,
         output,
       }),
-    ).toBe("PR ready: https://github.com/example/project/pull/42");
+    ).toBe(output);
+  });
+
+  test("keeps the beginning and ending of a long research answer", () => {
+    const output =
+      "The root cause is a missing guard.\n\n" +
+      "A complete explanation with supporting evidence. ".repeat(250) +
+      "\n\nNext: add the guard and exercise retries.";
+    expect(
+      buildTaskCompletionNotification({
+        state: "TASK_STATE_COMPLETED",
+        statusReason: null,
+        output,
+      }),
+    ).toBe(output);
+  });
+
+  test("does not hide a failed demo upload behind a PR link", () => {
+    const output = [
+      "Done — added the requested filter.",
+      "PR: https://github.com/example/project/pull/42",
+      "Validation: tests passed.",
+      "Demo: thread upload failed; recording linked in the PR.",
+      "Next: review, then promote.",
+    ].join("\n");
+    expect(
+      buildTaskCompletionNotification({
+        state: "TASK_STATE_COMPLETED",
+        statusReason: null,
+        output,
+      }),
+    ).toBe(output);
   });
 
   test("does not narrate a working task before it has a useful result", () => {

--- a/platform/backend/src/agents/task-completion-notification.ts
+++ b/platform/backend/src/agents/task-completion-notification.ts
@@ -15,8 +15,8 @@ export function buildTaskCompletionNotification(params: {
   }
 
   if (params.state === "TASK_STATE_COMPLETED") {
-    const output = conciseOutput(params.output);
-    if (output && isCompactCompletionReport(output)) {
+    const output = cleanFinalOutput(params.output);
+    if (output) {
       return output;
     }
 
@@ -25,7 +25,7 @@ export function buildTaskCompletionNotification(params: {
       return `PR ready: ${pullRequestUrl}`;
     }
 
-    return output || "Task finished.";
+    return "Task finished.";
   }
 
   const outcome =
@@ -43,17 +43,10 @@ function findPullRequestUrl(output: string): string | null {
   return matches?.at(-1) ?? null;
 }
 
-function isCompactCompletionReport(output: string): boolean {
-  return (
-    output.length <= MAX_COMPLETION_REPORT_CHARS &&
-    output.split("\n").length <= MAX_COMPLETION_REPORT_LINES
-  );
-}
-
-function conciseOutput(output: string): string {
+function cleanFinalOutput(output: string): string {
   // Native catalog clients write their complete interactive transcript to the
   // execution log. That belongs in the execution console, not in a completion
-  // message. PR links are extracted above before this guard.
+  // message. PR links remain available as a fallback after this guard.
   if (
     output.includes("[archestra] agent session exited") ||
     looksLikeTerminalControlStream(output)
@@ -66,7 +59,6 @@ function conciseOutput(output: string): string {
     .filter((line) => {
       const trimmed = line.trim();
       return (
-        trimmed.length > 0 &&
         !trimmed.startsWith("[tool]") &&
         trimmed !== "[waiting for direction]" &&
         !trimmed.startsWith("Agent Runtime run for ") &&
@@ -78,7 +70,9 @@ function conciseOutput(output: string): string {
     .join("\n")
     .trim();
 
-  return cleaned.length > 1_000 ? `…${cleaned.slice(-1_000)}` : cleaned;
+  // This is the final answer, not a log tail. Delivery providers split long
+  // messages at their own limits; preserve the outcome and any caveats here.
+  return cleaned;
 }
 
 function looksLikeTerminalControlStream(output: string): boolean {
@@ -99,6 +93,3 @@ function looksLikeTerminalControlStream(output: string): boolean {
   );
   return (bareControlSequences?.length ?? 0) >= 3;
 }
-
-const MAX_COMPLETION_REPORT_CHARS = 500;
-const MAX_COMPLETION_REPORT_LINES = 4;


### PR DESCRIPTION
A five-line completion report containing a PR link was reduced to “PR ready,” hiding validation and demo failures. Longer reports lost their beginning, and multi-step router replies included tool-retry commentary.

Preserve the complete cleaned final report and take A2A reply text from the final model step while retaining the full UI transcript. Delimit bare URLs before newlines because Slack’s Markdown converter otherwise absorbs the next line into the link.

Verified locally through Slack with an overlay of the released Lobster Claude Code 0.4.4 image: an actual MP4 upload, the complete completion report, retained-workspace continuation, and one recovered completion after a backend restart. A controlled model/tool exchange emitted intermediate commentary that stayed out of the Slack reply. Regression tests also reproduce the original report truncation and preserve existing links and code blocks.

The complementary Lobster startup, delivery-permission, and upload-confirmation changes are in https://github.com/archestra-ai/infra/pull/266.
