### PR TITLE
fix(llm-proxy): preserve Model Router virtual key attribution

### DIFF
--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -224,6 +224,8 @@ export type LLMProxyAuthOverride = {
   authenticated: boolean;
   source?: InteractionSource;
   authMethod?: InteractionAuthMethod;
+  /** Model Router virtual key ID, preserved for usage limits and interaction attribution. */
+  virtualKeyId?: string;
   authenticatedApp?: {
     id: string;
     name: string;
@@ -316,7 +318,7 @@ export async function handleLLMProxy<
   let userId = (await utils.headers.userId.getUser(headersForExtraction))
     ?.userId;
   let resolvedUser = userId ? await UserModel.getById(userId) : null;
-  let virtualKeyId: string | undefined;
+  let virtualKeyId = authOverride?.virtualKeyId;
   let passthroughVirtualKeyId: string | undefined;
   // Authenticated user identities, tracked per source for the consistency check.
   let passthroughUserId: string | undefined;

--- a/platform/backend/src/routes/proxy/routes/model-router.test.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.test.ts
@@ -131,6 +131,7 @@ async function createModelRouterVirtualKey(params: {
     },
   ) => Promise<{ id: string; provider: SupportedProvider }>;
   makeUser?: () => Promise<{ id: string }>;
+  virtualKeyScope?: "personal" | "org";
   apiKeyValue?: string;
   expiresAt?: Date | null;
 }) {
@@ -140,8 +141,9 @@ async function createModelRouterVirtualKey(params: {
     provider: params.provider,
     apiKey: apiKeyValue,
   });
-  const owner = requiresPerUser ? await params.makeUser?.() : undefined;
-  if (requiresPerUser && !owner) {
+  const needsOwner = requiresPerUser || params.virtualKeyScope === "personal";
+  const owner = needsOwner ? await params.makeUser?.() : undefined;
+  if (needsOwner && !owner) {
     throw new Error("Per-user Model Router fixtures require makeUser");
   }
   const chatApiKey = await params.makeLlmProviderApiKey(
@@ -982,9 +984,10 @@ describe("model router proxy routes", () => {
     expect(githubCopilotAdapterFactory.createClient).not.toHaveBeenCalled();
   });
 
-  test("records model router requests with a model router interaction source", async ({
+  test("records model router source and virtual key attribution", async ({
     makeAgent,
     makeOrganization,
+    makeUser,
     makeSecret,
     makeLlmProviderApiKey,
   }) => {
@@ -994,33 +997,38 @@ describe("model router proxy routes", () => {
     const modelId = "gpt-5.4";
     await upsertModel({ provider, modelId });
     const organization = await makeOrganization();
-    const { value } = await createModelRouterVirtualKey({
-      organizationId: organization.id,
-      provider,
-      makeSecret,
-      makeLlmProviderApiKey,
-    });
     const agent = await makeAgent({
       organizationId: organization.id,
       name: "Model Router Source Agent",
       agentType: "llm_proxy",
     });
+    const virtualKeys = [];
+    for (const virtualKeyScope of ["org", "personal"] as const) {
+      const virtualKeyResult = await createModelRouterVirtualKey({
+        organizationId: organization.id,
+        provider,
+        makeUser,
+        makeSecret,
+        makeLlmProviderApiKey,
+        virtualKeyScope,
+      });
+      virtualKeys.push(virtualKeyResult.virtualKey);
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/model-router/${agent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${virtualKeyResult.value}`,
+          [SOURCE_HEADER]: "chat",
+        },
+        payload: {
+          model: `${provider}:${modelId}`,
+          messages: [{ role: "user", content: "Hello" }],
+        },
+      });
+      expect(response.statusCode, response.body).toBe(200);
+    }
 
-    const response = await app.inject({
-      method: "POST",
-      url: `/v1/model-router/${agent.id}/chat/completions`,
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${value}`,
-        [SOURCE_HEADER]: "chat",
-      },
-      payload: {
-        model: `${provider}:${modelId}`,
-        messages: [{ role: "user", content: "Hello" }],
-      },
-    });
-
-    expect(response.statusCode, response.body).toBe(200);
     const interactions = await InteractionModel.findAllPaginated(
       { limit: 10, offset: 0 },
       undefined,
@@ -1028,8 +1036,23 @@ describe("model router proxy routes", () => {
       undefined,
       { profileId: (await AgentModel.getOrgLlmProxy(agent.organizationId)).id },
     );
-    expect(interactions.data).toHaveLength(1);
-    expect(interactions.data[0].source).toBe("model_router");
+    expect(interactions.data).toHaveLength(2);
+    expect(interactions.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "model_router",
+          authMethod: "virtual_key",
+          virtualKeyId: virtualKeys[0].id,
+          userId: null,
+        }),
+        expect.objectContaining({
+          source: "model_router",
+          authMethod: "virtual_key",
+          virtualKeyId: virtualKeys[1].id,
+          userId: virtualKeys[1].authorId,
+        }),
+      ]),
+    );
   });
 
   test("routes OpenAI embedding models through embeddings", async ({

--- a/platform/backend/src/routes/proxy/routes/model-router.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.ts
@@ -121,6 +121,7 @@ type ModelRouterUserProviderKey = Awaited<
 type ModelRouterVirtualKeyAuth = {
   authMethod: "virtual_key";
   organizationId: string;
+  virtualKeyId: string;
   virtualKeyScope: ResourceVisibilityScope;
   virtualKeyAuthorId: string | null;
   providerApiKeysByProvider: Map<
@@ -916,6 +917,7 @@ async function getModelRouterAuth(
     return {
       authMethod: "virtual_key",
       organizationId: resolved.virtualKey.organizationId,
+      virtualKeyId: resolved.virtualKey.id,
       virtualKeyScope: resolved.virtualKey.scope,
       virtualKeyAuthorId: resolved.virtualKey.authorId,
       providerApiKeysByProvider: new Map(
@@ -1023,12 +1025,21 @@ async function applyModelRouterAuthOverride(params: {
     authenticated: true,
     source: "model_router",
     authMethod: params.auth.authMethod,
+    virtualKeyId:
+      params.auth.authMethod === "virtual_key"
+        ? params.auth.virtualKeyId
+        : undefined,
     authenticatedApp:
       params.auth.authMethod === "oauth_user"
         ? (params.auth.oauthClient ?? undefined)
         : params.auth.oauthClient,
     userId:
-      params.auth.authMethod === "oauth_user" ? params.auth.userId : undefined,
+      params.auth.authMethod === "oauth_user"
+        ? params.auth.userId
+        : params.auth.authMethod === "virtual_key" &&
+            params.auth.virtualKeyScope === "personal"
+          ? (params.auth.virtualKeyAuthorId ?? undefined)
+          : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

- preserve the originating virtual key ID when Model Router forwards a request to the LLM proxy
- preserve the owner identity for personal virtual keys while keeping shared keys userless
- restore per-key usage limits, log attribution, and cost aggregation for Model Router traffic

## Scope and reproduction

This is provider-agnostic, not Gemini-specific. The issue was reproduced on the live localhost application through `POST /v1/model-router/responses` using an Anthropic model and a personal virtual key.

Before the fix, a successful request recorded `$0.003250` but persisted `virtual_key_id = NULL` and `user_id = NULL`. After the fix, the same request records the virtual key ID and personal owner while preserving the cost.

### Before

![Before fix: Model Router spend is recorded but the request is shown as No user — shared key](https://github.com/user-attachments/assets/58a4a196-931a-4a65-8cac-6c0467e0697b)

### After

![After fix: Model Router spend is attributed to Admin and Bug repro virtual key](https://github.com/user-attachments/assets/0ab1749e-a33c-4219-91b5-a8890412211f)

## Verification

- live localhost before/after requests through `/v1/model-router/responses`
- live LLM Logs UI before/after verification
- statistics API groups the post-fix request under the named virtual key
- 93 Model Router tests pass
- backend TypeScript check passes
- Biome and commit hooks pass

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>