### PR TITLE
ci: exempt xdrdak from automatic reviewer assignment

### DIFF
--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -22,7 +22,7 @@ permissions: {}
 
 env:
   ASSIGNEE_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","piercypixel"]'
-  CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk","piercypixel","arsenyinfo"]'
+  CORE_TEAM_LOGINS: '["joeyorlando","iskhakov","Konstantinov-Innokentii","Matvey-Kuk","piercypixel","arsenyinfo","xdrdak"]'
   # PRs opened by these bot accounts already have an owner shepherding them
   # (e.g. the task-env pipeline's requester), or are merged as part of a deliberate
   # process rather than reviewed (release-please PRs, opened by archestra-ci[bot], are


### PR DESCRIPTION
Add `xdrdak` to `CORE_TEAM_LOGINS` so his PRs skip automatic reviewer requests. This also applies the existing core-team exemption to issue assignment.

Validated the actual reviewer script with mocked GitHub responses for scheduled and manual runs: PRs by `xdrdak` are skipped, while an external contributor still receives a reviewer.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>