### PR TITLE
ci(release): guard stable backports against incompatible migration histories

### DIFF
--- a/.github/scripts/check-migration-upgrades.py
+++ b/.github/scripts/check-migration-upgrades.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Check Drizzle upgrade paths across release tracks without connecting to a DB.
+
+Drizzle executes only timestamps above the source database's high-water mark.
+SQL hashes identify equivalent backports even when their filenames differ.
+See platform/backend/src/database/migrations/README.md for repair policy.
+Explicit repair coverage is reviewed alongside the repair's database regression test.
+"""
+
+import argparse
+import hashlib
+import io
+import json
+import re
+import subprocess
+from pathlib import Path
+
+MIGRATIONS = "platform/backend/src/database/migrations"
+
+
+def git(*args):
+    return subprocess.check_output(["git", *args])
+
+
+def read_file(ref, name):
+    relative = f"{MIGRATIONS}/{name}"
+    if ref == "WORKTREE":
+        root = Path(git("rev-parse", "--show-toplevel").decode().strip())
+        return (root / relative).read_bytes()
+    return git("show", f"{ref}:{relative}")
+
+
+def load_history(ref):
+    entries = json.loads(read_file(ref, "meta/_journal.json"))["entries"]
+    if ref == "WORKTREE":
+        root = Path(git("rev-parse", "--show-toplevel").decode().strip()) / MIGRATIONS
+        contents = [(root / (entry["tag"] + ".sql")).read_bytes() for entry in entries]
+    else:
+        # Read blobs in one Git process: migration histories contain hundreds of
+        # files, and snapshots are much larger than the SQL we need here.
+        requests = "".join(f"{ref}:{MIGRATIONS}/{entry['tag']}.sql\n" for entry in entries)
+        output = subprocess.check_output(["git", "cat-file", "--batch"], input=requests.encode())
+        stream = io.BytesIO(output)
+        contents = []
+        for entry in entries:
+            header = stream.readline().split()
+            if len(header) != 3 or header[1] != b"blob":
+                raise ValueError(f"Cannot read {ref}:{entry['tag']}.sql")
+            contents.append(stream.read(int(header[2])))
+            if stream.read(1) != b"\n":
+                raise ValueError("Invalid git cat-file response")
+    return [dict(entry, hash=hashlib.sha256(content).hexdigest())
+            for entry, content in zip(entries, contents)]
+
+
+def load_repairs(ref):
+    # Older releases predate this manifest. Only absence is allowed; malformed
+    # JSON, unknown refs, and other read failures must still fail the check.
+    if ref == "WORKTREE":
+        root = Path(git("rev-parse", "--show-toplevel").decode().strip())
+        if not (root / MIGRATIONS / "upgrade-repairs.json").exists():
+            return {}
+    elif not git("ls-tree", "--full-tree", "--name-only", ref, f"{MIGRATIONS}/upgrade-repairs.json").strip():
+        return {}
+    return json.loads(read_file(ref, "upgrade-repairs.json"))
+
+
+def upgrade_errors(source, target, repairs):
+    high_water = max((entry["when"] for entry in source), default=-1)
+    source_hashes = {entry["hash"] for entry in source}
+    target_hashes = {entry["hash"] for entry in target}
+    target_by_tag = {entry["tag"]: entry for entry in target}
+    covered = set()
+    errors = []
+    for repair_tag, replacements in repairs.items():
+        repair = target_by_tag.get(repair_tag)
+        if not repair:
+            errors.append(f"Unknown repair migration: {repair_tag}")
+            continue
+        for tag, expected_hash in replacements.items():
+            original = target_by_tag.get(tag)
+            if not original or original["hash"] != expected_hash:
+                errors.append(f"{repair_tag}: repair coverage for {tag} does not match its SQL")
+            elif repair["when"] <= original["when"]:
+                errors.append(f"{repair_tag}: repair must be newer than {tag}")
+            elif repair["when"] > high_water or repair["hash"] in source_hashes:
+                covered.add(expected_hash)
+
+    for entry in source:
+        if entry["hash"] not in target_hashes:
+            errors.append(f"Source migration {entry['tag']} has no SQL-equivalent migration in target")
+    for entry in target:
+        applied = entry["hash"] in source_hashes
+        if entry["when"] <= high_water and not applied and entry["hash"] not in covered:
+            errors.append(f"Drizzle skips {entry['tag']} ({entry['when']} <= {high_water}); "
+                          "add a newer idempotent repair and register its tested coverage")
+        elif entry["when"] > high_water and applied:
+            errors.append(f"Drizzle replays already-applied SQL in {entry['tag']}; "
+                          "preserve migration timestamps when backporting")
+    return errors
+
+
+def check_upgrade(source_ref, target_ref):
+    errors = upgrade_errors(load_history(source_ref), load_history(target_ref), load_repairs(target_ref))
+    print(f"Migration upgrade: {source_ref} -> {target_ref}")
+    for error in errors:
+        print(f"  ERROR: {error}")
+    if not errors:
+        print("  All required migrations are applied or covered by an eligible repair.")
+    return not errors
+
+
+def release_paths(base_branch):
+    if re.fullmatch(r"release/\d+\.\d+", base_branch):
+        # A backport must support both upgrades within stable and a subsequent
+        # move to main. Land any required forward repair on main first.
+        return [(f"origin/{base_branch}", "WORKTREE"), ("WORKTREE", "origin/main")]
+    if base_branch != "main":
+        raise ValueError(f"Unsupported release base branch: {base_branch}")
+    refs = git("for-each-ref", "--format=%(refname:short)", "refs/remotes/origin/release/").decode().splitlines()
+    stable_refs = [ref for ref in refs if re.fullmatch(r"origin/release/\d+\.\d+", ref)]
+    if not stable_refs:
+        raise ValueError("No stable release refs found; fetch origin release/* before checking upgrades")
+    return [("origin/main", "WORKTREE"), *[(ref, "WORKTREE") for ref in stable_refs]]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-branch", help="PR base or release branch; checks all supported upgrade paths")
+    parser.add_argument("--source-ref", help="Source git ref (or WORKTREE)")
+    parser.add_argument("--target-ref", default="WORKTREE", help="Target git ref (default: WORKTREE)")
+    args = parser.parse_args()
+    if bool(args.base_branch) == bool(args.source_ref):
+        parser.error("provide exactly one of --base-branch or --source-ref")
+    paths = release_paths(args.base_branch) if args.base_branch else [(args.source_ref, args.target_ref)]
+    results = [check_upgrade(source, target) for source, target in paths]
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_migration_upgrades.py
+++ b/.github/scripts/test_check_migration_upgrades.py
@@ -1,0 +1,136 @@
+"""Exercise upgrade decisions and the CLI against real temporary Git histories."""
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("check-migration-upgrades.py").resolve()
+SPEC = importlib.util.spec_from_file_location("check_migration_upgrades", SCRIPT)
+checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checker)
+
+
+def migration(tag, when, sql=None):
+    return {"tag": tag, "when": when, "hash": hashlib.sha256((sql or tag).encode()).hexdigest()}
+
+
+class UpgradeTest(unittest.TestCase):
+    def setUp(self):
+        self.common = migration("0000_common", 100)
+        self.feature = migration("0001_feature", 200)
+        self.backport = migration("0001_backport", 400, "backport")
+        self.upstream = migration("0002_upstream", 300, "backport")
+        self.repair = migration("0003_repair", 500)
+        self.source = [self.common, self.backport]
+        self.target = [self.common, self.feature, self.upstream]
+        self.coverage = {self.repair["tag"]: {self.feature["tag"]: self.feature["hash"]}}
+
+    def test_monotonic_tracks_can_still_skip_a_feature(self):
+        errors = checker.upgrade_errors(self.source, self.target, {})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Drizzle skips 0001_feature", errors[0])
+
+    def test_new_repair_covers_the_gap_and_renamed_backport_is_recognized(self):
+        self.assertEqual(checker.upgrade_errors(self.source, self.target + [self.repair], self.coverage), [])
+
+    def test_repair_below_source_watermark_does_not_cover_gap(self):
+        source = self.source + [migration("later", 600)]
+        target = self.target + [self.repair, source[-1]]
+        errors = checker.upgrade_errors(source, target, self.coverage)
+        self.assertTrue(any("skips 0001_feature" in error for error in errors))
+
+    def test_previously_applied_repair_covers_gap(self):
+        self.assertEqual(checker.upgrade_errors(self.source + [self.repair], self.target + [self.repair], self.coverage), [])
+
+    def test_changed_covered_sql_invalidates_repair(self):
+        changed = dict(self.feature, hash="changed")
+        errors = checker.upgrade_errors(self.source, [self.common, changed, self.upstream, self.repair], self.coverage)
+        self.assertTrue(any("does not match its SQL" in error for error in errors))
+        self.assertTrue(any("skips 0001_feature" in error for error in errors))
+
+    def test_unknown_or_older_repair_fails(self):
+        errors = checker.upgrade_errors(self.source, self.target, self.coverage)
+        self.assertTrue(any("Unknown repair" in error for error in errors))
+        older = dict(self.repair, when=150)
+        errors = checker.upgrade_errors(self.source, self.target + [older], self.coverage)
+        self.assertTrue(any("repair must be newer" in error for error in errors))
+
+    def test_equal_timestamp_is_skipped(self):
+        feature = dict(self.feature, when=self.backport["when"])
+        self.assertTrue(any("skips 0001_feature" in error for error in checker.upgrade_errors(self.source, [self.common, feature, self.upstream], {})))
+
+    def test_timestamp_change_that_replays_backport_fails(self):
+        upstream = dict(self.upstream, when=450)
+        errors = checker.upgrade_errors(self.source, [self.common, upstream], {})
+        self.assertTrue(any("replays already-applied SQL" in error for error in errors))
+
+    def test_missing_source_migration_fails(self):
+        errors = checker.upgrade_errors(self.source, [self.common], {})
+        self.assertTrue(any("no SQL-equivalent migration" in error for error in errors))
+
+    def test_fresh_and_normal_incremental_upgrades_pass(self):
+        self.assertEqual(checker.upgrade_errors([], self.target, {}), [])
+        self.assertEqual(checker.upgrade_errors([self.common], self.target, {}), [])
+
+
+class CliTest(unittest.TestCase):
+    def test_release_track_checks_fail_before_repair_and_pass_after(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            folder = root / checker.MIGRATIONS
+            (folder / "meta").mkdir(parents=True)
+
+            def git(*args):
+                return subprocess.check_output(["git", "-C", directory, *args], stderr=subprocess.STDOUT)
+
+            def history(entries):
+                (folder / "meta/_journal.json").write_text(json.dumps({"entries": entries}))
+                for entry in entries:
+                    (folder / (entry["tag"] + ".sql")).write_text(entry["tag"])
+
+            def run(*args):
+                return subprocess.run(["python3", str(SCRIPT), *args], cwd=root / "platform", capture_output=True, text=True)
+
+            git("init", "-q")
+            git("config", "user.email", "test@example.com")
+            git("config", "user.name", "Test")
+            common = {"tag": "common", "when": 100}
+            backport = {"tag": "backport", "when": 400}
+            feature = {"tag": "feature", "when": 200}
+            repair = {"tag": "repair", "when": 500}
+            history([common, backport])
+            git("add", ".")
+            git("commit", "-qm", "stable")
+            git("update-ref", "refs/remotes/origin/release/1.3", "HEAD")
+            history([common, feature, backport])
+            git("add", ".")
+            git("commit", "-qm", "main")
+            git("update-ref", "refs/remotes/origin/main", "HEAD")
+            result = run("--base-branch", "main")
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertIn("Drizzle skips feature", result.stdout)
+            history([common, feature, backport, repair])
+            (folder / "upgrade-repairs.json").write_text(json.dumps({"repair": {"feature": hashlib.sha256(b"feature").hexdigest()}}))
+            result = run("--base-branch", "main")
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            git("add", ".")
+            git("commit", "-qm", "repair")
+            git("update-ref", "refs/remotes/origin/main", "HEAD")
+            git("checkout", "--detach", "origin/release/1.3")
+            result = run("--base-branch", "release/1.3")
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("WORKTREE -> origin/main", result.stdout)
+            result = run("--source-ref", "missing-ref")
+            self.assertNotEqual(result.returncode, 0)
+            git("update-ref", "-d", "refs/remotes/origin/release/1.3")
+            result = run("--base-branch", "main")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("No stable release refs", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -364,7 +364,15 @@ jobs:
           git -c credential.helper= \
               -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
               fetch --depth=1 origin \
-              "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+              "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}" \
+              "+refs/heads/release/*:refs/remotes/origin/release/*"
+
+      - name: Check migration upgrade paths across release tracks
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+        run: |
+          python3 ../.github/scripts/test_check_migration_upgrades.py
+          python3 ../.github/scripts/check-migration-upgrades.py --base-branch "${BASE_BRANCH#refs/heads/}"
 
       # Backend unit tests run in the parallel sharded "Backend Unit Tests"
       # jobs below; here the backend runs check:commit (same checks minus

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,6 +36,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Recheck after merge against current release refs, before creating a release.
+      - name: Check migration upgrade paths across release tracks
+        working-directory: ./platform
+        env:
+          BASE_BRANCH: ${{ github.ref_name }}
+        run: python3 ../.github/scripts/check-migration-upgrades.py --base-branch "$BASE_BRANCH"
+
       - name: Generate a token
         id: generate-token
         uses: ./.github/actions/github-app-token

--- a/platform/backend/src/database/migrations/README.md
+++ b/platform/backend/src/database/migrations/README.md
@@ -1,0 +1,41 @@
+# Migration upgrades across release tracks
+
+Drizzle runs migrations whose journal `when` is greater than the database's latest
+recorded timestamp. It does not look for gaps by filename or SQL hash. A backport
+can therefore make a later stable-to-beta upgrade silently skip beta migrations,
+even when both journals are individually ordered.
+
+PR validation and release creation run `.github/scripts/check-migration-upgrades.py`.
+The check compares stable release branches (`release/X.Y`) with main, and checks
+upgrades within the target release line. SQL hashes recognize identical migrations
+backported under different filenames. It rejects skipped migrations, absent source
+SQL, and timestamp changes that would replay already-applied SQL.
+
+Run from `platform/` after fetching the relevant refs:
+
+```sh
+python3 ../.github/scripts/check-migration-upgrades.py --base-branch main
+python3 ../.github/scripts/check-migration-upgrades.py --source-ref platform-v1.3.56
+```
+
+When backporting a migration, preserve its SQL and timestamp. Preserving the
+timestamp alone is not sufficient: earlier beta-only migrations may still be
+skipped. The cross-track check must pass before publishing the backport. Land any
+required forward repair on main first. Keep this guard in the active stable
+branch's PR and release workflows too.
+
+For an already-shipped gap, generate a new custom migration with a timestamp
+newer than both tracks. Make the repair idempotent and preserve existing data.
+Do not edit shipped migrations or rewind the database's migration ledger.
+
+`upgrade-repairs.json` records explicit repair coverage. Each key is the new
+repair's journal tag. Its value maps original migration tags to their SHA-256 SQL
+hashes. The checker accepts coverage only if the original SQL matches and the
+repair will run, or was already applied. This is reviewed coverage, not proof of
+SQL equivalence: test the repair against missing, partially repaired, and healthy
+schemas. Keep this file outside `meta/`, which Drizzle reserves for snapshots.
+
+Use the real migrator in upgrade regression tests. The ordinary backend test
+snapshot executes SQL files directly, so it cannot detect timestamp-based skips.
+The static check does not prove SQL correctness, migration dependency order, or
+lock safety; those still need database tests and migration review.

--- a/platform/dev/RELEASE.md
+++ b/platform/dev/RELEASE.md
@@ -9,7 +9,7 @@ Archestra uses two release pipelines:
 ## Release A Beta
 
 1. [ ] Open the release-please PR on `main` (for example, `1.4.0-beta.2`).
-2. [ ] Review the changelog and confirm checks pass.
+2. [ ] Review the changelog and confirm checks pass, including migration upgrades from the active stable line.
 3. [ ] Merge the PR and confirm the **Release Please** workflow publishes the beta release.
 
 ## Ship A Stable Fix
@@ -24,8 +24,38 @@ Archestra uses two release pipelines:
    - Only include necessary bug fixes. Do not include new features, refactors, or schema migrations.
    - If an unreleased candidate branch (such as `release/1.4`) also needs the fix, repeat step 2 for that candidate branch.
    - Never merge `main` into a release branch.
+   - Review the migration compatibility check. A green result does not permit schema migrations in a stable fix.
 4. [ ] Merge the generated release-please patch PR on `release/X.Y` (for example, `1.3.52`).
 5. [ ] Complete **Test And Approve Stable** below.
+
+## Migration Compatibility Across Release Tracks
+
+A higher application version does not guarantee a compatible migration history.
+Drizzle runs migrations newer than the database's latest recorded journal timestamp.
+A stable backport can advance that timestamp past beta-only migrations.
+The next beta upgrade can then report success while required columns remain missing.
+
+PR validation checks upgrades within a release line and from stable to main.
+Backport PRs also check their resulting stable history against main.
+Release creation repeats the check against the current branch refs.
+Keep these guards on both main and the active stable branch.
+
+The checker recognizes identical SQL under different backport filenames.
+It rejects migrations that would be skipped or replayed, and missing source SQL.
+It does not validate SQL semantics, dependency order, or database lock safety.
+Continue testing the actual upgrade against the saved release artifacts.
+
+If a published release already created a gap:
+
+1. Add a new idempotent repair on main, newer than both migration histories.
+2. Cover every skipped change and preserve values on already-migrated databases.
+3. Register the reviewed SQL hashes in `backend/src/database/migrations/upgrade-repairs.json`.
+4. Test with the real Drizzle migrator, including a database whose ledger already advanced past the gap.
+5. Publish the repaired beta before directing affected stable installations to that beta.
+
+Do not edit shipped migration SQL, renumber its timestamps, or rewind a database's migration ledger.
+The ordinary backend test snapshot executes SQL directly and cannot detect timestamp-based skips.
+See [migration upgrade checks](../backend/src/database/migrations/README.md) for commands and repair coverage rules.
 
 ## Cut A New Stable Feature Line
 


### PR DESCRIPTION
Backport the migration compatibility guards and release documentation from #7821 to `release/1.3`. A stable migration backport can advance Drizzle's timestamp past beta-only migrations, making a later upgrade silently skip required schema changes.

PR validation now checks the candidate stable history against main, and release creation repeats that check. The guard recognizes SQL-equivalent renamed backports and rejects skipped or replayed migrations. `platform/dev/RELEASE.md` documents the checks and recovery policy. This PR contains no schema migration; the column repair remains in #7819.

**Dependencies: merge #7819, then #7821, before this PR.** Until the repair and its coverage metadata are on main, this PR's cross-track check intentionally fails for the existing stable-to-beta gap. The local stable candidate passes against their combined repaired history. Guard tests exercise actual temporary Git branches, including this dependency and renamed backports; the existing release-publication tests also pass.
