### PR TITLE
fix(frontend): avoid reporting cancelled Apps requests

### DIFF
--- a/platform/frontend/src/lib/app.query.ts
+++ b/platform/frontend/src/lib/app.query.ts
@@ -632,6 +632,11 @@ function appsQueryOptions(params: AppsParams, toastOnError?: boolean) {
     queryKey: ["apps", "paginated", params],
     queryFn: async ({ signal }) => {
       const { data, error } = await getApps({ query: params, signal });
+      // TanStack aborts this request when its observer disappears (for example,
+      // when navigating away from Chat). The generated SDK returns that
+      // cancellation in `error`; hand it back to TanStack without reporting it
+      // as an API failure or sending it through Next's dev error overlay.
+      if (signal.aborted) throw signal.reason;
       throwOnApiError(error, { toastOnError });
       return data;
     },

--- a/platform/frontend/src/lib/navigation-data.test.tsx
+++ b/platform/frontend/src/lib/navigation-data.test.tsx
@@ -12,6 +12,7 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from "vitest";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useProfilesPaginated } from "@/lib/agent.query";
@@ -28,6 +29,7 @@ beforeEach(() => archestraApiClient.setConfig({ baseUrl: origin }));
 afterEach(() => {
   for (const client of clients.splice(0)) client.clear();
   server.resetHandlers();
+  vi.restoreAllMocks();
 });
 afterAll(() => server.close());
 
@@ -155,5 +157,41 @@ describe("navigation data reuse", () => {
     expect(client.getQueryCache().findAll({ queryKey: ["apps"] })).toHaveLength(
       0,
     );
+  });
+
+  it("does not report an Apps request cancelled during navigation", async () => {
+    const { client, wrapper } = setup();
+    client.setQueryData(authQueryKeys.userPermissions(), { app: ["read"] });
+    let markStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let markAborted: (() => void) | undefined;
+    const aborted = new Promise<void>((resolve) => {
+      markAborted = resolve;
+    });
+    server.use(
+      http.get(`${origin}/api/apps`, async ({ request }) => {
+        markStarted?.();
+        request.signal.addEventListener("abort", () => markAborted?.(), {
+          once: true,
+        });
+        await new Promise(() => {});
+        return HttpResponse.json({ data: [], pagination: { total: 0 } });
+      }),
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const query = renderHook(() => useApps({ limit: 100, offset: 0 }), {
+      wrapper,
+    });
+    await started;
+    query.unmount();
+    await aborted;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(consoleError).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Navigating away while the Apps request is in flight cancels its fetch through TanStack Query. The generated SDK returns that expected cancellation as an error, and the generic API error path logs the native `AbortError`, which Next development mode promotes to an error overlay.

- return confirmed signal cancellations to TanStack before generic API error reporting
- preserve existing handling for real Apps API failures
- cover query unmount cancellation with a focused regression test

## Validation

Reproduced the navigation lifecycle by mounting `useApps` with a pending request and unmounting it. Before the change this emitted one `console.error(AbortError)`; afterward the request is cancelled without reporting an error. Also exercised live navigation from Chat to Projects without a new AbortError overlay.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>