### PR TITLE
ci(release): open reviewed backport PRs from labels

### DIFF
--- a/.agents/skills/managing-archestra-releases/SKILL.md
+++ b/.agents/skills/managing-archestra-releases/SKILL.md
@@ -20,12 +20,11 @@ Starting a new stable branch adds configuration steps. It uses the same stable p
 ## Backporting Fixes
 
 1. Land fixes on `main` first. Fixes on `main` ship automatically in the next beta release.
-2. Backport fixes to the active stable branch (`release/X.Y`):
-   - Branch from `origin/release/X.Y`.
-   - Use `git cherry-pick -x <main-commit-sha>`.
-   - Include only necessary bug fixes. Do not include features, refactors, or schema changes.
-3. If an unreleased candidate branch also needs the fix, open a separate backport PR targeting that branch.
-4. Never merge `main` directly into `release/X.Y` or candidate branches.
+2. Read `.github/backport-targets.json` and apply `backport release/X.Y` labels to the source PR for the configured targets. Labels work before or after merge. **Open Backport PRs** creates separate `cherry-pick -x` PRs; it never merges or approves a release.
+3. Monitor the resulting backport PRs and their checks. Review the release-specific diff before queueing them under the user's merge authorization.
+4. On conflicts, use the manual `cherry-pick -x` procedure in `platform/dev/RELEASE.md`. Include only necessary fixes; no features, refactors, or schema changes. Never merge `main` into release or candidate branches.
+5. Retry API failures through **Open Backport PRs** workflow dispatch. Existing PRs are not duplicated or reopened, and existing branches are not overwritten. Investigate an unexpected existing branch instead of deleting it.
+6. During stable cutover, update the configured targets and their labels to include the new branch and remove the retired line. The automation's source of truth is the default branch.
 
 ## Cutting A New Stable Line End To End
 

--- a/.github/backport-targets.json
+++ b/.github/backport-targets.json
@@ -1,0 +1,3 @@
+{
+  "branches": ["release/1.3"]
+}

--- a/.github/scripts/backport.py
+++ b/.github/scripts/backport.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Open reviewed backport PRs for merged default-branch fixes; never merge them."""
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib.parse import urlencode
+
+
+class ManualBackportRequired(Exception):
+    pass
+
+
+class Backporter:
+    def __init__(self, repo, checkout, targets):
+        if not re.fullmatch(r"[\w.-]+/[\w.-]+", repo):
+            raise ValueError("Invalid repository name")
+        if not targets or any(not re.fullmatch(r"release/\d+\.\d+", target) for target in targets):
+            raise ValueError("Backport targets must be explicit release/X.Y branches")
+        self.repo = repo
+        self.checkout = Path(checkout)
+        self.targets = set(targets)
+
+    def poll(self):
+        # Scan the durable label requests, including old PRs after an outage.
+        # Fetch existing backports once per target to avoid reprocessing them.
+        for target in sorted(self.targets):
+            query = urlencode({"state": "all", "base": target, "per_page": 100})
+            existing = self.api(f"repos/{self.repo}/pulls?{query}", paginate=True)
+            heads = {pr["head"]["ref"] for pr in existing
+                     if (pr["head"].get("repo") or {}).get("full_name") == self.repo}
+            query = urlencode({"state": "closed", "labels": f"backport {target}", "per_page": 100})
+            requests = self.api(f"repos/{self.repo}/issues?{query}", paginate=True)
+            for issue in requests:
+                if "pull_request" not in issue:
+                    continue
+                branch = f"backport/{target.replace('/', '-')}/pr-{issue['number']}"
+                if branch in heads:
+                    continue
+                try:
+                    self.run(issue["number"], target)
+                except ValueError as error:
+                    print(f"Ignoring ineligible PR #{issue['number']}: {error}")
+
+    def run(self, number, target_override=""):
+        pr = self.api(f"repos/{self.repo}/pulls/{number}")
+        default = self.api(f"repos/{self.repo}")["default_branch"]
+        if not pr["merged"] or pr["base"]["ref"] != default:
+            raise ValueError("Only merged default-branch PRs can be backported")
+        sha = pr["merge_commit_sha"]
+        if not re.fullmatch(r"[0-9a-f]{40}", sha):
+            raise ValueError("Invalid merge commit SHA")
+        requested = {label["name"].removeprefix("backport ") for label in pr["labels"]
+                     if label["name"].startswith("backport ")}
+        if target_override:
+            requested = {target_override}
+        if not requested:
+            print("No backport labels found.")
+            return
+        self.git("fetch", "origin", f"+refs/heads/{default}:refs/remotes/origin/{default}")
+        self.git("merge-base", "--is-ancestor", sha, f"origin/{default}")
+        parents = self.git("show", "-s", "--format=%P", sha).stdout.split()
+        if not parents:
+            raise ValueError("Cannot backport a root commit")
+        files = self.git("diff", "--name-only", parents[0], sha).stdout.splitlines()
+        for target in sorted(requested):
+            if not re.fullmatch(r"release/\d+\.\d+", target):
+                raise ValueError("Backport labels must use backport release/X.Y")
+            if target not in self.targets:
+                self.report(number, target, "This branch is not enabled in .github/backport-targets.json. No backport was created.")
+                continue
+            try:
+                if has_schema_changes(files):
+                    raise ManualBackportRequired("This PR changes database schemas or migrations. Stable fixes exclude schema migrations; prepare a separately reviewed fix without those changes.")
+                self.backport(pr, target, sha, len(parents) > 1)
+            except ManualBackportRequired as error:
+                self.report(number, target, str(error))
+
+    def backport(self, pr, target, sha, is_merge):
+        number = pr["number"]
+        branch = f"backport/{target.replace('/', '-')}/pr-{number}"
+        query = urlencode({"state": "all", "head": f"{self.repo.split('/')[0]}:{branch}", "base": target})
+        existing = self.api(f"repos/{self.repo}/pulls?{query}")
+        if existing:
+            print(f"Backport already exists: {existing[0]['html_url']} ({existing[0]['state']})")
+            return
+        self.git("fetch", "origin", f"+refs/heads/{target}:refs/remotes/origin/{target}")
+        remote = self.git("ls-remote", "--exit-code", "--heads", "origin", f"refs/heads/{branch}", check=False)
+        if remote.returncode == 0:
+            # Recover a push that succeeded before PR creation failed. Never
+            # replace a branch or discard edits made by a reviewer.
+            self.git("fetch", "origin", f"+refs/heads/{branch}:refs/remotes/origin/{branch}")
+            message = self.git("show", "-s", "--format=%B", f"origin/{branch}").stdout
+            if f"(cherry picked from commit {sha})" not in message:
+                raise ManualBackportRequired(f"Branch `{branch}` already exists without the expected source commit. Inspect it manually; it was not modified.")
+        elif remote.returncode == 2:
+            self.create_branch(target=target, branch=branch, sha=sha, is_merge=is_merge)
+        else:
+            raise RuntimeError("Cannot inspect the remote backport branch")
+        suffix = f" (backport {target})"
+        title = " ".join(pr["title"].split())[:100 - len(suffix)] + suffix
+        body = (f"Backports #{number} to `{target}` using `git cherry-pick -x`.\n\n"
+                f"Source commit: `{sha}`.\n\n"
+                "Review this branch's diff and CI results before adding it to the merge queue. "
+                "Stable publication still requires the existing release approval.\n")
+        result = self.api(f"repos/{self.repo}/pulls", {"title": title, "head": branch, "base": target, "body": body})
+        self.report(number, target, f"Opened {result['html_url']} for review. This automation does not merge or approve releases.")
+        print(result["html_url"])
+
+    def create_branch(self, *, target, branch, sha, is_merge):
+        with tempfile.TemporaryDirectory(prefix="archestra-backport-") as directory:
+            worktree = Path(directory) / "checkout"
+            self.git("worktree", "add", "--detach", str(worktree), f"origin/{target}")
+            try:
+                args = ["cherry-pick", "-x"] + (["-m", "1"] if is_merge else []) + [sha]
+                result = self.git(*args, cwd=worktree, check=False)
+                if result.returncode:
+                    conflicts = self.git("ls-files", "--unmerged", cwd=worktree).stdout
+                    empty = self.git("diff", "--quiet", "HEAD", cwd=worktree, check=False).returncode == 0
+                    if not conflicts and empty:
+                        raise ManualBackportRequired("The change is already present on this branch. No duplicate backport PR was created.")
+                    raise ManualBackportRequired("The cherry-pick conflicts with this release branch. Resolve it manually with `git cherry-pick -x`; no branch was pushed.")
+                self.git("push", "origin", f"HEAD:refs/heads/{branch}", cwd=worktree)
+            finally:
+                self.git("worktree", "remove", "--force", str(worktree))
+
+    def report(self, number, target, message):
+        marker = f"<!-- archestra-backport:{number}:{target} -->"
+        body = f"{marker}\nBackport to `{target}`: {message}"
+        comments = self.api(f"repos/{self.repo}/issues/{number}/comments", paginate=True)
+        for comment in comments:
+            if comment.get("user", {}).get("type") == "Bot" and comment["body"].startswith(marker):
+                if comment["body"] != body:
+                    self.api(f"repos/{self.repo}/issues/comments/{comment['id']}", {"body": body}, method="PATCH")
+                return
+        self.api(f"repos/{self.repo}/issues/{number}/comments", {"body": body})
+
+    def api(self, endpoint, payload=None, *, method=None, paginate=False):
+        args = ["gh", "api", endpoint]
+        if method:
+            args += ["--method", method]
+        if payload is not None:
+            args += ["--input", "-"]
+        if paginate:
+            args += ["--paginate", "--slurp"]
+        result = subprocess.run(args, input=json.dumps(payload) if payload is not None else None,
+                                text=True, capture_output=True, check=True)
+        data = json.loads(result.stdout)
+        return [item for page in data for item in page] if paginate else data
+
+    def git(self, *args, cwd=None, check=True):
+        # No credentials are written to the checkout or included in argv.
+        command = ["git", "-c", "core.hooksPath=/dev/null", "-c", "credential.helper=",
+                   "-c", 'credential.helper=!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f',
+                   "-c", "user.name=Archestra backport automation",
+                   "-c", "user.email=backport-bot@users.noreply.github.com", *args]
+        return subprocess.run(command, cwd=cwd or self.checkout, text=True, capture_output=True,
+                              check=check, env={**os.environ, "GIT_TERMINAL_PROMPT": "0"})
+
+
+def has_schema_changes(files):
+    return any(name.startswith("platform/backend/src/database/schemas/") or
+               (name.startswith("platform/backend/src/database/migrations/") and
+                (name.endswith(".sql") or "/meta/" in name)) for name in files)
+
+
+def main():
+    root = Path(__file__).resolve().parents[2]
+    targets = json.loads((root / ".github/backport-targets.json").read_text())["branches"]
+    bot = Backporter(os.environ["GH_REPO"], root, targets)
+    source = os.environ.get("SOURCE_PR", "")
+    if source:
+        number = int(source)
+        if number <= 0:
+            raise ValueError("PR number must be positive")
+        bot.run(number, os.environ.get("TARGET_BRANCH", ""))
+    else:
+        bot.poll()
+
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_backport.py
+++ b/.github/scripts/test_backport.py
@@ -1,0 +1,245 @@
+"""Exercise real Git cherry-picks and pushes; fake only the GitHub API boundary."""
+
+import importlib.util
+import json
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+SPEC = importlib.util.spec_from_file_location("backport", Path(__file__).with_name("backport.py"))
+backport = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(backport)
+
+
+class FakeGitHubBackporter(backport.Backporter):
+    def __init__(self, checkout, pr):
+        super().__init__("fixture/repository", checkout, ["release/1.3", "release/1.4"])
+        self.pr = pr
+        self.pulls = []
+        self.comments = []
+
+    def api(self, endpoint, payload=None, *, method=None, paginate=False):
+        if endpoint == "repos/fixture/repository":
+            return {"default_branch": "main"}
+        if endpoint == "repos/fixture/repository/pulls/42":
+            return self.pr
+        if "pulls?" in endpoint:
+            query = parse_qs(urlparse(endpoint).query)
+            pulls = [pr for pr in self.pulls if pr["base"] == query["base"][0]]
+            if "head" in query:
+                return [pr for pr in pulls if pr["head"] == query["head"][0].split(":")[1]]
+            return [{**pr, "head": {"ref": pr["head"], "repo": {"full_name": self.repo}}} for pr in pulls]
+        if "issues?" in endpoint:
+            label = parse_qs(urlparse(endpoint).query)["labels"][0]
+            return [{"number": 42, "pull_request": {}, "updated_at": "2020-01-01T00:00:00Z"}] if any(item["name"] == label for item in self.pr["labels"]) else []
+        if endpoint.endswith("/pulls") and payload:
+            pr = {**payload, "state": "open", "html_url": "https://github.com/fixture/repository/pull/43"}
+            self.pulls.append(pr)
+            return pr
+        if endpoint.endswith("/comments"):
+            if payload:
+                comment = {**payload, "id": len(self.comments) + 1, "user": {"type": "Bot"}}
+                self.comments.append(comment)
+                return comment
+            return self.comments
+        if "/issues/comments/" in endpoint and method == "PATCH":
+            self.comments[int(endpoint.rsplit("/", 1)[1]) - 1].update(payload)
+            return payload
+        raise AssertionError((endpoint, payload, method, paginate))
+
+
+class BackportTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.repo = self.root / "checkout"
+        self.remote = self.root / "remote.git"
+        subprocess.run(["git", "init", "--bare", "-q", str(self.remote)], check=True)
+        subprocess.run(["git", "clone", "-q", str(self.remote), str(self.repo)], check=True, capture_output=True)
+        self.git("config", "user.name", "Test")
+        self.git("config", "user.email", "test@example.com")
+        self.git("checkout", "-b", "main")
+        (self.repo / "feature.txt").write_text("original\n")
+        self.commit("initial")
+        self.git("push", "origin", "main:main", "main:release/1.3", "main:release/1.4")
+        (self.repo / "feature.txt").write_text("fixed\n")
+        sha = self.commit("fix: correct feature")
+        self.git("push", "origin", "main")
+        self.pr = {"number": 42, "title": "fix: correct feature", "merged": True,
+                   "base": {"ref": "main"}, "merge_commit_sha": sha,
+                   "labels": [{"name": "backport release/1.3"}]}
+        self.bot = FakeGitHubBackporter(self.repo, self.pr)
+
+    def git(self, *args):
+        return subprocess.check_output(["git", *args], cwd=self.repo, stderr=subprocess.PIPE, text=True).strip()
+
+    def commit(self, message):
+        self.git("add", ".")
+        self.git("commit", "-qm", message)
+        return self.git("rev-parse", "HEAD")
+
+    def test_opens_a_backport_with_provenance_without_changing_stable(self):
+        stable = self.git("rev-parse", "origin/release/1.3")
+        self.bot.run(42)
+        self.assertEqual(len(self.bot.pulls), 1)
+        pr = self.bot.pulls[0]
+        self.assertEqual(pr["base"], "release/1.3")
+        self.assertNotIn("draft", pr)
+        self.git("fetch", "origin")
+        ref = "origin/backport/release-1.3/pr-42"
+        self.assertEqual(self.git("show", ref + ":feature.txt"), "fixed")
+        self.assertIn(f"(cherry picked from commit {self.pr['merge_commit_sha']})", self.git("show", "-s", "--format=%B", ref))
+        self.assertEqual(self.git("rev-parse", "origin/release/1.3"), stable)
+        self.assertEqual(self.git("branch", "--show-current"), "main")
+        self.assertEqual(len(self.git("worktree", "list", "--porcelain").split("worktree ")) - 1, 1)
+
+    def test_duplicate_event_and_closed_pr_do_not_create_duplicates(self):
+        self.bot.run(42)
+        self.bot.pulls[0]["state"] = "closed"
+        self.bot.run(42)
+        self.assertEqual(len(self.bot.pulls), 1)
+        self.assertEqual(len(self.bot.comments), 1)
+
+    def test_resumes_after_push_succeeded_but_pr_creation_failed(self):
+        self.bot.create_branch(target="release/1.3", branch="backport/release-1.3/pr-42",
+                               sha=self.pr["merge_commit_sha"], is_merge=False)
+        self.bot.run(42)
+        self.assertEqual(len(self.bot.pulls), 1)
+
+    def test_conflict_reports_manual_action_without_pushing(self):
+        self.git("checkout", "-b", "stable", "origin/release/1.3")
+        (self.repo / "feature.txt").write_text("stable changed independently\n")
+        self.commit("fix: stable divergence")
+        self.git("push", "origin", "HEAD:release/1.3")
+        self.git("checkout", "main")
+        self.bot.run(42)
+        self.bot.run(42)
+        self.assertEqual(self.bot.pulls, [])
+        self.assertEqual(len(self.bot.comments), 1)
+        self.assertIn("conflicts", self.bot.comments[0]["body"])
+        self.assertEqual(self.git("ls-remote", "--heads", "origin", "refs/heads/backport/*"), "")
+
+    def test_schema_changes_are_not_automatically_backported(self):
+        schema = self.repo / "platform/backend/src/database/migrations/0001_change.sql"
+        schema.parent.mkdir(parents=True)
+        schema.write_text("ALTER TABLE example ADD COLUMN value text;")
+        self.pr["merge_commit_sha"] = self.commit("fix: schema change")
+        self.git("push", "origin", "main")
+        self.bot.run(42)
+        self.assertEqual(self.bot.pulls, [])
+        self.assertIn("schema migrations", self.bot.comments[0]["body"])
+
+    def test_unmerged_or_non_main_source_is_rejected(self):
+        self.pr["merged"] = False
+        with self.assertRaisesRegex(ValueError, "Only merged"):
+            self.bot.run(42)
+        self.pr["merged"] = True
+        self.pr["base"]["ref"] = "release/1.3"
+        with self.assertRaisesRegex(ValueError, "Only merged"):
+            self.bot.run(42)
+
+    def test_no_label_is_noop_and_labels_added_after_merge_work(self):
+        self.pr["labels"] = []
+        self.bot.run(42)
+        self.assertEqual(self.bot.pulls, [])
+        self.pr["labels"] = [{"name": "backport release/1.3"}, {"name": "backport release/1.4"}]
+        self.bot.run(42)
+        self.assertEqual({pr["base"] for pr in self.bot.pulls}, {"release/1.3", "release/1.4"})
+
+    def test_unknown_target_is_not_pushed(self):
+        self.bot.run(42, "release/9.9")
+        self.assertEqual(self.bot.pulls, [])
+        self.assertIn("not enabled", self.bot.comments[0]["body"])
+
+    def test_existing_unrelated_branch_is_not_overwritten(self):
+        self.git("push", "origin", "origin/release/1.3:refs/heads/backport/release-1.3/pr-42")
+        self.bot.run(42)
+        self.assertEqual(self.bot.pulls, [])
+        self.assertIn("already exists", self.bot.comments[0]["body"])
+
+    def test_already_present_patch_does_not_open_empty_pr(self):
+        self.git("push", "origin", "main:release/1.3")
+        self.bot.run(42)
+        self.assertEqual(self.bot.pulls, [])
+        self.assertIn("already present", self.bot.comments[0]["body"])
+
+    def test_merge_commit_cherry_picks_first_parent_diff(self):
+        self.git("checkout", "-b", "feature")
+        (self.repo / "merge-feature.txt").write_text("feature\n")
+        self.commit("fix: merged feature")
+        self.git("checkout", "main")
+        (self.repo / "main-only.txt").write_text("main only\n")
+        self.commit("feat: main only")
+        self.git("merge", "--no-ff", "feature", "-m", "fix: merge feature")
+        self.pr["merge_commit_sha"] = self.git("rev-parse", "HEAD")
+        self.git("push", "origin", "main")
+        self.bot.run(42)
+        self.git("fetch", "origin")
+        ref = "origin/backport/release-1.3/pr-42"
+        self.assertEqual(self.git("show", ref + ":merge-feature.txt"), "feature")
+        self.assertEqual(self.git("show", ref + ":feature.txt"), "original")
+
+    def test_poll_recovers_old_label_requests_and_skips_existing_backports(self):
+        self.bot.poll()
+        self.bot.poll()
+        self.assertEqual(len(self.bot.pulls), 1)
+        self.assertEqual(len(self.bot.comments), 1)
+
+    def test_poll_ignores_closed_unmerged_requests(self):
+        self.pr["merged"] = False
+        self.bot.poll()
+        self.assertEqual(self.bot.pulls, [])
+
+    def test_untrusted_title_is_data_not_shell_code(self):
+        self.pr["title"] = "fix: $(touch SHOULD_NOT_EXIST) `touch ALSO_NOT_EXIST`"
+        self.bot.run(42)
+        self.assertFalse((self.repo / "SHOULD_NOT_EXIST").exists())
+        self.assertFalse((self.repo / "ALSO_NOT_EXIST").exists())
+        self.assertIn("$(touch", self.bot.pulls[0]["title"])
+
+
+class WorkflowPolicyTests(unittest.TestCase):
+    def test_backport_prs_run_checks_while_release_bot_prs_remain_exempt(self):
+        workflow = Path(__file__).parents[1] / "workflows/on-pull-requests.yml"
+        conditions = [line.split("if: ", 1)[1] for line in workflow.read_text().splitlines()
+                      if "if: " in line and "archestra-ci[bot]" in line]
+        self.assertTrue(conditions)
+        program = r"""
+const vm = require('node:vm');
+const assert = require('node:assert/strict');
+const conditions = JSON.parse(process.argv[1]);
+for (const condition of conditions) {
+  for (const [login, ref, expected] of [
+    ['archestra-ci[bot]', 'backport/release-1.3/pr-42', true],
+    ['archestra-ci[bot]', 'release-please--branches--main', false],
+    ['contributor', 'fix/example', true],
+    ['archestra-contributor-pr-bot[bot]', 'docs/example', false],
+  ]) {
+    const context = {github: {event_name: 'pull_request', event: {pull_request: {user: {login}, head: {ref}}}},
+      startsWith: (value, prefix) => value.startsWith(prefix), always: () => true};
+    assert.equal(vm.runInNewContext(condition, context), expected, condition);
+  }
+  assert.equal(vm.runInNewContext(condition, {github: {event_name:'merge_group'}, always: () => true}), true);
+}
+"""
+        subprocess.run(["node", "-e", program, json.dumps(conditions)], check=True)
+
+    def test_backport_bot_prs_receive_reviewers(self):
+        workflow = Path(__file__).parents[1] / "workflows/random-issue-pr-assignee.yml"
+        condition = re.search(r"if \((exemptLogins\.includes[\s\S]*?)\) \{", workflow.read_text()).group(1)
+        program = r"""
+const vm = require('node:vm');
+const assert = require('node:assert/strict');
+for (const [ref, expectedExempt] of [['backport/release-1.3/pr-42', false], ['release-please--main', true]]) {
+ assert.equal(vm.runInNewContext(process.argv[1], {exemptLogins:['archestra-ci[bot]'], pr:{user:{login:'archestra-ci[bot]'},head:{ref}}}), expectedExempt);
+}
+"""
+        subprocess.run(["node", "-e", program, condition], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,56 @@
+name: Open Backport PRs
+
+on:
+  # Poll from the trusted default branch, matching reviewer assignment's
+  # approach. This also handles labels added after merge and fork-origin PRs.
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Merged main PR number to backport
+        required: true
+        type: string
+      target_branch:
+        description: Optional configured release branch; otherwise use the PR's backport labels
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backport-requests
+  cancel-in-progress: false
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Only run automation from the trusted default branch. Cherry-picked code
+      # is never executed and no dependencies or repository hooks are installed.
+      - name: Checkout trusted automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      # An App token makes push/PR events trigger ordinary CI. GITHUB_TOKEN
+      # would suppress those events and leave the backport without its checks.
+      - name: Generate a backport token
+        id: token
+        uses: ./.github/actions/github-app-token
+        with:
+          app-id: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ARCHESTRA_RELEASER_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Open backport pull requests
+        working-directory: ./platform
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          SOURCE_PR: ${{ inputs.pull_request }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: python3 ../.github/scripts/backport.py

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   backport:
+    name: Open requested backport PRs
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -247,7 +247,7 @@ jobs:
   # same-named twin would mask real failures on merge_group. The guard only
   # bites on pull_request events: on merge_group, github.event.pull_request
   # is null and the first clause short-circuits, so queue validation runs
-  # unchanged.
+  # unchanged. Backport PRs from the same App run normal checks.
   #
   # EXCEPTION: platform-lint-and-unit-tests must still run on release-please
   # PRs — it auto-commits the regenerated docs/openapi.json version bump onto
@@ -377,6 +377,9 @@ jobs:
       - name: Release skill harness
         run: pnpm test:release-skill
 
+      - name: Test backport automation
+        run: python3 ../.github/scripts/test_backport.py
+
       # Guards white-labeling: fails when user- or LLM-facing copy hardcodes the
       # brand instead of resolving the deployment's app name. Occurrences that
       # legitimately name the vendor carry an inline `white-label-ok:` reason.
@@ -491,7 +494,7 @@ jobs:
   platform-rust-checks:
     name: Platform Rust Checks
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
-    if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
+    if: github.event_name != 'pull_request' || ((github.event.pull_request.user.login != 'archestra-ci[bot]' || startsWith(github.event.pull_request.head.ref, 'backport/')) && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
     runs-on: ${{ github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on' && fromJSON('["self-hosted", "mac-mini-1"]') || 'ubuntu-latest' }}
     timeout-minutes: 15
     permissions:
@@ -554,7 +557,7 @@ jobs:
   ai-labs-rust-checks:
     name: AI Labs Rust Checks
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
-    if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
+    if: github.event_name != 'pull_request' || ((github.event.pull_request.user.login != 'archestra-ci[bot]' || startsWith(github.event.pull_request.head.ref, 'backport/')) && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
     # mac-mini routing (see comment above platform-rust-checks)
     runs-on: ${{ github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on' && fromJSON('["self-hosted", "mac-mini-1"]') || 'ubuntu-latest' }}
     timeout-minutes: 15
@@ -618,7 +621,7 @@ jobs:
   backend-unit-tests:
     name: Backend Unit Tests (shard ${{ matrix.shard }}/8)
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
-    if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
+    if: github.event_name != 'pull_request' || ((github.event.pull_request.user.login != 'archestra-ci[bot]' || startsWith(github.event.pull_request.head.ref, 'backport/')) && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     # A full local suite run is ~4 min on comparable hardware; a shard is a
     # quarter of that plus setup and the cargo build (~3-3.5 min/shard in
@@ -725,7 +728,7 @@ jobs:
     # platform-lint-and-unit-tests): when the shards skip on a bot PR, the
     # gate must skip too — with plain always() it would run and fail on the
     # shards' "skipped" result.
-    if: always() && (github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'))
+    if: always() && (github.event_name != 'pull_request' || ((github.event.pull_request.user.login != 'archestra-ci[bot]' || startsWith(github.event.pull_request.head.ref, 'backport/')) && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'))
     needs: [backend-unit-tests]
     permissions: {}
     steps:
@@ -742,7 +745,7 @@ jobs:
   frontend-integration-tests:
     name: Frontend Integration Tests (MSW group ${{ matrix.group }}/2)
     # bot-pr-guard (see comment above platform-lint-and-unit-tests)
-    if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
+    if: github.event_name != 'pull_request' || ((github.event.pull_request.user.login != 'archestra-ci[bot]' || startsWith(github.event.pull_request.head.ref, 'backport/')) && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
     # mac-mini routing (see comment above platform-rust-checks)
     runs-on: ${{ github.event_name == 'merge_group' && vars.MAC_MINI_CI == 'on' && fromJSON('["self-hosted", "mac-mini-1"]') || 'blacksmith-8vcpu-ubuntu-2404' }}
     permissions:
@@ -875,7 +878,7 @@ jobs:
   frontend-integration-tests-gate:
     name: Frontend Integration Tests (MSW)
     runs-on: ubuntu-latest
-    if: always() && (github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'))
+    if: always() && (github.event_name != 'pull_request' || ((github.event.pull_request.user.login != 'archestra-ci[bot]' || startsWith(github.event.pull_request.head.ref, 'backport/')) && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'))
     needs: [frontend-integration-tests]
     permissions: {}
     steps:

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -27,6 +27,7 @@ env:
   # (e.g. the task-env pipeline's requester), or are merged as part of a deliberate
   # process rather than reviewed (release-please PRs, opened by archestra-ci[bot], are
   # merged by whoever cuts the release), so skip reviewer auto-assignment.
+  # Backport PRs from the release App still receive reviewers.
   REVIEW_REQUEST_EXEMPT_LOGINS: '["archestra-task-envs[bot]", "archestra-ci[bot]"]'
 
 concurrency:
@@ -185,7 +186,8 @@ jobs:
                     continue;
                   }
 
-                  if (exemptLogins.includes(pr.user.login)) {
+                  if (exemptLogins.includes(pr.user.login) &&
+                      !(pr.user.login === 'archestra-ci[bot]' && pr.head.ref.startsWith('backport/'))) {
                     console.log(`Skipping reviewer request because ${pr.user.login} is exempt from review assignment`);
                     continue;
                   }

--- a/platform/dev/RELEASE.md
+++ b/platform/dev/RELEASE.md
@@ -34,17 +34,43 @@ gitGraph
 ## Ship A Stable Fix
 
 1. [ ] Land the fix on `main` first. The fix ships automatically in the next beta.
-2. [ ] Create a backport branch from the active stable branch (`release/X.Y`):
-   ```bash
-   git checkout -b backport/fix-name origin/release/X.Y
-   git cherry-pick -x <main-commit-sha>
-   ```
-3. [ ] Open a PR targeting `release/X.Y`. Confirm tests pass and merge.
+2. [ ] Add the label `backport release/X.Y` for each configured target (for example, `backport release/1.3`).
+   - The label can be added before or after the main PR merges. The workflow checks requests every five minutes.
+   - **Open Backport PRs** cherry-picks the merged commit with `-x` and opens a separate PR per target.
+   - The automation opens PRs; it never merges them or approves stable publication.
+3. [ ] Review each generated backport PR, confirm its checks pass, then add it to that branch's merge queue.
    - Only include necessary bug fixes. Do not include new features, refactors, or schema migrations.
-   - If an unreleased candidate branch (such as `release/1.4`) also needs the fix, repeat step 2 for that candidate branch.
+   - Conflicts and schema changes produce a manual-action comment instead of a pushed backport.
    - Never merge `main` into a release branch.
 4. [ ] Merge the generated release-please patch PR on `release/X.Y` (for example, `1.3.52`).
 5. [ ] Complete **Test And Approve Stable** below.
+
+### Backport Targets And Recovery
+
+`.github/backport-targets.json` is the explicit list of branches that accept automatic backport requests.
+Add each new stable or candidate branch there, and create its `backport release/X.Y` label.
+Remove retired branches from that list when making them read-only.
+The workflow always runs trusted automation from the default branch, including manual retries.
+
+Use **Open Backport PRs → Run workflow** to retry a merged main PR.
+Supply its number and, optionally, one configured target branch.
+An existing backport PR, including a closed PR, is not duplicated or reopened.
+Label requests remain discoverable after workflow outages. Remove the request label when abandoning a backport.
+An existing backport branch is never force-pushed or reset.
+A push that succeeded before PR creation failed can resume if its source provenance matches.
+
+For conflicts, create a manual branch from the release target and resolve the cherry-pick:
+
+```bash
+git checkout -b backport/fix-name origin/release/X.Y
+git cherry-pick -x <main-commit-sha>
+```
+
+Open a PR against `release/X.Y` and complete the same review and release checks.
+A schema migration is not eligible for automatic backporting; prepare a stable fix without it.
+
+The workflow uses the existing release GitHub App token so generated PRs trigger CI.
+Backport PRs receive the usual reviewer assignment and run checks even though the release App authored them.
 
 ## Cut A New Stable Feature Line
 


### PR DESCRIPTION
Contributors currently recreate backport branches and PRs manually after landing fixes on main. Add `backport release/X.Y` labels to request separate backport PRs while preserving review, merge queues, and stable-release approval.

A scheduled workflow scans durable label requests every five minutes using trusted default-branch code and the existing release App. It cherry-picks merged commits with `-x`, supports labels added after merge and manual retries, and refuses schema changes or conflicts without pushing a branch. Deterministic branch names prevent duplicate PRs; existing branches are never overwritten. `.github/backport-targets.json` initially enables `release/1.3`.

Bot-created backport PRs run ordinary CI and receive reviewer assignment. Update `platform/dev/RELEASE.md` and the release-agent instructions with the label workflow and manual recovery.

Tests exercise real Git repositories, cherry-picks, and pushes with only the GitHub API boundary faked: clean and merge-commit backports, conflicts, duplicate/closed PRs, existing-branch recovery, schema rejection, old requests after outages, and untrusted title handling. Workflow policy tests verify that backport PRs run checks and receive reviewers while release-please PRs retain their existing exemptions. The release harness and workflow security checks pass.

After this merges, use its own backport label to create the `release/1.3` companion PR and verify the live workflow end to end. The workflow itself runs centrally from main; the backport keeps stable CI and release instructions aligned. Migration repair and compatibility checks remain in #7819, #7821, and #7820.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>