### PR TITLE
fix(observability): preserve route categories on context compaction spans

### DIFF
--- a/docs/pages/platform-observability.md
+++ b/docs/pages/platform-observability.md
@@ -324,6 +324,10 @@ chat {agentName}                       ← parent span (SpanKind.SERVER)
 
 The parent span (`route.category=chat`) carries the agent identity and session ID. LLM proxy calls from chat are linked via W3C `traceparent` header propagation, so the LLM spans appear as children rather than independent root traces. MCP tool executions run within the same async context and are automatically parented.
 
+Context compaction emits `context_compaction auto` or `context_compaction manual` spans, including skipped decisions.
+These spans inherit the invoking agent span’s `route.category`, keeping them visible in filtered traces.
+Standalone manual compaction uses `route.category=chat`.
+
 This same unified tracing applies to all agent invocation paths:
 
 | Invocation Path | `route.category` | `archestra.trigger.source` |

--- a/platform/backend/src/observability/request-context.ts
+++ b/platform/backend/src/observability/request-context.ts
@@ -1,4 +1,5 @@
 import { context, createContextKey } from "@opentelemetry/api";
+import type { RouteCategory } from "./tracing/attributes";
 
 /**
  * OTEL context key for the Archestra session ID (gen_ai.conversation.id).
@@ -17,4 +18,15 @@ export const SESSION_ID_KEY = createContextKey("archestra.session_id");
  */
 export function getActiveSessionId(): string | undefined {
   return context.active().getValue(SESSION_ID_KEY) as string | undefined;
+}
+
+/** The originating agent invocation category, preserved across child spans. */
+export const CHAT_ROUTE_CATEGORY_KEY = createContextKey(
+  "archestra.chat_route_category",
+);
+
+export function getActiveChatRouteCategory(): RouteCategory | undefined {
+  return context.active().getValue(CHAT_ROUTE_CATEGORY_KEY) as
+    | RouteCategory
+    | undefined;
 }

--- a/platform/backend/src/observability/tracing/chat.ts
+++ b/platform/backend/src/observability/tracing/chat.ts
@@ -5,7 +5,10 @@ import {
   SpanStatusCode,
   trace,
 } from "@opentelemetry/api";
-import { SESSION_ID_KEY } from "@/observability/request-context";
+import {
+  CHAT_ROUTE_CATEGORY_KEY,
+  SESSION_ID_KEY,
+} from "@/observability/request-context";
 import type { AgentType } from "@/types";
 import {
   ATTR_ARCHESTRA_AGENT_LABEL_PREFIX,
@@ -60,7 +63,7 @@ export async function startActiveChatSpan<T>(params: {
   const spanName = `chat ${params.agentName}`;
 
   // Inject session ID into context so it's available to the pino mixin for log correlation
-  let ctx = context.active();
+  let ctx = context.active().setValue(CHAT_ROUTE_CATEGORY_KEY, routeCategory);
   if (params.sessionId) {
     ctx = ctx.setValue(SESSION_ID_KEY, params.sessionId);
   }

--- a/platform/backend/src/routes/chat/context-compaction-tracing.test.ts
+++ b/platform/backend/src/routes/chat/context-compaction-tracing.test.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from "node:crypto";
+import { context, type TracerProvider, trace } from "@opentelemetry/api";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import {
+  ATTR_ROUTE_CATEGORY,
+  RouteCategory,
+} from "@/observability/tracing/attributes";
+import { startActiveChatSpan } from "@/observability/tracing/chat";
+import { compactMessagesForChat } from "./context-compaction";
+
+describe("context compaction tracing", () => {
+  const exporter = new InMemorySpanExporter();
+  let sdk: NodeSDK;
+  let originalProvider: TracerProvider;
+
+  beforeAll(() => {
+    originalProvider = trace.getTracerProvider();
+    trace.disable();
+    sdk = new NodeSDK({
+      autoDetectResources: false,
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+      logRecordProcessors: [],
+    });
+    sdk.start();
+  });
+
+  afterEach(() => exporter.reset());
+
+  afterAll(async () => {
+    await sdk.shutdown();
+    trace.disable();
+    context.disable();
+    trace.setGlobalTracerProvider(originalProvider);
+  });
+
+  test.each([
+    RouteCategory.CHAT,
+    RouteCategory.A2A,
+    RouteCategory.CHATOPS,
+    RouteCategory.EMAIL,
+  ])("preserves %s through an intermediate async span", async (routeCategory) => {
+    await startActiveChatSpan({
+      agentId: randomUUID(),
+      agentName: "Test Agent",
+      routeCategory,
+      callback: () =>
+        trace
+          .getTracer("archestra")
+          .startActiveSpan("intermediate", async (span) => {
+            try {
+              await Promise.resolve();
+              const result = await compactMessagesForChat(compactionParams());
+              expect(result.status).toBe("skipped");
+            } finally {
+              span.end();
+            }
+          }),
+    });
+
+    const spans = exporter.getFinishedSpans();
+    const compaction = spans.find(
+      (span) => span.name === "context_compaction auto",
+    );
+    const parent = spans.find((span) => span.name === "intermediate");
+    expect(compaction?.attributes[ATTR_ROUTE_CATEGORY]).toBe(routeCategory);
+    expect(compaction?.attributes["archestra.context_compaction.reason"]).toBe(
+      "below_threshold",
+    );
+    expect(compaction?.parentSpanContext?.spanId).toBe(
+      parent?.spanContext().spanId,
+    );
+    expect(compaction?.spanContext().traceId).toBe(
+      parent?.spanContext().traceId,
+    );
+  });
+
+  test("uses chat for standalone manual compaction after an email invocation", async () => {
+    await startActiveChatSpan({
+      agentId: randomUUID(),
+      agentName: "Test Agent",
+      routeCategory: RouteCategory.EMAIL,
+      callback: async () => {},
+    });
+    await compactMessagesForChat({ ...compactionParams(), trigger: "manual" });
+
+    const compaction = exporter
+      .getFinishedSpans()
+      .find((span) => span.name === "context_compaction manual");
+    expect(compaction?.attributes[ATTR_ROUTE_CATEGORY]).toBe(
+      RouteCategory.CHAT,
+    );
+    expect(compaction?.attributes["archestra.context_compaction.reason"]).toBe(
+      "nothing_to_compact",
+    );
+  });
+});
+
+function compactionParams(): Parameters<typeof compactMessagesForChat>[0] {
+  return {
+    conversationId: randomUUID(),
+    organizationId: randomUUID(),
+    userId: randomUUID(),
+    provider: "openai",
+    selectedModel: "gpt-4o-mini",
+    messages: [],
+    trigger: "auto",
+  };
+}

--- a/platform/backend/src/routes/chat/context-compaction.ts
+++ b/platform/backend/src/routes/chat/context-compaction.ts
@@ -18,11 +18,14 @@ import {
   MessageModel,
   ModelModel,
 } from "@/models";
+import { getActiveChatRouteCategory } from "@/observability/request-context";
 import {
   ATTR_GENAI_CONVERSATION_ID,
   ATTR_GENAI_OPERATION_NAME,
   ATTR_GENAI_PROVIDER_NAME,
   ATTR_GENAI_REQUEST_MODEL,
+  ATTR_ROUTE_CATEGORY,
+  RouteCategory,
 } from "@/observability/tracing";
 import {
   CONTEXT_COMPACTION_MAX_OUTPUT_TOKENS,
@@ -409,6 +412,8 @@ async function startContextCompactionSpan<T>(
     {
       kind: SpanKind.INTERNAL,
       attributes: {
+        [ATTR_ROUTE_CATEGORY]:
+          getActiveChatRouteCategory() ?? RouteCategory.CHAT,
         [ATTR_GENAI_OPERATION_NAME]: CONTEXT_COMPACTION_TRACE_OPERATION,
         [ATTR_GENAI_PROVIDER_NAME]: params.provider,
         [ATTR_GENAI_REQUEST_MODEL]: params.selectedModel,


### PR DESCRIPTION
Context-compaction spans lacked `route.category`, so category-based OTLP filtering discarded them. They now inherit the originating agent invocation category (`chat`, `a2a`, `chatops`, or `email`) through OpenTelemetry context. Standalone manual compaction defaults to `chat`.

Using context preserves the category across intermediate spans without inspecting SDK-specific span attributes or threading tracing parameters through compaction callers. The observability docs describe the resulting labels.

Regression tests run real compaction decisions against PGlite and inspect spans exported by the OpenTelemetry SDK. They cover category inheritance through an asynchronous intermediate span, trace parenting, and standalone manual compaction after an email invocation. Removing the attribute reproduces the missing-category failures; restoring it makes the tests pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>