### PR TITLE
fix(github-copilot): honor account API endpoints

### DIFF
--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -3,7 +3,7 @@ title: Supported LLM Providers
 category: LLM Proxy
 order: 2
 description: LLM providers supported by Archestra Platform
-lastUpdated: 2026-09-08
+lastUpdated: 2026-09-11
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -706,6 +706,8 @@ Copilot models are also reachable through the model router as `github-copilot:<m
 
 A GitHub Copilot provider key stores a **long-lived GitHub OAuth token** (`gho_`/`ghu_…`) for an account with an active Copilot subscription — not a Copilot API key, which does not exist. Archestra exchanges that token for a short-lived Copilot bearer on every request (cached and refreshed automatically), so clients only ever present the GitHub token.
 
+Archestra uses the account API endpoint returned by GitHub, falling back to `https://api.githubcopilot.com` when absent. A custom base URL takes precedence.
+
 Obtain the token in either way:
 
 - **Sign in with GitHub**: click **Connect** on the **GitHub Copilot** card on **Model Providers**. It runs GitHub's OAuth device flow — you approve a one-time code at `github.com/login/device`, and Archestra stores the resulting token.
@@ -716,7 +718,7 @@ Obtain the token in either way:
 | Variable                                       | Required | Description                                                                                       |
 | ---------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `ARCHESTRA_CHAT_GITHUB_COPILOT_API_KEY`        | No       | Default GitHub OAuth token for Copilot (can be overridden per conversation/team/org)              |
-| `ARCHESTRA_GITHUB_COPILOT_BASE_URL`            | No       | Copilot API base URL (default: `https://api.githubcopilot.com`; GHE: `https://copilot-api.<domain>`) |
+| `ARCHESTRA_GITHUB_COPILOT_BASE_URL`            | No       | Custom Copilot API base URL; otherwise uses the account endpoint returned by GitHub |
 | `ARCHESTRA_GITHUB_COPILOT_TOKEN_EXCHANGE_URL`  | No       | GitHub token-exchange endpoint (default: `https://api.github.com/copilot_internal/v2/token`)      |
 | `ARCHESTRA_GITHUB_COPILOT_DEVICE_AUTH_BASE_URL`| No       | Host for the device-flow sign-in (default: `https://github.com`)                                  |
 | `ARCHESTRA_GITHUB_COPILOT_CLIENT_ID`           | No       | GitHub App client id for the device flow (default: the standard VS Code client id)                |

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -105,7 +105,7 @@ ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai
 # ARCHESTRA_OPENAI_CODEX_CLIENT_ID=app_EMoamEEZ73f0CkXaXp7hrann
 # `originator` header the Codex backend attributes traffic by (defaults to archestra, matching OpenCode's own-identity approach; override to codex_cli_rs if OpenAI ever restricts unknown originators)
 # ARCHESTRA_OPENAI_CODEX_ORIGINATOR=archestra
-# GitHub Copilot Base URL (optional - defaults to https://api.githubcopilot.com; GHE: https://copilot-api.<ghe-domain>)
+# GitHub Copilot Base URL (optional - a custom URL overrides the account endpoint returned by GitHub)
 # ARCHESTRA_GITHUB_COPILOT_BASE_URL=https://api.githubcopilot.com
 # GitHub Copilot token exchange endpoint (optional - swaps a GitHub OAuth token for a short-lived Copilot bearer)
 # ARCHESTRA_GITHUB_COPILOT_TOKEN_EXCHANGE_URL=https://api.github.com/copilot_internal/v2/token

--- a/platform/backend/src/routes/proxy/routes/github-copilot.test.ts
+++ b/platform/backend/src/routes/proxy/routes/github-copilot.test.ts
@@ -159,3 +159,125 @@ describe("GitHub Copilot proxy — upstream model rejection (T-959)", () => {
     expect(response.body).toContain("The requested model is not supported.");
   });
 });
+
+describe("GitHub Copilot Responses account routing", () => {
+  test.for([
+    false,
+    true,
+  ])("completes a Responses request at the exchanged API endpoint (stream=%s)", async (stream, {
+    makeAgent,
+  }) => {
+    const app = createTestApp();
+    await app.register(githubCopilotProxyRoutes);
+    const agent = await makeAgent({ name: "Copilot Responses Agent" });
+    const model = "gpt-5.3-codex";
+    const text = "Hello from Copilot";
+    const result = {
+      id: "resp_test",
+      object: "response",
+      created_at: 123,
+      model,
+      status: "completed",
+      output: [
+        {
+          id: "msg_test",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text, annotations: [] }],
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+    };
+    let upstreamCalls = 0;
+    // Drain MSW's response clone so the SDK can cancel its SSE reader when
+    // the proxy stops at response.completed without waiting on the other tee.
+    const drainResponse = ({ response }: { response: Response }) => {
+      void response.arrayBuffer();
+    };
+    server.events.on("response:mocked", drainResponse);
+    server.use(
+      http.get(COPILOT_TOKEN_EXCHANGE_URL, () =>
+        HttpResponse.json({
+          token: "copilot-responses-bearer",
+          expires_at: Math.floor(Date.now() / 1000) + 1800,
+          endpoints: { api: "https://api.business.githubcopilot.com" },
+        }),
+      ),
+      http.post("https://api.githubcopilot.com/responses", () =>
+        HttpResponse.json(
+          {
+            error: { message: "", type: "api_not_found_error" },
+          },
+          { status: 404 },
+        ),
+      ),
+      http.post(
+        "https://api.business.githubcopilot.com/responses",
+        async ({ request }) => {
+          upstreamCalls++;
+          expect(request.headers.get("authorization")).toBe(
+            "Bearer copilot-responses-bearer",
+          );
+          expect(request.headers.get("copilot-integration-id")).toBe(
+            "vscode-chat",
+          );
+          expect(await request.json()).toMatchObject({ model, stream });
+          if (!stream) return HttpResponse.json(result);
+          const events = [
+            {
+              type: "response.created",
+              response: { ...result, status: "in_progress", output: [] },
+            },
+            {
+              type: "response.output_item.added",
+              output_index: 0,
+              item: { ...result.output[0], content: [] },
+            },
+            {
+              type: "response.output_text.delta",
+              output_index: 0,
+              content_index: 0,
+              item_id: "msg_test",
+              delta: text,
+            },
+            {
+              type: "response.output_item.done",
+              output_index: 0,
+              item: result.output[0],
+            },
+            { type: "response.completed", response: result },
+          ];
+          return new HttpResponse(
+            events
+              .map(
+                (event) =>
+                  `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+              )
+              .join(""),
+            {
+              headers: { "content-type": "text/event-stream" },
+            },
+          );
+        },
+      ),
+    );
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/github-copilot/${agent.id}/responses`,
+        headers: { authorization: `Bearer ${uniqueGithubToken()}` },
+        payload: { model, input: "Hello", stream },
+      });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.body).toContain(text);
+      expect(upstreamCalls).toBe(1);
+      if (stream) expect(response.body).toContain("response.completed");
+      else
+        expect(response.json()).toMatchObject({ model, output: result.output });
+    } finally {
+      server.events.removeListener("response:mocked", drainResponse);
+      await app.close();
+    }
+  });
+});

--- a/platform/backend/src/services/github-copilot-token.test.ts
+++ b/platform/backend/src/services/github-copilot-token.test.ts
@@ -19,9 +19,11 @@ function uniqueGithubToken(): string {
 function exchangeResponse(params?: {
   token?: string;
   expiresInSeconds?: number;
+  apiEndpoint?: string;
 }): Response {
   return Response.json({
     token: params?.token ?? "copilot-bearer",
+    endpoints: { api: params?.apiEndpoint },
     expires_at:
       Math.floor(Date.now() / 1000) + (params?.expiresInSeconds ?? 1800),
   });
@@ -31,13 +33,13 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("githubCopilotTokenManager.getBearerToken", () => {
+describe("githubCopilotTokenManager.getCredentials", () => {
   test("exchanges the GitHub token with the token scheme and editor headers", async () => {
     const githubToken = uniqueGithubToken();
     const fetchMock = vi.fn().mockResolvedValue(exchangeResponse());
     vi.stubGlobal("fetch", fetchMock);
 
-    const bearer = await githubCopilotTokenManager.getBearerToken(githubToken);
+    const bearer = await getBearerToken(githubToken);
 
     expect(bearer).toBe("copilot-bearer");
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -51,8 +53,8 @@ describe("githubCopilotTokenManager.getBearerToken", () => {
     const fetchMock = vi.fn().mockResolvedValue(exchangeResponse());
     vi.stubGlobal("fetch", fetchMock);
 
-    await githubCopilotTokenManager.getBearerToken(githubToken);
-    await githubCopilotTokenManager.getBearerToken(githubToken);
+    await getBearerToken(githubToken);
+    await getBearerToken(githubToken);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
@@ -68,8 +70,8 @@ describe("githubCopilotTokenManager.getBearerToken", () => {
       .mockResolvedValueOnce(exchangeResponse({ token: "fresh" }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await githubCopilotTokenManager.getBearerToken(githubToken);
-    const bearer = await githubCopilotTokenManager.getBearerToken(githubToken);
+    await getBearerToken(githubToken);
+    const bearer = await getBearerToken(githubToken);
 
     expect(bearer).toBe("fresh");
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -87,8 +89,8 @@ describe("githubCopilotTokenManager.getBearerToken", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const [first, second] = [
-      githubCopilotTokenManager.getBearerToken(githubToken),
-      githubCopilotTokenManager.getBearerToken(githubToken),
+      getBearerToken(githubToken),
+      getBearerToken(githubToken),
     ];
     resolveExchange(exchangeResponse());
 
@@ -105,11 +107,9 @@ describe("githubCopilotTokenManager.getBearerToken", () => {
       .mockResolvedValueOnce(exchangeResponse());
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(
-      githubCopilotTokenManager.getBearerToken(githubToken),
-    ).rejects.toThrow(ApiError);
+    await expect(getBearerToken(githubToken)).rejects.toThrow(ApiError);
 
-    const bearer = await githubCopilotTokenManager.getBearerToken(githubToken);
+    const bearer = await getBearerToken(githubToken);
     expect(bearer).toBe("copilot-bearer");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -121,9 +121,7 @@ describe("githubCopilotTokenManager.getBearerToken", () => {
       vi.fn().mockResolvedValue(new Response("forbidden", { status: 403 })),
     );
 
-    await expect(
-      githubCopilotTokenManager.getBearerToken(githubToken),
-    ).rejects.toMatchObject({
+    await expect(getBearerToken(githubToken)).rejects.toMatchObject({
       statusCode: 401,
       message: expect.stringContaining("Copilot subscription"),
     });
@@ -136,9 +134,9 @@ describe("githubCopilotTokenManager.getBearerToken", () => {
       vi.fn().mockResolvedValue(Response.json({ unexpected: true })),
     );
 
-    await expect(
-      githubCopilotTokenManager.getBearerToken(githubToken),
-    ).rejects.toMatchObject({ statusCode: 502 });
+    await expect(getBearerToken(githubToken)).rejects.toMatchObject({
+      statusCode: 502,
+    });
   });
 
   test("invalidate() with a stale bearer keeps an already-refreshed entry", async () => {
@@ -148,14 +146,10 @@ describe("githubCopilotTokenManager.getBearerToken", () => {
       .mockResolvedValueOnce(exchangeResponse({ token: "fresh" }));
     vi.stubGlobal("fetch", fetchMock);
 
-    expect(await githubCopilotTokenManager.getBearerToken(githubToken)).toBe(
-      "fresh",
-    );
+    expect(await getBearerToken(githubToken)).toBe("fresh");
     // A concurrent 401 handler that used an older bearer must not evict it.
     githubCopilotTokenManager.invalidate(githubToken, "stale");
-    expect(await githubCopilotTokenManager.getBearerToken(githubToken)).toBe(
-      "fresh",
-    );
+    expect(await getBearerToken(githubToken)).toBe("fresh");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -167,17 +161,54 @@ describe("githubCopilotTokenManager.getBearerToken", () => {
       .mockResolvedValueOnce(exchangeResponse({ token: "second" }));
     vi.stubGlobal("fetch", fetchMock);
 
-    expect(await githubCopilotTokenManager.getBearerToken(githubToken)).toBe(
-      "first",
-    );
+    expect(await getBearerToken(githubToken)).toBe("first");
     githubCopilotTokenManager.invalidate(githubToken);
-    expect(await githubCopilotTokenManager.getBearerToken(githubToken)).toBe(
-      "second",
-    );
+    expect(await getBearerToken(githubToken)).toBe("second");
   });
 });
 
 describe("createGithubCopilotFetch", () => {
+  test.each([
+    [
+      "https://api.githubcopilot.com/responses",
+      "https://api.business.githubcopilot.com/responses",
+    ],
+    [
+      "https://api.githubcopilot.com/chat/completions",
+      "https://api.business.githubcopilot.com/chat/completions",
+    ],
+    [
+      "https://api.githubcopilot.com/models?limit=10",
+      "https://api.business.githubcopilot.com/models?limit=10",
+    ],
+    [
+      "https://copilot-api.example.com/responses",
+      "https://copilot-api.example.com/responses",
+    ],
+    [
+      "http://localhost:8080/copilot/responses",
+      "http://localhost:8080/copilot/responses",
+    ],
+  ])("routes %s using the account endpoint while preserving custom URLs", async (input, expected) => {
+    const githubToken = uniqueGithubToken();
+    const exchangeMock = vi.fn().mockResolvedValue(
+      exchangeResponse({
+        apiEndpoint: "https://api.business.githubcopilot.com/",
+      }),
+    );
+    vi.stubGlobal("fetch", exchangeMock);
+    const innerFetch = vi.fn().mockImplementation(async (url, init) => {
+      expect(String(url)).toBe(expected);
+      expect(init.headers.get("authorization")).toBe("Bearer copilot-bearer");
+      return new Response("ok");
+    });
+    const copilotFetch = createGithubCopilotFetch({ githubToken, innerFetch });
+    await copilotFetch(input);
+    await copilotFetch(input);
+    expect(exchangeMock).toHaveBeenCalledTimes(1);
+    expect(innerFetch).toHaveBeenCalledTimes(2);
+  });
+
   test("injects the exchanged bearer and Copilot headers into requests", async () => {
     const githubToken = uniqueGithubToken();
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(exchangeResponse()));
@@ -191,7 +222,8 @@ describe("createGithubCopilotFetch", () => {
     });
 
     expect(innerFetch).toHaveBeenCalledTimes(1);
-    const [, init] = innerFetch.mock.calls[0];
+    const [url, init] = innerFetch.mock.calls[0];
+    expect(url).toBe("https://api.githubcopilot.com/chat/completions");
     const headers = init.headers as Headers;
     expect(headers.get("authorization")).toBe("Bearer copilot-bearer");
     expect(headers.get("copilot-integration-id")).toBe("vscode-chat");
@@ -203,8 +235,18 @@ describe("createGithubCopilotFetch", () => {
     const githubToken = uniqueGithubToken();
     const exchangeMock = vi
       .fn()
-      .mockResolvedValueOnce(exchangeResponse({ token: "stale" }))
-      .mockResolvedValueOnce(exchangeResponse({ token: "fresh" }));
+      .mockResolvedValueOnce(
+        exchangeResponse({
+          token: "stale",
+          apiEndpoint: "https://api.individual.githubcopilot.com",
+        }),
+      )
+      .mockResolvedValueOnce(
+        exchangeResponse({
+          token: "fresh",
+          apiEndpoint: "https://api.business.githubcopilot.com",
+        }),
+      );
     vi.stubGlobal("fetch", exchangeMock);
 
     const innerFetch = vi
@@ -223,6 +265,12 @@ describe("createGithubCopilotFetch", () => {
     expect(innerFetch).toHaveBeenCalledTimes(2);
     const retryHeaders = innerFetch.mock.calls[1][1].headers as Headers;
     expect(retryHeaders.get("authorization")).toBe("Bearer fresh");
+    expect(String(innerFetch.mock.calls[0][0])).toBe(
+      "https://api.individual.githubcopilot.com/chat/completions",
+    );
+    expect(String(innerFetch.mock.calls[1][0])).toBe(
+      "https://api.business.githubcopilot.com/chat/completions",
+    );
   });
 
   test("does not retry a 401 when the body is not replayable", async () => {
@@ -284,3 +332,7 @@ describe("createGithubCopilotFetch", () => {
     expect(init).toBeUndefined();
   });
 });
+
+async function getBearerToken(githubToken: string): Promise<string> {
+  return (await githubCopilotTokenManager.getCredentials(githubToken)).bearer;
+}

--- a/platform/backend/src/services/github-copilot-token.ts
+++ b/platform/backend/src/services/github-copilot-token.ts
@@ -39,18 +39,18 @@ class GithubCopilotTokenManager {
   private bearerCache = new LRUCacheManager<CachedBearer>({
     maxSize: MAX_CACHED_BEARERS,
   });
-  private inFlightExchanges = new Map<string, Promise<string>>();
+  private inFlightExchanges = new Map<string, Promise<CachedBearer>>();
 
   /**
-   * Returns a valid Copilot API bearer for the given GitHub OAuth token,
+   * Returns a valid Copilot bearer and account API endpoint for a GitHub token,
    * exchanging (and caching) it if needed.
    */
-  async getBearerToken(githubToken: string): Promise<string> {
+  async getCredentials(githubToken: string): Promise<CachedBearer> {
     const cacheKey = hashToken(githubToken);
 
     const cached = this.bearerCache.get(cacheKey);
     if (cached && cached.expiresAtMs - REFRESH_BUFFER_MS > Date.now()) {
-      return cached.bearer;
+      return cached;
     }
 
     const inFlight = this.inFlightExchanges.get(cacheKey);
@@ -86,7 +86,7 @@ class GithubCopilotTokenManager {
   private async exchangeToken(
     githubToken: string,
     cacheKey: string,
-  ): Promise<string> {
+  ): Promise<CachedBearer> {
     const response = await fetch(
       config.llm["github-copilot"].tokenExchangeUrl,
       {
@@ -120,6 +120,7 @@ class GithubCopilotTokenManager {
     const payload = (await response.json()) as {
       token?: string;
       expires_at?: number;
+      endpoints?: { api?: string };
     };
     if (!payload.token || typeof payload.expires_at !== "number") {
       throw new ApiError(
@@ -129,13 +130,18 @@ class GithubCopilotTokenManager {
     }
 
     const expiresAtMs = payload.expires_at * 1000;
+    const credentials = {
+      bearer: payload.token,
+      expiresAtMs,
+      apiEndpoint: payload.endpoints?.api,
+    };
     this.bearerCache.set(
       cacheKey,
-      { bearer: payload.token, expiresAtMs },
+      credentials,
       // LRU TTL is a backstop; freshness is enforced via expiresAtMs above.
       Math.max(expiresAtMs - Date.now(), 0),
     );
-    return payload.token;
+    return credentials;
   }
 }
 
@@ -145,7 +151,8 @@ export const githubCopilotTokenManager = new GithubCopilotTokenManager();
 /**
  * Wraps fetch so every Copilot request carries a fresh short-lived bearer
  * (exchanged from the GitHub OAuth token) plus the required editor-identity
- * headers. A 401 on a cached bearer invalidates it and retries exactly once.
+ * headers. Requests to the default host use the account endpoint returned by
+ * the exchange. A 401 refreshes both the bearer and endpoint and retries once.
  *
  * Used by the github-copilot proxy adapter, its /models routes, and the model
  * fetcher (the chat LLM client routes through the local proxy instead, so the
@@ -170,22 +177,27 @@ export function createGithubCopilotFetch(params: {
       return baseFetch(input, init);
     }
 
-    const doFetch = async (bearer: string) => {
-      const headers = new Headers(init?.headers);
+    const doFetch = async (credentials: CachedBearer) => {
+      const headers = new Headers(
+        init?.headers ?? (input instanceof Request ? input.headers : undefined),
+      );
       for (const [name, value] of Object.entries(GITHUB_COPILOT_HEADERS)) {
         headers.set(name, value);
       }
-      headers.set("authorization", `Bearer ${bearer}`);
-      return baseFetch(input, { ...init, headers });
+      headers.set("authorization", `Bearer ${credentials.bearer}`);
+      return baseFetch(
+        resolveCopilotRequestUrl(input, credentials.apiEndpoint),
+        { ...init, headers },
+      );
     };
 
-    let bearer: string;
+    let credentials: CachedBearer;
     try {
-      bearer = await githubCopilotTokenManager.getBearerToken(githubToken);
+      credentials = await githubCopilotTokenManager.getCredentials(githubToken);
     } catch (error) {
       return exchangeErrorResponse(error);
     }
-    const response = await doFetch(bearer);
+    const response = await doFetch(credentials);
 
     // A cached bearer can be rejected before its reported expiry (e.g. seat
     // revoked, token rotated). Re-exchange once; non-replayable bodies are
@@ -194,15 +206,15 @@ export function createGithubCopilotFetch(params: {
       init?.body === undefined || typeof init.body === "string";
     if (response.status === 401 && bodyIsReplayable) {
       await response.body?.cancel();
-      githubCopilotTokenManager.invalidate(githubToken, bearer);
-      let freshBearer: string;
+      githubCopilotTokenManager.invalidate(githubToken, credentials.bearer);
+      let freshCredentials: CachedBearer;
       try {
-        freshBearer =
-          await githubCopilotTokenManager.getBearerToken(githubToken);
+        freshCredentials =
+          await githubCopilotTokenManager.getCredentials(githubToken);
       } catch (error) {
         return exchangeErrorResponse(error);
       }
-      return doFetch(freshBearer);
+      return doFetch(freshCredentials);
     }
 
     return response;
@@ -219,6 +231,7 @@ type FetchLike = (
 interface CachedBearer {
   bearer: string;
   expiresAtMs: number;
+  apiEndpoint?: string;
 }
 
 /** Refresh this long before the bearer's reported expiry. */
@@ -254,4 +267,20 @@ const TOKEN_CACHE_HMAC_KEY = randomBytes(32);
 // keys can't pre-compute lookups against known token formats.
 function hashToken(token: string): string {
   return createHmac("sha256", TOKEN_CACHE_HMAC_KEY).update(token).digest("hex");
+}
+
+/** Use GitHub's account endpoint only for requests to the default API host. */
+function resolveCopilotRequestUrl(
+  input: string | URL | Request,
+  apiEndpoint: string | undefined,
+): string | URL | Request {
+  if (!apiEndpoint) return input;
+  const url = new URL(input instanceof Request ? input.url : input);
+  // Explicit custom base URLs (including GHE and local proxies) take precedence.
+  if (url.origin !== "https://api.githubcopilot.com") return input;
+  const base = new URL(apiEndpoint);
+  base.pathname = `${base.pathname.replace(/\/$/, "")}${url.pathname}`;
+  base.search = url.search;
+  base.hash = "";
+  return input instanceof Request ? new Request(base, input) : base;
 }


### PR DESCRIPTION
Archestra discarded the account API endpoint returned by the Copilot token exchange and always sent requests to the generic host. Cache `endpoints.api` alongside the bearer and use it for Responses, Chat Completions, and model discovery requests. Refresh both together on a 401; retain the generic-host fallback and custom base URLs. This follows the endpoint selection in the [official Copilot client](https://github.com/microsoft/vscode-copilot-chat/blob/main/src/platform/endpoint/node/domainServiceImpl.ts).

Regression tests exercise the real Responses route, SDK, and token exchange with mocked HTTP: the generic host returns 404 while the account endpoint completes the response. Both streaming and non-streaming tests fail before the fix and pass afterward. Coverage also checks cached endpoints, endpoint changes after token refresh, and custom URLs. No live Copilot request was made, so the reported account-specific failure still needs confirmation.

Addresses #7790.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>