### PR TITLE
ci(backport): process requests on main pushes and labels

### DIFF
--- a/.github/scripts/backport.py
+++ b/.github/scripts/backport.py
@@ -50,6 +50,8 @@ class Backporter:
         default = self.api(f"repos/{self.repo}")["default_branch"]
         if not pr["merged"] or pr["base"]["ref"] != default:
             raise ValueError("Only merged default-branch PRs can be backported")
+        if (pr.get("head", {}).get("repo") or {}).get("full_name") != self.repo:
+            raise ValueError("Only PRs from branches in this repository can be backported")
         sha = pr["merge_commit_sha"]
         if not re.fullmatch(r"[0-9a-f]{40}", sha):
             raise ValueError("Invalid merge commit SHA")

--- a/.github/scripts/test_backport.py
+++ b/.github/scripts/test_backport.py
@@ -82,6 +82,16 @@ class BackportTests(unittest.TestCase):
         self.git("commit", "-qm", message)
         return self.git("rev-parse", "HEAD")
 
+    def test_label_before_merge_is_processed_by_later_scan_once(self):
+        self.pr["merged"] = False
+        self.bot.poll()
+        self.assertEqual(self.bot.pulls, [])
+        self.pr["merged"] = True
+        self.bot.poll()
+        self.bot.poll()
+        self.assertEqual(len(self.bot.pulls), 1)
+        self.assertEqual(self.bot.pulls[0]["base"], "release/1.3")
+
     def test_opens_a_backport_with_provenance_without_changing_stable(self):
         stable = self.git("rev-parse", "origin/release/1.3")
         self.bot.run(42)
@@ -203,6 +213,33 @@ class BackportTests(unittest.TestCase):
 
 
 class WorkflowPolicyTests(unittest.TestCase):
+    def test_event_gate_only_allows_trusted_merged_backport_requests(self):
+        workflow = Path(__file__).parents[1] / "workflows/backport.yml"
+        condition = next(line.split("if: ", 1)[1] for line in workflow.read_text().splitlines()
+                         if line.startswith("    if: "))
+        program = r"""
+const vm = require('node:vm');
+const assert = require('node:assert/strict');
+const condition = process.argv[1];
+function allowed(eventName, {merged = true, base = 'main', label = 'backport release/1.3', repo = 'archestra-ai/archestra'} = {}) {
+  const github = {repository: repo, event_name: eventName, event: {repository:{default_branch:'main'}}};
+  if (eventName === 'pull_request_target') {
+    github.event.pull_request = {merged, base:{ref:base}, head:{repo:{full_name:'contributor/fork'}}};
+    github.event.label = {name:label};
+  }
+  return vm.runInNewContext(condition, {github, startsWith:(value, prefix) => value.startsWith(prefix)});
+}
+for (const eventName of ['push', 'schedule', 'workflow_dispatch', 'pull_request_target']) {
+  assert.equal(allowed(eventName), true, eventName);
+  assert.equal(allowed(eventName, {repo:'contributor/fork'}), false, eventName);
+}
+assert.equal(allowed('pull_request_target', {merged:false}), false);
+assert.equal(allowed('pull_request_target', {base:'release/1.3'}), false);
+assert.equal(allowed('pull_request_target', {label:'bug'}), false);
+assert.equal(allowed('pull_request_target', {label:'not-backport release/1.3'}), false);
+"""
+        subprocess.run(["node", "-e", program, condition], check=True)
+
     def test_backport_prs_run_checks_while_release_bot_prs_remain_exempt(self):
         workflow = Path(__file__).parents[1] / "workflows/on-pull-requests.yml"
         conditions = [line.split("if: ", 1)[1] for line in workflow.read_text().splitlines()

--- a/.github/scripts/test_backport.py
+++ b/.github/scripts/test_backport.py
@@ -71,6 +71,7 @@ class BackportTests(unittest.TestCase):
         self.git("push", "origin", "main")
         self.pr = {"number": 42, "title": "fix: correct feature", "merged": True,
                    "base": {"ref": "main"}, "merge_commit_sha": sha,
+                   "head": {"repo": {"full_name": "fixture/repository"}},
                    "labels": [{"name": "backport release/1.3"}]}
         self.bot = FakeGitHubBackporter(self.repo, self.pr)
 
@@ -81,6 +82,19 @@ class BackportTests(unittest.TestCase):
         self.git("add", ".")
         self.git("commit", "-qm", message)
         return self.git("rev-parse", "HEAD")
+
+    def test_fork_and_deleted_source_repositories_are_ineligible(self):
+        for repository in [{"full_name": "contributor/fork"}, None]:
+            with self.subTest(repository=repository):
+                self.pr["head"]["repo"] = repository
+                with self.assertRaisesRegex(ValueError, "branches in this repository"):
+                    self.bot.run(42)
+                with self.assertRaisesRegex(ValueError, "branches in this repository"):
+                    self.bot.run(42, "release/1.3")
+                self.bot.poll()
+                self.assertEqual(self.bot.pulls, [])
+                self.assertEqual(self.bot.comments, [])
+                self.assertEqual(self.git("ls-remote", "--heads", "origin", "refs/heads/backport/*"), "")
 
     def test_label_before_merge_is_processed_by_later_scan_once(self):
         self.pr["merged"] = False
@@ -221,22 +235,23 @@ class WorkflowPolicyTests(unittest.TestCase):
 const vm = require('node:vm');
 const assert = require('node:assert/strict');
 const condition = process.argv[1];
-function allowed(eventName, {merged = true, base = 'main', label = 'backport release/1.3', repo = 'archestra-ai/archestra'} = {}) {
+function allowed(eventName, {merged = true, base = 'main', label = 'backport release/1.3', repo = 'archestra-ai/archestra', headRepo = 'archestra-ai/archestra'} = {}) {
   const github = {repository: repo, event_name: eventName, event: {repository:{default_branch:'main'}}};
-  if (eventName === 'pull_request_target') {
-    github.event.pull_request = {merged, base:{ref:base}, head:{repo:{full_name:'contributor/fork'}}};
+  if (eventName === 'pull_request') {
+    github.event.pull_request = {merged, base:{ref:base}, head:{repo:headRepo === null ? null : {full_name:headRepo}}};
     github.event.label = {name:label};
   }
   return vm.runInNewContext(condition, {github, startsWith:(value, prefix) => value.startsWith(prefix)});
 }
-for (const eventName of ['push', 'schedule', 'workflow_dispatch', 'pull_request_target']) {
+for (const eventName of ['push', 'schedule', 'workflow_dispatch', 'pull_request']) {
   assert.equal(allowed(eventName), true, eventName);
   assert.equal(allowed(eventName, {repo:'contributor/fork'}), false, eventName);
 }
-assert.equal(allowed('pull_request_target', {merged:false}), false);
-assert.equal(allowed('pull_request_target', {base:'release/1.3'}), false);
-assert.equal(allowed('pull_request_target', {label:'bug'}), false);
-assert.equal(allowed('pull_request_target', {label:'not-backport release/1.3'}), false);
+assert.equal(allowed('pull_request', {merged:false}), false);
+assert.equal(allowed('pull_request', {headRepo:'contributor/fork'}), false);
+assert.equal(allowed('pull_request', {base:'release/1.3'}), false);
+assert.equal(allowed('pull_request', {label:'bug'}), false);
+assert.equal(allowed('pull_request', {label:'not-backport release/1.3'}), false);
 """
         subprocess.run(["node", "-e", program, condition], check=True)
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,8 +1,15 @@
 name: Open Backport PRs
 
 on:
-  # Poll from the trusted default branch, matching reviewer assignment's
-  # approach. This also handles labels added after merge and fork-origin PRs.
+  push:
+    branches: [main]
+  # Labels on merged fork PRs need the base repository's App credentials.
+  # Only merged main PRs pass the job gate. Checkout is always the trusted
+  # default branch; no event text, PR code, artifacts, or hooks are executed.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    branches: [main]
+    types: [labeled]
+  # Recover after event/API failures. GitHub can delay scheduled runs.
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:
@@ -20,12 +27,15 @@ permissions:
   contents: read
 
 concurrency:
+  # Every automatic run scans all outstanding labels, so replacement of a
+  # pending run by a newer event cannot drop that pending run's requests.
   group: backport-requests
   cancel-in-progress: false
 
 jobs:
   backport:
     name: Open requested backport PRs
+    if: github.repository == 'archestra-ai/archestra' && (github.event_name != 'pull_request_target' || (github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch && startsWith(github.event.label.name, 'backport ')))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -3,10 +3,8 @@ name: Open Backport PRs
 on:
   push:
     branches: [main]
-  # Labels on merged fork PRs need the base repository's App credentials.
-  # Only merged main PRs pass the job gate. Checkout is always the trusted
-  # default branch; no event text, PR code, artifacts, or hooks are executed.
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
+  # Only merged PRs from branches in this repository can request backports.
+  pull_request:
     branches: [main]
     types: [labeled]
   # Recover after event/API failures. GitHub can delay scheduled runs.
@@ -35,7 +33,7 @@ concurrency:
 jobs:
   backport:
     name: Open requested backport PRs
-    if: github.repository == 'archestra-ai/archestra' && (github.event_name != 'pull_request_target' || (github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch && startsWith(github.event.label.name, 'backport ')))
+    if: github.repository == 'archestra-ai/archestra' && (github.event_name != 'pull_request' || (github.event.pull_request.merged && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref == github.event.repository.default_branch && startsWith(github.event.label.name, 'backport ')))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/platform/dev/RELEASE.md
+++ b/platform/dev/RELEASE.md
@@ -54,7 +54,8 @@ gitGraph
 Add each new stable or candidate branch there, and create its `backport release/X.Y` label.
 Remove retired branches from that list when making them read-only.
 The workflow always runs trusted automation from the default branch, including manual retries.
-Label events only run for merged PRs targeting the default branch.
+Automatic backports only accept merged PRs from branches in this repository targeting the default branch.
+PRs from forks are ineligible, including through scheduled scans and manual retries.
 Each automatic run scans all outstanding labels, so overlapping triggers can share one job.
 
 Use **Open Backport PRs → Run workflow** to retry a merged main PR.

--- a/platform/dev/RELEASE.md
+++ b/platform/dev/RELEASE.md
@@ -35,7 +35,9 @@ gitGraph
 
 1. [ ] Land the fix on `main` first. The fix ships automatically in the next beta.
 2. [ ] Add the label `backport release/X.Y` for each configured target (for example, `backport release/1.3`).
-   - The label can be added before or after the main PR merges. The workflow checks requests every five minutes.
+   - Add the label before or after the main PR merges.
+   - Pushes to `main` and backport labels added after merge trigger processing without waiting for the scheduled scan.
+   - A five-minute schedule retries outstanding requests. GitHub can delay scheduled runs; the interval is not a delivery guarantee.
    - **Open Backport PRs** cherry-picks the merged commit with `-x` and opens a separate PR per target.
    - The automation opens PRs; it never merges them or approves stable publication.
 3. [ ] Review each generated backport PR, confirm its checks pass, then add it to that branch's merge queue.
@@ -52,6 +54,8 @@ gitGraph
 Add each new stable or candidate branch there, and create its `backport release/X.Y` label.
 Remove retired branches from that list when making them read-only.
 The workflow always runs trusted automation from the default branch, including manual retries.
+Label events only run for merged PRs targeting the default branch.
+Each automatic run scans all outstanding labels, so overlapping triggers can share one job.
 
 Use **Open Backport PRs → Run workflow** to retry a merged main PR.
 Supply its number and, optionally, one configured target branch.


### PR DESCRIPTION
Backport requests currently wait for a scheduled GitHub Actions run, which can arrive substantially later than its five-minute interval. Trigger the existing workflow on pushes to main and backport labels added to merged main PRs from branches in this repository. Retain the scheduled scan for recovery and manual dispatch for retries.

All automatic triggers use the same job and existing backport script. Each run scans outstanding labels, so overlapping events can coalesce without dropping requests or creating duplicate PRs. Update `platform/dev/RELEASE.md` to explain eligibility, triggers, and scheduling limits.

Label events use ordinary `pull_request: labeled`, gated on a merged main PR whose source repository matches this repository. The script also rejects fork-origin PRs during scans and manual retries. Checkout remains on the trusted default branch. No privileged PR trigger or workflow-security exception is needed.

Tests execute the workflow's actual job condition across eligible same-repository PRs, unmerged PRs, release-target PRs, unrelated labels, and forks. Real-Git tests verify that fork/deleted-repository sources produce no branches or PRs through scans or retries, a label applied before merge is picked up by a later scan, and repeated scans create only one backport. Local workflow security validation reports no findings or exceptions.

The `backport release/1.3` label requests the stable companion after main merges. Automation remains centralized on main; the backport keeps stable's workflow and release instructions aligned.
