### PR TITLE
test(release): replay released-tag stable upgrades in PR validation

### DIFF
--- a/.agents/skills/managing-archestra-releases/SKILL.md
+++ b/.agents/skills/managing-archestra-releases/SKILL.md
@@ -21,8 +21,8 @@ Starting a new stable branch adds configuration steps. It uses the same stable p
 
 1. Land fixes on `main` first. Fixes on `main` ship automatically in the next beta release.
 2. Read `.github/backport-targets.json` and apply `backport release/X.Y` labels to the source PR for the configured targets. Labels work before or after merge. **Open Backport PRs** creates separate `cherry-pick -x` PRs; it never merges or approves a release.
-3. Monitor the resulting backport PRs and their checks. Review the release-specific diff before queueing them under the user's merge authorization.
-4. On conflicts, use the manual `cherry-pick -x` procedure in `platform/dev/RELEASE.md`. Include only necessary fixes; no features, refactors, or schema changes. Never merge `main` into release or candidate branches.
+3. Monitor the resulting backport PRs and their checks — including the cross-track migration compatibility check and the released-tag upgrade replay. Review the release-specific diff before queueing them under the user's merge authorization.
+4. On conflicts, use the manual `cherry-pick -x` procedure in `platform/dev/RELEASE.md`. Include only necessary fixes; no features, refactors, or schema changes. Never merge `main` into release or candidate branches. A migration backport is only permissible under the prefix rule in `platform/dev/RELEASE.md` (the stable branch's migration history must remain a prefix of main's, matched by SQL content); forward repairs on `main` recover already-shipped gaps and are never a planned backport path.
 5. Retry API failures through **Open Backport PRs** workflow dispatch. Existing PRs are not duplicated or reopened, and existing branches are not overwritten. Investigate an unexpected existing branch instead of deleting it.
 6. During stable cutover, update the configured targets and their labels to include the new branch and remove the retired line. The automation's source of truth is the default branch.
 

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -356,7 +356,11 @@ jobs:
       # The credential helper is passed with -c so it applies to this one
       # command only: the token stays in the environment, never reaching argv,
       # .git/config, or any later step.
-      - name: Fetch base ref for the migration linter
+      # The release tag fetch feeds the released-tag upgrade replay matrix
+      # (backend test:migration-upgrades), which migrates a database with each
+      # active stable line's latest released history before upgrading it to
+      # this PR's history.
+      - name: Fetch base ref and release tags for migration checks
         env:
           GH_TOKEN: ${{ github.token }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -365,7 +369,8 @@ jobs:
               -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
               fetch --depth=1 origin \
               "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}" \
-              "+refs/heads/release/*:refs/remotes/origin/release/*"
+              "+refs/heads/release/*:refs/remotes/origin/release/*" \
+              "+refs/tags/platform-v*:refs/tags/platform-v*"
 
       - name: Check migration upgrade paths across release tracks
         env:
@@ -382,7 +387,7 @@ jobs:
           pnpm exec turbo check:ci --filter=!@backend
           pnpm exec turbo check:commit --filter=@backend
 
-      - name: Test release-track migration repairs
+      - name: Test migration upgrades across release tracks
         run: pnpm --dir backend test:migration-upgrades
 
       - name: Release skill harness

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -803,13 +803,35 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
 
+      # apt mirror outages must not fail the job when the runner image already
+      # carries Chromium's system libraries: retry install-deps, then prove the
+      # browser launches instead of trusting apt's exit code.
       - name: Install Chromium for Playwright
         if: runner.os == 'Linux' && steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @frontend exec playwright install --with-deps chromium
+        run: |
+          pnpm --filter @frontend exec playwright install chromium
+          for attempt in 1 2 3; do
+            if pnpm --filter @frontend exec playwright install-deps chromium; then
+              exit 0
+            fi
+            echo "install-deps attempt ${attempt} failed; retrying in 20s"
+            sleep 20
+          done
+          echo "install-deps failed; verifying Chromium launches with existing system libraries"
+          pnpm --filter @frontend exec playwright screenshot --browser chromium about:blank /tmp/chromium-deps-check.png
 
       - name: Install Chromium system dependencies
         if: runner.os == 'Linux' && steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter @frontend exec playwright install-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm --filter @frontend exec playwright install-deps chromium; then
+              exit 0
+            fi
+            echo "install-deps attempt ${attempt} failed; retrying in 20s"
+            sleep 20
+          done
+          echo "install-deps failed; verifying Chromium launches with existing system libraries"
+          pnpm --filter @frontend exec playwright screenshot --browser chromium about:blank /tmp/chromium-deps-check.png
 
       - name: Install Chromium (macOS)
         # No system deps to install on macOS; a version already present in

--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -19,7 +19,7 @@
     "dev": "tsdown --watch",
     "dev:debug": "DEBUG=1 tsdown --watch",
     "test": "vitest",
-    "test:migration-upgrades": "node --test scripts/migration-upgrades.test.mjs",
+    "test:migration-upgrades": "node --test scripts/migration-upgrades.test.mjs scripts/migration-tag-upgrades.test.mjs",
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "lint:fix:unsafe": "biome check --write --unsafe",

--- a/platform/backend/scripts/migration-tag-upgrades.test.mjs
+++ b/platform/backend/scripts/migration-tag-upgrades.test.mjs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+
+// Replays real released histories with the real Drizzle migrator: migrate a
+// database with the exact migration set of each active stable line's latest
+// release tag, then upgrade it to this worktree's history. The upgraded schema
+// must converge with a from-scratch install, no migration may replay, and
+// unrelated existing data must survive. This is the SQL-level complement to
+// .github/scripts/check-migration-upgrades.py, which validates journal
+// timestamps and hashes without executing anything.
+//
+// Release tags are discovered per active stable branch (release/X.Y ships
+// platform-vX.Y.Z tags), so new stable lines join the matrix automatically.
+// Fetch tags before running: git fetch origin '+refs/tags/platform-v*:refs/tags/platform-v*'
+
+const migrations = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../src/database/migrations",
+);
+const migrationsRepoPath = "platform/backend/src/database/migrations";
+const probeTable = "migration_upgrade_probe";
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  cwd: migrations,
+  encoding: "utf8",
+}).trim();
+
+// Production migrates over node-postgres, which accepts multi-command
+// statements; some early migrations rely on that. PGlite's query path uses the
+// extended protocol and rejects them, poisoning the surrounding transaction,
+// so multi-command statements must be routed to exec (simple protocol) before
+// PGlite parses them. The executed SQL text is unchanged, and Drizzle's ledger
+// hash is computed from the migration file, not per-statement chunks, so
+// replay fidelity is preserved.
+class MigrationPGlite extends PGlite {
+  async query(query, params, options) {
+    if ((!params || params.length === 0) && hasMultipleStatements(query)) {
+      await super.exec(query);
+      return { rows: [], fields: [], affectedRows: 0 };
+    }
+    return super.query(query, params, options);
+  }
+
+  async transaction(callback) {
+    return super.transaction(async (tx) => {
+      const original = tx.query.bind(tx);
+      tx.query = async (query, params, options) => {
+        if ((!params || params.length === 0) && hasMultipleStatements(query)) {
+          await tx.exec(query);
+          return { rows: [], fields: [], affectedRows: 0 };
+        }
+        return original(query, params, options);
+      };
+      return callback(tx);
+    });
+  }
+}
+
+// Counts top-level semicolons, skipping string literals, quoted identifiers,
+// comments, and dollar-quoted bodies. Two or more means node-postgres would
+// have run this as a multi-command simple query.
+function hasMultipleStatements(text) {
+  let semicolons = 0;
+  let i = 0;
+  while (i < text.length) {
+    const char = text[i];
+    if (char === "'") {
+      i++;
+      while (i < text.length) {
+        if (text[i] === "'" && text[i + 1] === "'") i += 2;
+        else if (text[i] === "'") { i++; break; }
+        else i++;
+      }
+    } else if (char === '"') {
+      i++;
+      while (i < text.length && text[i] !== '"') i++;
+      i++;
+    } else if (char === "-" && text[i + 1] === "-") {
+      while (i < text.length && text[i] !== "\n") i++;
+    } else if (char === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i += 2;
+    } else if (char === "$") {
+      const tag = /^\$[A-Za-z0-9_]*\$/.exec(text.slice(i))?.[0];
+      if (tag) {
+        const end = text.indexOf(tag, i + tag.length);
+        i = end === -1 ? text.length : end + tag.length;
+      } else {
+        i++;
+      }
+    } else {
+      if (char === ";") semicolons++;
+      i++;
+    }
+  }
+  return semicolons > 1;
+}
+
+const sourceTags = latestStableTags();
+assert.ok(
+  sourceTags.length > 0,
+  "No stable release tags found; fetch them with: " +
+    "git fetch origin '+refs/tags/platform-v*:refs/tags/platform-v*'",
+);
+
+const targetJournal = JSON.parse(
+  await readFile(path.join(migrations, "meta/_journal.json"), "utf8"),
+);
+const targetMaxWhen = Math.max(...targetJournal.entries.map((e) => e.when));
+const targetHashes = new Map(
+  await Promise.all(
+    targetJournal.entries.map(async (entry) => [
+      entry.tag,
+      hashSql(await readFile(path.join(migrations, `${entry.tag}.sql`))),
+    ]),
+  ),
+);
+
+test("from-scratch install and every released stable upgrade converge", async (t) => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "archestra-tag-upgrade-"),
+  );
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  const fresh = new MigrationPGlite("memory://", { extensions: { vector } });
+  t.after(() => fresh.close());
+  await migrate(drizzle(fresh), { migrationsFolder: migrations });
+  const freshCatalog = await catalogDump(fresh);
+
+  for (const tag of sourceTags) {
+    await t.test(`upgrade from ${tag}`, async (t) => {
+      const sourceFolder = await extractMigrations(
+        tag,
+        path.join(directory, tag),
+      );
+      const sourceJournal = JSON.parse(
+        await readFile(
+          path.join(sourceFolder, "meta/_journal.json"),
+          "utf8",
+        ),
+      );
+      const sourceHashes = new Set(
+        await Promise.all(
+          sourceJournal.entries.map(async (entry) =>
+            hashSql(await readFile(path.join(sourceFolder, `${entry.tag}.sql`)))
+          ),
+        ),
+      );
+      const sourceMaxWhen = Math.max(
+        ...sourceJournal.entries.map((e) => e.when),
+      );
+
+      const upgraded = new MigrationPGlite("memory://", { extensions: { vector } });
+      t.after(() => upgraded.close());
+      await migrate(drizzle(upgraded), { migrationsFolder: sourceFolder });
+      // Stand-in for pre-existing application data that no migration owns.
+      await upgraded.exec(
+        `CREATE TABLE ${probeTable} (id text PRIMARY KEY); INSERT INTO ${probeTable} VALUES ('keep-me');`,
+      );
+      await migrate(drizzle(upgraded), { migrationsFolder: migrations });
+
+      assert.deepEqual(
+        await catalogDump(upgraded),
+        freshCatalog,
+        "upgraded schema diverged from a fresh install",
+      );
+      assert.deepEqual(
+        (await upgraded.query(`SELECT id FROM ${probeTable}`)).rows,
+        [{ id: "keep-me" }],
+        "upgrade dropped pre-existing data",
+      );
+      assert.deepEqual(
+        (
+          await upgraded.query(
+            "SELECT hash FROM drizzle.__drizzle_migrations GROUP BY hash HAVING count(*) > 1",
+          )
+        ).rows,
+        [],
+        "a migration was applied twice",
+      );
+
+      // Every target migration newer than the source watermark must be
+      // recorded unless its exact SQL already ran on the source line (a
+      // renamed backport). This catches silently skipped data migrations,
+      // which a schema comparison cannot see.
+      const expectedLedger =
+        sourceJournal.entries.length +
+        targetJournal.entries.filter(
+          (entry) =>
+            entry.when > sourceMaxWhen &&
+            !sourceHashes.has(targetHashes.get(entry.tag)),
+        ).length;
+      const ledgerCount = (
+        await upgraded.query(
+          "SELECT count(*)::int AS count FROM drizzle.__drizzle_migrations",
+        )
+      ).rows[0].count;
+      assert.equal(
+        ledgerCount,
+        expectedLedger,
+        "migration ledger does not match the expected applied set",
+      );
+      const watermark = (
+        await upgraded.query(
+          "SELECT max(created_at)::text AS watermark FROM drizzle.__drizzle_migrations",
+        )
+      ).rows[0].watermark;
+      assert.equal(watermark, String(targetMaxWhen));
+    });
+  }
+});
+
+function latestStableTags() {
+  const branches = git([
+    "for-each-ref",
+    "--format=%(refname:short)",
+    "refs/remotes/origin/release/",
+  ])
+    .split("\n")
+    .map((ref) => /^origin\/release\/(\d+\.\d+)$/.exec(ref)?.[1])
+    .filter(Boolean);
+  const tags = [];
+  for (const line of branches) {
+    const candidates = git(["tag", "--list", `platform-v${line}.*`])
+      .split("\n")
+      .filter((tag) => /^platform-v\d+\.\d+\.\d+$/.test(tag))
+      .sort(compareVersions);
+    if (candidates.length > 0) {
+      tags.push(candidates[candidates.length - 1]);
+    }
+  }
+  return [...new Set(tags)];
+}
+
+async function extractMigrations(ref, directory) {
+  await mkdir(directory, { recursive: true });
+  const files = git([
+    "ls-tree",
+    "-r",
+    "--name-only",
+    ref,
+    "--",
+    migrationsRepoPath,
+  ])
+    .split("\n")
+    .filter((name) => name.endsWith(".sql") || name.endsWith("_journal.json"));
+  const archive = execFileSync("git", ["archive", ref, "--", ...files], {
+    cwd: repoRoot,
+    maxBuffer: 512 * 1024 * 1024,
+  });
+  const archivePath = path.join(directory, "migrations.tar");
+  await writeFile(archivePath, archive);
+  execFileSync("tar", ["-xf", archivePath, "-C", directory]);
+  await rm(archivePath);
+  return path.join(directory, migrationsRepoPath);
+}
+
+async function catalogDump(pg) {
+  const query = (sql) => pg.query(sql).then((result) => result.rows);
+  return {
+    tables: await query(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+       AND table_name <> '${probeTable}' ORDER BY 1`,
+    ),
+    columns: await query(
+      `SELECT table_name, column_name, udt_name, is_nullable, column_default
+       FROM information_schema.columns
+       WHERE table_schema = 'public' AND table_name <> '${probeTable}'
+       ORDER BY 1, 2`,
+    ),
+    constraints: await query(
+      `SELECT con.conname, pg_get_constraintdef(con.oid) AS def
+       FROM pg_constraint con
+       JOIN pg_class rel ON rel.oid = con.conrelid
+       JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+       WHERE nsp.nspname = 'public' AND rel.relname <> '${probeTable}'
+       ORDER BY 1, 2`,
+    ),
+    indexes: await query(
+      `SELECT indexname, indexdef FROM pg_indexes
+       WHERE schemaname = 'public' AND tablename <> '${probeTable}'
+       ORDER BY 1`,
+    ),
+    enums: await query(
+      `SELECT t.typname, e.enumlabel FROM pg_type t
+       JOIN pg_enum e ON e.enumtypid = t.oid
+       JOIN pg_namespace nsp ON nsp.oid = t.typnamespace
+       WHERE nsp.nspname = 'public' ORDER BY 1, e.enumsortorder`,
+    ),
+  };
+}
+
+function hashSql(content) {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function compareVersions(a, b) {
+  const pa = a.replace("platform-v", "").split(".").map(Number);
+  const pb = b.replace("platform-v", "").split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function git(args) {
+  return execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" }).trim();
+}

--- a/platform/backend/src/database/migrations/README.md
+++ b/platform/backend/src/database/migrations/README.md
@@ -5,11 +5,37 @@ recorded timestamp. It does not look for gaps by filename or SQL hash. A backpor
 can therefore make a later stable-to-beta upgrade silently skip beta migrations,
 even when both journals are individually ordered.
 
+## The prefix rule
+
+Every deployed stable version must upgrade cleanly to the next stable patch, to
+any later beta, and to the next stable line. The rule that guarantees this: a
+stable branch's migration history must remain a timestamp-ordered prefix of
+main's, matching migrations by SQL content so renamed backports count. Only
+backport a migration when every earlier main migration is already present on
+the stable branch. While the rule holds, an upgrade from any stable release
+applies exactly the remaining suffix of main's history in canonical order, so
+schema and data migrations converge with every other upgrade path.
+
+A backport that skips earlier main migrations violates the rule, and the
+cross-track check rejects it. Forward repairs exist to recover gaps that
+already shipped, not to make such backports acceptable.
+
 PR validation and release creation run `.github/scripts/check-migration-upgrades.py`.
 The check compares stable release branches (`release/X.Y`) with main, and checks
 upgrades within the target release line. SQL hashes recognize identical migrations
 backported under different filenames. It rejects skipped migrations, absent source
 SQL, and timestamp changes that would replay already-applied SQL.
+
+## Released-tag upgrade replay
+
+The static check proves journal compatibility; it cannot prove the SQL actually
+converges. `backend/scripts/migration-tag-upgrades.test.mjs` replays the latest
+release tag of every active stable branch with the real Drizzle migrator,
+upgrades the resulting database to the worktree's history, and requires schema
+convergence with a fresh install, no duplicate applied migrations, and survival
+of pre-existing data. Tags are discovered per stable branch, so new stable lines
+join the matrix automatically. Fetch `refs/tags/platform-v*` before running
+locally; CI fetches them in the pull-request workflow.
 
 Run from `platform/` after fetching the relevant refs:
 
@@ -19,11 +45,14 @@ python3 ../.github/scripts/check-migration-upgrades.py --source-ref platform-v1.
 pnpm --dir backend test:migration-upgrades
 ```
 
-When backporting a migration, preserve its SQL and timestamp. Preserving the
-timestamp alone is not sufficient: earlier beta-only migrations may still be
-skipped. The cross-track check must pass before publishing the backport. Land any
-required forward repair on main first. Keep this guard in the active stable
-branch's PR and release workflows too.
+## Backporting a migration
+
+Preserve the migration's SQL and timestamp, and confirm the prefix rule holds:
+every earlier main migration must already be on the stable branch. The
+cross-track check must pass before publishing the backport. Keep this guard in
+the active stable branch's PR and release workflows too.
+
+## Repairing an already-shipped gap
 
 For an already-shipped gap, generate a new custom migration with a timestamp
 newer than both tracks. Make the repair idempotent and preserve existing data.

--- a/platform/dev/RELEASE.md
+++ b/platform/dev/RELEASE.md
@@ -45,6 +45,7 @@ gitGraph
    - Conflicts and schema changes produce a manual-action comment instead of a pushed backport.
    - Never merge `main` into a release branch.
    - Review the migration compatibility check. A green result does not permit schema migrations in a stable fix.
+   - A migration backport is only permissible under the prefix rule below; in practice stable fixes ship without migrations.
 4. [ ] Merge the generated release-please patch PR on `release/X.Y` (for example, `1.3.52`).
 5. [ ] Complete **Test And Approve Stable** below.
 
@@ -85,10 +86,25 @@ Drizzle runs migrations newer than the database's latest recorded journal timest
 A stable backport can advance that timestamp past beta-only migrations.
 The next beta upgrade can then report success while required columns remain missing.
 
+Every deployed stable version must upgrade cleanly to the next stable patch, to
+any later beta, and to the next stable line. The rule that guarantees this is
+the **prefix rule**: a stable branch's migration history must remain a prefix
+of main's, matching migrations by SQL content so renamed backports count.
+Backport a migration only when every earlier main migration is already on the
+stable branch. While the rule holds, upgrading any stable release applies
+exactly the remaining suffix of main's history in canonical order, so schema
+and data migrations converge with every other upgrade path.
+
 PR validation checks upgrades within a release line and from stable to main.
 Backport PRs also check their resulting stable history against main.
 Release creation repeats the check against the current branch refs.
 Keep these guards on both main and the active stable branch.
+
+PR validation also replays the real upgrade. Backend `test:migration-upgrades`
+migrates a database with each active stable line's latest released migration
+history, upgrades it to the PR's history with the real Drizzle migrator, and
+requires the schema to match a fresh install, no migration to apply twice, and
+pre-existing data to survive.
 
 The checker recognizes identical SQL under different backport filenames.
 It rejects migrations that would be skipped or replayed, and missing source SQL.


### PR DESCRIPTION
The cross-track migration checker (#7821) validates journal timestamps and SQL hashes without executing anything, so it cannot prove that an upgrade's SQL actually converges. A stable installation could pass every static check and still upgrade to a schema that differs from a fresh install.

Add a replay matrix to `test:migration-upgrades` that executes the real upgrade path with the real Drizzle migrator:

- Discovers the latest release tag of every active `release/X.Y` branch, so new stable lines join automatically.
- Migrates a PGlite database with that tag's exact released history, plants a probe row in an unmanned table, then upgrades to the PR's migration history.
- Requires the upgraded schema (tables, columns, constraints, indexes, enums) to equal a fresh install, no migration hash to be applied twice, the probe data to survive, and the ledger to match the expected applied set — which also catches silently skipped data migrations that a schema comparison cannot see.

Two compatibility shims make full-history replay work under PGlite: multi-command statements from early migrations are routed to the simple protocol (node-postgres accepts them; PGlite's extended protocol does not), and the vector extension is loaded as in the backend test setup. The executed SQL text is unchanged and Drizzle's ledger hash is computed from file bytes, so replay fidelity is preserved.

Verified non-vacuous: replaying the 1.3.56 stable history into the pre-repair 1.4.0-beta.4 history fails with schema divergence, reproducing the incident from #7819; the repaired history passes.

Also documents the **prefix rule** — a stable branch's migration history must remain a prefix of main's, matched by SQL content — as the operative condition for any migration backport in `platform/dev/RELEASE.md` and the migrations README, with forward repairs explicitly reserved for already-shipped gaps.

CI fetches `refs/tags/platform-v*` alongside the release branches in the pull-request workflow.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>