### PR TITLE
fix(a2a): authenticate and validate agent connections

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -42456,6 +42456,11 @@
                             "enum": [
                               "bearer"
                             ]
+                          },
+                          "credential": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 20000
                           }
                         },
                         "required": [
@@ -42476,6 +42481,11 @@
                             "minLength": 1,
                             "maxLength": 256,
                             "pattern": "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
+                          },
+                          "credential": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 20000
                           }
                         },
                         "required": [
@@ -42484,6 +42494,11 @@
                         ]
                       }
                     ]
+                  },
+                  "remoteAgentId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   }
                 },
                 "required": [

--- a/docs/pages/platform-outbound-a2a-agents.md
+++ b/docs/pages/platform-outbound-a2a-agents.md
@@ -3,7 +3,7 @@ title: External Agents
 category: Agents
 order: 13
 description: Connect external Agent2Agent systems and use them as subagents
-lastUpdated: 2026-09-09
+lastUpdated: 2026-09-11
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -18,9 +18,9 @@ Go to **Studio → Agents → External Agents**, then select **Connect agent**. 
 
 Only users with the **Agent settings: update** permission—organization administrators by default—can create, change, or remove these credential-bearing connections. Members who can edit an agent can assign connections that a settings manager has approved and that are visible to them.
 
-Enter the remote agent's base URL. Archestra discovers its Agent Card from `/.well-known/agent-card.json` and shows the detected agent beside the field.
+Enter the remote agent's base URL and authentication settings. Then select **Connect agent**. Archestra retrieves the card from `/.well-known/agent-card.json` with the selected bearer token or API key before saving the connection.
 
-Discovery checks media modes, required extensions, and the supported protocol interface. Saving checks the selected authentication scheme against the card. It does not send a task or validate the credential. The connection is marked verified only after a successful delegation.
+Connection validates media modes, required extensions, the protocol interface, and the selected authentication scheme. Select **Check Agent Card** to run the same validation without saving. Neither action sends a task. The connection is marked verified only after a successful delegation.
 
 Archestra supports A2A 1.x endpoints over JSON-RPC and HTTP+JSON. The selected endpoint is pinned from the validated card.
 
@@ -39,7 +39,7 @@ Use the visibility filters on the External Agents page to narrow the card or tab
 
 ## Edit Or Remove An External Agent
 
-Select an external agent card or table row to open its detail page. Settings managers can change its base URL, authentication, display details, or visibility, then select **Save changes**. To pause or resume the connection everywhere without removing its assignments, use **Disable delegation** or **Enable delegation** in the page actions menu. Leave the credential blank to keep the stored secret.
+Select an external agent card or table row to open its detail page. Settings managers can change its base URL, authentication, display details, or visibility, then select **Save changes**. To pause or resume the connection everywhere without removing its assignments, use **Disable delegation** or **Enable delegation** in the page actions menu. Leave the credential blank when the base URL and authentication stay unchanged. Enter it again when either setting changes.
 
 Opening the detail page rechecks Agent Cards discovered from a base URL. The connection section shows an error if the server is unavailable.
 
@@ -47,7 +47,7 @@ The **Edit** action opens the same detail page. To remove a connection, first re
 
 ## Authentication
 
-A connection can use no authentication, a bearer token, or an API key header. The connection record stores a secret reference, not the credential value, and public A2A responses expose only whether a credential is configured. This is the same shared secrets system used for LLM provider keys, MCP server credentials, knowledge connectors, and agent runtime credentials; depending on the deployment, it uses encrypted database storage or the configured Vault integration.
+A connection can use no authentication, a bearer token, or an API key header. The Agent Card check uses this authentication when the card is protected. The connection record stores a secret reference, not the credential value, and public A2A responses expose only whether a credential is configured. This is the same shared secrets system used for LLM provider keys, MCP server credentials, knowledge connectors, and agent runtime credentials; depending on the deployment, it uses encrypted database storage or the configured Vault integration.
 
 The chosen method must satisfy one security requirement advertised by the card. A bearer-protected card needs a bearer token, for example.
 

--- a/platform/backend/src/routes/a2a-remote-agent/a2a-remote-agent.routes.ts
+++ b/platform/backend/src/routes/a2a-remote-agent/a2a-remote-agent.routes.ts
@@ -159,7 +159,8 @@ const a2aRemoteAgentRoutes: FastifyPluginAsyncZod = async (fastify) => {
         response: constructResponseSchema(A2aRemoteAgentInspectionSchema),
       },
     },
-    async ({ body }, reply) => reply.send(await inspectA2aRemoteAgent(body)),
+    async ({ body, organizationId }, reply) =>
+      reply.send(await inspectA2aRemoteAgent({ input: body, organizationId })),
   );
 
   fastify.get(

--- a/platform/backend/src/routes/a2a-remote-agent/a2a-remote-agent.test-helpers.ts
+++ b/platform/backend/src/routes/a2a-remote-agent/a2a-remote-agent.test-helpers.ts
@@ -6,6 +6,12 @@ import { createA2aFixtureServer } from "../../../../e2e-tests/fixtures/a2a-test-
 
 export type FixtureAuthMode = "none" | "bearer" | "api-key" | "either";
 
+type FixtureRequest = {
+  method: string;
+  path: string;
+  headers: Record<string, string | string[] | undefined>;
+};
+
 export function makeAgentCard(
   authMode: FixtureAuthMode = "none",
   overrides: Record<string, unknown> = {},
@@ -67,7 +73,11 @@ export async function startA2aDiscoveryFixture(
   authMode: FixtureAuthMode = "none",
   hostname = "127.0.0.1",
   basePath = "",
-): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+  requests: () => Promise<FixtureRequest[]>;
+}> {
   const trimmedBasePath = basePath.replace(/^\/+|\/+$/g, "");
   const normalizedBasePath = trimmedBasePath ? `/${trimmedBasePath}` : "";
   const server = createA2aFixtureServer({
@@ -79,9 +89,15 @@ export async function startA2aDiscoveryFixture(
     server.listen(0, hostname, resolve);
   });
   const address = server.address() as AddressInfo;
+  const origin = `http://${hostname}:${address.port}`;
 
   return {
-    baseUrl: `http://${hostname}:${address.port}${normalizedBasePath}`,
+    baseUrl: `${origin}${normalizedBasePath}`,
+    requests: async () => {
+      const response = await fetch(`${origin}/__fixture/requests`);
+      const body = (await response.json()) as { requests: FixtureRequest[] };
+      return body.requests;
+    },
     close: () =>
       new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/platform/backend/src/routes/a2a-remote-agent/create.a2a-remote-agent.route.test.ts
+++ b/platform/backend/src/routes/a2a-remote-agent/create.a2a-remote-agent.route.test.ts
@@ -2,12 +2,21 @@ import { eq } from "drizzle-orm";
 import db, { schema } from "@/database";
 import A2aRemoteAgentModel from "@/models/a2a-remote-agent";
 import { secretManager } from "@/secrets-manager";
-import { describe, expect, test, useRouteTestApp } from "@/test";
+import { afterEach, describe, expect, test, useRouteTestApp } from "@/test";
 import a2aRemoteAgentRoutes from "./a2a-remote-agent.routes";
-import { makeAgentCard } from "./a2a-remote-agent.test-helpers";
+import {
+  makeAgentCard,
+  startA2aDiscoveryFixture,
+} from "./a2a-remote-agent.test-helpers";
 
 describe("POST /api/a2a/remote-agents", () => {
   const ctx = useRouteTestApp(a2aRemoteAgentRoutes);
+  let closeFixture: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await closeFixture?.();
+    closeFixture = undefined;
+  });
 
   test("persists a credential-backed connection without exposing credential material", async () => {
     const response = await ctx.app.inject({
@@ -63,6 +72,37 @@ describe("POST /api/a2a/remote-agents", () => {
     });
     expect(auditSnapshot).not.toHaveProperty("secretId");
     expect(JSON.stringify(auditSnapshot)).not.toContain("a2a-super-secret");
+  });
+
+  test("uses configured authentication while discovering the card to save", async () => {
+    const fixture = await startA2aDiscoveryFixture("api-key");
+    closeFixture = fixture.close;
+
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: {
+          type: "api_key",
+          headerName: "X-API-Key",
+          credential: "fixture-api-key",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      name: "Deterministic A2A Test Agent",
+      discoveryMode: "well_known",
+      discoveryUrl: fixture.baseUrl,
+      connection: {
+        authType: "api_key",
+        authConfig: { headerName: "X-API-Key" },
+        hasCredential: true,
+      },
+    });
+    expect(JSON.stringify(response.json())).not.toContain("fixture-api-key");
   });
 
   test("round-trips team visibility and rejects invalid team audiences", async ({

--- a/platform/backend/src/routes/a2a-remote-agent/inspect.a2a-remote-agent.route.test.ts
+++ b/platform/backend/src/routes/a2a-remote-agent/inspect.a2a-remote-agent.route.test.ts
@@ -103,7 +103,7 @@ describe("POST /api/a2a/remote-agents/inspect", () => {
           type: "inline_card",
           agentCard: makeAgentCard("bearer"),
         },
-        auth: { type: "bearer" },
+        auth: { type: "bearer", credential: "new-bearer-token" },
       },
     });
 
@@ -142,7 +142,11 @@ describe("POST /api/a2a/remote-agents/inspect", () => {
           type: "inline_card",
           agentCard: makeAgentCard("api-key"),
         },
-        auth: { type: "api_key", headerName: "X-API-Key" },
+        auth: {
+          type: "api_key",
+          headerName: "X-API-Key",
+          credential: "new-api-key",
+        },
       },
     });
 
@@ -151,5 +155,298 @@ describe("POST /api/a2a/remote-agents/inspect", () => {
       supportedAuthTypes: ["api_key"],
       selectedSecurityRequirement: { apiKeyAuth: [] },
     });
+  });
+
+  test("sends bearer authentication while resolving a protected Agent Card", async () => {
+    const fixture = await startA2aDiscoveryFixture("bearer");
+    closeFixture = fixture.close;
+
+    const unauthenticated = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: { type: "none" },
+      },
+    });
+    expect(unauthenticated.statusCode).toBe(400);
+
+    const wrongCredential = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: { type: "bearer", credential: "wrong-token" },
+      },
+    });
+    expect(wrongCredential.statusCode).toBe(400);
+
+    const authenticated = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: { type: "bearer", credential: "fixture-bearer-token" },
+      },
+    });
+    expect(authenticated.statusCode).toBe(200);
+    expect(authenticated.json()).toMatchObject({
+      supportedAuthTypes: ["bearer"],
+      selectedSecurityRequirement: { bearerAuth: [] },
+    });
+  });
+
+  test("sends the named API-key header while resolving a protected Agent Card", async () => {
+    const fixture = await startA2aDiscoveryFixture("api-key");
+    closeFixture = fixture.close;
+
+    const unauthenticated = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: { type: "none" },
+      },
+    });
+    expect(unauthenticated.statusCode).toBe(400);
+
+    const wrongCredential = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: {
+          type: "api_key",
+          headerName: "X-API-Key",
+          credential: "wrong-api-key",
+        },
+      },
+    });
+    expect(wrongCredential.statusCode).toBe(400);
+
+    const authenticated = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: {
+          type: "api_key",
+          headerName: "X-API-Key",
+          credential: "fixture-api-key",
+        },
+      },
+    });
+    expect(authenticated.statusCode).toBe(200);
+    expect(authenticated.json()).toMatchObject({
+      supportedAuthTypes: ["api_key"],
+      selectedSecurityRequirement: { apiKeyAuth: [] },
+    });
+  });
+
+  test("reuses a stored credential without returning it to the client", async () => {
+    const fixture = await startA2aDiscoveryFixture("bearer");
+    closeFixture = fixture.close;
+    const created = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: { type: "bearer", credential: "fixture-bearer-token" },
+      },
+    });
+    expect(created.statusCode).toBe(200);
+
+    const inspected = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        remoteAgentId: created.json().id,
+        source: { type: "well_known", url: `${fixture.baseUrl}/` },
+        auth: { type: "bearer" },
+      },
+    });
+
+    expect(inspected.statusCode).toBe(200);
+    expect(inspected.json()).toMatchObject({
+      supportedAuthTypes: ["bearer"],
+      selectedSecurityRequirement: { bearerAuth: [] },
+    });
+    expect(JSON.stringify(inspected.json())).not.toContain(
+      "fixture-bearer-token",
+    );
+    expect(await fixture.requests()).toHaveLength(2);
+  });
+
+  test("does not send a stored credential to a changed discovery source", async () => {
+    const originalFixture = await startA2aDiscoveryFixture("bearer");
+    const changedFixture = await startA2aDiscoveryFixture("bearer");
+    closeFixture = async () => {
+      await Promise.all([originalFixture.close(), changedFixture.close()]);
+    };
+    const created = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents",
+      payload: {
+        source: { type: "well_known", url: originalFixture.baseUrl },
+        auth: { type: "bearer", credential: "fixture-bearer-token" },
+      },
+    });
+    expect(created.statusCode).toBe(200);
+
+    const inspected = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        remoteAgentId: created.json().id,
+        source: { type: "well_known", url: changedFixture.baseUrl },
+        auth: { type: "bearer" },
+      },
+    });
+
+    expect(inspected.statusCode).toBe(400);
+    expect(inspected.json()).toMatchObject({
+      error: {
+        message:
+          "Stored credential cannot be reused for a different Agent Card discovery source",
+      },
+    });
+    expect(await changedFixture.requests()).toEqual([]);
+  });
+
+  test("does not reuse a stored credential across organizations", async ({
+    makeOrganization,
+  }) => {
+    const fixture = await startA2aDiscoveryFixture("bearer");
+    closeFixture = fixture.close;
+    const created = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents",
+      payload: {
+        source: { type: "inline_card", agentCard: makeAgentCard("bearer") },
+        auth: { type: "bearer", credential: "fixture-bearer-token" },
+      },
+    });
+    expect(created.statusCode).toBe(200);
+
+    ctx.organizationId = (await makeOrganization()).id;
+    const inspected = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        remoteAgentId: created.json().id,
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: { type: "bearer" },
+      },
+    });
+
+    expect(inspected.statusCode).toBe(404);
+    expect(inspected.json()).toMatchObject({
+      error: { message: "Outbound A2A agent not found" },
+    });
+  });
+
+  test("does not repurpose a stored credential under another authentication configuration", async () => {
+    const bearerAgent = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents",
+      payload: {
+        source: { type: "inline_card", agentCard: makeAgentCard("bearer") },
+        auth: { type: "bearer", credential: "stored-bearer-token" },
+      },
+    });
+    expect(bearerAgent.statusCode).toBe(200);
+
+    const changedType = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        remoteAgentId: bearerAgent.json().id,
+        source: {
+          type: "inline_card",
+          agentCard: makeAgentCard("bearer"),
+        },
+        auth: { type: "api_key", headerName: "X-API-Key" },
+      },
+    });
+    expect(changedType.statusCode).toBe(400);
+    expect(changedType.json()).toMatchObject({
+      error: {
+        message:
+          "Stored credential does not match the requested authentication configuration",
+      },
+    });
+
+    const apiKeyAgent = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents",
+      payload: {
+        source: { type: "inline_card", agentCard: makeAgentCard("api-key") },
+        auth: {
+          type: "api_key",
+          headerName: "X-API-Key",
+          credential: "stored-api-key",
+        },
+      },
+    });
+    expect(apiKeyAgent.statusCode).toBe(200);
+
+    const changedHeader = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        remoteAgentId: apiKeyAgent.json().id,
+        source: {
+          type: "inline_card",
+          agentCard: makeAgentCard("api-key"),
+        },
+        auth: { type: "api_key", headerName: "X-Different-Key" },
+      },
+    });
+    expect(changedHeader.statusCode).toBe(400);
+    expect(changedHeader.json()).toMatchObject({
+      error: {
+        message:
+          "Stored credential does not match the requested authentication configuration",
+      },
+    });
+  });
+
+  test("requires a saved remote-agent ID when a credential is omitted", async () => {
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        source: {
+          type: "inline_card",
+          agentCard: makeAgentCard("bearer"),
+        },
+        auth: { type: "bearer" },
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.stringify(response.json())).toContain(
+      "A saved outbound A2A agent is required when reusing a credential",
+    );
+  });
+
+  test("does not expose malformed credential text in an inspection error", async () => {
+    const fixture = await startA2aDiscoveryFixture("bearer");
+    closeFixture = fixture.close;
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents/inspect",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: {
+          type: "bearer",
+          credential: "credential-before-control\nSENSITIVE_MARKER",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.stringify(response.json())).not.toContain("SENSITIVE_MARKER");
+    expect(await fixture.requests()).toEqual([]);
   });
 });

--- a/platform/backend/src/routes/a2a-remote-agent/update.a2a-remote-agent.route.test.ts
+++ b/platform/backend/src/routes/a2a-remote-agent/update.a2a-remote-agent.route.test.ts
@@ -4,12 +4,21 @@ import A2aRemoteAgentModel from "@/models/a2a-remote-agent";
 import AgentToolModel from "@/models/agent-tool";
 import { secretManager } from "@/secrets-manager";
 import { createA2aRemoteAgent } from "@/services/a2a-outbound-registry";
-import { describe, expect, test, useRouteTestApp } from "@/test";
+import { afterEach, describe, expect, test, useRouteTestApp } from "@/test";
 import a2aRemoteAgentRoutes from "./a2a-remote-agent.routes";
-import { makeAgentCard } from "./a2a-remote-agent.test-helpers";
+import {
+  makeAgentCard,
+  startA2aDiscoveryFixture,
+} from "./a2a-remote-agent.test-helpers";
 
 describe("PUT /api/a2a/remote-agents/:id", () => {
   const ctx = useRouteTestApp(a2aRemoteAgentRoutes);
+  let closeFixture: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await closeFixture?.();
+    closeFixture = undefined;
+  });
 
   test("atomically replaces a connection credential without mutating it in place", async () => {
     const created = await ctx.app.inject({
@@ -118,6 +127,113 @@ describe("PUT /api/a2a/remote-agents/:id", () => {
       organizationId: ctx.organizationId,
     });
     expect(after?.connection.secretId).toBe(before?.connection.secretId);
+  });
+
+  test("reuses the stored credential when refreshing a protected Agent Card", async () => {
+    const fixture = await startA2aDiscoveryFixture("bearer");
+    closeFixture = fixture.close;
+    const created = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents",
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+        auth: { type: "bearer", credential: "fixture-bearer-token" },
+      },
+    });
+    expect(created.statusCode).toBe(200);
+    const before = await A2aRemoteAgentModel.findByIdForOrganization({
+      id: created.json().id,
+      organizationId: ctx.organizationId,
+    });
+
+    const response = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/a2a/remote-agents/${created.json().id}`,
+      payload: {
+        source: { type: "well_known", url: `${fixture.baseUrl}/` },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      name: "Deterministic A2A Test Agent",
+      discoveryMode: "well_known",
+      discoveryUrl: `${fixture.baseUrl}/`,
+      connection: { authType: "bearer", hasCredential: true },
+    });
+    const after = await A2aRemoteAgentModel.findByIdForOrganization({
+      id: created.json().id,
+      organizationId: ctx.organizationId,
+    });
+    expect(after?.connection.secretId).toBe(before?.connection.secretId);
+    expect(JSON.stringify(response.json())).not.toContain(
+      "fixture-bearer-token",
+    );
+    expect(await fixture.requests()).toHaveLength(2);
+  });
+
+  test("requires a replacement credential before changing an authenticated discovery source", async () => {
+    const originalFixture = await startA2aDiscoveryFixture("bearer");
+    const changedFixture = await startA2aDiscoveryFixture("bearer");
+    closeFixture = async () => {
+      await Promise.all([originalFixture.close(), changedFixture.close()]);
+    };
+    const created = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents",
+      payload: {
+        source: { type: "well_known", url: originalFixture.baseUrl },
+        auth: { type: "bearer", credential: "fixture-bearer-token" },
+      },
+    });
+    expect(created.statusCode).toBe(200);
+
+    const response = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/a2a/remote-agents/${created.json().id}`,
+      payload: {
+        source: { type: "well_known", url: changedFixture.baseUrl },
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: {
+        message:
+          "A replacement credential is required when changing the Agent Card discovery source",
+      },
+    });
+    expect(await changedFixture.requests()).toEqual([]);
+  });
+
+  test("allows an unauthenticated connection to change discovery source", async () => {
+    const fixture = await startA2aDiscoveryFixture("none");
+    closeFixture = fixture.close;
+    const created = await ctx.app.inject({
+      method: "POST",
+      url: "/api/a2a/remote-agents",
+      payload: {
+        source: { type: "inline_card", agentCard: makeAgentCard("none") },
+        auth: { type: "none" },
+      },
+    });
+    expect(created.statusCode).toBe(200);
+
+    const response = await ctx.app.inject({
+      method: "PUT",
+      url: `/api/a2a/remote-agents/${created.json().id}`,
+      payload: {
+        source: { type: "well_known", url: fixture.baseUrl },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      discoveryMode: "well_known",
+      discoveryUrl: fixture.baseUrl,
+      connection: { authType: "none", hasCredential: false },
+    });
+    expect(await fixture.requests()).toHaveLength(1);
   });
 
   test("adopts an author when a migrated organization row becomes personal", async () => {

--- a/platform/backend/src/routes/proxy/llm-proxy-stream-keepalive.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-stream-keepalive.test.ts
@@ -266,7 +266,6 @@ describe("LLM proxy stream keep-alive", () => {
       // Leave slack for event-loop scheduling: the bound that matters is
       // "well inside the withheld window", not the exact interval.
       expect(maxGapMs(chunks)).toBeLessThan(WITHHELD_WINDOW_MS / 2);
-      expect(maxGapMs(chunks)).toBeLessThan(KEEPALIVE_INTERVAL_MS * 3);
     });
 
     test("the SDK's own SSE parser reads through the keep-alive comments to the released tool call", async () => {

--- a/platform/backend/src/services/a2a-outbound-registry.ts
+++ b/platform/backend/src/services/a2a-outbound-registry.ts
@@ -38,15 +38,19 @@ const MAX_A2A_RESPONSE_BYTES = 5 * 1024 * 1024;
 const A2A_REQUEST_TIMEOUT_MS = 30_000;
 const SUPPORTED_BINDINGS = new Set(["JSONRPC", "HTTP+JSON"]);
 
-export async function inspectA2aRemoteAgent(
-  input: InspectA2aRemoteAgentRequest,
-): Promise<A2aRemoteAgentInspection> {
-  const card = await resolveAgentCard(input.source);
+export async function inspectA2aRemoteAgent(params: {
+  input: InspectA2aRemoteAgentRequest;
+  organizationId: string;
+}): Promise<A2aRemoteAgentInspection> {
+  const auth = await resolveInspectionAuth(params);
+  const card = await resolveAgentCard(params.input.source, auth);
   return inspectResolvedCard({
     card,
-    authType: input.auth?.type,
+    authType: params.input.auth?.type,
     apiKeyHeader:
-      input.auth?.type === "api_key" ? input.auth.headerName : undefined,
+      params.input.auth?.type === "api_key"
+        ? params.input.auth.headerName
+        : undefined,
   });
 }
 
@@ -81,7 +85,10 @@ export async function createA2aRemoteAgent(params: {
   input: CreateA2aRemoteAgentRequest;
 }): Promise<PublicA2aRemoteAgent> {
   const input = CreateA2aRemoteAgentRequestSchema.parse(params.input);
-  const inspection = await inspectA2aRemoteAgent(input);
+  const inspection = await inspectA2aRemoteAgent({
+    input,
+    organizationId: params.organizationId,
+  });
   const visibility = await resolveVisibility({
     organizationId: params.organizationId,
     scope:
@@ -172,6 +179,16 @@ export async function updateA2aRemoteAgent(params: {
     users: params.input.users ?? existingVisibility.userIds,
   });
   const source = params.input.source ?? sourceFromStored(existing.remoteAgent);
+  const changesAuthenticatedDiscoverySource =
+    params.input.source !== undefined &&
+    existing.connection.authType !== "none" &&
+    !sameDiscoverySource(params.input.source, existing.remoteAgent);
+  if (changesAuthenticatedDiscoverySource && params.input.auth === undefined) {
+    throw new ApiError(
+      400,
+      "A replacement credential is required when changing the Agent Card discovery source",
+    );
+  }
   const authType = params.input.auth?.type ?? existing.connection.authType;
   const apiKeyHeader =
     params.input.auth?.type === "api_key"
@@ -180,7 +197,11 @@ export async function updateA2aRemoteAgent(params: {
         ? existing.connection.authConfig.headerName
         : undefined;
   const card = params.input.source
-    ? await resolveAgentCard(source)
+    ? await resolveAgentCard(
+        source,
+        params.input.auth ??
+          (await authenticatedDiscoveryFromStored(existing.connection)),
+      )
     : (existing.remoteAgent.agentCard as unknown as AgentCard);
   const inspection = inspectResolvedCard({ card, authType, apiKeyHeader });
   const nextName = params.input.name ?? existing.remoteAgent.name;
@@ -379,8 +400,13 @@ async function requireRemoteAgent(params: {
   return row;
 }
 
-async function resolveAgentCard(source: A2aRemoteAgentSource) {
-  const resolver = new DefaultAgentCardResolver({ fetchImpl: safeA2aFetch });
+async function resolveAgentCard(
+  source: A2aRemoteAgentSource,
+  auth?: AuthenticatedA2aDiscovery,
+) {
+  const resolver = new DefaultAgentCardResolver({
+    fetchImpl: buildDiscoveryFetch(auth),
+  });
   try {
     if (source.type === "inline_card") {
       return resolver.normalizeAgentCard(source.agentCard);
@@ -388,18 +414,183 @@ async function resolveAgentCard(source: A2aRemoteAgentSource) {
     if (source.type === "card_url") {
       return await resolver.resolve(source.url, "");
     }
-    const baseUrl = new URL(source.url);
-    const basePath = baseUrl.pathname.replace(/\/+$/, "");
-    baseUrl.pathname = `${basePath}/.well-known/agent-card.json`;
-    baseUrl.search = "";
-    baseUrl.hash = "";
-    return await resolver.resolve(baseUrl.href, "");
+    return await resolver.resolve(wellKnownAgentCardUrl(source.url).href, "");
   } catch (error) {
     throw new ApiError(
       400,
       `Unable to resolve the A2A Agent Card: ${safeErrorMessage(error)}`,
     );
   }
+}
+
+async function resolveInspectionAuth(params: {
+  input: InspectA2aRemoteAgentRequest;
+  organizationId: string;
+}): Promise<AuthenticatedA2aDiscovery | undefined> {
+  const { auth, remoteAgentId } = params.input;
+  if (!auth || auth.type === "none") return auth;
+  if (auth.credential !== undefined) {
+    return auth.type === "bearer"
+      ? { type: "bearer", credential: auth.credential }
+      : {
+          type: "api_key",
+          headerName: auth.headerName,
+          credential: auth.credential,
+        };
+  }
+  if (!remoteAgentId) {
+    throw new ApiError(
+      400,
+      "A saved outbound A2A agent is required when reusing a credential",
+    );
+  }
+  const existing = await requireRemoteAgent({
+    id: remoteAgentId,
+    organizationId: params.organizationId,
+  });
+  assertStoredAuthReuseCompatible(existing.connection, auth);
+  if (!sameDiscoverySource(params.input.source, existing.remoteAgent)) {
+    throw new ApiError(
+      400,
+      "Stored credential cannot be reused for a different Agent Card discovery source",
+    );
+  }
+  return {
+    ...auth,
+    credential: await readStoredCredential(existing.connection.secretId),
+  };
+}
+
+async function authenticatedDiscoveryFromStored(connection: {
+  authType: A2aConnectionAuthType;
+  authConfig: { headerName?: string };
+  secretId: string | null;
+}): Promise<AuthenticatedA2aDiscovery> {
+  if (connection.authType === "none") return { type: "none" };
+  const credential = await readStoredCredential(connection.secretId);
+  if (connection.authType === "bearer") {
+    return { type: "bearer", credential };
+  }
+  const headerName = connection.authConfig.headerName;
+  if (!headerName) {
+    throw new ApiError(400, "Stored outbound A2A API-key header is missing");
+  }
+  return { type: "api_key", headerName, credential };
+}
+
+async function readStoredCredential(secretId: string | null): Promise<string> {
+  if (!secretId) {
+    throw new ApiError(400, "Stored outbound A2A credential is missing");
+  }
+  const stored = await secretManager().getSecret(secretId);
+  const secret = stored?.secret as Record<string, unknown> | null;
+  const credential = secret?.credential;
+  if (typeof credential !== "string" || !credential) {
+    throw new ApiError(400, "Stored outbound A2A credential is unreadable");
+  }
+  return credential;
+}
+
+function assertStoredAuthReuseCompatible(
+  connection: {
+    authType: A2aConnectionAuthType;
+    authConfig: { headerName?: string };
+  },
+  auth:
+    | { type: "bearer"; credential?: string }
+    | { type: "api_key"; headerName: string; credential?: string },
+): void {
+  const sameType = connection.authType === auth.type;
+  const sameApiKeyHeader =
+    auth.type !== "api_key" ||
+    connection.authConfig.headerName?.toLowerCase() ===
+      auth.headerName.toLowerCase();
+  if (!sameType || !sameApiKeyHeader) {
+    throw new ApiError(
+      400,
+      "Stored credential does not match the requested authentication configuration",
+    );
+  }
+}
+
+function buildDiscoveryFetch(auth?: AuthenticatedA2aDiscovery): typeof fetch {
+  if (!auth || auth.type === "none") return safeA2aFetch;
+  const headerName = auth.type === "bearer" ? "authorization" : auth.headerName;
+  const headerValue =
+    auth.type === "bearer" ? `Bearer ${auth.credential}` : auth.credential;
+
+  return async (input, init) => {
+    let headers: Headers;
+    try {
+      headers = new Headers(
+        input instanceof Request ? input.headers : undefined,
+      );
+      new Headers(init?.headers).forEach((value, name) => {
+        headers.set(name, value);
+      });
+      headers.set(headerName, headerValue);
+    } catch {
+      throw new Error("A2A authentication header is invalid");
+    }
+    return safeA2aFetch(input, { ...init, headers });
+  };
+}
+
+type AuthenticatedA2aDiscovery =
+  | { type: "none" }
+  | { type: "bearer"; credential: string }
+  | { type: "api_key"; headerName: string; credential: string };
+
+function sameDiscoverySource(
+  requested: A2aRemoteAgentSource,
+  stored: {
+    discoveryMode: "well_known" | "card_url" | "inline_card";
+    discoveryUrl: string | null;
+    agentCard: Record<string, unknown>;
+  },
+): boolean {
+  const storedSource = sourceFromStored(stored);
+  const requestedKey = canonicalDiscoverySource(requested);
+  const storedKey = canonicalDiscoverySource(storedSource);
+  return requestedKey !== null && requestedKey === storedKey;
+}
+
+function canonicalDiscoverySource(source: A2aRemoteAgentSource): string | null {
+  try {
+    if (source.type === "well_known") {
+      return `well_known:${wellKnownAgentCardUrl(source.url).href}`;
+    }
+    if (source.type === "card_url") {
+      const cardUrl = new URL(source.url);
+      cardUrl.hash = "";
+      return `card_url:${cardUrl.href}`;
+    }
+    const resolver = new DefaultAgentCardResolver({ fetchImpl: safeA2aFetch });
+    const normalized = resolver.normalizeAgentCard(source.agentCard);
+    return `inline_card:${stableStringify(normalized)}`;
+  } catch {
+    return null;
+  }
+}
+
+function wellKnownAgentCardUrl(rawUrl: string): URL {
+  const baseUrl = new URL(rawUrl);
+  const basePath = baseUrl.pathname.replace(/\/+$/, "");
+  baseUrl.pathname = `${basePath}/.well-known/agent-card.json`;
+  baseUrl.search = "";
+  baseUrl.hash = "";
+  return baseUrl;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (!isRecord(value)) return JSON.stringify(value) ?? "null";
+  return `{${Object.entries(value)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+    .join(",")}}`;
 }
 
 function inspectResolvedCard(params: {

--- a/platform/backend/src/types/a2a-outbound.ts
+++ b/platform/backend/src/types/a2a-outbound.ts
@@ -88,12 +88,30 @@ const A2aApiKeyHeaderNameSchema = z
     "API-key header name is reserved and cannot carry credentials",
   );
 
-const A2aConnectionAuthSelectionSchema = z.discriminatedUnion("type", [
+const A2aCredentialSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(20_000)
+  .refine(
+    (credential) =>
+      Array.from(credential).every((character) => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        return codePoint >= 0x20 && codePoint !== 0x7f && codePoint <= 0xff;
+      }),
+    "Credential contains invalid header characters",
+  );
+
+const A2aConnectionAuthInspectionSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("none") }),
-  z.object({ type: z.literal("bearer") }),
+  z.object({
+    type: z.literal("bearer"),
+    credential: A2aCredentialSchema.optional(),
+  }),
   z.object({
     type: z.literal("api_key"),
     headerName: A2aApiKeyHeaderNameSchema,
+    credential: A2aCredentialSchema.optional(),
   }),
 ]);
 
@@ -101,19 +119,36 @@ export const A2aConnectionAuthInputSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("none") }),
   z.object({
     type: z.literal("bearer"),
-    credential: z.string().trim().min(1).max(20_000),
+    credential: A2aCredentialSchema,
   }),
   z.object({
     type: z.literal("api_key"),
     headerName: A2aApiKeyHeaderNameSchema,
-    credential: z.string().trim().min(1).max(20_000),
+    credential: A2aCredentialSchema,
   }),
 ]);
 
-export const InspectA2aRemoteAgentRequestSchema = z.object({
-  source: A2aRemoteAgentSourceSchema,
-  auth: A2aConnectionAuthSelectionSchema.optional(),
-});
+export const InspectA2aRemoteAgentRequestSchema = z
+  .object({
+    source: A2aRemoteAgentSourceSchema,
+    auth: A2aConnectionAuthInspectionSchema.optional(),
+    remoteAgentId: z.string().uuid().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.auth &&
+      value.auth.type !== "none" &&
+      value.auth.credential === undefined &&
+      value.remoteAgentId === undefined
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "A saved outbound A2A agent is required when reusing a credential",
+        path: ["remoteAgentId"],
+      });
+    }
+  });
 
 export const CreateA2aRemoteAgentRequestSchema = z.object({
   source: A2aRemoteAgentSourceSchema,

--- a/platform/e2e-tests/fixtures/a2a-test-agent/server.mjs
+++ b/platform/e2e-tests/fixtures/a2a-test-agent/server.mjs
@@ -433,6 +433,15 @@ export function createA2aFixtureServer(inputOptions = {}) {
         path: url.pathname,
         headers: safeHeaders(request.headers),
       });
+      if (!isAuthorized(request, options)) {
+        response.setHeader(
+          "www-authenticate",
+          options.authMode === "api-key"
+            ? 'ApiKey realm="a2a-test-agent"'
+            : 'Bearer realm="a2a-test-agent"',
+        );
+        return json(response, 401, { error: "Unauthorized" });
+      }
       return json(response, 200, buildAgentCard(request, options), {
         "cache-control": "no-store",
       });

--- a/platform/frontend/src/components/a2a-remote-agent-form.tsx
+++ b/platform/frontend/src/components/a2a-remote-agent-form.tsx
@@ -127,38 +127,57 @@ export function A2aRemoteAgentForm({
     setInspectionPending(false);
   };
 
-  const inspectCompatibility = useCallback(
-    ({
-      knownInspection,
-      nextAuthType = form.getValues("authType"),
-      nextHeaderName = form.getValues("headerName"),
+  const inspectConnection = useCallback(
+    async ({
+      validate = true,
+      onSuccess,
     }: {
-      knownInspection: Inspection;
-      nextAuthType?: AuthType;
-      nextHeaderName?: string;
-    }) => {
-      const draft = {
-        ...form.getValues(),
-        authType: nextAuthType,
-        headerName: nextHeaderName,
-      };
-      const source = sourceForInspection(draft, agent);
-      if (!source) return;
-      if (nextAuthType === "api_key" && !nextHeaderName.trim()) {
-        form.setError("headerName", { message: "A header name is required." });
+      validate?: boolean;
+      onSuccess?: (result: Inspection, draft: FormValues) => void;
+    } = {}) => {
+      const draft = form.getValues();
+      const fieldsToValidate: (keyof FormValues)[] = ["url"];
+      if (draft.authType === "api_key") fieldsToValidate.push("headerName");
+      if (validate && !(await form.trigger(fieldsToValidate))) return;
+
+      form.clearErrors("credential");
+      const credential = draft.credential.trim();
+      const usesStoredCredential =
+        !credential && keepsStoredCredential(draft, agent);
+      if (draft.authType !== "none" && !credential && !usesStoredCredential) {
+        form.setError("credential", {
+          message: agent
+            ? "Enter a credential when changing authentication."
+            : "A credential is required.",
+        });
         return;
       }
-      form.clearErrors("headerName");
+
+      const source = sourceForInspection(draft, agent);
+      if (!source) return;
+      const auth =
+        draft.authType === "none"
+          ? { type: "none" as const }
+          : draft.authType === "bearer"
+            ? {
+                type: "bearer" as const,
+                ...(credential ? { credential } : {}),
+              }
+            : {
+                type: "api_key" as const,
+                headerName: draft.headerName.trim(),
+                ...(credential ? { credential } : {}),
+              };
       const requestId = ++requestRef.current;
       setInspectionPending(true);
       setInspectionError(null);
+      setInspection(null);
+      setCompatibleStamp(null);
       inspectRemoteAgent(
         {
           source,
-          auth:
-            nextAuthType === "api_key"
-              ? { type: "api_key", headerName: nextHeaderName.trim() }
-              : { type: nextAuthType },
+          auth,
+          ...(usesStoredCredential && agent ? { remoteAgentId: agent.id } : {}),
         },
         {
           onSuccess: (result) => {
@@ -172,11 +191,11 @@ export function A2aRemoteAgentForm({
             setCapabilitiesInspected(true);
             setCompatibleStamp(connectionStamp(draft, agent));
             setInspectionPending(false);
+            onSuccess?.(result, draft);
           },
           onError: (error) => {
             if (requestId !== requestRef.current) return;
-            setInspection(knownInspection);
-            setCompatibleStamp(null);
+            setCapabilitiesInspected(false);
             setInspectionError(getApiErrorMessage(error));
             setInspectionPending(false);
           },
@@ -195,61 +214,13 @@ export function A2aRemoteAgentForm({
     )
       return;
     refreshedAgentIdRef.current = agent.id;
-    inspectCompatibility({ knownInspection: inspectionFromAgent(agent) });
+    void inspectConnection({ validate: false });
     return () => {
       if (refreshedAgentIdRef.current === agent.id) {
         refreshedAgentIdRef.current = null;
       }
     };
-  }, [agent, inspectCompatibility, readOnly]);
-
-  const inspectSource = async () => {
-    if (!(await form.trigger("url"))) return;
-    const draft = form.getValues();
-    const source = sourceForInspection(draft, agent);
-    if (!source) return;
-    const requestId = ++requestRef.current;
-    setInspectionPending(true);
-    setInspectionError(null);
-    setInspection(null);
-    setCompatibleStamp(null);
-    inspectRemoteAgent(
-      { source },
-      {
-        onSuccess: (result) => {
-          if (requestId !== requestRef.current) return;
-          if (!result) {
-            setInspectionError("The Agent Card inspection returned no data.");
-            setInspectionPending(false);
-            return;
-          }
-          setInspection(result);
-          setCapabilitiesInspected(true);
-          const nextAuthType = result.supportedAuthTypes.includes(
-            draft.authType,
-          )
-            ? draft.authType
-            : result.supportedAuthTypes[0];
-          if (!nextAuthType) {
-            setInspectionError(
-              "This Agent Card does not advertise a supported authentication method.",
-            );
-            setInspectionPending(false);
-            return;
-          }
-          if (nextAuthType !== draft.authType)
-            form.setValue("authType", nextAuthType, { shouldDirty: true });
-          inspectCompatibility({ knownInspection: result, nextAuthType });
-        },
-        onError: (error) => {
-          if (requestId !== requestRef.current) return;
-          setCapabilitiesInspected(false);
-          setInspectionError(getApiErrorMessage(error));
-          setInspectionPending(false);
-        },
-      },
-    );
-  };
+  }, [agent, inspectConnection, readOnly]);
 
   const validateCredential = () => {
     form.clearErrors("credential");
@@ -277,9 +248,15 @@ export function A2aRemoteAgentForm({
     return true;
   };
 
-  const buildSubmission = (): A2aRemoteAgentFormSubmission | null => {
+  const buildSubmission = ({
+    verifiedInspection = inspection,
+    verifiedStamp = compatibleStamp,
+  }: {
+    verifiedInspection?: Inspection | null;
+    verifiedStamp?: string | null;
+  } = {}): A2aRemoteAgentFormSubmission | null => {
     const current = form.getValues();
-    if (connectionStamp(current, agent) !== compatibleStamp) return null;
+    if (connectionStamp(current, agent) !== verifiedStamp) return null;
     const source = parseSource({ values: current, agent, form });
     const auth = parseAuth({ values: current, agent, form });
     if (source === null || auth === null || !validateAccess()) return null;
@@ -299,10 +276,13 @@ export function A2aRemoteAgentForm({
       };
     }
     const submission: A2aRemoteAgentFormSubmission = {};
+    const verifiedInspectionNeedsPersistence =
+      !!verifiedInspection && verifiedInspection.cardHash !== agent.cardHash;
     if (
       source &&
       (!sameSource(source, agent) ||
-        (inspectionNeedsPersistence && agent.discoveryMode === "well_known"))
+        (verifiedInspectionNeedsPersistence &&
+          agent.discoveryMode === "well_known"))
     )
       submission.source = source;
     if (auth) submission.auth = auth;
@@ -339,30 +319,52 @@ export function A2aRemoteAgentForm({
     setInspectionPending(false);
     resetRemoteAgentInspection();
   };
-  const submit = form.handleSubmit(() => {
-    if (!validateCredential()) return;
-    const submission = buildSubmission();
+  const completeSubmission = ({
+    verifiedInspection = inspection,
+    verifiedStamp = compatibleStamp,
+  }: {
+    verifiedInspection?: Inspection | null;
+    verifiedStamp?: string | null;
+  } = {}) => {
+    const submission = buildSubmission({
+      verifiedInspection,
+      verifiedStamp,
+    });
     if (!submission) return;
     if (agent && Object.keys(submission).length === 0) {
       discardChanges();
       return;
     }
     onSubmit(submission);
+  };
+  const submit = form.handleSubmit(() => {
+    if (!validateCredential() || !validateAccess()) return;
+    const draft = form.getValues();
+    const draftStamp = connectionStamp(draft, agent);
+    if (draftStamp === compatibleStamp && inspection) {
+      completeSubmission();
+      return;
+    }
+    void inspectConnection({
+      validate: false,
+      onSuccess: (result, inspectedDraft) => {
+        completeSubmission({
+          verifiedInspection: result,
+          verifiedStamp: connectionStamp(inspectedDraft, agent),
+        });
+      },
+    });
   });
+  const canReuseStoredCredential = keepsStoredCredential(values, agent);
   const hasRequiredCredential =
     values.authType === "none" ||
     !!values.credential.trim() ||
-    keepsStoredCredential(values, agent);
-  const hasValidAccessSelection =
-    (values.accessChoice !== "user" || values.userIds.length > 0) &&
-    (values.accessChoice !== "team" || values.teamIds.length > 0);
-  const canSubmit =
-    !inspectionPending &&
-    !connectionNeedsInspection &&
-    !!inspection &&
+    canReuseStoredCredential;
+  const canInspect =
+    !!values.url.trim() &&
     hasRequiredCredential &&
-    hasValidAccessSelection &&
-    (!agent || isDirty);
+    (values.authType !== "api_key" || !!values.headerName.trim());
+  const canSubmit = !agent || isDirty;
 
   if (readOnly && agent) {
     return <ReadOnlySummary agent={agent} currentUserId={session?.user?.id} />;
@@ -374,39 +376,26 @@ export function A2aRemoteAgentForm({
         <SettingsSectionGroup>
           <SettingsSection
             title="Connection"
-            description="Discover the Agent Card from the external agent's base URL."
+            description={`Set the external agent's base URL and how ${appName} authenticates. Connecting validates the Agent Card before saving.`}
           >
             <div className="space-y-2">
               <Label htmlFor="a2a-url">Agent base URL</Label>
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <Input
-                  id="a2a-url"
-                  type="url"
-                  aria-invalid={!!form.formState.errors.url}
-                  aria-describedby="a2a-url-help a2a-url-error"
-                  placeholder="https://agent.example.com"
-                  {...form.register("url", {
-                    required: urlRequiredMessage,
-                    validate: (value) =>
-                      keepsLegacySource && !value.trim()
-                        ? true
-                        : !!normalizeAgentBaseUrl(value.trim()) ||
-                          "Enter an HTTP(S) base URL without credentials, a query, or a fragment.",
-                    onChange: invalidateSource,
-                  })}
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="shrink-0"
-                  disabled={inspectionPending || !values.url.trim()}
-                  onClick={() => void inspectSource()}
-                >
-                  <span>
-                    {inspectionPending ? "Checking…" : "Check Agent Card"}
-                  </span>
-                </Button>
-              </div>
+              <Input
+                id="a2a-url"
+                type="url"
+                aria-invalid={!!form.formState.errors.url}
+                aria-describedby="a2a-url-help a2a-url-error"
+                placeholder="https://agent.example.com"
+                {...form.register("url", {
+                  required: urlRequiredMessage,
+                  validate: (value) =>
+                    keepsLegacySource && !value.trim()
+                      ? true
+                      : !!normalizeAgentBaseUrl(value.trim()) ||
+                        "Enter an HTTP(S) base URL without credentials, a query, or a fragment.",
+                  onChange: invalidateSource,
+                })}
+              />
               <FieldDescription id="a2a-url-help">
                 {keepsLegacySource
                   ? "This connection uses a legacy Agent Card source. Leave this blank to keep it, or enter a base URL to replace it."
@@ -421,53 +410,14 @@ export function A2aRemoteAgentForm({
                   {form.formState.errors.url.message}
                 </p>
               ) : null}
-              {inspectionPending ? (
-                <output
-                  aria-label="Checking Agent Card"
-                  className="flex items-center gap-2 text-sm text-muted-foreground"
-                >
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <span>
-                    Checking the Agent Card and authentication settings…
-                  </span>
-                </output>
-              ) : null}
-              {inspectionError ? (
-                <p
-                  role="alert"
-                  aria-label="Agent Card unavailable"
-                  className="text-sm text-destructive"
-                >
-                  {inspectionError}
-                </p>
-              ) : null}
-              {inspection && !inspectionError ? (
-                <output
-                  aria-label="Agent Card found"
-                  className="flex items-start gap-2 rounded-md border bg-muted/40 p-3 text-sm"
-                >
-                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-green-600" />
-                  <div>
-                    <p className="font-medium">{inspection.name}</p>
-                    <p className="text-muted-foreground">
-                      {inspection.selectedInterface.protocolBinding},{" "}
-                      {inspection.selectedInterface.protocolVersion}
-                    </p>
-                  </div>
-                </output>
-              ) : null}
             </div>
-          </SettingsSection>
-          <SettingsSection
-            title="Authentication"
-            description={`Configure how ${appName} authenticates requests to this external agent.`}
-          >
-            {!agent && !inspection ? (
-              <p className="text-sm text-muted-foreground">
-                Check the Agent Card to see its supported authentication
-                methods.
-              </p>
-            ) : null}
+            <div className="space-y-2">
+              <Label>Authentication</Label>
+              <FieldDescription>
+                These credentials are also used to retrieve protected Agent
+                Cards.
+              </FieldDescription>
+            </div>
             <RadioGroup
               aria-label="Authentication"
               value={values.authType}
@@ -477,11 +427,6 @@ export function A2aRemoteAgentForm({
                   shouldDirty: true,
                 });
                 invalidateCompatibility();
-                if (inspection)
-                  inspectCompatibility({
-                    knownInspection: inspection,
-                    nextAuthType,
-                  });
               }}
               className="grid gap-2 sm:grid-cols-3"
             >
@@ -523,12 +468,6 @@ export function A2aRemoteAgentForm({
                   {...form.register("headerName", {
                     required: "A header name is required.",
                     onChange: invalidateCompatibility,
-                    onBlur: () => {
-                      if (inspection && form.getValues("headerName").trim())
-                        inspectCompatibility({
-                          knownInspection: inspection,
-                        });
-                    },
                   })}
                 />
                 {form.formState.errors.headerName ? (
@@ -545,7 +484,7 @@ export function A2aRemoteAgentForm({
             {values.authType !== "none" ? (
               <div className="space-y-2">
                 <Label htmlFor="a2a-credential">
-                  {agent?.connection.hasCredential
+                  {canReuseStoredCredential
                     ? "Replace credential (optional)"
                     : "Credential"}
                 </Label>
@@ -555,12 +494,14 @@ export function A2aRemoteAgentForm({
                   aria-invalid={!!form.formState.errors.credential}
                   aria-describedby="a2a-credential-help a2a-credential-error"
                   placeholder={
-                    agent?.connection.hasCredential ? "••••••••" : undefined
+                    canReuseStoredCredential ? "••••••••" : undefined
                   }
-                  {...form.register("credential")}
+                  {...form.register("credential", {
+                    onChange: invalidateCompatibility,
+                  })}
                 />
                 <FieldDescription id="a2a-credential-help">
-                  {agent?.connection.hasCredential
+                  {canReuseStoredCredential
                     ? "Leave this blank to keep the stored credential, or enter a replacement."
                     : "The credential is stored securely and cannot be shown again."}
                 </FieldDescription>
@@ -574,6 +515,53 @@ export function A2aRemoteAgentForm({
                   </p>
                 ) : null}
               </div>
+            ) : null}
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={inspectionPending || !canInspect}
+                onClick={() => void inspectConnection()}
+              >
+                <span>
+                  {inspectionPending ? "Checking…" : "Check Agent Card"}
+                </span>
+              </Button>
+            </div>
+            {inspectionPending ? (
+              <output
+                aria-label="Checking Agent Card"
+                className="flex items-center gap-2 text-sm text-muted-foreground"
+              >
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span>
+                  Checking the Agent Card and authentication settings…
+                </span>
+              </output>
+            ) : null}
+            {inspectionError ? (
+              <p
+                role="alert"
+                aria-label="Agent Card unavailable"
+                className="text-sm text-destructive"
+              >
+                {inspectionError}
+              </p>
+            ) : null}
+            {inspection && !inspectionError ? (
+              <output
+                aria-label="Agent Card found"
+                className="flex items-start gap-2 rounded-md border bg-muted/40 p-3 text-sm"
+              >
+                <CheckCircle2 className="mt-0.5 h-4 w-4 text-green-600" />
+                <div>
+                  <p className="font-medium">{inspection.name}</p>
+                  <p className="text-muted-foreground">
+                    {inspection.selectedInterface.protocolBinding},{" "}
+                    {inspection.selectedInterface.protocolVersion}
+                  </p>
+                </div>
+              </output>
             ) : null}
             {inspection && !inspectionPending && !connectionNeedsInspection ? (
               <output
@@ -670,7 +658,11 @@ export function A2aRemoteAgentForm({
         </SettingsSectionGroup>
       </form>
       <FloatingActionBar>
-        <Button type="submit" form={formId} disabled={isSaving || !canSubmit}>
+        <Button
+          type="submit"
+          form={formId}
+          disabled={isSaving || inspectionPending || !canSubmit}
+        >
           {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
           <span>
             {isSaving
@@ -882,8 +874,13 @@ function sameSource(source: Source, agent: A2aRemoteAgent) {
   );
 }
 function keepsStoredCredential(values: FormValues, agent?: A2aRemoteAgent) {
+  const storedBaseUrl = storedWellKnownBaseUrl(agent);
+  const keepsSource = storedBaseUrl
+    ? normalizeAgentBaseUrl(values.url.trim()) === storedBaseUrl
+    : !values.url.trim();
   return (
     !!agent?.connection.hasCredential &&
+    keepsSource &&
     values.authType === agent.connection.authType &&
     (values.authType !== "api_key" ||
       values.headerName.trim().toLowerCase() ===

--- a/platform/frontend/src/components/a2a-remote-agent-page.test.tsx
+++ b/platform/frontend/src/components/a2a-remote-agent-page.test.tsx
@@ -165,54 +165,35 @@ describe("external A2A agent routed pages", () => {
     expect(
       screen.queryByRole("button", { name: "Validate Agent Card" }),
     ).toBeNull();
+    const connectButton = screen.getByRole("button", {
+      name: "Connect agent",
+    });
+    expect(connectButton).toBeEnabled();
+    await user.click(connectButton);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "An agent base URL is required.",
+    );
+    expect(inspectedBody).toBeUndefined();
+    expect(createdBody).toBeUndefined();
+    expect(connectButton).toBeEnabled();
+
     const baseUrlInput = screen.getByLabelText("Agent base URL");
     await user.click(baseUrlInput);
     await user.paste(remoteAgent.discoveryUrl);
     expect(
-      screen.getByRole("button", { name: "Connect agent" }),
-    ).toBeDisabled();
-    expect(
       screen.getByLabelText("Display name (optional)"),
-    ).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Check Agent Card" }));
-    expect(
-      await screen.findByRole("status", { name: "Connection compatible" }),
     ).toBeInTheDocument();
     const nameInput = screen.getByLabelText("Display name (optional)");
     const descriptionInput = screen.getByLabelText("Description (optional)");
     await user.type(nameInput, remoteAgent.name);
     await user.type(descriptionInput, remoteAgent.description);
-    await user.clear(screen.getByLabelText("Agent base URL"));
-    await user.type(
-      screen.getByLabelText("Agent base URL"),
-      "https://changed.example.com",
-    );
-    expect(
-      screen.getByRole("button", { name: "Connect agent" }),
-    ).toBeDisabled();
-    await user.clear(screen.getByLabelText("Agent base URL"));
-    await user.type(
-      screen.getByLabelText("Agent base URL"),
-      remoteAgent.discoveryUrl,
-    );
-    expect(
-      screen.getByRole("button", { name: "Connect agent" }),
-    ).toBeDisabled();
-    await user.click(screen.getByRole("button", { name: "Check Agent Card" }));
-    await screen.findByRole("status", { name: "Connection compatible" });
-    expect(screen.getByLabelText("Display name (optional)")).toHaveValue(
-      remoteAgent.name,
-    );
-    expect(screen.getByLabelText("Description (optional)")).toHaveValue(
-      remoteAgent.description,
-    );
-    expect(inspectedBody).toEqual({
-      source: { type: "well_known", url: remoteAgent.discoveryUrl },
-      auth: { type: "none" },
-    });
-    await user.click(screen.getByRole("button", { name: "Connect agent" }));
+    await user.click(connectButton);
 
-    await waitFor(() =>
+    await waitFor(() => {
+      expect(inspectedBody).toEqual({
+        source: { type: "well_known", url: remoteAgent.discoveryUrl },
+        auth: { type: "none" },
+      });
       expect(createdBody).toEqual({
         source: { type: "well_known", url: remoteAgent.discoveryUrl },
         auth: { type: "none" },
@@ -221,8 +202,8 @@ describe("external A2A agent routed pages", () => {
         scope: "personal",
         teams: [],
         users: [],
-      }),
-    );
+      });
+    });
     expect(push).toHaveBeenCalledWith("/a2a/agents/remote-agent-1");
   });
 
@@ -260,6 +241,88 @@ describe("external A2A agent routed pages", () => {
     expect(push).not.toHaveBeenCalled();
     await user.click(screen.getByRole("button", { name: "Discard changes" }));
     expect(push).toHaveBeenCalledWith("/a2a/agents");
+  });
+
+  it.each([
+    {
+      method: "Bearer token",
+      credential: "bearer-secret",
+      expectedAuth: { type: "bearer", credential: "bearer-secret" },
+    },
+    {
+      method: "API key header",
+      credential: "api-key-secret",
+      expectedAuth: {
+        type: "api_key",
+        headerName: "X-API-Key",
+        credential: "api-key-secret",
+      },
+    },
+  ])("connects after checking the Agent Card with $method authentication", async ({
+    method,
+    credential,
+    expectedAuth,
+  }) => {
+    const user = userEvent.setup();
+    let inspectedBody: unknown;
+    let createdBody: unknown;
+    server.use(
+      http.post(`${REGISTRY_URL}/inspect`, async ({ request }) => {
+        inspectedBody = await request.json();
+        return HttpResponse.json({
+          name: "Fixture Agent",
+          description: null,
+          agentCard: remoteAgent.agentCard,
+          cardHash: remoteAgent.cardHash,
+          selectedInterface: remoteAgent.connection.selectedInterface,
+          supportedAuthTypes: [expectedAuth.type],
+          selectedSecurityRequirement: { fixtureAuth: [] },
+        });
+      }),
+      http.post(REGISTRY_URL, async ({ request }) => {
+        createdBody = await request.json();
+        return HttpResponse.json(remoteAgent);
+      }),
+    );
+
+    renderPage(<CreateA2aRemoteAgentPage />);
+
+    const connectionSection = screen
+      .getByRole("heading", { name: "Connection" })
+      .closest("section");
+    expect(connectionSection).not.toBeNull();
+    expect(connectionSection).toContainElement(
+      screen.getByRole("radiogroup", { name: "Authentication" }),
+    );
+    expect(
+      screen.queryByRole("heading", { name: "Authentication" }),
+    ).toBeNull();
+
+    await user.type(
+      screen.getByLabelText("Agent base URL"),
+      remoteAgent.discoveryUrl,
+    );
+    await user.click(screen.getByRole("radio", { name: method }));
+    expect(
+      screen.getByRole("button", { name: "Check Agent Card" }),
+    ).toBeDisabled();
+
+    await user.type(screen.getByLabelText("Credential"), credential);
+    await user.click(screen.getByRole("button", { name: "Connect agent" }));
+
+    await waitFor(() => {
+      expect(inspectedBody).toEqual({
+        source: { type: "well_known", url: remoteAgent.discoveryUrl },
+        auth: expectedAuth,
+      });
+      expect(createdBody).toEqual({
+        source: { type: "well_known", url: remoteAgent.discoveryUrl },
+        auth: expectedAuth,
+        scope: "personal",
+        teams: [],
+        users: [],
+      });
+    });
   });
 
   it("rejects query parameters and discovers from a canonical path-prefixed base URL", async () => {
@@ -303,7 +366,7 @@ describe("external A2A agent routed pages", () => {
     expect(
       await screen.findByRole("status", { name: "Agent Card found" }),
     ).toHaveTextContent("Fixture Agent");
-    expect(inspectCalls).toBe(2);
+    expect(inspectCalls).toBe(1);
     expect(inspectedBody).toEqual({
       source: {
         type: "well_known",
@@ -315,6 +378,7 @@ describe("external A2A agent routed pages", () => {
 
   it("requires a selected user or team for explicit access choices", async () => {
     const user = userEvent.setup();
+    let inspectCalls = 0;
     vi.mocked(useOrganizationMembers).mockReturnValue({
       data: [
         { id: "user-1", name: "Test User", email: "owner@example.com" },
@@ -325,8 +389,9 @@ describe("external A2A agent routed pages", () => {
       data: [{ id: "team-1", name: "Operations", parentId: null }],
     } as unknown as ReturnType<typeof useTeams>);
     server.use(
-      http.post(`${REGISTRY_URL}/inspect`, () =>
-        HttpResponse.json({
+      http.post(`${REGISTRY_URL}/inspect`, () => {
+        inspectCalls += 1;
+        return HttpResponse.json({
           name: "Fixture Agent",
           description: null,
           agentCard: remoteAgent.agentCard,
@@ -334,8 +399,8 @@ describe("external A2A agent routed pages", () => {
           selectedInterface: remoteAgent.connection.selectedInterface,
           supportedAuthTypes: ["none"],
           selectedSecurityRequirement: null,
-        }),
-      ),
+        });
+      }),
     );
 
     renderPage(<CreateA2aRemoteAgentPage />);
@@ -347,14 +412,23 @@ describe("external A2A agent routed pages", () => {
     await screen.findByRole("status", { name: "Connection compatible" });
     await user.click(screen.getByRole("button", { name: /Personal/ }));
     await user.click(screen.getByRole("button", { name: /Users/ }));
-    expect(
-      screen.getByRole("button", { name: "Connect agent" }),
-    ).toBeDisabled();
+    const connectButton = screen.getByRole("button", {
+      name: "Connect agent",
+    });
+    expect(connectButton).toBeEnabled();
+    await user.click(connectButton);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Select at least one user.",
+    );
+    expect(inspectCalls).toBe(1);
     await user.click(screen.getByRole("button", { name: /Users/ }));
     await user.click(screen.getByRole("button", { name: /Teams/ }));
-    expect(
-      screen.getByRole("button", { name: "Connect agent" }),
-    ).toBeDisabled();
+    expect(connectButton).toBeEnabled();
+    await user.click(connectButton);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Select at least one team.",
+    );
+    expect(inspectCalls).toBe(1);
   });
 
   it("prefills edit and omits unchanged source and stored credential on a visibility-only update", async () => {
@@ -432,6 +506,7 @@ describe("external A2A agent routed pages", () => {
     expect(inspectedBody).toEqual({
       source: { type: "well_known", url: remoteAgent.discoveryUrl },
       auth: { type: remoteAgent.connection.authType },
+      remoteAgentId: remoteAgent.id,
     });
   });
 
@@ -499,14 +574,14 @@ describe("external A2A agent routed pages", () => {
     );
   });
 
-  it("rechecks an edited base URL without resubmitting its stored credential", async () => {
+  it("requires a credential when checking an edited base URL", async () => {
     const user = userEvent.setup();
-    let inspectedBody: unknown;
+    const inspectedBodies: unknown[] = [];
     let updatedBody: unknown;
     server.use(
       http.get(`${REGISTRY_URL}/:id`, () => HttpResponse.json(remoteAgent)),
       http.post(`${REGISTRY_URL}/inspect`, async ({ request }) => {
-        inspectedBody = await request.json();
+        inspectedBodies.push(await request.json());
         return HttpResponse.json({
           name: remoteAgent.name,
           description: remoteAgent.description,
@@ -528,32 +603,52 @@ describe("external A2A agent routed pages", () => {
 
     renderPage(<A2aRemoteAgentDetailPage id={remoteAgent.id} />);
 
+    await screen.findByRole("status", { name: "Connection compatible" });
+    expect(inspectedBodies).toHaveLength(1);
     const baseUrlInput = await screen.findByLabelText("Agent base URL");
     await user.clear(baseUrlInput);
     await user.click(baseUrlInput);
-    await user.paste(remoteAgent.discoveryUrl);
-    await user.click(screen.getByRole("button", { name: "Check Agent Card" }));
-
-    await waitFor(() =>
-      expect(inspectedBody).toEqual({
-        source: { type: "well_known", url: remoteAgent.discoveryUrl },
-        auth: { type: "bearer" },
-      }),
-    );
+    await user.paste(`${remoteAgent.discoveryUrl}/replacement`);
+    expect(screen.getByLabelText("Credential")).toHaveValue("");
     expect(
-      await screen.findByRole("status", { name: "Agent Card found" }),
-    ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: "Save changes" }),
-      ).toBeEnabled(),
+      screen.getByRole("button", { name: "Check Agent Card" }),
+    ).toBeDisabled();
+    const saveButton = screen.getByRole("button", { name: "Save changes" });
+    expect(saveButton).toBeEnabled();
+    await user.click(saveButton);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Enter a credential when changing authentication.",
     );
-    await user.click(screen.getByRole("button", { name: "Save changes" }));
-    await waitFor(() =>
+    expect(inspectedBodies).toHaveLength(1);
+    expect(updatedBody).toBeUndefined();
+    await user.type(
+      screen.getByLabelText("Credential"),
+      "replacement-bearer-token",
+    );
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(inspectedBodies).toContainEqual({
+        source: {
+          type: "well_known",
+          url: `${remoteAgent.discoveryUrl}/replacement`,
+        },
+        auth: {
+          type: "bearer",
+          credential: "replacement-bearer-token",
+        },
+      });
       expect(updatedBody).toEqual({
-        source: { type: "well_known", url: remoteAgent.discoveryUrl },
-      }),
-    );
+        source: {
+          type: "well_known",
+          url: `${remoteAgent.discoveryUrl}/replacement`,
+        },
+        auth: {
+          type: "bearer",
+          credential: "replacement-bearer-token",
+        },
+      });
+    });
   });
 
   it("uses one submit action for edit and enables it when dirty", async () => {
@@ -611,6 +706,7 @@ describe("external A2A agent routed pages", () => {
 
   it("shows why automatic Agent Card validation failed", async () => {
     const user = userEvent.setup();
+    let createCalls = 0;
     server.use(
       http.post(`${REGISTRY_URL}/inspect`, () =>
         HttpResponse.json(
@@ -622,6 +718,10 @@ describe("external A2A agent routed pages", () => {
           { status: 400 },
         ),
       ),
+      http.post(REGISTRY_URL, () => {
+        createCalls += 1;
+        return HttpResponse.json(remoteAgent);
+      }),
     );
 
     renderPage(<CreateA2aRemoteAgentPage />);
@@ -629,11 +729,13 @@ describe("external A2A agent routed pages", () => {
       screen.getByLabelText("Agent base URL"),
       remoteAgent.discoveryUrl,
     );
-    await user.click(screen.getByRole("button", { name: "Check Agent Card" }));
+    await user.click(screen.getByRole("button", { name: "Connect agent" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Agent Card must accept the text/plain input mode",
     );
+    expect(createCalls).toBe(0);
+    expect(screen.getByRole("button", { name: "Connect agent" })).toBeEnabled();
   });
 
   it("shows a read-only detail without exposing or replacing credentials", async () => {

--- a/platform/frontend/src/components/a2a-remote-agent-page.tsx
+++ b/platform/frontend/src/components/a2a-remote-agent-page.tsx
@@ -292,7 +292,7 @@ function DetailShell({
 function FormSkeleton() {
   return (
     <SettingsSectionGroup>
-      {["Agent Card", "Authentication", "Details", "Access"].map((title) => (
+      {["Connection", "Details", "Access"].map((title) => (
         <SettingsSection key={title} title={title}>
           <Skeleton className="h-10 w-full" />
           <Skeleton className="h-10 w-full" />

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -12782,10 +12782,13 @@ export type InspectA2aRemoteAgentData = {
             type: 'none';
         } | {
             type: 'bearer';
+            credential?: string;
         } | {
             type: 'api_key';
             headerName: string;
+            credential?: string;
         };
+        remoteAgentId?: string;
     };
     path?: never;
     query?: never;


### PR DESCRIPTION
## Problem

A2A Agent Card discovery was disconnected from authentication. Protected cards could not be inspected with bearer-token or API-key credentials, and the primary **Connect agent** action remained disabled until users ran a separate card check.

## Changes

- Treat the base URL, authentication method, and Agent Card inspection as one connection flow.
- Send the configured bearer token or API-key header when inspecting an Agent Card.
- Keep **Connect agent** enabled and make it validate the form, inspect the card, and persist the connection in sequence. The separate card check remains available as an optional preview.
- Reuse a stored credential only when the organization, authentication configuration, and canonical discovery source still match. A source change requires a replacement credential so a saved secret cannot be forwarded to another destination.

## Verification

Exercised routed create and edit flows with no authentication, bearer authentication, and API-key authentication. Valid submissions inspected the protected card and persisted the agent; invalid fields, unsupported cards, and source changes without replacement credentials stopped before persistence. Backend route coverage also confirms that rejected source changes make no outbound request.

---

<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
