### PR TITLE
fix(frontend): clarify inaccessible log sessions

### DIFF
--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.integration.test.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.integration.test.tsx
@@ -1,0 +1,110 @@
+import { archestraApiClient } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { usePathname, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import SessionDetailPage from "./page.client";
+
+vi.mock("next/navigation");
+vi.mock("@/lib/hooks/use-app-name");
+vi.mock("sonner");
+
+const origin = "http://localhost:9000";
+const sessionsUrl = `${origin}/api/interactions/sessions`;
+const emptySessions = {
+  data: [],
+  pagination: { limit: 1, nextCursor: null, hasNext: false },
+};
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+beforeEach(() => {
+  vi.mocked(useSearchParams).mockReturnValue(
+    new URLSearchParams() as ReturnType<typeof useSearchParams>,
+  );
+  vi.mocked(usePathname).mockReturnValue("/llm/logs/session/test-session");
+  archestraApiClient.setConfig({ baseUrl: origin });
+  server.use(
+    http.get(sessionsUrl, () => HttpResponse.json(emptySessions)),
+    http.get(`${origin}/api/interactions/summaries`, () =>
+      HttpResponse.json({ data: [], pagination: { total: 0 } }),
+    ),
+  );
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => {
+  server.close();
+  archestraApiClient.setConfig({ baseUrl: "" });
+});
+
+it("replaces authorization-filtered session details with access guidance and a way back", async () => {
+  await renderPage();
+  expect(await screen.findByRole("alert")).toHaveTextContent(
+    "Session unavailable",
+  );
+  expect(screen.getByText(/ask an administrator/)).toBeVisible();
+  for (const link of screen.getAllByRole("link", {
+    name: "Back to Sessions",
+  })) {
+    expect(link).toHaveAttribute("href", "/llm/logs");
+  }
+  expect(screen.queryByText("Requests")).not.toBeInTheDocument();
+  expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Export JSON" }),
+  ).not.toBeInTheDocument();
+});
+
+it("lets a failed session lookup recover on retry instead of claiming access is unavailable", async () => {
+  server.use(
+    http.get(sessionsUrl, () =>
+      HttpResponse.json(
+        {
+          error: {
+            message: "Unable to load session",
+            type: "api_internal_server_error",
+          },
+        },
+        { status: 500 },
+      ),
+    ),
+  );
+  await renderPage();
+  const retry = await screen.findByRole("button", { name: "Retry" });
+  expect(screen.queryByText("Session unavailable")).not.toBeInTheDocument();
+  server.use(http.get(sessionsUrl, () => HttpResponse.json(emptySessions)));
+  fireEvent.click(retry);
+  expect(await screen.findByRole("alert")).toHaveTextContent(
+    "Session unavailable",
+  );
+  expect(
+    screen.queryByRole("button", { name: "Retry" }),
+  ).not.toBeInTheDocument();
+});
+
+async function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const params = Promise.resolve({ sessionId: "test-session" });
+  await act(async () => {
+    render(
+      <QueryClientProvider client={client}>
+        <Suspense>
+          <SessionDetailPage paramsPromise={params} />
+        </Suspense>
+      </QueryClientProvider>,
+    );
+  });
+}

--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.test.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.test.tsx
@@ -73,7 +73,13 @@ describe("SessionDetailPage", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows the empty state after session interactions finish loading empty", async () => {
+  it("shows a permission-aware unavailable state when the requested session is not visible", async () => {
+    vi.mocked(useInteractionSessions).mockReturnValue({
+      data: {
+        data: [],
+        pagination: { limit: 1, nextCursor: null, hasNext: false },
+      },
+    } as unknown as ReturnType<typeof useInteractionSessions>);
     vi.mocked(useInteractionSummaries).mockReturnValue({
       data: {
         data: [],
@@ -92,8 +98,15 @@ describe("SessionDetailPage", () => {
     renderSessionDetailPage();
 
     expect(
-      await screen.findByText("No interactions found for this session"),
+      await screen.findByText(
+        "You do not have permission to view this session, or it no longer exists.",
+      ),
     ).toBeVisible();
+    expect(screen.getByRole("alert")).toHaveTextContent("Session unavailable");
+    expect(screen.queryByText("Requests")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("No interactions found for this session"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("status", { name: "Loading session logs…" }),
     ).not.toBeInTheDocument();

--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.test.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.test.tsx
@@ -99,7 +99,7 @@ describe("SessionDetailPage", () => {
 
     expect(
       await screen.findByText(
-        "You do not have permission to view this session, or it no longer exists.",
+        "You may not have permission to view this session, or it may no longer exist.",
       ),
     ).toBeVisible();
     expect(screen.getByRole("alert")).toHaveTextContent("Session unavailable");

--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
@@ -4,7 +4,16 @@ import {
   clientForExternalAgentIds,
   DynamicInteraction,
 } from "@archestra/shared";
-import { Bot, Download, Layers, Loader2, User } from "lucide-react";
+import {
+  ArrowLeft,
+  Bot,
+  Download,
+  Layers,
+  Loader2,
+  LockKeyhole,
+  User,
+} from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { use } from "react";
 import { BilledCost } from "@/components/billed-cost";
@@ -15,9 +24,15 @@ import { PageBackLink } from "@/components/page-back-link";
 import { PageLayout } from "@/components/page-layout";
 import { QueryLoadError } from "@/components/query-load-error";
 import { SourceBadge } from "@/components/source-badge";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+} from "@/components/ui/empty";
 import {
   Table,
   TableBody,
@@ -31,6 +46,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { UnattributedUserBadge } from "@/components/unattributed-user-badge";
 import { VirtualKeyBadge } from "@/components/virtual-key-badge";
 import { typeRole } from "@/lib/design/type-scale";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import {
   useExportSessionInteractions,
@@ -48,6 +64,7 @@ export default function SessionDetailPage({
   const rawParams = use(paramsPromise);
   const sessionId = decodeURIComponent(rawParams.sessionId);
   const router = useRouter();
+  const appName = useAppName();
   const { pageIndex, pageSize, offset, setPagination } =
     useDataTableQueryParams();
 
@@ -159,21 +176,37 @@ export default function SessionDetailPage({
 
   if (unavailableSession) {
     return (
-      <PageLayout
-        title="Session unavailable"
-        documentTitle="Session unavailable"
-        backLink={
-          <PageBackLink href="/llm/logs">Back to Sessions</PageBackLink>
-        }
-      >
-        <Alert variant="destructive">
-          <AlertTitle>Session unavailable</AlertTitle>
-          <AlertDescription>
-            You do not have permission to view this session, or it no longer
-            exists.
-          </AlertDescription>
-        </Alert>
-      </PageLayout>
+      <div className="flex h-full min-h-0 w-full items-center justify-center overflow-y-auto p-6">
+        <title>{`Session unavailable - ${appName}`}</title>
+        <Empty className="flex-none py-12 md:py-12">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <LockKeyhole aria-hidden="true" />
+            </EmptyMedia>
+            <div role="alert" className="space-y-2">
+              <h1 className="text-lg font-medium tracking-tight">
+                Session unavailable
+              </h1>
+              <EmptyDescription>
+                You may not have permission to view this session, or it may no
+                longer exist.
+              </EmptyDescription>
+            </div>
+          </EmptyHeader>
+          <EmptyContent>
+            <p className="text-sm text-muted-foreground">
+              If someone shared this link with you, ask an administrator to
+              check your log access.
+            </p>
+            <Button variant="outline" asChild>
+              <Link href="/llm/logs">
+                <ArrowLeft aria-hidden="true" />
+                <span>Back to Sessions</span>
+              </Link>
+            </Button>
+          </EmptyContent>
+        </Empty>
+      </div>
     );
   }
 

--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
@@ -13,7 +13,9 @@ import { type DetailFact, DetailFacts } from "@/components/detail-facts";
 import MessageThread from "@/components/message-thread";
 import { PageBackLink } from "@/components/page-back-link";
 import { PageLayout } from "@/components/page-layout";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SourceBadge } from "@/components/source-badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -59,9 +61,14 @@ export default function SessionDetailPage({
     });
 
   // Fetch session metadata (profile name, user names, etc.)
-  const { data: sessionResponse } = useInteractionSessions({
+  const {
+    data: sessionResponse,
+    isLoadingError: sessionLoadingError,
+    refetch: refetchSession,
+  } = useInteractionSessions({
     sessionId: sessionId,
     limit: 1,
+    toastOnError: false,
   });
 
   const interactions = interactionsResponse?.data ?? [];
@@ -130,6 +137,45 @@ export default function SessionDetailPage({
       )
     : [];
   const conversationChatErrors = lastMainRequest?.chatErrors ?? [];
+
+  const unavailableSession =
+    sessionResponse !== undefined && sessionResponse.data.length === 0;
+
+  if (sessionLoadingError) {
+    return (
+      <PageLayout
+        title="Session"
+        backLink={
+          <PageBackLink href="/llm/logs">Back to Sessions</PageBackLink>
+        }
+      >
+        <QueryLoadError
+          title="Couldn't load this session"
+          onRetry={() => refetchSession()}
+        />
+      </PageLayout>
+    );
+  }
+
+  if (unavailableSession) {
+    return (
+      <PageLayout
+        title="Session unavailable"
+        documentTitle="Session unavailable"
+        backLink={
+          <PageBackLink href="/llm/logs">Back to Sessions</PageBackLink>
+        }
+      >
+        <Alert variant="destructive">
+          <AlertTitle>Session unavailable</AlertTitle>
+          <AlertDescription>
+            You do not have permission to view this session, or it no longer
+            exists.
+          </AlertDescription>
+        </Alert>
+      </PageLayout>
+    );
+  }
 
   // The session's own numbers, as one wrapping row under the header. Labels
   // drop the "Total" every one of them used to carry: the page is a single


### PR DESCRIPTION
Shared log session links outside a viewer’s access scope previously showed zero metrics and an empty interactions table. The page now shows a centered unavailable state with access guidance and a link back to Sessions, without the session header. Failed lookups show a retry action.

Validation: 11 focused frontend tests passed, including HTTP-boundary integration coverage for filtered sessions and retry recovery. TypeScript, Biome, and knip passed. Checked desktop/mobile layouts and light/dark themes in Chrome. Existing access-control documentation remains accurate.

Backport requested to `release/1.3` after merge via the repository’s backport label.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>