### PR TITLE
fix(github-copilot): repair follow-up and nonstreaming inference

### DIFF
--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -1572,6 +1572,106 @@ describe("GitHub Copilot surface selection", () => {
     baseUrl: null,
   };
 
+  test("replays assistant text and tool calls instead of unavailable stored items", async () => {
+    const bodies: Record<string, unknown>[] = [];
+    vi.stubGlobal("fetch", async (_url: unknown, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      bodies.push(body);
+      if (
+        body.input.some(
+          (item: { type?: string }) => item.type === "item_reference",
+        )
+      ) {
+        return Response.json(
+          { error: { message: "Stored item not found", type: "not_found" } },
+          { status: 404 },
+        );
+      }
+      return Response.json({
+        id: "resp_test",
+        created_at: 0,
+        model: baseParams.modelName,
+        output: [
+          {
+            type: "message",
+            id: "msg_test",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "The marker is TEST_OK.",
+                annotations: [],
+              },
+            ],
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      });
+    });
+    const model = createLLMModel({
+      ...baseParams,
+      supportedEndpoints: ["/responses"],
+    });
+    const result = await generateText({
+      model,
+      maxRetries: 0,
+      providerOptions: { openai: { store: true } },
+      messages: [
+        { role: "user", content: "Look up the marker." },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Looking it up.",
+              providerOptions: { openai: { itemId: "msg_previous" } },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call_test",
+              toolName: "lookup_marker",
+              input: { name: "demo" },
+              providerOptions: { openai: { itemId: "fc_previous" } },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_test",
+              toolName: "lookup_marker",
+              output: { type: "text", value: "TEST_OK" },
+            },
+          ],
+        },
+        { role: "user", content: "What was the marker?" },
+      ],
+    });
+    expect(result.text).toBe("The marker is TEST_OK.");
+    expect(bodies[0]).toMatchObject({
+      store: false,
+      input: expect.arrayContaining([
+        expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "output_text", text: "Looking it up." }],
+        }),
+        expect.objectContaining({
+          type: "function_call",
+          call_id: "call_test",
+          name: "lookup_marker",
+          arguments: '{"name":"demo"}',
+        }),
+        expect.objectContaining({
+          type: "function_call_output",
+          call_id: "call_test",
+          output: "TEST_OK",
+        }),
+      ]),
+    });
+  });
+
   test("routes a Responses-only model to the Responses transport", () => {
     const model = createLLMModel({
       ...baseParams,

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -869,7 +869,24 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
     }) => {
       const client = createOpenAI({ apiKey, baseURL, headers, fetch });
       return requiresResponsesApi(supportedEndpoints)
-        ? client.responses(modelName)
+        ? wrapLanguageModel({
+            model: client.responses(modelName),
+            middleware: {
+              specificationVersion: "v3",
+              transformParams: async ({ params }) => ({
+                ...params,
+                providerOptions: {
+                  ...params.providerOptions,
+                  openai: {
+                    ...params.providerOptions?.openai,
+                    // Copilot cannot resolve stored output-item references.
+                    // Send the conversation contents on every turn instead.
+                    store: false,
+                  },
+                },
+              }),
+            },
+          })
         : client.chat(modelName);
     },
     defaultBaseUrl: config.llm["github-copilot"].baseUrl,

--- a/platform/backend/src/routes/chat/model-fetchers/github-copilot.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/github-copilot.test.ts
@@ -313,6 +313,41 @@ describe("fetchGithubCopilotModels", () => {
     expect(probeBody).toEqual({ model: "gpt-4", messages: [] });
   });
 
+  test.each([
+    "/chat/completions",
+    "/responses",
+  ])("drops an integrator-rejected model on %s without dropping payload validation errors", async (endpoint) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input, init) => {
+        const url = String(input);
+        if (url.includes("copilot_internal")) return tokenExchangeResponse();
+        if (url.endsWith("/models"))
+          return Response.json({
+            data: [
+              { id: "available-model", supported_endpoints: [endpoint] },
+              { id: "unavailable-model", supported_endpoints: [endpoint] },
+            ],
+          });
+        const body = JSON.parse(String(init?.body));
+        return Response.json(
+          {
+            error: {
+              type: "api_validation_error",
+              message:
+                body.model === "unavailable-model"
+                  ? 'The requested model is not available for integrator "vscode-chat". Available models: [available-model]. Verify the correct Copilot-Integration-Id header is being sent.'
+                  : "messages must be non-empty",
+            },
+          },
+          { status: 400 },
+        );
+      }),
+    );
+    const models = await fetchGithubCopilotModels(uniqueGithubToken());
+    expect(models.map((model) => model.id)).toEqual(["available-model"]);
+  });
+
   test("keeps a model when the invocability probe is inconclusive", async () => {
     const fetchMock = vi
       .fn()

--- a/platform/backend/src/routes/chat/model-fetchers/github-copilot.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/github-copilot.ts
@@ -112,7 +112,8 @@ const PROXY_SERVABLE_ENDPOINTS: readonly SupportedProviderEndpoint[] = [
  * `input` on responses (verified live). No tokens are generated and no model is
  * ever invoked, so the probe cannot consume a premium request.
  *
- * Only a definite `model_not_supported` drops a model. Anything inconclusive
+ * Only a definite model rejection drops a model, including Copilot's
+ * integrator-specific `api_validation_error`. Anything inconclusive
  * (429, 5xx, network failure — or a validation-order change upstream) keeps
  * it, so an outage degrades to an unverified catalog instead of an empty one.
  */
@@ -154,7 +155,7 @@ async function dropModelsRejectedUpstream(params: {
   if (dropped.length > 0) {
     logger.info(
       { droppedModelIds: dropped.map((model) => model.id) },
-      "Dropped GitHub Copilot models the chat/completions endpoint rejects",
+      "Dropped GitHub Copilot models their declared endpoint rejects",
     );
   }
   return candidates.filter((_, index) => invocable[index]);
@@ -192,8 +193,24 @@ async function isModelInvocable(params: {
     }
     const errorText = await response.text();
     try {
-      const parsed = JSON.parse(errorText) as { error?: { code?: string } };
-      return parsed.error?.code !== GithubCopilot.API.MODEL_NOT_SUPPORTED_CODE;
+      const parsed = JSON.parse(errorText) as {
+        error?: { code?: string; type?: string; message?: string };
+      };
+      const error = parsed.error;
+      if (error?.code === GithubCopilot.API.MODEL_NOT_SUPPORTED_CODE) {
+        return false;
+      }
+      // CAPI also reports model entitlement failures without a `code`. The
+      // type alone is not enough: valid models answer the empty-input probe
+      // with the same type, so only the model-specific message is definitive.
+      return !(
+        response.status === 400 &&
+        error?.type === "api_validation_error" &&
+        typeof error.message === "string" &&
+        /^The requested model is not (?:available for integrator\b|supported\.)/.test(
+          error.message,
+        )
+      );
     } catch {
       return true;
     }

--- a/platform/backend/src/routes/proxy/adapters/github-copilot.ts
+++ b/platform/backend/src/routes/proxy/adapters/github-copilot.ts
@@ -1,9 +1,9 @@
 /**
  * GitHub Copilot LLM Proxy Adapter - OpenAI-compatible
  *
- * Copilot serves an OpenAI-compatible chat completions API, so the whole
- * adapter is OpenAI's, configured via createOpenAiCompatibleAdapterFactory.
- * The provider-specific part is auth: the incoming "API key" is a long-lived
+ * Copilot reuses OpenAI's chat completions adapter, with missing response
+ * choice indices restored for clients that require them.
+ * Authentication also differs: the incoming "API key" is a long-lived
  * GitHub OAuth token (`gho_…`), which every outgoing request must swap for a
  * short-lived Copilot bearer (see services/github-copilot-token). The swap
  * happens in a fetch wrapper because `createClient` is synchronous.
@@ -12,12 +12,12 @@ import OpenAIProvider from "openai";
 import config from "@/config";
 import { metrics } from "@/observability";
 import { createGithubCopilotFetch } from "@/services/github-copilot-token";
-import type { CreateClientOptions } from "@/types";
+import type { CreateClientOptions, OpenAi } from "@/types";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
 import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
-export const githubCopilotAdapterFactory = createOpenAiCompatibleAdapterFactory(
-  {
+export const githubCopilotAdapterFactory = {
+  ...createOpenAiCompatibleAdapterFactory({
     provider: "github-copilot",
     interactionType: "github-copilot:chatCompletions",
     getBaseUrl: () => config.llm["github-copilot"].baseUrl,
@@ -45,5 +45,24 @@ export const githubCopilotAdapterFactory = createOpenAiCompatibleAdapterFactory(
         defaultHeaders: options.defaultHeaders,
       });
     },
+  }),
+
+  async execute(
+    client: unknown,
+    request: OpenAi.Types.ChatCompletionsRequest,
+  ): Promise<OpenAi.Types.ChatCompletionsResponse> {
+    const response = await (client as OpenAIProvider).chat.completions.create({
+      ...request,
+      stream: false,
+    } as OpenAIProvider.Chat.Completions.ChatCompletionCreateParamsNonStreaming);
+    // Copilot's Claude completions can omit choice indices. OpenAI clients
+    // require them even for a single choice, so restore the positional index.
+    return {
+      ...response,
+      choices: response.choices.map((choice, index) => ({
+        ...choice,
+        index: choice.index ?? index,
+      })),
+    } as unknown as OpenAi.Types.ChatCompletionsResponse;
   },
-);
+};

--- a/platform/backend/src/routes/proxy/routes/github-copilot.test.ts
+++ b/platform/backend/src/routes/proxy/routes/github-copilot.test.ts
@@ -13,6 +13,8 @@
  *     models.id UUID — plus the exchanged bearer and integration headers)
  *   - how the upstream rejection surfaces to the proxy caller
  */
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
 import Fastify from "fastify";
 import {
   serializerCompiler,
@@ -277,6 +279,116 @@ describe("GitHub Copilot Responses account routing", () => {
         expect(response.json()).toMatchObject({ model, output: result.output });
     } finally {
       server.events.removeListener("response:mocked", drainResponse);
+      await app.close();
+    }
+  });
+});
+
+describe("GitHub Copilot chat completion compatibility", () => {
+  test("the chat client accepts a completion whose upstream choices omit their indices", async ({
+    makeAgent,
+  }) => {
+    const app = createTestApp();
+    await app.register(githubCopilotProxyRoutes);
+    const agent = await makeAgent({ name: "Copilot Compatibility Agent" });
+    stubTokenExchange();
+    server.use(
+      http.post(COPILOT_CHAT_COMPLETIONS_URL, () =>
+        HttpResponse.json({
+          id: "completion-test",
+          model: "claude-sonnet-5",
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { role: "assistant", content: "Hello from Copilot" },
+            },
+          ],
+          usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+        }),
+      ),
+    );
+    const client = createOpenAI({
+      apiKey: uniqueGithubToken(),
+      baseURL: `http://proxy.test/v1/github-copilot/${agent.id}`,
+      fetch: async (input, init) => {
+        const request = new Request(input, init);
+        const response = await app.inject({
+          method: "POST",
+          url: new URL(request.url).pathname,
+          headers: Object.fromEntries(request.headers),
+          payload: await request.text(),
+        });
+        return new Response(response.body, {
+          status: response.statusCode,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+    try {
+      const result = await generateText({
+        model: client.chat("claude-sonnet-5"),
+        prompt: "Hello",
+        maxRetries: 0,
+      });
+      expect(result.text).toBe("Hello from Copilot");
+      expect(result.usage).toMatchObject({ inputTokens: 10, outputTokens: 4 });
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("fills missing choice indices while preserving upstream indices and tool calls", async ({
+    makeAgent,
+  }) => {
+    const app = createTestApp();
+    await app.register(githubCopilotProxyRoutes);
+    const agent = await makeAgent({ name: "Copilot Tool Compatibility Agent" });
+    const toolCall = {
+      id: "call_test",
+      type: "function",
+      function: { name: "lookup", arguments: '{"key":"example"}' },
+    };
+    stubTokenExchange();
+    server.use(
+      http.post(COPILOT_CHAT_COMPLETIONS_URL, () =>
+        HttpResponse.json({
+          id: "completion-test",
+          model: "claude-sonnet-5",
+          choices: [
+            {
+              index: 3,
+              finish_reason: "stop",
+              message: { role: "assistant", content: "First" },
+            },
+            {
+              finish_reason: "tool_calls",
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [toolCall],
+              },
+            },
+          ],
+          usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+        }),
+      ),
+    );
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/github-copilot/${agent.id}/chat/completions`,
+        headers: { authorization: `Bearer ${uniqueGithubToken()}` },
+        payload: {
+          model: "claude-sonnet-5",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+      });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.json().choices).toMatchObject([
+        { index: 3 },
+        { index: 1, message: { tool_calls: [toolCall] } },
+      ]);
+    } finally {
       await app.close();
     }
   });


### PR DESCRIPTION
Copilot Responses chat could answer the first turn, then fail with 404 when the AI SDK sent stored-item references on follow-ups or after tool calls. Disable response storage in the Copilot chat client so it sends the complete conversation history instead.

Also restore missing choice indices in Copilot chat-completion responses, which otherwise makes nonstreaming Claude inference fail AI SDK validation. Model discovery now excludes explicit integrator/model rejections while retaining models whose empty-input probe only reports a payload validation error.

Verified with a connected personal Copilot account: reproduced the follow-up 404 in the local chat UI, then confirmed Luna and Sol follow-ups succeed. Actual streaming and nonstreaming inference passed for nine models; twelve tool-call round trips passed across Luna, Sol, Astra, Claude Sonnet/Opus, and MAI. Regression tests exercise history serialization, client parsing of missing-index responses, and model rejection filtering. Burst testing initially hit upstream 429s; the final paced runs passed.

Follow-up to #7790. Requesting the `release/1.3` backport through the repository automation.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>