### PR TITLE
fix(agent-runtime): use a dedicated platform API pod selector

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -2,7 +2,7 @@
 title: Deployment
 category: Archestra Platform
 order: 3
-lastUpdated: 2026-09-10
+lastUpdated: 2026-09-11
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -957,7 +957,8 @@ Agent Runtime runs delegated Agent tasks in dedicated Kubernetes pods. You can v
   - Default: unset
 
 - **`ARCHESTRA_AGENT_RUNTIME_PLATFORM_POD_SELECTOR`** - Label selector matching the platform's own API pods, written as `key=value` pairs. Agent Runtime pods get an egress policy allowing exactly that destination. Override it when your deployment labels the platform differently.
-  - Default: `archestra.io/p4-shim-client=true`
+  - Default: `archestra.io/platform-api=true`
+  - Upgrade the Helm chart with the backend; the chart labels API pods automatically. For custom manifests, add this label before upgrading the backend, or configure a matching selector. Existing selector overrides remain supported.
 
 - **`ARCHESTRA_AGENT_RUNTIME_RECONCILE_INTERVAL_SECONDS`** - How often the reconciler syncs run state and applies the lifetime and idle stops.
   - Default: `30`

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -626,7 +626,7 @@ ARCHESTRA_AGENT_RUNTIME_ENABLED=false
 # ARCHESTRA_AGENT_RUNTIME_PLATFORM_BASE_URL=
 # Label selector matching the platform's own API pods, as key=value pairs.
 # Agent Runtime pods get an egress policy allowing exactly that destination.
-# ARCHESTRA_AGENT_RUNTIME_PLATFORM_POD_SELECTOR=archestra.io/p4-shim-client=true
+# ARCHESTRA_AGENT_RUNTIME_PLATFORM_POD_SELECTOR=archestra.io/platform-api=true
 # How often the reconciler syncs run state and applies TTL/idle stops.
 # ARCHESTRA_AGENT_RUNTIME_RECONCILE_INTERVAL_SECONDS=30
 # Maximum uncompressed output retained as a complete Agent Runtime transcript.

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2353,13 +2353,13 @@ const config = {
     /**
      * Selects the platform's own API-serving pods, so a run's egress policy
      * can allow exactly that destination and nothing else. The default is the
-     * label the Helm chart already stamps on both the platform and worker
-     * deployments; override it if your deployment labels them differently, or
-     * when the platform runs outside the cluster.
+     * dedicated label the Helm chart stamps on the platform API deployment.
+     * Override it if your deployment labels API pods differently. Worker pods
+     * are not API destinations.
      */
     platformPodSelector: parseLabelSelector(
       process.env.ARCHESTRA_AGENT_RUNTIME_PLATFORM_POD_SELECTOR,
-      { "archestra.io/p4-shim-client": "true" },
+      { "archestra.io/platform-api": "true" },
     ),
     /**
      * Steers Agent Runtime pods onto a dedicated node pool: a key=value list that

--- a/platform/backend/src/k8s/agent-runtime/manifests.test.ts
+++ b/platform/backend/src/k8s/agent-runtime/manifests.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
+import config, { parseLabelSelector } from "@/config";
 import {
   buildAgentRuntimePlatformEgressPolicy,
   buildAgentRuntimeSandbox,
@@ -360,6 +361,47 @@ describe("buildAgentRuntimeSecret", () => {
 });
 
 describe("buildAgentRuntimePlatformEgressPolicy", () => {
+  it.each([
+    {
+      name: "default API label",
+      selector: undefined,
+      apiLabels: { "archestra.io/platform-api": "true" },
+    },
+    {
+      name: "custom deployment selector",
+      selector: "app=custom-api,component=backend",
+      apiLabels: { app: "custom-api", component: "backend" },
+    },
+  ])("allows $name destinations without granting worker access", ({
+    selector,
+    apiLabels,
+  }) => {
+    const policy = buildAgentRuntimePlatformEgressPolicy({
+      spec: SPEC,
+      platformNamespace: "platform",
+      platformPodLabels: parseLabelSelector(
+        selector,
+        config.agentRuntime.platformPodSelector,
+      ),
+      platformPorts: [9000],
+    });
+    const destination = policy.spec?.egress?.[0]?.to?.[0];
+    expect(destination?.namespaceSelector?.matchLabels).toEqual({
+      "kubernetes.io/metadata.name": "platform",
+    });
+    const labels = destination?.podSelector?.matchLabels;
+    expect(labels).toEqual(apiLabels);
+    const workerLabels: Record<string, string> = {
+      "archestra.io/p4-shim-client": "true",
+      "app.kubernetes.io/component": "worker",
+    };
+    expect(
+      Object.entries(labels ?? {}).every(
+        ([key, value]) => workerLabels[key] === value,
+      ),
+    ).toBe(false);
+  });
+
   it("selects only this Agent Runtime run's pods so MCP pods are unaffected", () => {
     const policy = buildAgentRuntimePlatformEgressPolicy({
       spec: SPEC,

--- a/platform/helm/archestra/templates/archestra-platform.yaml
+++ b/platform/helm/archestra/templates/archestra-platform.yaml
@@ -111,6 +111,8 @@ spec:
       labels:
         {{- include "archestra-platform.labels" . | nindent 8 }}
         app.kubernetes.io/component: web
+        # Destination for Agent Runtime platform API egress.
+        archestra.io/platform-api: "true"
         {{- /*
           Grants this pod passage through the p4 shim's ingress NetworkPolicy
           (Perforce knowledge-connector permission sync; see

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -2,6 +2,16 @@ suite: test archestra platform -- Deployment/Service
 templates:
   - archestra-platform.yaml
 tests:
+  - it: should allow new and existing runtime policies to reach API pods
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["archestra.io/platform-api"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.labels["archestra.io/p4-shim-client"]
+          value: "true"
+
   - it: should create a Service with correct metadata
     documentIndex: 0
     asserts:

--- a/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
@@ -4,6 +4,14 @@ templates:
 values:
   - ../ci/test-values.yaml
 tests:
+  - it: excludes workers from runtime API egress destinations
+    asserts:
+      - isNull:
+          path: spec.template.metadata.labels["archestra.io/platform-api"]
+      - equal:
+          path: spec.template.metadata.labels["archestra.io/p4-shim-client"]
+          value: "true"
+
   - it: omits the worker deployment when maintenance mode is enabled
     set:
       archestra.env:


### PR DESCRIPTION
Agent Runtime currently identifies platform API destinations using a Perforce shim client label that also selects worker pods. Use a dedicated `archestra.io/platform-api=true` label on the API deployment so the default egress exception targets API-serving pods.

Keep the existing label for Perforce access and previously created runtime policies. Explicit `ARCHESTRA_AGENT_RUNTIME_PLATFORM_POD_SELECTOR` overrides remain supported. Update the environment example and deployment reference with the new default and the requirement to upgrade the chart alongside the backend; custom manifests must add the label first or set an explicit selector.

Validation:

- 36 backend manifest and network-policy tests passed, including default and custom selectors.
- 203 Helm deployment tests passed, including API labels, existing-policy compatibility, and worker exclusion.
- Full `pnpm commit:check` passed with a placeholder database URL for configuration loading.

Backport requested to `release/1.3`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>