### PR TITLE
fix(agent-runtime): allow platform Service IPs in runtime egress

### DIFF
--- a/docs/pages/platform-agent-runtime.md
+++ b/docs/pages/platform-agent-runtime.md
@@ -3,7 +3,7 @@ title: Agent Runtime (Beta)
 category: Agents
 order: 7
 description: Run delegated Agent tasks in an isolated runtime
-lastUpdated: "2026-09-09"
+lastUpdated: "2026-09-11"
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -189,6 +189,8 @@ Cilium `CiliumNetworkPolicy`, GKE `FQDNNetworkPolicy`, or AWS
 internet CIDR-exception, and floor behavior as MCP server pods and code sandboxes. DNS and the
 Archestra control plane remain reachable so the run can use the LLM
 proxy and MCP gateway.
+
+For a Kubernetes Service URL, runtime policies allow its exact ClusterIPs and configured port. This supports network plugins that enforce policy before translating Service addresses to pod addresses. The rest of the private network remains governed by the Environment policy.
 
 Continuations refresh the current Environment policy before starting the next turn.
 Obsolete policy types are removed, including when a suspended workspace resumes.

--- a/platform/backend/src/k8s/agent-runtime/manager.ts
+++ b/platform/backend/src/k8s/agent-runtime/manager.ts
@@ -75,6 +75,7 @@ import {
   type AgentRuntimeEgressPolicyObject,
   buildAgentRuntimeEnvironmentEgressPolicies,
 } from "./network-policy";
+import { resolvePlatformServiceDestination } from "./platform-service";
 import {
   type AgentRuntimeStartupProgress,
   type AgentRuntimeStartupProgressReporter,
@@ -173,6 +174,12 @@ class AgentRuntimeManager {
         platformNamespace: process.env.POD_NAMESPACE || getK8sNamespace(),
         platformPodLabels: config.agentRuntime.platformPodSelector,
         platformPorts: [config.api.port],
+        platformService: await resolvePlatformServiceDestination({
+          coreApi: clients.coreApi,
+          baseUrl: config.agentRuntime.platformBaseUrl,
+          runtimeNamespace: withOwner.namespace,
+          platformNamespace: process.env.POD_NAMESPACE || getK8sNamespace(),
+        }),
       }),
     );
 
@@ -1160,6 +1167,12 @@ class AgentRuntimeManager {
         platformNamespace: process.env.POD_NAMESPACE || getK8sNamespace(),
         platformPodLabels: config.agentRuntime.platformPodSelector,
         platformPorts: [config.api.port],
+        platformService: await resolvePlatformServiceDestination({
+          coreApi: clients.coreApi,
+          baseUrl: config.agentRuntime.platformBaseUrl,
+          runtimeNamespace: spec.namespace,
+          platformNamespace: process.env.POD_NAMESPACE || getK8sNamespace(),
+        }),
       }),
     );
     // Policies are additive. Leaving an old allow policy of a different kind

--- a/platform/backend/src/k8s/agent-runtime/manifests.ts
+++ b/platform/backend/src/k8s/agent-runtime/manifests.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import type * as k8s from "@kubernetes/client-node";
 import type { AgentRunLaunchSpec } from "@/services/agent-runtime/backends";
 import {
@@ -408,6 +409,7 @@ export function buildAgentRuntimePlatformEgressPolicy(params: {
   platformNamespace: string;
   platformPodLabels: Record<string, string>;
   platformPorts: number[];
+  platformService?: { ips: string[]; port: number };
 }): k8s.V1NetworkPolicy {
   const names = agentRuntimeNames(params.spec.frozenName);
   return {
@@ -444,6 +446,18 @@ export function buildAgentRuntimePlatformEgressPolicy(params: {
             port,
           })),
         },
+        // Some CNIs enforce egress before Service DNAT. Pod selectors cover
+        // endpoint IPs, so the configured Service also needs an exact IP rule.
+        ...(params.platformService?.ips.length
+          ? [
+              {
+                to: params.platformService.ips.map((ip) => ({
+                  ipBlock: { cidr: `${ip}/${isIP(ip) === 6 ? 128 : 32}` },
+                })),
+                ports: [{ protocol: "TCP", port: params.platformService.port }],
+              },
+            ]
+          : []),
         // DNS. Once any egress policy selects a pod, its egress is clamped to
         // the union of the selecting policies — and Agent Runtime pods carry labels no
         // other policy selects, so without this rule the session cannot resolve

--- a/platform/backend/src/k8s/agent-runtime/platform-service.cluster.test.ts
+++ b/platform/backend/src/k8s/agent-runtime/platform-service.cluster.test.ts
@@ -1,0 +1,327 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { isIP } from "node:net";
+import {
+  CoreV1Api,
+  KubeConfig,
+  type V1NetworkPolicy,
+} from "@kubernetes/client-node";
+import { expect, test } from "vitest";
+import { buildAgentRuntimePlatformEgressPolicy } from "./manifests";
+import { buildAgentRuntimeEnvironmentEgressPolicies } from "./network-policy";
+import { resolvePlatformServiceDestination } from "./platform-service";
+
+// Explicit local opt-in. Pod-local raw OUTPUT rules reproduce pre-DNAT
+// enforcement with real Service routing; this does not run the AWS CNI.
+// Build image: printf 'FROM node:22-alpine\nRUN apk add --no-cache iptables curl\n' | docker build -t archestra-egress-repro:test -
+// Run with ARCHESTRA_TEST_SERVICE_EGRESS_CONTEXT=orbstack.
+test.skipIf(process.env.ARCHESTRA_TEST_SERVICE_EGRESS_CONTEXT !== "orbstack")(
+  "permits Service traffic before DNAT only after allowing its exact IP and port",
+  async () => {
+    const namespace = `runtime-egress-${randomUUID().slice(0, 8)}`;
+    const image = "archestra-egress-repro:test";
+    const kubeConfig = new KubeConfig();
+    kubeConfig.loadFromDefault();
+    kubeConfig.setCurrentContext("orbstack");
+    const coreApi = kubeConfig.makeApiClient(CoreV1Api);
+    const apply = (object: unknown) =>
+      kubectl(["apply", "-f", "-"], JSON.stringify(object));
+    const curl = (url: string) =>
+      spawnSync(
+        "kubectl",
+        [
+          "--context",
+          "orbstack",
+          "exec",
+          "-n",
+          namespace,
+          "runtime",
+          "-c",
+          "agent-runtime",
+          "--",
+          "curl",
+          "--noproxy",
+          "*",
+          "-s",
+          "--connect-timeout",
+          "2",
+          "--max-time",
+          "3",
+          "-o",
+          "/dev/null",
+          "-w",
+          "%{http_code}",
+          `${url}/health`,
+        ],
+        { encoding: "utf8", timeout: 10_000 },
+      );
+    try {
+      apply({
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: { name: namespace },
+      });
+      apply({
+        apiVersion: "v1",
+        kind: "Pod",
+        metadata: { name: "api", namespace, labels: { app: "api" } },
+        spec: {
+          automountServiceAccountToken: false,
+          containers: [
+            {
+              name: "api",
+              image,
+              imagePullPolicy: "Never",
+              command: [
+                "node",
+                "-e",
+                "for (const port of [9000,9001]) require('http').createServer((q,s)=>s.end('healthy')).listen(port,'0.0.0.0')",
+              ],
+            },
+          ],
+        },
+      });
+      for (const name of ["api", "other"])
+        apply({
+          apiVersion: "v1",
+          kind: "Service",
+          metadata: { name, namespace },
+          spec: {
+            selector: { app: "api" },
+            ports: [
+              { name: "api", port: 8080, targetPort: 9000 },
+              { name: "other", port: 8081, targetPort: 9001 },
+            ],
+          },
+        });
+      apply({
+        apiVersion: "agents.x-k8s.io/v1beta1",
+        kind: "Sandbox",
+        metadata: { name: "runtime", namespace },
+        spec: {
+          operatingMode: "Running",
+          shutdownPolicy: "Retain",
+          service: false,
+          podTemplate: {
+            metadata: {
+              labels: { "archestra.io/agent-run-task-id": "test-task" },
+            },
+            spec: {
+              automountServiceAccountToken: false,
+              containers: [
+                {
+                  name: "agent-runtime",
+                  image,
+                  imagePullPolicy: "Never",
+                  command: ["sleep", "infinity"],
+                  securityContext: {
+                    runAsUser: 0,
+                    capabilities: { add: ["NET_ADMIN"] },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+      await expect
+        .poll(
+          () => {
+            const result = spawnSync(
+              "kubectl",
+              [
+                "--context",
+                "orbstack",
+                "get",
+                "pods",
+                "-n",
+                namespace,
+                "-o",
+                "json",
+              ],
+              { encoding: "utf8" },
+            );
+            if (result.status !== 0) return false;
+            const pods = JSON.parse(result.stdout).items;
+            return (
+              pods.length === 2 &&
+              pods.every(
+                (pod: {
+                  status?: {
+                    conditions?: Array<{ type: string; status: string }>;
+                  };
+                }) =>
+                  pod.status?.conditions?.some(
+                    (c) => c.type === "Ready" && c.status === "True",
+                  ),
+              )
+            );
+          },
+          { timeout: 60_000, interval: 1000 },
+        )
+        .toBe(true);
+      const baseUrl = `http://api.${namespace}.svc.cluster.local:8080`;
+      const podIp = JSON.parse(
+        kubectl(["get", "pod/api", "-n", namespace, "-o", "json"]),
+      ).status.podIP;
+      await expect
+        .poll(() => curl(baseUrl).stdout, { timeout: 15_000 })
+        .toBe("200");
+      const spec = {
+        frozenName: "runtime",
+        namespace,
+        taskId: "test-task",
+        agentRuntimeId: "test-agent",
+        ownerReferences: undefined,
+        effectiveNetworkPolicy: { source: "built_in" as const, policy: null },
+      };
+      const floor = buildAgentRuntimeEnvironmentEgressPolicies({ spec })[0]
+        .object as V1NetworkPolicy;
+      const params = {
+        spec,
+        platformNamespace: namespace,
+        platformPodLabels: { app: "api" },
+        platformPorts: [9000],
+      };
+      const oldPolicy = buildAgentRuntimePlatformEgressPolicy(params);
+      apply(floor);
+      apply(oldPolicy);
+      installPreDnatRules({
+        namespace,
+        policies: [floor, oldPolicy],
+        first: true,
+      });
+      expect(curl(`http://${podIp}:9000`).stdout).toBe("200");
+      const blocked = curl(baseUrl);
+      expect(blocked.status).toBe(28);
+      expect(blocked.stdout).toBe("000");
+      const fixedPolicy = buildAgentRuntimePlatformEgressPolicy({
+        ...params,
+        platformService: await resolvePlatformServiceDestination({
+          coreApi,
+          baseUrl,
+          platformNamespace: namespace,
+          runtimeNamespace: namespace,
+        }),
+      });
+      apply(fixedPolicy);
+      installPreDnatRules({
+        namespace,
+        policies: [floor, fixedPolicy],
+        first: false,
+      });
+      expect(curl(baseUrl).stdout).toBe("200");
+      expect(curl(`http://${podIp}:9000`).stdout).toBe("200");
+      expect(
+        curl(`http://other.${namespace}.svc.cluster.local:8080`).status,
+      ).toBe(28);
+      expect(
+        curl(`http://api.${namespace}.svc.cluster.local:8081`).status,
+      ).toBe(28);
+    } finally {
+      kubectl([
+        "delete",
+        "namespace",
+        namespace,
+        "--ignore-not-found",
+        "--wait=false",
+      ]);
+    }
+  },
+  120_000,
+);
+
+// Translate the generated IPv4 allow rules into a firewall inside this test
+// pod only. OUTPUT/raw runs before the node translates ClusterIPs to endpoints.
+function installPreDnatRules(params: {
+  namespace: string;
+  policies: V1NetworkPolicy[];
+  first: boolean;
+}) {
+  const iptables = (args: string[]) =>
+    kubectl([
+      "exec",
+      "-n",
+      params.namespace,
+      "runtime",
+      "-c",
+      "agent-runtime",
+      "--",
+      "iptables",
+      "-t",
+      "raw",
+      ...args,
+    ]);
+  const chain = params.first ? "RUNTIME_OLD" : "RUNTIME_FIXED";
+  iptables(["-N", chain]);
+  let peerId = 0;
+  for (const policy of params.policies)
+    for (const rule of policy.spec?.egress ?? []) {
+      for (const peer of rule.to ?? []) {
+        let cidrs: string[];
+        if (peer.ipBlock) {
+          if (peer.ipBlock.cidr.includes(":")) continue;
+          cidrs = [peer.ipBlock.cidr];
+        } else {
+          const namespace =
+            peer.namespaceSelector?.matchLabels?.[
+              "kubernetes.io/metadata.name"
+            ] ?? params.namespace;
+          const selector = Object.entries(peer.podSelector?.matchLabels ?? {})
+            .map(([key, value]) => `${key}=${value}`)
+            .join(",");
+          const pods = JSON.parse(
+            kubectl([
+              "get",
+              "pods",
+              "-n",
+              namespace,
+              "-l",
+              selector,
+              "-o",
+              "json",
+            ]),
+          );
+          cidrs = pods.items
+            .map((pod: { status: { podIP?: string } }) => pod.status.podIP)
+            .filter((ip: string) => isIP(ip) === 4)
+            .map((ip: string) => `${ip}/32`);
+        }
+        for (const cidr of cidrs) {
+          const peerChain = `${chain}_${peerId++}`;
+          iptables(["-N", peerChain]);
+          for (const except of peer.ipBlock?.except ?? [])
+            iptables(["-A", peerChain, "-d", except, "-j", "RETURN"]);
+          iptables(["-A", peerChain, "-j", "ACCEPT"]);
+          for (const port of rule.ports?.length ? rule.ports : [undefined])
+            iptables([
+              "-A",
+              chain,
+              "-d",
+              cidr,
+              ...(port
+                ? [
+                    "-p",
+                    (port.protocol ?? "TCP").toLowerCase(),
+                    "--dport",
+                    String(port.port),
+                  ]
+                : []),
+              "-j",
+              peerChain,
+            ]);
+        }
+      }
+    }
+  iptables(["-A", chain, "-j", "DROP"]);
+  iptables(["-I", "OUTPUT", "1", "-j", chain]);
+  if (!params.first) iptables(["-D", "OUTPUT", "-j", "RUNTIME_OLD"]);
+}
+
+function kubectl(args: string[], input?: string): string {
+  return execFileSync("kubectl", ["--context", "orbstack", ...args], {
+    encoding: "utf8",
+    input,
+    timeout: 20_000,
+  }).trim();
+}

--- a/platform/backend/src/k8s/agent-runtime/platform-service.test.ts
+++ b/platform/backend/src/k8s/agent-runtime/platform-service.test.ts
@@ -1,0 +1,157 @@
+import type * as k8s from "@kubernetes/client-node";
+import { describe, expect, it, vi } from "vitest";
+import { buildAgentRuntimePlatformEgressPolicy } from "./manifests";
+import { resolvePlatformServiceDestination } from "./platform-service";
+
+describe("platform Service egress", () => {
+  it("resolves an unqualified Service name in the runtime pod namespace", async () => {
+    const readNamespacedService = vi.fn(async () => ({
+      spec: { clusterIP: "172.21.40.50" },
+    }));
+    await resolvePlatformServiceDestination({
+      coreApi: { readNamespacedService } as unknown as k8s.CoreV1Api,
+      baseUrl: "http://api:9000",
+      platformNamespace: "control-plane",
+      runtimeNamespace: "runtime",
+    });
+    expect(readNamespacedService).toHaveBeenCalledWith({
+      name: "api",
+      namespace: "runtime",
+    });
+  });
+
+  it("allows exact Service IPs on the Service port alongside endpoint access", async () => {
+    const readNamespacedService = vi.fn(async () => ({
+      spec: { clusterIPs: ["172.21.40.50", "fd00:1234::50"] },
+    }));
+    const platformService = await resolvePlatformServiceDestination({
+      coreApi: { readNamespacedService } as unknown as k8s.CoreV1Api,
+      baseUrl: "http://api.platform.svc.cluster.local:8080",
+      platformNamespace: "platform",
+      runtimeNamespace: "platform",
+    });
+    expect(readNamespacedService).toHaveBeenCalledWith({
+      name: "api",
+      namespace: "platform",
+    });
+    const policy = buildAgentRuntimePlatformEgressPolicy({
+      spec: {
+        frozenName: "test-run",
+        namespace: "runtime",
+        taskId: "test-task",
+        agentRuntimeId: "test-agent",
+        ownerReferences: undefined,
+      },
+      platformNamespace: "platform",
+      platformPodLabels: { app: "api" },
+      platformPorts: [9000],
+      platformService,
+    });
+    expect(policy.spec?.egress?.[0]).toMatchObject({
+      to: [
+        {
+          namespaceSelector: {
+            matchLabels: { "kubernetes.io/metadata.name": "platform" },
+          },
+          podSelector: { matchLabels: { app: "api" } },
+        },
+      ],
+      ports: [{ protocol: "TCP", port: 9000 }],
+    });
+    expect(policy.spec?.egress?.[1]).toEqual({
+      to: [
+        { ipBlock: { cidr: "172.21.40.50/32" } },
+        { ipBlock: { cidr: "fd00:1234::50/128" } },
+      ],
+      ports: [{ protocol: "TCP", port: 8080 }],
+    });
+  });
+
+  it.each([
+    "http://api:9000",
+    "http://api.platform:9000",
+    "http://api.platform.svc:9000",
+    "http://api.platform.svc.custom.cluster:9000",
+  ])("resolves Service URL %s", async (baseUrl) => {
+    const readNamespacedService = vi.fn(async () => ({
+      spec: { clusterIP: "172.21.40.50" },
+    }));
+    expect(
+      await resolvePlatformServiceDestination({
+        coreApi: { readNamespacedService } as unknown as k8s.CoreV1Api,
+        baseUrl,
+        platformNamespace: "platform",
+        runtimeNamespace: "platform",
+      }),
+    ).toEqual({ ips: ["172.21.40.50"], port: 9000 });
+    expect(readNamespacedService).toHaveBeenCalledWith({
+      name: "api",
+      namespace: "platform",
+    });
+  });
+
+  it.each([
+    "",
+    "https://api.example.com",
+    "https://example.com",
+  ])("does not look up external or absent destination %s as a Service", async (baseUrl) => {
+    const readNamespacedService = vi.fn();
+    expect(
+      await resolvePlatformServiceDestination({
+        coreApi: { readNamespacedService } as unknown as k8s.CoreV1Api,
+        baseUrl,
+        platformNamespace: "platform",
+        runtimeNamespace: "platform",
+      }),
+    ).toBeUndefined();
+    expect(readNamespacedService).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { baseUrl: "http://172.21.40.50", ips: ["172.21.40.50"], port: 80 },
+    { baseUrl: "https://[fd00:1234::50]", ips: ["fd00:1234::50"], port: 443 },
+  ])("uses explicit destination $baseUrl without DNS lookup", async ({
+    baseUrl,
+    ips,
+    port,
+  }) => {
+    const readNamespacedService = vi.fn();
+    expect(
+      await resolvePlatformServiceDestination({
+        coreApi: { readNamespacedService } as unknown as k8s.CoreV1Api,
+        baseUrl,
+        platformNamespace: "platform",
+        runtimeNamespace: "platform",
+      }),
+    ).toEqual({ ips, port });
+    expect(readNamespacedService).not.toHaveBeenCalled();
+  });
+
+  it("does not render a CIDR for a headless Service", async () => {
+    const readNamespacedService = vi.fn(async () => ({
+      spec: { clusterIP: "None" },
+    }));
+    expect(
+      await resolvePlatformServiceDestination({
+        coreApi: { readNamespacedService } as unknown as k8s.CoreV1Api,
+        baseUrl: "https://api.platform.svc",
+        platformNamespace: "platform",
+        runtimeNamespace: "platform",
+      }),
+    ).toEqual({ ips: [], port: 443 });
+  });
+
+  it("fails a Service lookup error instead of silently installing an incomplete policy", async () => {
+    const readNamespacedService = vi.fn(async () => {
+      throw new Error("Service lookup unavailable");
+    });
+    await expect(
+      resolvePlatformServiceDestination({
+        coreApi: { readNamespacedService } as unknown as k8s.CoreV1Api,
+        baseUrl: "http://api.platform.svc:9000",
+        platformNamespace: "platform",
+        runtimeNamespace: "platform",
+      }),
+    ).rejects.toThrow("Service lookup unavailable");
+  });
+});

--- a/platform/backend/src/k8s/agent-runtime/platform-service.ts
+++ b/platform/backend/src/k8s/agent-runtime/platform-service.ts
@@ -1,0 +1,40 @@
+import { isIP } from "node:net";
+import type * as k8s from "@kubernetes/client-node";
+
+/** Resolve only the configured platform destination, without opening a service CIDR. */
+export async function resolvePlatformServiceDestination(params: {
+  coreApi: k8s.CoreV1Api;
+  baseUrl: string;
+  platformNamespace: string;
+  runtimeNamespace: string;
+}): Promise<{ ips: string[]; port: number } | undefined> {
+  if (!params.baseUrl) return undefined;
+  const url = new URL(params.baseUrl);
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  const port = Number(url.port || (url.protocol === "https:" ? 443 : 80));
+  if (hostname === "localhost") return undefined;
+  if (isIP(hostname)) return { ips: [hostname], port };
+
+  const parts = hostname.replace(/\.$/, "").split(".");
+  // Short Service names and Kubernetes Service DNS names are resolved through
+  // the API. External hostnames retain the existing Environment egress rules.
+  const isServiceName =
+    parts.length === 1 || parts.length === 2 || parts[2] === "svc";
+  if (!isServiceName) return undefined;
+  // A two-label external hostname is not necessarily a Service. Only recognize
+  // the platform namespace for this abbreviated form.
+  if (
+    parts.length === 2 &&
+    parts[1] !== params.platformNamespace &&
+    parts[1] !== params.runtimeNamespace
+  )
+    return undefined;
+  const service = await params.coreApi.readNamespacedService({
+    name: parts[0],
+    namespace: parts[1] ?? params.runtimeNamespace,
+  });
+  const ips = service.spec?.clusterIPs?.length
+    ? service.spec.clusterIPs
+    : [service.spec?.clusterIP ?? ""];
+  return { ips: [...new Set(ips.filter((ip) => isIP(ip) !== 0))], port };
+}


### PR DESCRIPTION
Agent Runtime permits platform pod IPs but omits the configured Service ClusterIP. With egress enforcement before Service address translation, direct endpoint requests succeed while requests through the Service time out against the private-network default deny.

Resolve the configured Kubernetes Service through the API and add its exact IPv4/IPv6 addresses on the URL port to the platform egress policy. Keep the existing endpoint rule on the backend port. Refresh the exception for both new launches and resumed workspaces. Headless Services add no IP exception; external hostnames retain their existing Environment policy behavior. No Service CIDR is opened.

Validation:

- Local packet-level reproduction passed on OrbStack with a real Sandbox-owned pod and Kubernetes Services. A pod-local raw OUTPUT firewall enforces the production-generated allow rules before Service translation. This reproduces the enforcement ordering, not the AWS CNI implementation.
- Before the exception: direct endpoint HTTP 200; Service HTTP 000 / curl exit 28.
- After the exception: both endpoint and Service HTTP 200; another Service and an unapproved port still time out.
- 49 backend tests passed; full `pnpm commit:check` passed.
- Disposable cluster resources were removed after the test.

The opt-in reproduction and image-build command are documented in `platform-service.cluster.test.ts`. Run from `platform/` with:

```sh
ARCHESTRA_DATABASE_URL=postgresql://localhost/unused \
ARCHESTRA_TEST_SERVICE_EGRESS_CONTEXT=orbstack \
pnpm --dir backend exec vitest run src/k8s/agent-runtime/platform-service.cluster.test.ts
```

Actual AWS CNI validation remains a deployment-level follow-up.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>