### PR TITLE
fix: recover agent runs from the current messaging thread

### DIFF
--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -2400,6 +2400,7 @@ Required RBAC permission: `agent:read`
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `agent_ids` | `string[]` | Yes |  |
+| `current_thread_only` | `boolean` | No | Restrict results to the current messaging thread. Requires messaging context. Defaults to false. |
 | `limit` | `integer` | No |  |
 
 ##### Output

--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -2400,7 +2400,7 @@ Required RBAC permission: `agent:read`
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `agent_ids` | `string[]` | Yes |  |
-| `current_thread_only` | `boolean` | No | Restrict results to the current messaging thread. Requires messaging context. Defaults to false. |
+| `current_thread_only` | `boolean` | No | Only runs originating in the current messaging thread. Requires messaging context; never falls back to an unfiltered list. |
 | `limit` | `integer` | No |  |
 
 ##### Output

--- a/platform/backend/src/archestra-mcp-server/tasks.test.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.test.ts
@@ -229,6 +229,7 @@ describe("run tools", () => {
     actorUserId: string;
     withTarget: boolean;
     bindingId?: string;
+    threadId?: string;
     prompt?: string;
   }) {
     const a2aContext = await A2AContextModel.create({
@@ -268,7 +269,7 @@ describe("run tools", () => {
             type: "chatops",
             bindingId:
               params.bindingId ?? "9c2b1f60-0000-4000-8000-000000000001",
-            threadId: "1788208728.803109",
+            threadId: params.threadId ?? "1788208728.803109",
           }
         : null,
     });
@@ -440,6 +441,99 @@ describe("run tools", () => {
     ).toMatch(new RegExp(`/chat/runs/${task.id}$`));
   });
 
+  test("recovers an older run only from the trusted current thread before limiting", async () => {
+    const bindingId = crypto.randomUUID();
+    const threadId = "thread-original";
+    const original = await seedChatopsTask({
+      actorUserId: actorId,
+      withTarget: true,
+      bindingId,
+      threadId,
+    });
+    await seedChatopsTask({
+      actorUserId: actorId,
+      withTarget: true,
+      bindingId,
+      threadId: "another-thread",
+    });
+    await seedChatopsTask({
+      actorUserId: actorId,
+      withTarget: true,
+      bindingId: crypto.randomUUID(),
+      threadId,
+    });
+    await seedChatopsTask({ actorUserId: actorId, withTarget: false });
+    const result = await executeArchestraTool(
+      TOOL_LIST_AGENT_RUNS_FULL_NAME,
+      { agent_ids: [callingAgent.id], current_thread_only: true, limit: 1 },
+      { ...context, chatOpsBindingId: bindingId, chatOpsThreadId: threadId },
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({
+      runs: [{ task_id: original.id }],
+      summary: { total: 1 },
+    });
+    expect(
+      await AgentRunModel.listDashboard({
+        agentIds: [callingAgent.id],
+        organizationId: crypto.randomUUID(),
+        limit: 100,
+        thread: { bindingId, threadId },
+      }),
+    ).toEqual([]);
+    expect(
+      await AgentRunModel.listDashboard({
+        agentIds: [crypto.randomUUID()],
+        organizationId,
+        limit: 100,
+        thread: { bindingId, threadId },
+      }),
+    ).toEqual([]);
+    const second = await seedChatopsTask({
+      actorUserId: actorId,
+      withTarget: true,
+      bindingId,
+      threadId,
+    });
+    const multiple = await executeArchestraTool(
+      TOOL_LIST_AGENT_RUNS_FULL_NAME,
+      { agent_ids: [callingAgent.id], current_thread_only: true },
+      { ...context, chatOpsBindingId: bindingId, chatOpsThreadId: threadId },
+    );
+    expect(multiple.structuredContent).toMatchObject({
+      summary: { total: 2 },
+      runs: [{ task_id: second.id }, { task_id: original.id }],
+    });
+    const empty = await executeArchestraTool(
+      TOOL_LIST_AGENT_RUNS_FULL_NAME,
+      { agent_ids: [callingAgent.id], current_thread_only: true },
+      { ...context, chatOpsBindingId: bindingId, chatOpsThreadId: "no-runs" },
+    );
+    expect(empty.structuredContent).toMatchObject({
+      runs: [],
+      summary: { total: 0 },
+    });
+  });
+
+  test("thread recovery fails closed when either trusted context field is missing", async () => {
+    await seedChatopsTask({ actorUserId: actorId, withTarget: true });
+    for (const messagingContext of [
+      {},
+      { chatOpsBindingId: crypto.randomUUID() },
+      { chatOpsThreadId: "thread" },
+    ]) {
+      const result = await executeArchestraTool(
+        TOOL_LIST_AGENT_RUNS_FULL_NAME,
+        { agent_ids: [callingAgent.id], current_thread_only: true },
+        { ...context, ...messagingContext },
+      );
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain(
+        "Current messaging thread context is unavailable",
+      );
+    }
+  });
+
   test("does not reveal runs for an inaccessible Agent", async ({
     makeAgent,
     makeUser,
@@ -454,8 +548,12 @@ describe("run tools", () => {
 
     const result = await executeArchestraTool(
       TOOL_LIST_AGENT_RUNS_FULL_NAME,
-      { agent_ids: [privateAgent.id] },
-      context,
+      { agent_ids: [privateAgent.id], current_thread_only: true },
+      {
+        ...context,
+        chatOpsBindingId: crypto.randomUUID(),
+        chatOpsThreadId: "thread",
+      },
     );
 
     expect(result.isError).toBe(true);

--- a/platform/backend/src/archestra-mcp-server/tasks.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.ts
@@ -532,15 +532,32 @@ const registry = defineArchestraTools([
     title: "List Agent Runs",
     description:
       "List recent runs across one or more accessible Agents for a read-only operations dashboard. " +
-      "Returns status, requester, run links, and originating messaging threads when present.",
+      "Returns status, requester, run links, and originating messaging threads when present. Use current_thread_only to recover runs from the current messaging thread even when no run link was posted.",
     schema: z.object({
       agent_ids: z.array(z.string().uuid()).min(1).max(20),
+      current_thread_only: z
+        .boolean()
+        .default(false)
+        .describe(
+          "Only runs originating in the current messaging thread. Requires messaging context; never falls back to an unfiltered list.",
+        ),
       limit: z.number().int().min(1).max(100).default(50),
     }),
     outputSchema: ListAgentRunsOutputSchema,
     handler: async ({ args, context }) => {
       try {
         const actor = requireActor(context);
+        const thread = args.current_thread_only
+          ? context.chatOpsBindingId && context.chatOpsThreadId
+            ? {
+                bindingId: context.chatOpsBindingId,
+                threadId: context.chatOpsThreadId,
+              }
+            : null
+          : undefined;
+        if (thread === null) {
+          return errorResult("Current messaging thread context is unavailable");
+        }
         const requestedAgentIds = [...new Set(args.agent_ids)];
         const isAgentAdmin = await userHasPermission(
           actor.id,
@@ -567,6 +584,7 @@ const registry = defineArchestraTools([
           agentIds: requestedAgentIds,
           organizationId: actor.organizationId,
           limit: args.limit,
+          thread,
         });
         const runs = rows.map((row) => ({
           task_id: row.taskId,

--- a/platform/backend/src/models/agent-run.ts
+++ b/platform/backend/src/models/agent-run.ts
@@ -252,6 +252,7 @@ class AgentRunModel {
     agentIds: string[];
     organizationId: string;
     limit: number;
+    thread?: { bindingId: string; threadId: string };
   }) {
     if (params.agentIds.length === 0) return [];
 
@@ -309,6 +310,18 @@ class AgentRunModel {
       )
       .where(
         and(
+          params.thread
+            ? and(
+                eq(
+                  sql`${schema.agentRunsTable.completionTarget}->>'bindingId'`,
+                  params.thread.bindingId,
+                ),
+                eq(
+                  sql`${schema.agentRunsTable.completionTarget}->>'threadId'`,
+                  params.thread.threadId,
+                ),
+              )
+            : undefined,
           inArray(schema.agentRunsTable.agentId, params.agentIds),
           eq(schema.agentRunsTable.organizationId, params.organizationId),
         ),


### PR DESCRIPTION
When a messaging launch reply omits its run URL, agents cannot reliably recover the run from a recent fleet listing. Add `current_thread_only` to `list_agent_runs`, using trusted execution context to filter the persisted channel binding and thread before applying the limit.

Missing messaging context returns an explicit error. Organization and Agent access checks remain enforced. The default fleet listing is unchanged. This is a generic messaging capability; routing policy lives in infra.

Validation: 45 targeted tests passed across run tools, run models, and delegation; real PGlite tests cover older runs, other bindings/threads, organization/Agent isolation, inaccessible Agents, missing context, empty results, and multiple matches. Full repository commit checks passed, including type checks, lint, backend dev/production knip, and migration checks.

Deployment order: deploy this platform change before applying the dependent Lobster router configuration. Live Slack continuation validation remains pending deployment.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>