### PR TITLE
fix: include run identifiers in model-visible tool output

### DIFF
--- a/platform/backend/src/archestra-mcp-server/tasks.test.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.test.ts
@@ -473,6 +473,14 @@ describe("run tools", () => {
       runs: [{ task_id: original.id }],
       summary: { total: 1 },
     });
+    // Chat sends MCP text content to the model. Structured data alone is not
+    // enough for the model to recover the ID and steer the matching run.
+    const modelText = result.content
+      .filter((item) => item.type === "text")
+      .map((item) => item.text)
+      .join("\n");
+    expect(JSON.parse(modelText)).toEqual(result.structuredContent);
+
     expect(
       await AgentRunModel.listDashboard({
         agentIds: [callingAgent.id],

--- a/platform/backend/src/archestra-mcp-server/tasks.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.ts
@@ -617,18 +617,15 @@ const registry = defineArchestraTools([
           return counts;
         }, {});
 
-        return structuredSuccessResult(
-          {
-            runs,
-            summary: {
-              total: runs.length,
-              active: runs.filter((run) => ACTIVE_TASK_STATES.has(run.state))
-                .length,
-              by_state: byState,
-            },
+        return structuredSuccessResult({
+          runs,
+          summary: {
+            total: runs.length,
+            active: runs.filter((run) => ACTIVE_TASK_STATES.has(run.state))
+              .length,
+            by_state: byState,
           },
-          `${runs.length} run(s)`,
-        );
+        });
       } catch (error) {
         return catchError(error, "listing Agent runs");
       }


### PR DESCRIPTION
A run lookup returned complete structured data but only `1 run(s)` in its text content. Chat passed that text to the model without any run ID, so a follow-up could not reliably steer the result.

Use the existing structured-result helper's JSON text default for `list_agent_runs`. Text-only model consumers now receive the same run IDs and metadata as structured consumers. Add a regression assertion that parses the model-visible text and compares it with the structured result.

Validation: 45 targeted tests passed across run tools, run models, and delegation. Full repository commit checks passed. The missing-link Slack regression exposed this after #7852. A live test with the corrected image confirmed that the model receives the persisted run ID and passes that exact ID to steering. Completed-run continuation reused the same pod and preserved the existing checkpoint file. Active Codex steering exposed a separate terminal submit issue: the correct follow-up reaches the input box but remains unsubmitted; this PR does not change terminal input handling. No output-schema or documentation changes are needed.
