### PR TITLE
fix: allow unhealthy staging pods to drain

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -1,12 +1,9 @@
 archestra:
   replicaCount: 4
 
-  # Staging runs on a 5-node pool that the cluster autoscaler cannot grow past
-  # its max, and the chart's default 2-vCPU request per pod (sized for
-  # production latency) left the nodes 90%+ requested while <10% utilized —
-  # deploy-surge pods sat Pending on every commit-to-main rollout. Staging pods
-  # actually use well under 500m, and there is no CPU limit, so pods can still
-  # burst to whatever is free on the node.
+  # Staging's measured CPU use is below the chart's production-sized requests.
+  # Keep scheduling room for rolling-update surge pods; no CPU limit prevents
+  # these smaller requests from restricting bursts into spare node capacity.
   resources:
     requests:
       cpu: "500m"
@@ -53,6 +50,9 @@ archestra:
   podDisruptionBudget:
     enabled: true
     maxUnavailable: 1
+    # Unready pods must not strand a draining node when the healthy-pod budget
+    # is exhausted. Healthy pods still require the budget above.
+    unhealthyPodEvictionPolicy: AlwaysAllow
 
   # Faster rolling updates: allow 2 pods to be created at once
   deploymentStrategy:

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -921,6 +921,8 @@ Upgrading from a chart that ran the included engine leaves its cache volume behi
 
 Agent Runtime runs delegated Agent tasks in dedicated Kubernetes pods. You can view logs, open a shell, and steer a run while it is active. It needs the Kubernetes runtime configured (see `ARCHESTRA_ORCHESTRATOR_*`); without it the capability stays unavailable.
 
+On GKE, custom Sandbox controllers can produce a “not backed by a controller” scale-down warning. Active runs must finish before their nodes can be removed safely. Idle workspace suspension releases pods through the runtime lifecycle. Setting `safe-to-evict: "true"` permits interruptions; persisted files do not preserve running processes.
+
 - **`ARCHESTRA_AGENT_RUNTIME_ENABLED`** - Enables Agent Runtime. A run can carry the credentials of the person who started it, so this gate is independent of `ARCHESTRA_BETA` and never turns on by implication.
   - Default: `false`
   - Values: `true`, `false`


### PR DESCRIPTION
Staging node drains can stall when an unhealthy web pod is covered by an exhausted disruption budget. Set `unhealthyPodEvictionPolicy: AlwaysAllow` while retaining `maxUnavailable: 1`, so unhealthy pods can be evicted without permitting additional disruption to healthy replicas.

Remove the stale five-node-cap comment and document why active Agent Runtime Sandbox pods can legitimately block scale-down. Their idle lifecycle releases pods; making active sessions freely evictable would interrupt running tasks.

Validation:
- All 14 existing Helm PodDisruptionBudget tests passed.
- Rendered the PDB using the staging values and tested eviction admission against local Kubernetes: the original policy denied eviction with two healthy replicas out of four; the new policy admitted unhealthy-pod eviction and still denied healthy-pod eviction. All eviction requests used server dry-run.
- Documentation link validation and diff whitespace checks passed.

No additional literal-only unit tests: existing chart tests cover this setting, and real Kubernetes admission verified the behavior.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>