### PR TITLE
fix(connection): load shared skills without proxy scoping

### DIFF
--- a/platform/frontend/src/app/connection/connect-command-panel.test.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.test.tsx
@@ -25,11 +25,13 @@ import { ConnectCommandPanel } from "./connect-command-panel";
 const {
   createSetupMock,
   allSkillsMock,
+  allSkillsMode,
   pluginsMock,
   skillsMarketplaceVisibleMock,
 } = vi.hoisted(() => ({
   createSetupMock: vi.fn(),
   allSkillsMock: vi.fn(),
+  allSkillsMode: { useRealQuery: false },
   pluginsMock: vi.fn(),
   skillsMarketplaceVisibleMock: vi.fn(() => true),
 }));
@@ -41,13 +43,22 @@ vi.mock("@/lib/connection-setup.query", () => ({
   }),
 }));
 
-vi.mock("./skills-marketplace-step", () => ({
-  useAllSkills: (params?: { enabled?: boolean }) => allSkillsMock(params),
-  // The marketplace step has its own test file; here it only matters whether
-  // the panel renders it as a step.
-  useSkillsMarketplaceVisible: () => skillsMarketplaceVisibleMock(),
-  SkillsMarketplaceStep: () => <div data-testid="skills-marketplace-step" />,
-}));
+vi.mock("./skills-marketplace-step", async () => {
+  const actual = await vi.importActual<
+    typeof import("./skills-marketplace-step")
+  >("./skills-marketplace-step");
+  const actualAllSkillsQuery = actual.useAllSkills;
+  return {
+    useAllSkills: (params?: Parameters<typeof actual.useAllSkills>[0]) =>
+      allSkillsMode.useRealQuery
+        ? actualAllSkillsQuery(params)
+        : allSkillsMock(params),
+    useSkillsMarketplaceVisible: () => skillsMarketplaceVisibleMock(),
+    // The component has its own test file; this suite only needs to know
+    // whether the panel mounts the step.
+    SkillsMarketplaceStep: () => <div data-testid="skills-marketplace-step" />,
+  };
+});
 
 vi.mock("@/lib/plugins/plugin.query", () => ({
   usePlugins: (enabled?: boolean) => pluginsMock(enabled),
@@ -154,6 +165,7 @@ beforeEach(() => {
     new URLSearchParams() as ReturnType<typeof useSearchParams>,
   );
   vi.clearAllMocks();
+  allSkillsMode.useRealQuery = false;
   vi.mocked(useFeature).mockReturnValue(true);
   vi.mocked(useConfig).mockReturnValue({
     data: { features: { plugins: true } },
@@ -472,6 +484,65 @@ describe("ConnectCommandPanel", () => {
     expect(
       screen.queryByText("http://localhost:9000/v1"),
     ).not.toBeInTheDocument();
+  });
+
+  it("loads shared skills without treating the LLM Proxy as a skills surface", async () => {
+    allSkillsMode.useRealQuery = true;
+    const requests: URL[] = [];
+    const server = setupServer(
+      http.get("http://localhost:9000/api/skills", ({ request }) => {
+        const url = new URL(request.url);
+        requests.push(url);
+        if (url.searchParams.has("forAgentId")) {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "This agent type does not expose skills",
+                type: "api_validation_error",
+                statusCode: 400,
+              },
+            },
+            { status: 400 },
+          );
+        }
+        return HttpResponse.json({
+          data: [
+            {
+              id: "s1",
+              name: "warehouse-postgres",
+              scope: "org",
+              teams: [],
+            },
+          ],
+          pagination: { total: 1, hasNext: false },
+        });
+      }),
+    );
+    server.listen({ onUnhandledRequest: "error" });
+    archestraApiClient.setConfig({ baseUrl: "http://localhost:9000" });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <ConnectCommandPanel {...renderPanelProps()} />
+      </QueryClientProvider>,
+    );
+
+    try {
+      await waitFor(() => expect(requests).toHaveLength(1));
+      await waitFor(() =>
+        expect(createSetupMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            skills: { skillIds: ["s1"], ttlDays: null },
+          }),
+        ),
+      );
+    } finally {
+      view.unmount();
+      queryClient.clear();
+      server.close();
+    }
   });
 
   it("omits skills from the setup when connecting skills is disabled", async () => {
@@ -1200,7 +1271,7 @@ describe("ConnectCommandPanel", () => {
     expect(allSkillsMock).toHaveBeenLastCalledWith(
       // objectContaining, so the deferral this list is fetched under stays an
       // implementation detail: what matters is that it is switched off.
-      expect.objectContaining({ enabled: false, forAgentId: "p1" }),
+      expect.objectContaining({ enabled: false }),
     );
     expect(
       screen.queryByTestId("skills-marketplace-step"),

--- a/platform/frontend/src/app/connection/connect-command-panel.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.tsx
@@ -104,6 +104,13 @@ export function isScriptClient(
 }
 
 /**
+ * How long the review step's skill list waits before it starts fetching.
+ * Long enough for the setup command above it to render and settle, short
+ * enough that the list is there by the time anyone scrolls to it.
+ */
+const CONNECT_SKILLS_DEFER_MS = 750;
+
+/**
  * Whether skills can ride along in the setup command: the caller can read
  * skills, and there is at least one to install. Reading is the bar because the
  * command registers the deployment's shared marketplace URL, which serves each
@@ -116,26 +123,13 @@ export function isScriptClient(
  * control the install does not have. Sharing a fixed subset is what a snapshot
  * link is for.
  */
-/**
- * How long the review step's skill list waits before it starts fetching.
- * Long enough for the setup command above it to render and settle, short
- * enough that the list is there by the time anyone scrolls to it.
- */
-const CONNECT_SKILLS_DEFER_MS = 750;
-
-function useConnectSkills(
-  llmProxyId: string | null,
-  enabled: boolean,
-): {
+function useConnectSkills(enabled: boolean): {
   eligible: boolean;
   skills: ConnectSkill[];
 } {
   const { data: canReadSkills } = useHasPermissions({ skill: ["read"] });
-  // Skills are environment-scoped: with a proxy selected, only skills in that
-  // proxy's environment are connectable.
   const { data: skills } = useAllSkills({
     enabled: enabled && canReadSkills === true,
-    forAgentId: llmProxyId,
     // Step 2's content, not step 1's: let the part of the page the user acts
     // on first render before walking the catalogue.
     deferMs: CONNECT_SKILLS_DEFER_MS,
@@ -197,10 +191,8 @@ export function ConnectCommandPanel({
   const [customizing, setCustomizing] = useState(false);
   const compact = !!connectRequest && !customizing;
   const requestedPlatform = searchParams.get("platform");
-  const { eligible: skillsEligible, skills: allSkills } = useConnectSkills(
-    llmProxyId,
-    skillsEnabled,
-  );
+  const { eligible: skillsEligible, skills: allSkills } =
+    useConnectSkills(skillsEnabled);
   // Providers are named the way this organization names them, so a renamed
   // provider reads the same here as in the model-provider settings.
   const providerCatalog = useModelProviderCatalog();
@@ -806,11 +798,6 @@ export function ConnectCommandPanel({
         />
         Install shared skills
       </label>
-      {llmProxyId !== null && (
-        <p className="pl-6 text-xs text-muted-foreground">
-          Only skills in the LLM Proxy's environment are listed.
-        </p>
-      )}
       <p className="pl-6 text-xs text-muted-foreground">
         Everything shared with you is installed, and stays current as skills are
         added or removed. To share a fixed subset instead, use a snapshot link.

--- a/platform/frontend/src/app/connection/skills-marketplace-step.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.tsx
@@ -772,18 +772,14 @@ export type ConnectSkill = Pick<
 >;
 
 /**
- * Query over the org's full skill set, for the connect-command step's
- * per-skill picker. Callers that prepare an artifact containing an explicit
- * skill snapshot can opt into a loud error, rather than silently producing an
- * artifact without the selected skills.
- *
- * `forAgentId` narrows the set to skills visible from that agent's
- * environment — the connect command passes the selected LLM proxy so only
- * skills the connection can actually reach are offered.
+ * Query the caller-visible skill catalog for the connect command's review step.
+ * It deliberately omits agent scoping because Connect registers the caller's
+ * shared marketplace, not an agent's effective skill surface. Callers that
+ * prepare an artifact containing an explicit skill snapshot can opt into a loud
+ * error rather than silently producing an artifact without the selected skills.
  */
 export function useAllSkills(params?: {
   enabled?: boolean;
-  forAgentId?: string | null;
   /** Surface a catalog failure to the caller instead of returning an empty list. */
   throwOnError?: boolean;
   /**
@@ -797,7 +793,6 @@ export function useAllSkills(params?: {
    */
   deferMs?: number;
 }) {
-  const forAgentId = params?.forAgentId ?? null;
   const enabled = useDeferredEnabled(
     params?.enabled ?? true,
     params?.deferMs ?? 0,
@@ -807,25 +802,21 @@ export function useAllSkills(params?: {
     queryKey: [
       "skills",
       "connect-all",
-      forAgentId,
       { throwOnError: params?.throwOnError ?? false },
     ],
-    queryFn: () => fetchAllSkills(forAgentId, params?.throwOnError ?? false),
+    queryFn: () => fetchAllSkills(params?.throwOnError ?? false),
     enabled,
   });
 }
 
 /** Fetch every skill page by page. */
-async function fetchAllSkills(
-  forAgentId: string | null = null,
-  throwOnError = false,
-): Promise<ConnectSkill[]> {
+async function fetchAllSkills(throwOnError = false): Promise<ConnectSkill[]> {
   const skills: ConnectSkill[] = [];
   const limit = 100;
   let offset = 0;
   while (true) {
     const { data, error } = await archestraApiSdk.getSkills({
-      query: { limit, offset, forAgentId: forAgentId ?? undefined },
+      query: { limit, offset },
     });
     if (error) {
       if (throwOnError) {


### PR DESCRIPTION
## Summary

The detailed Connect flow fetched skills with the singleton LLM Proxy ID as an agent scope. The skills API correctly rejects that agent type, so opening Other ways to connect produced the global “This agent type does not expose skills” toast and then silently generated a setup without shared skills.

This change makes Connect fetch the caller-visible shared-skill catalog without agent scoping, removes the stale proxy-environment explanation, and keeps the backend validation intact.

## Regression coverage

Adds an integration-style panel test that runs the real skills query against an MSW handler. The handler reproduces the production 400 whenever forAgentId is supplied, and the test verifies that the unscoped result is included in the generated connection setup.

## Verification 

Reproduced before the fix on localhost by opening /connection and selecting Other ways to connect. After the fix, the same flow shows the shared skills, emits no toast, requests /api/skills with pagination only, and regenerates the setup successfully.

The focused panel suite passes 47 tests, the full frontend suite passes 5,446 tests, and frontend type-check, lint, knip, targeted Biome, git diff checks, and the repository commit gate pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>