### PR TITLE
fix(runtime): preserve native reasoning and recover detached runs

### DIFF
--- a/platform/agent_images/Dockerfile
+++ b/platform/agent_images/Dockerfile
@@ -56,7 +56,7 @@ RUN --network=none \
 
 FROM agent-base AS agent-codex
 USER root
-RUN pnpm add --global @openai/codex@0.149.1 \
+RUN pnpm add --global @openai/codex@0.153.0 \
  && codex --version \
  && chown -R 1000:1000 /home/node
 USER 1000:1000

--- a/platform/backend/src/models/a2a/task.test.ts
+++ b/platform/backend/src/models/a2a/task.test.ts
@@ -3,7 +3,7 @@ import { A2AProtocolTaskState } from "@/agents/a2a/a2a-protocol";
 import db, { schema } from "@/database";
 import { AgentRunModel } from "@/models";
 import { agentRunTranscriptStore } from "@/services/agent-runtime/transcript-store";
-import { describe, expect, test } from "@/test";
+import { describe, expect, test, vi } from "@/test";
 import A2AContextModel from "./context";
 import A2AMessageModel from "./message";
 import A2ATaskModel from "./task";
@@ -71,7 +71,13 @@ describe("A2ATaskModel", () => {
         .from(schema.a2aTasksTable)
         .where(eq(schema.a2aTasksTable.id, task.id));
 
-      await A2ATaskModel.updateState(task.id, A2AProtocolTaskState.Completed);
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(beforeUpdate.updatedAt.getTime() + 1000));
+      try {
+        await A2ATaskModel.updateState(task.id, A2AProtocolTaskState.Completed);
+      } finally {
+        vi.useRealTimers();
+      }
 
       const [updatedTask] = await db
         .select()

--- a/platform/backend/src/models/a2a/task.ts
+++ b/platform/backend/src/models/a2a/task.ts
@@ -1,4 +1,14 @@
-import { and, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  lt,
+  notExists,
+  or,
+  sql,
+} from "drizzle-orm";
 import type {
   A2AProtocolPart,
   A2AProtocolStreamResponse,
@@ -491,17 +501,54 @@ class A2ATaskModel {
         and(
           inArray(schema.a2aTasksTable.state, ACTIVE_RUN_STATES),
           lt(schema.a2aTasksTable.lastHeartbeatAt, cutoff),
+          // Runtime workloads outlive the server that launched them. Their
+          // reconciler must inspect/adopt the workload and settle its result;
+          // a missing server heartbeat cannot establish that it failed.
+          notExists(
+            db
+              .select({ id: schema.agentRunsTable.id })
+              .from(schema.agentRunsTable)
+              .where(eq(schema.agentRunsTable.taskId, schema.a2aTasksTable.id)),
+          ),
         ),
       );
 
     let reaped = 0;
     for (const task of stale) {
-      const transitioned = await A2ATaskModel.transitionStateWithEvent({
-        id: task.id,
-        to: "TASK_STATE_FAILED",
-        allowedFrom: ACTIVE_RUN_STATES,
-        statusReason: params.statusReason,
-        eventPayload: params.buildEventPayload(task),
+      const transitioned = await db.transaction(async (tx) => {
+        // Recheck under the row lock: a heartbeat may have arrived since the
+        // candidate query, or another server may already be settling it.
+        const [current] = await tx
+          .select()
+          .from(schema.a2aTasksTable)
+          .where(
+            and(
+              eq(schema.a2aTasksTable.id, task.id),
+              inArray(schema.a2aTasksTable.state, ACTIVE_RUN_STATES),
+              lt(schema.a2aTasksTable.lastHeartbeatAt, cutoff),
+              notExists(
+                tx
+                  .select({ id: schema.agentRunsTable.id })
+                  .from(schema.agentRunsTable)
+                  .where(eq(schema.agentRunsTable.taskId, task.id)),
+              ),
+            ),
+          )
+          .for("update", { skipLocked: true });
+        if (!current) return null;
+        const updated = await A2ATaskModel.transitionInTx(tx, {
+          id: current.id,
+          to: "TASK_STATE_FAILED",
+          allowedFrom: ACTIVE_RUN_STATES,
+          statusReason: params.statusReason,
+        });
+        if (updated)
+          await A2ATaskModel.appendEventInTx(
+            tx,
+            current.id,
+            params.buildEventPayload(current),
+          );
+        return updated;
       });
       if (transitioned) {
         reaped += 1;

--- a/platform/backend/src/models/agent-run.test.ts
+++ b/platform/backend/src/models/agent-run.test.ts
@@ -6,6 +6,71 @@ import {
 } from "@/models";
 import { describe, expect, test, vi } from "@/test";
 
+test("runtime reconciliation owns stale workloads and recovers an ended run with an unsettled task", async ({
+  makeOrganization,
+  makeUser,
+  makeAgent,
+}) => {
+  const organization = await makeOrganization();
+  const owner = await makeUser();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const context = await A2AContextModel.create({
+    actorKind: "user",
+    actorId: owner.id,
+  });
+  const tasks = [];
+  for (const ended of [false, true]) {
+    const task = await A2ATaskModel.create({
+      contextId: context.id,
+      agentId: agent.id,
+      state: "TASK_STATE_WORKING",
+      lastHeartbeatAt: new Date(Date.now() - 3600_000),
+    });
+    const run = await AgentRunModel.create({
+      organizationId: organization.id,
+      taskId: task.id,
+      agentId: agent.id,
+      actorKind: "user",
+      actorId: owner.id,
+      actorUserId: owner.id,
+      workloadName: `runtime-recovery-${task.id}`,
+      backend: "kubernetes",
+      runtimeScope: "test",
+    });
+    if (ended)
+      await AgentRunModel.close({
+        id: run.id,
+        logs: "Completed runtime output",
+      });
+    tasks.push(task);
+  }
+  expect(
+    await A2ATaskModel.reapStaleRunning({
+      staleMs: 600_000,
+      statusReason: "orphaned server",
+      buildEventPayload: (task) => ({
+        statusUpdate: {
+          taskId: task.id,
+          contextId: task.contextId,
+          status: { state: "TASK_STATE_FAILED" },
+        },
+      }),
+    }),
+  ).toBe(0);
+  for (const task of tasks) {
+    expect((await A2ATaskModel.findById(task.id))?.state).toBe(
+      "TASK_STATE_WORKING",
+    );
+  }
+  expect((await AgentRunModel.listOpen()).map((run) => run.taskId)).toEqual(
+    expect.arrayContaining(tasks.map((task) => task.id)),
+  );
+  await A2ATaskModel.updateState(tasks[1].id, "TASK_STATE_COMPLETED");
+  expect(
+    (await AgentRunModel.listOpen()).map((run) => run.taskId),
+  ).not.toContain(tasks[1].id);
+});
+
 test("context continuation chooses the latest run without crossing owner or Agent boundaries", async ({
   makeOrganization,
   makeUser,

--- a/platform/backend/src/models/agent-run.ts
+++ b/platform/backend/src/models/agent-run.ts
@@ -184,10 +184,26 @@ class AgentRunModel {
 
   /** Sessions whose pod should still exist, across every organization. */
   static async listOpen(): Promise<AgentRunRecord[]> {
-    return db
-      .select()
-      .from(schema.agentRunsTable)
-      .where(isNull(schema.agentRunsTable.endedAt));
+    return (
+      db
+        .select(getTableColumns(schema.agentRunsTable))
+        .from(schema.agentRunsTable)
+        .innerJoin(
+          schema.a2aTasksTable,
+          eq(schema.agentRunsTable.taskId, schema.a2aTasksTable.id),
+        )
+        // Capturing the runtime's end and settling its task are separate writes.
+        // Recover a crash between them instead of abandoning an active task.
+        .where(
+          or(
+            isNull(schema.agentRunsTable.endedAt),
+            inArray(schema.a2aTasksTable.state, [
+              "TASK_STATE_SUBMITTED",
+              "TASK_STATE_WORKING",
+            ]),
+          ),
+        )
+    );
   }
 
   /** Terminal runs whose channel completion reply is still pending. */

--- a/platform/backend/src/routes/proxy/routes/model-router-native-responses.test.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router-native-responses.test.ts
@@ -1,0 +1,144 @@
+import Fastify from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { HttpResponse, http } from "msw";
+import config from "@/config";
+import {
+  LlmProviderApiKeyModelLinkModel,
+  ModelModel,
+  VirtualApiKeyModel,
+} from "@/models";
+import { expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
+import modelRouterProxyRoutes from "./model-router";
+
+// biome-ignore lint/correctness/useHookAtTopLevel: Vitest lifecycle helper, not a React hook.
+const server = useMswServer();
+
+test("preserves native Responses reasoning, replay state and tool calls through the model router", async ({
+  makeOrganization,
+  makeAgent,
+  makeSecret,
+  makeLlmProviderApiKey,
+}) => {
+  config.llm.openai.baseUrl = "https://native-responses.example.test/v1";
+  const organization = await makeOrganization();
+  const agent = await makeAgent({
+    organizationId: organization.id,
+    agentType: "agent",
+  });
+  const model = await ModelModel.upsert({
+    externalId: "openai/gpt-5.4",
+    provider: "openai",
+    modelId: "gpt-5.4",
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    lastSyncedAt: new Date(),
+  });
+  const secret = await makeSecret({ secret: { apiKey: "test-native-key" } });
+  const key = await makeLlmProviderApiKey(organization.id, secret.id, {
+    provider: "openai",
+    scope: "org",
+  });
+  await LlmProviderApiKeyModelLinkModel.linkModelsToApiKey(key.id, [model.id]);
+  const { value } = await VirtualApiKeyModel.create({
+    organizationId: organization.id,
+    name: "Native Responses test",
+    providerApiKeys: [{ provider: "openai", providerApiKeyId: key.id }],
+  });
+  const payload = {
+    model: "openai:gpt-5.4",
+    stream: false,
+    reasoning: { effort: "high" },
+    include: ["reasoning.encrypted_content"],
+    input: [
+      { role: "user", content: "Inspect the project." },
+      {
+        type: "message",
+        role: "assistant",
+        phase: "commentary",
+        content: [{ type: "output_text", text: "Checking the project." }],
+      },
+      {
+        type: "reasoning",
+        id: "rs_prior",
+        encrypted_content: "opaque-state",
+        summary: [],
+      },
+    ],
+    tools: [
+      {
+        type: "function",
+        name: "read_file",
+        parameters: { type: "object", properties: {} },
+      },
+    ],
+  };
+  const call = {
+    type: "function_call",
+    id: "fc_read",
+    call_id: "call_read",
+    name: "read_file",
+    arguments: "{}",
+    status: "completed",
+  };
+  const message = {
+    type: "message",
+    id: "msg_progress",
+    role: "assistant",
+    phase: "commentary",
+    status: "completed",
+    content: [
+      { type: "output_text", text: "Checking the project.", annotations: [] },
+    ],
+  };
+  let upstream: unknown;
+  server.use(
+    http.post(
+      "https://native-responses.example.test/v1/responses",
+      async ({ request }) => {
+        upstream = await request.json();
+        return HttpResponse.json({
+          id: "resp_native",
+          object: "response",
+          created_at: 1,
+          model: "gpt-5.4",
+          status: "completed",
+          output: [message, call],
+          usage: { input_tokens: 20, output_tokens: 10, total_tokens: 30 },
+        });
+      },
+    ),
+    http.post("https://native-responses.example.test/v1/chat/completions", () =>
+      HttpResponse.json(
+        {
+          error: { message: "Native Responses must not be translated to chat" },
+        },
+        { status: 400 },
+      ),
+    ),
+  );
+  const app = Fastify().withTypeProvider<ZodTypeProvider>();
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  await app.register(modelRouterProxyRoutes);
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/model-router/${agent.id}/responses`,
+      headers: {
+        authorization: `Bearer ${value}`,
+        "user-agent": "test-client",
+      },
+      payload,
+    });
+    expect(response.statusCode, response.body).toBe(200);
+    expect(upstream).toMatchObject({ ...payload, model: "gpt-5.4" });
+    expect(response.json().output).toEqual([message, call]);
+  } finally {
+    await app.close();
+  }
+});

--- a/platform/backend/src/routes/proxy/routes/model-router.test.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.test.ts
@@ -244,14 +244,18 @@ function createResponsesTestClient() {
 
   return {
     responses: {
-      create: async (params: { stream?: boolean }) => {
+      create: async (params: { stream?: boolean; model?: string }) => {
+        const response = {
+          ...completedResponse,
+          model: params.model ?? completedResponse.model,
+        };
         if (params.stream) {
           return {
             [Symbol.asyncIterator]: async function* () {
               yield {
                 type: "response.created",
                 response: {
-                  ...completedResponse,
+                  ...response,
                   status: "in_progress",
                   output: [],
                 },
@@ -260,11 +264,11 @@ function createResponsesTestClient() {
                 type: "response.output_text.delta",
                 delta: "Hello from Copilot Responses",
               };
-              yield { type: "response.completed", response: completedResponse };
+              yield { type: "response.completed", response };
             },
           };
         }
-        return completedResponse;
+        return response;
       },
     },
   };
@@ -610,7 +614,7 @@ describe("model router proxy routes", () => {
       expect(response.statusCode).toBe(200);
       expect(response.json()).toMatchObject({
         object: "response",
-        model: `${provider}:${modelId}`,
+        model: provider === "openai" ? modelId : `${provider}:${modelId}`,
       });
     });
 
@@ -725,7 +729,7 @@ describe("model router proxy routes", () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toMatchObject({
       object: "response",
-      model: "openai:gpt-5.4",
+      model: "gpt-5.4",
     });
   });
 

--- a/platform/backend/src/routes/proxy/routes/model-router.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.ts
@@ -512,10 +512,9 @@ async function routeResponse(request: FastifyRequest, reply: FastifyReply) {
     allowedApiKeyIds: getMappedApiKeyIds(auth),
   });
 
-  // A model its provider serves ONLY over Responses cannot survive the
-  // responses→chat→responses round trip the uniform path uses, so hand the
-  // caller's original Responses body to the provider's native Responses
-  // adapter untouched.
+  // Preserve native Responses semantics whenever that surface is available.
+  // A chat round trip loses reasoning settings, encrypted replay state,
+  // assistant phases and tools that are not Chat Completions functions.
   const nativeResponsesAdapter = getNativeResponsesAdapter(resolution);
   if (nativeResponsesAdapter) {
     await applyModelRouterAuthOverride({
@@ -626,22 +625,22 @@ function getModelRouterEmbeddingsProvider(
 }
 
 /**
- * The provider's native Responses adapter when the resolved model is served
- * only over Responses, otherwise null.
+ * Prefer OpenAI's native Responses surface even when a model also supports
+ * chat. Other providers retain their existing compatibility routing.
  *
  * Keyed off the model's published surfaces where available. OpenAI does not
  * publish those surfaces, so its known Responses-only model families use the
  * same model-id discriminator as foreground Agent chat.
  */
 function getNativeResponsesAdapter(resolution: ModelRouterResolution) {
+  if (resolution.provider === "openai") {
+    return openAiResponsesAdapterFactory;
+  }
   if (!modelRequiresResponses(resolution)) {
     return null;
   }
   if (resolution.provider === "github-copilot") {
     return githubCopilotResponsesAdapterFactory;
-  }
-  if (resolution.provider === "openai") {
-    return openAiResponsesAdapterFactory;
   }
   return null;
 }


### PR DESCRIPTION
Codex requests through the model router could lose reasoning state and assistant phases when translated through Chat Completions. Route OpenAI Responses requests directly to the native handler, preserving tool calls and replay state, and update the catalog CLI to 0.153.0.

Detached runtime workloads can survive their launching server. Leave their settlement to the runtime reconciler, including runs whose process ended before the task was settled, and recheck stale in-process tasks under a nonblocking row lock.

Exercised a Slack-triggered Codex run against the real development app: after native routing was restored, it executed tools, completed browser checks and delivered its recording. Regression coverage verifies native request/response fidelity and recovery eligibility for stale runtime tasks.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>