### PR TITLE
fix(agent-runtime): bound response previews to avoid completion delays

### DIFF
--- a/platform/backend/src/services/agent-runtime/output-capture.test.ts
+++ b/platform/backend/src/services/agent-runtime/output-capture.test.ts
@@ -12,6 +12,28 @@ import {
 } from "./runtime-contract";
 
 describe("AgentRuntimeOutputCapture", () => {
+  test("bounds response previews while retaining terminal output and the final answer", async () => {
+    const onTextDelta = vi.fn();
+    const prefix = "x".repeat(64 * 1024 - 1);
+    const final =
+      "\n===ARCHESTRA-FINAL-ANSWER===\nThe workflow passed.\n===ARCHESTRA-FINAL-ANSWER-END===\n";
+    const chunks = [prefix, "🦞".repeat(20_000), "later repaint", final];
+    const transcript = chunks.join("");
+    const capture = new AgentRuntimeOutputCapture({
+      backend: outputBackend({ liveChunks: chunks, snapshot: transcript }),
+      session,
+      onTextDelta,
+    });
+
+    await capture.follow();
+    expect(onTextDelta.mock.calls.flat().join("")).toBe(prefix);
+    expect(capture.completeTranscript).toBe(transcript);
+    await capture.recoverSnapshot();
+    expect(capture.completeTranscript).toBe(transcript);
+    expect(capture.retainedLogs).toContain("The workflow passed.");
+    expect(onTextDelta).toHaveBeenCalledOnce();
+  });
+
   test("a late live-stream close cannot overwrite the final readable snapshot", async () => {
     const readable = JSON.stringify({
       version: 1,

--- a/platform/backend/src/services/agent-runtime/output-capture.ts
+++ b/platform/backend/src/services/agent-runtime/output-capture.ts
@@ -22,6 +22,7 @@ export class AgentRuntimeOutputCapture {
   private retainedLogsValue = "";
   private readableTranscriptValue: string | null = null;
   private recoveredSnapshot = false;
+  private streamedPreviewBytes = 0;
 
   constructor(
     private readonly params: {
@@ -179,7 +180,22 @@ export class AgentRuntimeOutputCapture {
     if (!chunk) return;
     this.fullTranscript.append(chunk);
     this.retainedLogsValue = retainLogTail(this.retainedLogsValue, chunk);
-    this.params.onTextDelta?.(chunk);
+    // The terminal has its own live stream and retained transcript. A2A deltas
+    // repeatedly rewrite the response artifact; forwarding every TUI repaint
+    // builds a database queue that can outlive the completed runtime by minutes.
+    // Keep a bounded startup preview. Task settlement supplies the final answer.
+    const remaining = STREAMED_PREVIEW_BYTES - this.streamedPreviewBytes;
+    if (remaining > 0 && this.params.onTextDelta) {
+      const bytes = Buffer.from(chunk);
+      let end = Math.min(bytes.length, remaining);
+      // Do not emit half of a UTF-8 code point at the preview boundary.
+      if (end < bytes.length) {
+        while (end > 0 && (bytes[end] & 0xc0) === 0x80) end--;
+      }
+      const preview = bytes.subarray(0, end).toString("utf8");
+      this.streamedPreviewBytes += Math.min(bytes.length, remaining);
+      if (preview) this.params.onTextDelta(preview);
+    }
   }
 
   private finishLiveProtocol(): void {
@@ -190,6 +206,8 @@ export class AgentRuntimeOutputCapture {
 }
 
 // ===================== internals =====================
+
+const STREAMED_PREVIEW_BYTES = 64 * 1024;
 
 class AgentRuntimeOutputProtocolParser {
   private mode: "terminal" | "readable" = "terminal";


### PR DESCRIPTION
Long Agent Runtime tasks could finish in their container but remain “working” while queued terminal redraws repeatedly rewrote a multi-megabyte A2A response artifact. Bound the streamed response preview to 64 KiB; the live terminal, retained transcript and authoritative final answer keep their existing capture paths.

The regression exercises output beyond the preview limit, a multibyte boundary and final snapshot recovery. A real Slack continuation produced 2 MiB of terminal output, then completed and delivered its final reply using the same workspace.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>