### PR TITLE
fix(ci): fetch canonical release histories for private PRs

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -372,6 +372,16 @@ jobs:
               "+refs/heads/release/*:refs/remotes/origin/release/*" \
               "+refs/tags/platform-v*:refs/tags/platform-v*"
 
+      # The private development mirror does not publish stable release tracks.
+      # Test its changes against the actual released public histories, keeping
+      # origin/main above tied to this PR's own repository.
+      - name: Fetch canonical release histories in the private mirror
+        if: github.repository == 'archestra-ai/archestra-private'
+        run: |
+          git fetch --depth=1 https://github.com/archestra-ai/archestra.git \
+            "+refs/heads/release/*:refs/remotes/origin/release/*" \
+            "+refs/tags/platform-v*:refs/tags/platform-v*"
+
       - name: Check migration upgrade paths across release tracks
         env:
           BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}


### PR DESCRIPTION
Private development PRs fail before platform validation because the mirror has no stable release branches. Fetch the canonical public release histories only in the private mirror’s CI job, while retaining that PR’s own origin/main as its base comparison. The migration checks remain enabled.

A fresh shallow clone of the private mirror reproduced the missing-release-ref failure. After the same canonical fetch, the real upgrade checker passed both the mirror-main and stable-release upgrade paths.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>