### PR TITLE
fix(agent-runtime): retry recovery before waiting for completion

### DIFF
--- a/platform/backend/src/services/agent-runtime/reconciler.ts
+++ b/platform/backend/src/services/agent-runtime/reconciler.ts
@@ -245,6 +245,11 @@ class AgentRunReconciler {
     session: Awaited<ReturnType<typeof AgentRunModel.listOpen>>[number],
   ): Promise<void> {
     if (!session.completionTarget) return;
+    // Adoption can fail before its lifecycle settles the task (for example,
+    // while refreshing the heartbeat). Do not hold the recovery lease in a
+    // completion watcher: the next reconciliation must be able to retry.
+    const task = await A2ATaskModel.findById(session.taskId);
+    if (!task || !isTerminalA2ATaskState(task.state)) return;
     const agent = await AgentModel.findById(session.agentId);
     await watchTaskCompletion({
       taskId: session.taskId,

--- a/platform/backend/src/services/agent-runtime/recovery-retry.test.ts
+++ b/platform/backend/src/services/agent-runtime/recovery-retry.test.ts
@@ -1,0 +1,76 @@
+import { sql } from "drizzle-orm";
+import db from "@/database";
+import { A2AContextModel, A2ATaskModel, AgentRunModel } from "@/models";
+import { afterEach, expect, test, vi } from "@/test";
+import { kubernetesAgentRuntimeBackendDriver as backend } from "./backends/kubernetes";
+import { agentRunReconciler } from "./reconciler";
+
+afterEach(() => vi.restoreAllMocks());
+
+test("releases recovery after a heartbeat write fails so the next tick can retry", async ({
+  makeAgent,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const agent = await makeAgent();
+  const context = await A2AContextModel.create({
+    actorKind: "user",
+    actorId: user.id,
+  });
+  const task = await A2ATaskModel.create({
+    contextId: context.id,
+    agentId: agent.id,
+    state: "TASK_STATE_WORKING",
+    lastHeartbeatAt: new Date(0),
+  });
+  await AgentRunModel.create({
+    organizationId: agent.organizationId,
+    agentId: agent.id,
+    taskId: task.id,
+    actorKind: "user",
+    actorId: user.id,
+    actorUserId: user.id,
+    backend: "kubernetes",
+    runtimeScope: "local",
+    workloadName: `retry-${task.id}`,
+    completionTarget: {
+      type: "chatops",
+      bindingId: crypto.randomUUID(),
+      threadId: "recovery-test",
+    },
+  });
+  let releasedLeases = 0;
+  vi.spyOn(backend, "isEnabled", "get").mockReturnValue(true);
+  // The cluster lease is an external boundary; task loading and writes use
+  // the real database, including the failure before runtime adoption starts.
+  vi.spyOn(backend, "withSessionLease").mockImplementation(
+    async (_session, operation) => {
+      await operation();
+      releasedLeases++;
+      return true;
+    },
+  );
+  await db.execute(sql`
+    CREATE FUNCTION reject_recovery_heartbeat() RETURNS trigger AS $$
+    BEGIN
+      RAISE EXCEPTION 'transient heartbeat write failure';
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+  await db.execute(sql`
+    CREATE TRIGGER reject_recovery_heartbeat
+      BEFORE UPDATE ON a2a_task
+      FOR EACH ROW EXECUTE FUNCTION reject_recovery_heartbeat();
+  `);
+  try {
+    await agentRunReconciler.reconcile();
+    await expect.poll(() => releasedLeases).toBe(1);
+    expect((await A2ATaskModel.findById(task.id))?.state).toBe(
+      "TASK_STATE_WORKING",
+    );
+    await agentRunReconciler.reconcile();
+    await expect.poll(() => releasedLeases).toBe(2);
+  } finally {
+    await db.execute(sql`DROP FUNCTION reject_recovery_heartbeat() CASCADE`);
+  }
+});


### PR DESCRIPTION
A transient failure while recovering a surviving Agent Runtime could leave the task working: recovery held its lease while waiting for the completion it still needed to produce. Only watch completion after the task reaches a terminal state, so the next reconciliation can retry.

A regression induces a real database write failure and verifies that recovery releases its lease and retries on the next tick. It fails before this change and passes after it; the focused tests and full backend checks pass. Existing runtime documentation remains accurate.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>