### PR TITLE
fix(agents): backport canonical subagent selector to 1.3

### DIFF
--- a/platform/frontend/src/components/agent-form.test.tsx
+++ b/platform/frontend/src/components/agent-form.test.tsx
@@ -673,8 +673,16 @@ vi.mock("@/components/ui/command", () => ({
     <div>{children}</div>
   ),
   CommandInput: () => null,
-  CommandItem: ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
+  CommandItem: ({
+    children,
+    onSelect,
+  }: {
+    children?: React.ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <button type="button" role="option" onClick={onSelect}>
+      {children}
+    </button>
   ),
   CommandList: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
@@ -735,6 +743,9 @@ vi.mock("@/components/ui/overlapped-icons", () => ({
 
 vi.mock("@/components/ui/popover", () => ({
   Popover: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverAnchor: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
   PopoverContent: ({ children }: { children?: React.ReactNode }) => (
@@ -989,8 +1000,9 @@ describe("AgentForm delegation state", () => {
       ),
     ).toBeInTheDocument();
     await user.click(
-      within(section).getByRole("button", { name: "Add Target Agent" }),
+      within(section).getByRole("combobox", { name: "Add subagent" }),
     );
+    await user.click(screen.getByRole("option", { name: /Target Agent/ }));
     await user.click(screen.getByRole("button", { name: /update/i }));
 
     await waitFor(() =>
@@ -1002,6 +1014,96 @@ describe("AgentForm delegation state", () => {
     );
     expect(syncDelegations).toHaveBeenCalledWith(
       expect.objectContaining({ targetAgentIds: [targetAgent.id] }),
+    );
+  });
+
+  it.each([
+    "create",
+    "edit",
+  ])("uses canonical subagent details in the %s flow", async (flow) => {
+    const user = userEvent.setup();
+    useDelegationTargetAgentsMock.mockReturnValue({
+      data: [
+        {
+          ...targetAgent,
+          icon: "🔭",
+          scope: "personal",
+          authorName: "Agent Owner",
+        },
+      ],
+    });
+
+    render(
+      <AgentForm
+        agentType="agent"
+        agent={flow === "edit" ? baseAgent : undefined}
+      />,
+    );
+
+    await user.click(subagentModeTab("Manual"));
+    await user.click(screen.getByRole("combobox", { name: "Add subagent" }));
+
+    const option = screen.getByRole("option", { name: /Target Agent/ });
+    expect(within(option).getByText("🔭")).toBeInTheDocument();
+    expect(within(option).getByText("Agent Owner")).toBeInTheDocument();
+    expect(within(option).getByText("Personal")).toBeInTheDocument();
+  });
+
+  it.each([
+    "create",
+    "edit",
+  ])("offers creation of a missing subagent only in Manual mode in the %s flow", async (flow) => {
+    const user = userEvent.setup();
+    useDelegationTargetAgentsMock.mockReturnValue({ data: [] });
+    render(
+      <AgentForm
+        agentType="agent"
+        agent={flow === "edit" ? baseAgent : undefined}
+      />,
+    );
+
+    await user.click(subagentModeTab("Manual"));
+    await user.click(screen.getByRole("combobox", { name: "Add subagent" }));
+    expect(
+      screen.getByRole("link", { name: "Create a New Agent" }),
+    ).toHaveAttribute("href", "/agents/new");
+    await user.click(subagentModeTab("All"));
+    expect(
+      screen.queryByRole("link", { name: "Create a New Agent" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("saves the selected agent as an exclusion in All mode", async () => {
+    const user = userEvent.setup();
+    const autoAgent = { ...baseAgent, accessAllSubagents: true };
+    const syncExclusions = vi.fn().mockResolvedValue(undefined);
+    useProfileMock.mockReturnValue({ data: autoAgent, refetch: vi.fn() });
+    useAgentSubagentExclusionsMock.mockReturnValue({
+      data: { excludedSubagentIds: [] },
+      isSuccess: true,
+    });
+    useUpdateAgentSubagentExclusionsMock.mockReturnValue({
+      mutateAsync: syncExclusions,
+      isPending: false,
+    });
+    useUpdateProfileMock.mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue(autoAgent),
+      isPending: false,
+    });
+
+    render(<AgentForm agentType="agent" agent={autoAgent} />);
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Disable subagents" }),
+    );
+    await user.click(screen.getByRole("option", { name: /Target Agent/ }));
+    await user.click(screen.getByRole("button", { name: /update/i }));
+
+    await waitFor(() =>
+      expect(syncExclusions).toHaveBeenCalledWith({
+        agentId: baseAgent.id,
+        exclusions: { excludedSubagentIds: [targetAgent.id] },
+      }),
     );
   });
 

--- a/platform/frontend/src/components/agent-form.tsx
+++ b/platform/frontend/src/components/agent-form.tsx
@@ -67,6 +67,7 @@ import {
   type AgentRuntimeConfig,
   AgentRuntimeFields,
 } from "@/components/agent-runtime-fields";
+import { AgentSelector } from "@/components/agent-selector";
 import {
   AgentSkillsEditor,
   type EditableSkill,
@@ -509,12 +510,6 @@ function SubagentsEditor({
     }
   };
 
-  const comboboxItems: AssignmentComboboxItem[] = filteredAgents.map((a) => ({
-    id: a.id,
-    name: a.name,
-    description: a.description || undefined,
-  }));
-
   const selectedAgents = filteredAgents.filter((a) =>
     selectedAgentIds.includes(a.id),
   );
@@ -546,14 +541,15 @@ function SubagentsEditor({
           tone={tone}
         />
       ))}
-      <AssignmentCombobox
-        items={comboboxItems}
-        selectedIds={selectedAgentIds}
-        onToggle={handleToggle}
+      <AgentSelector
+        mode="multiple"
+        agents={filteredAgents}
+        value={selectedAgentIds}
+        onValueChange={onSelectionChange}
         // Without this the exclude side inherited the default "Add", so Auto
         // mode offered to add an agent and then disabled whichever was picked.
-        label={tone === "exclude" ? "Disable subagents" : "Add"}
-        placeholder={placeholder}
+        triggerLabel={tone === "exclude" ? "Disable subagents" : "Add subagent"}
+        searchPlaceholder={placeholder}
         emptyMessage="No agents found."
         createAction={
           showCreateAction

--- a/platform/frontend/src/components/agent-selector.test.tsx
+++ b/platform/frontend/src/components/agent-selector.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { AgentSelector, type AgentSelectorAgent } from "./agent-selector";
@@ -221,6 +221,112 @@ describe("AgentSelector sentinelOption", () => {
 });
 
 describe("AgentSelector (multiple, flat)", () => {
+  it("keeps the create action available after an empty search and closes on activation", async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentSelector
+        mode="multiple"
+        flat
+        agents={[personalProxy]}
+        value={[]}
+        onValueChange={vi.fn()}
+        triggerLabel="Add subagent"
+        createAction={{ label: "Create a New Agent", href: "/agents/new" }}
+        searchPlaceholder="Search agents..."
+      />,
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Add subagent" });
+    await user.click(trigger);
+    await user.type(
+      screen.getByPlaceholderText("Search agents..."),
+      "no match",
+    );
+    expect(screen.queryByRole("option")).toBeNull();
+    const create = screen.getByRole("link", { name: "Create a New Agent" });
+    expect(create).toHaveAttribute("target", "_blank");
+    await user.click(create);
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute("aria-expanded", "false"),
+    );
+  });
+
+  it("lets keyboard users remove badges in the default multiple selector", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <AgentSelector
+        mode="multiple"
+        flat
+        agents={[personalProxy, orgProxy]}
+        value={["p2"]}
+        onValueChange={onValueChange}
+      />,
+    );
+
+    await user.tab();
+    expect(
+      screen.getByRole("button", { name: "Remove Shared Proxy" }),
+    ).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(onValueChange).toHaveBeenCalledWith([]);
+  });
+
+  it("keeps focus on an outside control used to dismiss the compact selector", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <AgentSelector
+          mode="multiple"
+          flat
+          agents={[personalProxy, orgProxy]}
+          value={[]}
+          onValueChange={vi.fn()}
+          triggerLabel="Add subagent"
+        />
+        <input aria-label="Description" />
+      </>,
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Add subagent" });
+    const description = screen.getByRole("textbox", { name: "Description" });
+    await user.click(trigger);
+    await user.click(description);
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(description).toHaveFocus();
+    await user.keyboard("Continue editing");
+    expect(description).toHaveValue("Continue editing");
+  });
+
+  it("opens the compact selector by keyboard, searches owners, and restores focus", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <AgentSelector
+        mode="multiple"
+        flat
+        agents={[personalProxy, orgProxy]}
+        value={[]}
+        onValueChange={onValueChange}
+        triggerLabel="Add subagent"
+        searchPlaceholder="Search agents..."
+      />,
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Add subagent" });
+    await user.tab();
+    expect(trigger).toHaveFocus();
+    await user.keyboard(" ");
+    expect(screen.getByPlaceholderText("Search agents...")).toHaveFocus();
+    await user.keyboard("owner@example.com");
+    expect(screen.getByRole("option", { name: /My Proxy/ })).toBeVisible();
+    expect(screen.queryByRole("option", { name: /Shared Proxy/ })).toBeNull();
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(onValueChange).toHaveBeenCalledWith(["p1"]);
+    await user.keyboard("{Escape}");
+    expect(trigger).toHaveFocus();
+  });
+
   it("flat mode lists and toggles llm_proxy items that the grouped view would drop", async () => {
     const onValueChange = vi.fn();
     const user = userEvent.setup();

--- a/platform/frontend/src/components/agent-selector.tsx
+++ b/platform/frontend/src/components/agent-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, ChevronDown, X } from "lucide-react";
+import { Check, ChevronDown, ExternalLink, X } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { AgentIcon } from "@/components/agent-icon";
 import { RuntimeCapableIndicator } from "@/components/chat/runtime-capable-indicator";
@@ -100,6 +100,16 @@ type AgentSelectorProps =
       disabled?: boolean;
       disabledLabel?: string;
       className?: string;
+      /**
+       * Show a compact dropdown trigger instead of rendering selected values
+       * inside the control. Useful when selections are already displayed by
+       * the surrounding editor.
+       */
+      triggerLabel?: string;
+      createAction?: {
+        label: string;
+        href: string;
+      };
       /**
        * Render every agent in one ungrouped list regardless of `agentType`,
        * instead of the default "Agents"/"MCP Gateways" group headings. Use this
@@ -265,12 +275,15 @@ function MultiAgentSelector({
   disabled,
   disabledLabel,
   className,
+  triggerLabel,
+  createAction,
   flat,
   allOption,
 }: Extract<AgentSelectorProps, { mode: "multiple" }>) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const anchorRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef(false);
   const dialogContainer = dialogPortalContainer(anchorRef.current);
   const selectedAgents = agents.filter((agent) => value.includes(agent.id));
   const groupedAgents = useGroupedAgents(agents, search);
@@ -307,11 +320,14 @@ function MultiAgentSelector({
         <div
           ref={anchorRef}
           role="combobox"
+          aria-label={triggerLabel}
           aria-expanded={open}
           aria-disabled={disabled}
-          tabIndex={disabled ? undefined : -1}
+          tabIndex={disabled ? undefined : triggerLabel ? 0 : -1}
           className={cn(
             "flex min-h-9 w-full flex-wrap items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+            triggerLabel &&
+              "h-8 min-h-8 w-fit cursor-pointer justify-between py-1 text-xs shadow-xs hover:bg-accent hover:text-accent-foreground",
             disabled && "cursor-not-allowed opacity-60",
             className,
           )}
@@ -321,11 +337,17 @@ function MultiAgentSelector({
           onKeyDown={(event) => {
             if (disabled) return;
             if (event.key === "Enter" || event.key === " ") {
+              if (triggerLabel) event.preventDefault();
               setOpen(true);
             }
           }}
         >
-          {disabled && disabledLabel ? (
+          {triggerLabel ? (
+            <>
+              <span>{triggerLabel}</span>
+              <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
+            </>
+          ) : disabled && disabledLabel ? (
             <span className="text-muted-foreground">{disabledLabel}</span>
           ) : allSelected && allOption ? (
             <span>{allOption.label}</span>
@@ -365,7 +387,19 @@ function MultiAgentSelector({
         // control — capped to the viewport so it can't overflow a phone.
         className="flex max-h-[var(--radix-popover-content-available-height)] w-[var(--radix-popover-trigger-width)] min-w-[min(20rem,calc(100vw-2rem))] flex-col p-0"
         align="start"
-        onOpenAutoFocus={(event) => event.preventDefault()}
+        onOpenAutoFocus={(event) => {
+          if (!triggerLabel) event.preventDefault();
+        }}
+        onEscapeKeyDown={() => {
+          restoreFocusRef.current = true;
+        }}
+        onCloseAutoFocus={(event) => {
+          if (triggerLabel && restoreFocusRef.current) {
+            event.preventDefault();
+            anchorRef.current?.focus();
+          }
+          restoreFocusRef.current = false;
+        }}
         portalContainer={dialogContainer}
         collisionBoundary={dialogContainer ?? undefined}
         collisionPadding={8}
@@ -430,6 +464,25 @@ function MultiAgentSelector({
             )}
           </CommandList>
         </Command>
+        {createAction && (
+          <div className="border-t p-1">
+            <Button
+              asChild
+              variant="ghost"
+              className="h-8 w-full justify-between px-2 text-sm font-normal"
+            >
+              <a
+                href={createAction.href}
+                target="_blank"
+                rel="noopener"
+                onClick={() => setOpen(false)}
+              >
+                <span>{createAction.label}</span>
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </Button>
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
Backports #7866 to `release/1.3`. The subagent picker now shows the same icons, scope details, and searchable owners as the canonical agent selector. Manual mode retains creation in a separate tab; All mode retains the existing **Disable subagents** control.

Resolved the cherry-pick against 1.3’s existing form layout without importing main’s newer outbound A2A editor. Component workflows cover selecting and saving assignments and exclusions, owner search, keyboard and focus behavior, and the create action in both create and edit forms.

Source commit: `624e9f5c713a1b82c758587bbb7d0e863a6c9f48` (`git cherry-pick -x`).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>