### PR TITLE
fix(chat): preserve browser devtools shortcut

### DIFF
--- a/platform/frontend/src/lib/chat/conversation-search.hook.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-search.hook.test.ts
@@ -213,6 +213,40 @@ describe("useConversationSearch", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/chat?lockedChat=1");
   });
 
+  it.each([
+    { platform: "MacIntel", key: "Dead", metaKey: true, ctrlKey: false },
+    { platform: "MacIntel", key: "i", metaKey: true, ctrlKey: false },
+    { platform: "Win32", key: "i", metaKey: false, ctrlKey: true },
+  ])("leaves modified Alt+I available to the browser: %j", (shortcut) => {
+    mockPlatform(shortcut.platform);
+    renderHook(() => useConversationSearch());
+    const lockedChatShortcut = vi.fn();
+    window.addEventListener(
+      LOCKED_CHAT_DRAFT_SHORTCUT_EVENT,
+      lockedChatShortcut,
+    );
+
+    let event: KeyboardEvent;
+    try {
+      event = dispatchKeydown({
+        key: shortcut.key,
+        code: "KeyI",
+        altKey: true,
+        metaKey: shortcut.metaKey,
+        ctrlKey: shortcut.ctrlKey,
+      });
+    } finally {
+      window.removeEventListener(
+        LOCKED_CHAT_DRAFT_SHORTCUT_EVENT,
+        lockedChatShortcut,
+      );
+    }
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(lockedChatShortcut).not.toHaveBeenCalled();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
   it("blurs the focused editable while handling Alt+I, then restores focus", async () => {
     // macOS Option+I is a dead key whose composition Chromium starts even on
     // a preventDefault'ed keydown — the handler blurs the editable so the

--- a/platform/frontend/src/lib/chat/conversation-search.hook.ts
+++ b/platform/frontend/src/lib/chat/conversation-search.hook.ts
@@ -61,6 +61,8 @@ export function useConversationSearch() {
       if (
         lockedChatEnabled &&
         event.altKey &&
+        !event.metaKey &&
+        !event.ctrlKey &&
         event.code === SHORTCUT_NEW_LOCKED_CHAT.code
       ) {
         event.preventDefault();


### PR DESCRIPTION
Option+Command+I also triggered locked chat. Require Alt/Option+I without Command or Control, preserving physical-key matching for macOS dead keys.

In the real Tilt app, Option+Command+I left unlocked and locked drafts unchanged and its keyboard event uncanceled; Option+I still toggled locked chat while preserving the draft. The narrated demo shows the composer and observed events, not native macOS DevTools opening. Independent review of the substantive shortcut diff found no issues.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>