### PR TITLE
fix(agent-runtime): simplify runs empty state

### DIFF
--- a/platform/frontend/src/components/agent-pages/agent-runs.test.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-runs.test.tsx
@@ -43,6 +43,7 @@ describe("AgentRuns", () => {
   it("shows the live terminal while a run is active and retained output when it ends", () => {
     const view = render(<AgentRuns agentId="agent-1" />);
 
+    expect(screen.queryByRole("link", { name: "Chat" })).toBeNull();
     expect(screen.getByText("Live terminal")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Output" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Terminal" })).toBeNull();
@@ -54,6 +55,17 @@ describe("AgentRuns", () => {
     expect(screen.queryByText("Live terminal")).toBeNull();
     expect(screen.queryByRole("button", { name: "Output" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Terminal" })).toBeNull();
+  });
+
+  it("links an empty run history to a new Chat with this Agent selected", () => {
+    state.runs = [];
+
+    render(<AgentRuns agentId="agent/with spaces" />);
+
+    expect(screen.getByRole("link", { name: "Chat" })).toHaveAttribute(
+      "href",
+      "/chat/new?agent_id=agent%2Fwith%20spaces",
+    );
   });
 });
 

--- a/platform/frontend/src/components/agent-pages/agent-runs.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-runs.tsx
@@ -2,20 +2,15 @@
 
 import { formatDistanceToNow } from "date-fns";
 import { TerminalSquare } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { AgentRunLiveness } from "@/components/agent-run-liveness";
 import { AgentRunLogs } from "@/components/agent-run-logs";
 import { AgentRunState } from "@/components/agent-run-state";
 import { AgentRunTerminal } from "@/components/agent-run-terminal";
+import { EmptyState } from "@/components/empty-state";
 import { QueryLoadError } from "@/components/query-load-error";
 import { Button } from "@/components/ui/button";
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { type AgentRun, useAgentRuns } from "@/lib/agent-runtime.query";
 import { useSession } from "@/lib/auth/auth.query";
@@ -47,18 +42,22 @@ export function AgentRuns({ agentId }: { agentId: string }) {
   }
   if (runs.length === 0) {
     return (
-      <Empty className="border">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <TerminalSquare />
-          </EmptyMedia>
-          <EmptyTitle>No Agent Runtime runs yet</EmptyTitle>
-          <EmptyDescription>
-            A run appears here when another Agent delegates a task to this
-            Agent.
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
+      <EmptyState
+        icon={TerminalSquare}
+        title="No runs yet"
+        description={
+          <>
+            Start a run from{" "}
+            <Link
+              href={`/chat/new?agent_id=${encodeURIComponent(agentId)}`}
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              Chat
+            </Link>
+            .
+          </>
+        }
+      />
     );
   }
 


### PR DESCRIPTION
The empty Runs page now uses the compact shared empty state: “No runs yet” and “Start a run from Chat.” The inline Chat link replaces the misleading guidance that another Agent must delegate a task.

In the running Tilt app, following Chat opened the fully rendered dedicated-runtime composer with the same Agent selected. The navigation also worked at a narrow viewport.
