### PR TITLE
feat(agent-runs): show run owner and visibility

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -72757,6 +72757,45 @@
                         "nullable": true,
                         "type": "string",
                         "format": "date-time"
+                      },
+                      "initiatorName": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "shareVisibility": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "organization",
+                              "team",
+                              "user"
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "nullable": true,
+                            "enum": [
+                              null
+                            ]
+                          }
+                        ]
+                      },
+                      "shareTeamNames": {
+                        "nullable": true,
+                        "description": "Share recipient teams; null unless the viewer owns the run",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "shareUserNames": {
+                        "nullable": true,
+                        "description": "Share recipient users; null unless the viewer owns the run",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
                       }
                     },
                     "required": [
@@ -72781,7 +72820,11 @@
                       "statusReason",
                       "stateChangedAt",
                       "hardDeadlineAt",
-                      "lastModelActivityAt"
+                      "lastModelActivityAt",
+                      "initiatorName",
+                      "shareVisibility",
+                      "shareTeamNames",
+                      "shareUserNames"
                     ],
                     "additionalProperties": false
                   }

--- a/docs/pages/platform-agent-runtime.md
+++ b/docs/pages/platform-agent-runtime.md
@@ -3,7 +3,7 @@ title: Agent Runtime (Beta)
 category: Agents
 order: 7
 description: Configure isolated workspaces for coding agents and delegated tasks
-lastUpdated: "2026-09-11"
+lastUpdated: "2026-09-12"
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -206,9 +206,13 @@ Project access determines which members can review others' runs. Only the person
 
 Share a run with your organization, teams, or individual users. Recipients can review its details and live or retained output. Sharing grants read-only access; terminal control stays with the person who started the run.
 
+Only the run owner can view or change its sharing recipients. Agent readers can see run history, initiators, and sharing scopes without access to recipient names.
+
 ## View Runs From An Agent
 
 The Agent's **Runs** tab opens live terminals and completed recordings. Reattach while the client remains alive, or resume its saved conversation after suspension. Detaching leaves the run active.
+
+Run ownership follows the user who started it, not the Agent creator. Sharing grants read-only output access, never an interactive terminal. Agent administrators can read output even without an explicit share. Project access also permits reading runs when paired with permission to read all project sessions.
 
 Recordings preserve earlier terminal output, including screens replaced by redraws. Run history remains available after workspace removal and follows the configured retention period. See [Deployment](/docs/platform-deployment#agent-runtime) for retention and transcript limits.
 

--- a/platform/backend/src/models/agent-run.ts
+++ b/platform/backend/src/models/agent-run.ts
@@ -17,7 +17,7 @@ import config from "@/config";
 import db, { schema } from "@/database";
 import { createPaginatedResult } from "@/database/utils/pagination";
 import type {
-  AgentRun,
+  AgentRunListItem,
   AgentRunRecord,
   AgentRunSession,
   InsertAgentRunRecord,
@@ -227,7 +227,7 @@ class AgentRunModel {
   static async listForAgent(params: {
     agentId: string;
     organizationId: string;
-  }): Promise<AgentRun[]> {
+  }): Promise<AgentRunListItem[]> {
     const {
       logs: _logs,
       completionTarget: _completionTarget,
@@ -244,6 +244,24 @@ class AgentRunModel {
         stateChangedAt: schema.a2aTasksTable.stateChangedAt,
         hardDeadlineAt: hardDeadlineAtExpression(),
         lastModelActivityAt: lastModelActivityAtExpression(),
+        initiatorName: schema.usersTable.name,
+        shareVisibility: schema.agentRunSharesTable.visibility,
+        shareTeamNames: sql<string[]>`coalesce(array(
+          select ${schema.teamsTable.name}
+          from ${schema.agentRunShareTeamsTable}
+          inner join ${schema.teamsTable}
+            on ${schema.teamsTable.id} = ${schema.agentRunShareTeamsTable.teamId}
+          where ${schema.agentRunShareTeamsTable.shareId} = ${schema.agentRunSharesTable.id}
+          order by ${schema.teamsTable.name}
+        ), array[]::text[])`,
+        shareUserNames: sql<string[]>`coalesce(array(
+          select ${schema.usersTable.name}
+          from ${schema.agentRunShareUsersTable}
+          inner join ${schema.usersTable}
+            on ${schema.usersTable.id} = ${schema.agentRunShareUsersTable.userId}
+          where ${schema.agentRunShareUsersTable.shareId} = ${schema.agentRunSharesTable.id}
+          order by ${schema.usersTable.name}
+        ), array[]::text[])`,
       })
       .from(schema.agentRunsTable)
       .innerJoin(
@@ -253,6 +271,14 @@ class AgentRunModel {
       .innerJoin(
         schema.agentsTable,
         eq(schema.agentRunsTable.agentId, schema.agentsTable.id),
+      )
+      .leftJoin(
+        schema.usersTable,
+        eq(schema.agentRunsTable.actorUserId, schema.usersTable.id),
+      )
+      .leftJoin(
+        schema.agentRunSharesTable,
+        eq(schema.agentRunsTable.taskId, schema.agentRunSharesTable.taskId),
       )
       .where(
         and(

--- a/platform/backend/src/routes/agent-runtime/agent-runtime.routes.test.ts
+++ b/platform/backend/src/routes/agent-runtime/agent-runtime.routes.test.ts
@@ -11,6 +11,7 @@ import {
   A2AMessageModel,
   A2ATaskModel,
   AgentRunModel,
+  AgentRunShareModel,
   AgentWorkspaceModel,
   InteractionModel,
   LlmProviderApiKeyModelLinkModel,
@@ -298,8 +299,9 @@ describe("Agent Runtime routes", () => {
     expect(status).not.toHaveBeenCalled();
   });
 
-  test("lists only runs belonging to the selected Agent with their task outcome", async ({
+  test("lists runs with their initiator and visibility", async ({
     makeAgent,
+    makeTeam,
   }) => {
     const otherAgent = await makeAgent({
       organizationId,
@@ -321,6 +323,17 @@ describe("Agent Runtime routes", () => {
       runtimeScope: "archestra-dev",
       activeDeadlineSeconds: 3_600,
       virtualApiKeyId: null,
+    });
+    const visibleTeam = await makeTeam(organizationId, user.id, {
+      name: "Runtime reviewers",
+    });
+    await AgentRunShareModel.upsert({
+      taskId: selectedTask.id,
+      organizationId,
+      createdByUserId: user.id,
+      visibility: "team",
+      teamIds: [visibleTeam.id],
+      userIds: [],
     });
     const latestInteraction = await InteractionModel.create({
       profileId: agent.id,
@@ -388,7 +401,7 @@ describe("Agent Runtime routes", () => {
       url: `/api/agents/${agent.id}/runs`,
     });
 
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode, response.body).toBe(200);
     const [listedRun] = response.json();
     expect(listedRun).toEqual(
       expect.objectContaining({
@@ -396,6 +409,10 @@ describe("Agent Runtime routes", () => {
         agentId: agent.id,
         state: "TASK_STATE_FAILED",
         statusReason: "The run process exited with status 1",
+        initiatorName: user.name,
+        shareVisibility: "team",
+        shareTeamNames: ["Runtime reviewers"],
+        shareUserNames: [],
       }),
     );
     expect(
@@ -404,6 +421,143 @@ describe("Agent Runtime routes", () => {
     expect(listedRun.lastModelActivityAt).toBe(
       latestInteraction.createdAt.toISOString(),
     );
+  });
+
+  test("keeps the initiating user distinct from the Agent creator and follows current sharing", async ({
+    makeAdmin,
+    makeMember,
+  }) => {
+    const creator = user;
+    const owner = await makeAdmin({ name: "Alex Rivera" });
+    await makeMember(owner.id, organizationId, { role: "member" });
+    const recipient = await makeAdmin({ name: "Sam Chen" });
+    await makeMember(recipient.id, organizationId, { role: "member" });
+    const task = await createTask(agent.id);
+    await createRun({ taskId: task.id, actorUserId: owner.id });
+
+    const readRun = async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/agents/${agent.id}/runs`,
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toHaveLength(1);
+      return response.json()[0];
+    };
+    expect(await readRun()).toMatchObject({
+      actorUserId: owner.id,
+      initiatorName: owner.name,
+      shareVisibility: null,
+      shareTeamNames: null,
+      shareUserNames: null,
+    });
+    user = owner;
+    for (const visibility of ["user", "organization"] as const) {
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/agent-runs/${task.id}/share`,
+        payload: {
+          visibility,
+          ...(visibility === "user" ? { userIds: [recipient.id] } : {}),
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(await readRun()).toMatchObject({
+        shareUserNames: visibility === "user" ? [recipient.name] : [],
+        shareTeamNames: [],
+      });
+      user = creator;
+      expect(await readRun()).toMatchObject({
+        initiatorName: owner.name,
+        shareVisibility: visibility,
+        shareUserNames: null,
+        shareTeamNames: null,
+      });
+      user = owner;
+    }
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/agent-runs/${task.id}/share`,
+    });
+    expect(response.statusCode).toBe(200);
+    user = creator;
+    expect(await readRun()).toMatchObject({
+      initiatorName: owner.name,
+      shareVisibility: null,
+      shareUserNames: null,
+    });
+  });
+
+  test("preserves Agent history but restricts recipient membership to the run owner", async ({
+    makeAdmin,
+    makeMember,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    const owner = user;
+    const recipient = await makeAdmin({ name: "Release reviewer" });
+    await makeMember(recipient.id, organizationId, { role: "member" });
+    const outsider = await makeAdmin({ name: "Agent reader" });
+    await makeMember(outsider.id, organizationId, { role: "member" });
+    const administrator = await makeAdmin();
+    await makeMember(administrator.id, organizationId, { role: "admin" });
+    const team = await makeTeam(organizationId, owner.id, {
+      name: "Private reviewers",
+    });
+    await makeTeamMember(team.id, recipient.id);
+    const task = await createTask(agent.id);
+    await createRun({ taskId: task.id, actorUserId: owner.id });
+
+    for (const visibility of ["user", "team"] as const) {
+      await AgentRunShareModel.upsert({
+        taskId: task.id,
+        organizationId,
+        createdByUserId: owner.id,
+        visibility,
+        teamIds: visibility === "team" ? [team.id] : [],
+        userIds: visibility === "user" ? [recipient.id] : [],
+      });
+      for (const viewer of [owner, recipient, outsider, administrator]) {
+        user = viewer;
+        const history = await app.inject({
+          method: "GET",
+          url: `/api/agents/${agent.id}/runs`,
+        });
+        expect(history.statusCode).toBe(200);
+        expect(history.json()).toEqual([
+          expect.objectContaining({
+            taskId: task.id,
+            actorUserId: owner.id,
+            initiatorName: owner.name,
+            shareVisibility: visibility,
+            shareTeamNames:
+              viewer === owner
+                ? visibility === "team"
+                  ? [team.name]
+                  : []
+                : null,
+            shareUserNames:
+              viewer === owner
+                ? visibility === "user"
+                  ? [recipient.name]
+                  : []
+                : null,
+          }),
+        ]);
+        const settings = await app.inject({
+          method: "GET",
+          url: `/api/agent-runs/${task.id}/share`,
+        });
+        expect(settings.statusCode).toBe(viewer === owner ? 200 : 404);
+        const details = await app.inject({
+          method: "GET",
+          url: `/api/agent-runs/${task.id}`,
+        });
+        expect(details.statusCode).toBe(
+          viewer === owner || viewer === recipient ? 200 : 404,
+        );
+      }
+    }
   });
 
   test("keeps every run endpoint unavailable when no run backend is enabled", async () => {

--- a/platform/backend/src/routes/agent-runtime/agent-runtime.routes.ts
+++ b/platform/backend/src/routes/agent-runtime/agent-runtime.routes.ts
@@ -51,7 +51,7 @@ import {
   GetAgentRunResponseSchema,
   MissingAgentRuntimeCredentialSchema,
   type ResolvedAgentRuntime,
-  SelectAgentRunSchema,
+  SelectAgentRunListItemSchema,
   SelectAgentRunSessionSchema,
   SelectAgentRunShareWithTargetsSchema,
   StartAgentRunResponseSchema,
@@ -504,16 +504,25 @@ const agentRuntimeRoutes: FastifyPluginAsyncZod = async (fastify) => {
           "List Agent Runtime runs created by delegated tasks for this Agent",
         tags: ["Agents"],
         params: z.object({ id: z.string().uuid() }),
-        response: constructResponseSchema(z.array(SelectAgentRunSchema)),
+        response: constructResponseSchema(
+          z.array(SelectAgentRunListItemSchema),
+        ),
       },
     },
     async (request, reply) => {
       await requireReadableAgent(request);
+      const runs = await AgentRunModel.listForAgent({
+        agentId: request.params.id,
+        organizationId: request.organizationId,
+      });
       return reply.send(
-        await AgentRunModel.listForAgent({
-          agentId: request.params.id,
-          organizationId: request.organizationId,
-        }),
+        runs.map((run) => ({
+          ...run,
+          shareTeamNames:
+            run.actorUserId === request.user.id ? run.shareTeamNames : null,
+          shareUserNames:
+            run.actorUserId === request.user.id ? run.shareUserNames : null,
+        })),
       );
     },
   );

--- a/platform/backend/src/types/agent-runtime.ts
+++ b/platform/backend/src/types/agent-runtime.ts
@@ -7,6 +7,7 @@ import {
 import { z } from "zod";
 import { schema } from "@/database";
 import { A2ATaskStateSchema } from "./a2a-task";
+import { AgentRunShareVisibilitySchema } from "./agent-run-share";
 
 /**
  * Runtime backends an Agent Runtime configuration can name. The enum is the
@@ -270,6 +271,20 @@ export const SelectAgentRunSchema = SelectAgentRunRecordSchema.omit({
   lastModelActivityAt: z.date().nullable(),
 });
 
+/** Run metadata shown to Agent managers alongside the runtime state. */
+export const SelectAgentRunListItemSchema = SelectAgentRunSchema.extend({
+  initiatorName: z.string().nullable(),
+  shareVisibility: z.union([AgentRunShareVisibilitySchema, z.null()]),
+  shareTeamNames: z
+    .array(z.string())
+    .nullable()
+    .describe("Share recipient teams; null unless the viewer owns the run"),
+  shareUserNames: z
+    .array(z.string())
+    .nullable()
+    .describe("Share recipient users; null unless the viewer owns the run"),
+});
+
 /** A user's durable run session as rendered in Chat and its sidebar. */
 export const SelectAgentRunSessionSchema = SelectAgentRunSchema.extend({
   sessionId: z.string().uuid(),
@@ -347,6 +362,7 @@ export const StartAgentRunResponseSchema = z.object({
 export type AgentRunRecord = z.infer<typeof SelectAgentRunRecordSchema>;
 export type InsertAgentRunRecord = z.infer<typeof InsertAgentRunRecordSchema>;
 export type AgentRun = z.infer<typeof SelectAgentRunSchema>;
+export type AgentRunListItem = z.infer<typeof SelectAgentRunListItemSchema>;
 export type AgentRunSession = z.infer<typeof SelectAgentRunSessionSchema>;
 export type AgentRunViewerRole = z.infer<typeof AgentRunViewerRoleSchema>;
 export type GetAgentRunResponse = z.infer<typeof GetAgentRunResponseSchema>;

--- a/platform/backend/src/websocket.test.ts
+++ b/platform/backend/src/websocket.test.ts
@@ -348,7 +348,7 @@ describe("websocket Agent run authorization and cleanup", () => {
         type: "agent_run_logs_error",
         payload: {
           runId: task.id,
-          error: "Only the person who started this run can view its logs",
+          error: "You do not have access to this run's output",
         },
       }),
     );

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -705,7 +705,7 @@ class WebSocketService {
         type: "agent_run_logs_error",
         payload: {
           runId,
-          error: "Only the person who started this run can view its logs",
+          error: "You do not have access to this run's output",
         },
       });
       this.unsubscribeAgentRunLogs(ws);

--- a/platform/frontend/src/components/agent-pages/agent-runs.test.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-runs.test.tsx
@@ -1,24 +1,41 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentRun } from "@/lib/agent-runtime.query";
+import { archestraApiClient } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  type AgentRunListItem,
+  useShareAgentRun,
+  useUnshareAgentRun,
+} from "@/lib/agent-runtime.query";
+import { useSession } from "@/lib/auth/auth.query";
 
-const { state, refetch } = vi.hoisted(() => ({
-  state: { runs: [] as AgentRun[] },
-  refetch: vi.fn(),
-}));
+const state = { runs: [] as AgentRunListItem[] };
+const server = setupServer(
+  http.get("http://localhost:9000/api/agents/agent-1/runs", () =>
+    HttpResponse.json(state.runs),
+  ),
+);
+let queryClient: QueryClient;
 
-vi.mock("@/lib/agent-runtime.query", () => ({
-  useAgentRuns: () => ({
-    data: state.runs,
-    isPending: false,
-    isError: false,
-    refetch,
-  }),
-}));
-
-vi.mock("@/lib/auth/auth.query", () => ({
-  useSession: () => ({ data: { user: { id: "user-1" } } }),
-}));
+vi.mock("@/lib/auth/auth.query");
+vi.mock("sonner");
 
 vi.mock("@/components/agent-run-state", () => ({
   AgentRunState: () => <span>Run state</span>,
@@ -35,29 +52,215 @@ vi.mock("@/components/agent-run-logs", () => ({
 import { AgentRuns } from "./agent-runs";
 
 describe("AgentRuns", () => {
+  beforeAll(() => {
+    archestraApiClient.setConfig({ baseUrl: "http://localhost:9000" });
+    server.listen({ onUnhandledRequest: "error" });
+  });
+  afterEach(() => {
+    queryClient.clear();
+    server.resetHandlers();
+  });
+  afterAll(() => server.close());
   beforeEach(() => {
     vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "user-1" } },
+    } as ReturnType<typeof useSession>);
     state.runs = [createRun(null)];
   });
 
-  it("shows the live terminal while a run is active and retained output when it ends", () => {
-    const view = render(<AgentRuns agentId="agent-1" />);
+  it("shows the live terminal while a run is active and retained output when it ends", async () => {
+    renderRuns();
 
-    expect(screen.getByText("Live terminal")).toBeInTheDocument();
+    expect(await screen.findByText("Live terminal")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Output" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Terminal" })).toBeNull();
 
     state.runs = [createRun("2026-09-03T20:00:05.000Z")];
-    view.rerender(<AgentRuns agentId="agent-1" />);
+    await act(() => queryClient.invalidateQueries());
 
-    expect(screen.getByText("Retained output")).toBeInTheDocument();
+    expect(await screen.findByText("Retained output")).toBeInTheDocument();
     expect(screen.queryByText("Live terminal")).toBeNull();
     expect(screen.queryByRole("button", { name: "Output" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Terminal" })).toBeNull();
   });
+
+  it("identifies who started the selected run and who can see it", async () => {
+    state.runs = [
+      {
+        ...createRun(null),
+        initiatorName: "Alex Rivera",
+        shareVisibility: "team",
+        shareTeamNames: ["Platform", "Security"],
+      },
+    ];
+
+    renderRuns();
+
+    expect(
+      await screen.findByText("Started by Alex Rivera (you)"),
+    ).toBeVisible();
+    expect(screen.getByLabelText("Team: Platform, Security")).toBeVisible();
+  });
+
+  it("labels an unshared run as personal without promising owner-only output access", async () => {
+    renderRuns();
+
+    expect(await screen.findByLabelText("Personal")).toBeVisible();
+    fireEvent.focus(
+      screen.getByRole("button", { name: "Who can access this run?" }),
+    );
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Agent administrators can read output",
+    );
+  });
+
+  it("switches owner and visibility with the selected run and keeps non-owners read-only", async () => {
+    state.runs.push({
+      ...createRun(null),
+      id: "run-2",
+      taskId: "22345678-abcd-4000-8000-123456789abc",
+      actorUserId: "user-2",
+      actorId: "user-2",
+      initiatorName: "Sam Chen",
+      title: "Shared review",
+      shareVisibility: "organization",
+    });
+    renderRuns();
+    expect(
+      await screen.findByText("Started by Alex Rivera (you)"),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: /Shared review/ }));
+    expect(screen.getByText("Started by Sam Chen")).toBeVisible();
+    expect(screen.getByLabelText("Organization")).toBeVisible();
+    expect(screen.getByText("Retained output")).toBeVisible();
+    expect(screen.queryByText("Live terminal")).not.toBeInTheDocument();
+  });
+
+  it("shows named recipients instead of calling a user-shared run personal", async () => {
+    state.runs = [
+      {
+        ...createRun(null),
+        shareVisibility: "user",
+        shareUserNames: ["Sam Chen", "Taylor Morgan"],
+      },
+    ];
+    renderRuns();
+    expect(
+      await screen.findByLabelText("Shared with: Sam Chen, Taylor Morgan"),
+    ).toBeVisible();
+    expect(screen.queryByLabelText("Personal")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    "user",
+    "team",
+  ] as const)("keeps a redacted %s audience distinct from personal or empty sharing", async (shareVisibility) => {
+    state.runs = [
+      {
+        ...createRun(null),
+        actorUserId: "another-owner",
+        shareVisibility,
+        shareUserNames: null,
+        shareTeamNames: null,
+      },
+    ];
+    renderRuns();
+    const badge = await screen.findByText(
+      shareVisibility === "team" ? "Team" : "Shared",
+      { exact: true },
+    );
+    expect(badge).toBeVisible();
+    expect(screen.queryByText("No recipients")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Personal")).not.toBeInTheDocument();
+    fireEvent.focus(badge);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Only the run owner can see sharing recipients.",
+    );
+  });
+
+  it("refreshes the visible audience as soon as sharing is changed or removed", async () => {
+    server.use(
+      http.put("http://localhost:9000/api/agent-runs/:taskId/share", () => {
+        state.runs = [{ ...state.runs[0], shareVisibility: "organization" }];
+        return HttpResponse.json({ visibility: "organization" });
+      }),
+      http.delete("http://localhost:9000/api/agent-runs/:taskId/share", () => {
+        state.runs = [{ ...state.runs[0], shareVisibility: null }];
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    renderRuns();
+    const { result } = renderHook(
+      () => ({ share: useShareAgentRun(), unshare: useUnshareAgentRun() }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={queryClient}>
+            {children}
+          </QueryClientProvider>
+        ),
+      },
+    );
+    expect(await screen.findByLabelText("Personal")).toBeVisible();
+    await act(() =>
+      result.current.share.mutateAsync({
+        taskId: state.runs[0].taskId,
+        visibility: "organization",
+      }),
+    );
+    expect(await screen.findByLabelText("Organization")).toBeVisible();
+    await act(() => result.current.unshare.mutateAsync(state.runs[0].taskId));
+    expect(await screen.findByLabelText("Personal")).toBeVisible();
+  });
+
+  it("identifies additional project access without treating it as a run share", async () => {
+    state.runs = [{ ...createRun(null), projectId: "project-1" }];
+    renderRuns();
+    expect(await screen.findByText("+ project access")).toBeVisible();
+    fireEvent.focus(
+      screen.getByRole("button", { name: "Who can access this run?" }),
+    );
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "permission to read all project sessions",
+    );
+  });
+
+  it.each([
+    "user",
+    "team",
+  ] as const)("does not imply access when a %s share has no remaining recipients", async (shareVisibility) => {
+    state.runs = [{ ...createRun(null), shareVisibility }];
+    renderRuns();
+    expect(await screen.findByText("No recipients")).toBeVisible();
+    expect(screen.queryByLabelText("Personal")).not.toBeInTheDocument();
+  });
+
+  it("identifies automation when no initiating user exists", async () => {
+    state.runs = [
+      {
+        ...createRun(null),
+        actorKind: "system",
+        actorUserId: null,
+        initiatorName: null,
+      },
+    ];
+    renderRuns();
+    expect(await screen.findByText("Started by automation")).toBeVisible();
+  });
 });
 
-function createRun(endedAt: string | null): AgentRun {
+function renderRuns() {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentRuns agentId="agent-1" />
+    </QueryClientProvider>,
+  );
+}
+
+function createRun(endedAt: string | null): AgentRunListItem {
   return {
     id: "run-1",
     organizationId: "org-1",
@@ -81,5 +284,9 @@ function createRun(endedAt: string | null): AgentRun {
     state: endedAt ? "TASK_STATE_COMPLETED" : "TASK_STATE_WORKING",
     statusReason: null,
     stateChangedAt: "2026-09-03T20:00:05.000Z",
+    initiatorName: "Alex Rivera",
+    shareVisibility: null,
+    shareTeamNames: [],
+    shareUserNames: [],
   };
 }

--- a/platform/frontend/src/components/agent-pages/agent-runs.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-runs.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { formatDistanceToNow } from "date-fns";
-import { TerminalSquare } from "lucide-react";
+import { Info, TerminalSquare } from "lucide-react";
 import { useState } from "react";
 import { AgentRunLiveness } from "@/components/agent-run-liveness";
 import { AgentRunLogs } from "@/components/agent-run-logs";
 import { AgentRunState } from "@/components/agent-run-state";
 import { AgentRunTerminal } from "@/components/agent-run-terminal";
 import { QueryLoadError } from "@/components/query-load-error";
+import { ScopeBadge } from "@/components/scope-badge";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -17,7 +19,12 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { type AgentRun, useAgentRuns } from "@/lib/agent-runtime.query";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { type AgentRunListItem, useAgentRuns } from "@/lib/agent-runtime.query";
 import { useSession } from "@/lib/auth/auth.query";
 import { cn } from "@/lib/utils";
 
@@ -63,7 +70,7 @@ export function AgentRuns({ agentId }: { agentId: string }) {
   }
 
   return (
-    <div className="grid min-h-[520px] overflow-hidden rounded-xl border bg-card/30 lg:h-[calc(100dvh-16rem)] lg:grid-cols-[15.5rem_minmax(0,1fr)]">
+    <div className="grid min-h-[520px] grid-cols-1 overflow-hidden rounded-xl border bg-card/30 lg:h-[calc(100dvh-16rem)] lg:grid-cols-[15.5rem_minmax(0,1fr)]">
       <aside className="flex min-h-0 flex-col border-b bg-muted/10 lg:border-b-0 lg:border-r">
         <div className="flex items-center justify-between border-b px-4 py-3">
           <h2 className="text-sm font-medium">History</h2>
@@ -140,14 +147,21 @@ function RunDetails({
   canAttach,
   onClosed,
 }: {
-  run: AgentRun;
+  run: AgentRunListItem;
   canAttach: boolean;
   onClosed: () => void;
 }) {
   const active = !run.endedAt;
+  const startedBy = `Started by ${initiatorLabel(run)}${canAttach ? " (you)" : ""}`;
+  const hasNoRecipients =
+    (run.shareVisibility === "user" && run.shareUserNames?.length === 0) ||
+    (run.shareVisibility === "team" && run.shareTeamNames?.length === 0);
+  const recipientsHidden =
+    (run.shareVisibility === "user" && run.shareUserNames === null) ||
+    (run.shareVisibility === "team" && run.shareTeamNames === null);
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col">
+    <section className="flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="flex flex-shrink-0 items-center gap-4 border-b px-5 py-3.5">
         <div className="min-w-0">
           <div className="flex min-w-0 items-center gap-2">
@@ -166,6 +180,58 @@ function RunDetails({
             <span aria-hidden>·</span>
             <span>{new Date(run.startedAt).toLocaleString()}</span>
           </p>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span className="min-w-0 break-words">{startedBy}</span>
+            <span aria-hidden>·</span>
+            <span>Sharing</span>
+            {recipientsHidden ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge variant="outline" tabIndex={0}>
+                    {run.shareVisibility === "team" ? "Team" : "Shared"}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Only the run owner can see sharing recipients.
+                </TooltipContent>
+              </Tooltip>
+            ) : hasNoRecipients ? (
+              <Badge variant="outline">No recipients</Badge>
+            ) : (
+              <ScopeBadge
+                scope={runScope(run)}
+                teamNames={run.shareTeamNames}
+                userNames={run.shareUserNames}
+                showLabel
+              />
+            )}
+            {run.projectId && <span>+ project access</span>}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-5"
+                  aria-label="Who can access this run?"
+                >
+                  <Info className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p>
+                  The run owner and Agent administrators can read output.
+                  Sharing grants others read-only access. Only the run owner can
+                  use the live terminal.
+                </p>
+                {run.projectId && (
+                  <p className="mt-1">
+                    People with access to its project and permission to read all
+                    project sessions can also read this run.
+                  </p>
+                )}
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       </div>
 
@@ -190,4 +256,18 @@ function RunDetails({
 
 function shortTaskId(taskId: string): string {
   return taskId.slice(0, 8);
+}
+
+function initiatorLabel(run: AgentRunListItem): string {
+  if (run.initiatorName) return run.initiatorName;
+  if (run.actorKind === "organization") return "the organization";
+  if (run.actorKind === "team") return "a team";
+  if (run.actorKind === "system") return "automation";
+  return "an unknown user";
+}
+
+function runScope(run: AgentRunListItem): "personal" | "team" | "org" {
+  if (run.shareVisibility === "organization") return "org";
+  if (run.shareVisibility === "team") return "team";
+  return "personal";
 }

--- a/platform/frontend/src/lib/agent-runtime.query.ts
+++ b/platform/frontend/src/lib/agent-runtime.query.ts
@@ -22,7 +22,12 @@ const {
   updateAgentRun,
 } = archestraApiSdk;
 
-export type AgentRun = archestraApiTypes.GetAgentRunsResponses["200"][number];
+export type AgentRunListItem =
+  archestraApiTypes.GetAgentRunsResponses["200"][number];
+export type AgentRun = Omit<
+  AgentRunListItem,
+  "initiatorName" | "shareVisibility" | "shareTeamNames" | "shareUserNames"
+>;
 export type AgentRunSession =
   archestraApiTypes.GetMyAgentRunsResponses["200"]["data"][number];
 
@@ -278,9 +283,13 @@ export function useShareAgentRun() {
       if (error) throw reportApiError(error);
       return data;
     },
-    onSuccess: (data, { taskId, suppressSuccessToast }) => {
+    onSuccess: async (data, { taskId, suppressSuccessToast }) => {
       if (!data) return;
       queryClient.setQueryData(["agent-runs", taskId, "share"], data);
+      await queryClient.invalidateQueries({
+        predicate: ({ queryKey }) =>
+          queryKey[0] === "agents" && queryKey[2] === "runs",
+      });
       if (!suppressSuccessToast) {
         toast.success("Run visibility updated");
       }
@@ -296,8 +305,12 @@ export function useUnshareAgentRun() {
       if (error) throw reportApiError(error);
       return data;
     },
-    onSuccess: (_data, taskId) => {
+    onSuccess: async (_data, taskId) => {
       queryClient.setQueryData(["agent-runs", taskId, "share"], null);
+      await queryClient.invalidateQueries({
+        predicate: ({ queryKey }) =>
+          queryKey[0] === "agents" && queryKey[2] === "runs",
+      });
       toast.success("Run sharing removed");
     },
   });

--- a/platform/frontend/tests-integration/agent-run-visibility.spec.ts
+++ b/platform/frontend/tests-integration/agent-run-visibility.spec.ts
@@ -1,0 +1,86 @@
+import type { archestraApiTypes } from "@archestra/shared";
+import { makeAgent } from "../src/mocks/data/agents";
+import { expect, test } from "./fixtures";
+
+test("keeps a long run owner and sharing scope inside the phone viewport", async ({
+  page,
+  mswControl,
+  request,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const agent = makeAgent({
+    runtime: {
+      image: "example.com/runtime:1",
+      command: null,
+      inferenceProtocol: "anthropic",
+      backend: "kubernetes",
+      steerMode: "pipe",
+      privileged: false,
+      resources: null,
+      environment: null,
+      credentials: null,
+      ttlHours: null,
+      idleTimeoutMinutes: null,
+    },
+  });
+  const ownerName = "Samuel Chen — Release Engineering and Product Operations";
+  const run = {
+    id: "run-1",
+    taskId: "12345678-abcd-4000-8000-123456789abc",
+    agentId: agent.id,
+    organizationId: "test-org",
+    actorKind: "user",
+    actorId: "other-user",
+    actorUserId: "other-user",
+    title: "Release review",
+    pinnedAt: null,
+    projectId: null,
+    workloadName: "release-review",
+    backend: "kubernetes",
+    runtimeScope: "test",
+    virtualApiKeyId: null,
+    startedAt: "2026-09-01T12:00:00.000Z",
+    endedAt: "2026-09-01T12:01:00.000Z",
+    hardDeadlineAt: "2026-09-01T13:00:00.000Z",
+    lastModelActivityAt: null,
+    attentionState: null,
+    state: "TASK_STATE_COMPLETED",
+    statusReason: null,
+    stateChangedAt: "2026-09-01T12:01:00.000Z",
+    initiatorName: ownerName,
+    shareVisibility: "team",
+    shareTeamNames: ["Release reviewers"],
+    shareUserNames: [],
+  } satisfies archestraApiTypes.GetAgentRunsResponses["200"][number];
+  const config = await (
+    await request.get("/internal-test/api/api/config")
+  ).json();
+  await mswControl.use({
+    method: "get",
+    url: "/api/config",
+    body: { ...config, features: { ...config.features, agentRuntime: true } },
+  });
+  await mswControl.use({
+    method: "get",
+    url: `/api/agents/${agent.id}`,
+    body: agent,
+  });
+  await mswControl.use({
+    method: "get",
+    url: `/api/agents/${agent.id}/runs`,
+    body: [run],
+  });
+  await page.goto(`/agents/${agent.id}?section=runs`);
+  const owner = page.getByText(`Started by ${ownerName}`, { exact: true });
+  const sharing = page.getByLabel("Team: Release reviewers", { exact: true });
+  await expect(owner).toBeVisible();
+  await expect(sharing).toBeVisible();
+  await owner.scrollIntoViewIfNeeded();
+  for (const element of [owner, sharing]) {
+    const bounds = await element.boundingBox();
+    expect(bounds).not.toBeNull();
+    if (!bounds) throw new Error("Run metadata is not rendered");
+    expect(bounds.x).toBeGreaterThanOrEqual(0);
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(390);
+  }
+});

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -20746,6 +20746,16 @@ export type GetAgentRunsResponses = {
         stateChangedAt: string | null;
         hardDeadlineAt: string;
         lastModelActivityAt: string | null;
+        initiatorName: string | null;
+        shareVisibility: 'organization' | 'team' | 'user' | null;
+        /**
+         * Share recipient teams; null unless the viewer owns the run
+         */
+        shareTeamNames: Array<string> | null;
+        /**
+         * Share recipient users; null unless the viewer owns the run
+         */
+        shareUserNames: Array<string> | null;
     }>;
 };
 


### PR DESCRIPTION
The Agent Runs detail panel showed the Agent creator rather than who started the selected run or who could see it. It now shows the initiator and compact sharing scope, distinguishes project access, and refreshes after sharing changes. Recipient names follow the existing owner-only sharing-settings policy; other Agent readers see the scope without membership details, and history and output access rules remain unchanged.

Exercised real API-created runs in Tilt as the owner, a recipient, and an unrelated Agent reader. Selecting runs showed the correct initiator and audience; recipients retained read-only output, outsiders were denied output, and neither could retrieve recipient names. Inspected desktop and phone layouts, including long names and project access.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>