### PR TITLE
fix(agents): surface Claude account setup after creation

### DIFF
--- a/platform/frontend/src/components/agent-pages/agent-create-page.test.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-create-page.test.tsx
@@ -333,6 +333,19 @@ describe("AgentCreatePage", () => {
     expect(push).toHaveBeenCalledWith("/agents/new-1?section=connect");
   });
 
+  it("lands a new Claude Code agent where its personal account connection is shown", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useFeature).mockImplementation((feature) =>
+      feature === "agentRuntime" ? true : undefined,
+    );
+    render(<AgentCreatePage kind="agent" />);
+
+    await user.click(screen.getByRole("button", { name: /claude code/i }));
+    await user.click(screen.getByRole("button", { name: "fire created" }));
+
+    expect(push).toHaveBeenCalledWith("/agents/new-1");
+  });
+
   it("stays put with a success state when the creator may not read what it made", async () => {
     const user = userEvent.setup();
     mockPermissions({ canRead: false });

--- a/platform/frontend/src/components/agent-pages/agent-create-page.tsx
+++ b/platform/frontend/src/components/agent-pages/agent-create-page.tsx
@@ -78,9 +78,26 @@ export function AgentCreatePage({ kind }: { kind: AgentPageKind }) {
     !!created && isReadPermissionKnown && !canReadFamily;
   useEffect(() => {
     if (!created || !isReadPermissionKnown || !canReadFamily) return;
-    // Created: the next thing to do with it is connect something to it.
-    router.push(agentDetailHref(kind, created.id, "connect"));
-  }, [created, isReadPermissionKnown, canReadFamily, router, kind]);
+    // A personal Claude subscription still needs to be connected after the
+    // record exists. Its account control lives in General, so surface that
+    // required setup instead of sending the creator to the unrelated A2A tab.
+    // Other records keep their established next step: connecting a client.
+    const needsClaudeCodeSignIn = selectedTemplate?.id === "claude-code";
+    router.push(
+      agentDetailHref(
+        kind,
+        created.id,
+        needsClaudeCodeSignIn ? "general" : "connect",
+      ),
+    );
+  }, [
+    created,
+    isReadPermissionKnown,
+    canReadFamily,
+    router,
+    kind,
+    selectedTemplate,
+  ]);
 
   const [isDirty, setIsDirty] = useState(false);
   useBeforeUnloadWhileDirty(isDirty);

--- a/platform/frontend/src/components/claude-code-account.test.tsx
+++ b/platform/frontend/src/components/claude-code-account.test.tsx
@@ -1,0 +1,107 @@
+import { archestraApiClient } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { ClaudeCodeAccount } from "./claude-code-account";
+
+const origin = "http://localhost:9000";
+const accountUrl = `${origin}/api/agents/agent-1/runtime/claude-code/account`;
+const server = setupServer();
+let queryClient: QueryClient;
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => {
+  server.close();
+  archestraApiClient.setConfig({ baseUrl: "" });
+});
+afterEach(() => {
+  server.resetHandlers();
+  queryClient.clear();
+});
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  archestraApiClient.setConfig({ baseUrl: origin });
+});
+
+describe("ClaudeCodeAccount setup", () => {
+  it("guides an unconnected user from account status to native sign-in", async () => {
+    const user = userEvent.setup();
+    let started = false;
+    const status = () =>
+      started
+        ? {
+            state: "awaiting_code",
+            flowId: "flow-1",
+            authorizationUrl: "https://claude.ai/oauth/authorize",
+          }
+        : { state: "disconnected" };
+    server.use(
+      http.get(accountUrl, () => HttpResponse.json(status())),
+      http.post(accountUrl, () => {
+        started = true;
+        return HttpResponse.json(status());
+      }),
+    );
+    renderAccount();
+
+    expect(await screen.findByText("Sign in to use this agent.")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(
+      screen.getByRole("dialog", { name: "Connect Claude Code" }),
+    ).toBeVisible();
+    await user.click(
+      screen.getByRole("button", { name: "Sign in with Claude" }),
+    );
+
+    expect(
+      await screen.findByRole("link", { name: "Open Claude sign-in" }),
+    ).toHaveAttribute("href", "https://claude.ai/oauth/authorize");
+    expect(screen.getByLabelText("Authorization code")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Complete sign-in" }),
+    ).toBeDisabled();
+  });
+
+  it("lets an already-connected user manage their account without asking them to sign in again", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get(accountUrl, () => HttpResponse.json({ state: "connected" })),
+    );
+    renderAccount();
+
+    expect(await screen.findByText("Signed in for you")).toBeVisible();
+    expect(
+      screen.queryByText("Sign in to use this agent."),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Manage" }));
+    expect(
+      screen.getByRole("dialog", { name: "Claude Code account" }),
+    ).toBeVisible();
+    expect(screen.getByText("Connected for you")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Disconnect" })).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: "Sign in with Claude" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+function renderAccount() {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ClaudeCodeAccount agentId="agent-1" />
+    </QueryClientProvider>,
+  );
+}


### PR DESCRIPTION
Creating a Claude Code Agent now opens General so the user sees personal account setup before Chat. Other Agent types retain their existing destinations.

Verified creation and account-setup navigation in the real Tilt app on desktop and narrow screens. Connected/disconnected states have regression coverage, and the substantive changes passed independent review. Live OAuth completion and the live already-connected state remain unverified.
