### PR TITLE
fix(database): budget connections across backend rollout pods

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -1,6 +1,14 @@
 archestra:
   replicaCount: 4
 
+  # Requires Cloud SQL max_connections=600 before deploying this budget.
+  # Four web replicas can reach 10 pods during a rollout (50% surge plus
+  # terminating pods); three workers can reach 7 (25% surge plus terminating).
+  # 550 / 17 leaves 20 query connections plus 10 cache and 2 listeners per
+  # pod: 544 total, with 56 slots left for reserved connections and other users.
+  database:
+    connectionBudget: 550
+
   # Staging's measured CPU use is below the chart's production-sized requests.
   # Keep scheduling room for rolling-update surge pods; no CPU limit prevents
   # these smaller requests from restricting bursts into spare node capacity.
@@ -191,15 +199,6 @@ archestra:
     ARCHESTRA_LOCKED_CHAT_ESCROW_PUBLIC_KEY: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUFvakRQWU5RbjNSYktoamJ5MUVzTgpvYXYwNGUyQnpoOTFWaEs0TlErNDFEcGVwcjg0dGx6R3ZjandYVC9OQ0txODJvem9kUGwyZE5NeWFxdDE0UG5FCnQ0NUsvRXdrTXE0VlFEUWtlTUJJTFh6c1ZlY0YzQmZ3Rko1eGNLdGFCNXRsNXRRRWVPakhPU2xiamN0czVyaDkKN2wzcE5DdURoUXRkajNmSE80NTN2UXN4eDEyK0drZlpQVVNWeFpiNEhhYkdhazMxWTl3UG1pZVV5ajVzSkkwTwp6VzFrVHFiMkFocEVSQnIxUkNFeUgrSzlvdmRCZlZiYUdGTFZIdmtiSkdSbVNzYk85SVZsQUpNUHE5ZnJXam1VCm5oR2h0UVFzeTQ2TG92ZXFSaTMxM2RaeDUweXEvVGd2TFJLSVFDZEtKYmkvVEoyRmtVMk9VSXdpYWFTQjdyNTAKa0YvZDhGUTNsUVdKWlA4YXU1UWQzQjV1bzl1M3NTMWk1WTZOeHRBYWN0TjBEV2k2L3ZjbEtlRjg5YTFtbkZ3TApBTkZteENsbkVxL3UydmpwbWhOQS9JMnVFVXFvQmZ5NkUxVFFyNSsySUhnZGVXT2tPTFJnYXc5QWE3Z3g1SzlqCkdjaHhXUDkzMDhvN01SS1JsdjlPaTl2UUZsMVB3YUZPbEIyUzIvb2RCcTNhNDFzMkhNUU1ZalJZMC9wR0NuWjUKM2xuN1BzZm9qOEZMd1NoZkRHNVhmNTNnREo0UXB4a3N0amdrekx5ZkxHaThUVGdwSjVmeDJWdVZQajdtTk5JMwpoNWxYZnh4N09Gd1daZEJUVFBnZ3h6LzN1MUs5TTNoUnlObUxrOXZEUVhRS2k2TWdMNVF1THRvQTdVL01GSzBXClY2ZVIyTG4zMFhMVDduaDNlcnRNYnNFQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo="
     ARCHESTRA_CHAT_DEFAULT_PROVIDER: "anthropic"
     ARCHESTRA_CHAT_DEFAULT_MODEL: "claude-opus-4-5-20251101"
-    # 20 connections per Node process. The old value of 8 predates the Cloud
-    # SQL migration (it protected the fragile in-cluster Postgres) and caused
-    # silent connection-checkout queueing: every API request runs an auth
-    # lookup plus per-route query fanout, so bursts exhausted 8 connections and
-    # requests waited (up to the 10s connect timeout) for a free client —
-    # visible as trivial indexed selects with p95 ~370ms. Budget: 8 Node
-    # processes (4 web + 3 worker + 1 renderer) x 20 = 160, comfortably under
-    # Cloud SQL max_connections=200 with headroom for migration jobs.
-    ARCHESTRA_DATABASE_POOL_MAX: "20"
 
   diagnostics:
     enabled: true

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -2,7 +2,7 @@
 title: Deployment
 category: Archestra Platform
 order: 3
-lastUpdated: 2026-09-11
+lastUpdated: 2026-09-12
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -802,7 +802,13 @@ The following environment variables can be used to configure Archestra Platform.
 - **`ARCHESTRA_DATABASE_POOL_MAX`** - Maximum number of PostgreSQL connections per backend pod.
   - Default: `50`
   - Range: `1`–`500`
-  - Tune this when you have many concurrent users or long-running chat streams. The backend opens at most `ARCHESTRA_DATABASE_POOL_MAX` connections per pod, so coordinate with PostgreSQL `max_connections` to ensure `pods × ARCHESTRA_DATABASE_POOL_MAX < max_connections` with headroom for admin sessions. On managed Postgres (e.g. AWS RDS, Cloud SQL) the server limit is typically several thousand and rarely the binding constraint.
+  - Helm divides `archestra.database.connectionBudget` (default `200`) across peak backend pods, then subtracts 12 per pod. Those 12 connections cover the cache pool and two notification listeners. The query pool is capped at `500`.
+  - Peak pods include web/HPA maximum replicas, worker replicas, rollout surge, and one terminating old revision. Recreate deployments count only their target replicas. Each peak pod needs at least 13 budgeted connections; Helm rejects smaller budgets.
+  - For example, four web and three worker replicas with default surge budget for 16 peak pods. A `400`-connection budget gives each pod 13 query connections: `16 × (13 + 12) = 400`.
+  - Keep the budget below PostgreSQL `max_connections`, after subtracting reserved slots and other clients. The bundled database allows `250` connections, leaving `50` outside the default budget. External databases and multiple releases need explicitly allocated budgets.
+  - Finish one rollout before starting another. Before increasing replicas, roll out a smaller `archestra.database.poolMax` at the existing replica count. Then scale and clear the override. Old pods keep their previous limits until replaced; Helm cannot resize existing pools.
+  - Fixed overrides (`archestra.database.poolMax` or this environment variable) bypass automatic budgeting. Operators must budget their aggregate use separately.
+  - Unprefixed `archestra.envFrom` imports preserve their existing pool configuration by default. Helm omits its explicit pool variable so it cannot override a value from the Secret or ConfigMap; if neither supplies a pool limit, the backend default applies. Set `archestra.database.poolMaxFromEnvFrom: false` to opt into chart-managed sizing, or `true` to explicitly require an unprefixed bulk source. Exclusively prefixed sources cannot supply `ARCHESTRA_DATABASE_POOL_MAX`, so they use chart sizing by default.
 
 - **`ARCHESTRA_DATABASE_STATEMENT_TIMEOUT_MILLIS`** - Per-connection PostgreSQL `statement_timeout` (in milliseconds) applied to every pooled connection.
   - Default: `30000` (30s)

--- a/platform/backend/src/cache-manager.ts
+++ b/platform/backend/src/cache-manager.ts
@@ -157,6 +157,7 @@ class CacheManager {
     const store = new KeyvPostgres({
       uri: config.database.url,
       table: "keyv_cache",
+      max: 10,
       /**
        * From the PostgreSQL documentation:
        * If specified, the table is created as an unlogged table. Data written to unlogged tables is not written to the

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -103,6 +103,63 @@ The Bitnami chart auto-generates a strong password and persists it across helm u
 {{- end }}
 {{- end }}
 
+{{/*
+Budget a Deployment's target replicas, surge, and one terminating old revision.
+Percentage maxSurge values round up, matching Kubernetes Deployment behavior.
+*/}}
+{{- define "archestra-platform.rolloutPodCount" -}}
+{{- $replicas := int .replicas -}}
+{{- $surge := 0 -}}
+{{- $strategy := .strategy | default dict -}}
+{{- if eq ($strategy.type | default "RollingUpdate") "RollingUpdate" -}}
+  {{- $rollingUpdate := $strategy.rollingUpdate | default dict -}}
+  {{- $rawSurge := "25%" -}}
+  {{- if hasKey $rollingUpdate "maxSurge" -}}
+    {{- $rawSurge = toString $rollingUpdate.maxSurge -}}
+  {{- end -}}
+  {{- if hasSuffix "%" $rawSurge -}}
+    {{- $percent := int (trimSuffix "%" $rawSurge) -}}
+    {{- $surge = div (add (mul $replicas $percent) 99) 100 -}}
+  {{- else -}}
+    {{- $surge = int $rawSurge -}}
+  {{- end -}}
+  {{- $surge = add $surge $replicas -}}
+{{- end -}}
+{{- add $replicas $surge -}}
+{{- end }}
+
+{{/*
+Divide the connection budget across web and worker rollout pods. Each pod
+reserves ten cache connections and two notification listeners outside its query
+pool. HPA maxReplicas is the web ceiling. Overlapping rollouts need extra headroom.
+*/}}
+{{- define "archestra-platform.databasePoolMax" -}}
+{{- $webReplicas := int .Values.archestra.replicaCount -}}
+{{- if .Values.archestra.horizontalPodAutoscaler.enabled -}}
+  {{- $webReplicas = int .Values.archestra.horizontalPodAutoscaler.maxReplicas -}}
+{{- end -}}
+{{- $peakPods := int (include "archestra-platform.rolloutPodCount" (dict "replicas" $webReplicas "strategy" .Values.archestra.deploymentStrategy)) -}}
+{{- if .Values.archestra.worker.enabled -}}
+  {{- $workerPods := int (include "archestra-platform.rolloutPodCount" (dict "replicas" .Values.archestra.worker.replicaCount "strategy" .Values.archestra.worker.deploymentStrategy)) -}}
+  {{- $peakPods = add $peakPods $workerPods -}}
+{{- end -}}
+{{- $peakPods = max 1 $peakPods -}}
+{{- $configuredPoolMax := .Values.archestra.database.poolMax -}}
+{{- if ne (toString $configuredPoolMax) "<nil>" -}}
+  {{- if or (lt (int $configuredPoolMax) 1) (gt (int $configuredPoolMax) 500) -}}
+    {{- fail "Configuration error: archestra.database.poolMax must be between 1 and 500." -}}
+  {{- end -}}
+  {{- int $configuredPoolMax -}}
+{{- else -}}
+  {{- $budget := int .Values.archestra.database.connectionBudget -}}
+  {{- $connectionsPerPod := div $budget $peakPods -}}
+  {{- if lt $connectionsPerPod 13 -}}
+    {{- fail (printf "Configuration error: archestra.database.connectionBudget (%d) must provide at least 13 connections (1 query, 10 cache, 2 listeners) for each of the %d peak backend pods." $budget $peakPods) -}}
+  {{- end -}}
+  {{- min 500 (sub $connectionsPerPod 12) -}}
+{{- end -}}
+{{- end }}
+
 {{- define "archestra-platform.env" -}}
 {{/*
 List of sensitive environment variables that should be stored in the Secret
@@ -146,6 +203,46 @@ Additionally, any env var matching ARCHESTRA_CHAT_*_API_KEY is treated as sensit
   value: {{ .Values.archestra.migrationJob.enabled | quote }}
 {{- end }}
 {{- include "archestra-platform.databaseEnv" . }}
+{{- $databasePoolProvided := hasKey .Values.archestra.env "ARCHESTRA_DATABASE_POOL_MAX" }}
+{{- range .Values.archestra.envWithValueFrom }}
+  {{- if eq .name "ARCHESTRA_DATABASE_POOL_MAX" }}{{- $databasePoolProvided = true }}{{- end }}
+{{- end }}
+{{- range .Values.archestra.envFromSecrets }}
+  {{- if eq .name "ARCHESTRA_DATABASE_POOL_MAX" }}{{- $databasePoolProvided = true }}{{- end }}
+{{- end }}
+{{- $bulkPool := .Values.archestra.database.poolMaxFromEnvFrom }}
+{{- if ne (toString $bulkPool) "<nil>" }}
+  {{- if not (kindIs "bool" $bulkPool) }}
+    {{- fail "Configuration error: archestra.database.poolMaxFromEnvFrom must be true, false, or null." }}
+  {{- end }}
+  {{- if $bulkPool }}
+    {{- if not .Values.archestra.envFrom }}
+      {{- fail "Configuration error: archestra.database.poolMaxFromEnvFrom requires archestra.envFrom." }}
+    {{- end }}
+    {{- $hasUnprefixedSource := false }}
+    {{- range .Values.archestra.envFrom }}
+      {{- if not .prefix }}{{- $hasUnprefixedSource = true }}{{- end }}
+    {{- end }}
+    {{- if not $hasUnprefixedSource }}
+      {{- fail "Configuration error: archestra.database.poolMaxFromEnvFrom requires an unprefixed envFrom source supplying ARCHESTRA_DATABASE_POOL_MAX." }}
+    {{- end }}
+    {{- if or $databasePoolProvided (ne (toString .Values.archestra.database.poolMax) "<nil>") }}
+      {{- fail "Configuration error: archestra.database.poolMaxFromEnvFrom cannot be combined with an explicit pool override." }}
+    {{- end }}
+    {{- $databasePoolProvided = true }}
+  {{- end }}
+{{- else if and (not $databasePoolProvided) (eq (toString .Values.archestra.database.poolMax) "<nil>") }}
+  {{/* Preserve existing bulk environment imports on upgrade. Helm cannot
+       inspect their keys; explicit env would silently override a supplied pool.
+       Prefixed sources cannot supply ARCHESTRA_DATABASE_POOL_MAX. */}}
+  {{- range .Values.archestra.envFrom }}
+    {{- if not .prefix }}{{- $databasePoolProvided = true }}{{- end }}
+  {{- end }}
+{{- end }}
+{{- if not $databasePoolProvided }}
+- name: ARCHESTRA_DATABASE_POOL_MAX
+  value: {{ include "archestra-platform.databasePoolMax" . | quote }}
+{{- end }}
 {{/*
 When both external_database_url is null and postgresql.enabled is false,
 ARCHESTRA_DATABASE_URL is not set here. Use archestra.envFromSecrets to inject it from a pre-existing K8s secret.
@@ -161,6 +258,7 @@ If ARCHESTRA_AUTH_SECRET env variable is explicitly set, it will override the au
       name: {{ include "archestra-platform.authSecretName" . }}
       key: {{ include "archestra-platform.authSecretKey" . }}
 {{- end }}
+
 {{/*
 Inject the session-signing and secret-encryption secrets from the auth Secret
 (Helm-managed or authSecret.existingSecretName) under the fixed session-secret

--- a/platform/helm/archestra/tests/archestra_migration_job_test.yaml
+++ b/platform/helm/archestra/tests/archestra_migration_job_test.yaml
@@ -129,6 +129,7 @@ tests:
 
   - it: preserves shared external database environment sources
     set:
+      archestra.database.poolMaxFromEnvFrom: false
       postgresql.enabled: false
       postgresql.external_database_url: null
       archestra.envFromSecrets:

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -2,6 +2,57 @@ suite: test archestra platform -- Deployment/Service
 templates:
   - archestra-platform.yaml
 tests:
+  - it: preserves existing bulk environment imports on upgrade
+    documentIndex: 1
+    set:
+      archestra.envFrom:
+        - configMapRef:
+            name: database-pool
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: database-pool
+
+  - it: budgets pools when bulk imports are exclusively prefixed
+    documentIndex: 1
+    set:
+      archestra.envFrom:
+        - prefix: APP_
+          configMapRef:
+            name: unrelated-config
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "21"
+
+  - it: preserves a declared bulk database pool override
+    documentIndex: 1
+    set:
+      archestra.database.poolMaxFromEnvFrom: true
+      archestra.envFrom:
+        - configMapRef:
+            name: database-pool
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: database-pool
+
   - it: should allow new and existing runtime policies to reach API pods
     documentIndex: 1
     asserts:
@@ -96,10 +147,140 @@ tests:
           path: spec.replicas
           value: 4
 
+  - it: should divide the database connection budget across peak rollout pods
+    documentIndex: 1
+    set:
+      archestra.replicaCount: 4
+      archestra.worker.enabled: true
+      archestra.worker.replicaCount: 3
+      archestra.database.connectionBudget: 400
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "13"
+
+  - it: should use HPA max replicas when sizing the database pool
+    documentIndex: 1
+    set:
+      archestra.horizontalPodAutoscaler.enabled: true
+      archestra.horizontalPodAutoscaler.maxReplicas: 10
+      archestra.worker.enabled: false
+      archestra.database.connectionBudget: 400
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "5"
+
+  - it: should preserve an explicit database pool environment override
+    documentIndex: 1
+    set:
+      archestra.env.ARCHESTRA_DATABASE_POOL_MAX: "17"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "17"
+
+  - it: should support a fixed per-pod database pool override
+    documentIndex: 1
+    set:
+      archestra.database.poolMax: 12
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "12"
+
+  - it: should reject a database budget smaller than the peak pod count
+    set:
+      archestra.replicaCount: 4
+      archestra.worker.enabled: true
+      archestra.worker.replicaCount: 3
+      archestra.database.connectionBudget: 8
+    asserts:
+      - failedTemplate:
+          errorMessage: "Configuration error: archestra.database.connectionBudget (8) must provide at least 13 connections (1 query, 10 cache, 2 listeners) for each of the 16 peak backend pods."
+
+  - it: budgets Kubernetes default surge when no deployment strategy is provided
+    documentIndex: 1
+    set:
+      archestra.replicaCount: 3
+      archestra.worker.enabled: false
+      archestra.deploymentStrategy: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "16"
+
+  - it: preserves zero surge and reserves terminating replicas
+    documentIndex: 1
+    set:
+      archestra.replicaCount: 3
+      archestra.worker.enabled: false
+      archestra.deploymentStrategy.rollingUpdate.maxSurge: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "21"
+
+  - it: does not reserve overlapping replicas for Recreate
+    documentIndex: 1
+    set:
+      archestra.replicaCount: 4
+      archestra.worker.enabled: false
+      archestra.deploymentStrategy.type: Recreate
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "38"
+
+  - it: caps a large connection budget at the backend supported maximum
+    documentIndex: 1
+    set:
+      archestra.database.connectionBudget: 100000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "500"
+
+  - it: rejects a fixed pool larger than the backend supported maximum
+    set:
+      archestra.database.poolMax: 501
+    asserts:
+      - failedTemplate:
+          errorMessage: "Configuration error: archestra.database.poolMax must be between 1 and 500."
+
+  - it: permits scaling every backend deployment to zero
+    documentIndex: 1
+    set:
+      archestra.replicaCount: 0
+      archestra.worker.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "188"
+
   - it: should not have replicas field when HPA is enabled
     documentIndex: 1
     set:
       archestra.horizontalPodAutoscaler.enabled: true
+      archestra.database.connectionBudget: 400
     asserts:
       - isNull:
           path: spec.replicas
@@ -1166,6 +1347,7 @@ tests:
   - it: should allow chart-managed diagnostics with ReadWriteMany
     documentIndex: 1
     set:
+      archestra.database.connectionBudget: 400
       archestra.diagnostics.enabled: true
       archestra.replicaCount: 4
       archestra.worker.enabled: true
@@ -1497,6 +1679,7 @@ tests:
   - it: should add envFrom with multiple secretRef and configMapRef
     documentIndex: 1
     set:
+      archestra.database.poolMaxFromEnvFrom: false
       archestra.envFrom:
         - secretRef:
             name: secret-one
@@ -1518,6 +1701,7 @@ tests:
   - it: should add envFrom with optional flag
     documentIndex: 1
     set:
+      archestra.database.poolMaxFromEnvFrom: false
       archestra.envFrom:
         - secretRef:
             name: my-secret
@@ -1539,6 +1723,7 @@ tests:
   - it: should work with env, envFromSecrets, and envFrom all configured
     documentIndex: 1
     set:
+      archestra.database.poolMaxFromEnvFrom: false
       archestra.env:
         CUSTOM_VAR: "custom-value"
       archestra.envFromSecrets:
@@ -1574,6 +1759,7 @@ tests:
   - it: should add envFrom with prefix
     documentIndex: 1
     set:
+      archestra.database.poolMaxFromEnvFrom: false
       archestra.envFrom:
         - secretRef:
             name: my-secret

--- a/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
@@ -4,6 +4,120 @@ templates:
 values:
   - ../ci/test-values.yaml
 tests:
+  - it: rejects bulk pool sourcing when every source is prefixed
+    set:
+      archestra.database.poolMaxFromEnvFrom: true
+      archestra.envFrom:
+        - configMapRef:
+            name: database-pool
+          prefix: DB_
+    asserts:
+      - failedTemplate:
+          errorMessage: "Configuration error: archestra.database.poolMaxFromEnvFrom requires an unprefixed envFrom source supplying ARCHESTRA_DATABASE_POOL_MAX."
+
+  - it: allows unrelated prefixed sources alongside an unprefixed pool source
+    set:
+      archestra.database.poolMaxFromEnvFrom: true
+      archestra.envFrom:
+        - configMapRef:
+            name: database-pool
+        - secretRef:
+            name: other-settings
+          prefix: OTHER_
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: database-pool
+
+  - it: preserves a declared bulk database pool override in workers
+    set:
+      archestra.database.poolMaxFromEnvFrom: true
+      archestra.envFrom:
+        - secretRef:
+            name: database-pool
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: database-pool
+
+  - it: uses automatic sizing when explicitly chosen for unrelated bulk variables
+    set:
+      archestra.database.poolMaxFromEnvFrom: false
+      archestra.database.connectionBudget: 90
+      archestra.envFrom:
+        - configMapRef:
+            name: application-settings
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "3"
+
+  - it: requires a bulk source when choosing a bulk pool override
+    set:
+      archestra.database.poolMaxFromEnvFrom: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Configuration error: archestra.database.poolMaxFromEnvFrom requires archestra.envFrom."
+
+  - it: rejects conflicting bulk and fixed pool overrides
+    set:
+      archestra.database.poolMaxFromEnvFrom: true
+      archestra.database.poolMax: 17
+      archestra.envFrom:
+        - secretRef:
+            name: database-pool
+    asserts:
+      - failedTemplate:
+          errorMessage: "Configuration error: archestra.database.poolMaxFromEnvFrom cannot be combined with an explicit pool override."
+
+  - it: preserves an explicit per-key override with unrelated bulk variables
+    set:
+      archestra.envWithValueFrom:
+        - name: ARCHESTRA_DATABASE_POOL_MAX
+          valueFrom:
+            configMapKeyRef:
+              name: database-pool
+              key: pool-max
+      archestra.envFrom:
+        - configMapRef:
+            name: application-settings
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            valueFrom:
+              configMapKeyRef:
+                name: database-pool
+                key: pool-max
+
+  - it: shares the web and worker aggregate connection budget
+    set:
+      archestra.replicaCount: 4
+      archestra.worker.replicaCount: 3
+      archestra.database.connectionBudget: 400
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "13"
   - it: excludes workers from runtime API egress destinations
     asserts:
       - isNull:

--- a/platform/helm/archestra/tests/staging_database_pool_test.yaml
+++ b/platform/helm/archestra/tests/staging_database_pool_test.yaml
@@ -1,0 +1,49 @@
+suite: staging database pool sizing
+templates:
+  - archestra-platform.yaml
+  - archestra-worker.yaml
+values:
+  - ../../../../.github/values-staging.yaml
+set:
+  postgresql.external_database_url: postgresql://example:example@database.invalid/archestra
+tests:
+  - it: preserves web query capacity within the staging rollout budget
+    template: archestra-platform.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "20"
+  - it: reduces web query capacity when the web tier scales out
+    template: archestra-platform.yaml
+    documentIndex: 1
+    set:
+      archestra.replicaCount: 6
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "13"
+  - it: preserves worker query capacity within the staging rollout budget
+    template: archestra-worker.yaml
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "20"
+  - it: reduces worker query capacity when the web tier scales out
+    template: archestra-worker.yaml
+    documentIndex: 0
+    set:
+      archestra.replicaCount: 6
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_DATABASE_POOL_MAX
+            value: "13"

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -20,6 +20,25 @@ archestra:
   # as the HPA will manage the replica count dynamically
   replicaCount: 1
 
+  # Database connection pool sizing for all backend pods. By default, Helm
+  # divides connectionBudget across the maximum web and worker pods that can
+  # coexist, including HPA scale-out, surge, and a terminating old revision.
+  database:
+    # Total PostgreSQL connections available to Archestra backend pods. Each
+    # pod reserves 12 connections for its cache pool and notification listeners.
+    # At least 13 connections per peak pod are required; undersizing fails Helm.
+    # bundled database reserves the remaining 50 of its 250 connections for
+    # migrations, monitoring, administration, and other database clients.
+    # Set this below your external database's max_connections when using one.
+    connectionBudget: 200
+    # Optional fixed per-pod override. Prefer connectionBudget so scaling the
+    # chart automatically reduces each pod's pool allocation.
+    poolMax: null
+    # With unprefixed envFrom, null preserves inherited pool configuration on
+    # upgrade (or the backend default if the source supplies no pool limit).
+    # true explicitly uses the bulk pool value; false opts into chart sizing.
+    poolMaxFromEnvFrom: null
+
   # Annotations to add to pods created by the Deployment
   # This is useful for integrations that require pod-level annotations, such as:
   # - Service mesh sidecars (Istio, Linkerd)
@@ -997,12 +1016,10 @@ postgresql:
         grant-superuser.sql: |
           ALTER USER archestra WITH SUPERUSER;
     # Appended to postgresql.conf. max_connections must cover every backend
-    # pod's connection pool (ARCHESTRA_DATABASE_POOL_MAX, default 50 per pod)
-    # at peak pod count: web + worker replicas PLUS the extra surge pods that
-    # exist mid-rollout (deploymentStrategy maxSurge, default 25% => +1 pod
-    # per Deployment), plus the migration hook and the metrics exporter.
-    # Default sizing: (1 web + 1 worker + 2 surge) x 50 = 200, with headroom.
-    # Scale this up if you raise replicaCount, HPA maxReplicas, or the pool size.
+    # pod's query and cache pools, notification listeners, and non-app clients.
+    # Helm allocates database.connectionBudget across rollout pods, leaving
+    # the remainder for migrations, administration, and monitoring.
+    # Raise this ceiling before increasing database.connectionBudget.
     extendedConfiguration: |
       max_connections = 250
     resources:


### PR DESCRIPTION
Backend pods can exhaust PostgreSQL connections during scaling and rolling updates because query pools, caches, and notification listeners share the same server limit. Helm now divides an application connection budget across peak web and worker pods, including autoscaling, surge, and a terminating revision. Existing explicit pool limits and bulk environment imports retain their precedence.

Rendering the staging configuration preserves 20 query connections per pod and budgets 544 total connections at peak rollout. Cloud SQL max_connections has been raised to 600 through archestra-ai/infra#294, and staging health was verified after the restart. Render tests exercise staging scaling, rollout strategies, inherited configuration, and insufficient budgets.
