### PR TITLE
fix(connection): load skills without unsupported proxy filtering

### DIFF
--- a/platform/e2e-tests/playwright.config.ts
+++ b/platform/e2e-tests/playwright.config.ts
@@ -75,6 +75,7 @@ const uiTestMatch = [
   "**/quickstart.spec.ts",
   "**/skill-page-editing.spec.ts",
   "**/skill-share.spec.ts",
+  "**/connection-skills.spec.ts",
   "**/skill-version-history.spec.ts",
   "**/skills-bulk-actions.spec.ts",
   "**/static-credentials-management.spec.ts",

--- a/platform/e2e-tests/tests/connection-skills.spec.ts
+++ b/platform/e2e-tests/tests/connection-skills.spec.ts
@@ -4,7 +4,6 @@ import { expect, test } from "../fixtures";
 
 test("connection loads skills without treating the proxy as a skill agent", async ({
   page,
-  goToPage,
   makeRandomString,
 }) => {
   const skillName = makeRandomString(8, "connection-skill").toLowerCase();
@@ -18,7 +17,7 @@ test("connection loads skills without treating the proxy as a skill agent", asyn
   const skill = await skillResponse.json();
   const agentIds: string[] = [];
   const failedSkillRequests: string[] = [];
-  page.on("response", (response) => {
+  const trackSkillResponse = (response: Response) => {
     if (
       response.url().includes("/api/") &&
       response.url().includes("skill") &&
@@ -26,7 +25,8 @@ test("connection loads skills without treating the proxy as a skill agent", asyn
     ) {
       failedSkillRequests.push(`${response.status()} ${response.url()}`);
     }
-  });
+  };
+  page.on("response", trackSkillResponse);
 
   try {
     const proxyResponse = await page.request.get(
@@ -45,7 +45,9 @@ test("connection loads skills without treating the proxy as a skill agent", asyn
     const catalogResponse = page.waitForResponse(
       (response) => new URL(response.url()).pathname === "/api/skills",
     );
-    await goToPage(page, "/connection?clientId=claude-desktop");
+    await page.goto(`${UI_BASE_URL}/connection?clientId=claude-desktop`, {
+      waitUntil: "domcontentloaded",
+    });
     const catalog = await catalogResponse;
     await expectOk(catalog);
     expect((await catalog.json()).data).toEqual(
@@ -58,20 +60,25 @@ test("connection loads skills without treating the proxy as a skill agent", asyn
     ).toHaveCount(0);
 
     for (const agentType of ["agent", "mcp_gateway"] as const) {
-      const created = await page.request.post(`${UI_BASE_URL}/api/agents`, {
-        data: {
-          name: `${skillName}-${agentType}`,
-          agentType,
-          scope: "org",
-          teams: [],
+      const resourcePage = await page.context().newPage();
+      resourcePage.on("response", trackSkillResponse);
+      const created = await resourcePage.request.post(
+        `${UI_BASE_URL}/api/agents`,
+        {
+          data: {
+            name: `${skillName}-${agentType}`,
+            agentType,
+            scope: "org",
+            teams: [],
+          },
         },
-      });
+      );
       await expectOk(created);
       const agent = await created.json();
       agentIds.push(agent.id);
       if (agentType === "mcp_gateway") {
         await expectOk(
-          await page.request.put(
+          await resourcePage.request.put(
             `${UI_BASE_URL}/api/agents/${agent.id}/skills`,
             {
               data: { accessAllSkills: true, skillIds: [] },
@@ -79,9 +86,12 @@ test("connection loads skills without treating the proxy as a skill agent", asyn
           ),
         );
       }
-      const supported = await page.request.get(`${UI_BASE_URL}/api/skills`, {
-        params: { forAgentId: agent.id },
-      });
+      const supported = await resourcePage.request.get(
+        `${UI_BASE_URL}/api/skills`,
+        {
+          params: { forAgentId: agent.id },
+        },
+      );
       await expectOk(supported);
       expect((await supported.json()).data).toEqual(
         expect.arrayContaining([expect.objectContaining({ id: skill.id })]),
@@ -89,26 +99,41 @@ test("connection loads skills without treating the proxy as a skill agent", asyn
 
       const family = agentType === "agent" ? "/agents" : "/mcp/gateways";
       const section = agentType === "agent" ? "tools" : "settings";
-      await goToPage(page, `${family}/${agent.id}?section=${section}`);
-      const viewSkills = page.getByRole("button", {
-        name: /View (all.*skills|1 skill)/i,
-      });
-      await expect(viewSkills).toBeVisible();
-      await viewSkills.click();
-      const dialog = page.getByRole("dialog");
-      await expect(dialog.getByText(skillName, { exact: true })).toBeVisible();
+      await resourcePage.goto(
+        `${UI_BASE_URL}${family}/${agent.id}?section=${section}`,
+        { waitUntil: "domcontentloaded" },
+      );
       await expect(
-        page.getByText("This agent type does not expose skills"),
+        resourcePage.getByRole("heading", { name: new RegExp(agent.name) }),
+      ).toBeVisible();
+      if (agentType === "agent") {
+        const viewSkills = resourcePage.getByRole("button", {
+          name: /View (all.*skills|1 skill)/i,
+        });
+        await expect(viewSkills).toBeVisible();
+        await viewSkills.click();
+        const dialog = resourcePage.getByRole("dialog");
+        await expect(
+          dialog.getByText(skillName, { exact: true }),
+        ).toBeVisible();
+        await resourcePage.keyboard.press("Escape");
+      }
+      await expect(
+        resourcePage.getByText("This agent type does not expose skills"),
       ).toHaveCount(0);
-      await page.keyboard.press("Escape");
+      await resourcePage.close();
     }
 
-    await goToPage(page, "/llm/proxy");
+    const proxyPage = await page.context().newPage();
+    proxyPage.on("response", trackSkillResponse);
+    await proxyPage.goto(`${UI_BASE_URL}/llm/proxy`, {
+      waitUntil: "domcontentloaded",
+    });
     await expect(
-      page.getByRole("heading", { name: "LLM Proxy", exact: true }),
+      proxyPage.getByRole("heading", { name: "LLM Proxy", exact: true }),
     ).toBeVisible();
     await expect(
-      page.getByText("This agent type does not expose skills"),
+      proxyPage.getByText("This agent type does not expose skills"),
     ).toHaveCount(0);
     expect(failedSkillRequests).toEqual([]);
   } finally {

--- a/platform/e2e-tests/tests/connection-skills.spec.ts
+++ b/platform/e2e-tests/tests/connection-skills.spec.ts
@@ -1,0 +1,130 @@
+import type { APIResponse, Response } from "@playwright/test";
+import { UI_BASE_URL } from "../consts";
+import { expect, test } from "../fixtures";
+
+test("connection loads skills without treating the proxy as a skill agent", async ({
+  page,
+  goToPage,
+  makeRandomString,
+}) => {
+  const skillName = makeRandomString(8, "connection-skill").toLowerCase();
+  const skillResponse = await page.request.post(`${UI_BASE_URL}/api/skills`, {
+    data: {
+      scope: "org",
+      content: `---\nname: ${skillName}\ndescription: Review a client connection.\n---\nReview the client connection settings.`,
+    },
+  });
+  await expectOk(skillResponse);
+  const skill = await skillResponse.json();
+  const agentIds: string[] = [];
+  const failedSkillRequests: string[] = [];
+  page.on("response", (response) => {
+    if (
+      response.url().includes("/api/") &&
+      response.url().includes("skill") &&
+      !response.ok()
+    ) {
+      failedSkillRequests.push(`${response.status()} ${response.url()}`);
+    }
+  });
+
+  try {
+    const proxyResponse = await page.request.get(
+      `${UI_BASE_URL}/api/llm-proxy`,
+    );
+    await expectOk(proxyResponse);
+    const proxy = await proxyResponse.json();
+    const rejected = await page.request.get(`${UI_BASE_URL}/api/skills`, {
+      params: { forAgentId: proxy.id },
+    });
+    expect(rejected.status()).toBe(400);
+    expect((await rejected.json()).error.message).toBe(
+      "This agent type does not expose skills",
+    );
+
+    const catalogResponse = page.waitForResponse(
+      (response) => new URL(response.url()).pathname === "/api/skills",
+    );
+    await goToPage(page, "/connection?clientId=claude-desktop");
+    const catalog = await catalogResponse;
+    await expectOk(catalog);
+    expect((await catalog.json()).data).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: skill.id })]),
+    );
+    await expect(page.getByText(skillName, { exact: false })).toBeVisible();
+    await expect(page.getByText("Setup command ready")).toBeVisible();
+    await expect(
+      page.getByText("This agent type does not expose skills"),
+    ).toHaveCount(0);
+
+    for (const agentType of ["agent", "mcp_gateway"] as const) {
+      const created = await page.request.post(`${UI_BASE_URL}/api/agents`, {
+        data: {
+          name: `${skillName}-${agentType}`,
+          agentType,
+          scope: "org",
+          teams: [],
+        },
+      });
+      await expectOk(created);
+      const agent = await created.json();
+      agentIds.push(agent.id);
+      if (agentType === "mcp_gateway") {
+        await expectOk(
+          await page.request.put(
+            `${UI_BASE_URL}/api/agents/${agent.id}/skills`,
+            {
+              data: { accessAllSkills: true, skillIds: [] },
+            },
+          ),
+        );
+      }
+      const supported = await page.request.get(`${UI_BASE_URL}/api/skills`, {
+        params: { forAgentId: agent.id },
+      });
+      await expectOk(supported);
+      expect((await supported.json()).data).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: skill.id })]),
+      );
+
+      const family = agentType === "agent" ? "/agents" : "/mcp/gateways";
+      const section = agentType === "agent" ? "tools" : "settings";
+      await goToPage(page, `${family}/${agent.id}?section=${section}`);
+      const viewSkills = page.getByRole("button", {
+        name: /View (all.*skills|1 skill)/i,
+      });
+      await expect(viewSkills).toBeVisible();
+      await viewSkills.click();
+      const dialog = page.getByRole("dialog");
+      await expect(dialog.getByText(skillName, { exact: true })).toBeVisible();
+      await expect(
+        page.getByText("This agent type does not expose skills"),
+      ).toHaveCount(0);
+      await page.keyboard.press("Escape");
+    }
+
+    await goToPage(page, "/llm/proxy");
+    await expect(
+      page.getByRole("heading", { name: "LLM Proxy", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("This agent type does not expose skills"),
+    ).toHaveCount(0);
+    expect(failedSkillRequests).toEqual([]);
+  } finally {
+    for (const agentId of agentIds) {
+      await expectOk(
+        await page.request.delete(`${UI_BASE_URL}/api/agents/${agentId}`),
+      );
+    }
+    await expectOk(
+      await page.request.delete(`${UI_BASE_URL}/api/skills/${skill.id}`),
+    );
+  }
+});
+
+async function expectOk(response: APIResponse | Response): Promise<void> {
+  expect(response.ok(), `${response.status()} ${await response.text()}`).toBe(
+    true,
+  );
+}

--- a/platform/frontend/src/app/connection/connect-command-panel.test.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.test.tsx
@@ -1056,6 +1056,12 @@ describe("ConnectCommandPanel", () => {
     await screen.findByText(COMMAND);
 
     await user.click(screen.getByTestId("connect-change-skills"));
+    expect(
+      screen.getByText(/Everything shared with you is installed/),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(/Only skills in the LLM Proxy's environment/),
+    ).not.toBeInTheDocument();
     await user.click(screen.getByLabelText("Install shared skills"));
 
     await waitFor(() =>

--- a/platform/frontend/src/app/connection/connect-command-panel.test.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.test.tsx
@@ -43,7 +43,8 @@ vi.mock("@/lib/connection-setup.query", () => ({
 }));
 
 vi.mock("./skills-marketplace-step", () => ({
-  useAllSkills: (params?: { enabled?: boolean }) => allSkillsMock(params),
+  useAllSkills: (params?: { enabled?: boolean; forAgentId?: string | null }) =>
+    allSkillsMock(params),
   // The marketplace step has its own test file; here it only matters whether
   // the panel renders it as a step.
   useSkillsMarketplaceVisible: () => skillsMarketplaceVisibleMock(),
@@ -1271,11 +1272,25 @@ describe("ConnectCommandPanel", () => {
     expect(allSkillsMock).toHaveBeenLastCalledWith(
       // objectContaining, so the deferral this list is fetched under stays an
       // implementation detail: what matters is that it is switched off.
-      expect.objectContaining({ enabled: false, forAgentId: "p1" }),
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(allSkillsMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ forAgentId: expect.anything() }),
     );
     expect(
       screen.queryByTestId("skills-marketplace-step"),
     ).not.toBeInTheDocument();
+  });
+
+  it("does not scope the skills catalog to the LLM proxy", () => {
+    renderPanel();
+
+    expect(allSkillsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+    expect(allSkillsMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ forAgentId: expect.anything() }),
+    );
   });
 
   it("still offers the marketplace step when there is nothing to put in a command", async () => {

--- a/platform/frontend/src/app/connection/connect-command-panel.test.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.test.tsx
@@ -1274,23 +1274,9 @@ describe("ConnectCommandPanel", () => {
       // implementation detail: what matters is that it is switched off.
       expect.objectContaining({ enabled: false }),
     );
-    expect(allSkillsMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({ forAgentId: expect.anything() }),
-    );
     expect(
       screen.queryByTestId("skills-marketplace-step"),
     ).not.toBeInTheDocument();
-  });
-
-  it("does not scope the skills catalog to the LLM proxy", () => {
-    renderPanel();
-
-    expect(allSkillsMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ enabled: true }),
-    );
-    expect(allSkillsMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({ forAgentId: expect.anything() }),
-    );
   });
 
   it("still offers the marketplace step when there is nothing to put in a command", async () => {

--- a/platform/frontend/src/app/connection/connect-command-panel.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.tsx
@@ -802,11 +802,6 @@ export function ConnectCommandPanel({
         />
         Install shared skills
       </label>
-      {llmProxyId !== null && (
-        <p className="pl-6 text-xs text-muted-foreground">
-          Only skills in the LLM Proxy's environment are listed.
-        </p>
-      )}
       <p className="pl-6 text-xs text-muted-foreground">
         Everything shared with you is installed, and stays current as skills are
         added or removed. To share a fixed subset instead, use a snapshot link.

--- a/platform/frontend/src/app/connection/connect-command-panel.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.tsx
@@ -125,19 +125,13 @@ export function isScriptClient(
  */
 const CONNECT_SKILLS_DEFER_MS = 750;
 
-function useConnectSkills(
-  llmProxyId: string | null,
-  enabled: boolean,
-): {
+function useConnectSkills(enabled: boolean): {
   eligible: boolean;
   skills: ConnectSkill[];
 } {
   const { data: canReadSkills } = useHasPermissions({ skill: ["read"] });
-  // Skills are environment-scoped: with a proxy selected, only skills in that
-  // proxy's environment are connectable.
   const { data: skills } = useAllSkills({
     enabled: enabled && canReadSkills === true,
-    forAgentId: llmProxyId,
     // Step 2's content, not step 1's: let the part of the page the user acts
     // on first render before walking the catalogue.
     deferMs: CONNECT_SKILLS_DEFER_MS,
@@ -199,10 +193,8 @@ export function ConnectCommandPanel({
   const [customizing, setCustomizing] = useState(false);
   const compact = !!connectRequest && !customizing;
   const requestedPlatform = searchParams.get("platform");
-  const { eligible: skillsEligible, skills: allSkills } = useConnectSkills(
-    llmProxyId,
-    skillsEnabled,
-  );
+  const { eligible: skillsEligible, skills: allSkills } =
+    useConnectSkills(skillsEnabled);
   // Providers are named the way this organization names them, so a renamed
   // provider reads the same here as in the model-provider settings.
   const providerCatalog = useModelProviderCatalog();

--- a/platform/frontend/src/app/connection/skills-marketplace-step.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.tsx
@@ -784,9 +784,8 @@ export type ConnectSkill = Pick<
  * skill snapshot can opt into a loud error, rather than silently producing an
  * artifact without the selected skills.
  *
- * `forAgentId` narrows the set to skills visible from that agent's
- * environment — the connect command passes the selected LLM proxy so only
- * skills the connection can actually reach are offered.
+ * `forAgentId` narrows the set to skills visible from a supported skill agent's
+ * environment. LLM proxies do not expose skills and must not be passed here.
  */
 export function useAllSkills(params?: {
   enabled?: boolean;


### PR DESCRIPTION
Connection setup requested skills using an LLM proxy ID, producing “This agent type does not expose skills” on an otherwise valid setup page. Load the caller-visible skills catalog instead and remove the misleading proxy-environment copy.

Verified in a fresh local Tilt stack: the browser regression fails with the original 400 before the fix and passes after it. Connection shows shared skills, supported agents and MCP gateways still return their skills, and the Connection, Agent, Gateway, and LLM Proxy pages remain free of that error. The existing 500-skill setup limit is unchanged.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>