### PR TITLE
fix(agent-runtime): attach Project starters to current session turns

### DIFF
--- a/platform/backend/src/websocket.test.ts
+++ b/platform/backend/src/websocket.test.ts
@@ -932,7 +932,7 @@ describe("websocket Agent run authorization and cleanup", () => {
     expect(service.agentRunAttachSubscriptions.has(ws)).toBe(false);
   });
 
-  test("attaches a Project run owner from the stable session URL to the current turn", async ({
+  test("attaches only the Project run starter from the stable session URL to the current turn", async ({
     makeAgent,
     makeMember,
     makeOrganization,
@@ -1053,6 +1053,49 @@ describe("websocket Agent run authorization and cleanup", () => {
         },
       }),
     );
+
+    const viewer = await makeUser();
+    await makeMember(viewer.id, organization.id, { role: "admin" });
+    await projectService.setShare({
+      id: project.id,
+      organizationId: organization.id,
+      userId: owner.id,
+      visibility: "organization",
+      teamIds: [],
+    });
+    const viewerWs = {
+      readyState: WS.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+    } as unknown as WS;
+    service.clientContexts.set(viewerWs, {
+      userId: viewer.id,
+      organizationId: organization.id,
+      userIsMcpServerAdmin: true,
+    });
+    attach.mockClear();
+
+    for (const taskId of [firstTask.id, currentTask.id]) {
+      await service.handleMessage(
+        {
+          type: "subscribe_agent_run_attach",
+          payload: { runId: taskId },
+        },
+        viewerWs,
+      );
+
+      expect(viewerWs.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          type: "agent_run_attach_error",
+          payload: {
+            runId: taskId,
+            error: "Only the person who started this run can attach to it",
+          },
+        }),
+      );
+    }
+    expect(attach).not.toHaveBeenCalled();
+    expect(service.agentRunAttachSubscriptions.has(viewerWs)).toBe(false);
   });
 
   test("destroys Agent run streams and detaches the exec socket on disconnect", () => {

--- a/platform/backend/src/websocket.test.ts
+++ b/platform/backend/src/websocket.test.ts
@@ -15,6 +15,7 @@ import { WebSocket as WS } from "ws";
 import { betterAuth } from "@/auth";
 import db, { schema } from "@/database";
 import { browserStreamFeature } from "@/features/browser-stream/services/browser-stream.feature";
+import { agentRuntimeManager } from "@/k8s/agent-runtime";
 import McpServerRuntimeManager from "@/k8s/mcp-server-runtime/manager";
 import {
   A2AContextModel,
@@ -929,6 +930,129 @@ describe("websocket Agent run authorization and cleanup", () => {
       }),
     );
     expect(service.agentRunAttachSubscriptions.has(ws)).toBe(false);
+  });
+
+  test("attaches a Project run owner from the stable session URL to the current turn", async ({
+    makeAgent,
+    makeMember,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const organization = await makeOrganization();
+    const owner = await makeUser();
+    await makeMember(owner.id, organization.id, { role: "member" });
+    const project = await projectService.create({
+      organizationId: organization.id,
+      userId: owner.id,
+      name: "Project run",
+      description: null,
+    });
+    const agent = await makeAgent({
+      organizationId: organization.id,
+      authorId: owner.id,
+      agentType: "agent",
+      scope: "org",
+    });
+    const context = await A2AContextModel.create({
+      actorKind: "user",
+      actorId: owner.id,
+    });
+    const firstTask = await A2ATaskModel.create({
+      contextId: context.id,
+      agentId: agent.id,
+      state: "TASK_STATE_COMPLETED",
+    });
+    const currentTask = await A2ATaskModel.create({
+      contextId: context.id,
+      agentId: agent.id,
+      state: "TASK_STATE_WORKING",
+    });
+    const workloadName = `project-run-${crypto.randomUUID()}`;
+    await AgentRunModel.create({
+      organizationId: organization.id,
+      taskId: firstTask.id,
+      agentId: agent.id,
+      actorKind: "user",
+      actorId: owner.id,
+      actorUserId: owner.id,
+      projectId: project.id,
+      workloadName,
+      backend: "kubernetes",
+      runtimeScope: "archestra-dev",
+      virtualApiKeyId: null,
+    });
+    const currentRun = await AgentRunModel.create({
+      organizationId: organization.id,
+      taskId: currentTask.id,
+      agentId: agent.id,
+      actorKind: "user",
+      actorId: owner.id,
+      actorUserId: owner.id,
+      projectId: project.id,
+      workloadName,
+      backend: "kubernetes",
+      runtimeScope: "archestra-dev",
+      virtualApiKeyId: null,
+    });
+    await AgentWorkspaceModel.create({
+      id: firstTask.id,
+      organizationId: organization.id,
+      agentId: agent.id,
+      actorKind: "user",
+      actorId: owner.id,
+      workloadName,
+      backend: "kubernetes",
+      runtimeScope: "archestra-dev",
+      state: "active",
+      lastTaskId: currentTask.id,
+      expiresAt: new Date(Date.now() + 3600_000),
+    });
+    const socket = {
+      readyState: WS.OPEN,
+      close: vi.fn(),
+      on: vi.fn(),
+      send: vi.fn(),
+    };
+    vi.spyOn(agentRuntimeManager, "isEnabled", "get").mockReturnValue(true);
+    const attach = vi.spyOn(agentRuntimeManager, "attach").mockResolvedValue({
+      podName: "project-run-pod",
+      command: "tmux attach",
+      socket: socket as never,
+    });
+    const ws = {
+      readyState: WS.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+    } as unknown as WS;
+    service.clientContexts.set(ws, {
+      userId: owner.id,
+      organizationId: organization.id,
+      userIsMcpServerAdmin: false,
+    });
+
+    await service.handleMessage(
+      {
+        type: "subscribe_agent_run_attach",
+        payload: { runId: firstTask.id },
+      },
+      ws,
+    );
+
+    expect(attach).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({ id: currentRun.id }),
+      }),
+    );
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: "agent_run_attach_started",
+        payload: {
+          runId: firstTask.id,
+          command: "tmux attach",
+          resourceName: "project-run-pod",
+        },
+      }),
+    );
   });
 
   test("destroys Agent run streams and detaches the exec socket on disconnect", () => {

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -553,7 +553,18 @@ class WebSocketService {
   ): Promise<void> {
     this.unsubscribeAgentRunAttach(ws);
 
-    const session = await AgentRunModel.findByTaskId(runId);
+    // The URL may identify the retained workspace's original task while its
+    // live terminal belongs to a newer turn. Resolve that stable session alias
+    // with the same owner-scoped lookup as the HTTP detail route before
+    // falling back to the raw task for the denial response.
+    const ownedSession = await AgentRunModel.findCurrentSessionForActor({
+      taskId: runId,
+      actorUserId: clientContext.userId,
+      organizationId: clientContext.organizationId,
+    });
+    const session = await AgentRunModel.findByTaskId(
+      ownedSession?.taskId ?? runId,
+    );
     if (!session || session.organizationId !== clientContext.organizationId) {
       this.sendToClient(ws, {
         type: "agent_run_attach_error",

--- a/platform/frontend/src/app/chat/runs/page.client.test.tsx
+++ b/platform/frontend/src/app/chat/runs/page.client.test.tsx
@@ -143,7 +143,7 @@ describe("AgentRunChatSession", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("centers only the access notice, in the loader's placement, when the run cannot be opened", () => {
+  it("does not blame ownership when the run cannot be loaded", () => {
     queryState.value.isError = true;
     queryState.value.error = new Error("Run not found");
 
@@ -154,9 +154,14 @@ describe("AgentRunChatSession", () => {
     expect(screen.getByText("Terminal unavailable")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Only the person who started this run can attach to it.",
+        "This run could not be loaded. It may have failed to start, been removed, or you may not have access.",
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Only the person who started this run can attach to it.",
+      ),
+    ).not.toBeInTheDocument();
     // The old full-page error card is gone.
     expect(
       screen.queryByText("Couldn't load this run"),

--- a/platform/frontend/src/app/chat/runs/page.client.tsx
+++ b/platform/frontend/src/app/chat/runs/page.client.tsx
@@ -75,7 +75,7 @@ export function AgentRunChatSession({ taskId }: { taskId: string }) {
         <div className="flex min-h-0 flex-1 overflow-hidden rounded-md border bg-slate-950">
           <ExecTerminalStatus
             title="Terminal unavailable"
-            detail="Only the person who started this run can attach to it."
+            detail="This run could not be loaded. It may have failed to start, been removed, or you may not have access."
           />
         </div>
       </main>


### PR DESCRIPTION
Project starters could reopen an earlier session link but fail to attach after another coding turn started. Resolve terminal attachment through the same owner-scoped session lookup as run details, while retaining access denial for other users. Failed launches now show a load error instead of incorrectly blaming ownership.

The original Tilt/OpenCode workflow covered project launch, terminal attachment, continued turns, retained files, and denial for a separate administrator. Regression tests cover attachment through original and current task IDs and the load-error message. Native Codex execution was not verified in that workflow.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>