### PR TITLE
fix(connect): preserve startup wrappers across setup and retries

### DIFF
--- a/platform/backend/src/services/connection-setup-script.powershell.test.ts
+++ b/platform/backend/src/services/connection-setup-script.powershell.test.ts
@@ -1,0 +1,177 @@
+import { execFile, spawnSync } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { STARTUP_GUARD_INSTALL } from "@archestra/shared";
+import { describe, expect, test } from "vitest";
+import { renderSetupScript } from "@/services/connection-setup-script";
+
+const execFileAsync = promisify(execFile);
+const powershellAvailable =
+  process.platform !== "win32" &&
+  spawnSync("pwsh", ["-NoProfile", "-Command", "exit 0"]).status === 0;
+
+describe.skipIf(!powershellAvailable)(
+  "PowerShell session recovery (requires pwsh and POSIX CLI fixtures)",
+  () => {
+    test.each([
+      { clientId: "claude-code" as const, binary: "claude" },
+      { clientId: "codex" as const, binary: "codex" },
+      { clientId: "copilot-cli" as const, binary: "copilot" },
+    ])("$clientId: failed registration preserves the active guard, and retry reinstalls without duplicate hooks", async ({
+      clientId,
+      binary,
+    }) => {
+      const root = await mkdtemp(path.join(tmpdir(), "archestra-powershell-"));
+      const home = path.join(root, "home");
+      const bin = path.join(root, "bin");
+      const callsPath = path.join(root, "calls.jsonl");
+      const setupPath = path.join(root, "setup.ps1");
+      const driverPath = path.join(root, "driver.ps1");
+      const guard = STARTUP_GUARD_INSTALL[clientId];
+      const healthRequests: string[] = [];
+      const server = createServer((request, response) => {
+        healthRequests.push(request.url ?? "");
+        response.writeHead(200, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ mcp: "ok", llm: "ok" }));
+      });
+      try {
+        await Promise.all([home, bin].map((directory) => mkdir(directory)));
+        await new Promise<void>((resolve) =>
+          server.listen(0, "127.0.0.1", resolve),
+        );
+        const address = server.address();
+        if (!address || typeof address === "string")
+          throw new Error("Missing HTTP port");
+        const executable = path.join(bin, binary);
+        await writeFile(
+          executable,
+          `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.ARCHESTRA_TEST_COMMAND_LOG, JSON.stringify(args) + "\\n");
+if (args[0] !== "mcp") process.exit(23);
+if (args[1] === "remove") process.exit(1);
+process.exit(args[1] === "add" && process.env.ARCHESTRA_TEST_FAIL_ADD === "1" ? 42 : 0);
+`,
+        );
+        await chmod(executable, 0o755);
+        await writeFile(
+          setupPath,
+          renderSetupScript({
+            clientId,
+            platform: "windows",
+            appName: "Archestra",
+            mcp: {
+              serverName: "test_gateway",
+              url: `http://127.0.0.1:${address.port}/v1/mcp/test-gateway`,
+            },
+            proxy: null,
+            skills: null,
+          }),
+        );
+        await writeFile(
+          driverPath,
+          `
+$ErrorActionPreference = 'Stop'
+$setup = Get-Content -Raw $env:ARCHESTRA_TEST_SETUP_PATH
+$profilePath = $PROFILE.CurrentUserAllHosts
+$guardPath = Join-Path $env:USERPROFILE '${guard.psScriptRelpath}'
+$null = New-Item -ItemType Directory -Force (Split-Path $profilePath -Parent)
+Set-Content $profilePath '# unrelated profile setting'
+$originalProfile = Get-Content -Raw $profilePath
+$env:ARCHESTRA_TEST_FAIL_ADD = '1'
+$failed = $false
+try { Invoke-Expression $setup } catch {
+  if ($_.Exception.Message -notlike '*Could not register the MCP gateway*') { throw }
+  $failed = $true
+}
+if (-not $failed) { throw 'Initial registration unexpectedly succeeded' }
+if (Get-Item Function:${binary} -ErrorAction SilentlyContinue) { throw 'Failed first install created a wrapper' }
+if (Test-Path $guardPath) { throw 'Failed first install created a guard' }
+if ((Get-Content -Raw $profilePath) -cne $originalProfile) { throw 'Failed first install changed the profile' }
+$env:ARCHESTRA_TEST_FAIL_ADD = '0'
+Invoke-Expression $setup
+$invokeArgs = @('invoke', 'two words', '', 'single''quote', '$HOME', '*')
+foreach ($attempt in 1..2) {
+  $priorFunction = (Get-Item Function:${binary}).ScriptBlock
+  $priorProfile = Get-Content -Raw $profilePath
+  $priorGuard = Get-Content -Raw $guardPath
+  $env:ARCHESTRA_TEST_FAIL_ADD = '1'
+  $failed = $false
+  try { Invoke-Expression $setup } catch {
+    if ($_.Exception.Message -notlike '*Could not register the MCP gateway*') { throw }
+    $failed = $true
+  }
+  if (-not $failed) { throw 'Re-registration unexpectedly succeeded' }
+  $restoredFunction = Get-Item Function:${binary} -ErrorAction SilentlyContinue
+  if (-not $restoredFunction -or $restoredFunction.ScriptBlock.ToString() -cne $priorFunction.ToString()) { throw 'Loaded wrapper was not restored' }
+  if ((Get-Content -Raw $profilePath) -cne $priorProfile) { throw 'Failed reconnect changed the profile' }
+  if ((Get-Content -Raw $guardPath) -cne $priorGuard) { throw 'Failed reconnect changed the guard' }
+  ${binary} @invokeArgs
+  if ($LASTEXITCODE -ne 23) { throw 'Restored wrapper lost client exit status' }
+  $env:ARCHESTRA_TEST_FAIL_ADD = '0'
+  Invoke-Expression $setup
+  if (-not (Get-Item Function:${binary} -ErrorAction SilentlyContinue)) { throw 'Retry did not activate the wrapper' }
+  $profileText = Get-Content -Raw $profilePath
+  if ([regex]::Matches($profileText, [regex]::Escape('${guard.markerStart}')).Count -ne 1) { throw 'Retry duplicated the profile hook' }
+  if (-not $profileText.Contains('# unrelated profile setting')) { throw 'Retry lost unrelated profile settings' }
+  ${binary} @invokeArgs
+  if ($LASTEXITCODE -ne 23) { throw 'Reinstalled wrapper lost client exit status' }
+}
+exit 0
+`,
+        );
+        await execFileAsync(
+          "pwsh",
+          ["-NoLogo", "-NoProfile", "-NonInteractive", "-File", driverPath],
+          {
+            cwd: home,
+            env: {
+              HOME: home,
+              USERPROFILE: home,
+              PATH: `${bin}:${process.env.PATH}`,
+              NO_COLOR: "1",
+              ARCHESTRA_TEST_COMMAND_LOG: callsPath,
+              ARCHESTRA_TEST_SETUP_PATH: setupPath,
+            },
+            timeout: 30_000,
+          },
+        );
+        const calls: string[][] = (await readFile(callsPath, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(calls.filter((args) => args[0] === "invoke")).toEqual(
+          Array.from({ length: 4 }, () => [
+            "invoke",
+            "two words",
+            "",
+            "single'quote",
+            "$HOME",
+            "*",
+          ]),
+        );
+        expect(
+          calls.filter((args) => args[0] === "mcp" && args[1] === "add"),
+        ).toHaveLength(6);
+        expect(healthRequests).toHaveLength(4);
+        expect(
+          healthRequests.every((url) => url === "/v1/health?mcp=test-gateway"),
+        ).toBe(true);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  },
+);

--- a/platform/backend/src/services/connection-setup-script.test.ts
+++ b/platform/backend/src/services/connection-setup-script.test.ts
@@ -17,6 +17,7 @@ import {
   CLAUDE_CODE_CLIENT_ID,
   CODEX_CLIENT_ID,
   EXTERNAL_AGENT_ID_HEADER,
+  STARTUP_GUARD_INSTALL,
 } from "@archestra/shared";
 import { describe, expect, test } from "vitest";
 import {
@@ -415,6 +416,147 @@ function runInTerminal(body: string): Promise<string> {
 const ALL_CLIENTS = ["claude-code", "codex", "copilot-cli", "cursor"] as const;
 
 describe("renderSetupScript", () => {
+  test.each([
+    { clientId: "claude-code" as const, binary: "claude", mode: "-p" },
+    { clientId: "codex" as const, binary: "codex", mode: "exec" },
+  ])("$clientId: installed and reinstalled wrappers preserve PATH resolution, arguments and exit status", async ({
+    clientId,
+    binary,
+    mode,
+  }) => {
+    const root = await mkdtemp(path.join(tmpdir(), "archestra-installer-"));
+    const home = path.join(root, "home");
+    const bin = path.join(root, "bin");
+    const alternateBin = path.join(root, "alternate-bin");
+    const scriptPath = path.join(root, "setup.sh");
+    const callsPath = path.join(root, "calls.jsonl");
+    const guard = STARTUP_GUARD_INSTALL[clientId];
+    const args = [
+      mode,
+      "two words",
+      "",
+      "single'quote",
+      'double"quote',
+      "$HOME",
+      "*",
+      "--flag=value",
+    ];
+    try {
+      await Promise.all([home, bin, alternateBin].map((dir) => mkdir(dir)));
+      for (const directory of [bin, alternateBin]) {
+        const executable = path.join(directory, binary);
+        await writeFile(
+          executable,
+          `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.ARCHESTRA_TEST_COMMAND_LOG, JSON.stringify({ executable: process.argv[1], args }) + "\\n");
+process.exit(args[0] === "mcp" ? 0 : 23);
+`,
+        );
+        await chmod(executable, 0o755);
+      }
+      await writeFile(
+        path.join(bin, "curl"),
+        `#!/bin/sh
+printf '%s\\n' '{"health":true}' >> "$ARCHESTRA_TEST_COMMAND_LOG"
+printf '%s' '{"mcp":"ok","llm":"ok"}'
+`,
+      );
+      await chmod(path.join(bin, "curl"), 0o755);
+      const sentinel = "export ARCHESTRA_TEST_PROFILE_PRESERVED=1\n";
+      await writeFile(path.join(home, ".bashrc"), sentinel);
+      await writeFile(path.join(home, ".zshrc"), sentinel);
+      await writeFile(
+        scriptPath,
+        renderSetupScript({
+          ...fullContext(clientId, "linux"),
+          proxy: null,
+          skills: null,
+        }),
+      );
+      const env = {
+        HOME: home,
+        SHELL: "/bin/bash",
+        PATH: `${bin}:${process.env.PATH}`,
+        ARCHESTRA_TEST_COMMAND_LOG: callsPath,
+        NO_COLOR: "1",
+      };
+      for (let run = 0; run < 2; run++) {
+        await writeFile(callsPath, "");
+        await execFileAsync(
+          "bash",
+          [
+            "--noprofile",
+            "--norc",
+            "-c",
+            `
+source "$HOME/.bashrc"
+export -f ${binary} 2>/dev/null || true
+cat "$1" | bash
+`,
+            "installer",
+            scriptPath,
+          ],
+          { env, cwd: home },
+        );
+        const setupCalls = (await readFile(callsPath, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(setupCalls.length).toBeGreaterThan(0);
+        expect(
+          setupCalls.every(
+            (call) =>
+              call.executable === path.join(bin, binary) &&
+              call.args[0] === "mcp",
+          ),
+        ).toBe(true);
+        expect(setupCalls.some((call) => call.args.includes("add"))).toBe(true);
+        expect(
+          (await stat(path.join(home, guard.scriptRelpath))).mode & 0o111,
+        ).not.toBe(0);
+        for (const profile of [".bashrc", ".zshrc"]) {
+          const contents = await readFile(path.join(home, profile), "utf8");
+          expect(contents).toContain(sentinel);
+          expect(contents.split(guard.markerStart)).toHaveLength(2);
+        }
+        for (const directory of [bin, alternateBin]) {
+          await writeFile(callsPath, "");
+          await expect(
+            execFileAsync(
+              "bash",
+              [
+                "--noprofile",
+                "--norc",
+                "-c",
+                `
+source "$HOME/.bashrc"
+test "$ARCHESTRA_TEST_PROFILE_PRESERVED" = 1 || exit 99
+${binary} "$@"
+`,
+                "invoke",
+                ...args,
+              ],
+              { env: { ...env, PATH: `${directory}:${env.PATH}` }, cwd: home },
+            ),
+          ).rejects.toMatchObject({ code: 23 });
+          expect(
+            (await readFile(callsPath, "utf8"))
+              .trim()
+              .split("\n")
+              .map((line) => JSON.parse(line)),
+          ).toEqual([
+            { health: true },
+            { executable: path.join(directory, binary), args },
+          ]);
+        }
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   for (const clientId of ALL_CLIENTS) {
     test(`${clientId}: full script is valid bash with no placeholders`, async () => {
       const script = renderSetupScript(fullContext(clientId));

--- a/platform/backend/src/services/connection-setup-script.test.ts
+++ b/platform/backend/src/services/connection-setup-script.test.ts
@@ -1450,6 +1450,27 @@ cli sh -c '[ -t 1 ] && echo TTY-VIA-CLI || echo PIPE-VIA-CLI; cat'`;
 });
 
 describe("renderSetupScript (windows)", () => {
+  test.each([
+    { clientId: "claude-code" as const, binary: "claude" },
+    { clientId: "codex" as const, binary: "codex" },
+    { clientId: "copilot-cli" as const, binary: "copilot" },
+  ])("$clientId: failed native MCP registration aborts before installing the guard", ({
+    clientId,
+    binary,
+  }) => {
+    const script = renderSetupScript(fullContext(clientId, "windows"));
+    const registration = script.indexOf(`\n${binary} mcp add `);
+    const guardInstall = script.indexOf("$archGuardPath = Join-Path");
+    expect(registration).toBeGreaterThan(-1);
+    expect(guardInstall).toBeGreaterThan(registration);
+    const afterRegistration = script.slice(
+      script.indexOf("\n", registration + 1) + 1,
+    );
+    expect(afterRegistration.split("\n")[0]).toMatch(
+      /^if \(\$LASTEXITCODE -ne 0\) \{ throw '.*' \}$/,
+    );
+  });
+
   for (const clientId of ALL_CLIENTS) {
     test(`${clientId}: renders PowerShell, not bash, with secrets injected`, () => {
       const script = renderSetupScript(fullContext(clientId, "windows"));

--- a/platform/backend/src/services/connection-setup-script.ts
+++ b/platform/backend/src/services/connection-setup-script.ts
@@ -549,8 +549,6 @@ function indent(block: string, prefix: string): string {
 function claudeCodeSections(ctx: SetupScriptContext): string[] {
   const sections: string[] = [];
 
-  startupGuardUnshadowSection(ctx, CLAUDE_CODE_GUARD_CLIENT, sections);
-
   if (ctx.mcp) {
     // Register at USER scope so the gateway is visible in every directory for
     // this user. `claude mcp add` defaults to `local` (per-directory) scope,
@@ -597,9 +595,7 @@ ${claudeMarketplaceRegistration(ctx.skills.marketplaceName, ctx.skills.cloneUrl)
 ${installs.join("\n")}`);
   }
 
-  startupGuardSection(ctx, CLAUDE_CODE_GUARD_CLIENT, sections);
-
-  return sections;
+  return withStartupGuard(ctx, CLAUDE_CODE_GUARD_CLIENT, sections);
 }
 
 /**
@@ -729,41 +725,22 @@ esac`;
 }
 
 /**
- * Prepend the guard-unshadow step, gated exactly like the install so the two
- * always come as a pair. It runs before the connect steps invoke the client CLI
- * so a guard wrapper installed by an earlier connect can never splash over this
- * run. It is non-destructive (see {@link buildStartupGuardUnshadowSection}): the
- * install section at the end is what refreshes the on-disk guard, and leaving
- * the guard in place until then means a connect step failing under `set -e`
- * never strands the user without a startup screen. Call this FIRST in a client's
- * builder.
+ * Wrap a CLI client's setup steps with the same startup-guard lifecycle. The
+ * old guard is unshadowed before any client command runs and the refreshed
+ * guard is installed only after setup succeeds.
  */
-function startupGuardUnshadowSection(
+function withStartupGuard(
   ctx: SetupScriptContext,
   client: StartupGuardClient,
   sections: string[],
-): void {
-  if (ctx.mcp || ctx.proxy || ctx.skills) {
-    sections.push(buildStartupGuardUnshadowSection(client));
-  }
-}
-
-/**
- * Append the startup-guard install to a client's script when connect wired at
- * least one remote — the guard's whole job is to check those before launch, so
- * a script that configured nothing has nothing to guard. Shared by every CLI
- * client that gets a guard (Claude Code, Codex, Copilot CLI).
- */
-function startupGuardSection(
-  ctx: SetupScriptContext,
-  client: StartupGuardClient,
-  sections: string[],
-): void {
-  if (ctx.mcp || ctx.proxy || ctx.skills) {
-    sections.push(
-      buildStartupGuardInstallSection(buildStartupGuardContext(ctx), client),
-    );
-  }
+): string[] {
+  return ctx.mcp || ctx.proxy || ctx.skills
+    ? [
+        buildStartupGuardUnshadowSection(client),
+        ...sections,
+        buildStartupGuardInstallSection(buildStartupGuardContext(ctx), client),
+      ]
+    : sections;
 }
 
 // One shared source for the proxy env keys connect writes into
@@ -935,8 +912,6 @@ export function codexAttributionHeaderLines(
 function codexSections(ctx: SetupScriptContext): string[] {
   const sections: string[] = [];
 
-  startupGuardUnshadowSection(ctx, CODEX_GUARD_CLIENT, sections);
-
   if (ctx.mcp || ctx.proxy || ctx.skills) {
     // Codex owns config.toml wherever CODEX_HOME points (default ~/.codex),
     // and every action below edits that file — the mcp/skills registrations
@@ -1009,9 +984,7 @@ fi
 ${installs.join("\n")}`);
   }
 
-  startupGuardSection(ctx, CODEX_GUARD_CLIENT, sections);
-
-  return sections;
+  return withStartupGuard(ctx, CODEX_GUARD_CLIENT, sections);
 }
 
 // ===================================================================
@@ -1020,8 +993,6 @@ ${installs.join("\n")}`);
 
 function copilotSections(ctx: SetupScriptContext): string[] {
   const sections: string[] = [];
-
-  startupGuardUnshadowSection(ctx, COPILOT_GUARD_CLIENT, sections);
 
   if (ctx.mcp) {
     sections.push(`say ${sh(`Registering MCP gateway "${ctx.mcp.serverName}" (OAuth)`)}
@@ -1066,9 +1037,7 @@ fi
 ${installs.join("\n")}`);
   }
 
-  startupGuardSection(ctx, COPILOT_GUARD_CLIENT, sections);
-
-  return sections;
+  return withStartupGuard(ctx, COPILOT_GUARD_CLIENT, sections);
 }
 
 /**

--- a/platform/backend/src/services/connection-setup-script.windows.ts
+++ b/platform/backend/src/services/connection-setup-script.windows.ts
@@ -404,12 +404,22 @@ function withWindowsStartupGuard(
 ): string[] {
   return ctx.mcp || ctx.proxy || ctx.skills
     ? [
+        `$archPreviousStartupWrapper = Get-Item Function:${client.binary} -ErrorAction SilentlyContinue
+try {`,
         buildWindowsStartupGuardUnshadowSection(client),
         ...sections,
         buildWindowsStartupGuardInstallSection(
           buildStartupGuardContext(ctx),
           client,
         ),
+        `} catch {
+  if ($null -ne $archPreviousStartupWrapper) {
+    Set-Item Function:${client.binary} -Value $archPreviousStartupWrapper.ScriptBlock
+  }
+  throw
+} finally {
+  Remove-Variable archPreviousStartupWrapper -ErrorAction SilentlyContinue
+}`,
       ]
     : sections;
 }

--- a/platform/backend/src/services/connection-setup-script.windows.ts
+++ b/platform/backend/src/services/connection-setup-script.windows.ts
@@ -425,7 +425,8 @@ function claudeCodeSections(ctx: SetupScriptContext): string[] {
     sections.push(`Say ${psq(`Registering MCP gateway "${ctx.mcp.serverName}" (OAuth)`)}
 try { claude mcp remove --scope local ${psq(ctx.mcp.serverName)} 2>$null | Out-Null } catch { }
 try { claude mcp remove --scope user ${psq(ctx.mcp.serverName)} 2>$null | Out-Null } catch { }
-claude mcp add --scope user --transport http ${psq(ctx.mcp.serverName)} ${psq(ctx.mcp.url)}`);
+claude mcp add --scope user --transport http ${psq(ctx.mcp.serverName)} ${psq(ctx.mcp.url)}
+if ($LASTEXITCODE -ne 0) { throw 'Could not register the MCP gateway. Fix the error above and re-run setup.' }`);
   }
 
   if (ctx.proxy) {
@@ -711,7 +712,8 @@ if ((Test-Path $arch_config) -and -not (Test-Path ($arch_config + '.archestra-ba
   if (ctx.mcp) {
     sections.push(`Say ${psq(`Registering MCP gateway "${ctx.mcp.serverName}" (OAuth)`)}
 try { codex mcp remove ${psq(ctx.mcp.serverName)} 2>$null | Out-Null } catch { }
-codex mcp add ${psq(ctx.mcp.serverName)} --url ${psq(ctx.mcp.url)}`);
+codex mcp add ${psq(ctx.mcp.serverName)} --url ${psq(ctx.mcp.url)}
+if ($LASTEXITCODE -ne 0) { throw 'Could not register the MCP gateway. Fix the error above and re-run setup.' }`);
   }
 
   if (ctx.proxy) {
@@ -828,6 +830,7 @@ function copilotSections(ctx: SetupScriptContext): string[] {
     sections.push(`Say ${psq(`Registering MCP gateway "${ctx.mcp.serverName}" (OAuth)`)}
 try { copilot mcp remove ${psq(ctx.mcp.serverName)} 2>$null | Out-Null } catch { }
 copilot mcp add --transport http ${psq(ctx.mcp.serverName)} ${psq(ctx.mcp.url)}
+if ($LASTEXITCODE -ne 0) { throw 'Could not register the MCP gateway. Fix the error above and re-run setup.' }
 copilot mcp get ${psq(ctx.mcp.serverName)}`);
   }
 

--- a/platform/backend/src/services/connection-setup-script.windows.ts
+++ b/platform/backend/src/services/connection-setup-script.windows.ts
@@ -393,44 +393,29 @@ function psBareOrIndex(key: string): string {
 // ===================================================================
 
 /**
- * Prepend the guard-unshadow step for a client, gated exactly like its install
- * so the two come as a pair (mirrors the POSIX renderer). Non-destructive: the
- * reinstall at the end refreshes the on-disk guard, so a connect step failing
- * under 'Stop' never strands the user without a startup screen. Call FIRST.
+ * Wrap a CLI client's setup steps with the same startup-guard lifecycle. The
+ * old guard is unshadowed before any client command runs and the refreshed
+ * guard is installed only after setup succeeds.
  */
-function windowsStartupGuardUnshadowSection(
+function withWindowsStartupGuard(
   ctx: SetupScriptContext,
   client: StartupGuardClient,
   sections: string[],
-): void {
-  if (ctx.mcp || ctx.proxy || ctx.skills) {
-    sections.push(buildWindowsStartupGuardUnshadowSection(client));
-  }
-}
-
-/**
- * Append the guard install for a client when connect wired at least one remote.
- * Call LAST in a client's builder.
- */
-function windowsStartupGuardSection(
-  ctx: SetupScriptContext,
-  client: StartupGuardClient,
-  sections: string[],
-): void {
-  if (ctx.mcp || ctx.proxy || ctx.skills) {
-    sections.push(
-      buildWindowsStartupGuardInstallSection(
-        buildStartupGuardContext(ctx),
-        client,
-      ),
-    );
-  }
+): string[] {
+  return ctx.mcp || ctx.proxy || ctx.skills
+    ? [
+        buildWindowsStartupGuardUnshadowSection(client),
+        ...sections,
+        buildWindowsStartupGuardInstallSection(
+          buildStartupGuardContext(ctx),
+          client,
+        ),
+      ]
+    : sections;
 }
 
 function claudeCodeSections(ctx: SetupScriptContext): string[] {
   const sections: string[] = [];
-
-  windowsStartupGuardUnshadowSection(ctx, CLAUDE_CODE_GUARD_CLIENT, sections);
 
   if (ctx.mcp) {
     // Register at USER scope so the gateway is visible in every directory for
@@ -472,9 +457,7 @@ if ($LASTEXITCODE -ne 0) { Warn ${psq(`Could not install the skills automaticall
 ${pluginInstalls}`);
   }
 
-  windowsStartupGuardSection(ctx, CLAUDE_CODE_GUARD_CLIENT, sections);
-
-  return sections;
+  return withWindowsStartupGuard(ctx, CLAUDE_CODE_GUARD_CLIENT, sections);
 }
 
 /**
@@ -712,8 +695,6 @@ Write-Host 'Your existing AWS credentials keep working — only the base URL cha
 function codexSections(ctx: SetupScriptContext): string[] {
   const sections: string[] = [];
 
-  windowsStartupGuardUnshadowSection(ctx, CODEX_GUARD_CLIENT, sections);
-
   if (ctx.mcp || ctx.proxy || ctx.skills) {
     // Codex owns config.toml wherever CODEX_HOME points (default ~/.codex),
     // and every action below edits that file — the mcp/skills registrations
@@ -791,9 +772,7 @@ if ($LASTEXITCODE -ne 0) { Warn 'Marketplace may already be registered — run /
 ${pluginInstalls}`);
   }
 
-  windowsStartupGuardSection(ctx, CODEX_GUARD_CLIENT, sections);
-
-  return sections;
+  return withWindowsStartupGuard(ctx, CODEX_GUARD_CLIENT, sections);
 }
 
 // ===================================================================
@@ -844,8 +823,6 @@ Write-Host 'Restart any open Copilot CLI sessions to pick this up.'`;
 
 function copilotSections(ctx: SetupScriptContext): string[] {
   const sections: string[] = [];
-
-  windowsStartupGuardUnshadowSection(ctx, COPILOT_GUARD_CLIENT, sections);
 
   if (ctx.mcp) {
     sections.push(`Say ${psq(`Registering MCP gateway "${ctx.mcp.serverName}" (OAuth)`)}
@@ -902,9 +879,7 @@ if ($LASTEXITCODE -ne 0) { Warn "Marketplace may already be registered — run '
 ${pluginInstalls}`);
   }
 
-  windowsStartupGuardSection(ctx, COPILOT_GUARD_CLIENT, sections);
-
-  return sections;
+  return withWindowsStartupGuard(ctx, COPILOT_GUARD_CLIENT, sections);
 }
 
 /**


### PR DESCRIPTION
Keep Claude Code, Codex, and Copilot startup wrappers in one shared setup lifecycle. Failed PowerShell MCP registration stops setup and restores the previously loaded wrapper; a successful retry refreshes the wrapper without duplicating profile hooks.

The original workflow exercised generated installers, repeated installation, argument forwarding, health checks, and PowerShell registration failure/recovery. PowerShell coverage used version 7 on Linux; native Windows, Windows PowerShell 5.1, and Zsh remain unverified.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>