### PR TITLE
feat(chat): send queued steering messages on interrupt

### DIFF
--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -3,7 +3,7 @@ title: Chat
 category: Agents
 order: 2
 description: Built-in Chat interface for working with agents and MCP tools
-lastUpdated: 2026-09-07
+lastUpdated: 2026-09-12
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -49,7 +49,7 @@ Press Enter while a response is streaming to queue your message. Queued messages
 
 Queueing works during [context compaction](#context-compaction) too. A message you send while the conversation is being compacted waits in the queue, then sends once compaction finishes — so a long chat never drops what you typed.
 
-While a response streams, the send button becomes Stop. Clicking it or pressing Esc stops the response and discards any queued messages for that conversation. Nothing else is sent until you submit a new message.
+While a response streams, the send button becomes Stop. Clicking it or pressing Esc stops the response. If messages are queued, the oldest sends immediately and the rest continue in order. With an empty queue, stopping sends nothing else.
 
 ### MCP Elicitation
 

--- a/platform/e2e-tests/tests/chat-message-queue.spec.ts
+++ b/platform/e2e-tests/tests/chat-message-queue.spec.ts
@@ -17,7 +17,7 @@ const COMPACT_ROUTE = "**/api/chat/conversations/*/compact";
 test.describe("Chat message queue", () => {
   test.setTimeout(120_000);
 
-  test("interrupts the active response and immediately sends the queued message", async ({
+  test("interrupts once and delivers multiple queued messages in order", async ({
     page,
     request,
     makeApiRequest,
@@ -44,13 +44,26 @@ test.describe("Chat message queue", () => {
     await selectRuntimeModelFromDialog(page, runtimeModel);
 
     const textarea = page.getByTestId(E2eTestId.ChatPromptTextarea);
+    const sentTexts: string[] = [];
+    let stopRequests = 0;
+    page.on("request", (request) => {
+      if (request.method() !== "POST") return;
+      if (new URL(request.url()).pathname.endsWith("/stop")) stopRequests++;
+      if (new URL(request.url()).pathname === "/api/chat") {
+        const messages = request.postDataJSON().messages;
+        const latestUserMessage = messages.findLast(
+          (message: { role: string }) => message.role === "user",
+        );
+        sentTexts.push(latestUserMessage.parts[0].text);
+      }
+    });
     await textarea.fill("Start a slow response chat-reconnect-e2e-test");
     await page.keyboard.press("Enter");
     await expect(
       page.getByText(/Reconnect stream part one/).first(),
     ).toBeVisible({ timeout: 30_000 });
 
-    const queuedText = `steer now chat-ui-e2e-test ${Math.random().toString(36).slice(2, 10)}`;
+    const queuedText = `change direction ${Math.random().toString(36).slice(2, 10)}`;
     await textarea.fill(queuedText);
     await page.keyboard.press("Enter");
 
@@ -59,17 +72,43 @@ test.describe("Chat message queue", () => {
       .filter({ hasText: queuedText });
     await expect(queuedItem).toBeVisible();
 
-    await textarea.press("Escape");
+    const secondQueuedText = "Then summarize the revised plan";
+    await textarea.fill(secondQueuedText);
+    await textarea.press("Enter");
+    await expect(page.getByTestId(E2eTestId.ChatMessageQueueItem)).toHaveCount(
+      2,
+    );
+
+    await textarea.evaluate((element) => {
+      for (const _attempt of [1, 2, 3]) {
+        element.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+      }
+    });
 
     await expect(queuedItem).toHaveCount(0, { timeout: 30_000 });
+    expect(stopRequests).toBe(1);
+    await expect(page.getByText(/part three part four part five/)).toHaveCount(
+      0,
+    );
     await expect(page.getByText(queuedText).first()).toBeVisible({
       timeout: 30_000,
     });
-    await expect(
-      page.getByText(/part three part four part five/).first(),
-    ).toBeVisible({
-      timeout: 90_000,
-    });
+    await expect(page.getByText(/part three part four part five/)).toHaveCount(
+      2,
+      {
+        timeout: 90_000,
+      },
+    );
+    await expect(page.getByTestId(E2eTestId.ChatMessageQueueItem)).toHaveCount(
+      0,
+    );
+    expect(sentTexts).toEqual([
+      "Start a slow response chat-reconnect-e2e-test",
+      queuedText,
+      secondQueuedText,
+    ]);
   });
 
   // A manual /compact rewrites the thread over REST while the chat stream sits

--- a/platform/e2e-tests/tests/chat-message-queue.spec.ts
+++ b/platform/e2e-tests/tests/chat-message-queue.spec.ts
@@ -17,6 +17,61 @@ const COMPACT_ROUTE = "**/api/chat/conversations/*/compact";
 test.describe("Chat message queue", () => {
   test.setTimeout(120_000);
 
+  test("interrupts the active response and immediately sends the queued message", async ({
+    page,
+    request,
+    makeApiRequest,
+    syncModels,
+  }) => {
+    await expectWireMockReady();
+
+    const { apiKeyId, runtimeModel } =
+      await ensureWireMockAnthropicChatProvider({
+        request,
+        makeApiRequest,
+        syncModels,
+      });
+
+    await goToChat(page);
+    await expectChatReady(page);
+    await selectApiKeyById(page, apiKeyId);
+
+    const modelSelectorTrigger = page
+      .getByTestId(E2eTestId.ChatModelSelectorTrigger)
+      .or(page.getByRole("button", { name: /select model/i }))
+      .first();
+    await modelSelectorTrigger.click();
+    await selectRuntimeModelFromDialog(page, runtimeModel);
+
+    const textarea = page.getByTestId(E2eTestId.ChatPromptTextarea);
+    await textarea.fill("Start a slow response chat-reconnect-e2e-test");
+    await page.keyboard.press("Enter");
+    await expect(
+      page.getByText(/Reconnect stream part one/).first(),
+    ).toBeVisible({ timeout: 30_000 });
+
+    const queuedText = `steer now chat-ui-e2e-test ${Math.random().toString(36).slice(2, 10)}`;
+    await textarea.fill(queuedText);
+    await page.keyboard.press("Enter");
+
+    const queuedItem = page
+      .getByTestId(E2eTestId.ChatMessageQueueItem)
+      .filter({ hasText: queuedText });
+    await expect(queuedItem).toBeVisible();
+
+    await textarea.press("Escape");
+
+    await expect(queuedItem).toHaveCount(0, { timeout: 30_000 });
+    await expect(page.getByText(queuedText).first()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(
+      page.getByText(/part three part four part five/).first(),
+    ).toBeVisible({
+      timeout: 90_000,
+    });
+  });
+
   // A manual /compact rewrites the thread over REST while the chat stream sits
   // idle, so nothing about it is "in flight" from the composer's point of view.
   // The composer still has to stay usable, park the message in the queue rather

--- a/platform/e2e-tests/tests/chat-message-queue.spec.ts
+++ b/platform/e2e-tests/tests/chat-message-queue.spec.ts
@@ -17,99 +17,117 @@ const COMPACT_ROUTE = "**/api/chat/conversations/*/compact";
 test.describe("Chat message queue", () => {
   test.setTimeout(120_000);
 
-  test("interrupts once and delivers multiple queued messages in order", async ({
-    page,
-    request,
-    makeApiRequest,
-    syncModels,
-  }) => {
-    await expectWireMockReady();
+  for (const queueTiming of ["before", "during"] as const) {
+    test(`interrupts once and delivers messages queued ${queueTiming} the stop request in order`, async ({
+      page,
+      request,
+      makeApiRequest,
+      syncModels,
+    }) => {
+      await expectWireMockReady();
 
-    const { apiKeyId, runtimeModel } =
-      await ensureWireMockAnthropicChatProvider({
-        request,
-        makeApiRequest,
-        syncModels,
+      const { apiKeyId, runtimeModel } =
+        await ensureWireMockAnthropicChatProvider({
+          request,
+          makeApiRequest,
+          syncModels,
+        });
+
+      await goToChat(page);
+      await expectChatReady(page);
+      await selectApiKeyById(page, apiKeyId);
+
+      const modelSelectorTrigger = page
+        .getByTestId(E2eTestId.ChatModelSelectorTrigger)
+        .or(page.getByRole("button", { name: /select model/i }))
+        .first();
+      await modelSelectorTrigger.click();
+      await selectRuntimeModelFromDialog(page, runtimeModel);
+
+      const textarea = page.getByTestId(E2eTestId.ChatPromptTextarea);
+      const sentTexts: string[] = [];
+      let stopRequests = 0;
+      page.on("request", (request) => {
+        if (request.method() !== "POST") return;
+        if (new URL(request.url()).pathname.endsWith("/stop")) stopRequests++;
+        if (new URL(request.url()).pathname === "/api/chat") {
+          const messages = request.postDataJSON().messages;
+          const latestUserMessage = messages.findLast(
+            (message: { role: string }) => message.role === "user",
+          );
+          sentTexts.push(latestUserMessage.parts[0].text);
+        }
       });
+      await textarea.fill("Start a slow response chat-reconnect-e2e-test");
+      await page.keyboard.press("Enter");
+      await expect(
+        page.getByText(/Reconnect stream part one/).first(),
+      ).toBeVisible({ timeout: 30_000 });
 
-    await goToChat(page);
-    await expectChatReady(page);
-    await selectApiKeyById(page, apiKeyId);
-
-    const modelSelectorTrigger = page
-      .getByTestId(E2eTestId.ChatModelSelectorTrigger)
-      .or(page.getByRole("button", { name: /select model/i }))
-      .first();
-    await modelSelectorTrigger.click();
-    await selectRuntimeModelFromDialog(page, runtimeModel);
-
-    const textarea = page.getByTestId(E2eTestId.ChatPromptTextarea);
-    const sentTexts: string[] = [];
-    let stopRequests = 0;
-    page.on("request", (request) => {
-      if (request.method() !== "POST") return;
-      if (new URL(request.url()).pathname.endsWith("/stop")) stopRequests++;
-      if (new URL(request.url()).pathname === "/api/chat") {
-        const messages = request.postDataJSON().messages;
-        const latestUserMessage = messages.findLast(
-          (message: { role: string }) => message.role === "user",
+      let releaseStop: (() => void) | undefined;
+      if (queueTiming === "during") {
+        const pendingStop = new Promise<void>((resolve) => {
+          releaseStop = resolve;
+        });
+        await page.route("**/api/chat/conversations/*/stop", async (route) => {
+          await pendingStop;
+          await route.continue();
+        });
+        const stopRequested = page.waitForRequest(
+          "**/api/chat/conversations/*/stop",
         );
-        sentTexts.push(latestUserMessage.parts[0].text);
+        await textarea.press("Escape");
+        await stopRequested;
       }
-    });
-    await textarea.fill("Start a slow response chat-reconnect-e2e-test");
-    await page.keyboard.press("Enter");
-    await expect(
-      page.getByText(/Reconnect stream part one/).first(),
-    ).toBeVisible({ timeout: 30_000 });
 
-    const queuedText = `change direction ${Math.random().toString(36).slice(2, 10)}`;
-    await textarea.fill(queuedText);
-    await page.keyboard.press("Enter");
+      const queuedText = `change direction ${Math.random().toString(36).slice(2, 10)}`;
+      await textarea.fill(queuedText);
+      await page.keyboard.press("Enter");
 
-    const queuedItem = page
-      .getByTestId(E2eTestId.ChatMessageQueueItem)
-      .filter({ hasText: queuedText });
-    await expect(queuedItem).toBeVisible();
+      const queuedItem = page
+        .getByTestId(E2eTestId.ChatMessageQueueItem)
+        .filter({ hasText: queuedText });
+      await expect(queuedItem).toBeVisible();
 
-    const secondQueuedText = "Then summarize the revised plan";
-    await textarea.fill(secondQueuedText);
-    await textarea.press("Enter");
-    await expect(page.getByTestId(E2eTestId.ChatMessageQueueItem)).toHaveCount(
-      2,
-    );
+      const secondQueuedText = "Then summarize the revised plan";
+      await textarea.fill(secondQueuedText);
+      await textarea.press("Enter");
+      await expect(
+        page.getByTestId(E2eTestId.ChatMessageQueueItem),
+      ).toHaveCount(2);
 
-    await textarea.evaluate((element) => {
-      for (const _attempt of [1, 2, 3]) {
-        element.dispatchEvent(
-          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
-        );
-      }
-    });
+      await textarea.evaluate((element) => {
+        for (const _attempt of [1, 2, 3]) {
+          element.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+          );
+        }
+      });
+      releaseStop?.();
 
-    await expect(queuedItem).toHaveCount(0, { timeout: 30_000 });
-    expect(stopRequests).toBe(1);
-    await expect(page.getByText(/part three part four part five/)).toHaveCount(
-      0,
-    );
-    await expect(page.getByText(queuedText).first()).toBeVisible({
-      timeout: 30_000,
-    });
-    await expect(page.getByText(/part three part four part five/)).toHaveCount(
-      2,
-      {
+      await expect(queuedItem).toHaveCount(0, { timeout: 30_000 });
+      expect(stopRequests).toBe(1);
+      await expect(
+        page.getByText(/part three part four part five/),
+      ).toHaveCount(0);
+      await expect(page.getByText(queuedText).first()).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(
+        page.getByText(/part three part four part five/),
+      ).toHaveCount(2, {
         timeout: 90_000,
-      },
-    );
-    await expect(page.getByTestId(E2eTestId.ChatMessageQueueItem)).toHaveCount(
-      0,
-    );
-    expect(sentTexts).toEqual([
-      "Start a slow response chat-reconnect-e2e-test",
-      queuedText,
-      secondQueuedText,
-    ]);
-  });
+      });
+      await expect(
+        page.getByTestId(E2eTestId.ChatMessageQueueItem),
+      ).toHaveCount(0);
+      expect(sentTexts).toEqual([
+        "Start a slow response chat-reconnect-e2e-test",
+        queuedText,
+        secondQueuedText,
+      ]);
+    });
+  }
 
   // A manual /compact rewrites the thread over REST while the chat stream sits
   // idle, so nothing about it is "in flight" from the composer's point of view.

--- a/platform/frontend/src/app/chat/page.client.tsx
+++ b/platform/frontend/src/app/chat/page.client.tsx
@@ -2159,18 +2159,13 @@ export function ChatPageContent({
     });
   }, []);
 
-  // Stop the in-flight response. When follow-ups are queued, preserve them so
-  // the session sends the oldest one as soon as the abort settles — this turns
-  // Escape/Stop into an immediate steering action. A plain stop still clears
-  // pending work.
   const handleStopStreaming = () => {
     if (conversationId) {
       const preserveQueuedMessages =
         chatMessageQueue.get(conversationId).length > 0;
-      const stopRequest = stopChatStreamMutation.mutateAsync(conversationId);
       stop?.({
         preserveQueuedMessages,
-        after: stopRequest,
+        stopServer: () => stopChatStreamMutation.mutateAsync(conversationId),
       });
     } else {
       stop?.();

--- a/platform/frontend/src/app/chat/page.client.tsx
+++ b/platform/frontend/src/app/chat/page.client.tsx
@@ -2167,8 +2167,10 @@ export function ChatPageContent({
     if (conversationId) {
       const preserveQueuedMessages =
         chatMessageQueue.get(conversationId).length > 0;
-      void stopChatStreamMutation.mutateAsync(conversationId).finally(() => {
-        stop?.({ preserveQueuedMessages });
+      const stopRequest = stopChatStreamMutation.mutateAsync(conversationId);
+      stop?.({
+        preserveQueuedMessages,
+        after: stopRequest,
       });
     } else {
       stop?.();

--- a/platform/frontend/src/app/chat/page.client.tsx
+++ b/platform/frontend/src/app/chat/page.client.tsx
@@ -2159,16 +2159,16 @@ export function ChatPageContent({
     });
   }, []);
 
-  // Stop the in-flight response and discard its pending follow-ups. Wired to
-  // the submit button's Stop face in the prompt input.
+  // Stop the in-flight response. When follow-ups are queued, preserve them so
+  // the session sends the oldest one as soon as the abort settles — this turns
+  // Escape/Stop into an immediate steering action. A plain stop still clears
+  // pending work.
   const handleStopStreaming = () => {
     if (conversationId) {
-      // Clear synchronously so no status transition can drain a queued turn
-      // while the separate Stop request is in flight. onFinish repeats this
-      // idempotently for any abort path that did not originate on this page.
-      chatMessageQueue.clear(conversationId);
+      const preserveQueuedMessages =
+        chatMessageQueue.get(conversationId).length > 0;
       void stopChatStreamMutation.mutateAsync(conversationId).finally(() => {
-        stop?.();
+        stop?.({ preserveQueuedMessages });
       });
     } else {
       stop?.();

--- a/platform/frontend/src/app/chat/page.client.tsx
+++ b/platform/frontend/src/app/chat/page.client.tsx
@@ -2161,10 +2161,8 @@ export function ChatPageContent({
 
   const handleStopStreaming = () => {
     if (conversationId) {
-      const preserveQueuedMessages =
-        chatMessageQueue.get(conversationId).length > 0;
       stop?.({
-        preserveQueuedMessages,
+        preserveQueuedMessages: true,
         stopServer: () => stopChatStreamMutation.mutateAsync(conversationId),
       });
     } else {

--- a/platform/frontend/src/lib/chat/chat.query.test.tsx
+++ b/platform/frontend/src/lib/chat/chat.query.test.tsx
@@ -19,6 +19,7 @@ import {
   useKeepViewedConversationRead,
   useMarkConversationRead,
   useMemberDefaultModel,
+  useStopChatStream,
   useUpdateConversation,
 } from "./chat.query";
 
@@ -34,6 +35,7 @@ vi.mock("@archestra/shared", () => ({
     clearChatConversationErrors: vi.fn(),
     updateChatConversation: vi.fn(),
     createChatConversation: vi.fn(),
+    stopChatStream: vi.fn(),
   },
   PLAYWRIGHT_MCP_CATALOG_ID: "playwright-catalog-id",
   PLAYWRIGHT_MCP_SERVER_NAME: "playwright-mcp",
@@ -637,6 +639,31 @@ describe("useDeleteConversation project-list invalidation", () => {
       ([arg]) => Array.isArray(arg?.queryKey) && arg.queryKey[0] === "projects",
     );
     expect(touchedProjects).toBe(false);
+  });
+});
+
+describe("useStopChatStream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    500,
+    undefined,
+  ])("rejects a failed stop with status %s", async (status) => {
+    vi.mocked(archestraApiSdk.stopChatStream).mockResolvedValue(
+      errorResult(status) as Awaited<
+        ReturnType<typeof archestraApiSdk.stopChatStream>
+      >,
+    );
+    const { result } = renderHook(() => useStopChatStream(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync("c1")).rejects.toThrow("boom");
+    });
+    expect(mockedHandleApiError).toHaveBeenCalledWith({ message: "boom" });
   });
 });
 

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -29,7 +29,7 @@ import {
   lockedChatRequestHeaders,
   storeLockedChatKey,
 } from "@/lib/chat/locked-chat";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, toApiError } from "@/lib/utils";
 import websocketService from "@/lib/websocket/websocket";
 
 const {
@@ -779,8 +779,16 @@ export function useDeleteConversation() {
 
 export function useStopChatStream() {
   return useMutation({
-    mutationFn: (conversationId: string) =>
-      callApi(() => stopChatStream({ path: { id: conversationId } }), null),
+    mutationFn: async (conversationId: string) => {
+      const { data, error } = await stopChatStream({
+        path: { id: conversationId },
+      });
+      if (error) {
+        handleApiError(error);
+        throw toApiError(error);
+      }
+      return data;
+    },
   });
 }
 

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1716,6 +1716,55 @@ describe("stopping with queued messages", () => {
     await waitFor(() => expect(mocks.sendMessage).not.toHaveBeenCalled());
     expect(chatMessageQueue.get(conversationId)).toHaveLength(0);
   });
+
+  it("sends the oldest queued message immediately after a steering interrupt", async () => {
+    const latestSessionRef: { current: ChatSessionSnapshot } = {
+      current: undefined,
+    };
+    const tree = () => (
+      <ChatProvider>
+        <RegisterChatSession conversationId={conversationId} />
+        <CaptureChatSession
+          conversationId={conversationId}
+          onSession={(session) => {
+            latestSessionRef.current = session;
+          }}
+        />
+      </ChatProvider>
+    );
+    const { rerender } = render(tree());
+    await waitFor(() => expect(latestSessionRef.current).toBeDefined());
+
+    act(() => {
+      chatMessageQueue.enqueue(conversationId, { text: "change direction" });
+      chatMessageQueue.enqueue(conversationId, { text: "then summarize" });
+      latestSessionRef.current?.stop({ preserveQueuedMessages: true });
+    });
+    expect(mocks.stop).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: { id: "assistant-interrupted", role: "assistant", parts: [] },
+        isAbort: true,
+        isError: false,
+      });
+    });
+    expect(chatMessageQueue.get(conversationId)).toHaveLength(2);
+
+    status = "ready";
+    rerender(tree());
+    await waitFor(() =>
+      expect(mocks.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: "user",
+          parts: [{ type: "text", text: "change direction" }],
+        }),
+      ),
+    );
+    expect(
+      chatMessageQueue.get(conversationId).map(({ text }) => text),
+    ).toEqual(["then summarize"]);
+  });
 });
 
 describe("manual context compaction and the message queue", () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1764,6 +1764,119 @@ describe("stopping with queued messages", () => {
     expect(
       chatMessageQueue.get(conversationId).map(({ text }) => text),
     ).toEqual(["then summarize"]);
+
+    status = "streaming";
+    rerender(tree());
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: { id: "assistant-steered", role: "assistant", parts: [] },
+        isAbort: false,
+        isError: false,
+      });
+    });
+    status = "ready";
+    rerender(tree());
+    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(2));
+    expect(mocks.sendMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        parts: [{ type: "text", text: "then summarize" }],
+      }),
+    );
+    expect(chatMessageQueue.get(conversationId)).toHaveLength(0);
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "coalesces repeated interrupts and waits for the stop request to %s before draining",
+    async (outcome) => {
+      let session: ChatSessionSnapshot;
+      let settleStop: () => void = () => {};
+      const stopServer = vi.fn(
+        () =>
+          new Promise<void>((resolve, reject) => {
+            settleStop =
+              outcome === "resolve"
+                ? resolve
+                : () => reject(new Error("Stop unavailable"));
+          }),
+      );
+      const tree = () => (
+        <ChatProvider>
+          <RegisterChatSession conversationId={conversationId} />
+          <CaptureChatSession
+            conversationId={conversationId}
+            onSession={(value) => {
+              session = value;
+            }}
+          />
+        </ChatProvider>
+      );
+      const { rerender } = render(tree());
+      await waitFor(() => expect(session).toBeDefined());
+      act(() => {
+        chatMessageQueue.enqueue(conversationId, { text: "first correction" });
+        chatMessageQueue.enqueue(conversationId, { text: "second correction" });
+        session?.stop({ preserveQueuedMessages: true, stopServer });
+        session?.stop({ preserveQueuedMessages: true, stopServer });
+        session?.stop({ preserveQueuedMessages: true, stopServer });
+      });
+      expect(stopServer).toHaveBeenCalledTimes(1);
+      expect(mocks.stop).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await chatOptions?.onFinish?.({
+          message: { id: "assistant-stopped", role: "assistant", parts: [] },
+          isAbort: true,
+          isError: false,
+        });
+      });
+      status = "ready";
+      rerender(tree());
+      expect(mocks.sendMessage).not.toHaveBeenCalled();
+      expect(chatMessageQueue.get(conversationId)).toHaveLength(2);
+
+      await act(async () => settleStop());
+      await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
+      expect(mocks.stop).not.toHaveBeenCalled();
+      expect(mocks.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parts: [{ type: "text", text: "first correction" }],
+        }),
+      );
+      expect(chatMessageQueue.get(conversationId).map(({ text }) => text)).toEqual([
+        "second correction",
+      ]);
+    },
+  );
+
+  it("marks the queue-preserving interrupt before requesting the server stop", async () => {
+    let session: ChatSessionSnapshot;
+    render(
+      <ChatProvider>
+        <RegisterChatSession conversationId={conversationId} />
+        <CaptureChatSession
+          conversationId={conversationId}
+          onSession={(value) => {
+            session = value;
+          }}
+        />
+      </ChatProvider>,
+    );
+    await waitFor(() => expect(session).toBeDefined());
+    await act(async () => {
+      chatMessageQueue.enqueue(conversationId, { text: "keep this instruction" });
+      session?.stop({
+        preserveQueuedMessages: true,
+        stopServer: async () => {
+          await chatOptions?.onFinish?.({
+            message: { id: "assistant-stopped", role: "assistant", parts: [] },
+            isAbort: true,
+            isError: false,
+          });
+        },
+      });
+    });
+    expect(chatMessageQueue.get(conversationId)).toHaveLength(1);
+    expect(mocks.stop).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1881,7 +1881,10 @@ describe("stopping with queued messages", () => {
     expect(mocks.stop).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps streaming and preserves the queue when the server stop fails, then allows retry", async () => {
+  it.each([
+    "streaming",
+    "aborted",
+  ] as const)("preserves the queue after a failed stop when the server is %s", async (serverStatus) => {
     let session: ChatSessionSnapshot;
     render(
       <ChatProvider>
@@ -1910,6 +1913,22 @@ describe("stopping with queued messages", () => {
     expect(mocks.stop).not.toHaveBeenCalled();
     expect(mocks.sendMessage).not.toHaveBeenCalled();
     expect(chatMessageQueue.get(conversationId)).toHaveLength(2);
+
+    if (serverStatus === "aborted") {
+      await act(async () => {
+        await chatOptions?.onFinish?.({
+          message: {
+            id: "assistant-server-aborted",
+            role: "assistant",
+            parts: [],
+          },
+          isAbort: true,
+          isError: false,
+        });
+      });
+      expect(chatMessageQueue.get(conversationId)).toHaveLength(2);
+      return;
+    }
 
     stopServer.mockResolvedValueOnce(undefined);
     await act(async () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1848,7 +1848,7 @@ describe("stopping with queued messages", () => {
     ).toEqual(["second correction"]);
   });
 
-  it("marks the queue-preserving interrupt before requesting the server stop", async () => {
+  it("keeps instructions queued while an initially empty-queue stop is settling", async () => {
     let session: ChatSessionSnapshot;
     render(
       <ChatProvider>
@@ -1863,12 +1863,12 @@ describe("stopping with queued messages", () => {
     );
     await waitFor(() => expect(session).toBeDefined());
     await act(async () => {
-      chatMessageQueue.enqueue(conversationId, {
-        text: "keep this instruction",
-      });
       session?.stop({
         preserveQueuedMessages: true,
         stopServer: async () => {
+          chatMessageQueue.enqueue(conversationId, {
+            text: "keep this instruction",
+          });
           await chatOptions?.onFinish?.({
             message: { id: "assistant-stopped", role: "assistant", parts: [] },
             isAbort: true,
@@ -1879,6 +1879,52 @@ describe("stopping with queued messages", () => {
     });
     expect(chatMessageQueue.get(conversationId)).toHaveLength(1);
     expect(mocks.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps streaming and preserves the queue when the server stop fails, then allows retry", async () => {
+    let session: ChatSessionSnapshot;
+    render(
+      <ChatProvider>
+        <RegisterChatSession conversationId={conversationId} />
+        <CaptureChatSession
+          conversationId={conversationId}
+          onSession={(value) => {
+            session = value;
+          }}
+        />
+      </ChatProvider>,
+    );
+    await waitFor(() => expect(session).toBeDefined());
+    const stopServer = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Stop unavailable"));
+    await act(async () => {
+      chatMessageQueue.enqueue(conversationId, {
+        text: "keep the first correction",
+      });
+      chatMessageQueue.enqueue(conversationId, {
+        text: "keep the second correction",
+      });
+      session?.stop({ preserveQueuedMessages: true, stopServer });
+    });
+    expect(mocks.stop).not.toHaveBeenCalled();
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(chatMessageQueue.get(conversationId)).toHaveLength(2);
+
+    stopServer.mockResolvedValueOnce(undefined);
+    await act(async () => {
+      session?.stop({ preserveQueuedMessages: true, stopServer });
+    });
+    expect(stopServer).toHaveBeenCalledTimes(2);
+    expect(mocks.stop).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: { id: "assistant-stopped", role: "assistant", parts: [] },
+        isAbort: true,
+        isError: false,
+      });
+    });
+    expect(chatMessageQueue.get(conversationId)).toHaveLength(2);
   });
 });
 

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1785,68 +1785,68 @@ describe("stopping with queued messages", () => {
     expect(chatMessageQueue.get(conversationId)).toHaveLength(0);
   });
 
-  it.each(["resolve", "reject"] as const)(
-    "coalesces repeated interrupts and waits for the stop request to %s before draining",
-    async (outcome) => {
-      let session: ChatSessionSnapshot;
-      let settleStop: () => void = () => {};
-      const stopServer = vi.fn(
-        () =>
-          new Promise<void>((resolve, reject) => {
-            settleStop =
-              outcome === "resolve"
-                ? resolve
-                : () => reject(new Error("Stop unavailable"));
-          }),
-      );
-      const tree = () => (
-        <ChatProvider>
-          <RegisterChatSession conversationId={conversationId} />
-          <CaptureChatSession
-            conversationId={conversationId}
-            onSession={(value) => {
-              session = value;
-            }}
-          />
-        </ChatProvider>
-      );
-      const { rerender } = render(tree());
-      await waitFor(() => expect(session).toBeDefined());
-      act(() => {
-        chatMessageQueue.enqueue(conversationId, { text: "first correction" });
-        chatMessageQueue.enqueue(conversationId, { text: "second correction" });
-        session?.stop({ preserveQueuedMessages: true, stopServer });
-        session?.stop({ preserveQueuedMessages: true, stopServer });
-        session?.stop({ preserveQueuedMessages: true, stopServer });
-      });
-      expect(stopServer).toHaveBeenCalledTimes(1);
-      expect(mocks.stop).not.toHaveBeenCalled();
-
-      await act(async () => {
-        await chatOptions?.onFinish?.({
-          message: { id: "assistant-stopped", role: "assistant", parts: [] },
-          isAbort: true,
-          isError: false,
-        });
-      });
-      status = "ready";
-      rerender(tree());
-      expect(mocks.sendMessage).not.toHaveBeenCalled();
-      expect(chatMessageQueue.get(conversationId)).toHaveLength(2);
-
-      await act(async () => settleStop());
-      await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
-      expect(mocks.stop).not.toHaveBeenCalled();
-      expect(mocks.sendMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          parts: [{ type: "text", text: "first correction" }],
+  it.each([
+    "resolve",
+    "reject",
+  ] as const)("coalesces repeated interrupts and waits for the stop request to %s before draining", async (outcome) => {
+    let session: ChatSessionSnapshot;
+    let settleStop: () => void = () => {};
+    const stopServer = vi.fn(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          settleStop =
+            outcome === "resolve"
+              ? resolve
+              : () => reject(new Error("Stop unavailable"));
         }),
-      );
-      expect(chatMessageQueue.get(conversationId).map(({ text }) => text)).toEqual([
-        "second correction",
-      ]);
-    },
-  );
+    );
+    const tree = () => (
+      <ChatProvider>
+        <RegisterChatSession conversationId={conversationId} />
+        <CaptureChatSession
+          conversationId={conversationId}
+          onSession={(value) => {
+            session = value;
+          }}
+        />
+      </ChatProvider>
+    );
+    const { rerender } = render(tree());
+    await waitFor(() => expect(session).toBeDefined());
+    act(() => {
+      chatMessageQueue.enqueue(conversationId, { text: "first correction" });
+      chatMessageQueue.enqueue(conversationId, { text: "second correction" });
+      session?.stop({ preserveQueuedMessages: true, stopServer });
+      session?.stop({ preserveQueuedMessages: true, stopServer });
+      session?.stop({ preserveQueuedMessages: true, stopServer });
+    });
+    expect(stopServer).toHaveBeenCalledTimes(1);
+    expect(mocks.stop).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: { id: "assistant-stopped", role: "assistant", parts: [] },
+        isAbort: true,
+        isError: false,
+      });
+    });
+    status = "ready";
+    rerender(tree());
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(chatMessageQueue.get(conversationId)).toHaveLength(2);
+
+    await act(async () => settleStop());
+    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
+    expect(mocks.stop).not.toHaveBeenCalled();
+    expect(mocks.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parts: [{ type: "text", text: "first correction" }],
+      }),
+    );
+    expect(
+      chatMessageQueue.get(conversationId).map(({ text }) => text),
+    ).toEqual(["second correction"]);
+  });
 
   it("marks the queue-preserving interrupt before requesting the server stop", async () => {
     let session: ChatSessionSnapshot;
@@ -1863,7 +1863,9 @@ describe("stopping with queued messages", () => {
     );
     await waitFor(() => expect(session).toBeDefined());
     await act(async () => {
-      chatMessageQueue.enqueue(conversationId, { text: "keep this instruction" });
+      chatMessageQueue.enqueue(conversationId, {
+        text: "keep this instruction",
+      });
       session?.stop({
         preserveQueuedMessages: true,
         stopServer: async () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1658,6 +1658,7 @@ describe("stopping with queued messages", () => {
   const conversationId = "conversation-stop-queue";
   let chatOptions: Parameters<typeof mocks.useChat>[0] | undefined;
   let status: "ready" | "streaming";
+  let messages: UIMessage[];
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1665,7 +1666,7 @@ describe("stopping with queued messages", () => {
     chatOptions = undefined;
     status = "streaming";
     mocks.resumeStream.mockResolvedValue(undefined);
-    const messages: UIMessage[] = [];
+    messages = [];
     mocks.useChat.mockImplementation((options) => {
       chatOptions = options;
       return {
@@ -1846,6 +1847,81 @@ describe("stopping with queued messages", () => {
     expect(
       chatMessageQueue.get(conversationId).map(({ text }) => text),
     ).toEqual(["second correction"]);
+  });
+
+  it.each([
+    "same turn",
+    "new turn",
+  ] as const)("scopes steering preservation through a stream error to the %s", async (turn) => {
+    let session: ChatSessionSnapshot;
+    let resolveStop: () => void = () => {};
+    const stopServer = () =>
+      new Promise<void>((resolve) => {
+        resolveStop = resolve;
+      });
+    messages = [
+      {
+        id: "original-user",
+        role: "user",
+        parts: [{ type: "text", text: "Original request" }],
+      },
+    ];
+    const tree = () => (
+      <ChatProvider>
+        <RegisterChatSession conversationId={conversationId} />
+        <CaptureChatSession
+          conversationId={conversationId}
+          onSession={(value) => {
+            session = value;
+          }}
+        />
+      </ChatProvider>
+    );
+    const { rerender } = render(tree());
+    await waitFor(() => expect(session).toBeDefined());
+    act(() => {
+      chatMessageQueue.enqueue(conversationId, {
+        text: "keep this correction",
+      });
+      session?.stop({ preserveQueuedMessages: true, stopServer });
+    });
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: { id: "failed-stream", role: "assistant", parts: [] },
+        isAbort: false,
+        isError: true,
+      });
+    });
+    if (turn === "new turn") {
+      messages = [
+        ...messages,
+        {
+          id: "new-user",
+          role: "user",
+          parts: [{ type: "text", text: "A different request" }],
+        },
+      ];
+      rerender(tree());
+    }
+    await act(async () => resolveStop());
+    expect(mocks.stop).toHaveBeenCalledTimes(turn === "same turn" ? 1 : 0);
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: { id: "aborted-stream", role: "assistant", parts: [] },
+        isAbort: true,
+        isError: false,
+      });
+    });
+    expect(chatMessageQueue.get(conversationId)).toHaveLength(
+      turn === "same turn" ? 1 : 0,
+    );
+    status = "ready";
+    rerender(tree());
+    await waitFor(() =>
+      expect(mocks.sendMessage).toHaveBeenCalledTimes(
+        turn === "same turn" ? 1 : 0,
+      ),
+    );
   });
 
   it("keeps instructions queued while an initially empty-queue stop is settling", async () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -131,7 +131,10 @@ interface ChatSession {
     partIndex: number;
     text: string;
   }) => Promise<void>;
-  stop: (options?: { preserveQueuedMessages?: boolean }) => void;
+  stop: (options?: {
+    preserveQueuedMessages?: boolean;
+    after?: Promise<unknown>;
+  }) => void;
   status: "ready" | "submitted" | "streaming" | "error";
   error: Error | undefined;
   setMessages: ReturnType<typeof useChat>["setMessages"];
@@ -605,6 +608,7 @@ function ChatSessionHook({
   // onData), which close over the config object before `messages` exists.
   // Assigned every render right after useChat returns.
   const latestMessagesRef = useRef<UIMessage[]>(initialMessages);
+  const latestStatusRef = useRef<ChatSession["status"]>("ready");
   const preserveQueuedMessagesOnAbortRef = useRef(false);
 
   const {
@@ -671,6 +675,8 @@ function ChatSessionHook({
     experimental_throttle: 100,
     id: conversationId,
     onFinish: async ({ message, isAbort, isError }) => {
+      const preserveQueuedMessages = preserveQueuedMessagesOnAbortRef.current;
+      preserveQueuedMessagesOnAbortRef.current = false;
       setOptimisticToolCalls([]);
       setPendingMcpElicitation(null);
       clearActiveContextCompaction();
@@ -707,10 +713,9 @@ function ChatSessionHook({
         // An explicit steering interrupt preserves queued follow-ups so the
         // normal ready-state drain can deliver the oldest one immediately.
         // Other aborts remain a hard boundary and discard pending work.
-        if (!preserveQueuedMessagesOnAbortRef.current) {
+        if (!preserveQueuedMessages) {
           chatMessageQueue.clear(conversationId);
         }
-        preserveQueuedMessagesOnAbortRef.current = false;
         // The updater form runs against the SDK's live messages, not this
         // callback's (throttled, possibly stale) closure, so the most recently
         // streamed text is never rolled back.
@@ -1084,6 +1089,7 @@ function ChatSessionHook({
   } as Parameters<typeof useChat>[0]);
 
   latestMessagesRef.current = messages;
+  latestStatusRef.current = status;
 
   // Text and tool-call deltas update the SDK's raw message list. Track that
   // progress independently from displayedMessages, which can intentionally be
@@ -1348,10 +1354,34 @@ function ChatSessionHook({
   // update only — no state changes, no re-renders.
   const sessionRef = useRef<ChatSession>(null as unknown as ChatSession);
   const stopSession = useCallback(
-    (options?: { preserveQueuedMessages?: boolean }) => {
+    (options?: {
+      preserveQueuedMessages?: boolean;
+      after?: Promise<unknown>;
+    }) => {
       preserveQueuedMessagesOnAbortRef.current =
         options?.preserveQueuedMessages === true;
-      stop();
+      if (!options?.after) {
+        stop();
+        return;
+      }
+
+      const activeUserMessageId = [...latestMessagesRef.current]
+        .reverse()
+        .find((message) => message.role === "user")?.id;
+      void options.after.finally(() => {
+        const latestUserMessageId = [...latestMessagesRef.current]
+          .reverse()
+          .find((message) => message.role === "user")?.id;
+        const responseStillInFlight =
+          latestStatusRef.current === "submitted" ||
+          latestStatusRef.current === "streaming";
+        if (
+          responseStillInFlight &&
+          latestUserMessageId === activeUserMessageId
+        ) {
+          stop();
+        }
+      });
     },
     [stop],
   );

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -133,7 +133,7 @@ interface ChatSession {
   }) => Promise<void>;
   stop: (options?: {
     preserveQueuedMessages?: boolean;
-    after?: Promise<unknown>;
+    stopServer?: () => Promise<unknown>;
   }) => void;
   status: "ready" | "submitted" | "streaming" | "error";
   error: Error | undefined;
@@ -610,6 +610,8 @@ function ChatSessionHook({
   const latestMessagesRef = useRef<UIMessage[]>(initialMessages);
   const latestStatusRef = useRef<ChatSession["status"]>("ready");
   const preserveQueuedMessagesOnAbortRef = useRef(false);
+  const stopInFlightRef = useRef(false);
+  const [isStopping, setIsStopping] = useState(false);
 
   const {
     messages,
@@ -1230,6 +1232,8 @@ function ChatSessionHook({
     if (
       status !== "ready" ||
       error ||
+      isStopping ||
+      stopInFlightRef.current ||
       queuedMessages.length === 0 ||
       !resumeSettled ||
       queueDrainInFlightRef.current ||
@@ -1263,6 +1267,7 @@ function ChatSessionHook({
     status,
     error,
     queuedMessages,
+    isStopping,
     resumeSettled,
     hasPendingApprovalRequest,
     pendingMcpElicitation,
@@ -1356,19 +1361,22 @@ function ChatSessionHook({
   const stopSession = useCallback(
     (options?: {
       preserveQueuedMessages?: boolean;
-      after?: Promise<unknown>;
+      stopServer?: () => Promise<unknown>;
     }) => {
+      if (stopInFlightRef.current) return;
       preserveQueuedMessagesOnAbortRef.current =
         options?.preserveQueuedMessages === true;
-      if (!options?.after) {
+      if (!options?.stopServer) {
         stop();
         return;
       }
 
+      stopInFlightRef.current = true;
+      setIsStopping(true);
       const activeUserMessageId = [...latestMessagesRef.current]
         .reverse()
         .find((message) => message.role === "user")?.id;
-      void options.after.finally(() => {
+      const finishStop = async () => {
         const latestUserMessageId = [...latestMessagesRef.current]
           .reverse()
           .find((message) => message.role === "user")?.id;
@@ -1379,9 +1387,12 @@ function ChatSessionHook({
           responseStillInFlight &&
           latestUserMessageId === activeUserMessageId
         ) {
-          stop();
+          await stop();
         }
-      });
+        stopInFlightRef.current = false;
+        setIsStopping(false);
+      };
+      void options.stopServer().then(finishStop, finishStop);
     },
     [stop],
   );

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -131,7 +131,7 @@ interface ChatSession {
     partIndex: number;
     text: string;
   }) => Promise<void>;
-  stop: () => void;
+  stop: (options?: { preserveQueuedMessages?: boolean }) => void;
   status: "ready" | "submitted" | "streaming" | "error";
   error: Error | undefined;
   setMessages: ReturnType<typeof useChat>["setMessages"];
@@ -605,6 +605,7 @@ function ChatSessionHook({
   // onData), which close over the config object before `messages` exists.
   // Assigned every render right after useChat returns.
   const latestMessagesRef = useRef<UIMessage[]>(initialMessages);
+  const preserveQueuedMessagesOnAbortRef = useRef(false);
 
   const {
     messages,
@@ -703,9 +704,13 @@ function ChatSessionHook({
       // perpetually "running" tool. Drop those dangling parts so the live view
       // matches what the backend persists (and a reload would show).
       if (isAbort) {
-        // Stop is a hard boundary: queued follow-ups belong to the work the
-        // user just cancelled and must never auto-submit after the abort.
-        chatMessageQueue.clear(conversationId);
+        // An explicit steering interrupt preserves queued follow-ups so the
+        // normal ready-state drain can deliver the oldest one immediately.
+        // Other aborts remain a hard boundary and discard pending work.
+        if (!preserveQueuedMessagesOnAbortRef.current) {
+          chatMessageQueue.clear(conversationId);
+        }
+        preserveQueuedMessagesOnAbortRef.current = false;
         // The updater form runs against the SDK's live messages, not this
         // callback's (throttled, possibly stale) closure, so the most recently
         // streamed text is never rolled back.
@@ -1342,6 +1347,14 @@ function ChatSessionHook({
   // function references from useChat which change every render). This is a ref
   // update only — no state changes, no re-renders.
   const sessionRef = useRef<ChatSession>(null as unknown as ChatSession);
+  const stopSession = useCallback(
+    (options?: { preserveQueuedMessages?: boolean }) => {
+      preserveQueuedMessagesOnAbortRef.current =
+        options?.preserveQueuedMessages === true;
+      stop();
+    },
+    [stop],
+  );
   sessionRef.current = {
     conversationId,
     messages: displayedMessages,
@@ -1349,7 +1362,7 @@ function ChatSessionHook({
     responseProgressSequence: streamActivity.responseProgressSequence,
     sendMessage,
     regenerateUserMessage,
-    stop,
+    stop: stopSession,
     status,
     error,
     setMessages,
@@ -1401,7 +1414,7 @@ function ChatSessionHook({
     streamActivity,
     sendMessage,
     regenerateUserMessage,
-    stop,
+    stopSession,
     status,
     error,
     setMessages,

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -1392,7 +1392,11 @@ function ChatSessionHook({
         stopInFlightRef.current = false;
         setIsStopping(false);
       };
-      void options.stopServer().then(finishStop, finishStop);
+      void options.stopServer().then(finishStop, () => {
+        preserveQueuedMessagesOnAbortRef.current = false;
+        stopInFlightRef.current = false;
+        setIsStopping(false);
+      });
     },
     [stop],
   );

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -1393,7 +1393,6 @@ function ChatSessionHook({
         setIsStopping(false);
       };
       void options.stopServer().then(finishStop, () => {
-        preserveQueuedMessagesOnAbortRef.current = false;
         stopInFlightRef.current = false;
         setIsStopping(false);
       });

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -609,7 +609,9 @@ function ChatSessionHook({
   // Assigned every render right after useChat returns.
   const latestMessagesRef = useRef<UIMessage[]>(initialMessages);
   const latestStatusRef = useRef<ChatSession["status"]>("ready");
-  const preserveQueuedMessagesOnAbortRef = useRef(false);
+  const preserveQueuedMessagesOnAbortRef = useRef<{
+    userMessageId: string | undefined;
+  } | null>(null);
   const stopInFlightRef = useRef(false);
   const [isStopping, setIsStopping] = useState(false);
 
@@ -677,8 +679,18 @@ function ChatSessionHook({
     experimental_throttle: 100,
     id: conversationId,
     onFinish: async ({ message, isAbort, isError }) => {
-      const preserveQueuedMessages = preserveQueuedMessagesOnAbortRef.current;
-      preserveQueuedMessagesOnAbortRef.current = false;
+      const preservation = preserveQueuedMessagesOnAbortRef.current;
+      const preserveQueuedMessages =
+        preservation !== null &&
+        preservation.userMessageId ===
+          latestMessagesRef.current.findLast((part) => part.role === "user")
+            ?.id;
+      // A failed stream can reattach to the same turn while its server stop
+      // is pending. Preserve that intent until the turn actually finishes;
+      // a different user message must never inherit it.
+      if (!isError || !preserveQueuedMessages) {
+        preserveQueuedMessagesOnAbortRef.current = null;
+      }
       setOptimisticToolCalls([]);
       setPendingMcpElicitation(null);
       clearActiveContextCompaction();
@@ -1364,8 +1376,12 @@ function ChatSessionHook({
       stopServer?: () => Promise<unknown>;
     }) => {
       if (stopInFlightRef.current) return;
-      preserveQueuedMessagesOnAbortRef.current =
-        options?.preserveQueuedMessages === true;
+      const activeUserMessageId = latestMessagesRef.current.findLast(
+        (message) => message.role === "user",
+      )?.id;
+      preserveQueuedMessagesOnAbortRef.current = options?.preserveQueuedMessages
+        ? { userMessageId: activeUserMessageId }
+        : null;
       if (!options?.stopServer) {
         stop();
         return;
@@ -1373,13 +1389,10 @@ function ChatSessionHook({
 
       stopInFlightRef.current = true;
       setIsStopping(true);
-      const activeUserMessageId = [...latestMessagesRef.current]
-        .reverse()
-        .find((message) => message.role === "user")?.id;
       const finishStop = async () => {
-        const latestUserMessageId = [...latestMessagesRef.current]
-          .reverse()
-          .find((message) => message.role === "user")?.id;
+        const latestUserMessageId = latestMessagesRef.current.findLast(
+          (message) => message.role === "user",
+        )?.id;
         const responseStillInFlight =
           latestStatusRef.current === "submitted" ||
           latestStatusRef.current === "streaming";


### PR DESCRIPTION
Stop and Escape interrupt the active Chat answer and send the oldest queued instruction, with remaining messages delivered in order. Coalesce repeated interrupts, preserve messages queued while stopping, and retain the queue when the stop request fails. Stopping with an empty queue sends nothing else. Queue preservation survives stream recovery for the interrupted user turn and cannot leak into a later user turn.

The original real-streaming workflow covered two queued corrections, repeated Stop, empty-queue Escape, and stop-failure recovery. Regression coverage exercises queue changes during interruption, ordered delivery, ambiguous stop responses, and a stream error arriving before the requested stop completes. The recovery regression discarded the queued instruction before the fix and preserves it afterward; a later unrelated turn still clears its queue on abort. Chat documentation describes the updated behavior.
