### PR TITLE
fix(agent-runtime): validate and report continuation startup

### DIFF
--- a/docs/pages/platform-agent-runtime.md
+++ b/docs/pages/platform-agent-runtime.md
@@ -59,7 +59,7 @@ Assigned MCP tools are available through the Agent's gateway with the initiating
 - **Personal Claude subscription:** each person connects their own Pro or Max account. Subscription inference goes directly to Anthropic and bypasses Archestra's inference logs, cost limits, and inference guardrails. MCP tool policies still apply.
 - **API key or cloud provider:** use Anthropic, AWS Bedrock, or Anthropic on Vertex AI through Archestra's proxy. Platform inference controls apply. See [Supported LLM Providers](/docs/platform-supported-llm-providers) for setup.
 
-Personal Claude connections belong to one user, Agent, and Environment. They work only in the Claude Code runtime. Tokens use your configured secrets backend. Reconnect when the connection expires or to refresh available models.
+Personal Claude connections belong to one user, Agent, and Environment. They work only in the Claude Code runtime. Tokens use your configured secrets backend. Reconnect after changing the runtime image, when the connection expires, or to refresh available models.
 
 With read-only Vault, generate a token using `claude setup-token`, store it in Vault, and connect its `path#key` reference. Disconnect prevents new runs from using a connection; running sessions retain their issued token. Revoke it in Claude to end provider access.
 

--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -23,12 +23,12 @@ import {
 } from "@/models";
 import { RouteCategory, startActiveChatSpan } from "@/observability/tracing";
 import { validateMCPGatewayToken } from "@/routes/mcp-gateway/utils";
-import { preflightAgentRuntimeModelCompatibility } from "@/services/agent-runtime/model-compatibility";
 import {
   resolveAgentRuntime,
   resumeAgentRun,
   runTaskInAgentRuntime,
 } from "@/services/agent-runtime/pod-run";
+import { preflightAgentRuntimeLaunch } from "@/services/agent-runtime/preflight";
 import type {
   A2AContext,
   A2AMessage,
@@ -448,11 +448,10 @@ export class A2AManager {
         !task &&
         runtime
       ) {
-        await preflightAgentRuntimeModelCompatibility({
+        await preflightAgentRuntimeLaunch({
           runtime,
           agent,
-          organizationId: actor.organizationId,
-          userId: actor.kind === "user" ? actor.id : "system",
+          actor,
         });
       }
 

--- a/platform/backend/src/archestra-mcp-server/tasks.continuation.test.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.continuation.test.ts
@@ -1,0 +1,208 @@
+import {
+  TOOL_START_RUN_FULL_NAME,
+  TOOL_STEER_RUN_FULL_NAME,
+} from "@archestra/shared";
+import { onTestFinished, vi } from "vitest";
+import { chatOpsManager } from "@/agents/chatops/chatops-manager";
+import config from "@/config";
+import { agentRuntimeManager } from "@/k8s/agent-runtime";
+import { claudeCodeAccountRuntime } from "@/k8s/agent-runtime/claude-code-account";
+import {
+  A2AContextModel,
+  A2ATaskModel,
+  AgentRunModel,
+  AgentWorkspaceModel,
+} from "@/models";
+import { kubernetesAgentRuntimeBackendDriver as backend } from "@/services/agent-runtime/backends/kubernetes";
+import { claudeCodeAccountManager } from "@/services/agent-runtime/claude-code-account";
+import { resolveAgentRuntime } from "@/services/agent-runtime/pod-run";
+import { beforeEach, expect, test } from "@/test";
+import type { Agent, ResolvedAgentRuntime } from "@/types";
+import { type ArchestraContext, executeArchestraTool } from ".";
+
+let agent: Agent;
+let runtime: ResolvedAgentRuntime;
+let context: ArchestraContext;
+let userId: string;
+
+beforeEach(
+  async ({
+    makeOrganization,
+    makeAdmin,
+    makeMember,
+    makeAgent,
+    seedAndAssignArchestraTools,
+  }) => {
+    const previous = {
+      enabled: config.agentRuntime.enabled,
+      url: config.agentRuntime.platformBaseUrl,
+    };
+    config.agentRuntime.enabled = true;
+    config.agentRuntime.platformBaseUrl = "https://platform.example.test";
+    onTestFinished(() => {
+      config.agentRuntime.enabled = previous.enabled;
+      config.agentRuntime.platformBaseUrl = previous.url;
+    });
+    vi.spyOn(agentRuntimeManager, "isEnabled", "get").mockReturnValue(true);
+    vi.spyOn(backend, "isEnabled", "get").mockReturnValue(true);
+    const org = await makeOrganization();
+    const user = await makeAdmin();
+    userId = user.id;
+    await makeMember(userId, org.id, { role: "admin" });
+    agent = await makeAgent({
+      organizationId: org.id,
+      authorId: userId,
+      agentType: "agent",
+      scope: "org",
+      runtime: {
+        image: "example.test/claude-code:current",
+        command: ["archestra-claude-code"],
+        inferenceProtocol: "anthropic",
+        backend: "kubernetes",
+        steerMode: "tmux_keys",
+        privileged: false,
+        resources: null,
+        environment: null,
+        credentials: null,
+        ttlHours: null,
+        maxCostUsd: null,
+        idleTimeoutMinutes: null,
+        claudeCode: { authentication: "subscription" },
+      },
+    });
+    const resolved = resolveAgentRuntime(agent);
+    if (!resolved) throw new Error("Expected runtime");
+    runtime = resolved;
+    await seedAndAssignArchestraTools(agent.id);
+    context = {
+      agent: { id: agent.id, name: agent.name },
+      agentId: agent.id,
+      userId,
+      organizationId: org.id,
+    };
+  },
+);
+
+test.for([
+  "initial",
+  "continuation",
+] as const)("%s reports an image-bound credential refusal before creating detached work", async (mode) => {
+  await connect({ ...runtime, image: "example.test/claude-code:previous" });
+  const previous = mode === "continuation" ? await retainedRun() : null;
+  const result = await executeArchestraTool(
+    mode === "initial" ? TOOL_START_RUN_FULL_NAME : TOOL_STEER_RUN_FULL_NAME,
+    previous
+      ? { task_id: previous.taskId, message: "Revise the UI and demo it" }
+      : { agent_id: agent.id, message: "Implement the UI" },
+    context,
+  );
+  expect(result.isError).toBe(true);
+  expect(JSON.stringify(result.content)).toContain("CLAUDE_CODE_ACCOUNT");
+  expect(JSON.stringify(result.content)).toContain(
+    `/agents/${agent.id}?section=advanced&setup=credentials`,
+  );
+  const tasks = await A2ATaskModel.listForActor({
+    actorKind: "user",
+    actorId: userId,
+    agentId: agent.id,
+    pageSize: 100,
+  });
+  expect(tasks.tasks).toHaveLength(previous ? 1 : 0);
+});
+
+test("an accepted continuation exposes its new task ID and reports a later startup failure to the original thread", async () => {
+  await connect(runtime);
+  const previous = await retainedRun();
+  const notify = vi
+    .spyOn(chatOpsManager, "notifyBindingThread")
+    .mockResolvedValue();
+  vi.spyOn(backend, "continueRun").mockRejectedValue(
+    new Error("Runtime transport unavailable"),
+  );
+  vi.spyOn(backend, "stopRun").mockResolvedValue(undefined);
+  vi.spyOn(backend, "releaseRun").mockResolvedValue();
+  const result = await executeArchestraTool(
+    TOOL_STEER_RUN_FULL_NAME,
+    { task_id: previous.taskId, message: "Revise the UI and demo it" },
+    context,
+  );
+  expect(result.isError).toBe(false);
+  const reply = JSON.parse((result.content[0] as { text: string }).text);
+  expect(reply.task_id).not.toBe(previous.taskId);
+  expect(reply.status).toBe("accepted");
+  await expect
+    .poll(async () => (await A2ATaskModel.findById(reply.task_id))?.state)
+    .toBe("TASK_STATE_FAILED");
+  await expect.poll(() => notify.mock.calls.length).toBe(1);
+  expect(notify).toHaveBeenCalledWith(
+    expect.objectContaining({
+      bindingId:
+        previous.completionTarget?.type === "chatops"
+          ? previous.completionTarget.bindingId
+          : "",
+      threadId: "thread-test",
+      text: expect.stringContaining("Runtime transport unavailable"),
+    }),
+  );
+});
+
+async function connect(approvedRuntime: ResolvedAgentRuntime) {
+  vi.spyOn(claudeCodeAccountRuntime, "create").mockResolvedValue();
+  vi.spyOn(claudeCodeAccountRuntime, "delete").mockResolvedValue();
+  vi.spyOn(claudeCodeAccountRuntime, "status").mockResolvedValue({
+    state: "connecting",
+  });
+  vi.spyOn(claudeCodeAccountRuntime, "complete").mockResolvedValue({
+    state: "connected",
+    token: `sk-ant-oat01-${"example".repeat(8)}`,
+    models: [],
+  });
+  const owner = { runtime: approvedRuntime, userId };
+  const flow = await claudeCodeAccountManager.start(owner);
+  await claudeCodeAccountManager.complete({
+    ...owner,
+    flowId: flow.flowId as string,
+  });
+}
+
+async function retainedRun() {
+  const a2aContext = await A2AContextModel.create({
+    actorKind: "user",
+    actorId: userId,
+  });
+  const task = await A2ATaskModel.create({
+    contextId: a2aContext.id,
+    agentId: agent.id,
+    state: "TASK_STATE_COMPLETED",
+  });
+  const session = await AgentRunModel.create({
+    organizationId: agent.organizationId,
+    agentId: agent.id,
+    taskId: task.id,
+    actorKind: "user",
+    actorId: userId,
+    actorUserId: userId,
+    workloadName: `retained-${task.id}`,
+    backend: "kubernetes",
+    runtimeScope: backend.resolveRuntimeScope({}),
+    completionTarget: {
+      type: "chatops",
+      bindingId: crypto.randomUUID(),
+      threadId: "thread-test",
+    },
+  });
+  await AgentRunModel.close({ id: session.id });
+  await AgentWorkspaceModel.create({
+    organizationId: agent.organizationId,
+    agentId: agent.id,
+    actorKind: "user",
+    actorId: userId,
+    backend: "kubernetes",
+    runtimeScope: session.runtimeScope,
+    workloadName: session.workloadName,
+    state: "idle",
+    lastTaskId: task.id,
+    expiresAt: new Date(Date.now() + 3600_000),
+  });
+  return session;
+}

--- a/platform/backend/src/archestra-mcp-server/tasks.ts
+++ b/platform/backend/src/archestra-mcp-server/tasks.ts
@@ -13,6 +13,7 @@ import {
 import { z } from "zod";
 import { type A2AActor, A2AError, A2AErrorKind } from "@/agents/a2a/a2a-base";
 import { watchChatOpsTask } from "@/agents/chatops/chatops-task-watcher";
+import { watchTaskCompletion } from "@/agents/task-completion-watcher";
 import { userHasPermission } from "@/auth/utils";
 import config from "@/config";
 import logger from "@/logging";
@@ -666,7 +667,7 @@ const registry = defineArchestraTools([
         }
         const agent = await AgentModel.findById(session.agentId);
         const runtime = agent ? resolveAgentRuntime(agent) : null;
-        if (!runtime) {
+        if (!agent || !runtime) {
           return errorResult(
             "The Agent no longer has Agent Runtime configured.",
           );
@@ -686,15 +687,27 @@ const registry = defineArchestraTools([
               projectId: session.projectId ?? undefined,
             },
           });
-          return structuredSuccessResult(
-            {
-              success: true,
-              task_id: continuation.id,
-              previous_task_id: session.taskId,
-              session_id: workspace?.id ?? session.taskId,
-            },
-            "Continuation started in the retained workspace using the same Agent.",
-          );
+          if (session.completionTarget) {
+            void watchTaskCompletion({
+              taskId: continuation.id,
+              target: session.completionTarget,
+              agentName: agent.name,
+            }).catch((error) => {
+              logger.warn(
+                { error, taskId: continuation.id },
+                "Failed to watch Agent continuation for completion",
+              );
+            });
+          }
+          return structuredSuccessResult({
+            success: true,
+            status: "accepted",
+            task_id: continuation.id,
+            previous_task_id: session.taskId,
+            session_id: workspace?.id ?? session.taskId,
+            message:
+              "Continuation accepted in the retained workspace. Poll get_run with task_id to verify startup and report any failure.",
+          });
         }
 
         await resolveAgentRuntimeBackendDriver(session.backend).steer({
@@ -711,6 +724,10 @@ const registry = defineArchestraTools([
           "Steer delivered. It lands at the loop's next turn boundary (pipe) or is typed into the session (tmux keys).",
         );
       } catch (error) {
+        const needed = missingCredentialsFrom(error);
+        if (needed) {
+          return credentialsNeededResult(needed.agentId, needed.missing);
+        }
         return catchError(error, "steering the run");
       }
     },

--- a/platform/backend/src/services/agent-runtime/preflight.ts
+++ b/platform/backend/src/services/agent-runtime/preflight.ts
@@ -1,0 +1,63 @@
+import type { A2AActor } from "@/agents/a2a/a2a-base";
+import type { Agent, ResolvedAgentRuntime } from "@/types";
+import { AgentRuntimeCredentialsRequiredError, ApiError } from "@/types";
+import { claudeCodeAccountManager } from "./claude-code-account";
+import { preflightAgentRuntimeCredentials } from "./credentials";
+import { preflightAgentRuntimeModelCompatibility } from "./model-compatibility";
+
+/** Reject actionable setup failures before returning a detached task handle. */
+export async function preflightAgentRuntimeLaunch(params: {
+  runtime: ResolvedAgentRuntime;
+  agent: Agent;
+  actor: A2AActor;
+}) {
+  const { runtime, agent, actor } = params;
+  const userId = actor.kind === "user" ? actor.id : null;
+  const { usesClaudeCodeSubscription } =
+    await preflightAgentRuntimeModelCompatibility({
+      runtime,
+      agent,
+      organizationId: actor.organizationId,
+      userId: userId ?? "system",
+    });
+  const credentials = await preflightAgentRuntimeCredentials({
+    runtime,
+    organizationId: actor.organizationId,
+    userId,
+  });
+  if (credentials.misconfigured.length > 0) {
+    throw new ApiError(
+      409,
+      `This Agent's Agent Runtime is missing shared credentials an administrator must configure: ${credentials.misconfigured.map((entry) => entry.label).join(", ")}`,
+    );
+  }
+  if (credentials.missing.length > 0) {
+    throw new AgentRuntimeCredentialsRequiredError(
+      runtime.agentId,
+      credentials.missing,
+    );
+  }
+  if (usesClaudeCodeSubscription) {
+    if (!userId) {
+      throw new ApiError(
+        409,
+        "A personal Claude subscription requires a run acting as a signed-in user.",
+      );
+    }
+    const account = await claudeCodeAccountManager.status({
+      runtime,
+      userId,
+      inspectFlow: false,
+    });
+    if (account.state !== "connected") {
+      throw new AgentRuntimeCredentialsRequiredError(runtime.agentId, [
+        {
+          key: "CLAUDE_CODE_ACCOUNT",
+          label: "Claude Code account",
+          description:
+            "Sign in with your own Claude account for this runtime image.",
+        },
+      ]);
+    }
+  }
+}


### PR DESCRIPTION
A follow-up to a finished Agent Runtime run could report success even when startup immediately failed because the current image had no valid personal connection. Those continuations also lacked the completion watcher, so a failure before workspace creation never reached the originating messaging thread.

Validate runtime credentials before returning a detached task handle, return the continuation ID with an explicit accepted status for polling, and watch continuations for completion or failure. Existing image-bound credential isolation is preserved.

Exercised the real MCP handlers and persisted task lifecycle against the test database: a connection approved for an older image refuses initial and continuation work before creating a task; an accepted continuation whose runtime transport fails reports that failure to its original thread. Native runtime processes and message delivery are stubbed at their external boundaries.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>