### PR TITLE
ci: use Docker Hub cache for Kind image pulls

### DIFF
--- a/.github/actions/install-kind-cluster/action.yml
+++ b/.github/actions/install-kind-cluster/action.yml
@@ -42,6 +42,25 @@ runs:
         install_only: false
         wait: 300s
 
+    - name: Configure Docker Hub cache for Kind nodes
+      shell: bash
+      env:
+        KIND_CLUSTER_NAME: ${{ inputs.cluster-name }}
+      run: |
+        # Containerd inside Kind does not inherit the host Docker configuration.
+        # Prefer Google's public Docker Hub cache, with upstream as the fallback
+        # for uncached images. Cover both reference forms used by our charts.
+        for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+          for registry in docker.io registry-1.docker.io; do
+            docker exec "${node}" mkdir -p "/etc/containerd/certs.d/${registry}"
+            docker exec -i "${node}" tee "/etc/containerd/certs.d/${registry}/hosts.toml" >/dev/null <<'EOF'
+        server = "https://registry-1.docker.io"
+        [host."https://mirror.gcr.io"]
+          capabilities = ["pull", "resolve"]
+        EOF
+          done
+        done
+
     - name: Save Kind node image to cache
       if: ${{ steps.cache-kind-node.outputs.cache-hit != 'true' }}
       shell: bash


### PR DESCRIPTION
Kind-based CI can fail before tests start when Docker Hub requests time out, leaving Vault, WireMock, PostgreSQL, or the network-policy probe in ImagePullBackOff. Configure each CI node to try Google's public Docker Hub cache first and fall back to the upstream registry, covering both docker.io and registry-1.docker.io references. Image references and digest verification remain unchanged.

Exercised the actual action script on an isolated Kind v1.34.3 node: with Docker Hub blocked, all four affected images pulled successfully, including PostgreSQL by its pinned digest. Removing the cache configuration reproduced the pull failure. Blocking the cache instead confirmed a fresh Alpine pull falls back to Docker Hub. This changes CI setup only.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>