### PR TITLE
ci: cache Docker Hub pulls in embedded Kind clusters

### DIFF
--- a/.github/actions/configure-kind-registry-cache/action.yml
+++ b/.github/actions/configure-kind-registry-cache/action.yml
@@ -1,0 +1,37 @@
+name: Configure Kind Registry Cache
+description: Prefer the public Docker Hub cache for all nodes in an existing CI Kind cluster.
+
+inputs:
+  cluster-name:
+    description: Name of the existing Kind cluster
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Docker Hub cache for Kind nodes
+      shell: bash
+      env:
+        KIND_CLUSTER_NAME: ${{ inputs.cluster-name }}
+      run: |
+        # Embedded clusters share the runner's Docker socket, but the runner
+        # need not have the Kind CLI installed. Its node label identifies both
+        # embedded and host-created clusters without relying on node names.
+        nodes=$(docker ps --filter "label=io.x-k8s.kind.cluster=${KIND_CLUSTER_NAME}" --format '{{.Names}}')
+        if [ -z "${nodes}" ]; then
+          echo "No running Kind nodes found for ${KIND_CLUSTER_NAME}" >&2
+          exit 1
+        fi
+
+        # Containerd does not inherit the host Docker configuration. Cover both
+        # reference forms used by our charts, with upstream fallback on a miss.
+        for node in ${nodes}; do
+          for registry in docker.io registry-1.docker.io; do
+            docker exec "${node}" mkdir -p "/etc/containerd/certs.d/${registry}"
+            docker exec -i "${node}" tee "/etc/containerd/certs.d/${registry}/hosts.toml" >/dev/null <<'EOF'
+        server = "https://registry-1.docker.io"
+        [host."https://mirror.gcr.io"]
+          capabilities = ["pull", "resolve"]
+        EOF
+          done
+        done

--- a/.github/actions/install-kind-cluster/action.yml
+++ b/.github/actions/install-kind-cluster/action.yml
@@ -43,23 +43,9 @@ runs:
         wait: 300s
 
     - name: Configure Docker Hub cache for Kind nodes
-      shell: bash
-      env:
-        KIND_CLUSTER_NAME: ${{ inputs.cluster-name }}
-      run: |
-        # Containerd inside Kind does not inherit the host Docker configuration.
-        # Prefer Google's public Docker Hub cache, with upstream as the fallback
-        # for uncached images. Cover both reference forms used by our charts.
-        for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
-          for registry in docker.io registry-1.docker.io; do
-            docker exec "${node}" mkdir -p "/etc/containerd/certs.d/${registry}"
-            docker exec -i "${node}" tee "/etc/containerd/certs.d/${registry}/hosts.toml" >/dev/null <<'EOF'
-        server = "https://registry-1.docker.io"
-        [host."https://mirror.gcr.io"]
-          capabilities = ["pull", "resolve"]
-        EOF
-          done
-        done
+      uses: ./.github/actions/configure-kind-registry-cache
+      with:
+        cluster-name: ${{ inputs.cluster-name }}
 
     - name: Save Kind node image to cache
       if: ${{ steps.cache-kind-node.outputs.cache-hit != 'true' }}

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -910,6 +910,11 @@ jobs:
           MCP_SERVER_BASE_IMAGE: ${{ env.UNTRUSTED_PR == 'true' && format('{0}/{1}:latest', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME) || format('{0}/{1}:{2}', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME, github.sha) }}
         run: ./platform/scripts/e2e-lite.sh up
 
+      - name: Configure embedded Kind registry cache
+        uses: ./.github/actions/configure-kind-registry-cache
+        with:
+          cluster-name: archestra-mcp
+
       - name: Create e2e test env file
         run: |
           # UI/API must be "localhost", not 127.0.0.1: the SSO specs bounce the
@@ -1122,6 +1127,11 @@ jobs:
           fi
 
           echo "All services are ready!"
+
+      - name: Configure embedded Kind registry cache
+        uses: ./.github/actions/configure-kind-registry-cache
+        with:
+          cluster-name: archestra-mcp
 
       # The API and the Next.js server both bind IPv4 only, but `localhost`
       # resolves to ::1 first — getaddrinfo applies RFC 6724 precedence


### PR DESCRIPTION
The lite API tests can time out installing an MCP server because their embedded Kind cluster still pulls directly from Docker Hub. The host-cluster cache does not reach this separate cluster. Apply the same cache with upstream fallback to the embedded clusters used by lite and quickstart CI, before their tests run.

Move the existing configuration into a shared action that locates running nodes by their Kind cluster label, so it also works when the host has Docker but no Kind CLI. A missing cluster fails explicitly. Exercised the actual action against an isolated Kind v1.34.3 cluster: blocked direct Docker Hub access and successfully pulled the exact Context7 fixture image that timed out in CI; verified an unknown cluster fails. The cache and upstream-fallback paths were also exercised with real pulls in the preceding host-cluster fix. Application image references and test assertions are unchanged.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>