### PR TITLE
fix(llm): stop offering credentials for model providers the organization turned off

### DIFF
--- a/platform/frontend/src/components/chat/llm-provider-api-key-selector.test.tsx
+++ b/platform/frontend/src/components/chat/llm-provider-api-key-selector.test.tsx
@@ -1,3 +1,4 @@
+import { SupportedProviders } from "@archestra/shared";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -7,8 +8,14 @@ import {
   type LlmProviderApiKey,
   useAvailableLlmProviderApiKeys,
 } from "@/lib/llm-provider-api-keys.query";
+import { useOrganization } from "@/lib/organization.query";
 
 vi.mock("@/lib/auth/auth.query");
+
+// The selector resolves connectable subscriptions through
+// useModelProviderCatalog() -> useOrganization(); no organization data means
+// "no admin overrides", i.e. every provider available.
+vi.mock("@/lib/organization.query");
 
 vi.mock("@/lib/chat/chat.query", () => ({
   useUpdateConversation: vi.fn(),
@@ -97,6 +104,9 @@ describe("LlmProviderApiKeySelector subscriptions", () => {
       data: [],
       isLoading: false,
     } as unknown as ReturnType<typeof useAvailableLlmProviderApiKeys>);
+    vi.mocked(useOrganization).mockReturnValue({
+      data: undefined,
+    } as unknown as ReturnType<typeof useOrganization>);
   });
 
   it("shows every subscription when none are connected", () => {
@@ -113,6 +123,66 @@ describe("LlmProviderApiKeySelector subscriptions", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "SuperGrok Connect" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not offer a subscription whose provider the organization turned off", () => {
+    // Offering it opened a sign-in dialog that refuses the hidden provider,
+    // so the only outcome was "No compatible LLM providers are enabled".
+    vi.mocked(useOrganization).mockReturnValue({
+      data: { modelProviderOverrides: { xai: { hidden: true } } },
+    } as unknown as ReturnType<typeof useOrganization>);
+
+    renderSelector();
+
+    expect(
+      screen.queryByRole("button", { name: "SuperGrok Connect" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "ChatGPT Subscription Connect" }),
+    ).toBeInTheDocument();
+  });
+
+  it("drops the add-key option when every provider is turned off", () => {
+    vi.mocked(useOrganization).mockReturnValue({
+      data: {
+        modelProviderOverrides: Object.fromEntries(
+          SupportedProviders.map((provider) => [provider, { hidden: true }]),
+        ),
+      },
+    } as unknown as ReturnType<typeof useOrganization>);
+
+    renderSelector();
+
+    expect(
+      screen.queryByRole("button", { name: "Add provider key" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps a connected key selectable after its provider is turned off", () => {
+    // Switching a provider off withdraws the offer, not credentials that
+    // already exist — those go on working.
+    vi.mocked(useOrganization).mockReturnValue({
+      data: { modelProviderOverrides: { xai: { hidden: true } } },
+    } as unknown as ReturnType<typeof useOrganization>);
+    vi.mocked(useAvailableLlmProviderApiKeys).mockReturnValue({
+      data: [
+        {
+          id: "x-premium-key",
+          name: "SuperGrok",
+          provider: "xai",
+          scope: "personal",
+          userId: "current-user",
+          subscriptionKind: "x-premium",
+        },
+      ] as unknown as LlmProviderApiKey[],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAvailableLlmProviderApiKeys>);
+
+    renderSelector();
+
+    expect(
+      screen.getByRole("button", { name: /SuperGrok Connected/ }),
     ).toBeInTheDocument();
   });
 

--- a/platform/frontend/src/components/chat/llm-provider-api-key-selector.tsx
+++ b/platform/frontend/src/components/chat/llm-provider-api-key-selector.tsx
@@ -15,6 +15,7 @@ import type { LlmProviderApiKeyFormValues } from "@/components/llm-provider-api-
 import { useLlmProviderApiKeyCreateDialog } from "@/components/use-llm-provider-api-key-create-dialog";
 import { useSession } from "@/lib/auth/auth.query";
 import { useUpdateConversation } from "@/lib/chat/chat.query";
+import { useModelProviderCatalog } from "@/lib/integration-overrides";
 import {
   type LlmProviderApiKey,
   useAvailableLlmProviderApiKeys,
@@ -118,13 +119,19 @@ export function LlmProviderApiKeySelector({
       ),
     [fetchedAvailableKeys, session?.user.id],
   );
+  // A subscription whose provider the admins turned off is not connectable:
+  // the sign-in dialog refuses a hidden provider, so offering it here would
+  // only lead to a dead end. An already-connected credential keeps its entry
+  // below — existing keys go on working when a provider is switched off.
+  const providerCatalog = useModelProviderCatalog();
   const subscriptionOptions = useMemo(
     () =>
       SUBSCRIPTION_CONNECT_OPTIONS.filter(
         (option) =>
+          !providerCatalog.isHidden(option.provider) &&
           !availableKeys.some((key) => subscriptionMatchesKey(option, key)),
       ),
-    [availableKeys],
+    [availableKeys, providerCatalog],
   );
   const displayedKeys = useMemo(
     () => [...availableKeys, ...subscriptionOptions],
@@ -406,7 +413,11 @@ export function LlmProviderApiKeySelector({
         open={open}
         onOpenChange={handleOpenChange}
         onSelectKey={handleSelectKey}
-        onAddApiKey={onAddApiKey}
+        // With every provider switched off there is no key left to add, and
+        // the create dialog would open on an empty picker.
+        onAddApiKey={
+          providerCatalog.visibleIds.length > 0 ? onAddApiKey : undefined
+        }
         currentProvider={currentProvider}
         searchPlaceholder="Search credentials..."
         showChatTestIds

--- a/platform/frontend/src/components/no-api-key-setup.test.tsx
+++ b/platform/frontend/src/components/no-api-key-setup.test.tsx
@@ -1,7 +1,14 @@
+import { SupportedProviders } from "@archestra/shared";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useOrganization } from "@/lib/organization.query";
 import { NoApiKeySetup } from "./no-api-key-setup";
+
+// This empty state resolves what it may offer through
+// useModelProviderCatalog() -> useOrganization(); no organization data means
+// "no admin overrides", i.e. every provider available.
+vi.mock("@/lib/organization.query");
 
 vi.mock("@/components/create-llm-provider-api-key-dialog", () => ({
   CreateLlmProviderApiKeyDialog: ({
@@ -22,6 +29,12 @@ vi.mock("@/components/create-llm-provider-api-key-dialog", () => ({
 }));
 
 describe("NoApiKeySetup", () => {
+  beforeEach(() => {
+    vi.mocked(useOrganization).mockReturnValue({
+      data: undefined,
+    } as unknown as ReturnType<typeof useOrganization>);
+  });
+
   it("offers subscriptions alongside the API key setup", async () => {
     const user = userEvent.setup();
     render(<NoApiKeySetup />);
@@ -53,5 +66,43 @@ describe("NoApiKeySetup", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("openai")).toBeInTheDocument();
     expect(screen.getByText("subscription")).toBeInTheDocument();
+  });
+
+  it("drops a subscription whose provider the organization turned off", () => {
+    vi.mocked(useOrganization).mockReturnValue({
+      data: { modelProviderOverrides: { xai: { hidden: true } } },
+    } as unknown as ReturnType<typeof useOrganization>);
+
+    render(<NoApiKeySetup />);
+
+    expect(
+      screen.queryByRole("button", { name: "Sign in with Grok" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sign in with ChatGPT" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add API Key" }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers nothing to add when every provider is turned off", () => {
+    vi.mocked(useOrganization).mockReturnValue({
+      data: {
+        modelProviderOverrides: Object.fromEntries(
+          SupportedProviders.map((provider) => [provider, { hidden: true }]),
+        ),
+      },
+    } as unknown as ReturnType<typeof useOrganization>);
+
+    render(<NoApiKeySetup />);
+
+    expect(
+      screen.queryByRole("button", { name: "Add API Key" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/No model providers are available/),
+    ).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/no-api-key-setup.tsx
+++ b/platform/frontend/src/components/no-api-key-setup.tsx
@@ -7,10 +7,11 @@ import {
   type SupportedProvider,
 } from "@archestra/shared";
 import { Plus } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
 import type { LlmProviderApiKeyFormValues } from "@/components/llm-provider-api-key-form";
 import { Button } from "@/components/ui/button";
+import { useModelProviderCatalog } from "@/lib/integration-overrides";
 
 const DEFAULT_FORM_VALUES: Partial<LlmProviderApiKeyFormValues> = {
   isPrimary: true,
@@ -24,6 +25,9 @@ type SetupOption = {
   credentialMode: "api-key" | "subscription";
   showConsoleLink?: boolean;
 };
+
+/** A subscription entry, which always stands for exactly one provider. */
+type SubscriptionSetupOption = SetupOption & { provider: SupportedProvider };
 
 /**
  * Empty state shown when the user has no usable LLM provider key — on the new
@@ -44,6 +48,17 @@ export function NoApiKeySetup({
   onKeyAdded?: () => void;
 }) {
   const [setupOption, setSetupOption] = useState<SetupOption | null>(null);
+  // Nothing here may offer a provider the admins turned off: the create dialog
+  // refuses one, so the button would only open a dead end.
+  const providerCatalog = useModelProviderCatalog();
+  const subscriptionOptions = useMemo(
+    () =>
+      SUBSCRIPTION_SETUP_OPTIONS.filter(
+        (option) => !providerCatalog.isHidden(option.provider),
+      ),
+    [providerCatalog],
+  );
+  const hasVisibleProviders = providerCatalog.visibleIds.length > 0;
 
   return (
     <div className="flex h-full w-full items-center justify-center p-8">
@@ -53,35 +68,48 @@ export function NoApiKeySetup({
           <p className="text-sm text-muted-foreground">{description}</p>
         </div>
 
-        <div className="space-y-3">
-          <p className="text-sm font-medium">Personal subscriptions</p>
-          <div className="flex flex-wrap justify-center gap-2">
-            {SUBSCRIPTION_SETUP_OPTIONS.map((option) => (
-              <Button
-                key={option.title}
-                type="button"
-                variant="outline"
-                onClick={() => setSetupOption(option)}
-              >
-                {option.title}
-              </Button>
-            ))}
+        {subscriptionOptions.length > 0 && (
+          <div className="space-y-3">
+            <p className="text-sm font-medium">Personal subscriptions</p>
+            <div className="flex flex-wrap justify-center gap-2">
+              {subscriptionOptions.map((option) => (
+                <Button
+                  key={option.title}
+                  type="button"
+                  variant="outline"
+                  onClick={() => setSetupOption(option)}
+                >
+                  {option.title}
+                </Button>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
 
-        <div className="flex items-center gap-3 text-xs text-muted-foreground">
-          <div className="h-px flex-1 bg-border" />
-          <span>or use a provider API key</span>
-          <div className="h-px flex-1 bg-border" />
-        </div>
+        {hasVisibleProviders ? (
+          <>
+            {subscriptionOptions.length > 0 && (
+              <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                <div className="h-px flex-1 bg-border" />
+                <span>or use a provider API key</span>
+                <div className="h-px flex-1 bg-border" />
+              </div>
+            )}
 
-        <Button
-          data-testid={E2eTestId.QuickstartAddApiKeyButton}
-          onClick={() => setSetupOption(API_KEY_SETUP_OPTION)}
-        >
-          <Plus className="h-4 w-4" />
-          Add API Key
-        </Button>
+            <Button
+              data-testid={E2eTestId.QuickstartAddApiKeyButton}
+              onClick={() => setSetupOption(API_KEY_SETUP_OPTION)}
+            >
+              <Plus className="h-4 w-4" />
+              <span>Add API Key</span>
+            </Button>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No model providers are available. An administrator can turn one back
+            on under Settings → LLM.
+          </p>
+        )}
       </div>
       <CreateLlmProviderApiKeyDialog
         open={setupOption !== null}
@@ -116,13 +144,14 @@ const API_KEY_SETUP_OPTION: SetupOption = {
  * One "Sign in with <vendor>" entry per subscription in the shared registry,
  * so a new subscription appears on this empty state without editing it.
  */
-const SUBSCRIPTION_SETUP_OPTIONS: SetupOption[] =
+const SUBSCRIPTION_SETUP_OPTIONS: SubscriptionSetupOption[] =
   SUBSCRIPTION_CREDENTIAL_KINDS.map((kind) => {
     const { provider, label, marker, connect } = SUBSCRIPTION_CREDENTIALS[kind];
     return {
       title: connect.signInTitle,
       description: connect.signInDescription,
       credentialMode: "subscription" as const,
+      provider,
       allowedProviders: [provider],
       defaultValues: {
         name: label,

--- a/platform/frontend/src/lib/integration-overrides.integration.test.tsx
+++ b/platform/frontend/src/lib/integration-overrides.integration.test.tsx
@@ -1,0 +1,71 @@
+import { archestraApiSdk } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@archestra/shared", async () => {
+  const actual =
+    await vi.importActual<typeof import("@archestra/shared")>(
+      "@archestra/shared",
+    );
+  return {
+    ...actual,
+    archestraApiSdk: { ...actual.archestraApiSdk, getOrganization: vi.fn() },
+  };
+});
+
+import { useSession } from "@/lib/auth/auth.query";
+import { useModelProviderCatalog } from "@/lib/integration-overrides";
+import { organizationKeys } from "@/lib/organization.query";
+
+function XaiAvailability() {
+  const catalog = useModelProviderCatalog();
+  return <span>{catalog.isHidden("xai") ? "xai hidden" : "xai available"}</span>;
+}
+
+/**
+ * The catalog decides what every picker may offer, so it has to reflect what
+ * the server holds now — not what this browser cached before an admin changed
+ * it. The cache is seeded the way a refresh does it (the organization query is
+ * snapshotted and restored), which used to count as fresh for five minutes and
+ * left turned-off providers on offer until the entry aged out.
+ */
+describe("useModelProviderCatalog freshness", () => {
+  beforeEach(() => {
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "user-1" } },
+      isPending: false,
+    } as unknown as ReturnType<typeof useSession>);
+  });
+
+  it("re-reads the organization on mount instead of trusting a restored cache", async () => {
+    vi.mocked(archestraApiSdk.getOrganization).mockResolvedValue({
+      data: { modelProviderOverrides: { xai: { hidden: true } } },
+      error: undefined,
+    } as unknown as Awaited<
+      ReturnType<typeof archestraApiSdk.getOrganization>
+    >);
+
+    // The app's own default stale time, so this exercises the query's options
+    // rather than a client configured to refetch everything.
+    const client = new QueryClient({
+      defaultOptions: { queries: { staleTime: 60 * 1_000, retry: false } },
+    });
+    // Restored refresh snapshot: xAI was still available when it was written.
+    client.setQueryData(organizationKeys.details(), {
+      modelProviderOverrides: null,
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <XaiAvailability />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("xai hidden")).toBeInTheDocument(),
+    );
+    expect(archestraApiSdk.getOrganization).toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/lib/integration-overrides.integration.test.tsx
+++ b/platform/frontend/src/lib/integration-overrides.integration.test.tsx
@@ -21,7 +21,9 @@ import { organizationKeys } from "@/lib/organization.query";
 
 function XaiAvailability() {
   const catalog = useModelProviderCatalog();
-  return <span>{catalog.isHidden("xai") ? "xai hidden" : "xai available"}</span>;
+  return (
+    <span>{catalog.isHidden("xai") ? "xai hidden" : "xai available"}</span>
+  );
 }
 
 /**

--- a/platform/frontend/src/lib/integration-overrides.ts
+++ b/platform/frontend/src/lib/integration-overrides.ts
@@ -40,8 +40,24 @@ export type NamedIntegrationCatalog<Id extends string> =
     label: (id: Id) => string;
   };
 
+/**
+ * Read the organization the way availability decisions need it: revalidated on
+ * mount and whenever the tab regains focus.
+ *
+ * The plain read caches for five minutes and is kept current by mutations
+ * writing the key imperatively — enough for the app name and theme, wrong for
+ * a catalog. That write only lands in the tab that saved, and the query is
+ * restored from the refresh snapshot, so a tab that was already open (or
+ * merely reloaded within the window) went on offering a provider the admins
+ * had just switched off. Availability authorizes what may be configured, so it
+ * is read on the same terms as the connect page's settings.
+ */
+function useIntegrationOrganization() {
+  return useOrganization(true, { fresh: true });
+}
+
 export function useModelProviderCatalog(): NamedIntegrationCatalog<SupportedProvider> {
-  const { data: organization } = useOrganization();
+  const { data: organization } = useIntegrationOrganization();
   const overrides = organization?.modelProviderOverrides ?? null;
   return useMemo(
     () => ({
@@ -55,7 +71,7 @@ export function useModelProviderCatalog(): NamedIntegrationCatalog<SupportedProv
 }
 
 export function useMessagingChannelCatalog(): IntegrationCatalog<MessagingChannelId> {
-  const { data: organization } = useOrganization();
+  const { data: organization } = useIntegrationOrganization();
   const overrides = organization?.messagingChannelOverrides ?? null;
   return useMemo(
     () =>
@@ -68,7 +84,7 @@ export function useMessagingChannelCatalog(): IntegrationCatalog<MessagingChanne
 }
 
 export function useKnowledgeConnectorCatalog(): IntegrationCatalog<ConnectorType> {
-  const { data: organization } = useOrganization();
+  const { data: organization } = useIntegrationOrganization();
   const overrides = organization?.knowledgeConnectorOverrides ?? null;
   return useMemo(
     () =>


### PR DESCRIPTION
Switching a provider off under **Settings → LLM → Model providers** is documented as removing it from every picker, and the API refuses to configure it. Two things stopped that from holding in the UI.

**The offer lists were built from the subscription registry, not the catalog.** The chat composer's provider-key dropdown and the no-keys empty state each derived their "Connect <vendor>" entries straight from `SUBSCRIPTION_CREDENTIAL_KINDS`, so a turned-off vendor stayed on offer. Clicking one opened the create dialog with `allowedProviders` set to that single hidden provider, which the dialog intersects against the visible set — always empty, so the only reachable outcome was "No compatible LLM providers are enabled for this agent." The Model Providers page's subscription cards already filtered correctly; these two surfaces now resolve through the same catalog. With every provider off, the dropdown also drops its "Add provider key" row and the empty state says so rather than opening an empty picker.

**The catalog data itself went stale.** `useOrganization` caches for five minutes and is kept current by mutations writing the query key imperatively. That write only lands in the tab that saved, and the query carries `PERSISTED_QUERY_META`, so an entry restored from the refresh snapshot counted as fresh — a tab that was already open, or merely reloaded inside the window, kept offering a provider that had just been switched off. The three integration catalogs now read the organization on the terms the connect page already used (`fresh: true`): revalidated on mount and when the tab regains focus.

Credentials that already exist are deliberately untouched — a connected subscription stays listed and selectable after its provider is switched off, matching "keys that already exist keep working" elsewhere in the product.

### Tradeoffs

- This is revalidation, not push. A foreground tab nobody touches still waits for the next mount or focus before it notices an admin's change. True real-time would mean pushing invalidations over the existing websocket; that is not done here.
- The fresh read covers messaging channels and knowledge connectors too, since they share the same staleness trap. That adds one small `GET /api/organization` per mount of any surface using them.

### How it was exercised

On a dev stack, with xAI, GitHub Copilot and Microsoft 365 Copilot switched off and saved: the chat composer dropdown and the Model Providers cards both drop exactly those three and keep ChatGPT, across a full reload in a browser profile with a populated cache and across a second tab regaining focus. Before the second fix, both kept the pre-change answer; the clearest signal was resetting the overrides to none and watching the page still show a single subscription card instead of four.

Each new test was confirmed to fail with its corresponding fix reverted.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>